### PR TITLE
fix(tts): add resolveModelAsync to tts.test.ts mock

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -2,7 +2,7 @@ import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
-import { resolveModel } from "../agents/pi-embedded-runner/model.js";
+import { resolveModelAsync } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnv } from "../test-utils/env.js";
 import * as tts from "./tts.js";
@@ -20,8 +20,8 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthApiKey: vi.fn(async () => null),
 }));
 
-vi.mock("../agents/pi-embedded-runner/model.js", () => ({
-  resolveModel: vi.fn((provider: string, modelId: string) => ({
+vi.mock("../agents/pi-embedded-runner/model.js", () => {
+  const resolveResult = (provider: string, modelId: string) => ({
     model: {
       provider,
       id: modelId,
@@ -35,8 +35,14 @@ vi.mock("../agents/pi-embedded-runner/model.js", () => ({
     },
     authStorage: { profiles: {} },
     modelRegistry: { find: vi.fn() },
-  })),
-}));
+  });
+  return {
+    resolveModel: vi.fn(resolveResult),
+    resolveModelAsync: vi.fn(async (provider: string, modelId: string) =>
+      resolveResult(provider, modelId),
+    ),
+  };
+});
 
 vi.mock("../agents/model-auth.js", () => ({
   getApiKeyForModel: vi.fn(async () => ({
@@ -411,11 +417,11 @@ describe("tts", () => {
         timeoutMs: 30_000,
       });
 
-      expect(resolveModel).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
+      expect(resolveModelAsync).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
     });
 
     it("registers the Ollama api before direct summarization", async () => {
-      vi.mocked(resolveModel).mockReturnValue({
+      vi.mocked(resolveModelAsync).mockResolvedValue({
         model: {
           provider: "ollama",
           id: "qwen3:8b",


### PR DESCRIPTION
## Summary
- 8e4a1d87e (#45824) switched `tts-core.ts` from `resolveModel` to `resolveModelAsync` but didn't update the test mock
- Add `resolveModelAsync` to the `vi.mock` factory and update two test expectations accordingly
- Unblocks Windows CI for all PRs rebased onto latest main

Fixes #47053

## Test plan
- [x] `vitest run src/tts/tts.test.ts` — 32/32 pass