### PR TITLE
fix: isHeartbeatEnabledForAgent respects agents.defaults.heartbeat (closes #41879)

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -195,7 +195,7 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("enables all agents when only defaults.heartbeat is configured", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -203,6 +203,16 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("disables all agents when no heartbeat is configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -122,6 +122,10 @@ function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   return list.some((entry) => Boolean(entry?.heartbeat));
 }
 
+function hasDefaultHeartbeat(cfg: OpenClawConfig) {
+  return Boolean(cfg.agents?.defaults?.heartbeat);
+}
+
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
   const list = cfg.agents?.list ?? [];
@@ -131,7 +135,12 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  // When agents.defaults.heartbeat is configured, all agents are enabled.
+  if (hasDefaultHeartbeat(cfg)) {
+    return true;
+  }
+  // No heartbeat configured anywhere — disabled for all agents.
+  return false;
 }
 
 function resolveHeartbeatConfig(
@@ -208,8 +217,16 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       })
       .filter((entry) => entry.agentId);
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
-  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  if (hasDefaultHeartbeat(cfg)) {
+    // Defaults apply to all agents — include every agent in the list plus the default.
+    const agentIds = new Set(list.map((entry) => normalizeAgentId(entry.id)).filter(Boolean));
+    agentIds.add(resolveDefaultAgentId(cfg));
+    return [...agentIds].map((id) => ({
+      agentId: id,
+      heartbeat: resolveHeartbeatConfig(cfg, id),
+    }));
+  }
+  return [];
 }
 
 export function resolveHeartbeatIntervalMs(


### PR DESCRIPTION
## Summary
- Problem: `isHeartbeatEnabledForAgent` in `heartbeat-runner.ts` has two bugs: (1) when `agents.defaults.heartbeat` is configured but no per-agent heartbeat entries exist, only the default agent gets heartbeat instead of all agents; (2) when no heartbeat is configured anywhere, the default agent is implicitly enabled.
- Why it matters: Users who configure `agents.defaults.heartbeat` expecting it to apply to all agents find that only the default agent runs heartbeats. Users with no heartbeat config get unexpected heartbeat activity on the default agent.
- What changed: Fixed `isHeartbeatEnabledForAgent` to return `true` for all agents when `agents.defaults.heartbeat` is set, and `false` for all agents when no heartbeat is configured. Added `hasDefaultHeartbeat()` helper. Updated `resolveHeartbeatAgents` to enumerate all agents when only defaults are set. Updated tests to match corrected behavior.
- What did NOT change (scope boundary): Per-agent heartbeat override logic, heartbeat config resolution, heartbeat scheduling.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #41879

## User-visible / Behavior Changes
- When `agents.defaults.heartbeat` is configured without per-agent overrides, heartbeat now runs for ALL agents (previously only the default agent).
- When no heartbeat is configured anywhere, heartbeat is disabled for ALL agents (previously the default agent was implicitly enabled).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure `agents.defaults.heartbeat: { every: "30m" }` with multiple agents in list, no per-agent heartbeat
2. Check which agents have heartbeat enabled
### Expected
- All agents should have heartbeat enabled (inheriting defaults)
### Actual
- Previously only the default agent had heartbeat enabled

## Evidence
- [x] Failing test/log before + passing after
- All 26 heartbeat-runner tests pass
- All 8 heartbeat scheduler tests pass
- `pnpm tsgo` clean (only pre-existing ui type errors)
- `oxlint` clean

## Human Verification
- Verified scenarios: defaults-only config enables all agents; no-config disables all agents; per-agent config enables only specified agents
- Edge cases checked: empty agents list with defaults; mixed per-agent and defaults
- What you did NOT verify: runtime end-to-end testing with actual heartbeat execution

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (behavior change is intentional bug fix; users relying on the broken behavior may see more heartbeat activity)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
Users who had `agents.defaults.heartbeat` set may see heartbeats running for additional agents. This is the intended behavior per the config schema semantics.
