### PR TITLE
fix: preserve workspace skill source in Control Panel status

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -171,7 +171,6 @@ function buildSkillStatus(
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
-  bundledNames?: Set<string>,
 ): SkillStatusEntry {
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
@@ -186,10 +185,7 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const bundled =
-    bundledNames && bundledNames.size > 0
-      ? bundledNames.has(entry.skill.name)
-      : entry.skill.source === "openclaw-bundled";
+  const bundled = entry.skill.source === "openclaw-bundled";
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
@@ -247,7 +243,7 @@ export function buildWorkspaceSkillStatus(
     workspaceDir,
     managedSkillsDir,
     skills: skillEntries.map((entry) =>
-      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility, bundledContext.names),
+      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility),
     ),
   };
 }

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -108,6 +108,22 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.bundled).toBe(true);
   });
 
+  it("does not mark workspace overrides as bundled when names collide", async () => {
+    const entry = makeEntry({
+      name: "video-frames",
+      source: "openclaw-workspace",
+    });
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", {
+      entries: [entry],
+    });
+    const skill = report.skills.find((reportEntry) => reportEntry.name === "video-frames");
+
+    expect(skill).toBeDefined();
+    expect(skill?.source).toBe("openclaw-workspace");
+    expect(skill?.bundled).toBe(false);
+  });
+
   it("filters install options by OS", async () => {
     const entry = makeEntry({
       name: "install-skill",


### PR DESCRIPTION
## Summary\n- stop marking skills as bundled based only on name collisions with bundled skills\n- rely on the resolved skill source so workspace overrides keep their workspace origin in Control Panel\n- add a regression test for workspace skills that share a name with a bundled skill\n\n## Testing\n- pnpm exec vitest run src/agents/skills.buildworkspaceskillstatus.test.ts\n\nCloses #47139