### PR TITLE
fix(msteams): update FileConsentCard in-place after upload via updateActivity

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -91,8 +91,14 @@ function createInvokeContext(params: {
   conversationId: string;
   uploadId: string;
   action: "accept" | "decline";
-}): { context: MSTeamsTurnContext; sendActivity: ReturnType<typeof vi.fn> } {
+  replyToId?: string;
+}): {
+  context: MSTeamsTurnContext;
+  sendActivity: ReturnType<typeof vi.fn>;
+  updateActivity: ReturnType<typeof vi.fn>;
+} {
   const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
+  const updateActivity = vi.fn(async () => {});
   const uploadInfo =
     params.action === "accept"
       ? {
@@ -109,6 +115,7 @@ function createInvokeContext(params: {
         type: "invoke",
         name: "fileConsent/invoke",
         conversation: { id: params.conversationId },
+        replyToId: params.replyToId,
         value: {
           type: "fileUpload",
           action: params.action,
@@ -118,8 +125,10 @@ function createInvokeContext(params: {
       },
       sendActivity,
       sendActivities: async () => [],
+      updateActivity,
     } as unknown as MSTeamsTurnContext,
     sendActivity,
+    updateActivity,
   };
 }
 
@@ -158,6 +167,120 @@ describe("msteams file consent invoke authz", () => {
     expect(sendActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "invokeResponse",
+      }),
+    );
+  });
+
+  it("updates consent card in-place via updateActivity when replyToId is present", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("file content"),
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      conversationId: "19:user@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity, updateActivity } = createInvokeContext({
+      conversationId: "19:user@thread.v2;messageid=abc123",
+      uploadId,
+      action: "accept",
+      replyToId: "consent-card-activity-id",
+    });
+
+    await handler.run?.(context);
+
+    // Should update the original consent card in-place
+    expect(updateActivity).toHaveBeenCalledTimes(1);
+    expect(updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "consent-card-activity-id",
+        type: "message",
+        attachments: [
+          expect.objectContaining({
+            contentType: "application/vnd.microsoft.teams.card.file.info",
+            name: "secret.txt",
+          }),
+        ],
+      }),
+    );
+
+    // Should NOT send FileInfoCard as a new message
+    const fileInfoCalls = sendActivity.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        "attachments" in (call[0] as Record<string, unknown>),
+    );
+    expect(fileInfoCalls).toHaveLength(0);
+  });
+
+  it("falls back to sendActivity when updateActivity fails", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("file content"),
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      conversationId: "19:user@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity, updateActivity } = createInvokeContext({
+      conversationId: "19:user@thread.v2;messageid=abc123",
+      uploadId,
+      action: "accept",
+      replyToId: "consent-card-activity-id",
+    });
+
+    // Simulate updateActivity failure
+    updateActivity.mockRejectedValueOnce(new Error("Activity not found"));
+
+    await handler.run?.(context);
+
+    // Should have attempted updateActivity
+    expect(updateActivity).toHaveBeenCalledTimes(1);
+
+    // Should fall back to sending FileInfoCard as a new message
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        attachments: [
+          expect.objectContaining({
+            contentType: "application/vnd.microsoft.teams.card.file.info",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("sends FileInfoCard as new message when replyToId is not present", async () => {
+    const uploadId = storePendingUpload({
+      buffer: Buffer.from("file content"),
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      conversationId: "19:user@thread.v2",
+    });
+    const deps = createDeps();
+    const handler = registerMSTeamsHandlers(createActivityHandler(), deps);
+    const { context, sendActivity, updateActivity } = createInvokeContext({
+      conversationId: "19:user@thread.v2;messageid=abc123",
+      uploadId,
+      action: "accept",
+      // No replyToId
+    });
+
+    await handler.run?.(context);
+
+    // Should NOT call updateActivity
+    expect(updateActivity).not.toHaveBeenCalled();
+
+    // Should send FileInfoCard as a new message (fallback path)
+    expect(sendActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        attachments: [
+          expect.objectContaining({
+            contentType: "application/vnd.microsoft.teams.card.file.info",
+          }),
+        ],
       }),
     );
   });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -93,7 +93,10 @@ async function handleFileConsentInvoke(
           contentType: pendingFile.contentType,
         });
 
-        // Send confirmation card
+        // Replace the original FileConsentCard with a FileInfoCard.
+        // Using updateActivity (when available) transitions the card in-place
+        // so the user sees the consent card change to a file download card
+        // instead of a stale Allow/Deny prompt remaining in the conversation.
         const fileInfoCard = buildFileInfoCard({
           filename: consentResponse.uploadInfo.name,
           contentUrl: consentResponse.uploadInfo.contentUrl,
@@ -101,10 +104,34 @@ async function handleFileConsentInvoke(
           fileType: consentResponse.uploadInfo.fileType,
         });
 
-        await context.sendActivity({
-          type: "message",
-          attachments: [fileInfoCard],
-        });
+        const consentActivityId =
+          typeof activity.replyToId === "string" ? activity.replyToId : undefined;
+
+        if (consentActivityId && typeof context.updateActivity === "function") {
+          try {
+            await context.updateActivity({
+              id: consentActivityId,
+              type: "message",
+              attachments: [fileInfoCard],
+            });
+          } catch (updateErr) {
+            // Fallback: if update fails (e.g. permissions, expired activity),
+            // send the FileInfoCard as a new message so the user still gets it.
+            log.debug?.("failed to update consent card, sending as new message", {
+              error: String(updateErr),
+            });
+            await context.sendActivity({
+              type: "message",
+              attachments: [fileInfoCard],
+            });
+          }
+        } else {
+          // No activity ID or updateActivity not available — send as new message.
+          await context.sendActivity({
+            type: "message",
+            attachments: [fileInfoCard],
+          });
+        }
 
         log.info("file upload complete", {
           uploadId,

--- a/extensions/msteams/src/sdk-types.ts
+++ b/extensions/msteams/src/sdk-types.ts
@@ -16,4 +16,6 @@ export type MSTeamsTurnContext = {
   sendActivities: (
     activities: Array<{ type: string } & Record<string, unknown>>,
   ) => Promise<unknown>;
+  /** Update an existing activity in the conversation (e.g. replace a FileConsentCard). */
+  updateActivity?: (activity: { id: string } & Record<string, unknown>) => Promise<unknown>;
 };


### PR DESCRIPTION
## Summary

After a user clicks "Allow" on a `FileConsentCard`, the card remains frozen showing Allow/Deny buttons even though the file uploads successfully. This is because the `FileInfoCard` confirmation is sent as a **new message** instead of **replacing the original consent card** in-place.

This PR fixes the UX by using `context.updateActivity()` to replace the original `FileConsentCard` with a `FileInfoCard` after successful upload.

### Before (broken UX)

```
1. Bot sends FileConsentCard (Allow / Deny)
2. User clicks Allow
3. File uploads successfully
4. FileInfoCard sent as NEW message
5. Original consent card still shows stale Allow/Deny buttons ← bad
```

### After (fixed UX)

```
1. Bot sends FileConsentCard (Allow / Deny)
2. User clicks Allow
3. File uploads successfully
4. Original consent card REPLACED with FileInfoCard ← card transitions in-place
```

### Changes

| File | What changed |
|---|---|
| `extensions/msteams/src/sdk-types.ts` | Added optional `updateActivity` to `MSTeamsTurnContext` type |
| `extensions/msteams/src/monitor-handler.ts` | After upload, use `updateActivity()` with the invoke `replyToId` to replace the consent card in-place; fall back to `sendActivity` if update fails or is unavailable |
| `extensions/msteams/src/monitor-handler.file-consent.test.ts` | Added tests for: in-place card update, fallback on `updateActivity` failure, and fallback when `replyToId` is absent |

### Fallback Safety

The fix is fully backward-compatible:
- If `updateActivity` is not available on the context → falls back to `sendActivity` (current behavior)
- If `replyToId` is not present on the invoke activity → falls back to `sendActivity`
- If `updateActivity` throws (expired activity, permissions error) → catches error, falls back to `sendActivity`

In all fallback cases, the user still receives the `FileInfoCard` — just as a new message (existing behavior).

### Testing

- 3 new test cases covering the happy path, error fallback, and missing `replyToId` fallback
- Existing tests updated to expose `updateActivity` mock and `replyToId` field
- All existing tests continue to pass

### References

- [Microsoft Teams: Send and receive files](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-and-receive-files)
- [Bot Framework: Update activity](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#update-activity)

Fixes #47268