### PR TITLE
fix: send think: false in Ollama API requests to prevent empty responses from thinking models (closes #46680)

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -340,6 +340,7 @@ async function createOllamaTestStream(params: {
     maxTokens?: number;
     signal?: AbortSignal;
     headers?: Record<string, string>;
+    reasoning?: string;
   };
 }) {
   const streamFn = createOllamaStreamFn(params.baseUrl, params.defaultHeaders);
@@ -395,6 +396,45 @@ describe("createOllamaStreamFn", () => {
         };
         expect(requestBody.options.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
+      },
+    );
+  });
+
+  it("sends think: false by default to suppress thinking tokens", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+        });
+
+        await collectStreamEvents(stream);
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as { think?: boolean };
+        expect(requestBody.think).toBe(false);
+      },
+    );
+  });
+
+  it("sends think: true when reasoning is requested", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: { reasoning: "high" },
+        });
+
+        await collectStreamEvents(stream);
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as { think?: boolean };
+        expect(requestBody.think).toBe(true);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -43,6 +43,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -458,10 +459,16 @@ export function createOllamaStreamFn(
           ollamaOptions.num_predict = options.maxTokens;
         }
 
+        // Ollama 0.18+ thinking-capable models (qwen3.5, kimi-k2.5, etc.)
+        // default to producing thinking tokens which consumes the output budget.
+        // Explicitly send think: false unless the user requested reasoning.
+        const ollamaThink = !!options?.reasoning;
+
         const body: OllamaChatRequest = {
           model: model.id,
           messages: ollamaMessages,
           stream: true,
+          think: ollamaThink,
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
         };


### PR DESCRIPTION
## Summary
- Problem: Ollama 0.18+ thinking-capable models (qwen3.5, kimi-k2.5, glm-5) produce empty responses because they spend their output budget on thinking tokens. OpenClaw only reads `message.content`, so when all output goes to the `thinking` field, the response appears empty.
- Why it matters: All thinking-capable Ollama models silently produce empty responses in subagents, causing "failed to produce results" errors.
- What changed: Added `think` field to `OllamaChatRequest` interface. The request body now explicitly sends `think: false` by default, and `think: true` when the user has requested reasoning via `options.reasoning`.
- What did NOT change (scope boundary): No changes to response parsing, message conversion, or non-Ollama providers.

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue/PR
- Closes #46680

## User-visible / Behavior Changes
Ollama thinking-capable models now produce actual text/tool_call responses instead of empty content. When reasoning is explicitly requested, thinking is enabled.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same endpoint, additional body field)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run Ollama 0.18 with a thinking-capable model (e.g. qwen3.5:35b)
2. Spawn a subagent on `ollama/qwen3.5:35b`

### Expected
- Subagent returns actual content

### Actual (before fix)
- Subagent returns empty — all tokens spent on thinking field

## Evidence
- [x] Failing test/log before + passing after
- All 33 ollama-stream tests passing (including 2 new tests for think: false/true)

## Human Verification
- Verified scenarios: Default think: false, reasoning-enabled think: true; all existing tests still pass
- Edge cases checked: Non-thinking models safely ignore the think field; empty reasoning option defaults to false
- What you did NOT verify: runtime end-to-end testing with actual Ollama server

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None