### PR TITLE
fix(cron): verify reproducibility on current main, then fix cron se...

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -353,4 +353,46 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.model).toBe("gpt-4o");
     expect(cronSession.sessionEntry.modelProvider).toBe("openai");
   });
+
+  it("prefixes default provider for slash-containing model without providerOverride (#18556)", async () => {
+    // No cron payload model — the job has no model field
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest" },
+    });
+
+    // Session-level /model override with slashes but no provider override
+    // (e.g. Cloudflare Workers AI model IDs like "@cf/openai/gpt-oss-20b")
+    cronSession.sessionEntry = makeFreshSessionEntry({
+      modelOverride: "@cf/openai/gpt-oss-20b",
+      providerOverride: undefined,
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+
+    // Without the default-provider prefix, parseModelRef would split on the
+    // first "/" and misinterpret "@cf" as the provider.  With the fix, the
+    // resolver receives "anthropic/@cf/openai/gpt-oss-20b" so the default
+    // provider is correctly preserved.
+    resolveAllowedModelRefMock.mockImplementation(
+      (params: { raw: string; defaultProvider: string }) => {
+        if (
+          params.raw === "anthropic/@cf/openai/gpt-oss-20b" &&
+          params.defaultProvider === "anthropic"
+        ) {
+          return {
+            ref: { provider: "anthropic", model: "@cf/openai/gpt-oss-20b" },
+            key: "anthropic/@cf/openai/gpt-oss-20b",
+          };
+        }
+        return { error: `model not allowed: ${params.raw}` };
+      },
+    );
+
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    expect(cronSession.sessionEntry.model).toBe("@cf/openai/gpt-oss-20b");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
 });

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -333,10 +333,12 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     });
     resolveCronSessionMock.mockReturnValue(cronSession);
 
-    // The model ref should be passed as "gpt-4o" with defaultProvider "openai"
+    // The provider override is prepended to raw so the resolver sees "openai/gpt-4o",
+    // and defaultProvider stays aligned with the config default (anthropic) so the
+    // allowlist auto-added key does not create a policy bypass.
     resolveAllowedModelRefMock.mockImplementation(
       (params: { raw: string; defaultProvider: string }) => {
-        if (params.raw === "gpt-4o" && params.defaultProvider === "openai") {
+        if (params.raw === "openai/gpt-4o" && params.defaultProvider === "anthropic") {
           return { ref: { provider: "openai", model: "gpt-4o" }, key: "openai/gpt-4o" };
         }
         return { error: `model not allowed: ${params.raw}` };

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -250,4 +250,102 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
+
+  it("resolves alias-only session modelOverride without provider prefix (#18556)", async () => {
+    // No cron payload model — the job has no model field
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest" },
+    });
+
+    // Session-level /model override set to an alias (no provider prefix)
+    cronSession.sessionEntry = makeFreshSessionEntry({
+      modelOverride: "sonnet",
+      providerOverride: undefined,
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+
+    // BUG (#18556): before the fix, the session override path prepended the
+    // default provider ("anthropic/sonnet"), which caused resolveAllowedModelRef
+    // to skip alias lookup (aliases only resolve when raw has no '/').
+    // The mock discriminates: alias "sonnet" succeeds; "anthropic/sonnet" fails.
+    resolveAllowedModelRefMock.mockImplementation(
+      (params: { raw: string; defaultProvider: string }) => {
+        if (params.raw === "sonnet") {
+          return {
+            ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
+            key: "anthropic/claude-sonnet-4-6",
+          };
+        }
+        // Provider-prefixed alias → the old broken path
+        return { error: `model not allowed: ${params.defaultProvider}/${params.raw}` };
+      },
+    );
+
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    // The alias should resolve to the actual model, not fall back to the default.
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("resolves alias-only payload.model in cron jobs (#18556)", async () => {
+    // Cron payload uses an alias name
+    const jobWithAlias = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest", model: "sonnet" },
+    });
+
+    // Alias resolves correctly through resolveAllowedModelRef
+    resolveAllowedModelRefMock.mockImplementation((params: { raw: string }) => {
+      if (params.raw === "sonnet") {
+        return {
+          ref: { provider: "anthropic", model: "claude-sonnet-4-6" },
+          key: "anthropic/claude-sonnet-4-6",
+        };
+      }
+      return { error: `model not allowed: ${params.raw}` };
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithAlias }));
+
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
+  it("session modelOverride with explicit providerOverride still works (#18556)", async () => {
+    // No cron payload model
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest" },
+    });
+
+    // Session has an explicit provider + model override (not an alias)
+    cronSession.sessionEntry = makeFreshSessionEntry({
+      modelOverride: "gpt-4o",
+      providerOverride: "openai",
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+
+    // The model ref should be passed as "gpt-4o" with defaultProvider "openai"
+    resolveAllowedModelRefMock.mockImplementation(
+      (params: { raw: string; defaultProvider: string }) => {
+        if (params.raw === "gpt-4o" && params.defaultProvider === "openai") {
+          return { ref: { provider: "openai", model: "gpt-4o" }, key: "openai/gpt-4o" };
+        }
+        return { error: `model not allowed: ${params.raw}` };
+      },
+    );
+
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithoutModel }));
+
+    expect(result.status).toBe("error");
+    expect(cronSession.sessionEntry.model).toBe("gpt-4o");
+    expect(cronSession.sessionEntry.modelProvider).toBe("openai");
+  });
 });

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -308,11 +308,14 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
       return { error: `model not allowed: ${params.raw}` };
     });
 
-    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+    // Use rejected mock so the test asserts pre-run persist state (not the
+    // post-run setSessionRuntimeModel path which would mask a broken alias).
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error("LLM provider timeout"));
 
     const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithAlias }));
 
-    expect(result.status).toBe("ok");
+    expect(result.status).toBe("error");
+    // Model set by pre-run persist, proving alias was resolved before the run:
     expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -366,11 +366,14 @@ export async function runCronIsolatedAgentTurn(params: {
     if (sessionModelOverride) {
       const sessionProviderOverride =
         cronSession.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
+      // Pass the raw override without manually prepending the provider so
+      // that alias resolution inside resolveAllowedModelRef is not bypassed
+      // (aliases are only checked when the raw string has no '/').  #18556
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: cfgWithAgentDefaults,
         catalog: await loadCatalog(),
-        raw: `${sessionProviderOverride}/${sessionModelOverride}`,
-        defaultProvider: resolvedDefault.provider,
+        raw: sessionModelOverride,
+        defaultProvider: sessionProviderOverride,
         defaultModel: resolvedDefault.model,
       });
       if (!("error" in resolvedSessionOverride)) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -364,16 +364,21 @@ export async function runCronIsolatedAgentTurn(params: {
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
-      const sessionProviderOverride =
-        cronSession.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
-      // Pass the raw override without manually prepending the provider so
-      // that alias resolution inside resolveAllowedModelRef is not bypassed
-      // (aliases are only checked when the raw string has no '/').  #18556
+      const sessionProviderOverride = cronSession.sessionEntry.providerOverride?.trim();
+      // When the session has an explicit provider override that differs from
+      // the default, prepend it to the raw model string so the resolver looks
+      // up the correct provider. Keep defaultProvider/defaultModel aligned with
+      // resolvedDefault so buildAllowedModelSet does not auto-whitelist an
+      // unintended provider/model pair.  #18556
+      const raw =
+        sessionProviderOverride && sessionProviderOverride !== resolvedDefault.provider
+          ? `${sessionProviderOverride}/${sessionModelOverride}`
+          : sessionModelOverride;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: cfgWithAgentDefaults,
         catalog: await loadCatalog(),
-        raw: sessionModelOverride,
-        defaultProvider: sessionProviderOverride,
+        raw,
+        defaultProvider: resolvedDefault.provider,
         defaultModel: resolvedDefault.model,
       });
       if (!("error" in resolvedSessionOverride)) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -365,15 +365,14 @@ export async function runCronIsolatedAgentTurn(params: {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
       const sessionProviderOverride = cronSession.sessionEntry.providerOverride?.trim();
-      // When the session has an explicit provider override that differs from
-      // the default, prepend it to the raw model string so the resolver looks
-      // up the correct provider. Keep defaultProvider/defaultModel aligned with
-      // resolvedDefault so buildAllowedModelSet does not auto-whitelist an
-      // unintended provider/model pair.  #18556
-      const raw =
-        sessionProviderOverride && sessionProviderOverride !== resolvedDefault.provider
-          ? `${sessionProviderOverride}/${sessionModelOverride}`
-          : sessionModelOverride;
+      // Always prepend the session provider when one is set, even when it
+      // matches resolvedDefault.provider. Model IDs can themselves contain
+      // slashes (e.g. OpenRouter's "anthropic/claude-sonnet-4-5"), so passing
+      // the raw override without a provider prefix causes parseModelRef to
+      // split on the wrong delimiter and route to the wrong provider.  #18556
+      const raw = sessionProviderOverride
+        ? `${sessionProviderOverride}/${sessionModelOverride}`
+        : sessionModelOverride;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: cfgWithAgentDefaults,
         catalog: await loadCatalog(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -365,14 +365,16 @@ export async function runCronIsolatedAgentTurn(params: {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
       const sessionProviderOverride = cronSession.sessionEntry.providerOverride?.trim();
-      // Always prepend the session provider when one is set, even when it
-      // matches resolvedDefault.provider. Model IDs can themselves contain
-      // slashes (e.g. OpenRouter's "anthropic/claude-sonnet-4-5"), so passing
-      // the raw override without a provider prefix causes parseModelRef to
-      // split on the wrong delimiter and route to the wrong provider.  #18556
+      // When a provider override is set, always prepend it.  When absent,
+      // prefix the default provider only when the model ID contains slashes
+      // (e.g. "@cf/openai/gpt-oss-20b") so parseModelRef doesn't split on
+      // the wrong delimiter.  Slash-free strings are left bare so alias
+      // resolution in resolveAllowedModelRef still works.  #18556
       const raw = sessionProviderOverride
         ? `${sessionProviderOverride}/${sessionModelOverride}`
-        : sessionModelOverride;
+        : sessionModelOverride.includes("/")
+          ? `${resolvedDefault.provider}/${sessionModelOverride}`
+          : sessionModelOverride;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: cfgWithAgentDefaults,
         catalog: await loadCatalog(),


### PR DESCRIPTION
Cron jobs using model aliases may not resolve or persist the aliased model correctly, falling back to the default model instead.

Closes #18556

Changes:
- Reproduce on current main with a cron job using an alias-only payload.model; inspect both runtime provider/model selection and stored session fields.
- If reproduction only affects session output, adjust src/cron/isolated-agent/run.ts or src/gateway/session-utils.ts so cron sessions persist and display the resolved runtime model consistently.
- If reproduction shows the runner truly ignoring aliases, trace cfgWithAgentDefaults passed into resolveAllowedModelRef and patch the config-merge path so agents.defaults.models.*.alias survives into cron execution.
- Add a focused regression test covering alias-based payload.model in isolated cron runs, asserting both the executed model and the persisted session model fields.

Testing:
- pnpm build && pnpm check && pnpm test
- Run targeted Vitest coverage for src/cron/isolated-agent/run.cron-model-override.test.ts, add an alias-specific cron regression test, and confirm openclaw cron run <job> records the aliased model instead of the default in session JSON.

---
AI-assisted (Claude + Codex committee consensus, fully tested).

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate — equivalent to codex review)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved