### PR TITLE
fix(ui): treat /model status|list|info as info queries, not model names

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -323,6 +323,28 @@ describe("executeSlashCommand /model subcommands", () => {
       expect.objectContaining({ model: "info" }),
     );
   });
+
+  it("sets a real model name via sessions.patch (regression)", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return { ok: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "gpt-4.1",
+    );
+
+    expect(result.content).toContain("gpt-4.1");
+    expect(request).toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ model: "gpt-4.1" }),
+    );
+  });
 });
 
 describe("executeSlashCommand directives", () => {

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -230,6 +230,101 @@ describe("executeSlashCommand /kill", () => {
   });
 });
 
+describe("executeSlashCommand /model subcommands", () => {
+  it("treats /model status as an info query, not a model name", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: { model: "default-model" },
+          sessions: [
+            row("agent:main:main", {
+              model: "openai-codex/gpt-5.4",
+            }),
+          ],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [{ id: "openai-codex/gpt-5.4" }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "status",
+    );
+
+    // Should show current model info, NOT try to set the model to "status"
+    expect(result.content).toContain("Current model:");
+    expect(result.content).toContain("openai-codex/gpt-5.4");
+    // Ensure sessions.patch was never called
+    expect(request).not.toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ model: "status" }),
+    );
+  });
+
+  it("treats /model list as an info query", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: { model: "default-model" },
+          sessions: [row("agent:main:main", { model: "gpt-4.1" })],
+        };
+      }
+      if (method === "models.list") {
+        return { models: [{ id: "gpt-4.1" }, { id: "gpt-4.1-mini" }] };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "list",
+    );
+
+    expect(result.content).toContain("Current model:");
+    expect(request).not.toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ model: "list" }),
+    );
+  });
+
+  it("treats /model info as an info query", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: { model: "default-model" },
+          sessions: [row("agent:main:main", { model: "gpt-4.1" })],
+        };
+      }
+      if (method === "models.list") {
+        return { models: [{ id: "gpt-4.1" }] };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "info",
+    );
+
+    expect(result.content).toContain("Current model:");
+    expect(request).not.toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ model: "info" }),
+    );
+  });
+});
+
 describe("executeSlashCommand directives", () => {
   it("resolves the legacy main alias for bare /model", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -114,12 +114,15 @@ async function executeCompact(
   }
 }
 
+/** Subcommands that should show model info rather than set the model. */
+const MODEL_INFO_SUBCOMMANDS = new Set(["status", "list", "info"]);
+
 async function executeModel(
   client: GatewayBrowserClient,
   sessionKey: string,
   args: string,
 ): Promise<SlashCommandResult> {
-  if (!args) {
+  if (!args || MODEL_INFO_SUBCOMMANDS.has(args.trim().toLowerCase())) {
     try {
       const [sessions, models] = await Promise.all([
         client.request<SessionsListResult>("sessions.list", {}),


### PR DESCRIPTION
## Summary

The WebUI slash-command handler only distinguished between `/model` (no args) and `/model <name>`. Subcommands like `status`, `list`, and `info` were passed through as literal model names to `sessions.patch`, causing errors like:

```
GatewayRequestError: model not allowed: openai-codex/status
```

## Changes

- Added a `MODEL_INFO_SUBCOMMANDS` set (`status`, `list`, `info`) in `slash-command-executor.ts`
- When `/model` receives one of these subcommands, it routes to the info display path instead of setting the model
- Added 3 test cases confirming `/model status`, `/model list`, and `/model info` show model info without calling `sessions.patch`

## Test Plan

- `/model status` → shows current model + available models
- `/model list` → shows current model + available models
- `/model gpt-5.2` → still sets the model as before (no regression)

Fixes #46894