### PR TITLE
fix: surface model-not-found (404) errors in memory search tool (closes #29568)

### DIFF
--- a/src/agents/tools/memory-tool.test.ts
+++ b/src/agents/tools/memory-tool.test.ts
@@ -40,4 +40,20 @@ describe("memory_search unavailable payloads", () => {
       action: "Check embedding provider configuration and retry memory_search.",
     });
   });
+
+  it("returns model-not-found guidance for 404 errors", async () => {
+    setMemorySearchImpl(async () => {
+      throw new Error("Ollama embeddings HTTP 404: model 'all-minilm' not found");
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("notfound", { query: "hello" });
+    expectUnavailableMemorySearchDetails(result.details, {
+      error: "Ollama embeddings HTTP 404: model 'all-minilm' not found",
+      warning:
+        "Memory search is unavailable because the embedding model was not found (404). The model may need to be pulled or the model name may be incorrect.",
+      action:
+        "Pull the model (e.g. `ollama pull <model>`) or update `agents.defaults.memorySearch.model` in config, then retry memory_search.",
+    });
+  });
 });

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -223,13 +223,20 @@ function clampResultsByInjectedChars(
 
 function buildMemorySearchUnavailableResult(error: string | undefined) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
-  const isQuotaError = /insufficient_quota|quota|429/.test(reason.toLowerCase());
+  const reasonLower = reason.toLowerCase();
+  const isQuotaError = /insufficient_quota|quota|429/.test(reasonLower);
+  const isModelNotFound =
+    /model.*not found|not found.*model|model.*\b404\b|\b404\b.*model|pull.*model/.test(reasonLower);
   const warning = isQuotaError
     ? "Memory search is unavailable because the embedding provider quota is exhausted."
-    : "Memory search is unavailable due to an embedding/provider error.";
+    : isModelNotFound
+      ? "Memory search is unavailable because the embedding model was not found (404). The model may need to be pulled or the model name may be incorrect."
+      : "Memory search is unavailable due to an embedding/provider error.";
   const action = isQuotaError
     ? "Top up or switch embedding provider, then retry memory_search."
-    : "Check embedding provider configuration and retry memory_search.";
+    : isModelNotFound
+      ? "Pull the model (e.g. `ollama pull <model>`) or update `agents.defaults.memorySearch.model` in config, then retry memory_search."
+      : "Check embedding provider configuration and retry memory_search.";
   return {
     results: [],
     disabled: true,


### PR DESCRIPTION
## Summary
- Problem: When the configured memory embedding model returns a 404 (e.g., `ollama pull all-minilm` was never run), the memory search tool returns a generic "embedding/provider error" message with no guidance on how to fix it. Users spend time debugging why memory recall returns nothing.
- Why it matters: Users who misconfigure the embedding model or forget to pull it get no actionable feedback, making the agent appear to have no memories.
- What changed: Added 404/model-not-found detection in `buildMemorySearchUnavailableResult`. When the error contains a 404 status or "model not found" pattern, the tool now returns a specific warning and actionable guidance (e.g., `ollama pull <model>` or update config).
- What did NOT change (scope boundary): The error propagation chain itself is unchanged — errors already flow from the embedding provider through to the tool result. Only the error classification and message text improved.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #29568

## User-visible / Behavior Changes
When memory search fails with a 404 error, the agent now explains that the embedding model was not found and suggests pulling the model or updating the config, instead of showing a generic error.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure memory to use an Ollama embedding model that is not pulled
2. Ask the agent to recall a memory
### Expected
- Clear error: "embedding model was not found (404). The model may need to be pulled..."
### Actual (before fix)
- Generic error: "Memory search is unavailable due to an embedding/provider error"

## Evidence
- [x] Failing test/log before + passing after
- All 3 memory-tool tests pass including new test for 404 model-not-found

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + vitest all passing; reviewed diff matches issue description
- Edge cases checked: Quota errors still get their specific message; generic errors still get fallback message
- What you did NOT verify: runtime end-to-end testing with actual Ollama 404

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None