### PR TITLE
fix(test/whatsapp): use stale timestamp for append-skip test case

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-120_000),
           pushName: "History Sender",
         },
       ],


### PR DESCRIPTION
## Bug

After #42588 (843e3c1) added `APPEND_RECENT_GRACE_MS = 60_000`, the existing test `'handles append messages by marking them read but skipping auto-reply'` started failing.

**Root cause:** The test passed `nowSeconds()` (current time) as `messageTimestamp` for a message that was supposed to be treated as stale history. With the new grace window, a message timestamped *right now* is considered **recent**, so the monitor processes it instead of skipping it — which is the opposite of what the test expects.

## Fix

Change the test's message timestamp from `nowSeconds()` to `nowSeconds(-120_000)` (2 minutes ago), so it is clearly outside the 60-second grace window and gets skipped as intended.

```diff
- messageTimestamp: nowSeconds(),
+ messageTimestamp: nowSeconds(-120_000),
```

**One line change. No behavior change — only test correctness fix.**

## Impact

Unblocks the `checks (node, channels)` job which has been failing on multiple open PRs since 843e3c1 was merged.