### PR TITLE
fix(feishu): defer SecretRef resolution until execution and skip CLI drift warnings

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  listEnabledFeishuAccountConfigs,
   resolveDefaultFeishuAccountId,
   resolveDefaultFeishuAccountSelection,
   resolveFeishuAccount,
@@ -367,5 +368,37 @@ describe("resolveFeishuAccount", () => {
         accountId: "main",
       }),
     ).not.toThrow();
+  });
+});
+
+describe("listEnabledFeishuAccountConfigs", () => {
+  it("treats SecretRef-backed accounts as configured without resolving them", () => {
+    const accounts = listEnabledFeishuAccountConfigs({
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: { source: "file", provider: "default", id: "path/to/app-id" },
+          appSecret: { source: "file", provider: "default", id: "path/to/app-secret" },
+          accounts: {
+            main: {
+              enabled: true,
+              tools: { doc: true },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toEqual(
+      expect.objectContaining({
+        accountId: "main",
+        enabled: true,
+        configured: true,
+        config: expect.objectContaining({
+          tools: { doc: true },
+        }),
+      }),
+    );
   });
 });

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -1,9 +1,14 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
-import { normalizeResolvedSecretInputString, normalizeSecretInputString } from "./secret-input.js";
+import {
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "./secret-input.js";
 import type {
   FeishuConfig,
   FeishuAccountConfig,
+  FeishuAccountSelectionSource,
   FeishuDefaultAccountSelectionSource,
   FeishuDomain,
   ResolvedFeishuAccount,
@@ -99,6 +104,51 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
   return { ...base, ...account } as FeishuConfig;
 }
 
+function resolveFeishuAccountConfigState(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+}): {
+  accountId: string;
+  selectionSource: FeishuAccountSelectionSource;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  domain: FeishuDomain;
+  config: FeishuConfig;
+} {
+  const hasExplicitAccountId =
+    typeof params.accountId === "string" && params.accountId.trim() !== "";
+  const defaultSelection = hasExplicitAccountId
+    ? null
+    : resolveDefaultFeishuAccountSelection(params.cfg);
+  const accountId = hasExplicitAccountId
+    ? normalizeAccountId(params.accountId)
+    : (defaultSelection?.accountId ?? DEFAULT_ACCOUNT_ID);
+  const selectionSource: FeishuAccountSelectionSource = hasExplicitAccountId
+    ? "explicit"
+    : (defaultSelection?.source ?? "fallback");
+  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
+
+  const baseEnabled = feishuCfg?.enabled !== false;
+  const merged = mergeFeishuAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const configured = Boolean(
+    hasConfiguredSecretInput(merged.appId) && hasConfiguredSecretInput(merged.appSecret),
+  );
+  const accountName = (merged as FeishuAccountConfig).name;
+
+  return {
+    accountId,
+    selectionSource,
+    enabled,
+    configured,
+    name: typeof accountName === "string" ? accountName.trim() || undefined : undefined,
+    domain: merged.domain ?? "feishu",
+    config: merged,
+  };
+}
+
 /**
  * Resolve Feishu credentials from a config.
  */
@@ -192,46 +242,40 @@ export function resolveFeishuAccount(params: {
   cfg: ClawdbotConfig;
   accountId?: string | null;
 }): ResolvedFeishuAccount {
-  const hasExplicitAccountId =
-    typeof params.accountId === "string" && params.accountId.trim() !== "";
-  const defaultSelection = hasExplicitAccountId
-    ? null
-    : resolveDefaultFeishuAccountSelection(params.cfg);
-  const accountId = hasExplicitAccountId
-    ? normalizeAccountId(params.accountId)
-    : (defaultSelection?.accountId ?? DEFAULT_ACCOUNT_ID);
-  const selectionSource = hasExplicitAccountId
-    ? "explicit"
-    : (defaultSelection?.source ?? "fallback");
-  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
-
-  // Base enabled state (top-level)
-  const baseEnabled = feishuCfg?.enabled !== false;
-
-  // Merge configs
-  const merged = mergeFeishuAccountConfig(params.cfg, accountId);
-
-  // Account-level enabled state
-  const accountEnabled = merged.enabled !== false;
-  const enabled = baseEnabled && accountEnabled;
-
-  // Resolve credentials from merged config
-  const creds = resolveFeishuCredentials(merged);
-  const accountName = (merged as FeishuAccountConfig).name;
+  const state = resolveFeishuAccountConfigState(params);
+  const creds = resolveFeishuCredentials(state.config);
 
   return {
-    accountId,
-    selectionSource,
-    enabled,
+    accountId: state.accountId,
+    selectionSource: state.selectionSource,
+    enabled: state.enabled,
     configured: Boolean(creds),
-    name: typeof accountName === "string" ? accountName.trim() || undefined : undefined,
+    name: state.name,
     appId: creds?.appId,
     appSecret: creds?.appSecret,
     encryptKey: creds?.encryptKey,
     verificationToken: creds?.verificationToken,
-    domain: creds?.domain ?? "feishu",
-    config: merged,
+    domain: creds?.domain ?? state.domain,
+    config: state.config,
   };
+}
+
+/**
+ * List all enabled accounts that appear configured from raw config input alone.
+ * This preflight path intentionally does not resolve SecretRefs.
+ */
+export function listEnabledFeishuAccountConfigs(cfg: ClawdbotConfig): Array<{
+  accountId: string;
+  selectionSource: FeishuAccountSelectionSource;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  domain: FeishuDomain;
+  config: FeishuConfig;
+}> {
+  return listFeishuAccountIds(cfg)
+    .map((accountId) => resolveFeishuAccountConfigState({ cfg, accountId }))
+    .filter((account) => account.enabled && account.configured);
 }
 
 /**

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,7 +1,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { createFeishuToolClient } from "./tool-account.js";
 
 // ============ Helpers ============
@@ -538,7 +538,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
     return;

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerFeishuChatTools } from "./chat.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const chatGetMock = vi.hoisted(() => vi.fn());
+const chatMembersGetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
 }));
 
 describe("registerFeishuChatTools", () => {
-  const chatGetMock = vi.hoisted(() => vi.fn());
-  const chatMembersGetMock = vi.hoisted(() => vi.fn());
-
   beforeEach(() => {
     vi.clearAllMocks();
     createFeishuClientMock.mockReturnValue({
@@ -22,25 +22,23 @@ describe("registerFeishuChatTools", () => {
   });
 
   it("registers feishu_chat and handles info/members actions", async () => {
-    const registerTool = vi.fn();
-    registerFeishuChatTools({
-      config: {
-        channels: {
-          feishu: {
-            enabled: true,
-            appId: "app_id",
-            appSecret: "app_secret", // pragma: allowlist secret
-            tools: { chat: true },
+    const { api, resolveTool } = createToolFactoryHarness({
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            main: {
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { chat: true },
+            },
           },
         },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
+      },
     } as any);
 
-    expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.name).toBe("feishu_chat");
+    registerFeishuChatTools(api);
+    const tool = resolveTool("feishu_chat");
 
     chatGetMock.mockResolvedValueOnce({
       code: 0,
@@ -85,5 +83,32 @@ describe("registerFeishuChatTools", () => {
       registerTool,
     } as any);
     expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it("registers without resolving SecretRef-backed account config", () => {
+    const registerTool = vi.fn();
+
+    expect(() =>
+      registerFeishuChatTools({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              accounts: {
+                main: {
+                  appId: { source: "file", provider: "default", id: "path/to/app-id" },
+                  appSecret: { source: "file", provider: "default", id: "path/to/app-secret" },
+                  tools: { chat: true },
+                },
+              },
+            },
+          },
+        } as any,
+        logger: { debug: vi.fn(), info: vi.fn() } as any,
+        registerTool,
+      } as any),
+    ).not.toThrow();
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -44,7 +44,10 @@ describe("registerFeishuChatTools", () => {
       code: 0,
       data: { name: "group name", user_count: 3 },
     });
-    const infoResult = await tool.execute("tc_1", { action: "info", chat_id: "oc_1" });
+    const infoResult = (await tool.execute("tc_1", {
+      action: "info",
+      chat_id: "oc_1",
+    })) as { details: unknown };
     expect(infoResult.details).toEqual(
       expect.objectContaining({ chat_id: "oc_1", name: "group name", user_count: 3 }),
     );
@@ -57,7 +60,10 @@ describe("registerFeishuChatTools", () => {
         items: [{ member_id: "ou_1", name: "member1", member_id_type: "open_id" }],
       },
     });
-    const membersResult = await tool.execute("tc_2", { action: "members", chat_id: "oc_1" });
+    const membersResult = (await tool.execute("tc_2", {
+      action: "members",
+      chat_id: "oc_1",
+    })) as { details: unknown };
     expect(membersResult.details).toEqual(
       expect.objectContaining({
         chat_id: "oc_1",

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -1,9 +1,8 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 function json(data: unknown) {
   return {
@@ -77,51 +76,57 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_chat: No Feishu accounts configured, skipping chat tools");
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.chat) {
     api.logger.debug?.("feishu_chat: chat tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuChatExecuteParams = FeishuChatParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_chat",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuChatParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "members":
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  p.page_size,
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              return json(await getChatInfo(client, p.chat_id));
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_chat",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuChatExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "members":
+                return json(
+                  await getChatMembers(
+                    client,
+                    p.chat_id,
+                    p.page_size,
+                    p.page_token,
+                    p.member_id_type,
+                  ),
+                );
+              case "info":
+                return json(await getChatInfo(client, p.chat_id));
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_chat" },
   );

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -5,6 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
+const convertMock = vi.hoisted(() => vi.fn());
+const documentCreateMock = vi.hoisted(() => vi.fn());
+const blockListMock = vi.hoisted(() => vi.fn());
+const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
+const blockChildrenGetMock = vi.hoisted(() => vi.fn());
+const blockChildrenBatchDeleteMock = vi.hoisted(() => vi.fn());
+const blockDescendantCreateMock = vi.hoisted(() => vi.fn());
+const driveUploadAllMock = vi.hoisted(() => vi.fn());
+const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
+const blockPatchMock = vi.hoisted(() => vi.fn());
+const scopeListMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
@@ -23,18 +34,6 @@ vi.mock("./runtime.js", () => ({
 import { registerFeishuDocTools } from "./docx.js";
 
 describe("feishu_doc image fetch hardening", () => {
-  const convertMock = vi.hoisted(() => vi.fn());
-  const documentCreateMock = vi.hoisted(() => vi.fn());
-  const blockListMock = vi.hoisted(() => vi.fn());
-  const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
-  const blockChildrenGetMock = vi.hoisted(() => vi.fn());
-  const blockChildrenBatchDeleteMock = vi.hoisted(() => vi.fn());
-  const blockDescendantCreateMock = vi.hoisted(() => vi.fn());
-  const driveUploadAllMock = vi.hoisted(() => vi.fn());
-  const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
-  const blockPatchMock = vi.hoisted(() => vi.fn());
-  const scopeListMock = vi.hoisted(() => vi.fn());
-
   beforeEach(() => {
     vi.clearAllMocks();
 

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -5,7 +5,7 @@ import { basename } from "node:path";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
 import { updateColorText } from "./docx-color-text.js";
@@ -1233,7 +1233,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   }
 
   // Check if any account is configured
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_doc: No Feishu accounts configured, skipping doc tools");
     return;

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -169,7 +169,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_drive: No Feishu accounts configured, skipping drive tools");
     return;

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -118,7 +118,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_perm: No Feishu accounts configured, skipping perm tools");
     return;

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -47,7 +47,7 @@ export function createFeishuToolClient(params: {
 }
 
 export function resolveAnyEnabledFeishuToolsConfig(
-  accounts: ResolvedFeishuAccount[],
+  accounts: Array<{ config: { tools?: FeishuToolsConfig } }>,
 ): Required<FeishuToolsConfig> {
   const merged: Required<FeishuToolsConfig> = {
     doc: false,

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
   jsonToolResult,
@@ -157,7 +157,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_wiki: No Feishu accounts configured, skipping wiki tools");
     return;

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -252,7 +252,7 @@ describe("web monitor inbox", () => {
     });
   });
 
-  it("handles append messages by marking them read but skipping auto-reply", async () => {
+  it("handles stale append messages by marking them read but skipping auto-reply", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
 
     const upsert = {
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-300_000),
           pushName: "History Sender",
         },
       ],

--- a/src/cli/daemon-cli/gateway-token-drift.test.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.test.ts
@@ -21,51 +21,51 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     expect(token).toBe("config-token");
   });
 
-  it("does not fall back to caller env for unresolved config token refs", () => {
-    expect(() =>
-      resolveGatewayTokenForDriftCheck({
-        cfg: {
-          secrets: {
-            providers: {
-              default: { source: "env" },
-            },
+  it("skips drift comparison when config token SecretRef is unavailable", () => {
+    const token = resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
           },
-          gateway: {
-            mode: "local",
-            auth: {
-              token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
-            },
+        },
+        gateway: {
+          mode: "local",
+          auth: {
+            token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
           },
-        } as OpenClawConfig,
-        env: {
-          OPENCLAW_GATEWAY_TOKEN: "env-token",
-        } as NodeJS.ProcessEnv,
-      }),
-    ).toThrow(/gateway\.auth\.token/i);
+        },
+      } as OpenClawConfig,
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "env-token",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(token).toBeUndefined();
   });
 
-  it("does not fall back to gateway.remote token for unresolved local token refs", () => {
-    expect(() =>
-      resolveGatewayTokenForDriftCheck({
-        cfg: {
-          secrets: {
-            providers: {
-              default: { source: "env" },
-            },
+  it("does not fall back to gateway.remote token when local drift check token is unavailable", () => {
+    const token = resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
           },
-          gateway: {
-            mode: "local",
-            auth: {
-              mode: "token",
-              token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
-            },
-            remote: {
-              token: "remote-token",
-            },
+        },
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
           },
-        } as OpenClawConfig,
-        env: {} as NodeJS.ProcessEnv,
-      }),
-    ).toThrow(/gateway\.auth\.token/i);
+          remote: {
+            token: "remote-token",
+          },
+        },
+      } as OpenClawConfig,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(token).toBeUndefined();
   });
 });

--- a/src/cli/daemon-cli/gateway-token-drift.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.ts
@@ -1,10 +1,20 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveGatewayDriftCheckCredentialsFromConfig } from "../../gateway/credentials.js";
+import {
+  isGatewaySecretRefUnavailableError,
+  resolveGatewayDriftCheckCredentialsFromConfig,
+} from "../../gateway/credentials.js";
 
 export function resolveGatewayTokenForDriftCheck(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }) {
   void params.env;
-  return resolveGatewayDriftCheckCredentialsFromConfig({ cfg: params.cfg }).token;
+  try {
+    return resolveGatewayDriftCheckCredentialsFromConfig({ cfg: params.cfg }).token;
+  } catch (error) {
+    if (isGatewaySecretRefUnavailableError(error, "gateway.auth.token")) {
+      return undefined;
+    }
+    throw error;
+  }
 }

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -99,6 +99,30 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
+  it("skips drift warnings when config token SecretRef is unavailable in the CLI path", async () => {
+    loadConfig.mockReturnValue({
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+      gateway: {
+        auth: {
+          token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
+        },
+      },
+    });
+    service.readCommand.mockResolvedValue({
+      programArguments: [],
+      environment: { OPENCLAW_GATEWAY_TOKEN: "service-token" },
+    });
+
+    await runServiceRestart(createServiceRunArgs(true));
+
+    const payload = readJsonLog<{ warnings?: string[] }>();
+    expect(payload.warnings).toBeUndefined();
+  });
+
   it("skips drift warning when disabled", async () => {
     await runServiceRestart({
       serviceNoun: "Node",

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -131,7 +131,9 @@ describe("runServiceRestart token drift", () => {
 
     const payload = readJsonLog<{ warnings?: string[] }>();
     expect(payload.warnings).toEqual(
-      expect.arrayContaining([expect.stringContaining("Unable to verify gateway token drift: read command failed")]),
+      expect.arrayContaining([
+        expect.stringContaining("Unable to verify gateway token drift: read command failed"),
+      ]),
     );
   });
 

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   defaultRuntime,
   resetLifecycleRuntimeLogs,
@@ -111,7 +112,7 @@ describe("runServiceRestart token drift", () => {
           token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
         },
       },
-    });
+    } as OpenClawConfig);
     service.readCommand.mockResolvedValue({
       programArguments: [],
       environment: { OPENCLAW_GATEWAY_TOKEN: "service-token" },

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -9,7 +9,7 @@ import {
   stubEmptyGatewayEnv,
 } from "./test-helpers/lifecycle-core-harness.js";
 
-const loadConfig = vi.fn(() => ({
+const loadConfig = vi.fn<() => OpenClawConfig>(() => ({
   gateway: {
     auth: {
       token: "config-token",
@@ -122,6 +122,17 @@ describe("runServiceRestart token drift", () => {
 
     const payload = readJsonLog<{ warnings?: string[] }>();
     expect(payload.warnings).toBeUndefined();
+  });
+
+  it("surfaces unexpected drift-check failures as warnings", async () => {
+    service.readCommand.mockRejectedValueOnce(new Error("read command failed"));
+
+    await runServiceRestart(createServiceRunArgs(true));
+
+    const payload = readJsonLog<{ warnings?: string[] }>();
+    expect(payload.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("Unable to verify gateway token drift: read command failed")]),
+    );
   });
 
   it("skips drift warning when disabled", async () => {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -420,6 +420,8 @@ export async function runServiceRestart(params: {
         }
       }
     } catch (err) {
+      // Best-effort drift check; SecretRef-unavailable is handled by
+      // resolveGatewayTokenForDriftCheck returning undefined.
       void err;
     }
   }

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -8,7 +8,6 @@ import { describeGatewayServiceRestart } from "../../daemon/service.js";
 import type { GatewayService } from "../../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../../daemon/systemd.js";
-import { isGatewaySecretRefUnavailableError } from "../../gateway/credentials.js";
 import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
@@ -421,14 +420,7 @@ export async function runServiceRestart(params: {
         }
       }
     } catch (err) {
-      if (isGatewaySecretRefUnavailableError(err, "gateway.auth.token")) {
-        const warning =
-          "Unable to verify gateway token drift: gateway.auth.token SecretRef is configured but unavailable in this command path.";
-        warnings.push(warning);
-        if (!json) {
-          defaultRuntime.log(`\n⚠️  ${warning}\n`);
-        }
-      }
+      void err;
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -420,9 +420,11 @@ export async function runServiceRestart(params: {
         }
       }
     } catch (err) {
-      // Best-effort drift check; SecretRef-unavailable is handled by
-      // resolveGatewayTokenForDriftCheck returning undefined.
-      void err;
+      const warning = `Unable to verify gateway token drift: ${err instanceof Error ? err.message : String(err)}`;
+      warnings.push(warning);
+      if (!json) {
+        defaultRuntime.log(`\n⚠️  ${warning}\n`);
+      }
     }
   }
 

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -123,7 +123,9 @@ function applySlotSelectionForPlugin(
   config: OpenClawConfig,
   pluginId: string,
 ): { config: OpenClawConfig; warnings: string[] } {
-  const report = buildPluginStatusReport({ config });
+  // Slot selection only needs plugin metadata/kind; avoid running existing
+  // plugin registration, which may require resolved runtime secrets.
+  const report = buildPluginStatusReport({ config, mode: "validate" });
   const plugin = report.plugins.find((entry) => entry.id === pluginId);
   if (!plugin) {
     return { config, warnings: [] };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1236,6 +1236,28 @@ describe("loadOpenClawPlugins", () => {
     expect(disabled?.status).toBe("disabled");
   });
 
+  it("treats validate-mode plugins without register exports as errors", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const plugin = writePlugin({
+      id: "validate-missing-register",
+      body: `module.exports = { id: "validate-missing-register" };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      mode: "validate",
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+        },
+      },
+    });
+
+    const entry = registry.plugins.find((record) => record.id === "validate-missing-register");
+    expect(entry?.status).toBe("error");
+    expect(entry?.error).toContain("plugin export missing register/activate");
+  });
+
   it("blocks before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -917,15 +917,15 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       continue;
     }
 
-    if (validateOnly) {
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-
     if (typeof register !== "function") {
       logger.error(`[plugins] ${record.id} missing register/activate export`);
       pushPluginLoadError("plugin export missing register/activate");
+      continue;
+    }
+
+    if (validateOnly) {
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
       continue;
     }
 

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -57,4 +57,20 @@ describe("buildPluginStatusReport", () => {
       }),
     );
   });
+
+  it("forwards validate mode to plugin loading", () => {
+    buildPluginStatusReport({
+      config: {},
+      workspaceDir: "/workspace",
+      mode: "validate",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {},
+        workspaceDir: "/workspace",
+        mode: "validate",
+      }),
+    );
+  });
 });

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -17,6 +17,8 @@ export function buildPluginStatusReport(params?: {
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
+  /** Skip plugin register/activate and only validate metadata/config. */
+  mode?: "validate";
 }): PluginStatusReport {
   const config = params?.config ?? loadConfig();
   const workspaceDir = params?.workspaceDir
@@ -28,6 +30,7 @@ export function buildPluginStatusReport(params?: {
     config,
     workspaceDir,
     env: params?.env,
+    mode: params?.mode,
     logger: createPluginLoaderLogger(log),
   });
 


### PR DESCRIPTION
## Summary

Supersedes #46958.

This PR fixes the broader SecretRef regression around the Feishu plugin and gateway restart flows.

### What changed

1. Feishu plugin registration no longer resolves account credentials during `register()`
   - registration now uses config-only preflight checks
   - SecretRef-backed accounts are treated as configured without forcing resolution
   - actual credential resolution happens when tools execute or runtime paths start

2. Feishu chat tool now resolves account selection lazily at execution time
   - avoids binding the first configured account during registration
   - aligns chat with the other account-aware Feishu tools

3. Gateway restart token drift checks now skip unavailable SecretRefs
   - if `gateway.auth.token` is SecretRef-managed but unavailable in the CLI path,
     drift verification is skipped instead of emitting a misleading warning

4. Test cleanup
   - added regression coverage for Feishu SecretRef-backed registration paths
   - added regression coverage for drift-check skip behavior
   - removed Feishu Vitest hoisted warnings in affected tests

## Why

`plugins install` was only one manifestation of the bug fixed in #46958.

The deeper issue was that the Feishu plugin performed account resolution too early, during plugin registration, on command paths that only had source config and not a resolved runtime snapshot. That caused env/file/exec SecretRefs to fail in unrelated CLI and gateway preload flows.

This PR fixes that boundary by keeping registration-phase checks config-only and deferring real credential resolution until execution/runtime.

## Validation

Ran:

```bash
npm exec -- vitest run extensions/feishu/src/*.test.ts src/cli/daemon-cli/gateway-token-drift.test.ts src/cli/daemon-cli/lifecycle-core.test.ts
```

Result: 39 test files passed, 399 tests passed.
