### PR TITLE
fix(telegram): pass hasGroupAllowFrom to resolveChannelGroupPolicy (closes #28307)

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -375,6 +375,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       channel: "telegram",
       accountId: account.accountId,
       groupId: String(chatId),
+      hasGroupAllowFrom: Array.isArray(groupAllowFrom) && groupAllowFrom.length > 0,
     });
   const resolveGroupActivation = (params: {
     chatId: string | number;


### PR DESCRIPTION
## Summary
- Problem: In `extensions/telegram/src/bot.ts`, the `resolveGroupPolicy` closure calls `resolveChannelGroupPolicy` without passing `hasGroupAllowFrom`. When `groupPolicy: "allowlist"` is set with `groupAllowFrom` but no explicit `groups:` entries, `resolveChannelGroupPolicy` cannot activate the `senderFilterBypass` path, causing all group messages to be silently dropped.
- Why it matters: Users who set `groupAllowFrom` without explicit group IDs intend to allow any group gated by sender. Without `hasGroupAllowFrom`, every group message is rejected.
- What changed: Added `hasGroupAllowFrom: Array.isArray(groupAllowFrom) && groupAllowFrom.length > 0` to the `resolveChannelGroupPolicy` call in the `resolveGroupPolicy` closure.
- What did NOT change (scope boundary): No changes to `resolveChannelGroupPolicy` itself, no changes to per-group config handling, no changes to other channels.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #28307

## User-visible / Behavior Changes
Telegram group messages are no longer silently dropped when `groupPolicy: allowlist` is configured with `groupAllowFrom` but without explicit `groups:` entries. The sender-level filter now correctly gates access.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure `groupPolicy: allowlist` with `groupAllowFrom` containing usernames
2. Do NOT add any explicit group IDs under `groups:`
3. Send a message from an allowlisted sender in any Telegram group
### Expected
- Message is accepted and processed (sender-level filter gates access)
### Actual
- Message is silently dropped (no log entry)

## Evidence
- [x] Failing test/log before + passing after
- All 13 group-policy.test.ts tests pass
- All 3 telegram group-access.group-policy.test.ts tests pass
- pnpm tsgo passes (only pre-existing ui/ type errors)

## Human Verification
- Verified scenarios: all group-policy tests passing; reviewed diff matches issue description exactly
- Edge cases checked: empty groupAllowFrom array (still returns false), undefined groupAllowFrom (still returns false)
- What you did NOT verify: runtime end-to-end testing with actual Telegram groups

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
