### PR TITLE
Avoid plugin registration during install slot selection

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -123,7 +123,9 @@ function applySlotSelectionForPlugin(
   config: OpenClawConfig,
   pluginId: string,
 ): { config: OpenClawConfig; warnings: string[] } {
-  const report = buildPluginStatusReport({ config });
+  // Slot selection only needs plugin metadata/kind; avoid running existing
+  // plugin registration, which may require resolved runtime secrets.
+  const report = buildPluginStatusReport({ config, mode: "validate" });
   const plugin = report.plugins.find((entry) => entry.id === pluginId);
   if (!plugin) {
     return { config, warnings: [] };

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -57,4 +57,20 @@ describe("buildPluginStatusReport", () => {
       }),
     );
   });
+
+  it("forwards validate mode to plugin loading", () => {
+    buildPluginStatusReport({
+      config: {},
+      workspaceDir: "/workspace",
+      mode: "validate",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {},
+        workspaceDir: "/workspace",
+        mode: "validate",
+      }),
+    );
+  });
 });

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -17,6 +17,8 @@ export function buildPluginStatusReport(params?: {
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
+  /** Skip plugin register/activate and only validate metadata/config. */
+  mode?: "validate";
 }): PluginStatusReport {
   const config = params?.config ?? loadConfig();
   const workspaceDir = params?.workspaceDir
@@ -28,6 +30,7 @@ export function buildPluginStatusReport(params?: {
     config,
     workspaceDir,
     env: params?.env,
+    mode: params?.mode,
     logger: createPluginLoaderLogger(log),
   });
 


### PR DESCRIPTION
## Summary

`plugins install` currently builds a full plugin status report while selecting slots for the newly installed plugin. That path registers already-enabled plugins, which can fail when channel plugins depend on runtime-resolved `SecretRef`s.

This change makes slot selection use validate-only plugin loading. The install path only needs plugin metadata/kind, so registration is unnecessary and can incorrectly fail for configurations that are otherwise valid at runtime.

## Test

- `corepack pnpm exec vitest run --config vitest.unit.config.ts src/plugins/status.test.ts`