### PR TITLE
fix: strip tool_choice when tools array is empty (closes #44110)

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -36,6 +36,7 @@ import {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "./proxy-stream-wrappers.js";
+import { createEmptyToolChoiceSanitizer } from "./stream-payload-utils.js";
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -482,4 +483,8 @@ export function applyExtraParamsToAgent(
       log.warn(`ignoring invalid parallel_tool_calls param: ${summary}`);
     }
   }
+
+  // Strip tool_choice when no tools are present to avoid 400 errors on
+  // providers that reject tool_choice without tool definitions.
+  agent.streamFn = createEmptyToolChoiceSanitizer(agent.streamFn);
 }

--- a/src/agents/pi-embedded-runner/stream-payload-utils.ts
+++ b/src/agents/pi-embedded-runner/stream-payload-utils.ts
@@ -1,5 +1,37 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 
+/**
+ * Strip `tool_choice` from the outgoing payload when the `tools` array is
+ * empty or absent.  Sending `tool_choice: "auto"` without any tool
+ * definitions causes 400 errors on providers that don't support it
+ * (e.g. vLLM without `--enable-auto-tool-choice`).
+ */
+export function sanitizeToolChoicePayload(payload: Record<string, unknown>): void {
+  const tools = payload.tools;
+  const hasTools = Array.isArray(tools) && tools.length > 0;
+  if (!hasTools && payload.tool_choice !== undefined) {
+    delete payload.tool_choice;
+  }
+}
+
+/**
+ * Wrap a stream function to strip `tool_choice` when no tools are present.
+ */
+export function createEmptyToolChoiceSanitizer(baseStreamFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return baseStreamFn(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          sanitizeToolChoicePayload(payload as Record<string, unknown>);
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function streamWithPayloadPatch(
   underlying: StreamFn,
   model: Parameters<StreamFn>[0],
@@ -13,6 +45,7 @@ export function streamWithPayloadPatch(
     onPayload: (payload) => {
       if (payload && typeof payload === "object") {
         patchPayload(payload as Record<string, unknown>);
+        sanitizeToolChoicePayload(payload as Record<string, unknown>);
       }
       return originalOnPayload?.(payload, model);
     },


### PR DESCRIPTION
## Summary
- Problem: When an agent is configured with `tools.allow: []` (empty allowlist), the upstream library still sends `tool_choice: "auto"` in the API request payload. Providers like Venice AI (vLLM-hosted) that don't have `--enable-auto-tool-choice` enabled reject this with a 400 error.
- Why it matters: Blocks usage of any model hosted on providers that require explicit tool-choice opt-in when no tools are defined.
- What changed: Added `sanitizeToolChoicePayload()` in `stream-payload-utils.ts` that strips `tool_choice` from the outgoing payload when the `tools` array is empty or absent. Applied as: (1) an inline sanitizer in `streamWithPayloadPatch` for custom provider wrappers, and (2) the outermost stream wrapper via `createEmptyToolChoiceSanitizer` in `applyExtraParamsAndStreamOverrides` to cover all providers.
- What did NOT change (scope boundary): No changes to tool policy resolution, tool filtering, or how `tools.allow`/`tools.deny` work. Only the final API payload is sanitized.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #44110

## User-visible / Behavior Changes
Agents with empty tool allowlists no longer trigger 400 errors on providers that reject `tool_choice` without tool definitions.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure an agent with `tools.allow: []` and a Venice AI model
2. Send any message to the agent
### Expected
- Agent responds normally without tools
### Actual (before fix)
- 400 error: "auto" tool choice requires --enable-auto-tool-choice

## Evidence
- [x] Failing test/log before + passing after
All 21 related extra-params tests pass.

## Human Verification
- Verified scenarios: pnpm tsgo passes; all 21 extra-params tests pass; reviewed diff matches issue description
- Edge cases checked: payload with tools present is unchanged; payload with tool_choice=none and no tools still gets stripped (harmless); tool_choice with valid tools is preserved
- What you did NOT verify: runtime end-to-end testing with actual Venice AI service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
