### PR TITLE
fix: add circuit breaker to typing keepalive loop to prevent crash on network failure (closes #45759)

### DIFF
--- a/src/channels/typing-lifecycle.test.ts
+++ b/src/channels/typing-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
+
+describe("createTypingKeepaliveLoop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops after consecutive errors exceed threshold", async () => {
+    const onTick = vi.fn().mockRejectedValue(new Error("network error"));
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick,
+      maxConsecutiveErrors: 3,
+    });
+
+    loop.start();
+    expect(loop.isRunning()).toBe(true);
+
+    // Trigger 3 ticks that all fail
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(100);
+      await vi.runAllTimersAsync();
+    }
+
+    expect(loop.isRunning()).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(3);
+  });
+
+  it("resets consecutive error count on success", async () => {
+    let callCount = 0;
+    const onTick = vi.fn().mockImplementation(async () => {
+      callCount++;
+      // Fail on calls 1-2, succeed on 3
+      if (callCount <= 2) {
+        throw new Error("network error");
+      }
+    });
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick,
+      maxConsecutiveErrors: 3,
+    });
+
+    loop.start();
+
+    // Tick 1: fail (consecutive=1)
+    await loop.tick();
+    expect(loop.isRunning()).toBe(true);
+
+    // Tick 2: fail (consecutive=2)
+    await loop.tick();
+    expect(loop.isRunning()).toBe(true);
+
+    // Tick 3: success (consecutive=0)
+    await loop.tick();
+    expect(loop.isRunning()).toBe(true);
+
+    // Now make all subsequent fail again
+    onTick.mockRejectedValue(new Error("network error"));
+
+    // Tick 4: fail (consecutive=1)
+    await loop.tick();
+    expect(loop.isRunning()).toBe(true);
+
+    // Tick 5: fail (consecutive=2)
+    await loop.tick();
+    expect(loop.isRunning()).toBe(true);
+
+    // Tick 6: fail (consecutive=3) → circuit break
+    await loop.tick();
+    expect(loop.isRunning()).toBe(false);
+
+    loop.stop();
+  });
+
+  it("defaults to 3 consecutive errors", async () => {
+    const onTick = vi.fn().mockRejectedValue(new Error("network error"));
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick,
+    });
+
+    loop.start();
+
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(100);
+      await vi.runAllTimersAsync();
+    }
+
+    expect(loop.isRunning()).toBe(false);
+  });
+});

--- a/src/channels/typing-lifecycle.ts
+++ b/src/channels/typing-lifecycle.ts
@@ -1,5 +1,7 @@
 type AsyncTick = () => Promise<void> | void;
 
+const MAX_CONSECUTIVE_ERRORS = 3;
+
 export type TypingKeepaliveLoop = {
   tick: () => Promise<void>;
   start: () => void;
@@ -10,9 +12,21 @@ export type TypingKeepaliveLoop = {
 export function createTypingKeepaliveLoop(params: {
   intervalMs: number;
   onTick: AsyncTick;
+  maxConsecutiveErrors?: number;
 }): TypingKeepaliveLoop {
   let timer: ReturnType<typeof setInterval> | undefined;
   let tickInFlight = false;
+  let consecutiveErrors = 0;
+  const errorThreshold = params.maxConsecutiveErrors ?? MAX_CONSECUTIVE_ERRORS;
+
+  const stop = () => {
+    if (!timer) {
+      return;
+    }
+    clearInterval(timer);
+    timer = undefined;
+    tickInFlight = false;
+  };
 
   const tick = async () => {
     if (tickInFlight) {
@@ -21,6 +35,12 @@ export function createTypingKeepaliveLoop(params: {
     tickInFlight = true;
     try {
       await params.onTick();
+      consecutiveErrors = 0;
+    } catch {
+      consecutiveErrors++;
+      if (consecutiveErrors >= errorThreshold) {
+        stop();
+      }
     } finally {
       tickInFlight = false;
     }
@@ -30,18 +50,10 @@ export function createTypingKeepaliveLoop(params: {
     if (params.intervalMs <= 0 || timer) {
       return;
     }
+    consecutiveErrors = 0;
     timer = setInterval(() => {
       void tick();
     }, params.intervalMs);
-  };
-
-  const stop = () => {
-    if (!timer) {
-      return;
-    }
-    clearInterval(timer);
-    timer = undefined;
-    tickInFlight = false;
   };
 
   const isRunning = () => timer !== undefined;


### PR DESCRIPTION
## Summary
- Problem: `createTypingKeepaliveLoop` in `src/channels/typing-lifecycle.ts` has no circuit breaker. When the Telegram API becomes unreachable, the typing indicator loop continues firing `sendChatAction` calls every 6 seconds indefinitely. Each failed call triggers retries with backoff, saturating the event loop and causing the gateway to become unresponsive and crash.
- Why it matters: Network blips cause gateway crash loops (observed 3 crashes in one morning). Typing indicators are purely cosmetic and should never block real message processing.
- What changed: Added a consecutive-error circuit breaker (default: 3 errors). After `maxConsecutiveErrors` consecutive failures, the loop automatically stops. Successful ticks reset the counter. Added `maxConsecutiveErrors` optional parameter to allow customization.
- What did NOT change (scope boundary): No changes to the typing indicator tick function itself, no changes to how `sendChatAction` is called, no changes to other channels' typing behavior.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #45759

## User-visible / Behavior Changes
Typing indicator loops now automatically stop after 3 consecutive network errors, preventing gateway crashes during network outages. The typing indicator will resume on the next message cycle.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Start gateway with Telegram typing enabled
2. Interrupt network connectivity
3. Observe typing loop behavior
### Expected
- Typing loop stops after 3 consecutive failures
### Actual
- Typing loop continues indefinitely, saturating event loop

## Evidence
- [x] Failing test/log before + passing after
- 3 new unit tests for circuit breaker behavior: all pass
- pnpm tsgo passes (only pre-existing ui/ type errors)

## Human Verification
- Verified scenarios: 3 tests covering circuit break, error reset on success, and default threshold
- Edge cases checked: concurrent tick guard still works, start resets error count
- What you did NOT verify: runtime end-to-end testing with actual network failure

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
