### PR TITLE
fix: correct sandbox workspace guidance in system prompt (closes #16920)

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -655,7 +655,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("Your working directory is: /workspace");
     expect(prompt).toContain(
-      "For read/write/edit/apply_patch, file paths resolve against host workspace: /tmp/openclaw. For bash/exec commands, use sandbox container paths under /workspace (or relative paths from that workdir), not host paths.",
+      "All file tools (read/write/edit/apply_patch) and bash/exec commands operate inside the sandbox container. Use sandbox container paths under /workspace (or relative paths from that workdir), not host paths.",
     );
     expect(prompt).toContain("Sandbox container workdir: /workspace");
     expect(prompt).toContain(

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -389,7 +389,7 @@ export function buildAgentSystemPrompt(params: {
       : sanitizedWorkspaceDir;
   const workspaceGuidance =
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
-      ? `For read/write/edit/apply_patch, file paths resolve against host workspace: ${sanitizedWorkspaceDir}. For bash/exec commands, use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths. Prefer relative paths so both sandboxed exec and file tools work consistently.`
+      ? `All file tools (read/write/edit/apply_patch) and bash/exec commands operate inside the sandbox container. Use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths.`
       : "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
   const safetySection = [
     "## Safety",


### PR DESCRIPTION
## Summary
- Problem: The sandbox system prompt incorrectly told the agent that file tools (read/write/edit/apply_patch) resolve against the host workspace path. In reality, all file tools route through `SandboxFsBridge` which executes via `docker exec` inside the container.
- Why it matters: Agents receive incorrect information about their environment and may attempt to use host paths for file operations, causing confusion and potential errors.
- What changed: Updated the workspace guidance string to state that all file tools and bash/exec commands operate inside the sandbox container, using container paths.
- What did NOT change (scope boundary): No changes to actual file tool routing, sandbox bridge logic, or non-sandbox workspace guidance.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #16920

## User-visible / Behavior Changes
Sandbox system prompt now correctly tells the agent that all tools (file and exec) operate inside the sandbox container, using container paths.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Enable sandbox with `workspaceAccess: "rw"`
2. Send a message to the agent
3. Inspect the system prompt
### Expected
- Guidance says all tools operate inside the sandbox container
### Actual (before fix)
- Guidance incorrectly says file tools resolve against host workspace

## Evidence
- [x] Failing test/log before + passing after
All 43 system-prompt tests pass including updated sandbox workspace guidance assertion.

## Human Verification
- Verified scenarios: pnpm tsgo + oxlint + vitest all passing; reviewed diff matches issue description
- Edge cases checked: non-sandbox mode guidance unchanged, sandbox without container workspace unchanged
- What you did NOT verify: runtime end-to-end testing with actual sandbox container

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (prompt text change only)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None