### PR TITLE
fix: clamp heartbeat setTimeout delay to MAX_SAFE_TIMEOUT_MS (closes #28405)

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1086,7 +1086,8 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    const MAX_SAFE_TIMEOUT_MS = 2_147_483_647; // 2^31-1
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_SAFE_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });


### PR DESCRIPTION
## Summary
- Problem: When `heartbeat.every` exceeds ~24.85 days (2^31-1 ms), the `setTimeout` delay overflows Node.js's 32-bit signed integer limit, causing the timer to fire at 1ms. This creates an infinite re-arm loop that consumes 100% CPU, leaks memory at ~500MB/min, and produces ~17MB/s of `TimeoutOverflowWarning` stderr output.
- Why it matters: Gateway crashes from OOM within ~8 minutes, disconnecting all services. With launchd KeepAlive, this creates a crash loop (~50+ restarts/day).
- What changed: Clamped the heartbeat timer delay to `Math.min(delay, 2_147_483_647)` in `src/infra/heartbeat-runner.ts`.
- What did NOT change (scope boundary): No config validation changes. Only the timer scheduling was clamped.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #28405

## User-visible / Behavior Changes
Setting `heartbeat.every` to very large values (>24.85 days) no longer crashes the gateway. The timer is clamped to ~24.85 days and re-arms correctly.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Set `heartbeat.every: "999h"` in config
2. Start gateway
### Expected
- Gateway runs normally, heartbeat fires after the clamped delay
### Actual (before fix)
- Gateway enters infinite loop, 100% CPU, OOM crash in ~8 minutes

## Evidence
- [x] Failing test/log before + passing after
- pnpm tsgo passes (only pre-existing errors)
- Heartbeat tests: 59/59 pass (3 test files)

## Human Verification
- Verified scenarios: pnpm tsgo + heartbeat tests all passing; diff is a one-line clamp
- Edge cases checked: Normal intervals (<24.85 days) unaffected by `Math.min`; delay is already `Math.max(0, ...)` so negative values are handled
- What you did NOT verify: runtime end-to-end testing with actual 999h heartbeat interval

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
