### PR TITLE
fix(openrouter): enforce explicit Claude Sonnet default instead of auto-routing (closes #35842)

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -677,7 +677,7 @@ describe("applyAuthChoice", () => {
         expectEnvPrompt: true,
         expectedTextCalls: 0,
         expectedKey: "sk-openrouter-test",
-        expectedModel: "openrouter/auto",
+        expectedModel: "openrouter/anthropic/claude-sonnet-4-6",
       },
       {
         authChoice: "ai-gateway-api-key",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -335,7 +335,7 @@ export async function setVeniceApiKey(
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/anthropic/claude-sonnet-4-6";
 export const HUGGINGFACE_DEFAULT_MODEL_REF = "huggingface/deepseek-ai/DeepSeek-R1";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";


### PR DESCRIPTION
## Summary
- Problem: OpenRouter onboarding defaults to `openrouter/auto`, which delegates model selection to OpenRouter's API at runtime, often routing to Gemini instead of the intended model.
- Why it matters: Users get inconsistent, unpredictable model behavior after onboarding.
- What changed: Changed `OPENROUTER_DEFAULT_MODEL_REF` from `"openrouter/auto"` to `"openrouter/anthropic/claude-sonnet-4-6"` for an explicit, stable default. Updated corresponding test assertion.
- What did NOT change (scope boundary): No changes to other provider defaults, onboarding flow logic, or OpenRouter integration code.

## Change Type
- [x] Bug fix

## Scope
- [x] Auth / tokens

## Linked Issue/PR
- Closes #35842

## User-visible / Behavior Changes
OpenRouter onboarding now defaults to Claude Sonnet 4.6 instead of auto-routing.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run OpenRouter onboarding flow
2. Check the default model set

### Expected
- Default model is `openrouter/anthropic/claude-sonnet-4-6`

### Actual (before fix)
- Default model is `openrouter/auto` (unpredictable routing)

## Evidence
- [x] Failing test/log before + passing after
- All 27 auth-choice tests passing

## Human Verification
- Verified scenarios: auth-choice tests all pass with updated default; reviewed diff matches issue description
- Edge cases checked: Only the default constant and test assertion changed
- What you did NOT verify: runtime end-to-end testing with actual OpenRouter API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None