### PR TITLE
fix(platform): extend startup optimization hints to support macOS (darwin)

### DIFF
--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -78,4 +78,49 @@ describe("noteStartupOptimizationHints", () => {
 
     expect(noteFn).not.toHaveBeenCalled();
   });
+
+  it("warns on darwin (macOS) with ARM64 architecture", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+      },
+      { platform: "darwin", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message, title] = noteFn.mock.calls[0] ?? [];
+    expect(title).toBe("Startup optimization");
+    expect(message).toContain("NODE_COMPILE_CACHE points to /tmp");
+    expect(message).toContain("OPENCLAW_NO_RESPAWN is not set to 1");
+  });
+
+  it("warns on darwin (macOS) with low memory", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+      },
+      { platform: "darwin", arch: "x64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message] = noteFn.mock.calls[0] ?? [];
+    expect(message).toContain("NODE_COMPILE_CACHE points to /tmp");
+  });
+
+  it("skips startup optimization note on darwin with high memory and non-ARM arch", () => {
+    const noteFn = vi.fn();
+
+    noteStartupOptimizationHints(
+      {
+        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+      },
+      { platform: "darwin", arch: "x64", totalMemBytes: 32 * 1024 ** 3, noteFn },
+    );
+
+    expect(noteFn).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -86,7 +86,7 @@ describe("noteStartupOptimizationHints", () => {
       {
         NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
       },
-      { platform: "darwin", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
+      { platform: "darwin", arch: "arm64", totalMemBytes: 16 * 1024 ** 3, noteFn },
     );
 
     expect(noteFn).toHaveBeenCalledTimes(1);

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -172,9 +172,9 @@ export function noteStartupOptimizationHints(
   const arch = deps?.arch ?? os.arch();
   const totalMemBytes = deps?.totalMemBytes ?? os.totalmem();
   const isArmHost = arch === "arm" || arch === "arm64";
-  const isLowMemoryLinux =
-    platform === "linux" && totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
-  const isStartupTuneTarget = platform === "linux" && (isArmHost || isLowMemoryLinux);
+  const isLowMemory =
+    totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
+  const isStartupTuneTarget = (platform === "linux" || platform === "darwin") && (isArmHost || isLowMemory);
   if (!isStartupTuneTarget) {
     return;
   }

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -172,9 +172,9 @@ export function noteStartupOptimizationHints(
   const arch = deps?.arch ?? os.arch();
   const totalMemBytes = deps?.totalMemBytes ?? os.totalmem();
   const isArmHost = arch === "arm" || arch === "arm64";
-  const isLowMemory =
-    totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
-  const isStartupTuneTarget = (platform === "linux" || platform === "darwin") && (isArmHost || isLowMemory);
+  const isLowMemory = totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
+  const isStartupTuneTarget =
+    (platform === "linux" || platform === "darwin") && (isArmHost || isLowMemory);
   if (!isStartupTuneTarget) {
     return;
   }


### PR DESCRIPTION
## Summary

Extend startup optimization hints to macOS (darwin) platform, especially for Apple Silicon (ARM64) and low-memory environments.

## Problem

Previously, the startup optimization hints were gated behind a `platform === "linux"` check, which meant:
- macOS users running on ARM64 (M1/M2/M3) did not receive startup optimization guidance
- macOS users with low memory (<8GB) also did not receive guidance
- Memory information was available (via `os.totalmem()`) but never used for macOS

## Solution

Modified `noteStartupOptimizationHints` to:
1. Support both Linux and Darwin platforms
2. Renamed `isLowMemoryLinux` to `isLowMemory` (platform-agnostic)
3. Updated the `isStartupTuneTarget` check to include Darwin
4. Added comprehensive test coverage for macOS scenarios (ARM64, low-memory, high-memory)

## Changes

- `src/commands/doctor-platform-notes.ts`: Extended platform check and improved variable naming
- `src/commands/doctor-platform-notes.startup-optimization.test.ts`: Added 3 new test cases for Darwin platform

## Testing

Added tests for:
- Darwin with ARM64 (Apple Silicon)
- Darwin with low memory (<8GB)
- Darwin with high memory and non-ARM arch (should skip)

Fixes #47273