### PR TITLE
fix: honor suppressToolErrors for mutating tool warnings (closes #20140)

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -294,16 +294,15 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it("suppresses mutating tool errors when messages.suppressToolErrors is enabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "connection timeout" },
+      config: { messages: { suppressToolErrors: true } },
+    });
+    expect(payloads).toHaveLength(0);
+  });
+
   it.each([
-    {
-      name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",
-      payload: {
-        lastToolError: { toolName: "write", error: "connection timeout" },
-        config: { messages: { suppressToolErrors: true } },
-      },
-      title: "Write",
-      absentDetail: "connection timeout",
-    },
     {
       name: "shows recoverable tool errors for mutating tools",
       payload: {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -73,13 +73,13 @@ function resolveToolErrorWarningPolicy(params: {
   if (normalizedToolName === "sessions_send") {
     return { showWarning: false, includeDetails };
   }
+  if (params.suppressToolErrors) {
+    return { showWarning: false, includeDetails };
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
     return { showWarning: true, includeDetails };
-  }
-  if (params.suppressToolErrors) {
-    return { showWarning: false, includeDetails };
   }
   return {
     showWarning: !params.hasUserFacingReply && !isRecoverableToolError(params.lastToolError.error),


### PR DESCRIPTION
## Summary
- Problem: `shouldShowToolErrorWarning()` checked for mutating tools before checking `suppressToolErrors`, so mutating tool errors always showed warning badges even when `suppressToolErrors: true` was set.
- Why it matters: Users set `suppressToolErrors: true` to hide noisy warnings from tools with non-zero exit codes (e.g., `grep` partial matches), but the setting was ignored for mutating tools.
- What changed: Moved the `suppressToolErrors` check to the top of the function so it takes priority over the mutating tool check.
- What did NOT change (scope boundary): No changes to tool error detection, recoverable error logic, or payload building.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #20140

## User-visible / Behavior Changes
When `messages.suppressToolErrors: true` is set, ALL tool error warning badges are suppressed, including those from mutating tools.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Set `messages.suppressToolErrors: true` in config
2. Run a command that returns non-zero exit code (e.g. `grep "pattern" file1 file2`)
### Expected
- No warning badge in chat
### Actual (before fix)
- Warning badge still shown for mutating tools

## Evidence
- [x] Failing test/log before + passing after
All 29 payloads.errors tests pass including updated test for suppress + mutating.

## Human Verification
- Verified scenarios: pnpm tsgo + oxlint + vitest all passing; reviewed diff matches issue description
- Edge cases checked: suppressToolErrors false (mutating still shows), sessions_send (always suppressed), recoverable errors (still suppressed by default)
- What you did NOT verify: runtime end-to-end testing with actual Telegram delivery

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (opt-in config flag)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None