### PR TITLE
fix: Ollama think:false + fix: Windows terminal UTF-8 encoding (#46994, #46992)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -33,7 +33,11 @@ import {
   readEnvInt,
 } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
-import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
+import {
+  getShellConfig,
+  sanitizeBinaryOutput,
+  wrapCommandWithWindowsPowerShellUtf8,
+} from "./shell-utils.js";
 
 // Sanitize inherited host env before merge so dangerous variables from process.env
 // are not propagated into non-sandboxed executions.
@@ -417,11 +421,12 @@ export async function runExecProcess(opts: {
       };
     }
     const { shell, args: shellArgs } = getShellConfig();
-    const childArgv = [shell, ...shellArgs, execCommand];
+    const runtimeCommand = wrapCommandWithWindowsPowerShellUtf8(execCommand, shell);
+    const childArgv = [shell, ...shellArgs, runtimeCommand];
     if (opts.usePty) {
       return {
         mode: "pty" as const,
-        ptyCommand: execCommand,
+        ptyCommand: runtimeCommand,
         childFallbackArgv: childArgv,
         env: shellRuntimeEnv,
         stdinMode: "pipe-open" as const,

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -340,6 +340,7 @@ async function createOllamaTestStream(params: {
     maxTokens?: number;
     signal?: AbortSignal;
     headers?: Record<string, string>;
+    reasoning?: string;
   };
 }) {
   const streamFn = createOllamaStreamFn(params.baseUrl, params.defaultHeaders);
@@ -395,6 +396,45 @@ describe("createOllamaStreamFn", () => {
         };
         expect(requestBody.options.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
+      },
+    );
+  });
+
+  it("sends think: false by default to suppress thinking tokens", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+        });
+
+        await collectStreamEvents(stream);
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as { think?: boolean };
+        expect(requestBody.think).toBe(false);
+      },
+    );
+  });
+
+  it("sends think: true when reasoning is requested", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: { reasoning: "high" },
+        });
+
+        await collectStreamEvents(stream);
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as { think?: boolean };
+        expect(requestBody.think).toBe(true);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -43,6 +43,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -458,10 +459,16 @@ export function createOllamaStreamFn(
           ollamaOptions.num_predict = options.maxTokens;
         }
 
+        // Ollama 0.18+ thinking-capable models (qwen3.5, kimi-k2.5, etc.)
+        // default to producing thinking tokens which consumes the output budget.
+        // Explicitly send think: false unless the user requested reasoning.
+        const ollamaThink = !!options?.reasoning;
+
         const body: OllamaChatRequest = {
           model: model.id,
           messages: ollamaMessages,
           stream: true,
+          think: ollamaThink,
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
         };

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
-import { getShellConfig, resolvePowerShellPath, resolveShellFromPath } from "./shell-utils.js";
+import {
+  getShellConfig,
+  resolvePowerShellPath,
+  resolveShellFromPath,
+  wrapCommandWithWindowsPowerShellUtf8,
+} from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
 
@@ -205,5 +210,28 @@ describe("resolvePowerShellPath", () => {
     delete process.env.WINDIR;
 
     expect(resolvePowerShellPath()).toBe(ps51Path);
+  });
+});
+
+describe("wrapCommandWithWindowsPowerShellUtf8", () => {
+  it("wraps command with UTF-8 initialization on Windows PowerShell", () => {
+    const shell = process.platform === "win32" ? "powershell.exe" : "pwsh";
+    const wrapped = wrapCommandWithWindowsPowerShellUtf8("Write-Output 'ok'", shell);
+    const shouldWrap = process.platform === "win32";
+
+    if (shouldWrap) {
+      expect(wrapped).toContain("[Console]::OutputEncoding = $__openclawUtf8");
+      expect(wrapped).toContain("$OutputEncoding = $__openclawUtf8");
+      expect(wrapped).toContain("chcp 65001 > $null");
+      expect(wrapped).toContain("Write-Output 'ok'");
+      return;
+    }
+
+    expect(wrapped).toBe("Write-Output 'ok'");
+  });
+
+  it("does not wrap non-powershell shells", () => {
+    const wrapped = wrapCommandWithWindowsPowerShellUtf8("echo ok", "bash");
+    expect(wrapped).toBe("echo ok");
   });
 });

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -69,6 +69,34 @@ export function getShellConfig(): { shell: string; args: string[] } {
   return { shell, args: ["-c"] };
 }
 
+function isWindowsPowerShellShell(shell: string): boolean {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  const name = path
+    .basename(shell)
+    .replace(/\.(exe|cmd|bat)$/i, "")
+    .toLowerCase();
+  return name === "powershell" || name === "pwsh";
+}
+
+export function wrapCommandWithWindowsPowerShellUtf8(command: string, shell: string): string {
+  if (!isWindowsPowerShellShell(shell)) {
+    return command;
+  }
+
+  // Keep command semantics while forcing UTF-8 for both PowerShell text streams
+  // and external console apps (via code page 65001 when available).
+  return [
+    "$__openclawUtf8 = [System.Text.UTF8Encoding]::new($false)",
+    "[Console]::InputEncoding = $__openclawUtf8",
+    "[Console]::OutputEncoding = $__openclawUtf8",
+    "$OutputEncoding = $__openclawUtf8",
+    "try { chcp 65001 > $null } catch {}",
+    command,
+  ].join("; ");
+}
+
 export function resolveShellFromPath(name: string): string | undefined {
   const envPath = process.env.PATH ?? "";
   if (!envPath) {


### PR DESCRIPTION
## Summary
Merges fixes from upstream PRs:

- #46994 - fix: send think: false in Ollama API requests to prevent empty responses from thinking models (closes #46680)
- #46992 - Fix: Windows terminal encoding set to UTF-8

Refs: https://github.com/openclaw/openclaw/pull/46994, https://github.com/openclaw/openclaw/pull/46992