### PR TITLE
fix(control-ui): qualify model with catalog provider in chat header picker

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -613,6 +613,31 @@ function renderChatModelSelect(state: AppViewState) {
   `;
 }
 
+/**
+ * Build a qualified `provider/model` string from a bare catalog model id.
+ * When the picker sends a bare id the gateway falls back to DEFAULT_PROVIDER
+ * ("anthropic"), which breaks every non-Anthropic model.  This helper looks up
+ * the provider in the loaded catalog so the RPC always carries the correct
+ * provider prefix.  If the model is not in the catalog it is returned as-is
+ * (graceful fallback to current behaviour).
+ */
+function qualifyModelFromCatalog(catalog: ModelCatalogEntry[] | null, bareModel: string): string {
+  if (!bareModel || !catalog) {
+    return bareModel;
+  }
+  const entry = catalog.find((e) => e.id === bareModel);
+  if (!entry?.provider) {
+    return bareModel;
+  }
+  // Avoid double-prefixing when the id already starts with the provider
+  // (e.g. OpenRouter ids like "deepseek/deepseek-v3" with provider "openrouter"
+  // would NOT match, so we correctly produce "openrouter/deepseek/deepseek-v3").
+  if (bareModel.toLowerCase().startsWith(`${entry.provider.toLowerCase()}/`)) {
+    return bareModel;
+  }
+  return `${entry.provider}/${bareModel}`;
+}
+
 async function switchChatModel(state: AppViewState, nextModel: string) {
   if (!state.client || !state.connected) {
     return;
@@ -625,14 +650,19 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
   const prevOverride = state.chatModelOverrides[targetSessionKey];
   state.lastError = null;
   // Write the override cache immediately so the picker stays in sync during the RPC round-trip.
+  // The cache stores the bare model id so it stays consistent with sessions.list responses.
   state.chatModelOverrides = {
     ...state.chatModelOverrides,
     [targetSessionKey]: nextModel || null,
   };
+  // Qualify the model with its catalog provider before sending to the gateway.
+  const qualifiedModel = nextModel
+    ? qualifyModelFromCatalog(state.chatModelCatalog, nextModel)
+    : null;
   try {
     await state.client.request("sessions.patch", {
       key: targetSessionKey,
-      model: nextModel || null,
+      model: qualifiedModel,
     });
     await refreshSessionOptions(state);
   } catch (err) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -571,10 +571,54 @@ describe("chat view", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
-    expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("openai/gpt-5-mini");
+    vi.unstubAllGlobals();
+  });
+
+  it("qualifies the model with its catalog provider when switching (regression #46859)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState({
+      models: [
+        { id: "gpt-5", name: "GPT-5", provider: "openai" },
+        { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic" },
+        { id: "deepseek-r1:8b", name: "DeepSeek R1 8B", provider: "ollama" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+
+    // Switch to an Ollama model — the RPC must carry "ollama/" not "anthropic/"
+    modelSelect!.value = "deepseek-r1:8b";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "ollama/deepseek-r1:8b",
+    });
+
+    // Switch to an Anthropic model
+    request.mockClear();
+    modelSelect!.value = "claude-opus-4-6";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "anthropic/claude-opus-4-6",
+    });
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## Summary

The Control UI model picker sends bare model IDs (e.g. `gpt-5-mini`) to `sessions.patch`. The gateway's `parseModelRef()` falls back to `DEFAULT_PROVIDER` (`"anthropic"`) for bare IDs, so selecting any non-Anthropic model (Ollama, OpenAI, OpenRouter, etc.) produces:

```
GatewayRequestError: model not allowed: anthropic/<bare-id>
```

This makes the model picker unusable for multi-provider setups.

Fixes #46859, #46764, #46700

## Root cause

`buildChatModelOptions()` in `ui/src/ui/app-render.helpers.ts:566` uses `entry.id` as the `<option>` value and `entry.provider` only for the display label. `switchChatModel()` then forwards that bare value to the `sessions.patch` RPC unchanged. The gateway receives `"gpt-5-mini"`, sees no `/`, and prepends `DEFAULT_PROVIDER` → `"anthropic/gpt-5-mini"` → rejected.

The CLI model picker (`src/commands/model-picker.ts`) already sends qualified `provider/model` via `modelKey()`. Only the Control UI picker was missing this.

## Fix

Add `qualifyModelFromCatalog()` — a pure helper that looks up the model's provider in the loaded catalog and builds `"provider/model"` before sending the RPC. The picker option values and the local cache remain bare to stay consistent with `sessions.list` responses (which return bare model IDs with the provider in a separate `modelProvider` field).

### Key design decision: qualify on send, not on store

Changing the `<option>` values to qualified format would break the `?selected` comparison after page reload, because `resolveModelOverrideValue()` returns bare IDs from `sessions.list`. Qualifying only at the RPC call point avoids this mismatch.

### Edge cases

| Case | Result |
|------|--------|
| Simple model (`gpt-5` + `openai`) | Sends `openai/gpt-5` |
| Nested slash (`deepseek/deepseek-v3` + `openrouter`) | Sends `openrouter/deepseek/deepseek-v3` |
| ID already prefixed with provider | No double-prefixing |
| Model not in catalog (manual override) | Sent as-is (graceful fallback) |
| "Default" selection (`value=""`) | Sends `null`, unchanged |

## Test plan

- [x] Updated existing test to expect qualified model ID in `sessions.patch`
- [x] Added regression test with multi-provider catalog (OpenAI + Anthropic + Ollama) verifying correct provider prefix for each
- [x] All 25 chat UI tests pass (`pnpm test -- ui/src/ui/views/chat.test.ts`)
- [x] `pnpm check` passes (lint + format)
- [ ] Manual: open Control UI with multiple providers configured, switch between models from different providers, verify no `model not allowed` errors

## Files changed

- `ui/src/ui/app-render.helpers.ts` — added `qualifyModelFromCatalog()`, modified `switchChatModel()` to qualify before RPC
- `ui/src/ui/views/chat.test.ts` — updated existing assertion, added regression test