### PR TITLE
Markdown: preserve blockquote prefixes on continuation lines

### DIFF
--- a/src/markdown/ir.blockquote-spacing.test.ts
+++ b/src/markdown/ir.blockquote-spacing.test.ts
@@ -153,6 +153,27 @@ describe("blockquote spacing", () => {
 
       expect(result.text).toBe("> Line 1\n> Line 2");
     });
+
+    it("prefixes continuation lines on hard break inside a blockquote", () => {
+      const input = "> Line 1  \n> Line 2";
+      const result = markdownToIR(input, { blockquotePrefix: "> " });
+
+      expect(result.text).toBe("> Line 1\n> Line 2");
+    });
+
+    it("prefixes the next paragraph inside a blockquote", () => {
+      const input = "> Line 1\n>\n> Line 2";
+      const result = markdownToIR(input, { blockquotePrefix: "> " });
+
+      expect(result.text).toBe("> Line 1\n\n> Line 2");
+    });
+
+    it("repeats the prefix for nested blockquote continuation lines", () => {
+      const input = "> > Line 1\n> > Line 2";
+      const result = markdownToIR(input, { blockquotePrefix: "> " });
+
+      expect(result.text).toBe("> > Line 1\n> > Line 2");
+    });
   });
 
   describe("edge cases", () => {

--- a/src/markdown/ir.blockquote-spacing.test.ts
+++ b/src/markdown/ir.blockquote-spacing.test.ts
@@ -174,6 +174,13 @@ describe("blockquote spacing", () => {
 
       expect(result.text).toBe("> > Line 1\n> > Line 2");
     });
+
+    it("preserves the outer prefix after a nested blockquote paragraph", () => {
+      const input = "> > inner\n>\n> outer";
+      const result = markdownToIR(input, { blockquotePrefix: "> " });
+
+      expect(result.text).toBe("> > inner\n\n> outer");
+    });
   });
 
   describe("edge cases", () => {

--- a/src/markdown/ir.blockquote-spacing.test.ts
+++ b/src/markdown/ir.blockquote-spacing.test.ts
@@ -146,6 +146,13 @@ describe("blockquote spacing", () => {
       expect(result.text).toBe("> quote\n\nparagraph");
       expect(result.text).not.toContain("\n\n\n");
     });
+
+    it("prefixes continuation lines inside a blockquote", () => {
+      const input = "> Line 1\n> Line 2";
+      const result = markdownToIR(input, { blockquotePrefix: "> " });
+
+      expect(result.text).toBe("> Line 1\n> Line 2");
+    });
   });
 
   describe("edge cases", () => {

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -233,11 +233,16 @@ function appendText(state: RenderState, value: string) {
   target.text += value;
 }
 
+function appendBlockquotePrefix(state: RenderState, depth = state.blockquoteDepth) {
+  if (depth <= 0 || !state.blockquotePrefix) {
+    return;
+  }
+  appendText(state, state.blockquotePrefix.repeat(depth));
+}
+
 function appendLineBreak(state: RenderState) {
   appendText(state, "\n");
-  if (state.blockquoteDepth > 0 && state.blockquotePrefix) {
-    appendText(state, state.blockquotePrefix);
-  }
+  appendBlockquotePrefix(state);
 }
 
 function openStyle(state: RenderState, style: MarkdownStyle) {
@@ -260,14 +265,54 @@ function closeStyle(state: RenderState, style: MarkdownStyle) {
   }
 }
 
-function appendParagraphSeparator(state: RenderState) {
+function appendParagraphSeparator(
+  state: RenderState,
+  options: { continueBlockquote?: boolean } = {},
+) {
   if (state.env.listStack.length > 0) {
     return;
   }
   if (state.table) {
     return;
-  } // Don't add paragraph separators inside tables
-  state.text += "\n\n";
+  }
+  appendText(state, "\n\n");
+  if (options.continueBlockquote) {
+    appendBlockquotePrefix(state);
+  }
+}
+
+function tokenStartsBlockquoteContent(token: MarkdownToken | undefined) {
+  switch (token?.type) {
+    case "paragraph_open":
+    case "heading_open":
+    case "blockquote_open":
+    case "bullet_list_open":
+    case "ordered_list_open":
+    case "code_block":
+    case "fence":
+    case "html_block":
+    case "table_open":
+    case "hr":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function shouldContinueBlockquoteAfter(tokens: MarkdownToken[], currentIndex: number) {
+  for (let index = currentIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token) {
+      continue;
+    }
+    if (token.type === "blockquote_close") {
+      return false;
+    }
+    if (tokenStartsBlockquoteContent(token)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function appendListPrefix(state: RenderState) {
@@ -565,7 +610,8 @@ function renderTableAsCode(state: RenderState) {
 }
 
 function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
-  for (const token of tokens) {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
     switch (token.type) {
       case "inline":
         if (token.children) {
@@ -623,7 +669,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         appendLineBreak(state);
         break;
       case "paragraph_close":
-        appendParagraphSeparator(state);
+        appendParagraphSeparator(state, {
+          continueBlockquote:
+            state.blockquoteDepth > 0 && shouldContinueBlockquoteAfter(tokens, index),
+        });
         break;
       case "heading_open":
         if (state.headingStyle === "bold") {
@@ -634,12 +683,13 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         if (state.headingStyle === "bold") {
           closeStyle(state, "bold");
         }
-        appendParagraphSeparator(state);
+        appendParagraphSeparator(state, {
+          continueBlockquote:
+            state.blockquoteDepth > 0 && shouldContinueBlockquoteAfter(tokens, index),
+        });
         break;
       case "blockquote_open":
-        if (state.blockquotePrefix) {
-          appendText(state, state.blockquotePrefix);
-        }
+        appendBlockquotePrefix(state, 1);
         state.blockquoteDepth += 1;
         openStyle(state, "blockquote");
         break;

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -265,10 +265,7 @@ function closeStyle(state: RenderState, style: MarkdownStyle) {
   }
 }
 
-function appendParagraphSeparator(
-  state: RenderState,
-  options: { continueBlockquote?: boolean } = {},
-) {
+function appendParagraphSeparator(state: RenderState, options: { blockquoteDepth?: number } = {}) {
   if (state.env.listStack.length > 0) {
     return;
   }
@@ -276,8 +273,8 @@ function appendParagraphSeparator(
     return;
   }
   appendText(state, "\n\n");
-  if (options.continueBlockquote) {
-    appendBlockquotePrefix(state);
+  if (options.blockquoteDepth) {
+    appendBlockquotePrefix(state, options.blockquoteDepth);
   }
 }
 
@@ -299,20 +296,26 @@ function tokenStartsBlockquoteContent(token: MarkdownToken | undefined) {
   }
 }
 
-function shouldContinueBlockquoteAfter(tokens: MarkdownToken[], currentIndex: number) {
+function getParagraphSeparatorBlockquoteDepth(
+  tokens: MarkdownToken[],
+  currentIndex: number,
+  currentDepth: number,
+) {
+  let blockquoteDepth = currentDepth;
   for (let index = currentIndex + 1; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (!token) {
       continue;
     }
     if (token.type === "blockquote_close") {
-      return false;
+      blockquoteDepth = Math.max(0, blockquoteDepth - 1);
+      continue;
     }
     if (tokenStartsBlockquoteContent(token)) {
-      return true;
+      return blockquoteDepth;
     }
   }
-  return false;
+  return 0;
 }
 
 function appendListPrefix(state: RenderState) {
@@ -670,8 +673,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "paragraph_close":
         appendParagraphSeparator(state, {
-          continueBlockquote:
-            state.blockquoteDepth > 0 && shouldContinueBlockquoteAfter(tokens, index),
+          blockquoteDepth:
+            state.blockquoteDepth > 0
+              ? getParagraphSeparatorBlockquoteDepth(tokens, index, state.blockquoteDepth)
+              : 0,
         });
         break;
       case "heading_open":
@@ -684,8 +689,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
           closeStyle(state, "bold");
         }
         appendParagraphSeparator(state, {
-          continueBlockquote:
-            state.blockquoteDepth > 0 && shouldContinueBlockquoteAfter(tokens, index),
+          blockquoteDepth:
+            state.blockquoteDepth > 0
+              ? getParagraphSeparatorBlockquoteDepth(tokens, index, state.blockquoteDepth)
+              : 0,
         });
         break;
       case "blockquote_open":

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -82,6 +82,7 @@ type RenderState = RenderTarget & {
   env: RenderEnv;
   headingStyle: "none" | "bold";
   blockquotePrefix: string;
+  blockquoteDepth: number;
   enableSpoilers: boolean;
   tableMode: MarkdownTableMode;
   table: TableState | null;
@@ -230,6 +231,13 @@ function appendText(state: RenderState, value: string) {
   }
   const target = resolveRenderTarget(state);
   target.text += value;
+}
+
+function appendLineBreak(state: RenderState) {
+  appendText(state, "\n");
+  if (state.blockquoteDepth > 0 && state.blockquotePrefix) {
+    appendText(state, state.blockquotePrefix);
+  }
 }
 
 function openStyle(state: RenderState, style: MarkdownStyle) {
@@ -612,7 +620,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "softbreak":
       case "hardbreak":
-        appendText(state, "\n");
+        appendLineBreak(state);
         break;
       case "paragraph_close":
         appendParagraphSeparator(state);
@@ -630,12 +638,16 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "blockquote_open":
         if (state.blockquotePrefix) {
-          state.text += state.blockquotePrefix;
+          appendText(state, state.blockquotePrefix);
         }
+        state.blockquoteDepth += 1;
         openStyle(state, "blockquote");
         break;
       case "blockquote_close":
         closeStyle(state, "blockquote");
+        if (state.blockquoteDepth > 0) {
+          state.blockquoteDepth -= 1;
+        }
         break;
       case "bullet_list_open":
         // Add newline before nested list starts (so nested items appear on new line)
@@ -904,6 +916,7 @@ export function markdownToIRWithMeta(
     env,
     headingStyle: options.headingStyle ?? "none",
     blockquotePrefix: options.blockquotePrefix ?? "",
+    blockquoteDepth: 0,
     enableSpoilers: options.enableSpoilers ?? false,
     tableMode,
     table: null,


### PR DESCRIPTION
## Summary
- Fixed `markdownToIR` so quote-prefixed renderers keep the blockquote prefix on soft/hard line breaks.
- Added a regression test for multi-line quoted text.

## Validation
- `pnpm test -- src/markdown/ir.blockquote-spacing.test.ts` (20 passed)

## Automation
- Generated by local OpenClaw Codex automation on 2026/03/15 13:59:22 Beijing time.