### PR TITLE
fix(ui): limit sidebar markdown image max-width to prevent oversized display

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -84,8 +84,8 @@
 
 .sidebar-markdown .markdown-inline-image {
   display: block;
-  max-width: 100%;
-  max-height: 420px;
+  max-width: min(100%, 420px);
+  max-height: 320px;
   width: auto;
   height: auto;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

The sidebar markdown images were using `max-width: 100%`, which caused images to become abnormally large after extended chat sessions when the sidebar width was large.

## Changes

- Updated `.sidebar-markdown .markdown-inline-image` in `ui/src/styles/chat/sidebar.css`
  - Changed `max-width: 100%` to `max-width: min(100%, 420px)`
  - Changed `max-height: 420px` to `max-height: 320px`
  - Now consistent with main chat area image sizing

## Testing

Manual testing: Opened Web UI, started a chat with images, verified images display at reasonable size in both main chat and sidebar.

Fixes #45846