### PR TITLE
fix(plugins): carry forward httpRoutes across registry replacements

### DIFF
--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { PluginRegistry } from "../../plugins/registry.js";
+import type { PluginHttpRouteRegistration, PluginRegistry } from "../../plugins/registry.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -65,7 +65,14 @@ export function createGatewayPluginRequestHandler(params: {
 }): PluginHttpRequestHandler {
   const { registry, log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
-    const routes = registry.httpRoutes ?? [];
+    // Fall back to process-level route bridge when the registry's httpRoutes
+    // are empty. Plugin channels running in jiti VM contexts register routes
+    // on a different globalThis, so the registry captured at construction time
+    // may never see them. The process object is shared across all VM contexts.
+    const sharedRoutes = (
+      process as NodeJS.Process & { __openclawPluginHttpRoutes?: PluginHttpRouteRegistration[] }
+    ).__openclawPluginHttpRoutes;
+    const routes = (registry.httpRoutes?.length ? registry.httpRoutes : sharedRoutes) ?? [];
     if (routes.length === 0) {
       return false;
     }
@@ -76,7 +83,11 @@ export function createGatewayPluginRequestHandler(params: {
         const url = new URL(req.url ?? "/", "http://localhost");
         return resolvePluginRoutePathContext(url.pathname);
       })();
-    const matchedRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
+    // Use a registry view that includes the resolved routes so cross-context
+    // plugin routes are visible to the matcher.
+    const effectiveRegistry =
+      routes === registry.httpRoutes ? registry : { ...registry, httpRoutes: routes };
+    const matchedRoutes = findMatchingPluginHttpRoutes(effectiveRegistry, pathContext);
     if (matchedRoutes.length === 0) {
       return false;
     }

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -26,6 +26,16 @@ export { shouldEnforceGatewayAuthForPluginPath } from "./plugins-http/route-auth
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
+/** Merge two route arrays, preferring entries from `primary` on path+match collisions. */
+function deduplicateRoutes(
+  primary: PluginHttpRouteRegistration[],
+  secondary: PluginHttpRouteRegistration[],
+): PluginHttpRouteRegistration[] {
+  const seen = new Set(primary.map((r) => `${r.path}::${r.match}`));
+  const extra = secondary.filter((r) => !seen.has(`${r.path}::${r.match}`));
+  return extra.length > 0 ? [...primary, ...extra] : primary;
+}
+
 function createPluginRouteRuntimeClient(params: {
   requiresGatewayAuth: boolean;
   gatewayAuthSatisfied?: boolean;
@@ -65,14 +75,22 @@ export function createGatewayPluginRequestHandler(params: {
 }): PluginHttpRequestHandler {
   const { registry, log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
-    // Fall back to process-level route bridge when the registry's httpRoutes
-    // are empty. Plugin channels running in jiti VM contexts register routes
-    // on a different globalThis, so the registry captured at construction time
-    // may never see them. The process object is shared across all VM contexts.
-    const sharedRoutes = (
-      process as NodeJS.Process & { __openclawPluginHttpRoutes?: PluginHttpRouteRegistration[] }
-    ).__openclawPluginHttpRoutes;
-    const routes = (registry.httpRoutes?.length ? registry.httpRoutes : sharedRoutes) ?? [];
+    // Merge registry routes with the process-level bridge. Plugin channels
+    // running in jiti VM contexts register routes on a different globalThis,
+    // so the registry captured at construction time may never see them.
+    // The process object is shared across all VM contexts, so we merge both
+    // sources to handle mixed deployments where some routes are static and
+    // others are dynamically registered from a different context.
+    const registryRoutes = registry.httpRoutes ?? [];
+    const sharedRoutes =
+      (process as NodeJS.Process & { __openclawPluginHttpRoutes?: PluginHttpRouteRegistration[] })
+        .__openclawPluginHttpRoutes ?? [];
+    const routes =
+      registryRoutes.length && sharedRoutes.length
+        ? deduplicateRoutes(registryRoutes, sharedRoutes)
+        : registryRoutes.length
+          ? registryRoutes
+          : sharedRoutes;
     if (routes.length === 0) {
       return false;
     }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -83,10 +83,21 @@ export function registerPluginHttpRoute(params: {
   };
   routes.push(entry);
 
+  // Bridge routes via process so they remain visible across jiti VM contexts
+  // where globalThis (and therefore the plugin registry singleton) may differ.
+  const shared = ((
+    process as NodeJS.Process & { __openclawPluginHttpRoutes?: PluginHttpRouteRegistration[] }
+  ).__openclawPluginHttpRoutes ??= []);
+  shared.push(entry);
+
   return () => {
     const index = routes.indexOf(entry);
     if (index >= 0) {
       routes.splice(index, 1);
+    }
+    const sharedIndex = shared.indexOf(entry);
+    if (sharedIndex >= 0) {
+      shared.splice(sharedIndex, 1);
     }
   };
 }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -71,6 +71,16 @@ export function registerPluginHttpRoute(params: {
       `plugin: replacing stale webhook path ${normalizedPath} (${routeMatch})${suffix}${pluginHint}`,
     );
     routes.splice(existingIndex, 1);
+    // Also remove from the process-level bridge so stale handlers don't shadow replacements.
+    const sharedArr = (
+      process as NodeJS.Process & { __openclawPluginHttpRoutes?: PluginHttpRouteRegistration[] }
+    ).__openclawPluginHttpRoutes;
+    if (sharedArr) {
+      const sharedIdx = sharedArr.indexOf(existing);
+      if (sharedIdx >= 0) {
+        sharedArr.splice(sharedIdx, 1);
+      }
+    }
   }
 
   const entry: PluginHttpRouteRegistration = {

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -23,16 +23,6 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
-  const prev = state.registry;
-  // Merge dynamically registered plugin HTTP routes (e.g. BlueBubbles webhook)
-  // so they survive registry replacements from late loadOpenClawPlugins() calls.
-  if (prev && prev !== registry && prev.httpRoutes?.length) {
-    const newPaths = new Set((registry.httpRoutes ?? []).map((r) => `${r.path}::${r.match}`));
-    const missing = prev.httpRoutes.filter((r) => !newPaths.has(`${r.path}::${r.match}`));
-    if (missing.length > 0) {
-      registry.httpRoutes = [...missing, ...(registry.httpRoutes ?? [])];
-    }
-  }
   state.registry = registry;
   state.key = cacheKey ?? null;
   state.version += 1;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -23,6 +23,16 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+  const prev = state.registry;
+  // Merge dynamically registered plugin HTTP routes (e.g. BlueBubbles webhook)
+  // so they survive registry replacements from late loadOpenClawPlugins() calls.
+  if (prev && prev !== registry && prev.httpRoutes?.length) {
+    const newPaths = new Set((registry.httpRoutes ?? []).map((r) => `${r.path}::${r.match}`));
+    const missing = prev.httpRoutes.filter((r) => !newPaths.has(`${r.path}::${r.match}`));
+    if (missing.length > 0) {
+      registry.httpRoutes = [...missing, ...(registry.httpRoutes ?? [])];
+    }
+  }
   state.registry = registry;
   state.key = cacheKey ?? null;
   state.version += 1;


### PR DESCRIPTION
## Summary

- Fix BlueBubbles webhook returning 404 for all incoming POST requests by bridging plugin HTTP routes via `process` to survive jiti VM context isolation

## Root Cause

The provider-plugin refactor introduced jiti VM contexts where `registerPluginHttpRoute()` and `findMatchingPluginHttpRoutes()` see different `PluginRegistry` instances. Plugin channels (e.g. BlueBubbles) register their webhook route via `registerPluginHttpRoute()` in the plugin-sdk chunk, which writes to a registry resolved via `requireActivePluginRegistry()`. But the gateway HTTP handler reads from a registry captured at construction time in the gateway-cli chunk. Because jiti creates separate JS realms, `globalThis` differs between chunks — so `Symbol.for("openclaw.pluginRegistryState")` resolves to different state objects despite using the same key.

The webhook route is registered in one VM realm but looked up from another (empty) one — every POST returns 404 even though the plugin started cleanly and the log says "BlueBubbles webhook listening on /bluebubbles-webhook".

### Debug evidence

```
# Plugin registers route on registry "gwxp" in plugin-sdk VM context:
[DEBUG] registerPluginHttpRoute path: /bluebubbles-webhook → 1 route, registryId: gwxp

# Gateway HTTP handler sees empty routes in gateway-cli VM context:
# (same Symbol.for key, different globalThis → different state object)
[DEBUG] paramRoutes: 0 globalRoutes: 0 same: true version: 19
```

`process` is shared across jiti VM contexts (unlike `globalThis`), so bridging routes via `process.__openclawPluginHttpRoutes` makes them visible to the gateway HTTP handler regardless of which VM context registered them.

## Fix

Two changes:

1. **`src/plugins/http-registry.ts`** — `registerPluginHttpRoute()` also pushes entries to `process.__openclawPluginHttpRoutes` (and removes on teardown)
2. **`src/gateway/server/plugins-http.ts`** — `createGatewayPluginRequestHandler()` falls back to the process-level route array when the captured registry has no routes

See also #45105 which addresses the same jiti isolation root cause.

## Workaround (for 2026.3.13)

See [monkey-patch instructions on the issue](https://github.com/openclaw/openclaw/issues/46910#issuecomment-4062323692).

## Test plan

- [x] Send iMessage via BlueBubbles after gateway restart — webhook delivers (was 404, now 200)
- [x] Existing `src/gateway/server/plugins-http.test.ts` passes (13 tests)
- [x] `pnpm check` passes

Fixes #46910
Fixes #46924