### PR TITLE
fix: respect auth.order when selecting implicit Copilot provider profile (closes #46031)

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -6,12 +6,17 @@ import {
 } from "../providers/github-copilot-token.js";
 import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
-import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
 import {
   buildCloudflareAiGatewayModelDefinition,
   resolveCloudflareAiGatewayBaseUrl,
 } from "./cloudflare-ai-gateway.js";
+import { findNormalizedProviderValue } from "./model-selection.js";
 import {
   buildHuggingfaceProvider,
   buildKilocodeProviderWithDiscovery,
@@ -879,6 +884,7 @@ export async function resolveImplicitProviders(
   if (!providers["github-copilot"]) {
     const implicitCopilot = await resolveImplicitCopilotProvider({
       agentDir: params.agentDir,
+      config: params.config,
       env,
     });
     if (implicitCopilot) {
@@ -910,6 +916,7 @@ export async function resolveImplicitProviders(
 
 export async function resolveImplicitCopilotProvider(params: {
   agentDir: string;
+  config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<ProviderConfig | null> {
   const env = params.env ?? process.env;
@@ -926,9 +933,20 @@ export async function resolveImplicitCopilotProvider(params: {
 
   let selectedGithubToken = githubToken;
   if (!selectedGithubToken && hasProfile) {
-    // Use the first available profile as a default for discovery (it will be
-    // re-resolved per-run by the embedded runner).
-    const profileId = listProfilesForProvider(authStore, "github-copilot")[0];
+    // Respect auth.order when selecting the default Copilot profile instead of
+    // blindly taking the first entry from the store (#46031).
+    // Only use ordered selection when auth.order is explicitly configured to
+    // avoid changing the insertion-order default for users without auth.order.
+    const hasExplicitOrder =
+      !!findNormalizedProviderValue(authStore.order, "github-copilot") ||
+      !!findNormalizedProviderValue(params.config?.auth?.order, "github-copilot");
+    const profileId = hasExplicitOrder
+      ? (resolveAuthProfileOrder({
+          cfg: params.config,
+          store: authStore,
+          provider: "github-copilot",
+        })[0] ?? listProfilesForProvider(authStore, "github-copilot")[0])
+      : listProfilesForProvider(authStore, "github-copilot")[0];
     const profile = profileId ? authStore.profiles[profileId] : undefined;
     if (profile && profile.type === "token") {
       selectedGithubToken = profile.token?.trim() ?? "";


### PR DESCRIPTION
## Summary
- Problem: `auth.order` configuration is ignored when selecting the active GitHub Copilot auth profile. `resolveImplicitCopilotProvider` always uses `listProfilesForProvider(...)[0]` which returns profiles in JSON key insertion order, regardless of `auth.order` settings.
- Why it matters: Users with multiple Copilot tokens (e.g. for quota management) cannot reliably control which profile is used via config. Hot restart (`SIGUSR1`) resets JSON key order, making even the insertion-order workaround unreliable.
- What changed: Updated `resolveImplicitCopilotProvider` to accept `config` parameter and use `resolveAuthProfileOrder()` instead of directly taking `[0]` from `listProfilesForProvider()`. Falls back to the old behavior if `resolveAuthProfileOrder` returns empty.
- What did NOT change (scope boundary): Auth profile storage format, profile resolution at runtime (embedded runner already re-resolves per-run), other implicit provider discovery

## Change Type
- [x] Bug fix

## Scope
- [x] Auth / tokens

## Linked Issue/PR
- Closes #46031

## User-visible / Behavior Changes
`auth.order["github-copilot"]` in `openclaw.json` now controls which Copilot profile is used for API discovery at startup. Previously only JSON key insertion order in `auth-profiles.json` was used.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No — same profile resolution logic, just respecting config order
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure multiple Copilot profiles in `auth.profiles`
2. Set `auth.order["github-copilot"] = ["github-copilot:backup2"]`
3. Restart gateway
### Expected
- `backup2` profile used for API discovery
### Actual (before fix)
- First profile in `auth.profiles` object always used

## Evidence
- [x] Failing test/log before + passing after
- pnpm tsgo passing (only pre-existing errors in twitch/ui); auth profile order tests passing

## Human Verification
- Verified scenarios: pnpm tsgo passing; auth-profiles order tests passing (4/4)
- Edge cases checked: empty order returns fallback to listProfilesForProvider; config undefined still works
- What you did NOT verify: runtime end-to-end testing with multiple Copilot profiles

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes — when no auth.order is configured, behavior is unchanged (falls back to listProfilesForProvider)
- Config/env changes? No new config, existing auth.order now respected
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None