### PR TITLE
fix: thinkingDefault per-agent + fix: constrain SVG logo in empty session (#47028, #47027)

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -34,6 +34,7 @@ export const HeartbeatSchema = z
     ackMaxChars: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),
+    isolatedSession: z.boolean().optional(),
   })
   .strict()
   .superRefine((val, ctx) => {
@@ -770,6 +771,17 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     params: z.record(z.string(), z.unknown()).optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+        z.literal("adaptive"),
+      ])
+      .optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
   })

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -908,6 +908,9 @@
 .agent-chat__avatar--logo {
   width: 48px;
   height: 48px;
+  max-width: 48px;
+  max-height: 48px;
+  flex-shrink: 0;
   border-radius: 14px;
   background: var(--panel-strong);
   border: 1px solid var(--border);
@@ -919,6 +922,8 @@
 .agent-chat__avatar--logo img {
   width: 32px;
   height: 32px;
+  max-width: 32px;
+  max-height: 32px;
   object-fit: contain;
 }
 
@@ -990,3 +995,6 @@
   background: var(--panel-strong);
   border-color: var(--accent);
 }
+
+/* Mobile dropdown toggle — hidden on desktop */
+/* Mobile gear toggle + dropdown are hidden by default in layout.css */


### PR DESCRIPTION
## Summary
Merges fixes from upstream PRs:

- #47028 - fix: add thinkingDefault to AgentEntrySchema for per-agent config (closes #21097)
- #47027 - fix: constrain SVG logo size in empty session welcome state (closes #45148)

Refs: https://github.com/openclaw/openclaw/pull/47028, https://github.com/openclaw/openclaw/pull/47027