### PR TITLE
test(whatsapp): fix append-skip test using stale timestamp

### DIFF
--- a/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-300_000), // 5 min ago — stale append should be skipped
           pushName: "History Sender",
         },
       ],


### PR DESCRIPTION
## Summary
- The "handles append messages by marking them read but skipping auto-reply" test in `monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts` was failing on `main` because it used `nowSeconds()` (current time), but commit 843e3c1ef introduced a 60-second recency grace window for append messages
- Recent append messages now correctly pass through for processing, so the test needs a stale timestamp (5 min ago) to verify that old history messages are still skipped

## Test plan
- [ ] CI `test:channels` job passes (currently failing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)