### PR TITLE
fix: deduplicate tool call IDs within the same assistant message (closes #40897)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -702,6 +702,24 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("call_42");
   });
+
+  it("deduplicates identical tool call IDs within the same message", async () => {
+    const toolCallA = { type: "toolCall", id: "edit:22", name: "edit" };
+    const toolCallB = { type: "toolCall", id: "edit:22", name: "edit" };
+    const finalMessage = { role: "assistant", content: [toolCallA, toolCallB] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    await stream.result();
+
+    expect(toolCallA.id).toBe("edit:22");
+    expect(toolCallB.id).toBe("call_auto_1");
+  });
 });
 
 describe("wrapStreamFnRepairMalformedToolCallArguments", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -650,7 +650,8 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
     return;
   }
 
-  const usedIds = new Set<string>();
+  // First pass: collect all existing non-empty IDs so fallback generation avoids collisions.
+  const existingIds = new Set<string>();
   for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
@@ -663,9 +664,12 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
     if (!trimmedId) {
       continue;
     }
-    usedIds.add(trimmedId);
+    existingIds.add(trimmedId);
   }
 
+  // Second pass: assign IDs. Track which IDs have been claimed so duplicates
+  // within the same message get a unique fallback ID.
+  const assignedIds = new Set<string>();
   let fallbackIndex = 1;
   for (const block of content) {
     if (!block || typeof block !== "object") {
@@ -677,21 +681,22 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
     }
     if (typeof typedBlock.id === "string") {
       const trimmedId = typedBlock.id.trim();
-      if (trimmedId) {
+      if (trimmedId && !assignedIds.has(trimmedId)) {
         if (typedBlock.id !== trimmedId) {
           typedBlock.id = trimmedId;
         }
-        usedIds.add(trimmedId);
+        assignedIds.add(trimmedId);
         continue;
       }
     }
 
+    // Empty, blank, or duplicate ID — generate a unique fallback.
     let fallbackId = "";
-    while (!fallbackId || usedIds.has(fallbackId)) {
+    while (!fallbackId || existingIds.has(fallbackId) || assignedIds.has(fallbackId)) {
       fallbackId = `call_auto_${fallbackIndex++}`;
     }
     typedBlock.id = fallbackId;
-    usedIds.add(fallbackId);
+    assignedIds.add(fallbackId);
   }
 }
 


### PR DESCRIPTION
## Summary
- Problem: When an assistant message contains multiple tool call blocks with the same ID (e.g. two `edit:22` blocks), the duplicate IDs are sent as-is to OpenAI-compatible APIs, triggering HTTP 400 "duplicate tool_call_id" errors.
- Why it matters: Multi-turn tool calling breaks on the second turn when upstream clients generate `toolName:index` format IDs that collide within a single message.
- What changed: `normalizeToolCallIdsInMessage` now tracks which IDs have been claimed during the assignment pass. When a duplicate is encountered, it gets reassigned a unique fallback ID (`call_auto_N`) instead of being passed through.
- What did NOT change (scope boundary): No changes to tool call ID sanitization for cross-turn history, tool name normalization, or the fallback ID format.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #40897

## User-visible / Behavior Changes
Tool calls with duplicate IDs within the same message now get unique fallback IDs, preventing HTTP 400 errors from OpenAI-compatible APIs.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Trigger multiple tool calls in a single turn that result in the same ID (e.g. two `edit:22` blocks)
2. Continue the conversation to the next turn
### Expected
- Each tool call block has a unique ID; API accepts the request
### Actual
- Previously: duplicate IDs sent, API returns 400

## Evidence
- [x] Failing test/log before + passing after
- 65/65 attempt tests pass (including new duplicate ID deduplication test)
- `pnpm tsgo` passes (no new errors)
- `oxlint` passes with 0 warnings/errors

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + pnpm tsgo + vitest all passing; reviewed diff matches issue description
- Edge cases checked: first occurrence keeps original ID; second occurrence gets fallback; empty IDs still get fallback; whitespace trimming still works
- What you did NOT verify: runtime end-to-end testing with actual OpenAI API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None