### PR TITLE
fix: surface custom providers in model catalog + fix: reject empty skill name/desc (#47009, #47008)

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -115,36 +115,38 @@ def validate_skill(skill_path):
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    if not name:
+        return False, "Name cannot be empty"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
     description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    if not description:
+        return False, "Description cannot be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -68,5 +68,50 @@ metadata: |
         self.assertTrue(valid, message)
 
 
+    def test_rejects_empty_name(self):
+        skill_dir = self.temp_dir / "empty-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: ""\ndescription: A valid description\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name cannot be empty")
+
+    def test_rejects_whitespace_only_name(self):
+        skill_dir = self.temp_dir / "ws-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: "   "\ndescription: A valid description\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name cannot be empty")
+
+    def test_rejects_empty_description(self):
+        skill_dir = self.temp_dir / "empty-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: valid-skill\ndescription: ""\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description cannot be empty")
+
+    def test_rejects_whitespace_only_description(self):
+        skill_dir = self.temp_dir / "ws-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: valid-skill\ndescription: "   "\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description cannot be empty")
+
+
 if __name__ == "__main__":
     main()

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -252,7 +252,7 @@ describe("loadModelCatalog", () => {
     );
   });
 
-  it("does not merge configured models for providers that are not opted in", async () => {
+  it("merges configured models for custom providers", async () => {
     mockSingleOpenAiCatalogModel();
 
     const result = await loadModelCatalog({
@@ -281,7 +281,7 @@ describe("loadModelCatalog", () => {
 
     expect(
       result.some((entry) => entry.provider === "qianfan" && entry.id === "deepseek-v3.2"),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("does not duplicate opted-in configured models already present in ModelRegistry", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -40,7 +40,6 @@ const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
-const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
 type SyntheticCatalogFallback = {
   provider: string;
@@ -116,9 +115,6 @@ function readConfiguredOptInProviderModels(config: OpenClawConfig): ModelCatalog
   const out: ModelCatalogEntry[] = [];
   for (const [providerRaw, providerValue] of Object.entries(providers)) {
     const provider = providerRaw.toLowerCase().trim();
-    if (!NON_PI_NATIVE_MODEL_PROVIDERS.has(provider)) {
-      continue;
-    }
     if (!providerValue || typeof providerValue !== "object") {
       continue;
     }


### PR DESCRIPTION
## Summary
Merges fixes from upstream PRs:

- #47009 - fix: surface all configured custom providers in model catalog (closes #38639)
- #47008 - fix: reject empty name and description in skill quick_validate (closes #35110)

Refs: https://github.com/openclaw/openclaw/pull/47009, https://github.com/openclaw/openclaw/pull/47008