### PR TITLE
fix: include Gemini, Grok, and Kimi keys in web search key audit check (closes #34509)

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -330,7 +330,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary
- Problem: `hasWebSearchKey` only checks for Brave and Perplexity keys, missing Gemini, Grok, and Kimi web search provider keys (both config and env vars).
- Why it matters: Users with Gemini/Grok/Kimi-only web search configs get incorrect audit results showing no web search key present.
- What changed: Added `search?.gemini?.apiKey`, `search?.grok?.apiKey`, `search?.kimi?.apiKey` config checks and `GEMINI_API_KEY`, `XAI_API_KEY`, `KIMI_API_KEY`, `MOONSHOT_API_KEY` env var checks.
- What did NOT change (scope boundary): Existing Brave/Perplexity checks unchanged; web search execution logic untouched.

## Change Type
- [x] Bug fix

## Scope
- [x] Auth / tokens

## Linked Issue/PR
- Closes #34509

## User-visible / Behavior Changes
Security audit now correctly detects web search keys for all configured providers.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No (read-only check)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure only `tools.web.search.gemini.apiKey`
2. Run security audit

### Expected
- Audit recognizes web search key is present

### Actual (before fix)
- Audit says no web search key present

## Evidence
- [x] Failing test/log before + passing after
- All 7 audit-extra tests passing

## Human Verification
- Verified scenarios: All 7 existing audit-extra tests pass; new providers added match config schema
- Edge cases checked: MOONSHOT_API_KEY is an alias for KIMI_API_KEY per the search implementation
- What you did NOT verify: runtime end-to-end audit with actual API keys

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None