### PR TITLE
fix: strip empty thinkingSignature from Bedrock thinking blocks to prevent session errors (closes #45010)

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -8,6 +8,7 @@ import {
   sanitizeUserFacingText,
   stripThoughtSignatures,
 } from "./pi-embedded-helpers.js";
+import { stripEmptyThinkingSignatures } from "./pi-embedded-helpers/bootstrap.js";
 
 describe("sanitizeUserFacingText", () => {
   it("strips final tags", () => {
@@ -449,5 +450,47 @@ describe("isMessagingToolDuplicate", () => {
     },
   ])("returns $expected for duplicate check", ({ input, sentTexts, expected }) => {
     expect(isMessagingToolDuplicate(input, sentTexts)).toBe(expected);
+  });
+});
+
+describe("stripEmptyThinkingSignatures", () => {
+  it("strips empty thinkingSignature from thinking blocks", () => {
+    const input = [
+      { type: "thinking", thinking: "reasoning text", thinkingSignature: "" },
+      { type: "text", text: "hello" },
+    ];
+    const result = stripEmptyThinkingSignatures(input);
+    expect(result[0]).toEqual({ type: "thinking", thinking: "reasoning text" });
+    expect(result[1]).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("preserves valid thinkingSignature", () => {
+    const input = [
+      {
+        type: "thinking",
+        thinking: "reasoning text",
+        thinkingSignature: "dGhpcyBpcyBhIHZhbGlkIHNpZ25hdHVyZQ==",
+      },
+    ];
+    const result = stripEmptyThinkingSignatures(input);
+    expect(result[0]).toEqual(input[0]);
+  });
+
+  it("strips whitespace-only thinkingSignature", () => {
+    const input = [{ type: "thinking", thinking: "text", thinkingSignature: "   " }];
+    const result = stripEmptyThinkingSignatures(input);
+    expect(result[0]).toEqual({ type: "thinking", thinking: "text" });
+  });
+
+  it("returns non-array input unchanged", () => {
+    expect(stripEmptyThinkingSignatures("hello")).toBe("hello");
+    expect(stripEmptyThinkingSignatures(null)).toBe(null);
+    expect(stripEmptyThinkingSignatures(undefined)).toBe(undefined);
+  });
+
+  it("does not strip thinkingSignature from non-thinking blocks", () => {
+    const input = [{ type: "text", text: "hi", thinkingSignature: "" }];
+    const result = stripEmptyThinkingSignatures(input);
+    expect(result[0]).toEqual(input[0]);
   });
 });

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -82,6 +82,35 @@ export function stripThoughtSignatures<T>(
   }) as T;
 }
 
+/**
+ * Strip empty `thinkingSignature` fields from thinking content blocks.
+ * Bedrock may return `thinkingSignature: ""` which passes through the
+ * preserve-signatures path but later causes "Invalid signature in thinking
+ * block" errors when the history is replayed to the API.
+ */
+export function stripEmptyThinkingSignatures<T>(content: T): T {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  return content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    const rec = block as Record<string, unknown>;
+    if (
+      rec.type === "thinking" &&
+      "thinkingSignature" in rec &&
+      typeof rec.thinkingSignature === "string" &&
+      rec.thinkingSignature.trim().length === 0
+    ) {
+      const next = { ...rec };
+      delete next.thinkingSignature;
+      return next;
+    }
+    return block;
+  }) as T;
+}
+
 export const DEFAULT_BOOTSTRAP_MAX_CHARS = 20_000;
 export const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 150_000;
 export const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "once";

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -3,7 +3,7 @@ import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { ToolCallIdMode } from "../tool-call-id.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
 import { sanitizeContentBlocksImages } from "../tool-images.js";
-import { stripThoughtSignatures } from "./bootstrap.js";
+import { stripEmptyThinkingSignatures, stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 
@@ -122,7 +122,7 @@ export async function sanitizeSessionMessagesImages(
           continue;
         }
         const strippedContent = options?.preserveSignatures
-          ? content // Keep signatures for Antigravity Claude
+          ? stripEmptyThinkingSignatures(content) // Preserve valid signatures but strip empty ones
           : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures); // Strip for Gemini
 
         const filteredContent = strippedContent.filter((block) => {


### PR DESCRIPTION
## Summary
- Problem: Bedrock `bedrock-converse-stream` API occasionally returns thinking blocks with `thinkingSignature: ""` (empty string). OpenClaw persists this to the session transcript without validation. On subsequent turns when the history is replayed, the Anthropic API rejects the empty signature with "Invalid signature in thinking block", making the session unusable until `/reset`.
- Why it matters: Long-lived sessions become permanently broken, requiring manual `/reset` which loses all conversation context. Affects users multiple times per week.
- What changed: Added `stripEmptyThinkingSignatures()` in bootstrap.ts that removes empty/whitespace-only `thinkingSignature` fields from thinking content blocks. Applied in `sanitizeSessionMessagesImages()` even when `preserveSignatures` is true (Bedrock/Anthropic path), so valid signatures are preserved but empty ones are stripped before replay.
- What did NOT change (scope boundary): Model discovery, Bedrock API streaming, session persistence format, non-thinking content blocks

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue/PR
- Closes #45010

## User-visible / Behavior Changes
Sessions using Claude models via Bedrock with extended thinking will no longer hit "Invalid signature in thinking block" errors from empty signatures. Valid thinking signatures continue to be preserved.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Use Claude model with extended thinking via Bedrock
2. In long conversations (50+ turns), Bedrock occasionally returns `thinkingSignature: ""`
3. On next turn, API rejects with "Invalid signature in thinking block"
### Expected
- Empty signatures are stripped during sanitization; session continues working
### Actual (before fix)
- Empty signatures are persisted and replayed, causing unrecoverable session errors

## Evidence
- [x] Failing test/log before + passing after
- 66/66 sanitize tests passed including 5 new tests for `stripEmptyThinkingSignatures`

## Human Verification
- Verified scenarios: pnpm tsgo passing (only pre-existing errors in twitch/ui); all related tests passing
- Edge cases checked: empty string, whitespace-only, valid signature preservation, non-thinking blocks with thinkingSignature, non-array input
- What you did NOT verify: runtime end-to-end testing with actual Bedrock service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None