### PR TITLE
test(tts): add resolveModelAsync mock to fix 6 failing tests

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -36,6 +36,21 @@ vi.mock("../agents/pi-embedded-runner/model.js", () => ({
     authStorage: { profiles: {} },
     modelRegistry: { find: vi.fn() },
   })),
+  resolveModelAsync: vi.fn(async (provider: string, modelId: string) => ({
+    model: {
+      provider,
+      id: modelId,
+      name: modelId,
+      api: "openai-completions",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    },
+    authStorage: { profiles: {} },
+    modelRegistry: { find: vi.fn() },
+  })),
 }));
 
 vi.mock("../agents/model-auth.js", () => ({


### PR DESCRIPTION
## Summary

Fixes #47145

The `tts-core.ts` module was updated in #45824 to use `resolveModelAsync` instead of `resolveModel`, but the test mock in `tts.test.ts` was not updated.

This caused 6 tests in the `summarizeText` describe block to fail with:

```
Error: [vitest] No "resolveModelAsync" export is defined on the
"../agents/pi-embedded-runner/model.js" mock.
```

## Changes

Added `resolveModelAsync` to the mock in `tts.test.ts` with the same return structure as `resolveModel`.

## Testing

All 6 failing tests should now pass. CI will verify.
