### PR TITLE
fix(acp): release dormant oneshot runtimes under pressure

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1175,40 +1175,53 @@ export class AcpSessionManager {
 
     let reclaimed = 0;
     for (const candidate of candidates) {
-      const cached = this.runtimeCache.peek(candidate.actorKey);
-      if (!cached) {
-        continue;
-      }
-      let isStale = false;
-      if (cached.runtime.getStatus) {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 5_000);
-        try {
-          await cached.runtime.getStatus({ handle: cached.handle, signal: controller.signal });
-        } catch {
-          isStale = true;
-        } finally {
-          clearTimeout(timeout);
+      const evicted = await this.actorQueue.run(candidate.actorKey, async () => {
+        if (this.activeTurnBySession.has(candidate.actorKey)) {
+          return false;
         }
-      } else if (candidate.idleMs >= BLIND_IDLE_MS) {
-        isStale = true;
-      }
-      if (!isStale) {
-        continue;
-      }
-      this.runtimeCache.clear(candidate.actorKey);
-      reclaimed += 1;
-      logVerbose(
-        `acp-manager: back-pressure evicted stale session ${candidate.actorKey} (idle ${Math.round(candidate.idleMs / 1000)}s)`,
-      );
-      try {
-        await cached.runtime.close({ handle: cached.handle, reason: "stale-pressure-evicted" });
-      } catch (error) {
+        const cached = this.runtimeCache.peek(candidate.actorKey);
+        if (!cached) {
+          return false;
+        }
+        let isStale = false;
+        if (cached.runtime.getStatus) {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 5_000);
+          try {
+            await cached.runtime.getStatus({ handle: cached.handle, signal: controller.signal });
+          } catch {
+            isStale = true;
+          } finally {
+            clearTimeout(timeout);
+          }
+        } else if (candidate.idleMs >= BLIND_IDLE_MS) {
+          isStale = true;
+        }
+        if (!isStale) {
+          return false;
+        }
+        if (this.activeTurnBySession.has(candidate.actorKey)) {
+          return false;
+        }
+        this.runtimeCache.clear(candidate.actorKey);
+        this.evictedRuntimeCount += 1;
+        this.lastEvictedAt = Date.now();
         logVerbose(
-          `acp-manager: stale pressure eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+          `acp-manager: back-pressure evicted stale session ${candidate.actorKey} (idle ${Math.round(candidate.idleMs / 1000)}s)`,
         );
+        try {
+          await cached.runtime.close({ handle: cached.handle, reason: "stale-pressure-evicted" });
+        } catch (error) {
+          logVerbose(
+            `acp-manager: stale pressure eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+          );
+        }
+        return true;
+      });
+      if (evicted) {
+        reclaimed += 1;
+        break;
       }
-      break;
     }
     return reclaimed;
   }

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -184,15 +184,32 @@ export class AcpSessionManager {
             sessionKey: session.sessionKey,
             meta: resolution.meta,
           });
-          const reconciled = await this.reconcileRuntimeSessionIdentifiers({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            runtime,
-            handle,
-            meta,
-            failOnStatusError: false,
-          });
-          return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          try {
+            const reconciled = await this.reconcileRuntimeSessionIdentifiers({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              runtime,
+              handle,
+              meta,
+              failOnStatusError: false,
+            });
+            return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          } finally {
+            if (meta.mode === "oneshot") {
+              try {
+                await runtime.close({
+                  handle,
+                  reason: "startup-identity-reconcile-release",
+                });
+              } catch (error) {
+                logVerbose(
+                  `acp-manager: startup reconcile close failed for ${session.sessionKey}: ${String(error)}`,
+                );
+              } finally {
+                this.clearCachedRuntimeState(session.sessionKey);
+              }
+            }
+          }
         });
         if (becameResolved) {
           resolved += 1;
@@ -1067,7 +1084,10 @@ export class AcpSessionManager {
     cached.appliedControlSignature = undefined;
   }
 
-  private async enforceConcurrentSessionLimit(params: { cfg: OpenClawConfig; sessionKey: string }): Promise<void> {
+  private async enforceConcurrentSessionLimit(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+  }): Promise<void> {
     const configuredLimit = params.cfg.acp?.maxConcurrentSessions;
     if (typeof configuredLimit !== "number" || !Number.isFinite(configuredLimit)) {
       return;
@@ -1079,17 +1099,23 @@ export class AcpSessionManager {
     }
     const activeCount = this.runtimeCache.size();
     if (activeCount >= limit) {
-      const reclaimed = await this.evictStaleRuntimesUnderPressure({ cfg: params.cfg });
+      const reclaimedOneshot = await this.evictDormantOneshotRuntimesUnderPressure({
+        cfg: params.cfg,
+      });
+      const reclaimedStale = await this.evictStaleRuntimesUnderPressure({ cfg: params.cfg });
+      const reclaimed = reclaimedOneshot + reclaimedStale;
       const updatedCount = this.runtimeCache.size();
       if (updatedCount >= limit) {
         throw new AcpRuntimeError(
           "ACP_SESSION_INIT_FAILED",
           `ACP max concurrent sessions reached (${updatedCount}/${limit}).` +
-            (reclaimed > 0 ? ` Reclaimed ${reclaimed} stale session(s) but still at capacity.` : ""),
+            (reclaimed > 0
+              ? ` Reclaimed ${reclaimed} stale session(s) but still at capacity.`
+              : ""),
         );
       }
       logVerbose(
-        `acp-manager: back-pressure eviction freed ${reclaimed} stale session(s) (${activeCount} -> ${updatedCount}/${limit})`,
+        `acp-manager: back-pressure eviction freed ${reclaimed} runtime(s) (${activeCount} -> ${updatedCount}/${limit})`,
       );
     }
   }
@@ -1155,13 +1181,76 @@ export class AcpSessionManager {
     }
   }
 
+  private async evictDormantOneshotRuntimesUnderPressure(params: {
+    cfg: OpenClawConfig;
+  }): Promise<number> {
+    if (this.runtimeCache.size() === 0) {
+      return 0;
+    }
+
+    let reclaimed = 0;
+    const snapshot = this.runtimeCache.snapshot();
+    for (const candidate of snapshot) {
+      if (candidate.state.mode !== "oneshot") {
+        continue;
+      }
+      if (this.activeTurnBySession.has(candidate.actorKey)) {
+        continue;
+      }
+      const sessionEntry = this.deps.readSessionEntry({
+        cfg: params.cfg,
+        sessionKey: candidate.state.handle.sessionKey,
+      });
+      const meta = sessionEntry?.acp;
+      if (!meta || meta.mode !== "oneshot" || meta.state === "running") {
+        continue;
+      }
+
+      const evicted = await this.actorQueue.run(candidate.actorKey, async () => {
+        if (this.activeTurnBySession.has(candidate.actorKey)) {
+          return false;
+        }
+        const cached = this.runtimeCache.peek(candidate.actorKey);
+        if (!cached || cached.mode !== "oneshot") {
+          return false;
+        }
+        const latestMeta = this.deps.readSessionEntry({
+          cfg: params.cfg,
+          sessionKey: cached.handle.sessionKey,
+        })?.acp;
+        if (!latestMeta || latestMeta.mode !== "oneshot" || latestMeta.state === "running") {
+          return false;
+        }
+        this.runtimeCache.clear(candidate.actorKey);
+        this.evictedRuntimeCount += 1;
+        this.lastEvictedAt = Date.now();
+        try {
+          await cached.runtime.close({
+            handle: cached.handle,
+            reason: "oneshot-pressure-evicted",
+          });
+        } catch (error) {
+          logVerbose(
+            `acp-manager: oneshot pressure eviction close failed for ${cached.handle.sessionKey}: ${String(error)}`,
+          );
+        }
+        return true;
+      });
+      if (evicted) {
+        reclaimed += 1;
+      }
+    }
+
+    return reclaimed;
+  }
+
   /**
    * Under back-pressure (all slots full), attempt to reclaim sessions that are
    * likely stale: not currently executing a turn and idle for at least a short
    * grace period. Evicts oldest-idle-first until at least one slot is freed.
    * Falls back to probing runtime status when available.
    */
-  private async evictStaleRuntimesUnderPressure(params: { cfg: OpenClawConfig }): Promise<number> {
+  private async evictStaleRuntimesUnderPressure(_params: { cfg: OpenClawConfig }): Promise<number> {
     if (this.runtimeCache.size() === 0) {
       return 0;
     }
@@ -1170,8 +1259,10 @@ export class AcpSessionManager {
     const BLIND_IDLE_MS = 30 * 60 * 1000;
     const snapshot = this.runtimeCache.snapshot({ now });
     const candidates = snapshot
-      .filter((entry) => !this.activeTurnBySession.has(entry.actorKey) && entry.idleMs >= PROBE_IDLE_MS)
-      .sort((a, b) => b.idleMs - a.idleMs);
+      .filter(
+        (entry) => !this.activeTurnBySession.has(entry.actorKey) && entry.idleMs >= PROBE_IDLE_MS,
+      )
+      .toSorted((a, b) => b.idleMs - a.idleMs);
 
     let reclaimed = 0;
     for (const candidate of candidates) {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -227,7 +227,7 @@ export class AcpSessionManager {
       const runtime = backend.runtime;
       const initialRuntimeOptions = validateRuntimeOptionPatch({ cwd: input.cwd });
       const requestedCwd = initialRuntimeOptions.cwd;
-      this.enforceConcurrentSessionLimit({
+      await this.enforceConcurrentSessionLimit({
         cfg: input.cfg,
         sessionKey,
       });
@@ -926,7 +926,7 @@ export class AcpSessionManager {
       this.clearCachedRuntimeState(params.sessionKey);
     }
 
-    this.enforceConcurrentSessionLimit({
+    await this.enforceConcurrentSessionLimit({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
     });
@@ -1067,7 +1067,7 @@ export class AcpSessionManager {
     cached.appliedControlSignature = undefined;
   }
 
-  private enforceConcurrentSessionLimit(params: { cfg: OpenClawConfig; sessionKey: string }): void {
+  private async enforceConcurrentSessionLimit(params: { cfg: OpenClawConfig; sessionKey: string }): Promise<void> {
     const configuredLimit = params.cfg.acp?.maxConcurrentSessions;
     if (typeof configuredLimit !== "number" || !Number.isFinite(configuredLimit)) {
       return;
@@ -1079,9 +1079,17 @@ export class AcpSessionManager {
     }
     const activeCount = this.runtimeCache.size();
     if (activeCount >= limit) {
-      throw new AcpRuntimeError(
-        "ACP_SESSION_INIT_FAILED",
-        `ACP max concurrent sessions reached (${activeCount}/${limit}).`,
+      const reclaimed = await this.evictStaleRuntimesUnderPressure({ cfg: params.cfg });
+      const updatedCount = this.runtimeCache.size();
+      if (updatedCount >= limit) {
+        throw new AcpRuntimeError(
+          "ACP_SESSION_INIT_FAILED",
+          `ACP max concurrent sessions reached (${updatedCount}/${limit}).` +
+            (reclaimed > 0 ? ` Reclaimed ${reclaimed} stale session(s) but still at capacity.` : ""),
+        );
+      }
+      logVerbose(
+        `acp-manager: back-pressure eviction freed ${reclaimed} stale session(s) (${activeCount} -> ${updatedCount}/${limit})`,
       );
     }
   }
@@ -1145,6 +1153,64 @@ export class AcpSessionManager {
         }
       });
     }
+  }
+
+  /**
+   * Under back-pressure (all slots full), attempt to reclaim sessions that are
+   * likely stale: not currently executing a turn and idle for at least a short
+   * grace period. Evicts oldest-idle-first until at least one slot is freed.
+   * Falls back to probing runtime status when available.
+   */
+  private async evictStaleRuntimesUnderPressure(params: { cfg: OpenClawConfig }): Promise<number> {
+    if (this.runtimeCache.size() === 0) {
+      return 0;
+    }
+    const now = Date.now();
+    const PROBE_IDLE_MS = 5 * 60 * 1000;
+    const BLIND_IDLE_MS = 30 * 60 * 1000;
+    const snapshot = this.runtimeCache.snapshot({ now });
+    const candidates = snapshot
+      .filter((entry) => !this.activeTurnBySession.has(entry.actorKey) && entry.idleMs >= PROBE_IDLE_MS)
+      .sort((a, b) => b.idleMs - a.idleMs);
+
+    let reclaimed = 0;
+    for (const candidate of candidates) {
+      const cached = this.runtimeCache.peek(candidate.actorKey);
+      if (!cached) {
+        continue;
+      }
+      let isStale = false;
+      if (cached.runtime.getStatus) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 5_000);
+        try {
+          await cached.runtime.getStatus({ handle: cached.handle, signal: controller.signal });
+        } catch {
+          isStale = true;
+        } finally {
+          clearTimeout(timeout);
+        }
+      } else if (candidate.idleMs >= BLIND_IDLE_MS) {
+        isStale = true;
+      }
+      if (!isStale) {
+        continue;
+      }
+      this.runtimeCache.clear(candidate.actorKey);
+      reclaimed += 1;
+      logVerbose(
+        `acp-manager: back-pressure evicted stale session ${candidate.actorKey} (idle ${Math.round(candidate.idleMs / 1000)}s)`,
+      );
+      try {
+        await cached.runtime.close({ handle: cached.handle, reason: "stale-pressure-evicted" });
+      } catch (error) {
+        logVerbose(
+          `acp-manager: stale pressure eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+        );
+      }
+      break;
+    }
+    return reclaimed;
   }
 
   private async resolveRuntimeCapabilities(params: {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1298,4 +1298,266 @@ describe("AcpSessionManager", () => {
       }),
     ).rejects.toThrow("disk locked");
   });
+
+  it("back-pressure evicts stale sessions when getStatus fails at capacity", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-15T00:00:00.000Z"));
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+        sessionKey: "agent:codex:acp:session-b",
+        storeSessionKey: "agent:codex:acp:session-b",
+        acp: readySessionMeta(),
+      });
+      const limitedCfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      runtimeState.getStatus.mockRejectedValue(new Error("process not found"));
+
+      vi.advanceTimersByTime(6 * 60 * 1000);
+
+      await manager.initializeSession({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "stale-pressure-evicted" }),
+      );
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not evict healthy sessions under back-pressure", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-15T00:00:00.000Z"));
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      const limitedCfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      vi.advanceTimersByTime(6 * 60 * 1000);
+
+      await expect(
+        manager.initializeSession({
+          cfg: limitedCfg,
+          sessionKey: "agent:codex:acp:session-b",
+          agent: "codex",
+          mode: "persistent",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: expect.stringContaining("max concurrent sessions"),
+      });
+
+      expect(runtimeState.close).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "stale-pressure-evicted" }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("back-pressure evicts sessions without getStatus after blind idle threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-15T00:00:00.000Z"));
+      const ensureSession = vi.fn(
+        async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => ({
+          sessionKey: input.sessionKey,
+          backend: "acpx",
+          runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime`,
+        }),
+      );
+      const runTurn = vi.fn(async function* () {
+        yield { type: "done" as const };
+      });
+      const cancel = vi.fn(async () => {});
+      const close = vi.fn(async () => {});
+      const runtimeNoStatus: AcpRuntime = {
+        ensureSession,
+        runTurn,
+        cancel,
+        close,
+      };
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeNoStatus,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+        sessionKey: "agent:codex:acp:session-b",
+        storeSessionKey: "agent:codex:acp:session-b",
+        acp: readySessionMeta(),
+      });
+      const limitedCfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      vi.advanceTimersByTime(31 * 60 * 1000);
+
+      await manager.initializeSession({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      expect(close).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "stale-pressure-evicted" }),
+      );
+      expect(ensureSession).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("back-pressure does not evict sessions without getStatus before blind idle threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-15T00:00:00.000Z"));
+      const runtimeNoStatus: AcpRuntime = {
+        ensureSession: vi.fn(
+          async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => ({
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime`,
+          }),
+        ),
+        runTurn: vi.fn(async function* () {
+          yield { type: "done" as const };
+        }),
+        cancel: vi.fn(async () => {}),
+        close: vi.fn(async () => {}),
+      };
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeNoStatus,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      const limitedCfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      await expect(
+        manager.initializeSession({
+          cfg: limitedCfg,
+          sessionKey: "agent:codex:acp:session-b",
+          agent: "codex",
+          mode: "persistent",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: expect.stringContaining("max concurrent sessions"),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -383,6 +383,157 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
   });
 
+  it("startup identity reconciliation releases cached oneshot handles after resolving", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "status=alive",
+      acpxRecordId: "acpx-record-oneshot",
+      backendSessionId: "acpx-session-oneshot",
+      agentSessionId: "agent-session-oneshot",
+      details: { status: "alive" },
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+
+    const sessionKey = "agent:claude:acp:oneshot-pending";
+    let currentMeta: SessionAcpMeta = {
+      ...readySessionMeta(),
+      agent: "claude",
+      mode: "oneshot",
+      identity: {
+        state: "pending",
+        source: "ensure",
+        acpxSessionId: "acpx-stale",
+        lastUpdatedAt: Date.now(),
+      },
+    };
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      {
+        cfg: baseCfg,
+        storePath: "/tmp/sessions-acp.json",
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          acp: currentMeta,
+        },
+        acp: currentMeta,
+      },
+    ]);
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      if (key !== sessionKey) {
+        return null;
+      }
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: currentMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      const next = params.mutate(currentMeta, { acp: currentMeta });
+      if (next) {
+        currentMeta = next;
+      }
+      return {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        acp: currentMeta,
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    const result = await manager.reconcilePendingSessionIdentities({ cfg: baseCfg });
+
+    expect(result).toEqual({ checked: 1, resolved: 1, failed: 0 });
+    expect(runtimeState.close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "startup-identity-reconcile-release",
+        handle: expect.objectContaining({ sessionKey }),
+      }),
+    );
+    expect(manager.getObservabilitySnapshot(baseCfg).runtimeCache.activeSessions).toBe(0);
+  });
+
+  it("evicts dormant oneshot handles under pressure before rejecting new sessions", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          mode:
+            sessionKey === "agent:claude:acp:oneshot-a" ||
+            sessionKey === "agent:claude:acp:oneshot-b"
+              ? "oneshot"
+              : "persistent",
+          state: "idle",
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 2,
+      },
+    } as OpenClawConfig;
+    hoisted.upsertAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      const sessionKey = params.sessionKey ?? "agent:codex:acp:session-c";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          mode: sessionKey === "agent:codex:acp:session-c" ? "persistent" : "oneshot",
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.getSessionStatus({
+      cfg: limitedCfg,
+      sessionKey: "agent:claude:acp:oneshot-a",
+    });
+    await manager.getSessionStatus({
+      cfg: limitedCfg,
+      sessionKey: "agent:claude:acp:oneshot-b",
+    });
+
+    expect(manager.getObservabilitySnapshot(limitedCfg).runtimeCache.activeSessions).toBe(2);
+
+    await manager.initializeSession({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-c",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(runtimeState.close).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "oneshot-pressure-evicted" }),
+    );
+    expect(manager.getObservabilitySnapshot(limitedCfg).runtimeCache.activeSessions).toBe(1);
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(3);
+  });
+
   it("enforces acp.maxConcurrentSessions when opening new runtime handles", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({


### PR DESCRIPTION
## Summary
- release cached oneshot runtime handles after startup identity reconciliation
- evict dormant oneshot ACP runtimes before stale-status probing under concurrent session pressure
- add regression coverage for pending-identity oneshot sessions and pressure eviction of idle oneshot handles

## Problem
OpenClaw could report `ACP max concurrent sessions reached (13/12)` even when ACPX session registry and process state looked clean. In our repro, dormant oneshot sessions could remain counted inside the ACP manager runtime cache, especially after startup identity reconciliation or quick oneshot completion.

## Root cause
The ACP session manager only reclaimed obviously stale runtimes under pressure. Oneshoot handles that were no longer actively running could still remain cached and count toward `acp.maxConcurrentSessions`.

## Fix
1. During `reconcilePendingSessionIdentities()`, if the reconciled session is `mode: "oneshot"`, always `runtime.close()` it and clear the cached handle.
2. Before the existing stale-runtime probe path, evict cached oneshot handles whose persisted ACP metadata is no longer `running`.
3. Keep the existing stale probing as a fallback for genuinely stale persistent runtimes.

## Tests
- `pnpm exec vitest run src/acp/control-plane/*.test.ts`
  - 34 passed

## Notes
This patch addresses the manager-side leak/counting path. I observed separate downstream task-completion heuristics in a local `spawn-interceptor` plugin, but those are outside the OpenClaw core change in this PR.
