### PR TITLE
fix(openai-completions): Mistral API uses max_tokens parameter, not max_completion_tokens

### DIFF
--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -167,6 +167,9 @@ export function buildMistralModelDefinition(): ModelDefinitionConfig {
     cost: MISTRAL_DEFAULT_COST,
     contextWindow: MISTRAL_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MISTRAL_DEFAULT_MAX_TOKENS,
+    compat: {
+      maxTokensField: "max_tokens",
+    },
   };
 }
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -631,6 +631,7 @@ describe("applyMistralProviderConfig", () => {
     );
     expect(mistralDefault?.contextWindow).toBe(262144);
     expect(mistralDefault?.maxTokens).toBe(262144);
+    expect(mistralDefault?.compat?.maxTokensField).toBe("max_tokens");
   });
 });
 


### PR DESCRIPTION
## Problem
Mistral API rejects requests with the `max_completion_tokens` parameter, returning 422 error:
```
"Extra inputs are not permitted"
```

This breaks all OpenClaw users who configure Mistral as their LLM provider.

## Root Cause
The `openai-completions` adapter in pi-ai sends `max_completion_tokens` by default. Mistral's API only accepts `max_tokens`.

## Solution
Set `maxTokensField: 'max_tokens'` in the compat config for Mistral models so that pi-ai's openai-completions adapter sends the correct parameter name.

## Changes
- Modified `buildMistralModelDefinition()` in `src/commands/onboard-auth.models.ts` to include compat config
- Added test assertion in `src/commands/onboard-auth.test.ts` to verify the compat setting

## Fixes
Fixes #47079