### PR TITLE
Attach provenance to spawned subagent tasks

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -622,6 +622,12 @@ export async function spawnSubagentDirect(
         deliver: false,
         lane: AGENT_LANE_SUBAGENT,
         extraSystemPrompt: childSystemPrompt,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: requesterInternalKey,
+          sourceChannel: requesterOrigin?.channel,
+          sourceTool: "sessions_spawn",
+        },
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -122,6 +122,12 @@ function getRegisteredRun() {
     | undefined;
 }
 
+function getAgentCall() {
+  return hoisted.callGatewayMock.mock.calls.find(
+    ([opts]) => (opts as { method?: string } | undefined)?.method === "agent",
+  )?.[0] as { method?: string; params?: Record<string, unknown> } | undefined;
+}
+
 describe("spawnSubagentDirect workspace inheritance", () => {
   beforeEach(() => {
     hoisted.callGatewayMock.mockClear();
@@ -166,6 +172,30 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(result.status).toBe("accepted");
     expect(getRegisteredRun()).toMatchObject({
       workspaceDir: "/tmp/workspace-ops",
+    });
+  });
+
+  it("attaches inter-session provenance to spawned child tasks", async () => {
+    const result = await spawnSubagentDirect(
+      {
+        task: "inspect workspace",
+        agentId: "main",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "telegram",
+        agentAccountId: "123",
+        agentTo: "456",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(getAgentCall()?.params?.inputProvenance).toMatchObject({
+      kind: "inter_session",
+      sourceSessionKey: "agent:main:main",
+      sourceChannel: "telegram",
+      sourceTool: "sessions_spawn",
     });
   });
 


### PR DESCRIPTION
## Summary

This adds explicit inter-session provenance to child tasks launched via `sessions_spawn`.

Changes in this PR:

- attach `inputProvenance` when `spawnSubagentDirect()` starts the child `agent` run
- preserve requester session/channel lineage on the spawned task
- set `sourceTool: "sessions_spawn"`
- add a focused test that asserts the spawned child receives the expected provenance payload

Closes #47070.

## Why

Other inter-session paths already preserve provenance. Spawned child tasks should also see that their input came from another session/tool, rather than looking like clean first-party input.

## Validation

Ran:

- `pnpm exec vitest run src/agents/subagent-spawn.workspace.test.ts`
