### PR TITLE
fix: default supportsStore to false for non-native openai-completions endpoints (closes #43086)

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -32,6 +32,10 @@ function supportsStrictMode(model: Model<Api>): boolean | undefined {
   return (model.compat as { supportsStrictMode?: boolean } | undefined)?.supportsStrictMode;
 }
 
+function supportsStore(model: Model<Api>): boolean | undefined {
+  return (model.compat as { supportsStore?: boolean } | undefined)?.supportsStore;
+}
+
 function createTemplateModel(provider: string, id: string): Model<Api> {
   return {
     id,
@@ -306,6 +310,29 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(false);
     expect(supportsUsageInStreaming(normalized)).toBe(false);
     expect(supportsStrictMode(normalized)).toBe(false);
+    expect(supportsStore(normalized)).toBe(false);
+  });
+
+  it("forces supportsStore off for Google AI OpenAI-compatible endpoint", () => {
+    const model = {
+      ...baseModel(),
+      provider: "google-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsStore(normalized)).toBe(false);
+  });
+
+  it("respects explicit supportsStore true on non-native endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsStore: true },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsStore(normalized)).toBe(true);
   });
 
   it("respects explicit supportsStrictMode true on non-native endpoints", () => {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -67,11 +67,13 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   }
   const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
   const forcedUsageStreaming = compat?.supportsUsageInStreaming === true;
+  const forcedStore = compat?.supportsStore === true;
   const targetStrictMode = compat?.supportsStrictMode ?? false;
   if (
     compat?.supportsDeveloperRole !== undefined &&
     compat?.supportsUsageInStreaming !== undefined &&
-    compat?.supportsStrictMode !== undefined
+    compat?.supportsStrictMode !== undefined &&
+    compat?.supportsStore !== undefined
   ) {
     return model;
   }
@@ -84,11 +86,13 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
           supportsUsageInStreaming: forcedUsageStreaming || false,
+          supportsStore: forcedStore || false,
           supportsStrictMode: targetStrictMode,
         }
       : {
           supportsDeveloperRole: false,
           supportsUsageInStreaming: false,
+          supportsStore: false,
           supportsStrictMode: false,
         },
   } as typeof model;


### PR DESCRIPTION
## Summary
- Problem: Google AI's OpenAI-compatible endpoint (`generativelanguage.googleapis.com`) rejects the `store` parameter with a 400 error. The pi-ai SDK defaults `supportsStore` to `true` for providers not in its non-standard list, causing `store: false` to be sent to Google's API.
- Why it matters: All Gemini models fail with a 400 error when using Google AI's OpenAI-compatible API, completely blocking usage.
- What changed: `normalizeModelCompat` now defaults `supportsStore` to `false` for all non-native openai-completions endpoints, consistent with how `supportsDeveloperRole`, `supportsUsageInStreaming`, and `supportsStrictMode` are handled. Users can explicitly opt in with `compat.supportsStore: true`.
- What did NOT change (scope boundary): Native OpenAI endpoints (`api.openai.com`) are unaffected. The `openai-responses` API store handling in `createOpenAIResponsesContextManagementWrapper` is unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #43086

## User-visible / Behavior Changes
Non-native openai-completions endpoints no longer receive `store: false` in API requests by default. This fixes 400 errors for Google AI, and is safe for other providers since omitting `store` is equivalent to `store: false`.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (removes an unsupported parameter from requests)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure `google-ai` provider with `api: "openai-completions"` and `baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai/"`
2. Send a message using any Gemini model
### Expected
- Request succeeds (no `store` parameter in request body)
### Actual
- Request fails with 400: `Unknown name "store": Cannot find field`

## Evidence
- [x] Failing test/log before + passing after
```
 ✓ src/agents/model-compat.test.ts (39 tests) 5ms
   Tests  39 passed (39)
```

## Human Verification
- Verified scenarios: pnpm tsgo + all 39 model-compat tests passing; reviewed diff follows existing pattern for supportsDeveloperRole/supportsUsageInStreaming/supportsStrictMode
- Edge cases checked: Native OpenAI endpoints unaffected; explicit `compat.supportsStore: true` override respected; models without any compat still get supportsStore: false
- What you did NOT verify: runtime end-to-end testing with actual Google AI API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None