### PR TITLE
fix: show provider/model format in /model command available list (closes #46091)

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -245,7 +245,10 @@ describe("executeSlashCommand directives", () => {
       }
       if (method === "models.list") {
         return {
-          models: [{ id: "gpt-4.1-mini" }, { id: "gpt-4.1" }],
+          models: [
+            { id: "gpt-4.1-mini", provider: "openai" },
+            { id: "gpt-4.1", provider: "openai" },
+          ],
         };
       }
       throw new Error(`unexpected method: ${method}`);
@@ -259,7 +262,7 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(result.content).toBe(
-      "**Current model:** `gpt-4.1-mini`\n**Available:** `gpt-4.1-mini`, `gpt-4.1`",
+      "**Current model:** `gpt-4.1-mini`\n**Available:** `openai/gpt-4.1-mini`, `openai/gpt-4.1`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -127,7 +127,8 @@ async function executeModel(
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
       const model = session?.model || sessions?.defaults?.model || "default";
-      const available = models?.models?.map((m: ModelCatalogEntry) => m.id) ?? [];
+      const available =
+        models?.models?.map((m: ModelCatalogEntry) => `${m.provider}/${m.id}`) ?? [];
       const lines = [`**Current model:** \`${model}\``];
       if (available.length > 0) {
         lines.push(


### PR DESCRIPTION
## Summary
- Problem: The `/model` slash command in Control UI shows short model names (e.g. `claude-opus-4-6`) in the available list, but the command requires the fully qualified `provider/model` format to switch models.
- Why it matters: Users following the UI suggestion get errors because the short name is not recognized without the provider prefix.
- What changed: Updated the available models list in `executeModel` to display `provider/id` format (e.g. `openai/gpt-4.1-mini`) instead of just `id`.
- What did NOT change (scope boundary): The model switching logic itself is unchanged; only the display format of available models in the `/model` response was updated.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX

## Linked Issue/PR
- Closes #46091

## User-visible / Behavior Changes
The `/model` command now shows available models in `provider/model` format that users can directly copy and use to switch models.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Open Control UI webchat
2. Type `/model` with no arguments

### Expected
- Available models show as `provider/model` (e.g. `anthropic/claude-opus-4-6`)

### Actual (before fix)
- Available models show as just `model` (e.g. `claude-opus-4-6`)

## Evidence
- [x] Failing test/log before + passing after
- All 13 slash-command-executor tests passing

## Human Verification
- Verified scenarios: `/model` display shows provider-qualified names; test assertions updated
- Edge cases checked: Models without provider field would show `undefined/id` but all catalog entries have provider
- What you did NOT verify: runtime end-to-end testing with actual Control UI

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None