### PR TITLE
Add per-binding groupScope for routing group channels to main session

### DIFF
--- a/extensions/irc/src/active-clients.ts
+++ b/extensions/irc/src/active-clients.ts
@@ -22,3 +22,14 @@ export function getActiveClient(accountId: string): IrcClient | undefined {
 export function removeActiveClient(accountId: string): void {
   activeClients.delete(accountId);
 }
+
+/**
+ * Only remove the active client if it matches the expected instance.
+ * Prevents a stopping monitor from deregistering a newer monitor's
+ * healthy client during reconnect races.
+ */
+export function removeActiveClientIfMatch(accountId: string, expected: IrcClient): void {
+  if (activeClients.get(accountId) === expected) {
+    activeClients.delete(accountId);
+  }
+}

--- a/extensions/irc/src/active-clients.ts
+++ b/extensions/irc/src/active-clients.ts
@@ -1,0 +1,24 @@
+import type { IrcClient } from "./client.js";
+
+/**
+ * Registry of active IRC clients from the monitor.
+ * Keyed by accountId. Allows sendMessageIrc to use the persistent
+ * monitor client instead of creating a transient connection.
+ */
+const activeClients = new Map<string, IrcClient>();
+
+export function setActiveClient(accountId: string, client: IrcClient): void {
+  activeClients.set(accountId, client);
+}
+
+export function getActiveClient(accountId: string): IrcClient | undefined {
+  const client = activeClients.get(accountId);
+  if (client && client.isReady()) {
+    return client;
+  }
+  return undefined;
+}
+
+export function removeActiveClient(accountId: string): void {
+  activeClients.delete(accountId);
+}

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,6 +1,6 @@
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
 import { resolveIrcAccount } from "./accounts.js";
-import { setActiveClient, removeActiveClient } from "./active-clients.js";
+import { setActiveClient, removeActiveClientIfMatch } from "./active-clients.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
 import { handleIrcInbound } from "./inbound.js";
@@ -141,7 +141,9 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
 
   return {
     stop: () => {
-      removeActiveClient(account.accountId);
+      if (client) {
+        removeActiveClientIfMatch(account.accountId, client);
+      }
       client?.quit("shutdown");
       client = null;
     },

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,5 +1,6 @@
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
 import { resolveIrcAccount } from "./accounts.js";
+import { setActiveClient, removeActiveClient } from "./active-clients.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
 import { handleIrcInbound } from "./inbound.js";
@@ -136,8 +137,11 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${client.nick}`,
   );
 
+  setActiveClient(account.accountId, client);
+
   return {
     stop: () => {
+      removeActiveClient(account.accountId);
       client?.quit("shutdown");
       client = null;
     },

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -1,4 +1,5 @@
 import { resolveIrcAccount } from "./accounts.js";
+import { getActiveClient } from "./active-clients.js";
 import type { IrcClient } from "./client.js";
 import { connectIrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
@@ -67,13 +68,19 @@ export async function sendMessageIrc(
   if (client?.isReady()) {
     client.sendPrivmsg(target, payload);
   } else {
-    const transient = await connectIrcClient(
-      buildIrcConnectOptions(account, {
-        connectTimeoutMs: 12000,
-      }),
-    );
-    transient.sendPrivmsg(target, payload);
-    transient.quit("sent");
+    // Try the monitor's persistent client first (already connected and joined to channels)
+    const active = getActiveClient(account.accountId);
+    if (active) {
+      active.sendPrivmsg(target, payload);
+    } else {
+      const transient = await connectIrcClient(
+        buildIrcConnectOptions(account, {
+          connectTimeoutMs: 12000,
+        }),
+      );
+      transient.sendPrivmsg(target, payload);
+      transient.quit("sent");
+    }
   }
 
   runtime.channel.activity.record({

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -41,6 +41,8 @@ export type AgentRouteBinding = {
   agentId: string;
   comment?: string;
   match: AgentBindingMatch;
+  /** When "main", group/channel messages matching this binding route to the agent's main session. */
+  groupScope?: "main" | "per-channel";
 };
 
 export type AgentAcpBinding = {

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -40,6 +40,7 @@ const RouteBindingSchema = z
     agentId: z.string(),
     comment: z.string().optional(),
     match: BindingMatchSchema,
+    groupScope: z.union([z.literal("main"), z.literal("per-channel")]).optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -34,7 +34,6 @@ export const SessionSchema = z
         z.literal("per-account-channel-peer"),
       ])
       .optional(),
-    groupScope: z.union([z.literal("main"), z.literal("per-channel")]).optional(),
     identityLinks: z.record(z.string(), z.array(z.string())).optional(),
     resetTriggers: z.array(z.string()).optional(),
     idleMinutes: z.number().int().positive().optional(),

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -34,6 +34,7 @@ export const SessionSchema = z
         z.literal("per-account-channel-peer"),
       ])
       .optional(),
+    groupScope: z.union([z.literal("main"), z.literal("per-channel")]).optional(),
     identityLinks: z.record(z.string(), z.array(z.string())).optional(),
     resetTriggers: z.array(z.string()).optional(),
     idleMinutes: z.number().int().positive().optional(),

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -95,6 +95,8 @@ export function buildAgentSessionKey(params: {
   peer?: RoutePeer | null;
   /** DM session scope. */
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  /** Group/channel session scope. When "main", group messages route to the main session. */
+  groupScope?: "main" | "per-channel";
   identityLinks?: Record<string, string[]>;
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
@@ -107,6 +109,7 @@ export function buildAgentSessionKey(params: {
     peerKind: peer?.kind ?? "direct",
     peerId: peer ? normalizeId(peer.id) || "unknown" : null,
     dmScope: params.dmScope,
+    groupScope: params.groupScope,
     identityLinks: params.identityLinks,
   });
 }
@@ -625,6 +628,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
   const dmScope = input.cfg.session?.dmScope ?? "main";
+  const groupScope =
+    ((input.cfg.session as Record<string, unknown> | undefined)?.groupScope as
+      | "main"
+      | "per-channel"
+      | undefined) ?? "per-channel";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
@@ -666,6 +674,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       accountId,
       peer,
       dmScope,
+      groupScope,
       identityLinks,
     }).toLowerCase();
     const mainSessionKey = buildAgentMainSessionKey({

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -628,11 +628,6 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
   const dmScope = input.cfg.session?.dmScope ?? "main";
-  const groupScope =
-    ((input.cfg.session as Record<string, unknown> | undefined)?.groupScope as
-      | "main"
-      | "per-channel"
-      | undefined) ?? "per-channel";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
@@ -666,7 +661,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
+  const choose = (
+    agentId: string,
+    matchedBy: ResolvedAgentRoute["matchedBy"],
+    bindingGroupScope?: "main" | "per-channel",
+  ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
@@ -674,7 +673,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       accountId,
       peer,
       dmScope,
-      groupScope,
+      groupScope: bindingGroupScope ?? "per-channel",
       identityLinks,
     }).toLowerCase();
     const mainSessionKey = buildAgentMainSessionKey({
@@ -805,7 +804,8 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      const routeBinding = matched.binding as { groupScope?: "main" | "per-channel" };
+      return choose(matched.binding.agentId, tier.matchedBy, routeBinding.groupScope);
     }
   }
 

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -134,6 +134,8 @@ export function buildAgentPeerSessionKey(params: {
   identityLinks?: Record<string, string[]>;
   /** DM session scope. */
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  /** Group/channel session scope. When "main", group messages route to the main session. */
+  groupScope?: "main" | "per-channel";
 }): string {
   const peerKind = params.peerKind ?? "direct";
   if (peerKind === "direct") {
@@ -163,6 +165,14 @@ export function buildAgentPeerSessionKey(params: {
     if (dmScope === "per-peer" && peerId) {
       return `agent:${normalizeAgentId(params.agentId)}:direct:${peerId}`;
     }
+    return buildAgentMainSessionKey({
+      agentId: params.agentId,
+      mainKey: params.mainKey,
+    });
+  }
+  // For group/channel peer kinds: if groupScope is "main", collapse to main session
+  const groupScope = params.groupScope ?? "per-channel";
+  if (groupScope === "main") {
     return buildAgentMainSessionKey({
       agentId: params.agentId,
       mainKey: params.mainKey,


### PR DESCRIPTION
## Summary

- Adds an optional `groupScope` property to route bindings. When set to `"main"`, group/channel messages matching that binding route to the agent's main session instead of creating isolated per-channel sessions.
- Default is `"per-channel"` (existing behavior, no change for anyone who doesn't use it).
- Surgical: only the specific binding gets the merge. All other channels stay isolated. No global privacy boundary collapse.

## Motivation

In multi-agent setups where agents share an IRC channel (or Discord channel, etc.) as a coordination space, the per-channel session isolation means the agent's main session never sees those conversations. The agent has multiple isolated "selves" — one per channel — that don't share context.

For use cases where specific channels serve as the agent's primary coordination space, routing those channels to the main session creates unified awareness without sacrificing isolation on other channels.

## Example config

```json5
{
  bindings: [
    {
      agentId: "main",
      match: { channel: "irc", peer: { kind: "channel", id: "#team" } },
      groupScope: "main"
    }
  ]
}
```

Only `#team` merges into main. All other IRC channels, Discord channels, etc. remain isolated.

## Changes

4 files changed, ~15 lines added:

| File | Change |
|------|--------|
| `src/config/types.agents.ts` | Add `groupScope?: "main" \| "per-channel"` to `AgentRouteBinding` type |
| `src/config/zod-schema.agents.ts` | Add `groupScope` to route binding Zod schema |
| `src/routing/session-key.ts` | When `groupScope === "main"`, return main session key for group/channel peers |
| `src/routing/resolve-route.ts` | Thread matched binding's `groupScope` into session key builder |

## Note: also includes IRC active client fix

This branch includes the commits from #45662 (IRC active client registry fix) plus the Greptile review feedback. If #45662 merges first, this can be rebased cleanly.

## Testing

- [x] AI-assisted (Claude Opus 4.6)
- [x] Tested locally with OpenClaw v2026.3.13 + ergo IRC server + 3 agents on LAN
- [x] Confirmed: IRC #clawmune messages route to main session with binding
- [x] Confirmed: other channels remain isolated without the binding
- [x] Confirmed: inbound messages, replies, and proactive sends all work
- [x] `pnpm build` passes
- [x] `pnpm test` — 919/919 passed (1 pre-existing failure in `plugins/install.test.ts`, unrelated)
- [x] `pnpm check` — no new errors (pre-existing type errors in unrelated test files only)

## Test plan

- [ ] Verify group channel messages route to main session when `groupScope: "main"` is set on binding
- [ ] Verify group channel messages route to per-channel session when `groupScope` is absent (default behavior)
- [ ] Verify DM routing is unaffected
- [ ] Verify `groupScope: "per-channel"` explicit setting matches default behavior
- [ ] Verify proactive sends from main session work for merged channels

## Security considerations

`groupScope: "main"` collapses the privacy boundary between a specific group channel and the main session. This is opt-in per-binding and only affects the matched channel. Documentation should note that messages from the merged channel become context for all other interactions in the main session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Previously discussed in the OpenClaw Discord #help channel (2026-03-14) — no responses received.*