### PR TITLE
fix(ui): reset transient chat overlays and style context notice

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -491,6 +491,37 @@
   background: color-mix(in srgb, var(--danger) 85%, #fff);
 }
 
+.context-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  max-width: min(100%, 520px);
+  margin: 8px 0 4px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--ctx-color, var(--warning)) 35%, var(--border));
+  background: var(--ctx-bg, color-mix(in srgb, var(--warning) 10%, var(--panel)));
+  color: var(--ctx-color, var(--warning));
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.context-notice__icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  stroke: currentColor;
+}
+
+.context-notice__detail {
+  margin-left: auto;
+  opacity: 0.8;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
 .slash-menu {
   position: absolute;
   bottom: 100%;

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -172,6 +172,10 @@
   display: none;
 }
 
+.chat-tools-summary::marker {
+  content: "";
+}
+
 .chat-tools-summary::before {
   content: "▸";
   font-size: 10px;
@@ -257,6 +261,10 @@
   display: none;
 }
 
+.chat-json-summary::marker {
+  content: "";
+}
+
 .chat-json-summary::before {
   content: "▸";
   font-size: 10px;
@@ -339,6 +347,10 @@
 
 .chat-tool-msg-summary::-webkit-details-marker {
   display: none;
+}
+
+.chat-tool-msg-summary::marker {
+  content: "";
 }
 
 .chat-tool-msg-summary::before {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -177,14 +177,20 @@
 }
 
 .chat-tools-summary::before {
-  content: "▸";
-  font-size: 10px;
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transform-origin: 55% 55%;
   flex-shrink: 0;
+  opacity: 0.9;
   transition: transform 150ms ease;
 }
 
 .chat-tools-collapse[open] > .chat-tools-summary::before {
-  transform: rotate(90deg);
+  transform: rotate(45deg);
 }
 
 .chat-tools-summary:hover {
@@ -266,14 +272,20 @@
 }
 
 .chat-json-summary::before {
-  content: "▸";
-  font-size: 10px;
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transform-origin: 55% 55%;
   flex-shrink: 0;
+  opacity: 0.9;
   transition: transform 150ms ease;
 }
 
 .chat-json-collapse[open] > .chat-json-summary::before {
-  transform: rotate(90deg);
+  transform: rotate(45deg);
 }
 
 .chat-json-summary:hover {
@@ -354,14 +366,20 @@
 }
 
 .chat-tool-msg-summary::before {
-  content: "▸";
-  font-size: 10px;
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transform-origin: 55% 55%;
   flex-shrink: 0;
+  opacity: 0.9;
   transition: transform 150ms ease;
 }
 
 .chat-tool-msg-collapse[open] > .chat-tool-msg-summary::before {
-  transform: rotate(90deg);
+  transform: rotate(45deg);
 }
 
 .chat-tool-msg-summary:hover {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2545,6 +2545,53 @@
   background: var(--bg);
 }
 
+.json-collapse {
+  margin: 0.4rem 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--panel-2);
+}
+
+.json-collapse > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  user-select: none;
+}
+
+.json-collapse > summary::-webkit-details-marker {
+  display: none;
+}
+
+.json-collapse > summary::marker {
+  content: "";
+}
+
+.json-collapse > summary::before {
+  content: "▸";
+  color: var(--accent);
+  transition: transform 0.15s ease;
+}
+
+.json-collapse[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.json-collapse > summary:hover {
+  background: color-mix(in srgb, var(--panel-2) 88%, var(--accent-soft));
+}
+
+.json-collapse .code-block-wrapper {
+  border-top: 1px solid var(--border);
+}
+
 .chat-stamp {
   font-size: 11px;
   color: var(--muted);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2515,6 +2515,10 @@
   display: none;
 }
 
+.chat-tool-card__summary::marker {
+  content: "";
+}
+
 .chat-tool-card__summary-meta {
   color: var(--muted);
   opacity: 0.7;

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -13,6 +13,7 @@ import { normalizeBasePath } from "./navigation.ts";
 import type { ModelCatalogEntry } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
+import { resetChatTransientUi } from "./views/chat.ts";
 
 export type ChatHost = {
   client: GatewayBrowserClient | null;
@@ -240,6 +241,7 @@ export async function handleSendChat(
     host.chatMessage = "";
     host.chatAttachments = [];
   }
+  resetChatTransientUi();
 
   if (isChatBusy(host)) {
     enqueueChatMessage(host, message, attachmentsToSend, refreshSessions);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -218,6 +218,7 @@ export async function handleSendChat(
         host.chatMessage = "";
         host.chatAttachments = [];
       }
+      resetChatTransientUi();
       enqueueChatMessage(host, message, undefined, isChatResetCommand(message), {
         args: parsed.args,
         name: parsed.command.name,
@@ -229,6 +230,7 @@ export async function handleSendChat(
       host.chatMessage = "";
       host.chatAttachments = [];
     }
+    resetChatTransientUi();
     await dispatchSlashCommand(host, parsed.command.name, parsed.args, {
       previousDraft: prevDraft,
       restoreDraft: Boolean(messageOverride && opts?.restoreDraft),

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -181,6 +181,13 @@ export function resetChatViewState() {
   Object.assign(vs, createChatEphemeralState());
 }
 
+export function resetChatTransientUi() {
+  vs.slashMenuOpen = false;
+  resetSlashMenuState();
+  vs.searchOpen = false;
+  vs.searchQuery = "";
+}
+
 export const cleanupChatModuleState = resetChatViewState;
 
 function adjustTextareaHeight(el: HTMLTextAreaElement) {


### PR DESCRIPTION
## Summary
- add the missing styles for the chat context warning notice
- clear transient slash/search UI when sending chat messages
- reduce residual overlay/icon artifacts during chat rerenders

## Problem
Users occasionally saw a large triangle / exclamation-style overlay cover the Control UI chat surface.
Two recurring triggers were reported:
- immediately when sending a message
- when chat output/context state changed enough to surface warning UI

## Root cause hypothesis
Two high-confidence issues were found in the chat UI:
1. `renderContextNotice()` rendered a warning icon via `.context-notice*` classes, but no CSS existed for those classes anywhere in the UI bundle.
2. The chat send flow did not explicitly clear transient slash/search UI state, so ephemeral overlay state could survive a send-triggered rerender.

## Fix
1. add compact, bounded styles for `.context-notice`, `.context-notice__icon`, and `.context-notice__detail`
2. introduce `resetChatTransientUi()`
3. call it from `handleSendChat()` before the send/queue path continues

## Validation
- `pnpm ui:build` passes
- local deploy completed successfully
- after deployment, the previously recurring large overlay symptom did not immediately reappear in follow-up use

## Scope
This PR intentionally only touches Control UI chat state / styling. It is independent from the auth-profile fallback fixes.
