### PR TITLE
fix(gateway): skip Control UI pairing when auth.mode=none (closes #42931)

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -226,6 +226,22 @@ describe("ws connect policy", () => {
     expect(shouldSkipControlUiPairing(strict, "operator", true)).toBe(true);
   });
 
+  test("auth.mode=none skips pairing for operator control-ui only", () => {
+    const strict = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: undefined,
+      deviceRaw: null,
+    });
+    // Operator + auth.mode=none: skip pairing (the fix for #42931)
+    expect(shouldSkipControlUiPairing(strict, "operator", false, "none")).toBe(true);
+    // Node role + auth.mode=none: still require pairing (prevents #43478 regression)
+    expect(shouldSkipControlUiPairing(strict, "node", false, "none")).toBe(false);
+    // Operator + auth.mode=shared-key: no change, still requires pairing
+    expect(shouldSkipControlUiPairing(strict, "operator", false, "shared-key")).toBe(false);
+    // Operator + no authMode (undefined): no change, still requires pairing
+    expect(shouldSkipControlUiPairing(strict, "operator", false)).toBe(false);
+  });
+
   test("trusted-proxy control-ui bypass only applies to operator + trusted-proxy auth", () => {
     const cases: Array<{
       role: "operator" | "node";

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -36,8 +36,17 @@ export function shouldSkipControlUiPairing(
   policy: ControlUiAuthPolicy,
   role: GatewayRole,
   trustedProxyAuthOk = false,
+  authMode?: string,
 ): boolean {
   if (trustedProxyAuthOk) {
+    return true;
+  }
+  // When auth is completely disabled (mode=none), there is no shared secret
+  // or token to gate pairing. Requiring pairing in this configuration adds
+  // friction without security value since any client can already connect
+  // without credentials. Scope to operator role so node-role sessions still
+  // need device identity (#43478 was reverted for skipping ALL clients).
+  if (role === "operator" && authMode === "none") {
     return true;
   }
   // dangerouslyDisableDeviceAuth is the break-glass path for Control UI

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -674,18 +674,14 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
-        // auth.mode=none disables all authentication — device pairing is an
-        // auth mechanism and must also be skipped when the operator opted out.
         const skipPairing =
-          resolvedAuth.mode === "none" ||
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) ||
-          shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -681,7 +681,7 @@ export function attachGatewayWsMessageHandler(params: {
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk, resolvedAuth.mode);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
## Summary
- When `gateway.auth.mode=none`, Control UI operator sessions no longer get stuck on "pairing required"
- Adds `authMode` parameter to `shouldSkipControlUiPairing` so the bypass is scoped to Control UI + operator role + `auth.mode=none` only
- Prevents the #43478 regression where a top-level OR disabled pairing for ALL websocket clients

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR
- Closes #42931
- Supersedes the reverted approach in #43478 (which was too broad)

## What changed

`shouldSkipControlUiPairing` in `connect-policy.ts` gains an optional `authMode` parameter. When `auth.mode=none` and the client is a Control UI operator session, pairing is skipped. The rationale: auth.mode=none means no authentication at all, so requiring device pairing adds friction without security value since any client can already connect without credentials.

The call site in `message-handler.ts` passes `resolvedAuth.mode` as the 4th argument.

## What did NOT change (scope boundary)

- Non-Control-UI clients (CLI, mobile, backend nodes) are unaffected. `shouldSkipControlUiPairing` is only called inside the `isControlUi` guard.
- Node-role sessions are unaffected. The `role === "operator"` check prevents node bypass.
- Other auth modes (shared-key, trusted-proxy) are unaffected. Only `authMode === "none"` triggers the new path.
- `evaluateMissingDeviceIdentity` is unchanged. Over Tailscale Serve (HTTPS), SubtleCrypto is available, so device identity still works.
- `shouldSkipBackendSelfPairing` is unchanged.

## Regression test

4 new assertions in `connect-policy.test.ts`:
1. `operator + auth.mode=none` -> skip pairing (the fix)
2. `node + auth.mode=none` -> still require pairing (prevents #43478 regression)
3. `operator + auth.mode=shared-key` -> still require pairing (no change)
4. `operator + undefined authMode` -> still require pairing (no change)

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- auth.mode=none is an explicit opt-out of all auth. Pairing without auth is friction without security value. This change does not reduce security for any configuration where auth is enabled.

## User-visible / Behavior Changes
- `openclaw gateway status` and Control UI chat over reverse proxies (Tailscale Serve, nginx, etc.) now work correctly when `gateway.auth.mode=none` is configured