### PR TITLE
fix(telegram): support non-ASCII provider IDs in /model callback parser (closes #41118)

### DIFF
--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -18,6 +18,8 @@ describe("parseModelCallbackData", () => {
       ["mdl_back", { type: "back" }],
       ["mdl_list_anthropic_2", { type: "list", provider: "anthropic", page: 2 }],
       ["mdl_list_open-ai_1", { type: "list", provider: "open-ai", page: 1 }],
+      ["mdl_list_新加坡_1", { type: "list", provider: "新加坡", page: 1 }],
+      ["mdl_list_阿里云CodingPlan_3", { type: "list", provider: "阿里云CodingPlan", page: 3 }],
       [
         "mdl_sel_anthropic/claude-sonnet-4-5",
         { type: "select", provider: "anthropic", model: "claude-sonnet-4-5" },

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -60,7 +60,7 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   }
 
   // mdl_list_{provider}_{page}
-  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
+  const listMatch = trimmed.match(/^mdl_list_(.+)_(\d+)$/);
   if (listMatch) {
     const [, provider, pageStr] = listMatch;
     const page = Number.parseInt(pageStr ?? "1", 10);


### PR DESCRIPTION
## Summary
- Problem: In `extensions/telegram/src/model-buttons.ts`, the callback parser for `/model` inline buttons uses `[a-z0-9_-]+` regex for provider IDs, which rejects non-ASCII characters (e.g., Chinese `新加坡`, `阿里云CodingPlan`). This prevents the model picker from opening when tapping a non-ASCII provider button.
- Why it matters: Users with localized provider IDs cannot browse models via Telegram's `/model` command.
- What changed: Replaced `[a-z0-9_-]+` with `.+` in the `mdl_list_` callback regex to accept any provider ID characters. Added test cases for non-ASCII provider IDs.
- What did NOT change (scope boundary): No changes to callback data generation, model selection, or other callback handlers.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #41118

## User-visible / Behavior Changes
Telegram `/model` inline buttons now work with non-ASCII provider IDs (e.g., Chinese, Japanese, Korean characters).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure provider IDs with non-ASCII names (e.g., `新加坡`)
2. In Telegram, send `/model` and tap `Browse providers`
3. Tap a non-ASCII provider button
### Expected
- Model list for the provider opens
### Actual
- Nothing happens (callback not parsed)

## Evidence
- [x] Failing test/log before + passing after
- All 20 model-buttons.test.ts tests pass (including 2 new non-ASCII cases)
- pnpm tsgo passes (only pre-existing ui/ type errors)

## Human Verification
- Verified scenarios: all 20 model-buttons tests passing; ASCII provider IDs still work; non-ASCII provider IDs now work
- Edge cases checked: provider IDs with underscores and digits (e.g., `阿里云CodingPlan_3`) correctly parse page number
- What you did NOT verify: runtime end-to-end testing with actual Telegram bot

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
