### PR TITLE
fix: respect totalTokensFresh flag to avoid showing stale token counts

### DIFF
--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -78,6 +78,7 @@ export type GatewaySessionList = {
       lastAccountId?: string;
       derivedTitle?: string;
       lastMessagePreview?: string;
+      totalTokensFresh?: boolean;
     }
   >;
 };

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -36,6 +36,7 @@ type SessionInfoDefaults = {
 type SessionInfoEntry = SessionInfo & {
   modelOverride?: string;
   providerOverride?: string;
+  totalTokensFresh?: boolean;
 };
 
 export function createSessionActions(context: SessionActionContext) {
@@ -185,8 +186,15 @@ export function createSessionActions(context: SessionActionContext) {
     if (entry?.outputTokens !== undefined) {
       next.outputTokens = entry.outputTokens;
     }
-    if (entry?.totalTokens !== undefined) {
-      next.totalTokens = entry.totalTokens;
+    // Only update totalTokens if totalTokensFresh is not false.
+    // When totalTokensFresh is false, the totalTokens value may be stale/historical
+    // (e.g., accumulated from previous compaction) and should not be displayed.
+    // Gateway already filters via resolveFreshSessionTotalTokens, but we check again
+    // here for safety and for patches that may include the raw entry.
+    if (entry?.totalTokens !== undefined && entry.totalTokens !== null) {
+      if (entry.totalTokensFresh !== false) {
+        next.totalTokens = entry.totalTokens;
+      }
     }
     if (entry?.contextTokens !== undefined || defaults?.contextTokens !== undefined) {
       next.contextTokens =

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -22,7 +22,9 @@ export function formatNextRun(ms?: number | null) {
 }
 
 export function formatSessionTokens(row: GatewaySessionRow) {
-  if (row.totalTokens == null) {
+  // When totalTokensFresh is false, totalTokens may be stale/historical
+  // (e.g., accumulated from previous compaction) and should not be displayed.
+  if (row.totalTokens == null || row.totalTokensFresh === false) {
     return "n/a";
   }
   const total = row.totalTokens ?? 0;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -399,6 +399,7 @@ export type GatewaySessionRow = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  totalTokensFresh?: boolean;
   model?: string;
   modelProvider?: string;
   contextTokens?: number;


### PR DESCRIPTION
## Problem
When a session's `totalTokensFresh` flag is `false`, the `totalTokens` value may be stale/historical (e.g., accumulated from previous compaction) and should not be displayed.

This caused incorrect displays like "100% context used 2.6M / 200k" in both TUI and Web UI when the token count was stale.

## Root Cause
The Gateway already correctly filters stale token counts via `resolveFreshSessionTotalTokens`, but:
1. **TUI**: Type definition was missing `totalTokensFresh` field, so TUI couldn't check it
2. **UI**: `formatSessionTokens` function didn't check the freshness flag

## Solution

### TUI (commit 368ca03f1)
- Add `totalTokensFresh` to `GatewaySessionList` type in `gateway-chat.ts`
- Add `totalTokensFresh` to `SessionInfoEntry` type in `tui-session-actions.ts`
- Check `totalTokensFresh !== false` before updating `sessionInfo.totalTokens`

### UI (commit 446fdd13a)
- Add `totalTokensFresh` to `GatewaySessionRow` type in `types.ts`
- Check `totalTokensFresh === false` in `formatSessionTokens` function, return "n/a" when stale

## Testing
- TypeScript compilation passes for both TUI and UI
- The fix ensures stale token counts are not displayed in sessions list

## Files Changed
- `src/tui/gateway-chat.ts` - Add `totalTokensFresh` to type definition
- `src/tui/tui-session-actions.ts` - Add type and check before using `totalTokens`
- `ui/src/ui/types.ts` - Add `totalTokensFresh` to type definition
- `ui/src/ui/presenter.ts` - Check freshness before displaying tokens