### PR TITLE
docs: update claude-max-api-proxy links to maintained fork (closes #20260)

### DIFF
--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -138,8 +138,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## Links
 
 - **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/atalovesyou/claude-max-api-proxy](https://github.com/atalovesyou/claude-max-api-proxy)
-- **Issues:** [https://github.com/atalovesyou/claude-max-api-proxy/issues](https://github.com/atalovesyou/claude-max-api-proxy/issues)
+- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 

--- a/docs/zh-CN/providers/claude-max-api-proxy.md
+++ b/docs/zh-CN/providers/claude-max-api-proxy.md
@@ -139,8 +139,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## 链接
 
 - **npm:** https://www.npmjs.com/package/claude-max-api-proxy
-- **GitHub:** https://github.com/atalovesyou/claude-max-api-proxy
-- **Issues:** https://github.com/atalovesyou/claude-max-api-proxy/issues
+- **GitHub:** https://github.com/wende/claude-max-api-proxy
+- **Issues:** https://github.com/wende/claude-max-api-proxy/issues
 
 ## 注意事项
 


### PR DESCRIPTION
## Summary
- Problem: Documentation links for claude-max-api-proxy point to `atalovesyou/claude-max-api-proxy`, which is abandoned and has a broken package (returns `[object Object]` instead of content).
- Why it matters: Users following the docs would install a non-functional package.
- What changed: Updated GitHub and Issues links in `docs/providers/claude-max-api-proxy.md` and its Chinese translation to point to `wende/claude-max-api-proxy`, the actively maintained fork.
- What did NOT change (scope boundary): npm package name is unchanged. Install instructions, CHANGELOG, README contributors, and clawtributors-map are unmodified.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX

## Linked Issue/PR
- Closes #20260

## User-visible / Behavior Changes
Documentation links now point to the maintained fork with working package.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Open `docs/providers/claude-max-api-proxy.md`
2. Check GitHub and Issues links

### Expected
- Links point to `wende/claude-max-api-proxy`

### Actual (before fix)
- Links pointed to `atalovesyou/claude-max-api-proxy` (abandoned)

## Evidence
- [x] Docs-only change, no code or tests affected

## Human Verification
- Verified scenarios: Both English and Chinese docs updated; links verified
- Edge cases checked: No other references to the old repo in codebase
- What you did NOT verify: runtime end-to-end testing with actual service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None