### PR TITLE
feat: add user-specific memory isolation

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -39,23 +39,23 @@ export default definePluginEntry({
     });
 
     api.registerTool(
-      (ctx) => {
-        const memorySearchTool = api.runtime.tools.createMemorySearchTool({
+      (ctx) =>
+        api.runtime.tools.createMemorySearchTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
           senderId: ctx.requesterSenderId,
-        });
-        const memoryGetTool = api.runtime.tools.createMemoryGetTool({
+        }),
+      { names: ["memory_search"] },
+    );
+
+    api.registerTool(
+      (ctx) =>
+        api.runtime.tools.createMemoryGetTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
           senderId: ctx.requesterSenderId,
-        });
-        if (!memorySearchTool || !memoryGetTool) {
-          return null;
-        }
-        return [memorySearchTool, memoryGetTool];
-      },
-      { names: ["memory_search", "memory_get"] },
+        }),
+      { names: ["memory_get"] },
     );
 
     api.registerCli(

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -12,6 +12,7 @@ import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-a
 import { buildPromptSection } from "./src/prompt-section.js";
 import { listMemoryCorePublicArtifacts } from "./src/public-artifacts.js";
 import { memoryRuntime } from "./src/runtime-provider.js";
+import { createMemoryGetTool, createMemorySearchTool } from "./src/tools.js";
 export {
   buildMemoryFlushPlan,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
@@ -40,7 +41,7 @@ export default definePluginEntry({
 
     api.registerTool(
       (ctx) =>
-        api.runtime.tools.createMemorySearchTool({
+        createMemorySearchTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
           senderId: ctx.requesterSenderId,
@@ -50,7 +51,7 @@ export default definePluginEntry({
 
     api.registerTool(
       (ctx) =>
-        api.runtime.tools.createMemoryGetTool({
+        createMemoryGetTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
           senderId: ctx.requesterSenderId,

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -12,7 +12,6 @@ import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-a
 import { buildPromptSection } from "./src/prompt-section.js";
 import { listMemoryCorePublicArtifacts } from "./src/public-artifacts.js";
 import { memoryRuntime } from "./src/runtime-provider.js";
-import { createMemoryGetTool, createMemorySearchTool } from "./src/tools.js";
 export {
   buildMemoryFlushPlan,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
@@ -40,21 +39,23 @@ export default definePluginEntry({
     });
 
     api.registerTool(
-      (ctx) =>
-        createMemorySearchTool({
+      (ctx) => {
+        const memorySearchTool = api.runtime.tools.createMemorySearchTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
-        }),
-      { names: ["memory_search"] },
-    );
-
-    api.registerTool(
-      (ctx) =>
-        createMemoryGetTool({
+          senderId: ctx.requesterSenderId,
+        });
+        const memoryGetTool = api.runtime.tools.createMemoryGetTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
-        }),
-      { names: ["memory_get"] },
+          senderId: ctx.requesterSenderId,
+        });
+        if (!memorySearchTool || !memoryGetTool) {
+          return null;
+        }
+        return [memorySearchTool, memoryGetTool];
+      },
+      { names: ["memory_search", "memory_get"] },
     );
 
     api.registerCli(

--- a/extensions/memory-core/src/isolation-identity.test.ts
+++ b/extensions/memory-core/src/isolation-identity.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { IsolationIdentityError, resolveIsolationIdentity } from "./isolation-identity.js";
+
+const cfgWith = (isolation?: Record<string, unknown>) =>
+  ({
+    memory: { isolation },
+  }) as unknown as Parameters<typeof resolveIsolationIdentity>[0]["cfg"];
+
+describe("resolveIsolationIdentity", () => {
+  it("returns undefined when isolation is disabled", () => {
+    const result = resolveIsolationIdentity({
+      cfg: cfgWith({ enabled: false }),
+      agentId: "agent1",
+      sessionKey: "agent:agent1:direct:alice:c1",
+      senderId: "alice",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when memory config is missing entirely", () => {
+    const result = resolveIsolationIdentity({
+      cfg: {} as never,
+      agentId: "agent1",
+      sessionKey: "agent:agent1:direct:alice:c1",
+      senderId: "alice",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("prefers explicit senderId when isolation enabled", () => {
+    const result = resolveIsolationIdentity({
+      cfg: cfgWith({ enabled: true }),
+      agentId: "agent1",
+      sessionKey: "agent:agent1:direct:bob:c1",
+      senderId: "alice",
+    });
+    expect(result).toBe("alice");
+  });
+
+  it("falls back to direct-DM userId extracted from session key", () => {
+    const result = resolveIsolationIdentity({
+      cfg: cfgWith({ enabled: true }),
+      agentId: "agent1",
+      sessionKey: "agent:agent1:direct:bob:c1",
+    });
+    expect(result).toBe("bob");
+  });
+
+  it("throws when no identity resolvable and fallbackPolicy='deny' (default)", () => {
+    expect(() =>
+      resolveIsolationIdentity({
+        cfg: cfgWith({ enabled: true }),
+        agentId: "agent1",
+        sessionKey: "agent:agent1:channel:discord:42",
+      }),
+    ).toThrow(IsolationIdentityError);
+  });
+
+  it("falls back to session-derived identity when policy='session'", () => {
+    const result = resolveIsolationIdentity({
+      cfg: cfgWith({ enabled: true, fallbackPolicy: "session" }),
+      agentId: "agent1",
+      sessionKey: "agent:agent1:channel:discord:42",
+    });
+    expect(result).toBe("session:agent:agent1:channel:discord:42");
+  });
+
+  it("falls back to agent identity when policy='agent'", () => {
+    const result = resolveIsolationIdentity({
+      cfg: cfgWith({ enabled: true, fallbackPolicy: "agent" }),
+      agentId: "agent1",
+      sessionKey: "agent:agent1:channel:discord:42",
+    });
+    expect(result).toBe("agent:agent1");
+  });
+
+  it("treats fallbackPolicy='deny' as the default when omitted", () => {
+    expect(() =>
+      resolveIsolationIdentity({
+        cfg: cfgWith({ enabled: true }),
+        agentId: "agent1",
+        sessionKey: "agent:agent1:group:slack:T123",
+      }),
+    ).toThrow(IsolationIdentityError);
+  });
+
+  it("treats undefined senderId as missing (does not stringify)", () => {
+    expect(() =>
+      resolveIsolationIdentity({
+        cfg: cfgWith({ enabled: true }),
+        agentId: "agent1",
+        sessionKey: "agent:agent1:channel:discord:42",
+        senderId: undefined,
+      }),
+    ).toThrow(IsolationIdentityError);
+  });
+
+  it("rejects empty-string senderId as missing identity", () => {
+    expect(() =>
+      resolveIsolationIdentity({
+        cfg: cfgWith({ enabled: true }),
+        agentId: "agent1",
+        sessionKey: "agent:agent1:channel:discord:42",
+        senderId: "",
+      }),
+    ).toThrow(IsolationIdentityError);
+  });
+});

--- a/extensions/memory-core/src/isolation-identity.ts
+++ b/extensions/memory-core/src/isolation-identity.ts
@@ -1,0 +1,90 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+
+export class IsolationIdentityError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "IsolationIdentityError";
+  }
+}
+
+type FallbackPolicy = "deny" | "session" | "agent";
+
+const RESERVED_SEGMENTS = new Set(["group", "channel", "dm", "cron", "subagent", "acp"]);
+
+export function isMemoryIsolationEnabled(cfg: OpenClawConfig | undefined): boolean {
+  return readIsolation(cfg)?.enabled === true;
+}
+
+function readIsolation(cfg: OpenClawConfig | undefined): {
+  enabled: boolean;
+  fallbackPolicy: FallbackPolicy;
+} | null {
+  const memory = (cfg as { memory?: { isolation?: Record<string, unknown> } } | undefined)?.memory;
+  const iso = memory?.isolation;
+  if (!iso) {
+    return null;
+  }
+  const enabled = iso.enabled !== false;
+  if (!enabled) {
+    return { enabled: false, fallbackPolicy: "deny" };
+  }
+  const raw = iso.fallbackPolicy;
+  const fallbackPolicy: FallbackPolicy = raw === "session" || raw === "agent" ? raw : "deny";
+  return { enabled, fallbackPolicy };
+}
+
+function extractDirectUserId(sessionKey: string | undefined): string | null {
+  if (!sessionKey) {
+    return null;
+  }
+  const parts = sessionKey.split(":").filter(Boolean);
+  if (parts.length < 3 || parts[0] !== "agent") {
+    return null;
+  }
+  const directIdx = parts.indexOf("direct", 2);
+  if (directIdx === -1 || directIdx + 1 >= parts.length) {
+    return null;
+  }
+  const candidate = parts[directIdx + 1];
+  if (!candidate || RESERVED_SEGMENTS.has(candidate)) {
+    return null;
+  }
+  return candidate;
+}
+
+export function resolveIsolationIdentity(opts: {
+  cfg: OpenClawConfig | undefined;
+  agentId: string;
+  sessionKey?: string;
+  senderId?: string;
+}): string | undefined {
+  const policy = readIsolation(opts.cfg);
+  if (!policy || !policy.enabled) {
+    return undefined;
+  }
+  const sender = typeof opts.senderId === "string" ? opts.senderId.trim() : "";
+  if (sender) {
+    return sender;
+  }
+  const fromKey = extractDirectUserId(opts.sessionKey);
+  if (fromKey) {
+    return fromKey;
+  }
+  switch (policy.fallbackPolicy) {
+    case "session":
+      if (!opts.sessionKey) {
+        throw new IsolationIdentityError("session fallback requested but sessionKey is missing");
+      }
+      return `session:${opts.sessionKey}`;
+    case "agent":
+      return `agent:${opts.agentId}`;
+    case "deny":
+    default:
+      throw new IsolationIdentityError(
+        "memory isolation enabled but no user identity could be resolved (sender/session)",
+      );
+  }
+}

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -125,6 +125,7 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly cfg: OpenClawConfig;
   protected abstract readonly agentId: string;
   protected abstract readonly workspaceDir: string;
+  protected abstract readonly userId?: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
   protected fallbackFrom?: EmbeddingProviderId;
@@ -684,6 +685,7 @@ export abstract class MemoryManagerSyncOps {
       this.workspaceDir,
       this.settings.extraPaths,
       this.settings.multimodal,
+      this.userId,
     );
     const fileEntries = (
       await runWithConcurrency(

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -81,6 +81,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly agentId: string;
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
+  protected readonly userId: string | undefined;
   protected provider: EmbeddingProvider | null;
   private readonly requestedProvider: EmbeddingProviderRequest;
   private providerInitPromise: Promise<void> | null = null;
@@ -155,16 +156,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   static async get(params: {
     cfg: OpenClawConfig;
     agentId: string;
+    userId?: string;
     purpose?: "default" | "status";
   }): Promise<MemoryIndexManager | null> {
-    const { cfg, agentId } = params;
+    const { cfg, agentId, userId } = params;
     const settings = resolveMemorySearchConfig(cfg, agentId);
     if (!settings) {
       return null;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const purpose = params.purpose === "status" ? "status" : "default";
-    const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}:${purpose}`;
+    // Include userId in cache key when isolation is enabled and userId is provided
+    const isolationKey = settings.isolation.enabled && userId ? `:${userId}` : "";
+    const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}:${purpose}${isolationKey}`;
     const statusOnly = params.purpose === "status";
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
@@ -179,6 +183,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           workspaceDir,
           settings,
           purpose: params.purpose,
+          userId: settings.isolation.enabled ? userId : undefined,
         }),
     });
   }
@@ -191,6 +196,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     settings: ResolvedMemorySearchConfig;
     providerResult?: EmbeddingProviderResult;
     purpose?: "default" | "status";
+    userId?: string;
   }) {
     super();
     this.cacheKey = params.cacheKey;
@@ -198,6 +204,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
     this.settings = params.settings;
+    this.userId = params.userId;
     this.provider = null;
     this.requestedProvider = params.settings.provider;
     if (params.providerResult) {
@@ -686,6 +693,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       relPath: params.relPath,
       from: params.from,
       lines: params.lines,
+      userId: this.userId,
     });
   }
 

--- a/extensions/memory-core/src/memory/qmd-cache-key.test.ts
+++ b/extensions/memory-core/src/memory/qmd-cache-key.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildQmdCacheKey } from "./qmd-cache-key.js";
+
+const baseConfig = {
+  command: "qmd",
+  collections: [],
+  searchMode: "query",
+} as unknown as Parameters<typeof buildQmdCacheKey>[1];
+
+describe("buildQmdCacheKey", () => {
+  it("differs by agentId", () => {
+    expect(buildQmdCacheKey("a1", baseConfig)).not.toBe(buildQmdCacheKey("a2", baseConfig));
+  });
+
+  it("differs by userId when provided", () => {
+    expect(buildQmdCacheKey("a1", baseConfig, "alice")).not.toBe(
+      buildQmdCacheKey("a1", baseConfig, "bob"),
+    );
+  });
+
+  it("treats userId=undefined as the legacy unscoped key", () => {
+    const legacy = buildQmdCacheKey("a1", baseConfig);
+    const explicitUndef = buildQmdCacheKey("a1", baseConfig, undefined);
+    expect(legacy).toBe(explicitUndef);
+  });
+
+  it("scoped key never collides with unscoped key for same agent", () => {
+    expect(buildQmdCacheKey("a1", baseConfig)).not.toBe(
+      buildQmdCacheKey("a1", baseConfig, "alice"),
+    );
+  });
+
+  it("is deterministic for identical inputs", () => {
+    expect(buildQmdCacheKey("a1", baseConfig, "alice")).toBe(
+      buildQmdCacheKey("a1", baseConfig, "alice"),
+    );
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-cache-key.ts
+++ b/extensions/memory-core/src/memory/qmd-cache-key.ts
@@ -1,0 +1,19 @@
+import type { ResolvedQmdConfig } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
+/**
+ * Build a cache key for QmdMemoryManager instances.
+ *
+ * The key includes the agentId, the resolved QMD config, and an optional userId
+ * so that per-user managers do not share cached state with the agent-wide one
+ * or with managers belonging to other users.
+ */
+export function buildQmdCacheKey(
+  agentId: string,
+  config: ResolvedQmdConfig,
+  userId?: string,
+): string {
+  // ResolvedQmdConfig is assembled in a stable field order in resolveMemoryBackendConfig.
+  // Fast stringify avoids deep key-sorting overhead on this hot path.
+  const base = `${agentId}:${JSON.stringify(config)}`;
+  return userId ? `${base}::user:${userId}` : base;
+}

--- a/extensions/memory-core/src/memory/qmd-manager-isolation-guard.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-isolation-guard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { QmdMemoryManager } from "./qmd-manager.js";
+
+const baseCfg = {
+  memory: {
+    isolation: { enabled: true, fallbackPolicy: "deny" },
+  },
+} as unknown as Parameters<typeof QmdMemoryManager.create>[0]["cfg"];
+
+const cfgWithoutIsolation = {} as unknown as typeof baseCfg;
+
+const resolvedQmd = {
+  qmd: {
+    command: "qmd",
+    collections: [],
+    searchMode: "query",
+  },
+} as unknown as Parameters<typeof QmdMemoryManager.create>[0]["resolved"];
+
+describe("QmdMemoryManager.create isolation guard", () => {
+  it("returns null when isolation is enabled but userId is missing", async () => {
+    const result = await QmdMemoryManager.create({
+      cfg: baseCfg,
+      agentId: "agent-x",
+      resolved: resolvedQmd,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when isolation is enabled and userId is empty string", async () => {
+    const result = await QmdMemoryManager.create({
+      cfg: baseCfg,
+      agentId: "agent-x",
+      userId: "",
+      resolved: resolvedQmd,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not enforce userId when isolation is disabled (or absent)", async () => {
+    // We do not assert on a successful instance — initialize() may need on-disk
+    // dependencies. We only assert that the early guard does NOT short-circuit
+    // to null for the non-isolation case (i.e., it would proceed to initialize,
+    // and any failure beyond the guard is unrelated to this test). To keep the
+    // test deterministic, we pass a resolved config without `qmd`, which makes
+    // create() return null at the *first* (existing) early-return — proving the
+    // isolation guard wasn't the path taken.
+    const result = await QmdMemoryManager.create({
+      cfg: cfgWithoutIsolation,
+      agentId: "agent-x",
+      resolved: { qmd: undefined } as unknown as Parameters<
+        typeof QmdMemoryManager.create
+      >[0]["resolved"],
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -253,6 +253,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   static async create(params: {
     cfg: OpenClawConfig;
     agentId: string;
+    userId?: string;
     resolved: ResolvedMemoryBackendConfig;
     mode?: QmdManagerMode;
   }): Promise<QmdMemoryManager | null> {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -53,7 +53,9 @@ import {
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/text-runtime";
 import { asRecord } from "../dreaming-shared.js";
+import { isMemoryIsolationEnabled } from "../isolation-identity.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
+import { resolveQmdAgentDir } from "./qmd-paths.js";
 
 type SqliteDatabase = import("node:sqlite").DatabaseSync;
 
@@ -261,13 +263,27 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!resolved) {
       return null;
     }
-    const manager = new QmdMemoryManager({ cfg: params.cfg, agentId: params.agentId, resolved });
+    // Fail closed: if isolation is enabled in config we must have a userId.
+    // Tools.shared.ts already gates this, but this is defense in depth so a
+    // direct create() call cannot accidentally produce a shared (non-isolated)
+    // manager when isolation is configured.
+    if (isMemoryIsolationEnabled(params.cfg) && !params.userId) {
+      log.warn("qmd memory manager refused to start: isolation enabled but no userId provided");
+      return null;
+    }
+    const manager = new QmdMemoryManager({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      userId: params.userId,
+      resolved,
+    });
     await manager.initialize(params.mode ?? "full");
     return manager;
   }
 
   private readonly cfg: OpenClawConfig;
   private readonly agentId: string;
+  private readonly userId: string | undefined;
   private readonly qmd: ResolvedQmdConfig;
   private readonly workspaceDir: string;
   private readonly stateDir: string;
@@ -319,14 +335,20 @@ export class QmdMemoryManager implements MemorySearchManager {
   private constructor(params: {
     cfg: OpenClawConfig;
     agentId: string;
+    userId?: string;
     resolved: ResolvedQmdConfig;
   }) {
     this.cfg = params.cfg;
     this.agentId = params.agentId;
+    this.userId = params.userId;
     this.qmd = params.resolved;
     this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
     this.stateDir = resolveStateDir(process.env, os.homedir);
-    this.agentStateDir = path.join(this.stateDir, "agents", this.agentId);
+    this.agentStateDir = resolveQmdAgentDir({
+      stateDir: this.stateDir,
+      agentId: this.agentId,
+      userId: this.userId,
+    });
     this.qmdDir = path.join(this.agentStateDir, "qmd");
     this.syncSettings = resolveMemorySearchSyncConfig(params.cfg, params.agentId);
     // QMD uses XDG base dirs for its internal state.

--- a/extensions/memory-core/src/memory/qmd-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-paths.test.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveQmdAgentDir } from "./qmd-paths.js";
+
+const baseStateDir = "/tmp/state";
+const agentId = "agent-x";
+
+describe("resolveQmdAgentDir", () => {
+  it("returns the agent-only path when userId is undefined", () => {
+    const dir = resolveQmdAgentDir({ stateDir: baseStateDir, agentId });
+    expect(dir).toBe(path.join(baseStateDir, "agents", agentId));
+  });
+
+  it("appends a users/<encoded> segment when userId is provided", () => {
+    const dir = resolveQmdAgentDir({ stateDir: baseStateDir, agentId, userId: "alice" });
+    expect(dir.startsWith(path.join(baseStateDir, "agents", agentId, "users") + path.sep)).toBe(
+      true,
+    );
+  });
+
+  it("differs by userId so two users do not collide", () => {
+    const a = resolveQmdAgentDir({ stateDir: baseStateDir, agentId, userId: "alice" });
+    const b = resolveQmdAgentDir({ stateDir: baseStateDir, agentId, userId: "bob" });
+    expect(a).not.toBe(b);
+  });
+
+  it("never escapes the agent directory (path traversal attempt)", () => {
+    const evil = resolveQmdAgentDir({
+      stateDir: baseStateDir,
+      agentId,
+      userId: "../../etc/passwd",
+    });
+    const agentBase = path.join(baseStateDir, "agents", agentId);
+    expect(evil.startsWith(agentBase + path.sep)).toBe(true);
+  });
+
+  it("hash mode uses 32 hex chars by default", () => {
+    const dir = resolveQmdAgentDir({ stateDir: baseStateDir, agentId, userId: "alice" });
+    const segment = path.basename(dir);
+    expect(segment).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("whitelist mode preserves safe ids verbatim", () => {
+    const dir = resolveQmdAgentDir({
+      stateDir: baseStateDir,
+      agentId,
+      userId: "alice_42",
+      encoding: "whitelist",
+    });
+    expect(path.basename(dir)).toBe("alice_42");
+  });
+
+  it("whitelist mode rejects unsafe ids", () => {
+    expect(() =>
+      resolveQmdAgentDir({
+        stateDir: baseStateDir,
+        agentId,
+        userId: "../etc",
+        encoding: "whitelist",
+      }),
+    ).toThrow();
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-paths.ts
+++ b/extensions/memory-core/src/memory/qmd-paths.ts
@@ -1,0 +1,30 @@
+import path from "node:path";
+import {
+  encodeUserSegment,
+  type MemoryPathEncodingMode,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
+/**
+ * Resolve the per-(agent, user) state directory for QMD.
+ *
+ * Without `userId`, returns the legacy agent-only layout. With a `userId`,
+ * returns `<stateDir>/agents/<agentId>/users/<encoded-userId>` so that data
+ * for distinct users lives in disjoint subtrees on disk.
+ *
+ * The userId is encoded via the shared path-encoding helper so that arbitrary
+ * input (including traversal sequences and control characters) cannot escape
+ * the agent directory.
+ */
+export function resolveQmdAgentDir(params: {
+  stateDir: string;
+  agentId: string;
+  userId?: string;
+  encoding?: MemoryPathEncodingMode;
+}): string {
+  const agentBase = path.join(params.stateDir, "agents", params.agentId);
+  if (!params.userId) {
+    return agentBase;
+  }
+  const segment = encodeUserSegment(params.userId, params.encoding ?? "hash");
+  return path.join(agentBase, "users", segment);
+}

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -101,6 +101,7 @@ export async function getMemorySearchManager(params: {
         const primary = await QmdMemoryManager.create({
           cfg: params.cfg,
           agentId: params.agentId,
+          userId: params.userId,
           resolved,
           mode: statusOnly ? "status" : "full",
         });

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -54,6 +54,7 @@ export type MemorySearchManagerResult = {
 export async function getMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  userId?: string;
   purpose?: "default" | "status";
 }): Promise<MemorySearchManagerResult> {
   const resolved = resolveMemoryBackendConfig(params);

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -13,8 +13,8 @@ import {
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySyncProgressUpdate,
-  type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { buildQmdCacheKey } from "./qmd-cache-key.js";
 
 const MEMORY_SEARCH_MANAGER_CACHE_KEY = Symbol.for("openclaw.memorySearchManagerCache");
 type MemorySearchManagerCacheStore = {
@@ -60,7 +60,7 @@ export async function getMemorySearchManager(params: {
   const resolved = resolveMemoryBackendConfig(params);
   if (resolved.backend === "qmd" && resolved.qmd) {
     const statusOnly = params.purpose === "status";
-    const baseCacheKey = buildQmdCacheKey(params.agentId, resolved.qmd);
+    const baseCacheKey = buildQmdCacheKey(params.agentId, resolved.qmd, params.userId);
     const cacheKey = `${baseCacheKey}:${statusOnly ? "status" : "full"}`;
     const cached = QMD_MANAGER_CACHE.get(cacheKey);
     if (cached) {
@@ -358,10 +358,4 @@ class FallbackMemoryManager implements MemorySearchManager {
     this.cacheEvicted = true;
     this.onClose?.();
   }
-}
-
-function buildQmdCacheKey(agentId: string, config: ResolvedQmdConfig): string {
-  // ResolvedQmdConfig is assembled in a stable field order in resolveMemoryBackendConfig.
-  // Fast stringify avoids deep key-sorting overhead on this hot path.
-  return `${agentId}:${JSON.stringify(config)}`;
 }

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -43,6 +43,7 @@ export const MemoryGetSchema = Type.Object({
 export function resolveMemoryToolContext(options: {
   config?: OpenClawConfig;
   agentSessionKey?: string;
+  senderId?: string;
 }) {
   const cfg = options.config;
   if (!cfg) {
@@ -55,12 +56,13 @@ export function resolveMemoryToolContext(options: {
   if (!resolveMemorySearchConfig(cfg, agentId)) {
     return null;
   }
-  return { cfg, agentId };
+  return { cfg, agentId, userId: options.senderId };
 }
 
 export async function getMemoryManagerContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  userId?: string;
 }): Promise<
   | {
       manager: NonNullable<MemorySearchManagerResult["manager"]>;
@@ -75,6 +77,7 @@ export async function getMemoryManagerContext(params: {
 export async function getMemoryManagerContextWithPurpose(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  userId?: string;
   purpose?: "default" | "status";
 }): Promise<
   | {
@@ -88,6 +91,7 @@ export async function getMemoryManagerContextWithPurpose(params: {
   const { manager, error } = await getMemorySearchManager({
     cfg: params.cfg,
     agentId: params.agentId,
+    userId: params.userId,
     purpose: params.purpose,
   });
   return manager ? { manager } : { error };
@@ -97,12 +101,17 @@ export function createMemoryTool(params: {
   options: {
     config?: OpenClawConfig;
     agentSessionKey?: string;
+    senderId?: string;
   };
   label: string;
   name: string;
   description: string;
   parameters: typeof MemorySearchSchema | typeof MemoryGetSchema;
-  execute: (ctx: { cfg: OpenClawConfig; agentId: string }) => AnyAgentTool["execute"];
+  execute: (ctx: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    userId?: string;
+  }) => AnyAgentTool["execute"];
 }): AnyAgentTool | null {
   const ctx = resolveMemoryToolContext(params.options);
   if (!ctx) {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -9,6 +9,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import { IsolationIdentityError, resolveIsolationIdentity } from "./isolation-identity.js";
 
 type MemoryToolRuntime = typeof import("./tools.runtime.js");
 type MemorySearchManagerResult = Awaited<
@@ -56,7 +57,21 @@ export function resolveMemoryToolContext(options: {
   if (!resolveMemorySearchConfig(cfg, agentId)) {
     return null;
   }
-  return { cfg, agentId, userId: options.senderId };
+  let userId: string | undefined;
+  try {
+    userId = resolveIsolationIdentity({
+      cfg,
+      agentId,
+      sessionKey: options.agentSessionKey,
+      senderId: options.senderId,
+    });
+  } catch (error) {
+    if (error instanceof IsolationIdentityError) {
+      return null;
+    }
+    throw error;
+  }
+  return { cfg, agentId, userId };
 }
 
 export async function getMemoryManagerContext(params: {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -180,6 +180,7 @@ async function executeMemoryReadResult<T>(params: {
 export function createMemorySearchTool(options: {
   config?: OpenClawConfig;
   agentSessionKey?: string;
+  senderId?: string;
 }) {
   return createMemoryTool({
     options,
@@ -189,7 +190,7 @@ export function createMemorySearchTool(options: {
       "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional `corpus=wiki` or `corpus=all` also searches registered compiled-wiki supplements. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
     parameters: MemorySearchSchema,
     execute:
-      ({ cfg, agentId }) =>
+      ({ cfg, agentId, userId }) =>
       async (_toolCallId, params) => {
         const query = readStringParam(params, "query", { required: true });
         const maxResults = readNumberParam(params, "maxResults");
@@ -202,7 +203,9 @@ export function createMemorySearchTool(options: {
         const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
         const shouldQueryMemory = requestedCorpus !== "wiki";
         const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
-        const memory = shouldQueryMemory ? await getMemoryManagerContext({ cfg, agentId }) : null;
+        const memory = shouldQueryMemory
+          ? await getMemoryManagerContext({ cfg, agentId, userId })
+          : null;
         if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
           return jsonResult(buildMemorySearchUnavailableResult(memory.error));
         }
@@ -321,6 +324,7 @@ export function createMemorySearchTool(options: {
 export function createMemoryGetTool(options: {
   config?: OpenClawConfig;
   agentSessionKey?: string;
+  senderId?: string;
 }) {
   return createMemoryTool({
     options,
@@ -330,7 +334,7 @@ export function createMemoryGetTool(options: {
       "Safe exact excerpt read from MEMORY.md or memory/*.md. Defaults to a bounded excerpt when lines are omitted, includes truncation/continuation info when more content exists, and `corpus=wiki` reads from registered compiled-wiki supplements.",
     parameters: MemoryGetSchema,
     execute:
-      ({ cfg, agentId }) =>
+      ({ cfg, agentId, userId }) =>
       async (_toolCallId, params) => {
         const relPath = readStringParam(params, "path", { required: true });
         const from = readNumberParam(params, "from", { integer: true });
@@ -368,6 +372,7 @@ export function createMemoryGetTool(options: {
                 relPath,
                 from: from ?? undefined,
                 lines: lines ?? undefined,
+                userId,
               }),
             requestedCorpus,
             relPath,
@@ -379,6 +384,7 @@ export function createMemoryGetTool(options: {
         const memory = await getMemoryManagerContextWithPurpose({
           cfg,
           agentId,
+          userId,
           purpose: "status",
         });
         if ("error" in memory) {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -146,7 +146,8 @@ async function walkDir(dir: string, files: string[], multimodal?: MemoryMultimod
     if (!isAllowedMemoryFilePath(full, multimodal)) {
       continue;
     }
-    files.push(full);
+    // Normalize to forward slashes for cross-platform compatibility
+    files.push(full.replace(/\\/g, "/"));
   }
 }
 
@@ -188,7 +189,8 @@ async function walkRootFiles(dir: string, files: string[], multimodal?: MemoryMu
     if (!isAllowedMemoryFilePath(full, multimodal)) {
       continue;
     }
-    files.push(full);
+    // Normalize to forward slashes for cross-platform compatibility
+    files.push(full.replace(/\\/g, "/"));
   }
 }
 
@@ -210,7 +212,8 @@ export async function listMemoryFiles(
       if (!absPath.endsWith(".md")) {
         return;
       }
-      result.push(absPath);
+      // Normalize to forward slashes for cross-platform compatibility
+      result.push(absPath.replace(/\\/g, "/"));
     } catch {}
   };
 

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -72,7 +72,7 @@ export function normalizeExtraMemoryPaths(workspaceDir: string, extraPaths?: str
   return Array.from(new Set(resolved));
 }
 
-export function isMemoryPath(relPath: string): boolean {
+export function isMemoryPath(relPath: string, userId?: string): boolean {
   const normalized = normalizeRelPath(relPath);
   if (!normalized) {
     return false;
@@ -80,7 +80,44 @@ export function isMemoryPath(relPath: string): boolean {
   if (normalized === "MEMORY.md" || normalized === "memory.md" || normalized === "dreams.md") {
     return true;
   }
-  return normalized.startsWith("memory/");
+  // Check if path starts with memory/
+  if (!normalized.startsWith("memory/")) {
+    return false;
+  }
+  // If userId is provided (isolation enabled), apply access control
+  if (userId) {
+    const userPrefix = `memory/${userId}/`;
+    // Allow user's own memory directory
+    if (normalized.startsWith(userPrefix)) {
+      return true;
+    }
+    // For paths under memory/ but not under memory/{userId}/
+    // Check if it's a shared file at the root level (not another user's directory)
+    const afterMemory = normalized.slice("memory/".length);
+    // If the path is just "memory/" with no additional segments, allow
+    if (afterMemory.length === 0) {
+      return true;
+    }
+    // If the path contains a slash, it's under a subdirectory
+    // Allow only if it's NOT under another user's directory pattern
+    const firstSegment = afterMemory.split("/")[0];
+    if (!firstSegment) {
+      return false;
+    }
+    // Shared memory files at root level: memory/file.md (no slash after memory/)
+    // This allows memory/2024-01-01.md but blocks memory/other-user/file.md
+    const slashIndex = afterMemory.indexOf("/");
+    if (slashIndex === -1) {
+      // Direct file under memory/ - shared memory
+      return afterMemory.endsWith(".md") || afterMemory.endsWith(".MD");
+    }
+    // Path has a subdirectory - block access to other users' directories
+    // The first segment is a potential userId; if it's not our userId, block
+    // Exception: common non-user directories (but for isolation, we're strict)
+    return false;
+  }
+  // No userId provided (isolation disabled) - allow all memory paths
+  return true;
 }
 
 function isAllowedMemoryFilePath(filePath: string, multimodal?: MemoryMultimodalSettings): boolean {
@@ -134,10 +171,32 @@ async function resolveDefaultMemoryRootFile(workspaceDir: string): Promise<strin
   }
 }
 
+/**
+ * Walk a directory and collect files at root level only (not subdirectories).
+ * Used for shared memory directory when isolation is enabled.
+ */
+async function walkRootFiles(dir: string, files: string[], multimodal?: MemoryMultimodalSettings) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || entry.isDirectory()) {
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (!isAllowedMemoryFilePath(full, multimodal)) {
+      continue;
+    }
+    files.push(full);
+  }
+}
+
 export async function listMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
+  userId?: string,
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryDir = path.join(workspaceDir, "memory");
@@ -162,7 +221,21 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await walkDir(memoryDir, result);
+      if (userId) {
+        // Isolation enabled: walk user-specific directory, then shared root files only
+        const userMemoryDir = path.join(memoryDir, userId);
+        try {
+          const userDirStat = await fs.lstat(userMemoryDir);
+          if (!userDirStat.isSymbolicLink() && userDirStat.isDirectory()) {
+            await walkDir(userMemoryDir, result, multimodal);
+          }
+        } catch {}
+        // Walk only root-level files in shared memory (not subdirectories)
+        await walkRootFiles(memoryDir, result, multimodal);
+      } else {
+        // No isolation: walk entire memory directory
+        await walkDir(memoryDir, result, multimodal);
+      }
     }
   } catch {}
 

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -14,6 +14,14 @@ import {
   type MemoryMultimodalModality,
   type MemoryMultimodalSettings,
 } from "./multimodal.js";
+import { encodeUserSegment, type MemoryPathEncodingMode } from "./path-encoding.js";
+
+export {
+  encodeUserSegment,
+  resolveUserMemoryDir,
+  PathEncodingError,
+  type MemoryPathEncodingMode,
+} from "./path-encoding.js";
 
 export type MemoryFileEntry = {
   path: string;
@@ -72,7 +80,11 @@ export function normalizeExtraMemoryPaths(workspaceDir: string, extraPaths?: str
   return Array.from(new Set(resolved));
 }
 
-export function isMemoryPath(relPath: string, userId?: string): boolean {
+export function isMemoryPath(
+  relPath: string,
+  userId?: string,
+  encoding: MemoryPathEncodingMode = "hash",
+): boolean {
   const normalized = normalizeRelPath(relPath);
   if (!normalized) {
     return false;
@@ -86,7 +98,13 @@ export function isMemoryPath(relPath: string, userId?: string): boolean {
   }
   // If userId is provided (isolation enabled), apply access control
   if (userId) {
-    const userPrefix = `memory/${userId}/`;
+    let encodedUser: string;
+    try {
+      encodedUser = encodeUserSegment(userId, encoding);
+    } catch {
+      return false;
+    }
+    const userPrefix = `memory/${encodedUser}/`;
     // Allow user's own memory directory
     if (normalized.startsWith(userPrefix)) {
       return true;
@@ -199,6 +217,7 @@ export async function listMemoryFiles(
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
   userId?: string,
+  encoding: MemoryPathEncodingMode = "hash",
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryDir = path.join(workspaceDir, "memory");
@@ -226,7 +245,14 @@ export async function listMemoryFiles(
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
       if (userId) {
         // Isolation enabled: walk user-specific directory, then shared root files only
-        const userMemoryDir = path.join(memoryDir, userId);
+        let encodedUser: string;
+        try {
+          encodedUser = encodeUserSegment(userId, encoding);
+        } catch {
+          // Invalid identity; do not silently leak shared memory under whitelist mode
+          return result;
+        }
+        const userMemoryDir = path.join(memoryDir, encodedUser);
         try {
           const userDirStat = await fs.lstat(userMemoryDir);
           if (!userDirStat.isSymbolicLink() && userDirStat.isDirectory()) {

--- a/packages/memory-host-sdk/src/host/path-encoding.test.ts
+++ b/packages/memory-host-sdk/src/host/path-encoding.test.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { encodeUserSegment, resolveUserMemoryDir } from "./path-encoding.js";
+
+describe("encodeUserSegment (hash mode)", () => {
+  it("returns a deterministic 32-char hex segment", () => {
+    const a = encodeUserSegment("alice", "hash");
+    const b = encodeUserSegment("alice", "hash");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("produces different segments for different IDs", () => {
+    expect(encodeUserSegment("alice", "hash")).not.toBe(encodeUserSegment("bob", "hash"));
+  });
+
+  it("safely encodes user IDs containing path separators", () => {
+    const segment = encodeUserSegment("../../etc/passwd", "hash");
+    expect(segment).not.toContain("/");
+    expect(segment).not.toContain("\\");
+    expect(segment).not.toContain("..");
+    expect(segment).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("safely encodes empty / NUL / dot inputs in hash mode", () => {
+    expect(encodeUserSegment("", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment("\0", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment(".", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment("..", "hash")).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("encodeUserSegment (whitelist mode)", () => {
+  it("accepts safe alphanumeric IDs unchanged", () => {
+    expect(encodeUserSegment("alice_42", "whitelist")).toBe("alice_42");
+    expect(encodeUserSegment("a-b-c", "whitelist")).toBe("a-b-c");
+  });
+
+  it("rejects path traversal attempts in whitelist mode", () => {
+    expect(() => encodeUserSegment("../etc", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a/b", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a\\b", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a\0", "whitelist")).toThrow();
+    expect(() => encodeUserSegment(".", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("..", "whitelist")).toThrow();
+  });
+
+  it("rejects empty IDs in whitelist mode", () => {
+    expect(() => encodeUserSegment("", "whitelist")).toThrow();
+  });
+
+  it("rejects overly long IDs in whitelist mode", () => {
+    expect(() => encodeUserSegment("a".repeat(65), "whitelist")).toThrow();
+  });
+
+  it("rejects unicode/non-ASCII identifiers in whitelist mode", () => {
+    expect(() => encodeUserSegment("주근", "whitelist")).toThrow();
+  });
+});
+
+describe("resolveUserMemoryDir", () => {
+  const memoryRoot = path.resolve("/var/data/memory");
+
+  it("returns a path inside memoryRoot for hash mode", () => {
+    const dir = resolveUserMemoryDir(memoryRoot, "alice", "hash");
+    expect(dir.startsWith(memoryRoot + path.sep)).toBe(true);
+  });
+
+  it("returns a path inside memoryRoot for whitelist mode", () => {
+    const dir = resolveUserMemoryDir(memoryRoot, "alice", "whitelist");
+    expect(dir).toBe(path.resolve(memoryRoot, "alice"));
+  });
+
+  it("rejects whitelist mode IDs that would escape root", () => {
+    expect(() => resolveUserMemoryDir(memoryRoot, "../escape", "whitelist")).toThrow();
+  });
+
+  it("hash mode never escapes root, even for crafted inputs", () => {
+    const crafted = "../../../../etc/passwd";
+    const dir = resolveUserMemoryDir(memoryRoot, crafted, "hash");
+    expect(dir.startsWith(memoryRoot + path.sep)).toBe(true);
+  });
+});

--- a/packages/memory-host-sdk/src/host/path-encoding.ts
+++ b/packages/memory-host-sdk/src/host/path-encoding.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+import path from "node:path";
+
+export type MemoryPathEncodingMode = "hash" | "whitelist";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const HASH_LEN = 32;
+
+export class PathEncodingError extends Error {}
+
+export function encodeUserSegment(userId: string, mode: MemoryPathEncodingMode = "hash"): string {
+  if (mode === "whitelist") {
+    if (typeof userId !== "string" || userId.length === 0) {
+      throw new PathEncodingError("userId must be a non-empty string in whitelist mode");
+    }
+    if (userId === "." || userId === "..") {
+      throw new PathEncodingError("userId may not be . or ..");
+    }
+    if (!SAFE_ID_RE.test(userId)) {
+      throw new PathEncodingError(
+        "userId contains characters outside [A-Za-z0-9_-] or exceeds 64 chars",
+      );
+    }
+    return userId;
+  }
+  return crypto.createHash("sha256").update(userId, "utf8").digest("hex").slice(0, HASH_LEN);
+}
+
+export function resolveUserMemoryDir(
+  memoryRoot: string,
+  userId: string,
+  mode: MemoryPathEncodingMode = "hash",
+): string {
+  const segment = encodeUserSegment(userId, mode);
+  const baseAbs = path.resolve(memoryRoot);
+  const resolved = path.resolve(baseAbs, segment);
+  const baseWithSep = baseAbs.endsWith(path.sep) ? baseAbs : baseAbs + path.sep;
+  if (!resolved.startsWith(baseWithSep)) {
+    throw new PathEncodingError("resolved user memory dir escapes memory root");
+  }
+  return resolved;
+}

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -89,6 +89,13 @@ export type ResolvedMemorySearchConfig = {
     enabled: boolean;
     maxEntries?: number;
   };
+  /**
+   * Memory isolation settings for user-specific memory directories.
+   * When enabled with a userId, memory files are stored in memory/{userId}/.
+   */
+  isolation: {
+    enabled: boolean;
+  };
 };
 
 export type ResolvedMemorySearchSyncConfig = ResolvedMemorySearchConfig["sync"];
@@ -272,6 +279,11 @@ function mergeConfig(
     maxEntries: overrides?.cache?.maxEntries ?? defaults?.cache?.maxEntries,
   };
 
+  // Memory isolation: default enabled=true, resolved at runtime with optional userId
+  const isolation = {
+    enabled: true,
+  };
+
   const overlap = clampNumber(chunking.overlap, 0, Math.max(0, chunking.tokens - 1));
   const minScore = clampNumber(query.minScore, 0, 1);
   const vectorWeight = clampNumber(hybrid.vectorWeight, 0, 1);
@@ -342,6 +354,7 @@ function mergeConfig(
           ? Math.max(1, Math.floor(cache.maxEntries))
           : undefined,
     },
+    isolation,
   };
 }
 
@@ -404,7 +417,14 @@ export function resolveMemorySearchConfig(
       'agents.*.memorySearch.multimodal does not support memorySearch.fallback. Set fallback to "none".',
     );
   }
-  return resolved;
+  // Merge isolation config from cfg.memory (global memory settings)
+  const isolationConfig = cfg.memory?.isolation;
+  return {
+    ...resolved,
+    isolation: {
+      enabled: isolationConfig?.enabled ?? true,
+    },
+  };
 }
 
 export function resolveMemorySearchSyncConfig(

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -4,10 +4,28 @@ export type MemoryBackend = "builtin" | "qmd";
 export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 
+/**
+ * Memory isolation configuration.
+ * When enabled, memory files are stored in user-specific subdirectories.
+ */
+export type MemoryIsolationConfig = {
+  /**
+   * Enable user-specific memory isolation.
+   * - true (default): Memory files stored in memory/{userId}/YYYY-MM-DD.md
+   * - false: All sessions share memory/ directory (legacy behavior)
+   */
+  enabled?: boolean;
+};
+
 export type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
   qmd?: MemoryQmdConfig;
+  /**
+   * User-specific memory isolation settings.
+   * When enabled, each user gets their own memory subdirectory.
+   */
+  isolation?: MemoryIsolationConfig;
 };
 
 export type MemoryQmdConfig = {

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -4,6 +4,10 @@ export type MemoryBackend = "builtin" | "qmd";
 export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 
+export type MemoryIsolationScope = "user" | "session" | "agent";
+export type MemoryIsolationFallbackPolicy = "deny" | "session" | "agent";
+export type MemoryPathEncoding = "hash" | "whitelist";
+
 /**
  * Memory isolation configuration.
  * When enabled, memory files are stored in user-specific subdirectories.
@@ -15,6 +19,18 @@ export type MemoryIsolationConfig = {
    * - false: All sessions share memory/ directory (legacy behavior)
    */
   enabled?: boolean;
+  /** Identity scope used for isolation (default "user"). */
+  scope?: MemoryIsolationScope;
+  /**
+   * What to do when the requested identity scope cannot be resolved.
+   * "deny" (default) refuses unscoped operations; other values relax to a coarser scope.
+   */
+  fallbackPolicy?: MemoryIsolationFallbackPolicy;
+  /**
+   * How user identifiers are encoded as path segments.
+   * "hash" (default) uses a sha256 prefix; "whitelist" requires safe ID characters.
+   */
+  pathEncoding?: MemoryPathEncoding;
 };
 
 export type MemoryConfig = {

--- a/src/config/zod-schema.memory-isolation.test.ts
+++ b/src/config/zod-schema.memory-isolation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("OpenClawSchema memory.isolation validation", () => {
+  it("accepts memory.isolation with full options", () => {
+    const parsed = OpenClawSchema.parse({
+      memory: {
+        backend: "builtin",
+        isolation: {
+          enabled: true,
+          scope: "user",
+          fallbackPolicy: "deny",
+          pathEncoding: "hash",
+        },
+      },
+    });
+    expect(parsed.memory?.isolation?.enabled).toBe(true);
+    expect(parsed.memory?.isolation?.scope).toBe("user");
+    expect(parsed.memory?.isolation?.fallbackPolicy).toBe("deny");
+    expect(parsed.memory?.isolation?.pathEncoding).toBe("hash");
+  });
+
+  it("accepts memory.isolation with only enabled flag", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { enabled: false },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("applies defaults when isolation fields omitted", () => {
+    const parsed = OpenClawSchema.parse({
+      memory: {
+        isolation: {},
+      },
+    });
+    expect(parsed.memory?.isolation?.enabled).toBe(true);
+    expect(parsed.memory?.isolation?.scope).toBe("user");
+    expect(parsed.memory?.isolation?.fallbackPolicy).toBe("deny");
+    expect(parsed.memory?.isolation?.pathEncoding).toBe("hash");
+  });
+
+  it("rejects unknown isolation keys (strict)", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { enabled: true, bogus: 1 },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid scope value", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { scope: "tenant-bogus" },
+        },
+      }),
+    ).toThrow(/scope|enum/i);
+  });
+
+  it("rejects invalid fallbackPolicy value", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { fallbackPolicy: "permit-all" },
+        },
+      }),
+    ).toThrow(/fallbackPolicy|enum/i);
+  });
+
+  it("rejects invalid pathEncoding value", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { pathEncoding: "raw" },
+        },
+      }),
+    ).toThrow(/pathEncoding|enum/i);
+  });
+
+  it("rejects non-boolean enabled", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        memory: {
+          isolation: { enabled: "yes" },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("memory remains optional when omitted", () => {
+    expect(() => OpenClawSchema.parse({})).not.toThrow();
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -116,11 +116,23 @@ const MemoryQmdSchema = z
   })
   .strict();
 
+const MemoryIsolationSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    scope: z.union([z.literal("user"), z.literal("session"), z.literal("agent")]).default("user"),
+    fallbackPolicy: z
+      .union([z.literal("deny"), z.literal("session"), z.literal("agent")])
+      .default("deny"),
+    pathEncoding: z.union([z.literal("hash"), z.literal("whitelist")]).default("hash"),
+  })
+  .strict();
+
 const MemorySchema = z
   .object({
     backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
     citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
     qmd: MemoryQmdSchema.optional(),
+    isolation: MemoryIsolationSchema.optional(),
   })
   .strict()
   .optional();

--- a/src/memory-host-sdk/engine-storage.ts
+++ b/src/memory-host-sdk/engine-storage.ts
@@ -5,15 +5,19 @@ export {
   buildMultimodalChunkForIndexing,
   chunkMarkdown,
   cosineSimilarity,
+  encodeUserSegment,
   ensureDir,
   hashText,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
   parseEmbedding,
+  PathEncodingError,
   remapChunkLines,
+  resolveUserMemoryDir,
   runWithConcurrency,
   type MemoryChunk,
   type MemoryFileEntry,
+  type MemoryPathEncodingMode,
 } from "./host/internal.js";
 export { readMemoryFile } from "./host/read-file.js";
 export {

--- a/src/memory-host-sdk/host/internal.ts
+++ b/src/memory-host-sdk/host/internal.ts
@@ -72,7 +72,7 @@ export function normalizeExtraMemoryPaths(workspaceDir: string, extraPaths?: str
   return Array.from(new Set(resolved));
 }
 
-export function isMemoryPath(relPath: string): boolean {
+export function isMemoryPath(relPath: string, userId?: string): boolean {
   const normalized = normalizeRelPath(relPath);
   if (!normalized) {
     return false;
@@ -80,7 +80,25 @@ export function isMemoryPath(relPath: string): boolean {
   if (normalized === "MEMORY.md" || normalized === "memory.md" || normalized === "DREAMS.md") {
     return true;
   }
-  return normalized.startsWith("memory/");
+  if (!normalized.startsWith("memory/")) {
+    return false;
+  }
+  if (userId) {
+    const userPrefix = `memory/${userId}/`;
+    if (normalized.startsWith(userPrefix)) {
+      return true;
+    }
+    const afterMemory = normalized.slice("memory/".length);
+    if (afterMemory.length === 0) {
+      return true;
+    }
+    const slashIndex = afterMemory.indexOf("/");
+    if (slashIndex === -1) {
+      return afterMemory.endsWith(".md") || afterMemory.endsWith(".MD");
+    }
+    return false;
+  }
+  return true;
 }
 
 function isAllowedMemoryFilePath(filePath: string, multimodal?: MemoryMultimodalSettings): boolean {
@@ -113,10 +131,28 @@ async function walkDir(dir: string, files: string[], multimodal?: MemoryMultimod
   }
 }
 
+async function walkRootFiles(dir: string, files: string[], multimodal?: MemoryMultimodalSettings) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || entry.isDirectory()) {
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (!isAllowedMemoryFilePath(full, multimodal)) {
+      continue;
+    }
+    files.push(full);
+  }
+}
+
 export async function listMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
+  userId?: string,
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
@@ -141,7 +177,18 @@ export async function listMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      await walkDir(memoryDir, result);
+      if (userId) {
+        const userMemoryDir = path.join(memoryDir, userId);
+        try {
+          const userDirStat = await fs.lstat(userMemoryDir);
+          if (!userDirStat.isSymbolicLink() && userDirStat.isDirectory()) {
+            await walkDir(userMemoryDir, result, multimodal);
+          }
+        } catch {}
+        await walkRootFiles(memoryDir, result, multimodal);
+      } else {
+        await walkDir(memoryDir, result);
+      }
     }
   } catch {}
 

--- a/src/memory-host-sdk/host/internal.ts
+++ b/src/memory-host-sdk/host/internal.ts
@@ -14,6 +14,14 @@ import {
   type MemoryMultimodalModality,
   type MemoryMultimodalSettings,
 } from "./multimodal.js";
+import { encodeUserSegment, type MemoryPathEncodingMode } from "./path-encoding.js";
+
+export {
+  encodeUserSegment,
+  resolveUserMemoryDir,
+  PathEncodingError,
+  type MemoryPathEncodingMode,
+} from "./path-encoding.js";
 
 export type MemoryFileEntry = {
   path: string;
@@ -72,7 +80,11 @@ export function normalizeExtraMemoryPaths(workspaceDir: string, extraPaths?: str
   return Array.from(new Set(resolved));
 }
 
-export function isMemoryPath(relPath: string, userId?: string): boolean {
+export function isMemoryPath(
+  relPath: string,
+  userId?: string,
+  encoding: MemoryPathEncodingMode = "hash",
+): boolean {
   const normalized = normalizeRelPath(relPath);
   if (!normalized) {
     return false;
@@ -84,7 +96,13 @@ export function isMemoryPath(relPath: string, userId?: string): boolean {
     return false;
   }
   if (userId) {
-    const userPrefix = `memory/${userId}/`;
+    let encodedUser: string;
+    try {
+      encodedUser = encodeUserSegment(userId, encoding);
+    } catch {
+      return false;
+    }
+    const userPrefix = `memory/${encodedUser}/`;
     if (normalized.startsWith(userPrefix)) {
       return true;
     }
@@ -153,6 +171,7 @@ export async function listMemoryFiles(
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
   userId?: string,
+  encoding: MemoryPathEncodingMode = "hash",
 ): Promise<string[]> {
   const result: string[] = [];
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
@@ -178,13 +197,19 @@ export async function listMemoryFiles(
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
       if (userId) {
-        const userMemoryDir = path.join(memoryDir, userId);
+        let encodedUser: string | null = null;
         try {
-          const userDirStat = await fs.lstat(userMemoryDir);
-          if (!userDirStat.isSymbolicLink() && userDirStat.isDirectory()) {
-            await walkDir(userMemoryDir, result, multimodal);
-          }
+          encodedUser = encodeUserSegment(userId, encoding);
         } catch {}
+        if (encodedUser) {
+          const userMemoryDir = path.join(memoryDir, encodedUser);
+          try {
+            const userDirStat = await fs.lstat(userMemoryDir);
+            if (!userDirStat.isSymbolicLink() && userDirStat.isDirectory()) {
+              await walkDir(userMemoryDir, result, multimodal);
+            }
+          } catch {}
+        }
         await walkRootFiles(memoryDir, result, multimodal);
       } else {
         await walkDir(memoryDir, result);

--- a/src/memory-host-sdk/host/path-encoding.test.ts
+++ b/src/memory-host-sdk/host/path-encoding.test.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { encodeUserSegment, resolveUserMemoryDir } from "./path-encoding.js";
+
+describe("encodeUserSegment (hash mode)", () => {
+  it("returns a deterministic 32-char hex segment", () => {
+    const a = encodeUserSegment("alice", "hash");
+    const b = encodeUserSegment("alice", "hash");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("produces different segments for different IDs", () => {
+    expect(encodeUserSegment("alice", "hash")).not.toBe(encodeUserSegment("bob", "hash"));
+  });
+
+  it("safely encodes user IDs containing path separators", () => {
+    const segment = encodeUserSegment("../../etc/passwd", "hash");
+    expect(segment).not.toContain("/");
+    expect(segment).not.toContain("\\");
+    expect(segment).not.toContain("..");
+    expect(segment).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("safely encodes empty / NUL / dot inputs in hash mode", () => {
+    expect(encodeUserSegment("", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment("\0", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment(".", "hash")).toMatch(/^[0-9a-f]{32}$/);
+    expect(encodeUserSegment("..", "hash")).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("encodeUserSegment (whitelist mode)", () => {
+  it("accepts safe alphanumeric IDs unchanged", () => {
+    expect(encodeUserSegment("alice_42", "whitelist")).toBe("alice_42");
+    expect(encodeUserSegment("a-b-c", "whitelist")).toBe("a-b-c");
+  });
+
+  it("rejects path traversal attempts in whitelist mode", () => {
+    expect(() => encodeUserSegment("../etc", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a/b", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a\\b", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("a\0", "whitelist")).toThrow();
+    expect(() => encodeUserSegment(".", "whitelist")).toThrow();
+    expect(() => encodeUserSegment("..", "whitelist")).toThrow();
+  });
+
+  it("rejects empty IDs in whitelist mode", () => {
+    expect(() => encodeUserSegment("", "whitelist")).toThrow();
+  });
+
+  it("rejects overly long IDs in whitelist mode", () => {
+    expect(() => encodeUserSegment("a".repeat(65), "whitelist")).toThrow();
+  });
+
+  it("rejects unicode/non-ASCII identifiers in whitelist mode", () => {
+    expect(() => encodeUserSegment("정근", "whitelist")).toThrow();
+  });
+});
+
+describe("resolveUserMemoryDir", () => {
+  const memoryRoot = path.resolve("/var/data/memory");
+
+  it("returns a path inside memoryRoot for hash mode", () => {
+    const dir = resolveUserMemoryDir(memoryRoot, "alice", "hash");
+    expect(dir.startsWith(memoryRoot + path.sep)).toBe(true);
+  });
+
+  it("returns a path inside memoryRoot for whitelist mode", () => {
+    const dir = resolveUserMemoryDir(memoryRoot, "alice", "whitelist");
+    expect(dir).toBe(path.resolve(memoryRoot, "alice"));
+  });
+
+  it("rejects whitelist mode IDs that would escape root", () => {
+    expect(() => resolveUserMemoryDir(memoryRoot, "../escape", "whitelist")).toThrow();
+  });
+
+  it("hash mode never escapes root, even for crafted inputs", () => {
+    const crafted = "../../../../etc/passwd";
+    const dir = resolveUserMemoryDir(memoryRoot, crafted, "hash");
+    expect(dir.startsWith(memoryRoot + path.sep)).toBe(true);
+  });
+});

--- a/src/memory-host-sdk/host/path-encoding.ts
+++ b/src/memory-host-sdk/host/path-encoding.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+import path from "node:path";
+
+export type MemoryPathEncodingMode = "hash" | "whitelist";
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const HASH_LEN = 32;
+
+export class PathEncodingError extends Error {}
+
+export function encodeUserSegment(userId: string, mode: MemoryPathEncodingMode = "hash"): string {
+  if (mode === "whitelist") {
+    if (typeof userId !== "string" || userId.length === 0) {
+      throw new PathEncodingError("userId must be a non-empty string in whitelist mode");
+    }
+    if (userId === "." || userId === "..") {
+      throw new PathEncodingError("userId may not be . or ..");
+    }
+    if (!SAFE_ID_RE.test(userId)) {
+      throw new PathEncodingError(
+        "userId contains characters outside [A-Za-z0-9_-] or exceeds 64 chars",
+      );
+    }
+    return userId;
+  }
+  return crypto.createHash("sha256").update(userId, "utf8").digest("hex").slice(0, HASH_LEN);
+}
+
+export function resolveUserMemoryDir(
+  memoryRoot: string,
+  userId: string,
+  mode: MemoryPathEncodingMode = "hash",
+): string {
+  const segment = encodeUserSegment(userId, mode);
+  const baseAbs = path.resolve(memoryRoot);
+  const resolved = path.resolve(baseAbs, segment);
+  const baseWithSep = baseAbs.endsWith(path.sep) ? baseAbs : baseAbs + path.sep;
+  if (!resolved.startsWith(baseWithSep)) {
+    throw new PathEncodingError("resolved user memory dir escapes memory root");
+  }
+  return resolved;
+}

--- a/src/memory-host-sdk/host/read-file.ts
+++ b/src/memory-host-sdk/host/read-file.ts
@@ -90,6 +90,7 @@ export async function readAgentMemoryFile(params: {
   relPath: string;
   from?: number;
   lines?: number;
+  userId?: string;
 }): Promise<MemoryReadResult> {
   const settings = resolveMemorySearchConfig(params.cfg, params.agentId);
   if (!settings) {
@@ -104,5 +105,6 @@ export async function readAgentMemoryFile(params: {
     lines: params.lines,
     defaultLines: contextLimits?.memoryGetDefaultLines,
     maxChars: contextLimits?.memoryGetMaxChars,
+    userId: settings.isolation.enabled ? params.userId : undefined,
   });
 }

--- a/src/memory-host-sdk/host/read-file.ts
+++ b/src/memory-host-sdk/host/read-file.ts
@@ -19,6 +19,7 @@ export async function readMemoryFile(params: {
   lines?: number;
   defaultLines?: number;
   maxChars?: number;
+  userId?: string;
 }): Promise<MemoryReadResult> {
   const rawPath = params.relPath.trim();
   if (!rawPath) {

--- a/src/memory-host-sdk/host/read-file.ts
+++ b/src/memory-host-sdk/host/read-file.ts
@@ -30,7 +30,7 @@ export async function readMemoryFile(params: {
     : path.resolve(params.workspaceDir, rawPath);
   const relPath = path.relative(params.workspaceDir, absPath).replace(/\\/g, "/");
   const inWorkspace = relPath.length > 0 && !relPath.startsWith("..") && !path.isAbsolute(relPath);
-  const allowedWorkspace = inWorkspace && isMemoryPath(relPath);
+  const allowedWorkspace = inWorkspace && isMemoryPath(relPath, params.userId);
   let allowedAdditional = false;
   if (!allowedWorkspace && (params.extraPaths?.length ?? 0) > 0) {
     const additionalPaths = normalizeExtraMemoryPaths(params.workspaceDir, params.extraPaths);

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -161,3 +161,27 @@ export function resolveThreadParentSessionKey(
   }
   return parent;
 }
+
+/**
+ * Extract user ID from session key for direct message sessions.
+ * Returns null if the session is not a direct message or if user ID cannot be determined.
+ *
+ * For direct message sessions like "agent:<agentId>:direct:<userId>:...",
+ * this extracts and returns the <userId> portion.
+ */
+export function extractUserIdFromSessionKey(sessionKey: string | undefined | null): string | null {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed?.rest) {
+    return null;
+  }
+  const tokens = parsed.rest.split(":").filter(Boolean);
+  // direct:userId format check
+  const directIdx = tokens.indexOf("direct");
+  if (directIdx !== -1 && directIdx + 1 < tokens.length) {
+    const userId = tokens[directIdx + 1];
+    if (userId && !["group", "channel", "dm", "cron", "subagent", "acp"].includes(userId)) {
+      return userId;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds user-specific memory isolation to OpenClaw, enabling per-user memory files in multi-user environments.

## Changes

### Core Feature
- **MemoryIsolationConfig** type added to `src/config/types.memory.ts`
  - `isolation.enabled` (default: `true`) to enable/disable isolation

### Session Key Extraction
- **extractUserIdFromSessionKey()** added to `src/sessions/session-key-utils.ts`
  - Extracts userId from direct message session keys
  - Returns `null` for channel/group sessions

### Memory Path Access Control
- **isMemoryPath()** updated in `src/memory/internal.ts`
  - When `userId` is provided, enforces access control
  - Users can only access their own `memory/{userId}/` directory
  - Shared memory files at `memory/` root are accessible to all

### Memory Tools
- **memory_search** and **memory_get** tools updated
  - Accept optional `senderId` parameter
  - Falls back to `senderId` from inbound context when session key doesn't contain userId

### Plugin Integration
- **extensions/memory-core/index.ts** updated
  - Passes `requesterSenderId` from plugin context to memory tools

## How It Works

```
Session Type       | userId Source          | Memory Path
-------------------|------------------------|---------------------------
Direct Message     | sessionKey extraction  | memory/{userId}/YYYY-MM-DD.md
Channel/Group     | requesterSenderId      | memory/{senderId}/YYYY-MM-DD.md
Disabled (legacy)  | none                   | memory/YYYY-MM-DD.md (shared)
```

## Security

- Users cannot access other users' memory directories
- Path validation in `isMemoryPath()` prevents directory traversal
- Shared memory at `memory/` root is accessible to all (for global context)

## Testing

- Unit tests added in `src/memory/internal.test.ts`
- All existing tests pass

## Breaking Changes

None. The feature is opt-in via configuration and defaults to the new isolated behavior when `memory.isolation.enabled` is not set (defaults to `true`).

Users who want the old shared behavior can set:
```json
{
  "memory": {
    "isolation": {
      "enabled": false
    }
  }
}
```