### PR TITLE
fix: include google-antigravity in Gemini 3.1 forward-compat model resolution (closes #35512)

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -275,7 +275,11 @@ function resolveGoogle31ForwardCompatModel(
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
-  if (normalizedProvider !== "google" && normalizedProvider !== "google-gemini-cli") {
+  if (
+    normalizedProvider !== "google" &&
+    normalizedProvider !== "google-gemini-cli" &&
+    normalizedProvider !== "google-antigravity"
+  ) {
     return undefined;
   }
   const trimmed = modelId.trim();


### PR DESCRIPTION
## Summary
- Problem: The `resolveGoogle31ForwardCompatModel` function only checks for `google` and `google-gemini-cli` providers, missing `google-antigravity`. Models like `gemini-3.1-pro-preview-customtools` are rejected with "Model not allowed" when used with the google-antigravity provider.
- Why it matters: Users cannot use Gemini 3.1 Pro variants (including the customtools preview) through google-antigravity.
- What changed: Added `google-antigravity` to the eligible provider check in `resolveGoogle31ForwardCompatModel`.
- What did NOT change (scope boundary): No changes to model resolution logic, template cloning, or other providers.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## Linked Issue/PR
- Closes #35512

## User-visible / Behavior Changes
google-antigravity provider now resolves Gemini 3.1 model variants via forward-compat.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure google-antigravity provider
2. Set model to `gemini-3.1-pro-preview-customtools`

### Expected
- Model resolves via forward-compat from gemini-3-pro-preview template

### Actual (before fix)
- "Model not allowed" / "Unknown model" error

## Evidence
- [x] Failing test/log before + passing after
- All 50 model tests passing

## Human Verification
- Verified scenarios: google-antigravity now included in eligible providers for Gemini 3.1 forward-compat
- Edge cases checked: Existing google and google-gemini-cli paths unchanged
- What you did NOT verify: runtime end-to-end testing with actual Google API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None