### PR TITLE
Fix last heartbeat status rendering

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -346,10 +346,7 @@ export async function statusCommand(
     if (!lastHeartbeat) {
       return muted("none");
     }
-    const age = formatTimeAgo(Date.now() - lastHeartbeat.ts);
-    const channel = lastHeartbeat.channel ?? "unknown";
-    const accountLabel = lastHeartbeat.accountId ? `account ${lastHeartbeat.accountId}` : null;
-    return [lastHeartbeat.status, `${age} ago`, channel, accountLabel].filter(Boolean).join(" · ");
+    return formatLastHeartbeatDetail(lastHeartbeat);
   })();
 
   const storeLabel =

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -30,6 +30,7 @@ import {
   formatTokensCompact,
   shortenText,
 } from "./status.format.js";
+import { formatLastHeartbeatDetail } from "./status.last-heartbeat.js";
 import { scanStatus } from "./status.scan.js";
 import {
   formatUpdateAvailableHint,

--- a/src/commands/status.last-heartbeat.test.ts
+++ b/src/commands/status.last-heartbeat.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatLastHeartbeatDetail } from "./status.last-heartbeat.js";
+
+describe("formatLastHeartbeatDetail", () => {
+  it("does not duplicate the relative-time suffix", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T05:37:00Z"));
+    try {
+      const rendered = formatLastHeartbeatDetail({
+        status: "ok-token",
+        ts: Date.now() - 60_000,
+        silent: true,
+        indicatorType: "ok",
+      });
+      expect(rendered).toContain("ok-token");
+      expect(rendered).toContain("1m ago");
+      expect(rendered).not.toContain("ago ago");
+      expect(rendered).not.toContain("unknown");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("includes channel and account when provided", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T05:37:00Z"));
+    try {
+      const rendered = formatLastHeartbeatDetail({
+        status: "ok-token",
+        ts: Date.now() - 60_000,
+        channel: "telegram",
+        accountId: "default",
+        silent: true,
+        indicatorType: "ok",
+      });
+      expect(rendered).toContain("telegram");
+      expect(rendered).toContain("account default");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/commands/status.last-heartbeat.ts
+++ b/src/commands/status.last-heartbeat.ts
@@ -1,0 +1,12 @@
+import { formatTimeAgo } from "../infra/format-time/format-relative.js";
+import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
+
+export function formatLastHeartbeatDetail(
+  lastHeartbeat: HeartbeatEventPayload,
+  nowMs = Date.now(),
+): string {
+  const age = formatTimeAgo(nowMs - lastHeartbeat.ts);
+  const channel = lastHeartbeat.channel ?? null;
+  const accountLabel = lastHeartbeat.accountId ? `account ${lastHeartbeat.accountId}` : null;
+  return [lastHeartbeat.status, age, channel, accountLabel].filter(Boolean).join(" · ");
+}


### PR DESCRIPTION
## Summary
- fix `status --deep` so last-heartbeat ages are not rendered as `ago ago`
- stop showing `unknown` when the last heartbeat simply lacks optional channel/account metadata
- add a focused helper + tests for last-heartbeat display formatting

Closes #46932.

## Problem
The current `status --deep` rendering path duplicates the relative-time suffix and falls back to `unknown` when the heartbeat payload does not include `channel` / `accountId`. That is especially confusing for silent/internal heartbeat events that are otherwise healthy.

## Fix
- extract `formatLastHeartbeatDetail(...)` into a small helper
- reuse `formatTimeAgo(...)` output directly without appending another ` ago`
- omit missing channel/account fields instead of rendering `unknown`
- add focused unit coverage for both cases

## Tests
- `pnpm exec vitest run src/commands/status.last-heartbeat.test.ts src/commands/status.summary.test.ts`
