### PR TITLE
fix(exec): honor explicit host parameter when tools.exec.host is not configured

### DIFF
--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -212,8 +212,23 @@ describe("exec host env validation", () => {
     const text = normalizeText(result.content.find((c) => c.type === "text")?.text);
     expect(text).toContain("ok");
 
+    // When tools.exec.host is NOT configured, explicit host="gateway" should succeed
+    // (It will return approval-pending, not throw an error)
+    const result2 = await tool.execute("call2", {
+      command: "echo ok",
+      host: "gateway",
+    });
+    // Should get approval-pending status instead of throwing an error
+    const details = result2.details as { status: string };
+    expect(details.status).toBe("approval-pending");
+  });
+
+  it("rejects mismatched host when tools.exec.host is explicitly configured", async () => {
+    const tool = createExecTool({ host: "sandbox", security: "full", ask: "off" });
+
+    // When tools.exec.host is explicitly set to "sandbox", requesting host="gateway" should fail
     const err = await tool
-      .execute("call2", {
+      .execute("call1", {
         command: "echo ok",
         host: "gateway",
       })

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -211,15 +211,19 @@ describe("exec host env validation", () => {
     });
     const text = normalizeText(result.content.find((c) => c.type === "text")?.text);
     expect(text).toContain("ok");
+  });
+
+  it("allows explicit host override when tools.exec.host is not configured", async () => {
+    const tool = createExecTool({ security: "full", ask: "off" });
 
     // When tools.exec.host is NOT configured, explicit host="gateway" should succeed
     // (It will return approval-pending, not throw an error)
-    const result2 = await tool.execute("call2", {
+    const result = await tool.execute("call1", {
       command: "echo ok",
       host: "gateway",
     });
     // Should get approval-pending status instead of throwing an error
-    const details = result2.details as { status: string };
+    const details = result.details as { status: string };
     expect(details.status).toBe("approval-pending");
   });
 

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -214,10 +214,13 @@ describe("exec host env validation", () => {
   });
 
   it("allows explicit host override when tools.exec.host is not configured", async () => {
-    const tool = createExecTool({ security: "full", ask: "off" });
+    // Use ask: "always" to force the approval gate and confirm approval-pending is returned
+    // (rather than an error). With ask: "off", requiresExecApproval returns false and the
+    // command would be executed directly instead of entering the approval flow.
+    const tool = createExecTool({ security: "full", ask: "always" });
 
     // When tools.exec.host is NOT configured, explicit host="gateway" should succeed
-    // (It will return approval-pending, not throw an error)
+    // (enters the approval flow and returns approval-pending, not throw an error)
     const result = await tool.execute("call1", {
       command: "echo ok",
       host: "gateway",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -308,7 +308,7 @@ export function createExecTool(
       const sandboxHostConfigured = defaults?.host === "sandbox";
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
-      if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
+      if (!elevatedRequested && requestedHost && defaults?.host && requestedHost !== configuredHost) {
         throw new Error(
           `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
             `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -308,6 +308,9 @@ export function createExecTool(
       const sandboxHostConfigured = defaults?.host === "sandbox";
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
+      // Prevent host override when tools.exec.host is explicitly configured, unless elevated (which bypasses approvals).
+      // Note: Even with ask: "off", approval-pending may be returned if tools.exec.host is not configured and host is overridden—
+      // this is because bypassApprovals logic (below) only applies when elevatedRequested && elevatedMode === "full".
       if (!elevatedRequested && requestedHost && defaults?.host && requestedHost !== configuredHost) {
         throw new Error(
           `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +


### PR DESCRIPTION
## Problem

When `tools.exec.host` is **not configured**, there is an inconsistency:

- Implicit exec (no `host` param) → runs silently on gateway when sandbox is unavailable ✅
- Explicit `host="gateway"` → throws `exec host not allowed` ❌

This makes the explicit path *stricter* than the implicit path, violating the principle of least surprise and creating confusing security semantics.

Reported in #47244.

## Root Cause

```typescript
const configuredHost = defaults?.host ?? "sandbox";  // defaults to "sandbox" when unset
if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
  throw new Error(`exec host not allowed ...`);  // always rejects gateway
}
```

`configuredHost` uses `"sandbox"` as a default even when `defaults?.host` is undefined. The guard then rejects explicit `host="gateway"` because `"gateway" !== "sandbox"` — even though no restriction was intended by the operator.

## Fix

**One-line change:** Add a `defaults?.host` guard so the mismatch check only fires when the operator has *explicitly* configured `tools.exec.host`:

```diff
- if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
+ if (!elevatedRequested && requestedHost && defaults?.host && requestedHost !== configuredHost) {
```

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| `tools.exec.host` unset, `host="gateway"` | ❌ throws | ✅ proceeds to approval flow |
| `tools.exec.host=gateway`, `host="node"` | ❌ throws | ❌ throws (unchanged) |
| `tools.exec.host=node`, `host="gateway"` | ❌ throws | ❌ throws (unchanged) |

## Tests

- Modified existing test to verify gateway proceeds to approval-pending (not error) when host is unconfigured
- Added new test: explicit `tools.exec.host` still enforces host restriction as before