### PR TITLE
fix(exec-approvals): preserve outbound tool context for forwarded not…

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -100,6 +100,7 @@ export type ChannelOutboundContext = {
   accountId?: string | null;
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
+  toolContext?: ChannelThreadingToolContext;
   silent?: boolean;
 };
 

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -377,6 +377,62 @@ describe("exec approval forwarder", () => {
     });
   });
 
+  it("prefers turn-source routing over stale session last route", async () => {
+    vi.useFakeTimers();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approval-forwarder-test-"));
+    try {
+      const storePath = path.join(tmpDir, "sessions.json");
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": {
+            updatedAt: 1,
+            channel: "slack",
+            to: "U1",
+            lastChannel: "slack",
+            lastTo: "U1",
+          },
+        }),
+        "utf-8",
+      );
+
+      const cfg = {
+        session: { store: storePath },
+        approvals: { exec: { enabled: true, mode: "session" } },
+      } as OpenClawConfig;
+
+      const { deliver, forwarder } = createForwarder({ cfg });
+      await expect(
+        forwarder.handleRequested({
+          ...baseRequest,
+          request: {
+            ...baseRequest.request,
+            turnSourceChannel: "whatsapp",
+            turnSourceTo: "+15555550123",
+            turnSourceAccountId: "work",
+            turnSourceThreadId: "1739201675.123",
+          },
+        }),
+      ).resolves.toBe(true);
+
+      expect(deliver).toHaveBeenCalledTimes(1);
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "whatsapp",
+          to: "+15555550123",
+          accountId: "work",
+          threadId: "1739201675.123",
+          toolContext: expect.objectContaining({
+            currentChannelId: "+15555550123",
+            currentChannelProvider: "whatsapp",
+          }),
+        }),
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("can forward resolved notices without pending cache when request payload is present", async () => {
     vi.useFakeTimers();
     const cfg = {
@@ -403,6 +459,16 @@ describe("exec approval forwarder", () => {
     });
 
     expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "123",
+        toolContext: expect.objectContaining({
+          currentChannelId: "123",
+          currentChannelProvider: "telegram",
+        }),
+      }),
+    );
   });
 
   it("uses a longer fence when command already contains triple backticks", async () => {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -345,6 +345,10 @@ async function deliverToTargets(params: {
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
+        toolContext: {
+          currentChannelId: target.to,
+          currentChannelProvider: channel,
+        },
         payloads: [payload],
       });
     } catch (err) {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -15,6 +15,7 @@ import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load
 import type {
   ChannelOutboundAdapter,
   ChannelOutboundContext,
+  ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
@@ -189,6 +190,7 @@ function createChannelOutboundContextBase(
     gifPlayback: params.gifPlayback,
     forceDocument: params.forceDocument,
     deps: params.deps,
+    toolContext: params.toolContext,
     silent: params.silent,
     mediaLocalRoots: params.mediaLocalRoots,
   };
@@ -208,6 +210,7 @@ type DeliverOutboundPayloadsCoreParams = {
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   forceDocument?: boolean;
+  toolContext?: ChannelThreadingToolContext;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -108,6 +108,7 @@ type ChannelHandlerParams = {
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   forceDocument?: boolean;
+  toolContext?: ChannelThreadingToolContext;
   silent?: boolean;
   mediaLocalRoots?: readonly string[];
 };


### PR DESCRIPTION
## Summary
- preserve outbound tool context for forwarded exec-approval notices
- pass target-derived currentChannelId/currentChannelProvider through outbound delivery
- add regression coverage for forwarded request/resolved deliveries

## Problem
When multiple channels are enabled (for example telegram + line), resolving an exec approval could fail during forwarded follow-up delivery with:

`Channel is required when multiple channels are configured: telegram, line`

The exec-approval forwarder already knew the resolved delivery target, but it forwarded notices through outbound delivery without preserving channel threading/tool context. Downstream routing then lost the current channel identity in multi-channel setups.

## Fix
- extend outbound delivery context to carry optional `toolContext`
- thread that context into channel outbound adapter calls
- have exec approval forwarding derive `currentChannelId` and `currentChannelProvider` from the resolved target when sending forwarded notices

## Validation
- `pnpm test -- --run src/infra/exec-approval-forwarder.test.ts src/infra/outbound/deliver.test.ts`