### PR TITLE
fix: reject empty name and description in skill quick_validate (closes #35110)

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -115,36 +115,38 @@ def validate_skill(skill_path):
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    if not name:
+        return False, "Name cannot be empty"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
     description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    if not description:
+        return False, "Description cannot be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -68,5 +68,50 @@ metadata: |
         self.assertTrue(valid, message)
 
 
+    def test_rejects_empty_name(self):
+        skill_dir = self.temp_dir / "empty-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: ""\ndescription: A valid description\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name cannot be empty")
+
+    def test_rejects_whitespace_only_name(self):
+        skill_dir = self.temp_dir / "ws-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: "   "\ndescription: A valid description\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name cannot be empty")
+
+    def test_rejects_empty_description(self):
+        skill_dir = self.temp_dir / "empty-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: valid-skill\ndescription: ""\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description cannot be empty")
+
+    def test_rejects_whitespace_only_description(self):
+        skill_dir = self.temp_dir / "ws-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: valid-skill\ndescription: "   "\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description cannot be empty")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Problem: `quick_validate.py` silently accepted empty-string or whitespace-only `name` and `description` fields. The `if name:` / `if description:` guards skipped all validation when the value was falsy, so an empty `name: ""` or `description: "   "` passed validation without error.
- Why it matters: Invalid skills with empty names or descriptions could be created and published, leading to broken skill listings and confusing errors downstream.
- What changed: Replaced conditional guards with explicit empty-check after `.strip()`. Empty or whitespace-only values now produce clear error messages ("Name cannot be empty" / "Description cannot be empty"). Added 4 regression tests.
- What did NOT change (scope boundary): No changes to name format validation (hyphen-case regex), description content checks (angle brackets, length limit), or any other validation logic.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #35110

## User-visible / Behavior Changes
Skills with empty or whitespace-only `name` or `description` fields now fail validation with a clear error message instead of silently passing.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Create a SKILL.md with `name: ""` and a valid description
2. Run `python3 quick_validate.py <skill-dir>`
### Expected
- Validation fails with "Name cannot be empty"
### Actual (before fix)
- Validation passed with "Skill is valid!"

## Evidence
- [x] Failing test/log before + passing after
All 7 tests pass including 4 new regression tests for empty/whitespace name and description.

## Human Verification
- Verified scenarios: pytest passes all 7 tests; manual testing with empty, whitespace-only, and valid values
- Edge cases checked: empty string, whitespace-only string, None value (caught by type check), valid values
- What you did NOT verify: runtime end-to-end testing with actual skill creation service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (previously invalid skills now correctly rejected)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None