### PR TITLE
fix: strip -1m suffix from Anthropic model ID before API call (closes #20079)

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -205,7 +205,15 @@ export function lookupContextTokens(modelId?: string): number | undefined {
   }
   // Best-effort: kick off loading, but don't block.
   void ensureContextWindowCacheLoaded();
-  return MODEL_CACHE.get(modelId);
+  const direct = MODEL_CACHE.get(modelId);
+  if (direct !== undefined) {
+    return direct;
+  }
+  // Fallback: strip -1m suffix (Anthropic 1M context convention) and retry
+  if (modelId.endsWith("-1m")) {
+    return MODEL_CACHE.get(modelId.replace(/-1m$/, ""));
+  }
+  return undefined;
 }
 
 if (!shouldSkipEagerContextWindowWarmup()) {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1544,6 +1544,32 @@ describe("applyExtraParamsToAgent", () => {
     expect(headers).toEqual({ "X-Custom": "1" });
   });
 
+  it("strips -1m suffix from model ID when context1m beta is injected", () => {
+    const modelCalls: Array<{ id: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      modelCalls.push({ id: model.id });
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6-1m", { context1m: true });
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-6-1m");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-opus-4-6-1m",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-api03-test", // pragma: allowlist secret
+    });
+
+    expect(modelCalls).toHaveLength(1);
+    expect(modelCalls[0]?.id).toBe("claude-opus-4-6");
+  });
+
   it("forces store=true for direct OpenAI Responses payloads", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -271,11 +271,19 @@ export function createAnthropicBetaHeadersWrapper(
       );
     }
 
+    // Strip the -1m suffix from model IDs before sending to the Anthropic API.
+    // The suffix is an OpenClaw convention for opting into 1M context; the
+    // Anthropic API only accepts the base model name (e.g. "claude-opus-4-6").
+    const effectiveModel =
+      requestedContext1m && model.id.endsWith("-1m")
+        ? ({ ...model, id: model.id.replace(/-1m$/, "") } as typeof model)
+        : model;
+
     const piAiBetas = isOauth
       ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
       : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);
     const allBetas = [...new Set([...piAiBetas, ...effectiveBetas])];
-    return underlying(model, context, {
+    return underlying(effectiveModel, context, {
       ...options,
       headers: mergeAnthropicBetaHeader(options?.headers, allBetas),
     });


### PR DESCRIPTION
## Summary
- Problem: When using Anthropic `-1m` model IDs (e.g. `claude-opus-4-6-1m`), the `-1m` suffix was sent directly to the Anthropic API, causing a 404 error. Additionally, `lookupContextTokens` did not fall back to the base model name for `-1m` variants.
- Why it matters: Users opting into 1M context via the `-1m` naming convention got 404 errors instead of a working session.
- What changed: `createAnthropicBetaHeadersWrapper` now strips the `-1m` suffix from the model ID when the `context1m` beta header is active. `lookupContextTokens` now falls back to the base model name (without `-1m`) when the suffixed variant is not in the cache.
- What did NOT change (scope boundary): No changes to beta header injection, OAuth handling, or non-Anthropic providers.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #20079

## User-visible / Behavior Changes
Anthropic `-1m` model IDs (e.g. `claude-opus-4-6-1m`) now work correctly — the suffix is stripped before sending to the API, and context token lookup falls back to the base model.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure a model with ID `claude-opus-4-6-1m` and `context1m: true`
2. Start a session using that model
### Expected
- API receives `claude-opus-4-6` as model ID; context window resolves to 1M tokens
### Actual
- API receives `claude-opus-4-6-1m` causing 404; context window may not resolve to 1M

## Evidence
- [x] Failing test/log before + passing after
- 80/80 extra-params tests pass (including new `-1m` suffix stripping test)
- 12/12 context lookup tests pass
- `pnpm tsgo` passes (no new errors)

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + pnpm tsgo + vitest all passing; reviewed diff matches issue description
- Edge cases checked: non-1m models unaffected; OAuth path still strips context1m beta; non-opus/sonnet models still reject context1m
- What you did NOT verify: runtime end-to-end testing with actual Anthropic API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None