### PR TITLE
fix: recognize Codex/OpenAI server_error in failover classifier (closes #43591)

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,20 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies Codex/OpenAI server_error JSON as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."}}',
+      ),
+    ).toBe("timeout");
+  });
+
+  it("classifies wrapped Codex server_error as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"Something went wrong"}}',
+      ),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -853,7 +853,15 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // OpenAI Codex / Responses API wraps server errors as:
+  // {"type":"error","error":{"type":"server_error","code":"server_error",...}}
+  if (value.includes('"type":"server_error"') || value.includes('"code":"server_error"')) {
+    return true;
+  }
+  return false;
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary
- Problem: When the OpenAI Codex API returns a `server_error` (HTTP 500), the failover classifier does not recognize the error format (`"type":"server_error"`, `"code":"server_error"`), so no model fallback is triggered. The error is surfaced directly to the user.
- Why it matters: Users with fallback chains configured lose automatic failover for Codex/OpenAI transient server errors, requiring manual `/model` switching.
- What changed: `isJsonApiInternalServerError` now also matches the OpenAI/Codex `server_error` JSON format in addition to the existing Anthropic `api_error` format. Both are classified as `"timeout"` (retryable) which triggers the fallback chain.
- What did NOT change (scope boundary): No changes to other error classifiers, rate limit detection, or the fallback chain logic itself.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #43591

## User-visible / Behavior Changes
Codex/OpenAI `server_error` responses now trigger model fallback instead of being surfaced as unrecoverable errors.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Set default model to `openai-codex/gpt-5.4` with fallbacks
2. Encounter (or simulate) a Codex API `server_error`
### Expected
- Fallback chain is triggered; next model is attempted
### Actual
- Previously: error surfaced to user, no fallback attempted

## Evidence
- [x] Failing test/log before + passing after
- 73/73 billing/failover classifier tests pass (including 2 new Codex server_error tests)
- `pnpm tsgo` passes (no new errors)
- `oxlint` passes with 0 warnings/errors

## Human Verification
- Verified scenarios: pnpm format:fix + oxlint + pnpm tsgo + vitest all passing; reviewed diff matches issue description
- Edge cases checked: Anthropic api_error still classified correctly; wrapped Codex errors (with prefix) also matched
- What you did NOT verify: runtime end-to-end testing with actual Codex API errors

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None