### PR TITLE
fix: CJK text chunking breaks at sentence punctuation instead of mid-word (closes #38597)

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -90,6 +90,24 @@ describe("chunkText", () => {
     expect(chunks).toEqual(["Supercalif", "ragilistic", "expialidoc", "ious"]);
   });
 
+  it("breaks CJK text at sentence-ending punctuation instead of mid-character", () => {
+    const text = "這是第一句話。這是第二句話。這是第三句話。";
+    const chunks = chunkText(text, 10);
+    // Should break after 。 (7 chars including punctuation) rather than at hard limit
+    expect(chunks[0]).toBe("這是第一句話。");
+    expect(chunks[1]).toBe("這是第二句話。");
+    expect(chunks[2]).toBe("這是第三句話。");
+  });
+
+  it("prefers whitespace over CJK punctuation when both are available", () => {
+    const text = "Hello world。Goodbye world";
+    const chunks = chunkText(text, 15);
+    // Should break at whitespace, not at 。
+    expect(chunks[0]).toBe("Hello");
+    expect(chunks[1]).toBe("world。Goodbye");
+    expect(chunks[2]).toBe("world");
+  });
+
   runChunkCases(chunkText, [parentheticalCases[0]]);
 });
 

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -306,9 +306,14 @@ export function chunkText(text: string, limit: number): string[] {
   }
   return chunkTextByBreakResolver(text, limit, (window) => {
     // 1) Prefer a newline break inside the window (outside parentheses).
-    const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(window, 0, window.length);
+    const { lastNewline, lastWhitespace, lastCjkBreak } = scanParenAwareBreakpoints(
+      window,
+      0,
+      window.length,
+    );
     // 2) Otherwise prefer the last whitespace (word boundary) inside the window.
-    return lastNewline > 0 ? lastNewline : lastWhitespace;
+    // 3) For CJK text without whitespace, break at sentence-ending punctuation.
+    return lastNewline > 0 ? lastNewline : lastWhitespace > 0 ? lastWhitespace : lastCjkBreak;
   });
 }
 
@@ -426,8 +431,11 @@ function pickSafeBreakIndex(
   end: number,
   spans: ReturnType<typeof parseFenceSpans>,
 ): number {
-  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(text, start, end, (index) =>
-    isSafeFenceBreak(spans, index),
+  const { lastNewline, lastWhitespace, lastCjkBreak } = scanParenAwareBreakpoints(
+    text,
+    start,
+    end,
+    (index) => isSafeFenceBreak(spans, index),
   );
 
   if (lastNewline > start) {
@@ -436,17 +444,24 @@ function pickSafeBreakIndex(
   if (lastWhitespace > start) {
     return lastWhitespace;
   }
+  if (lastCjkBreak > start) {
+    return lastCjkBreak;
+  }
   return -1;
 }
+
+/** CJK sentence-ending punctuation suitable as chunk break points. */
+const CJK_BREAK_PUNCTUATION = /[。！？；]/;
 
 function scanParenAwareBreakpoints(
   text: string,
   start: number,
   end: number,
   isAllowed: (index: number) => boolean = () => true,
-): { lastNewline: number; lastWhitespace: number } {
+): { lastNewline: number; lastWhitespace: number; lastCjkBreak: number } {
   let lastNewline = -1;
   let lastWhitespace = -1;
+  let lastCjkBreak = -1;
   let depth = 0;
 
   for (let i = start; i < end; i++) {
@@ -470,7 +485,11 @@ function scanParenAwareBreakpoints(
     } else if (/\s/.test(char)) {
       lastWhitespace = i;
     }
+    if (CJK_BREAK_PUNCTUATION.test(char)) {
+      // Break AFTER the punctuation mark so it stays with its sentence.
+      lastCjkBreak = i + 1;
+    }
   }
 
-  return { lastNewline, lastWhitespace };
+  return { lastNewline, lastWhitespace, lastCjkBreak };
 }


### PR DESCRIPTION
## Summary
- Problem: CJK text (Chinese, Japanese, Korean) with no word-separating spaces gets split at arbitrary character positions when exceeding the chunk limit (e.g. Discord 2000-char boundary), producing broken mid-word splits.
- Why it matters: Affects all channels with text chunk limits when the response is in CJK. Discord, Telegram, Slack, etc. all produce unreadable split messages.
- What changed: Added CJK sentence-ending punctuation (。！？；) as a third-priority break point in `scanParenAwareBreakpoints`. Both `chunkText` and `pickSafeBreakIndex` (markdown chunker) now use CJK breaks when no whitespace or newline is available.
- What did NOT change (scope boundary): Break priority (newline > whitespace) is unchanged. English/Latin text behavior is identical. Only CJK text without spaces benefits from the new break detection.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #38597

## User-visible / Behavior Changes
CJK responses that exceed channel text limits (e.g. Discord 2000-char) are now split at sentence-ending punctuation (。！？；) instead of at arbitrary character positions.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Send a prompt that generates a long CJK response (>2000 chars)
2. Observe the split messages in Discord/Telegram/etc.
### Expected
- Messages split at sentence boundaries (after 。or ！)
### Actual
- Previously split at arbitrary character positions (mid-word)

## Evidence
- [x] Failing test/log before + passing after
- All 33 chunk tests pass (31 existing + 2 new CJK tests)
- `pnpm tsgo` clean
- `oxlint` clean

## Human Verification
- Verified scenarios: CJK-only text splits at 。; mixed CJK/Latin prefers whitespace; existing English text unchanged
- Edge cases checked: text with no CJK punctuation still hard-breaks at limit; ！？； also work as break points
- What you did NOT verify: runtime testing with actual Discord channel and CJK response

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — existing break behavior unchanged for Latin text
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
The CJK punctuation regex is conservative (sentence-enders only). Comma (，) and colon (：) are deliberately excluded to avoid splitting at clause boundaries within a sentence.
