### PR TITLE
fix: increase sessions_spawn gateway timeout from 10s to 30s (closes #29186)

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -2,6 +2,9 @@ import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
 import { formatThinkingLevels, normalizeThinkLevel } from "../auto-reply/thinking.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
+
+/** Gateway call timeout for sub-agent spawn operations (30 seconds). */
+const SPAWN_GATEWAY_TIMEOUT_MS = 30_000;
 import { loadConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -146,7 +149,7 @@ async function cleanupProvisionalSession(
         emitLifecycleHooks: options?.emitLifecycleHooks === true,
         deleteTranscript: options?.deleteTranscript === true,
       },
-      timeoutMs: 10_000,
+      timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
     });
   } catch {
     // Best-effort cleanup only.
@@ -430,7 +433,7 @@ export async function spawnSubagentDirect(
       await callGateway({
         method: "sessions.patch",
         params: { key: childSessionKey, ...patch },
-        timeoutMs: 10_000,
+        timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
       });
       return undefined;
     } catch (err) {
@@ -494,7 +497,7 @@ export async function spawnSubagentDirect(
         await callGateway({
           method: "sessions.delete",
           params: { key: childSessionKey, emitLifecycleHooks: false },
-          timeoutMs: 10_000,
+          timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
         });
       } catch {
         // Best-effort cleanup only.
@@ -627,7 +630,7 @@ export async function spawnSubagentDirect(
         label: label || undefined,
         ...publicSpawnedMetadata,
       },
-      timeoutMs: 10_000,
+      timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
     });
     if (typeof response?.runId === "string" && response.runId) {
       childRunId = response.runId;
@@ -677,7 +680,7 @@ export async function spawnSubagentDirect(
             deleteTranscript: true,
             emitLifecycleHooks: !endedHookEmitted,
           },
-          timeoutMs: 10_000,
+          timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
         });
       } catch {
         // Best-effort only.
@@ -724,7 +727,7 @@ export async function spawnSubagentDirect(
       await callGateway({
         method: "sessions.delete",
         params: { key: childSessionKey, deleteTranscript: true, emitLifecycleHooks: false },
-        timeoutMs: 10_000,
+        timeoutMs: SPAWN_GATEWAY_TIMEOUT_MS,
       });
     } catch {
       // Best-effort cleanup only.


### PR DESCRIPTION
## Summary
- Problem: `callGateway()` calls in `subagent-spawn.ts` use a hardcoded 10-second timeout (`timeoutMs: 10_000`). In embedded gateway mode (e.g., Docker Compose), this is a loopback WebSocket call to the same process, and under load (parent agent running + processing a complex request), the sub-agent spawn easily exceeds 10 seconds and fails.
- Why it matters: Users see spurious "Sub-agent hit a gateway issue" errors; the LLM falls back to working directly with degraded tool access.
- What changed: Extracted a named constant `SPAWN_GATEWAY_TIMEOUT_MS = 30_000` and replaced all 6 hardcoded `timeoutMs: 10_000` references in `subagent-spawn.ts`.
- What did NOT change (scope boundary): No retry logic, no config field, no error message changes — just the timeout value increase.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #29186

## User-visible / Behavior Changes
Sub-agent spawn operations now have 30 seconds (up from 10) to complete the gateway call, reducing spurious timeout failures under load.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run OpenClaw in embedded gateway mode
2. Send a complex request that triggers `sessions_spawn` while other agent runs are active
3. Previously the spawn timed out after 10s
### Expected
- Sub-agent spawn succeeds within 30s under load
### Actual
- Sub-agent spawn fails after 10s with gateway timeout

## Evidence
- [x] Failing test/log before + passing after
- All 9 sessions-spawn-tool tests pass
- `pnpm tsgo` clean (only pre-existing ui type errors)
- `oxlint` clean

## Human Verification
- Verified scenarios: pnpm tsgo + sessions-spawn-tool.test.ts all passing; reviewed diff matches issue description
- Edge cases checked: all 6 callGateway sites use the same constant; no other 10_000 timeouts elsewhere in the file
- What you did NOT verify: runtime end-to-end testing with actual embedded gateway under load

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None — increasing timeout is strictly more lenient; no behavior change for fast spawns.
