### PR TITLE
fix: normalize codex-cli provider for embedded/helper paths (closes #38212)

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -99,6 +99,22 @@ export function normalizeProviderIdForAuth(provider: string): string {
   return normalized;
 }
 
+/**
+ * Map CLI-only providers to their API-backed equivalents for embedded/helper paths.
+ * CLI providers route through the CLI runner for interactive sessions but need
+ * their API-backed provider for embedded LLM calls (e.g. slug generator).
+ */
+export function normalizeCliProviderForEmbedded(provider: string): string {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "codex-cli") {
+    return "openai-codex";
+  }
+  if (normalized === "claude-cli") {
+    return "anthropic";
+  }
+  return normalized;
+}
+
 export function findNormalizedProviderValue<T>(
   entries: Record<string, T> | undefined,
   provider: string,

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,7 +12,7 @@ import {
   resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
-import { parseModelRef } from "../agents/model-selection.js";
+import { normalizeCliProviderForEmbedded, parseModelRef } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -47,7 +47,11 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
     // Resolve model from agent config instead of using hardcoded defaults
     const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
     const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
-    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
+    // CLI-only providers (codex-cli, claude-cli) route through the CLI runner
+    // for interactive sessions but need their API-backed equivalent in embedded
+    // helper paths.
+    const rawProvider = parsed?.provider ?? DEFAULT_PROVIDER;
+    const provider = normalizeCliProviderForEmbedded(rawProvider);
     const model = parsed?.model ?? DEFAULT_MODEL;
 
     const result = await runEmbeddedPiAgent({


### PR DESCRIPTION
## Summary
- Problem: When the primary model is `codex-cli/gpt-5.4`, embedded/helper paths (e.g. session-memory slug generator) fail because `codex-cli` is a CLI-only provider not recognized by the embedded runner.
- Why it matters: Helper hooks like slug generation silently fail, preventing session memory features from working with codex-cli models.
- What changed: Added `normalizeCliProviderForEmbedded()` function that maps `codex-cli` → `openai-codex` and `claude-cli` → `anthropic` for embedded paths. Applied it in the LLM slug generator.
- What did NOT change (scope boundary): `isCliProvider` detection unchanged; interactive CLI routing unchanged; `normalizeProviderId` unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## Linked Issue/PR
- Closes #38212

## User-visible / Behavior Changes
Session memory slug generation now works when primary model uses codex-cli or claude-cli provider.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Set primary model to `codex-cli/gpt-5.4`
2. Start a session with session-memory enabled
3. Observe slug generation in logs

### Expected
- Slug generated successfully using openai-codex API path

### Actual (before fix)
- Slug generation fails silently (codex-cli not recognized by embedded runner)

## Evidence
- [x] Failing test/log before + passing after
- 60/61 model-selection tests pass (1 pre-existing failure on main); tsgo type check clean

## Human Verification
- Verified scenarios: codex-cli → openai-codex; claude-cli → anthropic; other providers pass through unchanged
- Edge cases checked: normalizeProviderId is called first, so variants like mixed case are handled
- What you did NOT verify: runtime end-to-end testing with actual codex-cli configuration

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None