### PR TITLE
fix: use configured primary provider for unprefixed image model refs (closes #38816)

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1402,6 +1402,33 @@ describe("runWithModelFallback", () => {
 });
 
 describe("runWithImageModelFallback", () => {
+  it("uses configured primary model provider for unprefixed image model refs", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: "ollama/llama3",
+          imageModel: {
+            primary: "moondream",
+            fallbacks: ["qwen2.5vl:7b"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockRejectedValueOnce(new Error("timeout")).mockResolvedValueOnce("ok");
+
+    const result = await runWithImageModelFallback({
+      cfg,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    // "moondream" should resolve to "ollama/moondream" (not "anthropic/moondream")
+    expect(run.mock.calls).toEqual([
+      ["ollama", "moondream"],
+      ["ollama", "qwen2.5vl:7b"],
+    ]);
+  });
+
   it("keeps explicit image fallbacks reachable when models allowlist is present", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -208,13 +208,25 @@ function resolveImageFallbackCandidates(params: {
   defaultProvider: string;
   modelOverride?: string;
 }): ModelCandidate[] {
+  // Use the user's configured primary model provider as the default for
+  // unprefixed image model refs so that e.g. "moondream" resolves to
+  // "ollama/moondream" instead of always falling back to "anthropic".
+  const primaryRef = params.cfg
+    ? resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: params.defaultProvider,
+        defaultModel: DEFAULT_MODEL,
+      })
+    : null;
+  const effectiveDefaultProvider = primaryRef?.provider ?? params.defaultProvider;
+
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
-    defaultProvider: params.defaultProvider,
+    defaultProvider: effectiveDefaultProvider,
   });
   const allowlist = buildConfiguredAllowlistKeys({
     cfg: params.cfg,
-    defaultProvider: params.defaultProvider,
+    defaultProvider: effectiveDefaultProvider,
   });
   const { candidates, addExplicitCandidate, addAllowlistedCandidate } =
     createModelCandidateCollector(allowlist);
@@ -222,7 +234,7 @@ function resolveImageFallbackCandidates(params: {
   const addRaw = (raw: string, opts?: { allowlist?: boolean }) => {
     const resolved = resolveModelRefFromString({
       raw: String(raw ?? ""),
-      defaultProvider: params.defaultProvider,
+      defaultProvider: effectiveDefaultProvider,
       aliasIndex,
     });
     if (!resolved) {


### PR DESCRIPTION
## Summary
- Problem: `resolveImageFallbackCandidates` always used `DEFAULT_PROVIDER` ("anthropic") as the default provider for unprefixed image model IDs, causing models like `"moondream"` (an Ollama model) to incorrectly resolve to `"anthropic/moondream"`.
- Why it matters: Users configuring custom image models without explicit provider prefixes (e.g. Ollama, LiteLLM) get `Unknown model: anthropic/<model>` errors, making the image tool unusable with non-Anthropic providers.
- What changed: `resolveImageFallbackCandidates` now derives the effective default provider from the user's configured primary model (`agents.defaults.model`), matching the behavior of the main `resolveFallbackCandidates` function.
- What did NOT change (scope boundary): The main model fallback pipeline, the `resolveImageModelConfigForTool` auto-detection logic, and provider-specific image model routing are unchanged.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #38816

## User-visible / Behavior Changes
Unprefixed image model IDs (e.g. `"moondream"`, `"qwen2.5vl:7b"`) now resolve using the user's configured primary model provider instead of always defaulting to Anthropic.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure `agents.defaults.model` to `"ollama/llama3"` and `agents.defaults.imageModel.primary` to `"moondream"` (no provider prefix)
2. Call the `image` tool
### Expected
- Image tool resolves model to `ollama/moondream`
### Actual
- Image tool resolved model to `anthropic/moondream`, causing `Unknown model` error

## Evidence
- [x] Failing test/log before + passing after
```
 ✓ src/agents/model-fallback.test.ts (61 tests | 59 skipped) 4ms
   Tests  2 passed | 59 skipped (61)
```

## Human Verification
- Verified scenarios: pnpm tsgo + vitest tests passing; reviewed diff matches issue description
- Edge cases checked: When no primary model configured, falls back to DEFAULT_PROVIDER ("anthropic") as before; prefixed image model refs (e.g. "openai/gpt-5-mini") unaffected
- What you did NOT verify: runtime end-to-end testing with actual Ollama service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None