### PR TITLE
fix: clarify status bootstrap wording to "bootstrapping" (closes #43527)

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -288,8 +288,8 @@ export async function statusCommand(
   const agentsValue = (() => {
     const pending =
       agentStatus.bootstrapPendingCount > 0
-        ? `${agentStatus.bootstrapPendingCount} bootstrap file${agentStatus.bootstrapPendingCount === 1 ? "" : "s"} present`
-        : "no bootstrap files";
+        ? `${agentStatus.bootstrapPendingCount} bootstrapping`
+        : "0 bootstrapping";
     const def = agentStatus.agents.find((a) => a.id === agentStatus.defaultId);
     const defActive = def?.lastActiveAgeMs != null ? formatTimeAgo(def.lastActiveAgeMs) : "unknown";
     const defSuffix = def ? ` · default ${def.id} active ${defActive}` : "";

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -451,7 +451,7 @@ describe("statusCommand", () => {
       "Memory",
       "Channels",
       "WhatsApp",
-      "bootstrap files",
+      "bootstrapping",
       "Sessions",
       "+1000",
       "50%",


### PR DESCRIPTION
## Summary
- Problem: `openclaw status` displays "no bootstrap files" when `BOOTSTRAP.md` is absent, implying that workspace bootstrap file injection is broken. In reality, standard files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, etc.) are still injected normally; only the one-shot `BOOTSTRAP.md` is absent (expected steady-state).
- Why it matters: Misleads operators into thinking bootstrap injection is missing when the workspace is actually healthy.
- What changed: Changed status wording from "N bootstrap file(s) present" / "no bootstrap files" to "N bootstrapping" / "0 bootstrapping" to accurately describe the count of agents with pending `BOOTSTRAP.md` files. Updated corresponding test assertion.
- What did NOT change (scope boundary): No changes to bootstrap logic, config schema, or `status-all.ts` (which already used correct wording).

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #43527

## User-visible / Behavior Changes
`openclaw status` now shows "0 bootstrapping" instead of "no bootstrap files" for mature workspaces where `BOOTSTRAP.md` is absent (expected state).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run `openclaw status` on a mature workspace where BOOTSTRAP.md is absent
### Expected
- Status shows "0 bootstrapping" (clear that no agents have pending bootstrap)
### Actual
- Previously showed "no bootstrap files" (misleadingly implies bootstrap injection is missing)

## Evidence
- [x] Failing test/log before + passing after
- 11/12 status tests pass (1 pre-existing SecretRef failure unrelated to this change)
- `pnpm tsgo` clean (only pre-existing ui type errors)
- `oxlint` clean

## Human Verification
- Verified scenarios: pnpm tsgo + status tests passing; reviewed diff matches issue description; confirmed `status-all.ts` already uses consistent "bootstrapping" wording
- Edge cases checked: both zero and non-zero bootstrapPendingCount paths updated
- What you did NOT verify: runtime end-to-end testing with actual gateway

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None — cosmetic wording change only.
