### PR TITLE
feat(directives): add inbound 'reply in thread' user directive

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -111,6 +111,8 @@ export async function buildReplyPayloads(params: {
   originatingTo?: string;
   accountId?: string;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
+  /** User requested reply to be threaded (e.g., "reply in thread" directive). */
+  replyInThreadDirective?: boolean;
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
   const sanitizedPayloads = params.isHeartbeat
@@ -137,10 +139,20 @@ export async function buildReplyPayloads(params: {
         return [{ ...payload, text: stripped.text }];
       });
 
+  // Apply reply-in-thread directive from inbound user message.
+  // When the user includes a trigger phrase like "reply in thread" or "rit",
+  // force the response to be threaded (equivalent to [[reply_to_current]]).
+  const payloadsWithDirective = params.replyInThreadDirective
+    ? sanitizedPayloads.map((payload) => ({
+        ...payload,
+        replyToCurrent: true,
+      }))
+    : sanitizedPayloads;
+
   const replyTaggedPayloads = (
     await Promise.all(
       applyReplyThreading({
-        payloads: sanitizedPayloads,
+        payloads: payloadsWithDirective,
         replyToMode: params.replyToMode,
         replyToChannel: params.replyToChannel,
         currentMessageId: params.currentMessageId,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -506,6 +506,7 @@ export async function runReplyAgent(params: {
       }),
       accountId: sessionCtx.AccountId,
       normalizeMediaPaths: normalizeReplyMediaPaths,
+      replyInThreadDirective: sessionCtx.ReplyInThreadDirective,
     });
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -1,6 +1,7 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
+import { extractInboundUserDirectives } from "./inbound-user-directives.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
 
 export type FinalizeInboundContextOptions = {
@@ -54,6 +55,29 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
     ).filter((entry) => Boolean(entry));
     normalized.UntrustedContext = normalizedUntrusted;
   }
+
+  // Detect and strip inbound user directives (e.g., "reply in thread", "rit")
+  // These are trigger phrases at the end of the message that affect outbound behavior.
+  // Check all relevant body fields for the directive.
+  const bodyDirectiveResult = extractInboundUserDirectives(normalized.Body ?? "");
+  const rawBodyDirectiveResult = extractInboundUserDirectives(normalized.RawBody ?? "");
+  const commandBodyDirectiveResult = extractInboundUserDirectives(normalized.CommandBody ?? "");
+
+  const replyInThreadDirective =
+    bodyDirectiveResult.replyInThread ||
+    rawBodyDirectiveResult.replyInThread ||
+    commandBodyDirectiveResult.replyInThread;
+
+  if (bodyDirectiveResult.replyInThread) {
+    normalized.Body = bodyDirectiveResult.cleaned;
+  }
+  if (rawBodyDirectiveResult.replyInThread) {
+    normalized.RawBody = rawBodyDirectiveResult.cleaned;
+  }
+  if (commandBodyDirectiveResult.replyInThread) {
+    normalized.CommandBody = commandBodyDirectiveResult.cleaned;
+  }
+  normalized.ReplyInThreadDirective = replyInThreadDirective;
 
   const chatType = normalizeChatType(normalized.ChatType);
   if (chatType && (opts.forceChatType || normalized.ChatType !== chatType)) {

--- a/src/auto-reply/reply/inbound-user-directives.test.ts
+++ b/src/auto-reply/reply/inbound-user-directives.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  extractInboundUserDirectives,
+  hasReplyInThreadDirective,
+} from "./inbound-user-directives.js";
+
+describe("extractInboundUserDirectives", () => {
+  describe("reply in thread", () => {
+    it("detects 'reply in thread' at end of message", () => {
+      const result = extractInboundUserDirectives("Hello world reply in thread");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("detects 'rit' at end of message", () => {
+      const result = extractInboundUserDirectives("Hello world rit");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("detects 'thread' at end of message", () => {
+      const result = extractInboundUserDirectives("Hello world thread");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("detects 'in thread' at end of message", () => {
+      const result = extractInboundUserDirectives("Hello world in thread");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("is case-insensitive", () => {
+      const result = extractInboundUserDirectives("Hello world REPLY IN THREAD");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("handles punctuation after trigger", () => {
+      const result = extractInboundUserDirectives("Hello world reply in thread!");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("handles multiple punctuation", () => {
+      const result = extractInboundUserDirectives("Hello world reply in thread!!!");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("handles whitespace around trigger", () => {
+      const result = extractInboundUserDirectives("Hello world   reply in thread   ");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello world");
+    });
+
+    it("does not trigger in middle of message", () => {
+      const result = extractInboundUserDirectives("reply in thread is what I want to do");
+      assert.strictEqual(result.replyInThread, false);
+      assert.strictEqual(result.cleaned, "reply in thread is what I want to do");
+    });
+
+    it("does not trigger when part of a word", () => {
+      const result = extractInboundUserDirectives("Hello threadworld");
+      assert.strictEqual(result.replyInThread, false);
+      assert.strictEqual(result.cleaned, "Hello threadworld");
+    });
+
+    it("returns empty string for empty input", () => {
+      const result = extractInboundUserDirectives("");
+      assert.strictEqual(result.replyInThread, false);
+      assert.strictEqual(result.cleaned, "");
+    });
+
+    it("returns empty string for whitespace-only input", () => {
+      const result = extractInboundUserDirectives("   ");
+      assert.strictEqual(result.replyInThread, false);
+      assert.strictEqual(result.cleaned, "   ");
+    });
+
+    it("handles multiline messages", () => {
+      const result = extractInboundUserDirectives("Hello\nworld\nreply in thread");
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "Hello\nworld");
+    });
+
+    it("preserves message content before trigger", () => {
+      const result = extractInboundUserDirectives(
+        "This is a complex message with numbers 123 and symbols! rit",
+      );
+      assert.strictEqual(result.replyInThread, true);
+      assert.strictEqual(result.cleaned, "This is a complex message with numbers 123 and symbols!");
+    });
+  });
+});
+
+describe("hasReplyInThreadDirective", () => {
+  it("returns true for message with trigger", () => {
+    assert.strictEqual(hasReplyInThreadDirective("Hello rit"), true);
+  });
+
+  it("returns false for message without trigger", () => {
+    assert.strictEqual(hasReplyInThreadDirective("Hello world"), false);
+  });
+
+  it("returns false for empty string", () => {
+    assert.strictEqual(hasReplyInThreadDirective(""), false);
+  });
+});

--- a/src/auto-reply/reply/inbound-user-directives.ts
+++ b/src/auto-reply/reply/inbound-user-directives.ts
@@ -1,0 +1,78 @@
+/**
+ * Inbound user directive detection and stripping.
+ *
+ * Handles user-facing directives that affect outbound behavior without
+ * requiring LLM cooperation (e.g., "reply in thread" triggers).
+ */
+
+/**
+ * Default trigger phrases for the reply-in-thread directive.
+ * Case-insensitive, matched at the end of the message.
+ */
+const DEFAULT_REPLY_IN_THREAD_TRIGGERS = [
+  "reply in thread",
+  "rit",
+  "thread",
+  "in thread",
+] as const;
+
+/**
+ * Regex pattern for detecting reply-in-thread triggers at the end of a message.
+ * Matches trigger phrases preceded by whitespace (to avoid stripping punctuation from message).
+ * Allows optional trailing punctuation and whitespace.
+ * Note: Not using global flag to get match.index for position information.
+ */
+const REPLY_IN_THREAD_RE = new RegExp(
+  `\\s+(${DEFAULT_REPLY_IN_THREAD_TRIGGERS.map((t) =>
+    t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+  ).join("|")})[\\s\\p{P}]*$`,
+  "iu",
+);
+
+export type InboundUserDirectiveResult = {
+  /** The message text with trigger phrases stripped. */
+  cleaned: string;
+  /** True if a reply-in-thread trigger was detected and stripped. */
+  replyInThread: boolean;
+};
+
+/**
+ * Detects and strips inbound user directives from message text.
+ *
+ * Currently handles:
+ * - "reply in thread" / "rit" / "thread" / "in thread" at end of message
+ *
+ * @param text - The message text to process
+ * @returns The cleaned text and detected directive flags
+ */
+export function extractInboundUserDirectives(text: string): InboundUserDirectiveResult {
+  if (!text || !text.trim()) {
+    return { cleaned: text ?? "", replyInThread: false };
+  }
+
+  let replyInThread = false;
+  let cleaned = text;
+
+  // Detect reply-in-thread trigger at end of message
+  const match = cleaned.match(REPLY_IN_THREAD_RE);
+  if (match) {
+    replyInThread = true;
+    cleaned = cleaned.slice(0, match.index).trim();
+  }
+
+  return { cleaned, replyInThread };
+}
+
+/**
+ * Checks if the given text contains a reply-in-thread trigger.
+ * Does not modify the text.
+ *
+ * @param text - The message text to check
+ * @returns True if a reply-in-thread trigger is present
+ */
+export function hasReplyInThreadDirective(text: string): boolean {
+  if (!text || !text.trim()) {
+    return false;
+  }
+  return REPLY_IN_THREAD_RE.test(text);
+}

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -179,6 +179,12 @@ export type MsgContext = {
    * Used for hook confirmation messages like "Session context saved to memory".
    */
   HookMessages?: string[];
+  /**
+   * User directive: force the response to be a threaded reply.
+   * Set when the user includes a trigger phrase like "reply in thread" or "rit"
+   * at the end of their message. Equivalent to the LLM emitting [[reply_to_current]].
+   */
+  ReplyInThreadDirective?: boolean;
 };
 
 export type FinalizedMsgContext = Omit<MsgContext, "CommandAuthorized"> & {


### PR DESCRIPTION
## Summary

Implements #47131 - adds inbound preprocessing for the 'reply in thread' user directive.

### Problem
Threaded replies are controlled by the LLM via \[[reply_to_current]]\ tags. This is unreliable because the LLM must notice the trigger phrase and remember to emit the tag.

### Solution
Added inbound preprocessing that:
1. Detects trigger phrases at the end of the inbound message: \eply in thread\, \it\, \	hread\, \in thread\
2. Strips the trigger phrase before passing to LLM
3. Forces \eplyToId\ on the outbound response (equivalent to \[[reply_to_current]]\)

### Changes
- **\src/auto-reply/reply/inbound-user-directives.ts\**: New module for detecting and stripping inbound user directives
- **\src/auto-reply/reply/inbound-context.ts\**: Integrated directive detection into \inalizeInboundContext\
- **\src/auto-reply/templating.ts\**: Added \ReplyInThreadDirective\ field to \MsgContext\
- **\src/auto-reply/reply/agent-runner-payloads.ts\**: Added \eplyInThreadDirective\ parameter to \uildReplyPayloads\
- **\src/auto-reply/reply/agent-runner.ts\**: Passes \ReplyInThreadDirective\ from context to payload builder
- **\src/auto-reply/reply/inbound-user-directives.test.ts\**: Test coverage for directive detection

### Example
\\\
User: 'Hello world reply in thread'
-> LLM sees: 'Hello world'
-> Response is threaded (replyToId set to current message)
\\\

### Test Plan
- Unit tests for directive detection and stripping
- All existing tests pass

Closes #47131