### PR TITLE
fix: validate UUID in pickSessionId + fix: toolName unknown when missing (#47011, #47010)

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -158,6 +158,8 @@ function collectText(value: unknown): string {
   return "";
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function pickSessionId(
   parsed: Record<string, unknown>,
   backend: CliBackendConfig,
@@ -171,7 +173,11 @@ function pickSessionId(
   for (const field of fields) {
     const value = parsed[field];
     if (typeof value === "string" && value.trim()) {
-      return value.trim();
+      const trimmed = value.trim();
+      if (!UUID_RE.test(trimmed)) {
+        continue;
+      }
+      return trimmed;
     }
   }
   return undefined;

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -180,6 +180,27 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.toolName).toBe("read");
   });
 
+  it("sets toolName to 'unknown' when toolName is entirely missing", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    // Tool result without any toolName property and no matching pending tool call
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_orphan",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<{
+      role: string;
+      toolName?: string;
+    }>;
+    expect(messages[0]?.toolName).toBe("unknown");
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -65,7 +65,9 @@ function normalizePersistedToolResultName(
   if (typeof rawToolName === "string") {
     return { ...toolResult, toolName: "unknown" };
   }
-  return toolResult;
+  // toolName is entirely missing (undefined) — set a fallback to prevent
+  // Google API 400 errors where function_response.name cannot be empty.
+  return { ...toolResult, toolName: "unknown" };
 }
 
 export function installSessionToolResultGuard(


### PR DESCRIPTION
## Summary
Merges fixes from upstream PRs:

- #47011 - fix: validate UUID format in pickSessionId to reject error sentinels (closes #43288)
- #47010 - fix: set toolName to "unknown" when entirely missing to prevent Gemini 400 errors (closes #46717)

Refs: https://github.com/openclaw/openclaw/pull/47011, https://github.com/openclaw/openclaw/pull/47010