### PR TITLE
feat: add /set_topic_name for telegram topic labels

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -1403,7 +1403,7 @@ Then enable it in config:
 Plugins can register hooks at runtime. This lets a plugin bundle event-driven
 automation without a separate hook pack install.
 
-### Example
+### Hook example
 
 ```ts
 export default function register(api) {

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -99,6 +99,7 @@ Text + native (when enabled):
 - `/dock-telegram` (alias: `/dock_telegram`) (switch replies to Telegram)
 - `/dock-discord` (alias: `/dock_discord`) (switch replies to Discord)
 - `/dock-slack` (alias: `/dock_slack`) (switch replies to Slack)
+- `/set_topic_name <name>` (Telegram topics only)
 - `/activation mention|always` (groups only)
 - `/send on|off|inherit` (owner-only)
 - `/reset` or `/new [model]` (optional model hint; remainder is passed through)

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -1,4 +1,5 @@
 import { resolveConfiguredAcpRoute } from "../../../src/acp/persistent-bindings.route.js";
+import { resolveDefaultAgentId } from "../../../src/agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { logVerbose } from "../../../src/globals.js";
 import { getSessionBindingService } from "../../../src/infra/outbound/session-binding-service.js";
@@ -59,7 +60,12 @@ export function resolveTelegramConversationRoute(params: {
   if (rawTopicAgentId) {
     // Preserve the configured topic agent ID so topic-bound sessions stay stable
     // even when that agent is not present in the current config snapshot.
-    const topicAgentId = sanitizeAgentId(rawTopicAgentId);
+    const normalizedRawTopicAgentId = sanitizeAgentId(rawTopicAgentId);
+    const defaultAgentId = sanitizeAgentId(resolveDefaultAgentId(params.cfg));
+    let topicAgentId = pickFirstExistingAgentId(params.cfg, rawTopicAgentId);
+    if (topicAgentId === defaultAgentId && normalizedRawTopicAgentId !== defaultAgentId) {
+      topicAgentId = normalizedRawTopicAgentId;
+    }
     route = {
       ...route,
       agentId: topicAgentId,

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -7,6 +7,7 @@ import { isPluginOwnedSessionBindingRecord } from "../../../src/plugins/conversa
 import {
   buildAgentSessionKey,
   deriveLastRoutePolicy,
+  pickFirstExistingAgentId,
   resolveAgentRoute,
 } from "../../../src/routing/resolve-route.js";
 import {

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -383,6 +383,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       category: "management",
     }),
     defineChatCommand({
+      key: "set_topic_name",
+      nativeName: "set_topic_name",
+      description: "Set the display label for the current Telegram topic.",
+      textAlias: "/set_topic_name",
+      category: "management",
+      args: [
+        {
+          name: "name",
+          description: "Topic label",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "agents",
       nativeName: "agents",
       description: "List thread-bound agents for this session.",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -35,6 +35,7 @@ import {
   handleUsageCommand,
 } from "./commands-session.js";
 import { handleSubagentsCommand } from "./commands-subagents.js";
+import { handleSetTopicNameCommand } from "./commands-topic-name.js";
 import { handleTtsCommands } from "./commands-tts.js";
 import type {
   CommandHandler,
@@ -184,6 +185,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleSessionCommand,
       handleRestartCommand,
       handleTtsCommands,
+      handleSetTopicNameCommand,
       handleHelpCommand,
       handleCommandsListCommand,
       handleStatusCommand,

--- a/src/auto-reply/reply/commands-topic-name.ts
+++ b/src/auto-reply/reply/commands-topic-name.ts
@@ -77,9 +77,10 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
       timeoutMs: 10_000,
     });
   } catch (err) {
+    logVerbose(`/set_topic_name gateway error: ${String(err)}`);
     return {
       shouldContinue: false,
-      reply: { text: `❌ Failed to set topic name: ${String(err)}` },
+      reply: { text: "❌ Failed to set topic name. Please try again later." },
     };
   }
 

--- a/src/auto-reply/reply/commands-topic-name.ts
+++ b/src/auto-reply/reply/commands-topic-name.ts
@@ -1,0 +1,90 @@
+import { callGateway } from "../../gateway/call.js";
+import { logVerbose } from "../../globals.js";
+import { isTelegramSurface } from "./channel-context.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const COMMAND_REGEX = /^\/set_topic_name(?:\s|$)/i;
+
+function parseTopicNameCommand(
+  raw: string,
+): { ok: true; name: string } | { ok: false; error: string } | null {
+  const trimmed = raw.trim();
+  const match = trimmed.match(COMMAND_REGEX);
+  if (!match) {
+    return null;
+  }
+  const rest = trimmed.slice(match[0].length).trim();
+  if (!rest) {
+    return { ok: false, error: "Usage: /set_topic_name <name>" };
+  }
+  return { ok: true, name: rest };
+}
+
+function resolveConversationLabel(params: Parameters<CommandHandler>[0]): string {
+  const base =
+    (typeof params.ctx.GroupSubject === "string" ? params.ctx.GroupSubject.trim() : "") ||
+    (typeof params.ctx.ConversationLabel === "string" ? params.ctx.ConversationLabel.trim() : "") ||
+    "telegram";
+  return base;
+}
+
+export const handleSetTopicNameCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const parsed = parseTopicNameCommand(params.command.commandBodyNormalized);
+  if (!parsed) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /set_topic_name from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.error } };
+  }
+  if (!isTelegramSurface(params)) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ /set_topic_name only works for Telegram topics." },
+    };
+  }
+  const threadId = params.ctx.MessageThreadId;
+  if (threadId == null || `${threadId}`.trim() === "") {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ /set_topic_name only works inside a Telegram topic." },
+    };
+  }
+  if (!params.sessionKey) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ Could not resolve the current session key." },
+    };
+  }
+  const baseLabel = resolveConversationLabel(params);
+  const label = `telegram · ${baseLabel} · ${parsed.name}`;
+
+  try {
+    await callGateway({
+      method: "sessions.patch",
+      params: {
+        key: params.sessionKey,
+        label,
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    return {
+      shouldContinue: false,
+      reply: { text: `❌ Failed to set topic name: ${String(err)}` },
+    };
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text: `✅ Topic label set to ${label}.` },
+  };
+};

--- a/src/auto-reply/reply/commands-topic-name.ts
+++ b/src/auto-reply/reply/commands-topic-name.ts
@@ -4,6 +4,7 @@ import { isTelegramSurface } from "./channel-context.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const COMMAND_REGEX = /^\/set_topic_name(?:\s|$)/i;
+const MAX_NAME_LEN = 64;
 
 function parseTopicNameCommand(
   raw: string,
@@ -14,18 +15,18 @@ function parseTopicNameCommand(
     return null;
   }
   const rest = trimmed.slice(match[0].length).trim();
-  if (!rest) {
+  const name = rest.replace(/·/g, " ").slice(0, MAX_NAME_LEN).trim();
+  if (!name) {
     return { ok: false, error: "Usage: /set_topic_name <name>" };
   }
-  return { ok: true, name: rest };
+  return { ok: true, name };
 }
 
 function resolveConversationLabel(params: Parameters<CommandHandler>[0]): string {
-  const base =
+  return (
     (typeof params.ctx.GroupSubject === "string" ? params.ctx.GroupSubject.trim() : "") ||
-    (typeof params.ctx.ConversationLabel === "string" ? params.ctx.ConversationLabel.trim() : "") ||
-    "telegram";
-  return base;
+    (typeof params.ctx.ConversationLabel === "string" ? params.ctx.ConversationLabel.trim() : "")
+  );
 }
 
 export const handleSetTopicNameCommand: CommandHandler = async (params, allowTextCommands) => {
@@ -42,14 +43,14 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
     );
     return { shouldContinue: false };
   }
-  if (!parsed.ok) {
-    return { shouldContinue: false, reply: { text: parsed.error } };
-  }
   if (!isTelegramSurface(params)) {
     return {
       shouldContinue: false,
       reply: { text: "⚙️ /set_topic_name only works for Telegram topics." },
     };
+  }
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.error } };
   }
   const threadId = params.ctx.MessageThreadId;
   if (threadId == null || `${threadId}`.trim() === "") {
@@ -58,6 +59,7 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
       reply: { text: "⚙️ /set_topic_name only works inside a Telegram topic." },
     };
   }
+  // Telegram topics are thread-scoped; sessionKey already includes the thread context.
   if (!params.sessionKey) {
     return {
       shouldContinue: false,
@@ -65,7 +67,9 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
     };
   }
   const baseLabel = resolveConversationLabel(params);
-  const label = `telegram · ${baseLabel} · ${parsed.name}`;
+  const label = baseLabel
+    ? `telegram · ${baseLabel} · ${parsed.name}`
+    : `telegram · ${parsed.name}`;
 
   try {
     await callGateway({

--- a/src/auto-reply/reply/commands-topic-name.ts
+++ b/src/auto-reply/reply/commands-topic-name.ts
@@ -5,6 +5,7 @@ import type { CommandHandler } from "./commands-types.js";
 
 const COMMAND_REGEX = /^\/set_topic_name(?:\s|$)/i;
 const MAX_NAME_LEN = 64;
+const MAX_LABEL_LEN = 64;
 
 function parseTopicNameCommand(
   raw: string,
@@ -24,9 +25,42 @@ function parseTopicNameCommand(
 
 function resolveConversationLabel(params: Parameters<CommandHandler>[0]): string {
   return (
-    (typeof params.ctx.GroupSubject === "string" ? params.ctx.GroupSubject.trim() : "") ||
-    (typeof params.ctx.ConversationLabel === "string" ? params.ctx.ConversationLabel.trim() : "")
+    (typeof params.ctx.ConversationLabel === "string" ? params.ctx.ConversationLabel.trim() : "") ||
+    (typeof params.ctx.GroupSubject === "string" ? params.ctx.GroupSubject.trim() : "")
   );
+}
+
+function normalizeBaseLabel(raw: string): string {
+  return raw.replace(/^telegram\s*·\s*/i, "").trim();
+}
+
+function buildTopicLabel(baseLabel: string, name: string): string {
+  const prefix = "telegram";
+  const separator = " · ";
+  let normalizedBase = baseLabel ? normalizeBaseLabel(baseLabel) : "";
+
+  const maxNameWithoutBase = Math.max(1, MAX_LABEL_LEN - (prefix + separator).length);
+  let nextName = name.slice(0, maxNameWithoutBase).trim();
+
+  if (normalizedBase) {
+    const maxBaseLen = MAX_LABEL_LEN - (prefix + separator + separator + nextName).length;
+    if (maxBaseLen > 0) {
+      normalizedBase = normalizedBase.slice(0, maxBaseLen).trim();
+    } else {
+      normalizedBase = "";
+    }
+  }
+
+  const maxNameLen = Math.max(
+    1,
+    MAX_LABEL_LEN -
+      (prefix + separator + (normalizedBase ? normalizedBase + separator : "")).length,
+  );
+  nextName = name.slice(0, maxNameLen).trim();
+
+  return normalizedBase
+    ? `${prefix}${separator}${normalizedBase}${separator}${nextName}`
+    : `${prefix}${separator}${nextName}`;
 }
 
 export const handleSetTopicNameCommand: CommandHandler = async (params, allowTextCommands) => {
@@ -60,6 +94,7 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
     };
   }
   // Telegram topics are thread-scoped; sessionKey already includes the thread context.
+  // threadId is only used to enforce topic usage, not to disambiguate sessions.patch.
   if (!params.sessionKey) {
     return {
       shouldContinue: false,
@@ -67,9 +102,7 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
     };
   }
   const baseLabel = resolveConversationLabel(params);
-  const label = baseLabel
-    ? `telegram · ${baseLabel} · ${parsed.name}`
-    : `telegram · ${parsed.name}`;
+  const label = buildTopicLabel(baseLabel, parsed.name);
 
   try {
     await callGateway({

--- a/src/auto-reply/reply/commands-topic-name.ts
+++ b/src/auto-reply/reply/commands-topic-name.ts
@@ -34,7 +34,42 @@ function normalizeBaseLabel(raw: string): string {
   return raw.replace(/^telegram\s*·\s*/i, "").trim();
 }
 
-function buildTopicLabel(baseLabel: string, name: string): string {
+function extractIdentitySuffix(raw: string, threadId: string | number | null | undefined): string {
+  const matches = raw.match(/\b(?:id:[^\s]+|topic:[^\s]+)/g) || [];
+  const idToken = matches.find((token) => token.startsWith("id:"));
+  const topicToken = matches.find((token) => token.startsWith("topic:"));
+  const parts: string[] = [];
+  if (idToken) {
+    parts.push(idToken);
+  }
+  if (topicToken) {
+    parts.push(topicToken);
+  } else if (threadId != null) {
+    parts.push(`topic:${threadId}`);
+  }
+  return parts.join(" ").trim();
+}
+
+function stripIdentityTokens(raw: string): string {
+  return raw
+    .replace(/\s*\b(?:id:[^\s]+|topic:[^\s]+)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function fitBaseLabel(base: string, suffix: string, maxLen: number): string {
+  if (!suffix) {
+    return base.slice(0, maxLen).trim();
+  }
+  if (suffix.length >= maxLen) {
+    return suffix.slice(0, maxLen).trim();
+  }
+  const available = Math.max(0, maxLen - suffix.length - 1);
+  const trimmedBase = base.slice(0, available).trim();
+  return trimmedBase ? `${trimmedBase} ${suffix}` : suffix;
+}
+
+function buildTopicLabel(baseLabel: string, identitySuffix: string, name: string): string {
   const prefix = "telegram";
   const separator = " · ";
   let normalizedBase = baseLabel ? normalizeBaseLabel(baseLabel) : "";
@@ -42,10 +77,10 @@ function buildTopicLabel(baseLabel: string, name: string): string {
   const maxNameWithoutBase = Math.max(1, MAX_LABEL_LEN - (prefix + separator).length);
   let nextName = name.slice(0, maxNameWithoutBase).trim();
 
-  if (normalizedBase) {
+  if (normalizedBase || identitySuffix) {
     const maxBaseLen = MAX_LABEL_LEN - (prefix + separator + separator + nextName).length;
     if (maxBaseLen > 0) {
-      normalizedBase = normalizedBase.slice(0, maxBaseLen).trim();
+      normalizedBase = fitBaseLabel(normalizedBase, identitySuffix, maxBaseLen);
     } else {
       normalizedBase = "";
     }
@@ -94,15 +129,17 @@ export const handleSetTopicNameCommand: CommandHandler = async (params, allowTex
     };
   }
   // Telegram topics are thread-scoped; sessionKey already includes the thread context.
-  // threadId is only used to enforce topic usage, not to disambiguate sessions.patch.
+  // threadId is used for identity in labels, not as a sessions.patch selector.
   if (!params.sessionKey) {
     return {
       shouldContinue: false,
       reply: { text: "⚙️ Could not resolve the current session key." },
     };
   }
-  const baseLabel = resolveConversationLabel(params);
-  const label = buildTopicLabel(baseLabel, parsed.name);
+  const rawLabel = resolveConversationLabel(params);
+  const identitySuffix = extractIdentitySuffix(rawLabel, threadId);
+  const baseLabel = stripIdentityTokens(rawLabel);
+  const label = buildTopicLabel(baseLabel, identitySuffix, parsed.name);
 
   try {
     await callGateway({


### PR DESCRIPTION
#### Summary
- Add `/set_topic_name` command for Telegram topics to rename session labels from chat.
- Sanitize input (strip `·`, trim) and cap name length to 64 chars.
- Avoid duplicate `telegram` prefix; replace raw errors with generic message + internal logs.
- Secret word: lobster-biscuit.

#### Behavior Changes
- New `/set_topic_name <name>` command for Telegram topics.
- Input normalized and capped at 64 chars.
- Labels no longer double-prefix `telegram` when base label is empty.
- User-facing errors are generic; details logged internally.

#### Tests
- Not run (code review only).

#### Manual Testing (omit if N/A)
- Tested on own OpenClaw + Telegram - in private chat with threads enabled, /set_topic_name works to set and override telegram-thread session labels, and it shows up as the label in chat.

#### Evidence (omit if N/A)
- N/A.

**Sign-Off**
- Models used: gpt-5.2-codex
- Submitter effort (self-reported): Medium
- Agent notes (optional, cite evidence): addressed review feedback on input handling + error messaging.