### PR TITLE
fix: strip images from all history turns when model lacks vision support (closes #29290)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2428,9 +2428,11 @@ export async function runEmbeddedAttempt(
           (sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
 
         try {
-          // Idempotent cleanup for legacy sessions with persisted image payloads.
-          // Called each run; only mutates already-answered user turns that still carry image blocks.
-          const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
+          // Strip image blocks from history to prevent poison-turn loops.
+          // When model lacks vision support, strips ALL image turns (#29290).
+          const didPruneImages = pruneProcessedHistoryImages(activeSession.messages, {
+            modelHasVision,
+          });
           if (didPruneImages) {
             activeSession.agent.replaceMessages(activeSession.messages);
           }

--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -2,7 +2,11 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
-import { PRUNED_HISTORY_IMAGE_MARKER, pruneProcessedHistoryImages } from "./history-image-prune.js";
+import {
+  NO_VISION_IMAGE_MARKER,
+  PRUNED_HISTORY_IMAGE_MARKER,
+  pruneProcessedHistoryImages,
+} from "./history-image-prune.js";
 
 describe("pruneProcessedHistoryImages", () => {
   const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
@@ -86,5 +90,48 @@ describe("pruneProcessedHistoryImages", () => {
     expect(didMutate).toBe(false);
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
     expect(firstUser?.content).toBe("noop");
+  });
+
+  it("strips images from ALL turns when modelHasVision is false (no assistant reply)", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "Here is an image" }, { ...image }],
+      }),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages, { modelHasVision: false });
+
+    expect(didMutate).toBe(true);
+    const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const content = firstUser?.content as Array<{ type: string; text?: string }>;
+    expect(content[1]).toMatchObject({ type: "text", text: NO_VISION_IMAGE_MARKER });
+  });
+
+  it("strips images from ALL turns when modelHasVision is false (with assistant reply)", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "image 1" }, { ...image }],
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: "got it",
+      }),
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "image 2" }, { ...image }],
+      }),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages, { modelHasVision: false });
+
+    expect(didMutate).toBe(true);
+    const firstContent = (messages[0] as Extract<AgentMessage, { role: "user" }>)
+      ?.content as Array<{ type: string; text?: string }>;
+    const thirdContent = (messages[2] as Extract<AgentMessage, { role: "user" }>)
+      ?.content as Array<{ type: string; text?: string }>;
+    expect(firstContent[1]).toMatchObject({ type: "text", text: NO_VISION_IMAGE_MARKER });
+    expect(thirdContent[1]).toMatchObject({ type: "text", text: NO_VISION_IMAGE_MARKER });
   });
 });

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -1,25 +1,44 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
+export const NO_VISION_IMAGE_MARKER = "[image data removed - model does not support vision]";
 
 /**
- * Idempotent cleanup for legacy sessions that persisted image blocks in history.
- * Called each run; mutates only user turns that already have an assistant reply.
+ * Idempotent cleanup for sessions that contain image blocks in history.
+ *
+ * When `modelHasVision` is false, strips images from ALL turns to prevent
+ * poison-turn loops where a failed image turn has no assistant reply and
+ * is never pruned by the legacy heuristic (see #29290).
+ *
+ * When `modelHasVision` is true (or omitted), only strips images from
+ * turns before the last assistant reply (legacy behavior).
  */
-export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
-  let lastAssistantIndex = -1;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.role === "assistant") {
-      lastAssistantIndex = i;
-      break;
+export function pruneProcessedHistoryImages(
+  messages: AgentMessage[],
+  options?: { modelHasVision?: boolean },
+): boolean {
+  const modelHasVision = options?.modelHasVision ?? true;
+
+  let upperBound: number;
+  if (modelHasVision) {
+    let lastAssistantIndex = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "assistant") {
+        lastAssistantIndex = i;
+        break;
+      }
     }
-  }
-  if (lastAssistantIndex < 0) {
-    return false;
+    if (lastAssistantIndex < 0) {
+      return false;
+    }
+    upperBound = lastAssistantIndex;
+  } else {
+    upperBound = messages.length;
   }
 
+  const marker = modelHasVision ? PRUNED_HISTORY_IMAGE_MARKER : NO_VISION_IMAGE_MARKER;
   let didMutate = false;
-  for (let i = 0; i < lastAssistantIndex; i++) {
+  for (let i = 0; i < upperBound; i++) {
     const message = messages[i];
     if (
       !message ||
@@ -38,7 +57,7 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
       }
       message.content[j] = {
         type: "text",
-        text: PRUNED_HISTORY_IMAGE_MARKER,
+        text: marker,
       } as (typeof message.content)[number];
       didMutate = true;
     }


### PR DESCRIPTION
## Summary
- Problem: When an image enters the session transcript and the model doesn't support vision, the session enters an unrecoverable error loop. The image causes a 400 error, no assistant reply is saved, and `pruneProcessedHistoryImages` only strips images before the last assistant reply — so the poisoned image turn is never cleaned up.
- Why it matters: Sessions become permanently broken after a single image upload when the model lacks vision support. Only `/new` or `/reset` can recover.
- What changed: `pruneProcessedHistoryImages` now accepts an optional `modelHasVision` parameter. When `false`, it strips images from ALL user/toolResult turns (not just those before the last assistant reply). The call site in `attempt.ts` passes the existing `modelHasVision` flag.
- What did NOT change (scope boundary): Vision-capable model behavior is unchanged. Image detection, prompt injection, and the vision pipeline are untouched.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #29290

## User-visible / Behavior Changes
Sessions with non-vision models no longer enter an unrecoverable error loop when images are present in the transcript. Images are automatically stripped with a `[image data removed - model does not support vision]` marker.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure a model without vision support
2. Upload an image via webchat or receive one from a channel
3. Send a follow-up text message
### Expected
- Image is stripped from transcript, text message processed normally
### Actual
- Previously: session entered permanent 400 error loop

## Evidence
- [x] Failing test/log before + passing after
- All 6 history-image-prune tests pass (4 existing + 2 new)
- `pnpm tsgo` clean (only pre-existing extension type errors)
- `oxlint` clean

## Human Verification
- Verified scenarios: vision model behavior unchanged (existing 4 tests pass); non-vision strips ALL image turns including after last assistant reply
- Edge cases checked: no assistant reply at all + no vision = images still stripped; toolResult image blocks also stripped
- What you did NOT verify: runtime testing with actual non-vision model and image upload

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — default behavior (modelHasVision: true) is unchanged
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None — the new behavior only activates when model explicitly lacks vision. Vision-capable models retain the original pruning behavior.
