### PR TITLE
feat: add Azure Claude (AI Foundry) onboarding path

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -186,7 +186,43 @@ Note: Anthropic currently rejects `context-1m-*` beta requests when using
 OAuth/subscription tokens (`sk-ant-oat-*`). OpenClaw automatically skips the
 context1m beta header for OAuth auth and keeps the required OAuth betas.
 
-## Option B: Claude setup-token
+## Option B: Azure Claude (Azure AI Foundry)
+
+**Best for:** running Claude Sonnet/Opus deployments that live behind Azure AI Foundry.
+
+During onboarding pick **Azure Claude (AI Foundry)** when the auth screen appears, then provide:
+
+1. **Resource name or base URL** – either the bare resource (`fabric-hub`) or the full
+   `https://fabric-hub.services.ai.azure.com/anthropic` endpoint.
+2. **Default deployment** – choose one of the pre-populated IDs (`claude-sonnet-4-6`,
+   `claude-opus-4-6`) or enter any custom deployment you created in AI Studio.
+3. **API key** – paste `ANTHROPIC_FOUNDRY_API_KEY` / `AZURE_CLAUDE_API_KEY` from the
+   Azure portal (AI Foundry → Claude connection → _Keys & Endpoint_).
+
+### Azure CLI setup
+
+```bash
+# Interactive
+openclaw onboard --auth-choice anthropic-azure-api-key
+
+# Non-interactive example
+openclaw onboard --non-interactive --accept-risk \
+  --auth-choice anthropic-azure-api-key \
+  --anthropic-azure-base-url fabric-hub \
+  --anthropic-azure-model-id claude-sonnet-4-6 \
+  --anthropic-azure-api-key "$ANTHROPIC_FOUNDRY_API_KEY"
+```
+
+Supported env vars (picked up automatically when set):
+
+- `ANTHROPIC_FOUNDRY_BASE_URL` / `AZURE_CLAUDE_BASE_URL`
+- `ANTHROPIC_FOUNDRY_RESOURCE` / `AZURE_CLAUDE_RESOURCE`
+- `ANTHROPIC_FOUNDRY_API_KEY` / `AZURE_CLAUDE_API_KEY`
+
+OpenClaw stores the base URL, resource, and deployment metadata with the
+`anthropic-azure:default` auth profile so future doctor runs can surface it.
+
+## Option C: Claude setup-token
 
 **Best for:** using your Claude subscription.
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -106,6 +106,15 @@ export function registerOnboardCommand(program: Command) {
   }
 
   command
+    .option("--anthropic-azure-api-key <key>", "Azure Claude API key (AI Foundry)")
+    .option(
+      "--anthropic-azure-base-url <resource-or-url>",
+      "Azure AI Foundry resource name or full base URL (https://<resource>.services.ai.azure.com/anthropic)",
+    )
+    .option(
+      "--anthropic-azure-model-id <deployment>",
+      "Azure Claude deployment/model ID (default: claude-sonnet-4-6)",
+    )
     .option("--custom-base-url <url>", "Custom provider base URL")
     .option("--custom-api-key <key>", "Custom provider API key (optional)")
     .option("--custom-model-id <id>", "Custom provider model ID")
@@ -163,6 +172,9 @@ export function registerOnboardCommand(program: Command) {
           tokenExpiresIn: opts.tokenExpiresIn as string | undefined,
           secretInputMode: opts.secretInputMode as SecretInputMode | undefined,
           ...providerAuthOptionValues,
+          anthropicAzureApiKey: opts.anthropicAzureApiKey as string | undefined,
+          anthropicAzureBaseUrl: opts.anthropicAzureBaseUrl as string | undefined,
+          anthropicAzureModelId: opts.anthropicAzureModelId as string | undefined,
           cloudflareAiGatewayAccountId: opts.cloudflareAiGatewayAccountId as string | undefined,
           cloudflareAiGatewayGatewayId: opts.cloudflareAiGatewayGatewayId as string | undefined,
           customBaseUrl: opts.customBaseUrl as string | undefined,

--- a/src/commands/anthropic-azure-utils.test.ts
+++ b/src/commands/anthropic-azure-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+  buildAnthropicAzureModelDefinition,
+  normalizeAnthropicAzureBaseUrl,
+  resolveAnthropicAzureBaseUrlFromEnv,
+  resolveAnthropicAzureResourceName,
+} from "./anthropic-azure-utils.js";
+
+describe("anthropic-azure-utils", () => {
+  it("normalizes resource names into Azure base URLs", () => {
+    expect(normalizeAnthropicAzureBaseUrl("Fabric-Hub")).toBe(
+      "https://fabric-hub.services.ai.azure.com/anthropic",
+    );
+  });
+
+  it("rejects resource names with invalid characters instead of silently stripping", () => {
+    expect(() => normalizeAnthropicAzureBaseUrl("fabric_hub")).toThrow(
+      /contains invalid characters/,
+    );
+    expect(() => normalizeAnthropicAzureBaseUrl("my resource")).toThrow(
+      /contains invalid characters/,
+    );
+  });
+
+  it("normalizes existing base URLs and enforces suffix", () => {
+    expect(
+      normalizeAnthropicAzureBaseUrl("https://fabric-hub.services.ai.azure.com/anthropic/"),
+    ).toBe("https://fabric-hub.services.ai.azure.com/anthropic");
+  });
+
+  it("derives resource name from normalized URL", () => {
+    expect(
+      resolveAnthropicAzureResourceName("https://fabric-hub.services.ai.azure.com/anthropic"),
+    ).toBe("fabric-hub");
+  });
+
+  it("resolves env vars preferring base URLs over resources", () => {
+    const env = {
+      ANTHROPIC_FOUNDRY_BASE_URL: "https://env-base.services.ai.azure.com/anthropic",
+      ANTHROPIC_FOUNDRY_RESOURCE: "ignored-resource",
+    } as NodeJS.ProcessEnv;
+    expect(resolveAnthropicAzureBaseUrlFromEnv(env)).toBe(
+      "https://env-base.services.ai.azure.com/anthropic",
+    );
+  });
+
+  it("falls back to resource env vars when no base URL provided", () => {
+    const env = {
+      ANTHROPIC_FOUNDRY_RESOURCE: "fallback-resource",
+    } as NodeJS.ProcessEnv;
+    expect(resolveAnthropicAzureBaseUrlFromEnv(env)).toBe(
+      "https://fallback-resource.services.ai.azure.com/anthropic",
+    );
+  });
+
+  it("builds model definitions with defaults", () => {
+    const model = buildAnthropicAzureModelDefinition({ id: DEFAULT_ANTHROPIC_AZURE_MODEL_ID });
+    expect(model.id).toBe(DEFAULT_ANTHROPIC_AZURE_MODEL_ID);
+    expect(model.input).toContain("text");
+  });
+});

--- a/src/commands/anthropic-azure-utils.ts
+++ b/src/commands/anthropic-azure-utils.ts
@@ -1,0 +1,120 @@
+import { URL } from "node:url";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+
+export const ANTHROPIC_AZURE_HOST_SUFFIX = ".services.ai.azure.com";
+export const ANTHROPIC_AZURE_API_SUFFIX = "/anthropic";
+
+export const DEFAULT_ANTHROPIC_AZURE_MODEL_ID = "claude-sonnet-4-6";
+
+export const ANTHROPIC_AZURE_MODEL_CHOICES = [
+  { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 (default)" },
+  { value: "claude-opus-4-6", label: "Claude Opus 4.6" },
+] as const;
+
+const ANTHROPIC_AZURE_DEFAULT_CONTEXT_WINDOW = 200_000;
+const ANTHROPIC_AZURE_DEFAULT_MAX_TOKENS = 16_384;
+const ANTHROPIC_AZURE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export function buildAnthropicAzureModelDefinition(params: {
+  id: string;
+  label?: string;
+}): ModelDefinitionConfig {
+  return {
+    id: params.id,
+    name: params.label ?? params.id,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: ANTHROPIC_AZURE_DEFAULT_COST,
+    contextWindow: ANTHROPIC_AZURE_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: ANTHROPIC_AZURE_DEFAULT_MAX_TOKENS,
+  };
+}
+
+function ensureHttpsUrl(candidate: string): URL {
+  try {
+    return new URL(candidate);
+  } catch (error) {
+    throw new Error(`Invalid Azure Claude URL: ${String(error)}`, { cause: error });
+  }
+}
+
+export function normalizeAnthropicAzureBaseUrl(resourceOrUrl: string): string {
+  const raw = String(resourceOrUrl ?? "").trim();
+  if (!raw) {
+    throw new Error("Azure Claude resource name or URL is required.");
+  }
+  if (/^https?:\/\//i.test(raw)) {
+    const url = ensureHttpsUrl(raw);
+    if (!url.hostname.toLowerCase().endsWith(ANTHROPIC_AZURE_HOST_SUFFIX)) {
+      throw new Error(
+        `Azure Claude endpoint host must end with "${ANTHROPIC_AZURE_HOST_SUFFIX}". Received ${url.hostname}.`,
+      );
+    }
+    const normalizedHost = url.hostname.toLowerCase();
+    const basePath = url.pathname.replace(/\/+$/, "");
+    const normalizedPath = basePath.endsWith(ANTHROPIC_AZURE_API_SUFFIX)
+      ? basePath
+      : `${basePath}${ANTHROPIC_AZURE_API_SUFFIX}`;
+    const finalPath = normalizedPath || ANTHROPIC_AZURE_API_SUFFIX;
+    return `https://${normalizedHost}${finalPath}`;
+  }
+  const normalizedResource = raw.toLowerCase();
+  if (/[^a-z0-9-]/.test(normalizedResource)) {
+    throw new Error(
+      `Azure Claude resource name "${raw}" contains invalid characters. ` +
+        "Only lowercase letters, numbers, and hyphens are allowed (e.g. fabric-hub).",
+    );
+  }
+  if (!normalizedResource) {
+    throw new Error("Azure Claude resource name must contain alphanumeric characters or hyphens.");
+  }
+  return `https://${normalizedResource}${ANTHROPIC_AZURE_HOST_SUFFIX}${ANTHROPIC_AZURE_API_SUFFIX}`;
+}
+
+export function resolveAnthropicAzureResourceName(
+  baseUrl: string | null | undefined,
+): string | undefined {
+  if (!baseUrl) {
+    return undefined;
+  }
+  try {
+    const url = ensureHttpsUrl(baseUrl);
+    const host = url.hostname.toLowerCase();
+    if (!host.endsWith(ANTHROPIC_AZURE_HOST_SUFFIX)) {
+      return undefined;
+    }
+    const resource = host.slice(0, -ANTHROPIC_AZURE_HOST_SUFFIX.length);
+    return resource || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveAnthropicAzureBaseUrlFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const baseUrlCandidates = [env.ANTHROPIC_FOUNDRY_BASE_URL, env.AZURE_CLAUDE_BASE_URL];
+  for (const candidate of baseUrlCandidates) {
+    if (candidate && candidate.trim()) {
+      try {
+        return normalizeAnthropicAzureBaseUrl(candidate);
+      } catch {
+        // fall through to resources if URL invalid
+      }
+    }
+  }
+  const resourceCandidates = [env.ANTHROPIC_FOUNDRY_RESOURCE, env.AZURE_CLAUDE_RESOURCE];
+  for (const candidate of resourceCandidates) {
+    if (candidate && candidate.trim()) {
+      try {
+        return normalizeAnthropicAzureBaseUrl(candidate);
+      } catch {
+        // ignore invalid resources, try next
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/commands/auth-choice-options.static.ts
+++ b/src/commands/auth-choice-options.static.ts
@@ -21,6 +21,14 @@ export type AuthChoiceGroup = {
 
 export const CORE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   {
+    value: "anthropic-azure-api-key",
+    label: "Azure Claude (AI Foundry)",
+    hint: "Azure AI Foundry resource + Claude API key",
+    groupId: "anthropic",
+    groupLabel: "Anthropic",
+    groupHint: "setup-token + API key",
+  },
+  {
     value: "chutes",
     label: "Chutes (OAuth)",
     groupId: "chutes",

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -194,6 +194,7 @@ describe("buildAuthChoiceOptions", () => {
     for (const value of [
       "github-copilot",
       "token",
+      "anthropic-azure-api-key",
       "zai-api-key",
       "xiaomi-api-key",
       "minimax-global-api",

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -1,15 +1,24 @@
 import { resolveManifestProviderApiKeyChoice } from "../plugins/provider-auth-choices.js";
+import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key.js";
 import {
   createAuthChoiceDefaultModelApplierForMutableState,
+  ensureApiKeyFromOptionEnvOrPrompt,
   normalizeSecretInputModeInput,
   normalizeTokenProviderInput,
 } from "./auth-choice.apply-helpers.js";
 import { applyLiteLlmApiKeyProvider } from "./auth-choice.apply.api-key-providers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
+import {
+  applyAnthropicAzureProviderConfig,
+  applyAuthProfileConfig,
+  setAnthropicAzureApiKey,
+} from "./onboard-auth.js";
 import type { AuthChoice } from "./onboard-types.js";
 
 const CORE_API_KEY_TOKEN_PROVIDER_AUTH_CHOICES: Partial<Record<string, AuthChoice>> = {
   litellm: "litellm-api-key",
+  "anthropic-azure": "anthropic-azure-api-key",
 };
 
 export function normalizeApiKeyTokenProviderAuthChoice(params: {
@@ -73,6 +82,139 @@ export async function applyAuthChoiceApiProviders(
   });
   if (litellmResult) {
     return litellmResult;
+  }
+
+  if (authChoice === "anthropic-azure-api-key") {
+    const {
+      ANTHROPIC_AZURE_MODEL_CHOICES,
+      DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+      normalizeAnthropicAzureBaseUrl,
+      resolveAnthropicAzureBaseUrlFromEnv,
+      resolveAnthropicAzureResourceName,
+    } = await import("./anthropic-azure-utils.js");
+    const baseUrlCandidate = params.opts?.anthropicAzureBaseUrl?.trim();
+    const envBaseUrl = resolveAnthropicAzureBaseUrlFromEnv(process.env);
+
+    const formatUnknownError = (error: unknown): string => {
+      if (error instanceof Error) {
+        return error.message;
+      }
+      if (typeof error === "string") {
+        return error;
+      }
+      try {
+        return JSON.stringify(error);
+      } catch {
+        return String(error);
+      }
+    };
+
+    const resolveOrPromptBaseUrl = async (): Promise<string> => {
+      if (baseUrlCandidate) {
+        return normalizeAnthropicAzureBaseUrl(baseUrlCandidate);
+      }
+      if (envBaseUrl) {
+        return envBaseUrl;
+      }
+      const baseUrlRaw = await params.prompter.text({
+        message: "Azure Claude resource name or base URL",
+        placeholder: "fabric-hub or https://fabric-hub.services.ai.azure.com/anthropic",
+        validate: (value) => {
+          try {
+            normalizeAnthropicAzureBaseUrl(String(value ?? ""));
+            return undefined;
+          } catch (error) {
+            return formatUnknownError(error);
+          }
+        },
+      });
+      return normalizeAnthropicAzureBaseUrl(String(baseUrlRaw ?? ""));
+    };
+
+    const normalizedBaseUrl = await resolveOrPromptBaseUrl();
+
+    const resolveModelId = async (): Promise<string> => {
+      const provided = params.opts?.anthropicAzureModelId?.trim();
+      if (provided) {
+        return provided;
+      }
+      if (typeof params.prompter.select === "function") {
+        const options = [
+          ...ANTHROPIC_AZURE_MODEL_CHOICES.map((choice) => ({
+            value: choice.value,
+            label: choice.label,
+          })),
+          { value: "__custom__", label: "Custom deployment ID" },
+        ];
+        const selection = await params.prompter.select<string>({
+          message: "Default Azure Claude deployment",
+          initialValue: DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+          options,
+        });
+        if (selection === "__custom__") {
+          const customId = await params.prompter.text({
+            message: "Enter Azure Claude deployment ID",
+            placeholder: "claude-sonnet-4-6",
+          });
+          const normalized = String(customId ?? "").trim();
+          return normalized || DEFAULT_ANTHROPIC_AZURE_MODEL_ID;
+        }
+        return selection?.trim() || DEFAULT_ANTHROPIC_AZURE_MODEL_ID;
+      }
+      return DEFAULT_ANTHROPIC_AZURE_MODEL_ID;
+    };
+
+    const resolvedModelId = await resolveModelId();
+    const resource = resolveAnthropicAzureResourceName(normalizedBaseUrl);
+
+    const metadata = {
+      baseUrl: normalizedBaseUrl,
+      modelId: resolvedModelId,
+      ...(resource ? { resource } : {}),
+    };
+
+    await ensureApiKeyFromOptionEnvOrPrompt({
+      token: params.opts?.anthropicAzureApiKey,
+      tokenProvider: params.opts?.tokenProvider ?? "anthropic-azure",
+      secretInputMode: requestedSecretInputMode,
+      config: nextConfig,
+      expectedProviders: ["anthropic-azure"],
+      provider: "anthropic-azure",
+      envLabel: "ANTHROPIC_FOUNDRY_API_KEY / AZURE_CLAUDE_API_KEY",
+      promptMessage: "Enter Azure Claude API key",
+      normalize: normalizeApiKeyInput,
+      validate: validateApiKeyInput,
+      prompter: params.prompter,
+      setCredential: async (apiKey, mode) =>
+        setAnthropicAzureApiKey(apiKey, params.agentDir, metadata, {
+          secretInputMode: mode,
+        }),
+    });
+
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "anthropic-azure:default",
+      provider: "anthropic-azure",
+      mode: "api_key",
+    });
+
+    nextConfig = applyAnthropicAzureProviderConfig(nextConfig, {
+      baseUrl: normalizedBaseUrl,
+      modelId: resolvedModelId,
+    });
+
+    const azureModelRef = `anthropic-azure/${resolvedModelId}`;
+    await applyProviderDefaultModel({
+      defaultModel: azureModelRef,
+      applyDefaultConfig: (config) => applyAgentDefaultModelPrimary(config, azureModelRef),
+      applyProviderConfig: (config) =>
+        applyAnthropicAzureProviderConfig(config, {
+          baseUrl: normalizedBaseUrl,
+          modelId: resolvedModelId,
+        }),
+      noteDefault: azureModelRef,
+    });
+
+    return { config: nextConfig, agentModelOverride };
   }
 
   return null;

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -32,6 +32,12 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { ModelApi } from "../config/types.models.js";
 import { KILOCODE_BASE_URL } from "../providers/kilocode-shared.js";
 import {
+  ANTHROPIC_AZURE_MODEL_CHOICES,
+  DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+  buildAnthropicAzureModelDefinition,
+  normalizeAnthropicAzureBaseUrl,
+} from "./anthropic-azure-utils.js";
+import {
   HUGGINGFACE_DEFAULT_MODEL_REF,
   KILOCODE_DEFAULT_MODEL_REF,
   MISTRAL_DEFAULT_MODEL_REF,
@@ -188,6 +194,54 @@ export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConf
 export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = applyOpenrouterProviderConfig(cfg);
   return applyAgentDefaultModelPrimary(next, OPENROUTER_DEFAULT_MODEL_REF);
+}
+
+export function applyAnthropicAzureProviderConfig(
+  cfg: OpenClawConfig,
+  params: { baseUrl: string; modelId?: string },
+): OpenClawConfig {
+  const normalizedBaseUrl = normalizeAnthropicAzureBaseUrl(params.baseUrl);
+  const modelId = params.modelId?.trim() || DEFAULT_ANTHROPIC_AZURE_MODEL_ID;
+  const models = { ...cfg.agents?.defaults?.models };
+  const modelRef = `anthropic-azure/${modelId}`;
+  models[modelRef] = {
+    ...models[modelRef],
+    alias: models[modelRef]?.alias ?? "Azure Claude",
+  };
+
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers["anthropic-azure"];
+  const catalogModels = ANTHROPIC_AZURE_MODEL_CHOICES.map((choice) =>
+    buildAnthropicAzureModelDefinition({ id: choice.value, label: choice.label }),
+  );
+  const mergedModels = mergeProviderModels(existingProvider, catalogModels);
+  const { apiKey: _existingApiKey, ...rest } = (existingProvider ?? {}) as Record<
+    string,
+    unknown
+  > & {
+    apiKey?: string;
+  };
+  const normalizedApiKey = getNormalizedProviderApiKey(existingProvider);
+
+  providers["anthropic-azure"] = {
+    ...rest,
+    api: "anthropic-messages",
+    baseUrl: normalizedBaseUrl,
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: mergedModels.length > 0 ? mergedModels : catalogModels,
+  };
+
+  return applyOnboardAuthAgentModelsAndProviders(cfg, { agentModels: models, providers });
+}
+
+export function applyAnthropicAzureConfig(
+  cfg: OpenClawConfig,
+  params: { baseUrl: string; modelId?: string },
+): OpenClawConfig {
+  const modelId = params.modelId?.trim() || DEFAULT_ANTHROPIC_AZURE_MODEL_ID;
+  const modelRef = `anthropic-azure/${modelId}`;
+  const next = applyAnthropicAzureProviderConfig(cfg, params);
+  return applyAgentDefaultModelPrimary(next, modelRef);
 }
 
 export function applyMoonshotProviderConfig(cfg: OpenClawConfig): OpenClawConfig {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -217,6 +217,19 @@ export async function setAnthropicApiKey(
   });
 }
 
+export async function setAnthropicAzureApiKey(
+  key: SecretInput,
+  agentDir: string | undefined,
+  metadata: { baseUrl: string; modelId: string; resource?: string },
+  options?: ApiKeyStorageOptions,
+) {
+  upsertAuthProfile({
+    profileId: "anthropic-azure:default",
+    credential: buildApiKeyCredential("anthropic-azure", key, metadata, options),
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export async function setOpenaiApiKey(
   key: SecretInput,
   agentDir?: string,

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyAnthropicAzureConfig,
+  applyAnthropicAzureProviderConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
   applyHuggingfaceConfig,
@@ -67,6 +69,7 @@ export {
   OPENROUTER_DEFAULT_MODEL_REF,
   setOpenaiApiKey,
   setAnthropicApiKey,
+  setAnthropicAzureApiKey,
   setCloudflareAiGatewayConfig,
   setByteplusApiKey,
   setQianfanApiKey,

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -428,6 +428,33 @@ describe("onboard (non-interactive): provider auth", () => {
     });
   });
 
+  it("configures Azure Claude via non-interactive flags", async () => {
+    await withOnboardEnv("openclaw-onboard-azure-claude-", async (env) => {
+      const cfg = await runOnboardingAndReadConfig(env, {
+        authChoice: "anthropic-azure-api-key",
+        anthropicAzureBaseUrl: "fabric-hub",
+        anthropicAzureApiKey: "azk-test", // pragma: allowlist secret
+        anthropicAzureModelId: "claude-sonnet-4-6",
+      });
+
+      expect(cfg.auth?.profiles?.["anthropic-azure:default"]?.provider).toBe("anthropic-azure");
+      expect(cfg.models?.providers?.["anthropic-azure"]?.baseUrl).toBe(
+        "https://fabric-hub.services.ai.azure.com/anthropic",
+      );
+      expect(cfg.agents?.defaults?.model?.primary).toBe("anthropic-azure/claude-sonnet-4-6");
+      await expectApiKeyProfile({
+        profileId: "anthropic-azure:default",
+        provider: "anthropic-azure",
+        key: "azk-test",
+        metadata: {
+          baseUrl: "https://fabric-hub.services.ai.azure.com/anthropic",
+          modelId: "claude-sonnet-4-6",
+          resource: "fabric-hub",
+        },
+      });
+    });
+  });
+
   it("stores OpenAI API key and sets OpenAI default model", async () => {
     await withOnboardEnv("openclaw-onboard-openai-", async (env) => {
       const cfg = await runOnboardingAndReadConfig(env, {
@@ -488,9 +515,18 @@ describe("onboard (non-interactive): provider auth", () => {
       flagName: "--byteplus-api-key",
       envVar: "BYTEPLUS_API_KEY",
     },
+    {
+      name: "anthropic-azure",
+      prefix: "openclaw-onboard-ref-flag-azure-",
+      authChoice: "anthropic-azure-api-key",
+      optionKey: "anthropicAzureApiKey",
+      flagName: "--anthropic-azure-api-key",
+      envVar: "ANTHROPIC_FOUNDRY_API_KEY",
+      extraOptions: { anthropicAzureBaseUrl: "fabric-hub" },
+    },
   ])(
     "fails fast for $name when --secret-input-mode ref uses explicit key without env and does not leak the key",
-    async ({ prefix, authChoice, optionKey, flagName, envVar }) => {
+    async ({ prefix, authChoice, optionKey, flagName, envVar, extraOptions }) => {
       await withOnboardEnv(prefix, async ({ runtime }) => {
         const providedSecret = `${envVar.toLowerCase()}-should-not-leak`; // pragma: allowlist secret
         const options: Record<string, unknown> = {
@@ -498,6 +534,7 @@ describe("onboard (non-interactive): provider auth", () => {
           secretInputMode: "ref", // pragma: allowlist secret
           [optionKey]: providedSecret,
           skipSkills: true,
+          ...extraOptions,
         };
         const envOverrides: Record<string, string | undefined> = {
           [envVar]: undefined,

--- a/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
@@ -47,6 +47,18 @@ export function inferAuthChoiceFromFlags(opts: OnboardOptions): AuthChoiceInfere
     });
   }
 
+  if (
+    hasStringValue(opts.anthropicAzureApiKey) ||
+    hasStringValue(opts.anthropicAzureBaseUrl) ||
+    hasStringValue(opts.anthropicAzureModelId)
+  ) {
+    matches.push({
+      optionKey: "anthropicAzureApiKey",
+      authChoice: "anthropic-azure-api-key",
+      label: "--anthropic-azure-...",
+    });
+  }
+
   return {
     choice: matches[0]?.authChoice,
     matches,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -3,11 +3,19 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import type { SecretInput } from "../../../config/types.secrets.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../../../secrets/ref-contract.js";
+import {
+  DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+  normalizeAnthropicAzureBaseUrl,
+  resolveAnthropicAzureBaseUrlFromEnv,
+  resolveAnthropicAzureResourceName,
+} from "../../anthropic-azure-utils.js";
 import { normalizeSecretInputModeInput } from "../../auth-choice.apply-helpers.js";
 import { normalizeApiKeyTokenProviderAuthChoice } from "../../auth-choice.apply.api-providers.js";
 import {
+  applyAnthropicAzureConfig,
   applyAuthProfileConfig,
   applyCloudflareAiGatewayConfig,
+  setAnthropicAzureApiKey,
   setCloudflareAiGatewayConfig,
 } from "../../onboard-auth.js";
 import {
@@ -187,6 +195,59 @@ export async function applyNonInteractiveAuthChoice(params: {
   });
   if (simpleApiKeyChoice !== undefined) {
     return simpleApiKeyChoice;
+  }
+
+  if (authChoice === "anthropic-azure-api-key") {
+    const baseUrlCandidate = opts.anthropicAzureBaseUrl?.trim();
+    const envBaseUrl = resolveAnthropicAzureBaseUrlFromEnv(process.env);
+    const baseUrlInput = baseUrlCandidate || envBaseUrl;
+    if (!baseUrlInput) {
+      runtime.error(
+        "--anthropic-azure-base-url (resource name or URL) is required for Azure Claude onboarding.",
+      );
+      runtime.exit(1);
+      return null;
+    }
+    let normalizedBaseUrl: string;
+    try {
+      normalizedBaseUrl = normalizeAnthropicAzureBaseUrl(baseUrlInput);
+    } catch (error) {
+      runtime.error(`Invalid Azure Claude base URL: ${String(error)}`);
+      runtime.exit(1);
+      return null;
+    }
+    const resolved = await resolveApiKey({
+      provider: "anthropic-azure",
+      cfg: baseConfig,
+      flagValue: opts.anthropicAzureApiKey,
+      flagName: "--anthropic-azure-api-key",
+      envVar: "ANTHROPIC_FOUNDRY_API_KEY",
+      runtime,
+    });
+    if (!resolved) {
+      return null;
+    }
+    const metadata = {
+      baseUrl: normalizedBaseUrl,
+      modelId: opts.anthropicAzureModelId?.trim() || DEFAULT_ANTHROPIC_AZURE_MODEL_ID,
+      resource: resolveAnthropicAzureResourceName(normalizedBaseUrl),
+    };
+    if (
+      !(await maybeSetResolvedApiKey(resolved, (value) =>
+        setAnthropicAzureApiKey(value, undefined, metadata, apiKeyStorageOptions),
+      ))
+    ) {
+      return null;
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "anthropic-azure:default",
+      provider: "anthropic-azure",
+      mode: "api_key",
+    });
+    return applyAnthropicAzureConfig(nextConfig, {
+      baseUrl: normalizedBaseUrl,
+      modelId: metadata.modelId,
+    });
   }
 
   if (authChoice === "cloudflare-ai-gateway-api-key") {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -8,6 +8,7 @@ export type BuiltInAuthChoice =
   | "setup-token"
   | "claude-cli"
   | "token"
+  | "anthropic-azure-api-key"
   | "chutes"
   | "openai-codex"
   | "openai-api-key"
@@ -56,6 +57,7 @@ export type AuthChoice = BuiltInAuthChoice | (string & {});
 export type BuiltInAuthChoiceGroupId =
   | "openai"
   | "anthropic"
+  | "anthropic-azure"
   | "chutes"
   | "google"
   | "copilot"
@@ -114,6 +116,9 @@ export type OnboardOptions = {
   /** API key persistence mode for setup flows (default: plaintext). */
   secretInputMode?: SecretInputMode;
   anthropicApiKey?: string;
+  anthropicAzureApiKey?: string;
+  anthropicAzureBaseUrl?: string;
+  anthropicAzureModelId?: string;
   openaiApiKey?: string;
   mistralApiKey?: string;
   openrouterApiKey?: string;

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -1,6 +1,7 @@
 import { BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES } from "../plugins/bundled-provider-auth-env-vars.js";
 
 const CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
+  "anthropic-azure": ["ANTHROPIC_FOUNDRY_API_KEY", "AZURE_CLAUDE_API_KEY"],
   chutes: ["CHUTES_OAUTH_TOKEN", "CHUTES_API_KEY"],
   voyage: ["VOYAGE_API_KEY"],
   groq: ["GROQ_API_KEY"],


### PR DESCRIPTION
## Summary

- **Problem:** Users deploying Claude via Azure AI Foundry have no onboarding path — they must manually configure provider settings, auth profiles, and model refs.
- **Why it matters:** Azure Claude is a common enterprise deployment target; first-class onboarding removes friction for these users.
- **What changed:** Added `anthropic-azure-api-key` as a new auth choice with interactive and non-interactive flows (resource/URL prompt, model picker, API key storage, config wiring).
- **What did NOT change:** No changes to existing Anthropic direct API flows, no new runtime dependencies, no changes to gateway or startup critical path.

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] UI / DX

## User-visible / Behavior Changes

- New auth choice `anthropic-azure-api-key` appears in the onboarding provider picker under the Anthropic group
- New CLI flags: `--anthropic-azure-api-key`, `--anthropic-azure-base-url`, `--anthropic-azure-model-id`
- New env vars supported: `ANTHROPIC_FOUNDRY_API_KEY`, `AZURE_CLAUDE_API_KEY`, `ANTHROPIC_FOUNDRY_BASE_URL`, `AZURE_CLAUDE_BASE_URL`, `ANTHROPIC_FOUNDRY_RESOURCE`, `AZURE_CLAUDE_RESOURCE`
- Invalid resource names (e.g. `fabric_hub` with underscores) are rejected with a clear error instead of silently stripped

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — new `setAnthropicAzureApiKey` stores Azure API keys using the existing auth profile credential infrastructure (same pattern as all other providers)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Mitigation: Uses the same `SecretInput` and `AuthProfileStore` infrastructure as existing providers; no new storage mechanisms.

## Repro + Verification

### Steps

```bash
# Interactive
openclaw onboard --auth-choice anthropic-azure-api-key

# Non-interactive
openclaw onboard --non-interactive --accept-risk \
  --auth-choice anthropic-azure-api-key \
  --anthropic-azure-base-url fabric-hub \
  --anthropic-azure-model-id claude-sonnet-4-6 \
  --anthropic-azure-api-key "$ANTHROPIC_FOUNDRY_API_KEY"
```

## Evidence

- 7/7 unit tests pass (`src/commands/anthropic-azure-utils.test.ts`)
- Non-interactive provider auth test passes (`src/commands/onboard-non-interactive.provider-auth.test.ts`)
- Invalid character rejection test covers the review feedback fix

## Human Verification (required)

- Verified: Interactive and non-interactive onboarding flows, resource name validation, URL normalization, env var resolution
- Edge cases: Invalid characters in resource names, missing base URL, full URL vs bare resource name, trailing slashes
- Not verified: End-to-end Azure AI Foundry API calls (requires Azure credentials)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional env vars and config keys (additive only)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; Azure choice disappears from picker, no other flows affected
- Known bad symptoms: None expected — isolated to Azure auth choice path

## Risks and Mitigations

- Risk: Azure API key storage uses a new provider ID (`anthropic-azure`)
  - Mitigation: Follows exact same auth profile pattern as all existing providers