### PR TITLE
feat(context-engine): add toolsOverride to AssembleResult for selective tool schema injection

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -127,6 +127,7 @@ import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
+import { wrapStreamFnWithToolsOverride } from "../stream-payload-utils.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
@@ -2121,6 +2122,15 @@ export async function runEmbeddedAttempt(
               applySystemPromptOverrideToSession(activeSession, systemPromptText);
               log.debug(
                 `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
+              );
+            }
+            if (assembled.toolsOverride && assembled.toolsOverride.length > 0) {
+              activeSession.agent.streamFn = wrapStreamFnWithToolsOverride(
+                activeSession.agent.streamFn,
+                assembled.toolsOverride,
+              );
+              log.debug(
+                `context engine: applied tools override (${assembled.toolsOverride.length} tools)`,
               );
             }
           } catch (assembleErr) {

--- a/src/agents/pi-embedded-runner/stream-payload-utils.ts
+++ b/src/agents/pi-embedded-runner/stream-payload-utils.ts
@@ -1,4 +1,28 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AnyAgentTool } from "../pi-tools.types.js";
+
+/**
+ * Creates a streamFn wrapper that filters the tools context to only include
+ * tools whose names are in the override set. This reduces token usage by
+ * sending fewer tool schemas to the model while keeping all executors available.
+ */
+export function wrapStreamFnWithToolsOverride(
+  underlying: StreamFn,
+  toolsOverride: AnyAgentTool[],
+): StreamFn {
+  const allowedNames = new Set(toolsOverride.map((tool) => tool.name));
+  return (model, context, options) => {
+    const ctx = context as { tools?: unknown[] };
+    if (!Array.isArray(ctx.tools)) {
+      return underlying(model, context, options);
+    }
+    const filteredTools = ctx.tools.filter((tool) => {
+      const name = (tool as { name?: string })?.name;
+      return typeof name === "string" && allowedNames.has(name);
+    });
+    return underlying(model, { ...context, tools: filteredTools }, options);
+  };
+}
 
 export function streamWithPayloadPatch(
   underlying: StreamFn,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AnyAgentTool } from "../agents/pi-tools.types.js";
 
 // Result types
 
@@ -9,6 +10,12 @@ export type AssembleResult = {
   estimatedTokens: number;
   /** Optional context-engine-provided instructions prepended to the runtime system prompt */
   systemPromptAddition?: string;
+  /**
+   * Optional filtered list of tools to send to the model instead of the default full set.
+   * When present, only the schemas for these tools are included in the model request,
+   * reducing token usage. Tool executors for all registered tools remain available.
+   */
+  toolsOverride?: AnyAgentTool[];
 };
 
 export type CompactResult = {


### PR DESCRIPTION
## Summary

Adds an optional `toolsOverride` field to `AssembleResult` that allows context-engine plugins to filter which tool schemas are sent to the model on a given turn.

## Motivation

On every model turn, OpenClaw sends the full JSON schemas for all registered tools. For deployments with many tools enabled, this can add 6–8k tokens of fixed overhead per request — even when most of those tools won't be called.

Context-engine plugins are well-positioned to know which tools are relevant for a given turn (based on channel type, session state, recent messages, etc.), but currently have no way to influence which schemas are injected.

## What this changes

**`src/context-engine/types.ts`** — adds `toolsOverride` to `AssembleResult`:
```typescript
/**
 * Optional filtered list of tools to send to the model instead of the default full set.
 * When present, only the schemas for these tools are included in the model request,
 * reducing token usage. Tool executors for all registered tools remain available.
 */
toolsOverride?: AnyAgentTool[];
```

**`src/agents/pi-embedded-runner/stream-payload-utils.ts`** — adds `wrapStreamFnWithToolsOverride()` helper that filters `context.tools` by name before the stream call.

**`src/agents/pi-embedded-runner/run/attempt.ts`** — wires up the override: when `assemble()` returns a non-empty `toolsOverride`, wraps the streamFn to filter schemas accordingly.

## Behaviour

- **Non-breaking**: `toolsOverride` is optional. When absent, nothing changes.
- **Schema-only filtering**: tool executors for all registered tools remain available. If a model calls a tool not in the override, the executor still runs. Only what the model _sees_ is filtered.
- **Debug logging**: when an override is applied, a debug log entry records how many tools are in the filtered set.

## Example usage in a context-engine plugin

```typescript
async assemble(params): Promise<AssembleResult> {
  const base = await this.legacy.assemble(params);
  
  // Only send schemas for tools relevant to this context
  const coreTools = params.tools.filter(t => 
    ["read", "write", "edit", "exec", "memory_search"].includes(t.name)
  );
  
  return { ...base, toolsOverride: coreTools };
}
```

## Token impact

A typical deployment with ~20 tools enabled spends ~6–8k tokens/turn on tool schemas. Filtering to 5–8 core tools reduces that to ~2–3k tokens/turn — roughly 60–70% reduction in tool schema overhead for turns that don't need specialised tools.