### PR TITLE
macOS tests: update CommandResolver node fixture

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -45,7 +45,7 @@ import Testing
         let nodePath = tmp.appendingPathComponent("node_modules/.bin/node")
         let scriptPath = tmp.appendingPathComponent("bin/openclaw.js")
         try makeExecutableForTests(at: nodePath)
-        try "#!/bin/sh\necho v22.0.0\n".write(to: nodePath, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\necho v22.16.0\n".write(to: nodePath, atomically: true, encoding: .utf8)
         try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: nodePath.path)
         try makeExecutableForTests(at: scriptPath)
 


### PR DESCRIPTION
## Summary

- Update macOS CommandResolver test node fixture version from `v22.0.0` to `v22.16.0`.
- Keep test fixture aligned with current Node 22 baseline.
- Scope is test-only; no production behavior changes.

## Change Type

- [x] Chore/infra

## User-visible / Behavior Changes

None.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Human Verification

Obvious fix verified by inspection: one-line test fixture version bump only (`v22.0.0` -> `v22.16.0`), no runtime code changed.
