### PR TITLE
fix(plugins): route send-deps imports through plugin-sdk for Docker compat

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -8,6 +8,7 @@ import {
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   buildAgentSessionKey,
   resolveThreadSessionKeys,
@@ -31,7 +32,6 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/discord";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { normalizeMessageChannel } from "../../../src/utils/message-channel.js";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
@@ -6,7 +7,6 @@ import {
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { OutboundIdentity } from "../../../src/infra/outbound/identity.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import type { DiscordComponentMessageSpec } from "./components.js";
 import { getThreadBindingManager, type ThreadBindingRecord } from "./monitor/thread-bindings.js";
 import { normalizeDiscordOutboundTarget } from "./normalize.js";

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -3,6 +3,7 @@ import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import { buildAgentSessionKey, type RoutePeer } from "openclaw/plugin-sdk/core";
 import {
   buildChannelConfigSchema,
@@ -23,7 +24,6 @@ import {
   setAccountEnabledInConfigSection,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/imessage";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import {
   listIMessageAccountIds,

--- a/extensions/imessage/src/outbound-adapter.ts
+++ b/extensions/imessage/src/outbound-adapter.ts
@@ -1,11 +1,8 @@
+import { resolveOutboundSendDep, type OutboundSendDeps } from "openclaw/plugin-sdk/compat";
 import {
   createScopedChannelMediaMaxBytesResolver,
   createDirectTextMediaOutbound,
 } from "../../../src/channels/plugins/outbound/direct-text-media.js";
-import {
-  resolveOutboundSendDep,
-  type OutboundSendDeps,
-} from "../../../src/infra/outbound/send-deps.js";
 import { sendMessageIMessage } from "./send.js";
 
 function resolveIMessageSender(deps: OutboundSendDeps | undefined) {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/matrix";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
 import { getMatrixRuntime } from "./runtime.js";
 

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/msteams";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -4,6 +4,7 @@ import {
   createScopedAccountConfigAccessors,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import { buildAgentSessionKey, type RoutePeer } from "openclaw/plugin-sdk/core";
 import {
   buildBaseAccountStatusSnapshot,
@@ -26,7 +27,6 @@ import {
 } from "openclaw/plugin-sdk/signal";
 import { resolveTextChunkLimit } from "../../../src/auto-reply/chunk.js";
 import { resolveMarkdownTableMode } from "../../../src/config/markdown-tables.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import {
   listSignalAccountIds,
   resolveDefaultSignalAccountId,

--- a/extensions/signal/src/outbound-adapter.ts
+++ b/extensions/signal/src/outbound-adapter.ts
@@ -1,11 +1,8 @@
+import { resolveOutboundSendDep, type OutboundSendDeps } from "openclaw/plugin-sdk/compat";
 import { resolveTextChunkLimit } from "../../../src/auto-reply/chunk.js";
 import { createScopedChannelMediaMaxBytesResolver } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import { resolveMarkdownTableMode } from "../../../src/config/markdown-tables.js";
-import {
-  resolveOutboundSendDep,
-  type OutboundSendDeps,
-} from "../../../src/infra/outbound/send-deps.js";
 import { markdownToSignalTextChunks } from "./format.js";
 import { sendMessageSignal } from "./send.js";
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -7,6 +7,7 @@ import {
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   buildAgentSessionKey,
   resolveThreadSessionKeys,
@@ -30,7 +31,6 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/slack";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { inspectSlackAccount } from "./account-inspect.js";
 import {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -1,3 +1,4 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
@@ -5,7 +6,6 @@ import {
 } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import type { OutboundIdentity } from "../../../src/infra/outbound/identity.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import {
   resolveInteractiveTextFallback,
   type InteractiveReply,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -7,6 +7,7 @@ import {
   createScopedDmSecurityResolver,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { type OutboundSendDeps, resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   buildAgentSessionKey,
   resolveThreadSessionKeys,
@@ -34,10 +35,6 @@ import {
 import { parseTelegramTopicConversation } from "../../../src/acp/conversation-id.js";
 import { resolveExecApprovalCommandDisplay } from "../../../src/infra/exec-approval-command-display.js";
 import { buildExecApprovalPendingReplyPayload } from "../../../src/infra/exec-approval-reply.js";
-import {
-  type OutboundSendDeps,
-  resolveOutboundSendDep,
-} from "../../../src/infra/outbound/send-deps.js";
 import { normalizeMessageChannel } from "../../../src/utils/message-channel.js";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -1,13 +1,10 @@
+import { resolveOutboundSendDep, type OutboundSendDeps } from "openclaw/plugin-sdk/compat";
 import type { ReplyPayload } from "../../../src/auto-reply/types.js";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
 } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
-import {
-  resolveOutboundSendDep,
-  type OutboundSendDeps,
-} from "../../../src/infra/outbound/send-deps.js";
 import { resolveInteractiveTextFallback } from "../../../src/interactive/payload.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -1,8 +1,8 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import { chunkText } from "../../../src/auto-reply/chunk.js";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import { shouldLogVerbose } from "../../../src/globals.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { resolveWhatsAppOutboundTarget } from "../../../src/whatsapp/resolve-outbound-target.js";
 import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -633,6 +633,8 @@ export type { HookEntry } from "../hooks/types.js";
 export { clamp, escapeRegExp, normalizeE164, safeParseJson, sleep } from "../utils.js";
 export { stripAnsi } from "../terminal/ansi.js";
 export { missingTargetError } from "../infra/outbound/target-errors.js";
+export { resolveOutboundSendDep } from "../infra/outbound/send-deps.js";
+export type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 export { registerLogTransport } from "../logging/logger.js";
 export type { LogTransport, LogTransportRecord } from "../logging/logger.js";
 export {


### PR DESCRIPTION
## Summary
- #46301 extracted `resolveOutboundSendDep` into `src/infra/outbound/send-deps.ts` but kept raw relative `../../../src/` imports in all 10 extension files. In Docker multi-stage builds the final image only ships `dist/`, so the `src/` path doesn't resolve at runtime.
- Export `resolveOutboundSendDep` and `OutboundSendDeps` from `openclaw/plugin-sdk` and update all extension imports to use the SDK path.

Fixes #46609
Fixes #46443

## Test plan
- [x] `pnpm build` passes (plugin-sdk DTS + bundle include the new export)
- [x] Verified `resolveOutboundSendDep` appears in `dist/plugin-sdk/index.js` built output
- [x] All 10 extension files updated, no remaining `send-deps.js` relative imports