### PR TITLE
fix: increase ACP queueOwnerTtlSeconds default from 0.1s to 30s (closes #39724)

### DIFF
--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -60,7 +60,7 @@ export type ResolvedAcpxPluginConfig = {
 
 const DEFAULT_PERMISSION_MODE: AcpxPermissionMode = "approve-reads";
 const DEFAULT_NON_INTERACTIVE_POLICY: AcpxNonInteractivePermissionPolicy = "fail";
-const DEFAULT_QUEUE_OWNER_TTL_SECONDS = 0.1;
+const DEFAULT_QUEUE_OWNER_TTL_SECONDS = 30;
 const DEFAULT_STRICT_WINDOWS_CMD_WRAPPER = true;
 
 type ParseResult =

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -156,7 +156,7 @@ describe("createAcpxRuntimeService", () => {
 
     expect(runtimeFactory).toHaveBeenCalledWith(
       expect.objectContaining({
-        queueOwnerTtlSeconds: 0.1,
+        queueOwnerTtlSeconds: 30,
       }),
     );
   });


### PR DESCRIPTION
## Summary
- Problem: The default `queueOwnerTtlSeconds` for the acpx plugin is 0.1 seconds — far too low for any real ACP agent to cold-start and claim the queue. Codex CLI, for example, requires 15-25 seconds for OAuth handshake, model resolution, and sandbox init.
- Why it matters: With 0.1s TTL, ACP-spawned tasks silently fail with `ACP_TURN_FAILED` because the queue is abandoned before the agent process starts. The session shows "accepted" with no error feedback.
- What changed: Increased `DEFAULT_QUEUE_OWNER_TTL_SECONDS` from 0.1 to 30 in `extensions/acpx/src/config.ts`.
- What did NOT change (scope boundary): No logic changes. Users who already set an explicit `queueOwnerTtlSeconds` in config are unaffected.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #39724

## User-visible / Behavior Changes
ACP-spawned agent tasks (e.g. Codex CLI) will now have 30 seconds to cold-start and claim the queue, instead of 0.1 seconds. This eliminates silent `ACP_TURN_FAILED` errors for typical agent startup times.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure acpx with default settings (no explicit queueOwnerTtlSeconds)
2. Spawn a Codex task via ACP: `sessions_spawn({ runtime: "acp", agentId: "codex" })`
### Expected
- Codex CLI has enough time to cold-start and claim the ACP queue; task executes successfully
### Actual (before fix)
- Queue abandoned after 0.1s, ACP_TURN_FAILED, task silently vanishes

## Evidence
- [x] Failing test/log before + passing after
- pnpm tsgo passes (only pre-existing ui/ errors)
- acpx config tests: 10/10 pass

## Human Verification
- Verified scenarios: pnpm tsgo + acpx config tests all passing; diff is a single constant change
- Edge cases checked: Users with explicit queueOwnerTtlSeconds in config are unaffected (value overrides default)
- What you did NOT verify: runtime end-to-end testing with actual Codex CLI spawn

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — existing explicit configs override the default
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit, or set `queueOwnerTtlSeconds: 0.1` in config

## Risks and Mitigations
None — the old default of 0.1s was effectively broken for all real agent spawns.
