### PR TITLE
test(providers): add DashScope/Bailian endpoint verification tests

### DIFF
--- a/src/agents/models-config.providers.modelstudio.dashscope-compat.test.ts
+++ b/src/agents/models-config.providers.modelstudio.dashscope-compat.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { upsertAuthProfile } from "./auth-profiles.js";
+import { normalizeModelCompat } from "./model-compat.js";
+import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
+
+/**
+ * DashScope/Bailian endpoint compatibility tests for the Model Studio provider.
+ *
+ * Verifies that models resolved through the modelstudio implicit provider
+ * receive correct compat flags when processed by normalizeModelCompat:
+ * - supportsDeveloperRole must be false (DashScope rejects the `developer` role)
+ * - supportsUsageInStreaming defaults to false for non-native OpenAI endpoints
+ *
+ * Related issues:
+ * - #28731: `developer` role not supported by Alibaba Cloud Bailian API
+ * - #45038: Token usage always 0 for non-native OpenAI endpoints
+ * - #21114: DashScope non-streaming fails without `enable_thinking`
+ */
+
+const modelStudioApiKeyEnv = ["MODELSTUDIO_API", "KEY"].join("_");
+
+describe("Model Studio DashScope compatibility", () => {
+  it("includes modelstudio when auth profile uses env keyRef (no env var set)", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv([modelStudioApiKeyEnv]);
+    delete process.env[modelStudioApiKeyEnv];
+
+    upsertAuthProfile({
+      profileId: "modelstudio:default",
+      credential: {
+        type: "api_key",
+        provider: "modelstudio",
+        keyRef: { source: "env", provider: "default", id: modelStudioApiKeyEnv },
+      },
+      agentDir,
+    });
+
+    try {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.modelstudio?.apiKey).toBe(modelStudioApiKeyEnv);
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("resolves modelstudio base URL to DashScope international endpoint", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv([modelStudioApiKeyEnv]);
+    process.env[modelStudioApiKeyEnv] = "test-key"; // pragma: allowlist secret
+
+    try {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.modelstudio?.baseUrl).toMatch(/dashscope\.aliyuncs\.com/);
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("forces supportsDeveloperRole off for modelstudio DashScope endpoint", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
+    expect(compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for China DashScope endpoint", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
+    expect(compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsUsageInStreaming off for modelstudio DashScope endpoint by default", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (normalized as { compat?: { supportsUsageInStreaming?: boolean } }).compat;
+    expect(compat?.supportsUsageInStreaming).toBe(false);
+  });
+
+  it("respects explicit supportsUsageInStreaming override on DashScope endpoint", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+      compat: { supportsUsageInStreaming: true },
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (normalized as { compat?: { supportsUsageInStreaming?: boolean } }).compat;
+    expect(compat?.supportsUsageInStreaming).toBe(true);
+  });
+
+  it("respects explicit supportsDeveloperRole override on DashScope endpoint", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+      compat: { supportsDeveloperRole: true },
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
+    expect(compat?.supportsDeveloperRole).toBe(true);
+  });
+
+  it("forces compat flags off for user-configured DashScope compatible-mode endpoints", () => {
+    const model = {
+      id: "qwen-turbo",
+      api: "openai-completions" as const,
+      provider: "custom-dashscope",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      name: "qwen-turbo",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (
+      normalized as {
+        compat?: { supportsDeveloperRole?: boolean; supportsUsageInStreaming?: boolean };
+      }
+    ).compat;
+    expect(compat?.supportsDeveloperRole).toBe(false);
+    expect(compat?.supportsUsageInStreaming).toBe(false);
+  });
+
+  it("forces compat flags off for international DashScope compatible-mode endpoints", () => {
+    const model = {
+      id: "qwen-max",
+      api: "openai-completions" as const,
+      provider: "custom-dashscope-intl",
+      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      name: "qwen-max",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    const compat = (
+      normalized as {
+        compat?: { supportsDeveloperRole?: boolean; supportsUsageInStreaming?: boolean };
+      }
+    ).compat;
+    expect(compat?.supportsDeveloperRole).toBe(false);
+    expect(compat?.supportsUsageInStreaming).toBe(false);
+  });
+
+  it("does not mutate the original model object", () => {
+    const model = {
+      id: "qwen3.5-plus",
+      api: "openai-completions" as const,
+      provider: "modelstudio",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      name: "qwen3.5-plus",
+    };
+
+    const normalized = normalizeModelCompat(model);
+    expect(normalized).not.toBe(model);
+    expect((model as { compat?: unknown }).compat).toBeUndefined();
+  });
+
+  it("uses openai-completions API type for all modelstudio catalog models", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv([modelStudioApiKeyEnv]);
+    process.env[modelStudioApiKeyEnv] = "test-key"; // pragma: allowlist secret
+
+    try {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.modelstudio?.api).toBe("openai-completions");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+});

--- a/src/agents/models-config.providers.modelstudio.dashscope-compat.test.ts
+++ b/src/agents/models-config.providers.modelstudio.dashscope-compat.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Api, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { upsertAuthProfile } from "./auth-profiles.js";
@@ -22,6 +23,30 @@ import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js"
  */
 
 const modelStudioApiKeyEnv = ["MODELSTUDIO_API", "KEY"].join("_");
+
+const dashScopeModel = (overrides?: Partial<Model<Api>>): Model<Api> =>
+  ({
+    id: "qwen3.5-plus",
+    name: "qwen3.5-plus",
+    api: "openai-completions",
+    provider: "modelstudio",
+    baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+    ...overrides,
+  }) as Model<Api>;
+
+function supportsDeveloperRole(model: Model<Api>): boolean | undefined {
+  return (model.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole;
+}
+
+function supportsUsageInStreaming(model: Model<Api>): boolean | undefined {
+  return (model.compat as { supportsUsageInStreaming?: boolean } | undefined)
+    ?.supportsUsageInStreaming;
+}
 
 describe("Model Studio DashScope compatibility", () => {
   it("includes modelstudio when auth profile uses env keyRef (no env var set)", async () => {
@@ -61,127 +86,72 @@ describe("Model Studio DashScope compatibility", () => {
   });
 
   it("forces supportsDeveloperRole off for modelstudio DashScope endpoint", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-    };
-
-    const normalized = normalizeModelCompat(model);
-    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
-    expect(compat?.supportsDeveloperRole).toBe(false);
+    const normalized = normalizeModelCompat(dashScopeModel());
+    expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
   it("forces supportsDeveloperRole off for China DashScope endpoint", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-    };
-
-    const normalized = normalizeModelCompat(model);
-    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
-    expect(compat?.supportsDeveloperRole).toBe(false);
+    const normalized = normalizeModelCompat(
+      dashScopeModel({ baseUrl: "https://coding.dashscope.aliyuncs.com/v1" }),
+    );
+    expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
   it("forces supportsUsageInStreaming off for modelstudio DashScope endpoint by default", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-    };
-
-    const normalized = normalizeModelCompat(model);
-    const compat = (normalized as { compat?: { supportsUsageInStreaming?: boolean } }).compat;
-    expect(compat?.supportsUsageInStreaming).toBe(false);
+    const normalized = normalizeModelCompat(dashScopeModel());
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
   });
 
   it("respects explicit supportsUsageInStreaming override on DashScope endpoint", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-      compat: { supportsUsageInStreaming: true },
+    const model = dashScopeModel();
+    (model as { compat?: Record<string, boolean> }).compat = {
+      supportsUsageInStreaming: true,
     };
-
     const normalized = normalizeModelCompat(model);
-    const compat = (normalized as { compat?: { supportsUsageInStreaming?: boolean } }).compat;
-    expect(compat?.supportsUsageInStreaming).toBe(true);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
   });
 
   it("respects explicit supportsDeveloperRole override on DashScope endpoint", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-      compat: { supportsDeveloperRole: true },
+    const model = dashScopeModel();
+    (model as { compat?: Record<string, boolean> }).compat = {
+      supportsDeveloperRole: true,
     };
-
     const normalized = normalizeModelCompat(model);
-    const compat = (normalized as { compat?: { supportsDeveloperRole?: boolean } }).compat;
-    expect(compat?.supportsDeveloperRole).toBe(true);
+    expect(supportsDeveloperRole(normalized)).toBe(true);
   });
 
   it("forces compat flags off for user-configured DashScope compatible-mode endpoints", () => {
-    const model = {
-      id: "qwen-turbo",
-      api: "openai-completions" as const,
-      provider: "custom-dashscope",
-      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
-      name: "qwen-turbo",
-    };
-
-    const normalized = normalizeModelCompat(model);
-    const compat = (
-      normalized as {
-        compat?: { supportsDeveloperRole?: boolean; supportsUsageInStreaming?: boolean };
-      }
-    ).compat;
-    expect(compat?.supportsDeveloperRole).toBe(false);
-    expect(compat?.supportsUsageInStreaming).toBe(false);
+    const normalized = normalizeModelCompat(
+      dashScopeModel({
+        id: "qwen-turbo",
+        name: "qwen-turbo",
+        provider: "custom-dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      }),
+    );
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
   });
 
   it("forces compat flags off for international DashScope compatible-mode endpoints", () => {
-    const model = {
-      id: "qwen-max",
-      api: "openai-completions" as const,
-      provider: "custom-dashscope-intl",
-      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-      name: "qwen-max",
-    };
-
-    const normalized = normalizeModelCompat(model);
-    const compat = (
-      normalized as {
-        compat?: { supportsDeveloperRole?: boolean; supportsUsageInStreaming?: boolean };
-      }
-    ).compat;
-    expect(compat?.supportsDeveloperRole).toBe(false);
-    expect(compat?.supportsUsageInStreaming).toBe(false);
+    const normalized = normalizeModelCompat(
+      dashScopeModel({
+        id: "qwen-max",
+        name: "qwen-max",
+        provider: "custom-dashscope-intl",
+        baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      }),
+    );
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
   });
 
   it("does not mutate the original model object", () => {
-    const model = {
-      id: "qwen3.5-plus",
-      api: "openai-completions" as const,
-      provider: "modelstudio",
-      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-      name: "qwen3.5-plus",
-    };
-
+    const model = dashScopeModel();
     const normalized = normalizeModelCompat(model);
     expect(normalized).not.toBe(model);
-    expect((model as { compat?: unknown }).compat).toBeUndefined();
+    expect(supportsDeveloperRole(model)).toBeUndefined();
+    expect(supportsUsageInStreaming(model)).toBeUndefined();
   });
 
   it("uses openai-completions API type for all modelstudio catalog models", async () => {


### PR DESCRIPTION
## Summary

Adds 11 offline tests for DashScope/Bailian (Alibaba Cloud Model Studio) endpoint compatibility. Covers auth profile resolution, `supportsDeveloperRole` enforcement, `supportsUsageInStreaming` defaults, and explicit user overrides for both China and international DashScope endpoints.

## Why this matters

DashScope is the only major Chinese model provider in OpenClaw without endpoint verification tests. BytePlus has `models-config.providers.volcengine-byteplus.test.ts`. Minimax has `provider-usage.fetch.minimax.test.ts`. DashScope has 13+ open bugs sharing a root cause: no test coverage for its specific API behavior.

| Source | Evidence | Status |
|--------|----------|--------|
| [#28731](https://github.com/openclaw/openclaw/issues/28731) | `developer` role not supported by Bailian API | open |
| [#45038](https://github.com/openclaw/openclaw/issues/45038) | Token usage always 0 for non-native OpenAI endpoints | open |
| [#21114](https://github.com/openclaw/openclaw/issues/21114) | Non-streaming fails without `enable_thinking` | open |
| [#42958](https://github.com/openclaw/openclaw/issues/42958) | DashScope API usage not recorded | open |
| [#26376](https://github.com/openclaw/openclaw/issues/26376) | DataInspectionFailed error unhandled | open |

These tests document the current compat behavior that prevents #28731 and #45038, and catch regressions if the logic changes.

## Changes

New file: `src/agents/models-config.providers.modelstudio.dashscope-compat.test.ts`

Tests cover:
- Auth profile resolution via env keyRef (matching the BytePlus test pattern)
- `supportsDeveloperRole` forced off for `coding-intl.dashscope.aliyuncs.com` and `coding.dashscope.aliyuncs.com`
- `supportsUsageInStreaming` forced off by default for DashScope endpoints
- Explicit user overrides respected for both flags
- Compatible-mode endpoint detection (`dashscope.aliyuncs.com/compatible-mode/v1`, `dashscope-intl.aliyuncs.com/compatible-mode/v1`)
- Model object immutability
- API type assertion (`openai-completions`)

## Testing

```
pnpm test -- src/agents/models-config.providers.modelstudio
```

All 13 tests pass (2 existing + 11 new).

Relates to #28731, #45038, #21114, #42958, #26376

This contribution was developed with AI assistance (Claude Code).