### PR TITLE
feat(feishu): add tool/compaction status callbacks to streaming cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/health monitor: add configurable stale-event thresholds and restart limits, plus per-channel and per-account `healthMonitor.enabled` overrides, while keeping the existing global disable path on `gateway.channelHealthCheckMinutes=0`. (#42107) Thanks @rstar327.
 - Feishu/cards: add identity-aware structured card headers and note footers for Feishu replies and direct sends, while keeping that presentation wired through the shared outbound identity path. (#29938) Thanks @nszhsl.
 - Feishu/streaming: add `onReasoningStream` and `onReasoningEnd` support to streaming cards, so `/reasoning stream` renders thinking tokens as markdown blockquotes in the same card — matching the Telegram channel's reasoning lane behavior.
+- Feishu/streaming: add `onToolStart`, `onAssistantMessageStart`, `onCompactionStart`, and `onCompactionEnd` callbacks to streaming cards, showing real-time tool usage and context compaction status in the card — matching the Telegram channel's status reaction behavior.
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) thanks @scoootscooob.
 - Android/nodes: add `callLog.search` plus shared Call Log permission wiring so Android nodes can search recent call history through the gateway. (#44073) Thanks @lxk7280.
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -728,24 +728,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       chatId: "oc_chat",
     });
 
-    resolveFeishuAccountMock.mockReturnValue({
-      accountId: "main",
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-      config: { renderMode: "auto", streaming: false },
-    });
-    const result2 = createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: {} as never,
-      chatId: "oc_chat",
-    });
-
-    expect(result2.replyOptions.onToolStart).toBeUndefined();
-    expect(result2.replyOptions.onAssistantMessageStart).toBeUndefined();
-    expect(result2.replyOptions.onCompactionStart).toBeUndefined();
-    expect(result2.replyOptions.onCompactionEnd).toBeUndefined();
+    expect(result.replyOptions.onToolStart).toBeUndefined();
+    expect(result.replyOptions.onAssistantMessageStart).toBeUndefined();
+    expect(result.replyOptions.onCompactionStart).toBeUndefined();
+    expect(result.replyOptions.onCompactionEnd).toBeUndefined();
   });
 
   it("onToolStart shows tool name in streaming card", async () => {
@@ -774,6 +760,25 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const lastUpdateCall = session.update.mock.calls.at(-1)?.[0] as string;
     expect(lastUpdateCall).toContain("🔧");
     expect(lastUpdateCall).toContain("web_search");
+  });
+
+  it("separates reasoning blockquote from status line with blank line", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_analyzing_" });
+    await vi.waitFor(() => expect(streamingInstances.length).toBeGreaterThan(0));
+
+    result.replyOptions.onToolStart?.({ name: "web_search" });
+    const session = streamingInstances[0];
+    await vi.waitFor(() => expect(session.update.mock.calls.length).toBeGreaterThan(1));
+    const combined = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(combined).toContain("> analyzing");
+    expect(combined).toMatch(/analyzing\n\n🔧/);
   });
 
   it("onCompactionStart shows compaction status, onCompactionEnd clears it", async () => {
@@ -815,10 +820,19 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const toolUpdate = session.update.mock.calls.at(-1)?.[0] as string;
     expect(toolUpdate).toContain("code_interpreter");
 
+    const updateCountBeforeClear = session.update.mock.calls.length;
     result.replyOptions.onAssistantMessageStart?.();
 
+    await vi.waitFor(() =>
+      expect(session.update.mock.calls.length).toBeGreaterThan(updateCountBeforeClear),
+    );
+    const clearedUpdate = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(clearedUpdate).not.toContain("code_interpreter");
+
     result.replyOptions.onPartialReply?.({ text: "Here is the result" });
-    await vi.waitFor(() => expect(session.update.mock.calls.length).toBeGreaterThan(1));
+    await vi.waitFor(() =>
+      expect(session.update.mock.calls.length).toBeGreaterThan(updateCountBeforeClear + 1),
+    );
     const answerUpdate = session.update.mock.calls.at(-1)?.[0] as string;
     expect(answerUpdate).toContain("Here is the result");
     expect(answerUpdate).not.toContain("code_interpreter");

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -704,4 +704,154 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       streamingInstances.push = origPush;
     }
   });
+
+  it("provides onToolStart, onAssistantMessageStart, onCompactionStart/End when streaming is enabled", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions.onToolStart).toBeTypeOf("function");
+    expect(result.replyOptions.onAssistantMessageStart).toBeTypeOf("function");
+    expect(result.replyOptions.onCompactionStart).toBeTypeOf("function");
+    expect(result.replyOptions.onCompactionEnd).toBeTypeOf("function");
+  });
+
+  it("omits tool/compaction callbacks when streaming is disabled", () => {
+    setupNonStreamingAutoDispatcher();
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: { renderMode: "auto", streaming: false },
+    });
+    const result2 = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result2.replyOptions.onToolStart).toBeUndefined();
+    expect(result2.replyOptions.onAssistantMessageStart).toBeUndefined();
+    expect(result2.replyOptions.onCompactionStart).toBeUndefined();
+    expect(result2.replyOptions.onCompactionEnd).toBeUndefined();
+  });
+
+  it("onToolStart shows tool name in streaming card", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    const { onToolStart } =
+      options._opts?.replyOptions ??
+      createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: {} as never,
+        chatId: "oc_chat",
+      }).replyOptions;
+
+    onToolStart?.({ name: "web_search" });
+    await vi.waitFor(() => expect(streamingInstances.length).toBeGreaterThan(0));
+
+    const session = streamingInstances[0];
+    await vi.waitFor(() => expect(session.update).toHaveBeenCalled());
+    const lastUpdateCall = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(lastUpdateCall).toContain("🔧");
+    expect(lastUpdateCall).toContain("web_search");
+  });
+
+  it("onCompactionStart shows compaction status, onCompactionEnd clears it", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    result.replyOptions.onCompactionStart?.();
+    await vi.waitFor(() => expect(streamingInstances.length).toBeGreaterThan(0));
+
+    const session = streamingInstances[0];
+    await vi.waitFor(() => expect(session.update).toHaveBeenCalled());
+    const compactingUpdate = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(compactingUpdate).toContain("📦");
+    expect(compactingUpdate).toContain("Compacting");
+
+    result.replyOptions.onCompactionEnd?.();
+    await vi.waitFor(() => expect(session.update.mock.calls.length).toBeGreaterThan(1));
+    const clearedUpdate = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(clearedUpdate).not.toContain("📦");
+  });
+
+  it("onAssistantMessageStart clears tool status line", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    result.replyOptions.onToolStart?.({ name: "code_interpreter" });
+    await vi.waitFor(() => expect(streamingInstances.length).toBeGreaterThan(0));
+
+    const session = streamingInstances[0];
+    await vi.waitFor(() => expect(session.update).toHaveBeenCalled());
+    const toolUpdate = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(toolUpdate).toContain("code_interpreter");
+
+    result.replyOptions.onAssistantMessageStart?.();
+
+    result.replyOptions.onPartialReply?.({ text: "Here is the result" });
+    await vi.waitFor(() => expect(session.update.mock.calls.length).toBeGreaterThan(1));
+    const answerUpdate = session.update.mock.calls.at(-1)?.[0] as string;
+    expect(answerUpdate).toContain("Here is the result");
+    expect(answerUpdate).not.toContain("code_interpreter");
+  });
+
+  it("status line is excluded from final closed card", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    result.replyOptions.onToolStart?.({ name: "calculator" });
+    await vi.waitFor(() => expect(streamingInstances.length).toBeGreaterThan(0));
+
+    result.replyOptions.onPartialReply?.({ text: "The answer is 42" });
+    const session = streamingInstances.at(-1)!;
+    await vi.waitFor(() => expect(session.update).toHaveBeenCalled());
+
+    const opts2 = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
+    await opts2.deliver({ text: "The answer is 42" }, { kind: "final" });
+    expect(session.close).toHaveBeenCalled();
+    const closedText = session.close.mock.calls[0]?.[0] as string;
+    expect(closedText).toContain("The answer is 42");
+    expect(closedText).not.toContain("🔧");
+    expect(closedText).not.toContain("calculator");
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -201,7 +201,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (thinking) parts.push(formatReasoningPrefix(thinking));
     if (thinking && answer) parts.push("\n\n---\n\n");
     if (answer) parts.push(answer);
-    if (statusLine && !answer) parts.push(statusLine);
+    if (statusLine && !answer) parts.push(thinking ? `\n\n${statusLine}` : statusLine);
     else if (statusLine) parts.push(`\n\n${statusLine}`);
     return parts.join("");
   };
@@ -512,6 +512,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       onAssistantMessageStart: streamingEnabled
         ? () => {
             statusLine = "";
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
           }
         : undefined,
       onCompactionStart: streamingEnabled

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -182,6 +182,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   let reasoningText = "";
+  let statusLine = "";
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -200,6 +201,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (thinking) parts.push(formatReasoningPrefix(thinking));
     if (thinking && answer) parts.push("\n\n---\n\n");
     if (answer) parts.push(answer);
+    if (statusLine && !answer) parts.push(statusLine);
+    else if (statusLine) parts.push(`\n\n${statusLine}`);
     return parts.join("");
   };
 
@@ -282,6 +285,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     await partialUpdateQueue;
     if (streaming?.isActive()) {
+      statusLine = "";
       let text = buildCombinedStreamText(reasoningText, streamText);
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
@@ -294,6 +298,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamText = "";
     lastPartial = "";
     reasoningText = "";
+    statusLine = "";
   };
 
   const sendChunkedTextReply = async (params: {
@@ -496,6 +501,32 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : undefined,
       onReasoningEnd: streamingEnabled ? () => {} : undefined,
+      onToolStart: streamingEnabled
+        ? (payload: { name?: string; phase?: string }) => {
+            const label = payload.name ?? payload.phase ?? "tool";
+            statusLine = `🔧 *Using: ${label}...*`;
+            startStreaming();
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
+      onAssistantMessageStart: streamingEnabled
+        ? () => {
+            statusLine = "";
+          }
+        : undefined,
+      onCompactionStart: streamingEnabled
+        ? () => {
+            statusLine = "📦 *Compacting context...*";
+            startStreaming();
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
+      onCompactionEnd: streamingEnabled
+        ? () => {
+            statusLine = "";
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
     },
     markDispatchIdle,
   };


### PR DESCRIPTION
## Summary

- Wire `onToolStart`, `onAssistantMessageStart`, `onCompactionStart`, and `onCompactionEnd` callbacks into the Feishu streaming reply dispatcher
- When streaming is enabled, tool usage shows as `🔧 *Using: tool_name...*` and context compaction shows as `📦 *Compacting context...*` at the bottom of the streaming card
- `onAssistantMessageStart` and `onCompactionEnd` clear the status line; the final closed card never includes transient status text
- Matches the Telegram channel's `statusReactionController` behavior, adapted for Feishu's single streaming card paradigm

## Changes

| File | What changed |
|------|-------------|
| `extensions/feishu/src/reply-dispatcher.ts` | Added `statusLine` state variable, integrated it into `buildCombinedStreamText`, added 4 new callbacks in `replyOptions`, clear status in `closeStreaming` |
| `extensions/feishu/src/reply-dispatcher.test.ts` | 6 new test cases covering callback presence/absence, tool status display, compaction status, assistant message boundary clearing, and final card exclusion |
| `CHANGELOG.md` | Added unreleased changelog entry |

## How it works

The streaming card now renders an optional status line below the answer text (or standalone when no answer has arrived yet):

```
> 💭 **Thinking**
> analyzing the request...

---

Here is some partial answer...

🔧 *Using: web_search...*
```

When `onAssistantMessageStart` fires (answer tokens begin), the status line is cleared so it doesn't persist into the answer. When the card is finalized via `closeStreaming()`, `statusLine` is reset first to ensure the closed card contains only reasoning + answer content.

## Test plan

- [x] All 35 existing + new tests pass locally (`vitest run extensions/feishu/src/reply-dispatcher.test.ts`)
- [ ] CI passes
- [ ] Manual verification with `/reasoning stream` + tool-using agent on Feishu


Made with [Cursor](https://cursor.com)