### PR TITLE
Docs: replace stale Clawdbot reference with OpenClaw in imsg SKILL.md

### DIFF
--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -47,7 +47,7 @@ Use `imsg` to read and send iMessage/SMS via macOS Messages.app.
 - Slack messages → use `slack` skill
 - Group chat management (adding/removing members) → not supported
 - Bulk/mass messaging → always confirm with user first
-- Replying in current conversation → just reply normally (Clawdbot routes automatically)
+- Replying in current conversation → just reply normally (OpenClaw routes automatically)
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Fixed stale `Clawdbot` branding reference in `skills/imsg/SKILL.md`.

## Changes
- `Clawdbot routes automatically` → `OpenClaw routes automatically`

## Why
Project renamed from Clawdbot → OpenClaw. This skill doc still used the old name.

## Testing
N/A — documentation fix only.