### PR TITLE
fix(ui): distinguish command palette hover and selection states

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3536,9 +3536,20 @@ td.data-table-key-col {
   transition: background var(--duration-fast) ease;
 }
 
-.cmd-palette__item:hover,
+.cmd-palette__item:hover {
+  background: color-mix(in srgb, var(--bg-hover) 90%, transparent);
+}
+
 .cmd-palette__item--active {
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--bg-hover) 94%, #fff);
+}
+
+:root[data-theme-mode="light"] .cmd-palette__item:hover {
+  background: color-mix(in srgb, var(--bg-hover) 90%, #fff);
+}
+
+:root[data-theme-mode="light"] .cmd-palette__item--active {
+  background: color-mix(in srgb, var(--bg-hover) 94%, #000);
 }
 
 .cmd-palette__item .nav-item__icon {


### PR DESCRIPTION
AI-assisted: Yes
Testing: Fully manually tested

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In the dashboard command palette, mouse hover and keyboard selection used the same background color, so the two interaction states were hard to distinguish when both were present.
- Why it matters: The command palette supports both mouse and keyboard navigation, and identical styling makes the current selection target ambiguous.
- What changed: Split the shared background rule in `ui/src/styles/components.css` so `:hover` uses a slightly lighter background and `.cmd-palette__item--active` uses a slightly darker background.
- What did NOT change (scope boundary): No command palette logic, keyboard behavior, layout, icons, spacing, borders, shadows, or other UI surfaces were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

The dashboard command palette now renders mouse hover and keyboard selection with slightly different background brightness levels, making the currently selected item easier to distinguish during mixed mouse/keyboard use.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 LTS
- Runtime/container: Local OpenClaw dashboard UI
- Model/provider: N/A
- Integration/channel (if any): Dashboard command palette
- Relevant config (redacted): None

### Steps

1. Open the dashboard and trigger the command palette.
2. Move the mouse over one result item while also navigating results with `ArrowUp` / `ArrowDown`.
3. Compare the hover item background with the keyboard-selected item background.

### Expected

- Mouse hover and keyboard selection should be visually distinct, while staying within the existing palette.

### Actual

- Before this change, both states used the same background color and were difficult to distinguish.
- After this change, hover is slightly lighter and keyboard selection is slightly darker.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manually verified the dashboard command palette styling and confirmed that hover and keyboard selection now render with different background brightness levels.
- Edge cases checked: Confirmed the change only affects `ui/src/styles/components.css` and does not modify command palette logic or other UI surfaces.
- What you did **not** verify: I did not run automated tests in this session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the `ui/src/styles/components.css` hunk for `.cmd-palette__item:hover` and `.cmd-palette__item--active`.
- Files/config to restore: `ui/src/styles/components.css`
- Known bad symptoms reviewers should watch for: Hover and keyboard selection becoming too similar again, or contrast becoming too subtle in some themes.

## Risks and Mitigations

None.