### PR TITLE
feat(doctor): add --check-config for deep config validation

### DIFF
--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -25,8 +25,23 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
     .option("--deep", "Scan system services for extra gateway installs", false)
+    .option(
+      "--check-config",
+      "Deep config validation: schema + subsystem dry-run init (non-zero exit on failure)",
+      false,
+    )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        if (opts.checkConfig) {
+          const { runCheckConfig, formatCheckConfigResults } =
+            await import("../../commands/doctor-check-config.js");
+          const { results, hasFailures } = await runCheckConfig();
+          for (const line of formatCheckConfigResults(results)) {
+            defaultRuntime.log(line);
+          }
+          defaultRuntime.exit(hasFailures ? 1 : 0);
+          return;
+        }
         await doctorCommand(defaultRuntime, {
           workspaceSuggestions: opts.workspaceSuggestions,
           yes: Boolean(opts.yes),

--- a/src/commands/doctor-check-config.test.ts
+++ b/src/commands/doctor-check-config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { formatCheckConfigResults, type CheckConfigResult } from "./doctor-check-config.js";
+
+describe("formatCheckConfigResults", () => {
+  it("formats ok results with checkmark", () => {
+    const results: CheckConfigResult[] = [
+      { category: "schema", label: "Config schema", status: "ok" },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("\u2705");
+    expect(lines[0]).toContain("Config schema");
+  });
+
+  it("formats fail results with cross mark", () => {
+    const results: CheckConfigResult[] = [
+      {
+        category: "model",
+        label: "Primary model",
+        status: "fail",
+        message: "could not resolve",
+      },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("\u274C");
+    expect(lines[0]).toContain("Primary model");
+    expect(lines[0]).toContain("could not resolve");
+  });
+
+  it("formats warn results with warning sign", () => {
+    const results: CheckConfigResult[] = [
+      {
+        category: "tts",
+        label: "TTS provider",
+        status: "warn",
+        message: 'will fall back to "edge"',
+      },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("\u26A0");
+    expect(lines[0]).toContain("TTS provider");
+    expect(lines[0]).toContain("fall back");
+  });
+
+  it("formats results without message", () => {
+    const results: CheckConfigResult[] = [
+      { category: "schema", label: "Config schema", status: "ok" },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines[0]).not.toContain("\u2014");
+  });
+
+  it("formats multiple results", () => {
+    const results: CheckConfigResult[] = [
+      { category: "schema", label: "Config schema", status: "ok" },
+      {
+        category: "model",
+        label: "Primary model",
+        status: "ok",
+        message: "anthropic/claude-opus-4-6",
+      },
+      { category: "tts", label: "TTS", status: "ok", message: "disabled" },
+      { category: "channels", label: "Channel: telegram", status: "ok", message: "enabled" },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines).toHaveLength(4);
+    expect(lines.every((line) => line.includes("\u2705"))).toBe(true);
+  });
+
+  it("returns empty array for empty results", () => {
+    const lines = formatCheckConfigResults([]);
+    expect(lines).toEqual([]);
+  });
+});

--- a/src/commands/doctor-check-config.test.ts
+++ b/src/commands/doctor-check-config.test.ts
@@ -52,7 +52,7 @@ describe("formatCheckConfigResults", () => {
     expect(lines[0]).not.toContain("\u2014");
   });
 
-  it("formats multiple results", () => {
+  it("formats multiple results including fallback validation", () => {
     const results: CheckConfigResult[] = [
       { category: "schema", label: "Config schema", status: "ok" },
       {
@@ -61,12 +61,34 @@ describe("formatCheckConfigResults", () => {
         status: "ok",
         message: "anthropic/claude-opus-4-6",
       },
+      {
+        category: "model",
+        label: "Model fallbacks",
+        status: "ok",
+        message: "2 fallbacks validated",
+      },
       { category: "tts", label: "TTS", status: "ok", message: "disabled" },
       { category: "channels", label: "Channel: telegram", status: "ok", message: "enabled" },
     ];
     const lines = formatCheckConfigResults(results);
-    expect(lines).toHaveLength(4);
+    expect(lines).toHaveLength(5);
     expect(lines.every((line) => line.includes("\u2705"))).toBe(true);
+  });
+
+  it("formats fallback validation failure", () => {
+    const results: CheckConfigResult[] = [
+      {
+        category: "model",
+        label: "Model fallbacks",
+        status: "fail",
+        message: 'agents.defaults.model.fallbacks: could not parse fallback "kimi-coding/k2p5"',
+      },
+    ];
+    const lines = formatCheckConfigResults(results);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("\u274C");
+    expect(lines[0]).toContain("Model fallbacks");
+    expect(lines[0]).toContain("kimi-coding/k2p5");
   });
 
   it("returns empty array for empty results", () => {

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -64,6 +64,16 @@ export async function runCheckConfig(): Promise<{
     return { results, hasFailures: true };
   }
 
+  // Surface snapshot-level warnings (e.g., unresolved ${ENV_VAR} substitutions)
+  for (const warning of snapshot.warnings) {
+    results.push({
+      category: "schema",
+      label: warning.path || "config",
+      status: "warn",
+      message: warning.message,
+    });
+  }
+
   // Schema passed — also run plugin-aware validation
   const pluginValidation = validateConfigObjectWithPlugins(snapshot.config);
   if (!pluginValidation.ok) {

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -1,0 +1,305 @@
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import {
+  getModelRefStatus,
+  parseModelRef,
+  resolveConfiguredModelRef,
+} from "../agents/model-selection.js";
+import { readConfigFileSnapshot, validateConfigObjectWithPlugins } from "../config/config.js";
+import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { resolveTtsConfig, isTtsProviderConfigured, TTS_PROVIDERS } from "../tts/tts.js";
+
+export type CheckConfigResult = {
+  category: string;
+  label: string;
+  status: "ok" | "warn" | "fail";
+  message?: string;
+};
+
+/**
+ * Deep config validation that exercises subsystem initialization paths.
+ * Goes beyond Zod schema validation to catch runtime config degradation.
+ *
+ * Two layers:
+ * 1. Schema validation (fast, catches typos and structural errors)
+ * 2. Subsystem dry-run checks (catches silent runtime failures)
+ */
+export async function runCheckConfig(): Promise<{
+  results: CheckConfigResult[];
+  hasFailures: boolean;
+}> {
+  const results: CheckConfigResult[] = [];
+
+  // Layer 1: Schema validation
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.exists) {
+    results.push({
+      category: "schema",
+      label: "Config file",
+      status: "fail",
+      message: "config file not found",
+    });
+    return { results, hasFailures: true };
+  }
+
+  if (!snapshot.valid) {
+    const issues = normalizeConfigIssues(snapshot.issues);
+    results.push({
+      category: "schema",
+      label: "Config schema",
+      status: "fail",
+      message: formatConfigIssueLines(issues, "", { normalizeRoot: true })
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .join("; "),
+    });
+    return { results, hasFailures: true };
+  }
+
+  // Schema passed — also run plugin-aware validation
+  const pluginValidation = validateConfigObjectWithPlugins(snapshot.config);
+  if (!pluginValidation.ok) {
+    for (const issue of pluginValidation.issues) {
+      results.push({
+        category: "schema",
+        label: issue.path || "config",
+        status: "fail",
+        message: issue.message,
+      });
+    }
+  } else {
+    results.push({
+      category: "schema",
+      label: "Config schema",
+      status: "ok",
+    });
+
+    if ("warnings" in pluginValidation && Array.isArray(pluginValidation.warnings)) {
+      for (const warning of pluginValidation.warnings) {
+        results.push({
+          category: "schema",
+          label: warning.path || "config",
+          status: "warn",
+          message: warning.message,
+        });
+      }
+    }
+  }
+
+  const cfg = snapshot.config;
+
+  // Layer 2: Subsystem dry-run checks
+  checkModelResolution(cfg, results);
+  await checkModelCatalog(cfg, results);
+  checkTtsConfig(cfg, results);
+  checkChannelConfig(cfg, results);
+
+  const hasFailures = results.some((r) => r.status === "fail");
+  return { results, hasFailures };
+}
+
+function checkModelResolution(cfg: OpenClawConfig, results: CheckConfigResult[]): void {
+  try {
+    const { provider, model } = resolveConfiguredModelRef({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
+    if (!provider || !model) {
+      results.push({
+        category: "model",
+        label: "Primary model",
+        status: "fail",
+        message: "could not resolve primary model — check agents.defaults.model",
+      });
+      return;
+    }
+
+    const parsed = parseModelRef(model, provider);
+    if (!parsed) {
+      results.push({
+        category: "model",
+        label: "Primary model",
+        status: "fail",
+        message: `could not parse model ref "${model}" with provider "${provider}"`,
+      });
+      return;
+    }
+
+    results.push({
+      category: "model",
+      label: "Primary model",
+      status: "ok",
+      message: `${provider}/${model}`,
+    });
+  } catch (err) {
+    results.push({
+      category: "model",
+      label: "Primary model",
+      status: "fail",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function checkModelCatalog(cfg: OpenClawConfig, results: CheckConfigResult[]): Promise<void> {
+  try {
+    const catalog = await loadModelCatalog({ config: cfg });
+    const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+
+    const primaryRef = parseModelRef(defaultModel, defaultProvider);
+    if (primaryRef) {
+      const status = getModelRefStatus({
+        cfg,
+        catalog,
+        ref: primaryRef,
+        defaultProvider,
+        defaultModel,
+      });
+      if (!status.inCatalog) {
+        results.push({
+          category: "model",
+          label: "Model catalog",
+          status: "warn",
+          message: `primary model "${status.key}" not in catalog (may fail at runtime)`,
+        });
+      } else {
+        results.push({
+          category: "model",
+          label: "Model catalog",
+          status: "ok",
+        });
+      }
+    }
+  } catch (err) {
+    results.push({
+      category: "model",
+      label: "Model catalog",
+      status: "warn",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function checkTtsConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): void {
+  try {
+    const ttsConfig = resolveTtsConfig(cfg);
+
+    if (ttsConfig.auto === "off") {
+      results.push({
+        category: "tts",
+        label: "TTS",
+        status: "ok",
+        message: "disabled",
+      });
+      return;
+    }
+
+    // TTS is enabled — check if the configured provider is actually available
+    const configuredProvider = ttsConfig.provider;
+    const isConfigured = isTtsProviderConfigured(ttsConfig, configuredProvider);
+
+    if (!isConfigured && configuredProvider !== "edge") {
+      // Check if any fallback provider is available
+      const availableFallback = TTS_PROVIDERS.find(
+        (p) => p !== configuredProvider && isTtsProviderConfigured(ttsConfig, p),
+      );
+
+      if (availableFallback) {
+        results.push({
+          category: "tts",
+          label: "TTS provider",
+          status: "warn",
+          message: `configured provider "${configuredProvider}" missing API key — will fall back to "${availableFallback}"`,
+        });
+      } else {
+        results.push({
+          category: "tts",
+          label: "TTS provider",
+          status: "fail",
+          message: `configured provider "${configuredProvider}" missing API key and no fallback available`,
+        });
+      }
+      return;
+    }
+
+    results.push({
+      category: "tts",
+      label: "TTS provider",
+      status: "ok",
+      message: configuredProvider,
+    });
+  } catch (err) {
+    results.push({
+      category: "tts",
+      label: "TTS",
+      status: "fail",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function checkChannelConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): void {
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    results.push({
+      category: "channels",
+      label: "Channels",
+      status: "ok",
+      message: "no channels configured",
+    });
+    return;
+  }
+
+  const channelEntries = Object.entries(channels).filter(
+    ([key]) => key !== "defaults" && key !== "modelByChannel",
+  );
+
+  if (channelEntries.length === 0) {
+    results.push({
+      category: "channels",
+      label: "Channels",
+      status: "ok",
+      message: "no channels configured",
+    });
+    return;
+  }
+
+  for (const [channelId, channelConfig] of channelEntries) {
+    if (!channelConfig || typeof channelConfig !== "object") {
+      continue;
+    }
+    const config = channelConfig as Record<string, unknown>;
+    const enabled = config.enabled !== false;
+    if (!enabled) {
+      continue;
+    }
+
+    results.push({
+      category: "channels",
+      label: `Channel: ${channelId}`,
+      status: "ok",
+      message: "enabled",
+    });
+  }
+}
+
+/**
+ * Format check-config results for terminal output.
+ */
+export function formatCheckConfigResults(results: CheckConfigResult[]): string[] {
+  const lines: string[] = [];
+  for (const result of results) {
+    const icon =
+      result.status === "ok" ? "\u2705" : result.status === "warn" ? "\u26A0\uFE0F" : "\u274C";
+    const detail = result.message ? ` \u2014 ${result.message}` : "";
+    lines.push(`${icon} ${result.label}${detail}`);
+  }
+  return lines;
+}

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -2,9 +2,11 @@ import { resolveAgentModelFallbacksOverride } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
+  buildModelAliasIndex,
   getModelRefStatus,
   parseModelRef,
   resolveConfiguredModelRef,
+  resolveModelRefFromString,
 } from "../agents/model-selection.js";
 import { readConfigFileSnapshot, validateConfigObjectWithPlugins } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
@@ -253,16 +255,24 @@ function checkFallbackModels(cfg: OpenClawConfig, results: CheckConfigResult[]):
     return;
   }
 
+  // Use resolveModelRefFromString (same parser as runtime fallback execution)
+  // which strips trailing auth-profile syntax and handles aliases.
+  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+
   let hasIssue = false;
   for (const { source, fallbacks } of allFallbackSources) {
     for (const fallback of fallbacks) {
-      const ref = parseModelRef(String(fallback), defaultProvider);
-      if (!ref) {
+      const raw = String(fallback).trim();
+      if (!raw) {
+        continue;
+      }
+      const resolved = resolveModelRefFromString({ raw, defaultProvider, aliasIndex });
+      if (!resolved) {
         results.push({
           category: "model",
           label: "Model fallbacks",
           status: "fail",
-          message: `${source}: could not parse fallback "${fallback}"`,
+          message: `${source}: could not resolve fallback "${fallback}"`,
         });
         hasIssue = true;
       }

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -8,7 +8,10 @@ import {
 } from "../agents/model-selection.js";
 import { readConfigFileSnapshot, validateConfigObjectWithPlugins } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
-import { resolveAgentModelFallbackValues } from "../config/model-input.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveTtsConfig, isTtsProviderConfigured, TTS_PROVIDERS } from "../tts/tts.js";
 
@@ -104,6 +107,9 @@ export async function runCheckConfig(): Promise<{
 
 function checkModelResolution(cfg: OpenClawConfig, results: CheckConfigResult[]): void {
   try {
+    // Check if the user explicitly configured a model that silently fell back
+    const rawConfigured = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)?.trim();
+
     const { provider, model } = resolveConfiguredModelRef({
       cfg,
       defaultProvider: DEFAULT_PROVIDER,
@@ -120,15 +126,28 @@ function checkModelResolution(cfg: OpenClawConfig, results: CheckConfigResult[])
       return;
     }
 
-    const parsed = parseModelRef(model, provider);
-    if (!parsed) {
+    // Detect silent fallback: user configured a model but resolution fell back to default
+    if (rawConfigured && rawConfigured !== `${provider}/${model}` && !rawConfigured.includes("/")) {
+      // User wrote a bare model name without provider — resolved but may not be what they intended
       results.push({
         category: "model",
         label: "Primary model",
-        status: "fail",
-        message: `could not parse model ref "${model}" with provider "${provider}"`,
+        status: "warn",
+        message: `"${rawConfigured}" resolved as ${provider}/${model} — consider using the full provider/model format`,
       });
       return;
+    }
+    if (rawConfigured && rawConfigured.includes("/")) {
+      const parsed = parseModelRef(rawConfigured, DEFAULT_PROVIDER);
+      if (parsed && (parsed.provider !== provider || parsed.model !== model)) {
+        results.push({
+          category: "model",
+          label: "Primary model",
+          status: "warn",
+          message: `configured "${rawConfigured}" could not be resolved — fell back to ${provider}/${model}`,
+        });
+        return;
+      }
     }
 
     results.push({

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -1,3 +1,4 @@
+import { resolveAgentModelFallbacksOverride } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
@@ -7,6 +8,7 @@ import {
 } from "../agents/model-selection.js";
 import { readConfigFileSnapshot, validateConfigObjectWithPlugins } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveTtsConfig, isTtsProviderConfigured, TTS_PROVIDERS } from "../tts/tts.js";
 
@@ -92,6 +94,7 @@ export async function runCheckConfig(): Promise<{
   // Layer 2: Subsystem dry-run checks
   checkModelResolution(cfg, results);
   await checkModelCatalog(cfg, results);
+  checkFallbackModels(cfg, results);
   checkTtsConfig(cfg, results);
   checkChannelConfig(cfg, results);
 
@@ -176,6 +179,13 @@ async function checkModelCatalog(cfg: OpenClawConfig, results: CheckConfigResult
           status: "ok",
         });
       }
+    } else {
+      results.push({
+        category: "model",
+        label: "Model catalog",
+        status: "warn",
+        message: "skipped — primary model ref could not be parsed",
+      });
     }
   } catch (err) {
     results.push({
@@ -183,6 +193,76 @@ async function checkModelCatalog(cfg: OpenClawConfig, results: CheckConfigResult
       label: "Model catalog",
       status: "warn",
       message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function checkFallbackModels(cfg: OpenClawConfig, results: CheckConfigResult[]): void {
+  const { provider: defaultProvider } = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+
+  // Collect all fallback refs: global defaults + per-agent overrides
+  const globalFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+  const allFallbackSources: Array<{ source: string; fallbacks: string[] }> = [];
+
+  if (globalFallbacks.length > 0) {
+    allFallbackSources.push({
+      source: "agents.defaults.model.fallbacks",
+      fallbacks: globalFallbacks,
+    });
+  }
+
+  if (Array.isArray(cfg.agents?.list)) {
+    for (const agent of cfg.agents.list) {
+      if (!agent?.id) {
+        continue;
+      }
+      const override = resolveAgentModelFallbacksOverride(cfg, agent.id);
+      if (override && override.length > 0) {
+        allFallbackSources.push({
+          source: `agents.list[${agent.id}].model.fallbacks`,
+          fallbacks: override,
+        });
+      }
+    }
+  }
+
+  if (allFallbackSources.length === 0) {
+    results.push({
+      category: "model",
+      label: "Model fallbacks",
+      status: "ok",
+      message: "no fallbacks configured",
+    });
+    return;
+  }
+
+  let hasIssue = false;
+  for (const { source, fallbacks } of allFallbackSources) {
+    for (const fallback of fallbacks) {
+      const ref = parseModelRef(String(fallback), defaultProvider);
+      if (!ref) {
+        results.push({
+          category: "model",
+          label: "Model fallbacks",
+          status: "fail",
+          message: `${source}: could not parse fallback "${fallback}"`,
+        });
+        hasIssue = true;
+      }
+    }
+  }
+
+  if (!hasIssue) {
+    const totalCount = allFallbackSources.reduce((sum, s) => sum + s.fallbacks.length, 0);
+    results.push({
+      category: "model",
+      label: "Model fallbacks",
+      status: "ok",
+      message: `${totalCount} fallback${totalCount === 1 ? "" : "s"} validated`,
     });
   }
 }
@@ -205,25 +285,30 @@ function checkTtsConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): void
     const configuredProvider = ttsConfig.provider;
     const isConfigured = isTtsProviderConfigured(ttsConfig, configuredProvider);
 
-    if (!isConfigured && configuredProvider !== "edge") {
+    if (!isConfigured) {
       // Check if any fallback provider is available
       const availableFallback = TTS_PROVIDERS.find(
         (p) => p !== configuredProvider && isTtsProviderConfigured(ttsConfig, p),
       );
+
+      const reason =
+        configuredProvider === "edge"
+          ? 'configured provider "edge" is disabled'
+          : `configured provider "${configuredProvider}" missing API key`;
 
       if (availableFallback) {
         results.push({
           category: "tts",
           label: "TTS provider",
           status: "warn",
-          message: `configured provider "${configuredProvider}" missing API key — will fall back to "${availableFallback}"`,
+          message: `${reason} — will fall back to "${availableFallback}"`,
         });
       } else {
         results.push({
           category: "tts",
           label: "TTS provider",
           status: "fail",
-          message: `configured provider "${configuredProvider}" missing API key and no fallback available`,
+          message: `${reason} and no fallback available`,
         });
       }
       return;
@@ -271,6 +356,7 @@ function checkChannelConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): 
     return;
   }
 
+  let enabledCount = 0;
   for (const [channelId, channelConfig] of channelEntries) {
     if (!channelConfig || typeof channelConfig !== "object") {
       continue;
@@ -280,12 +366,21 @@ function checkChannelConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): 
     if (!enabled) {
       continue;
     }
-
+    enabledCount++;
     results.push({
       category: "channels",
       label: `Channel: ${channelId}`,
       status: "ok",
       message: "enabled",
+    });
+  }
+
+  if (enabledCount === 0) {
+    results.push({
+      category: "channels",
+      label: "Channels",
+      status: "ok",
+      message: "all channels disabled",
     });
   }
 }

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -156,35 +156,29 @@ async function checkModelCatalog(cfg: OpenClawConfig, results: CheckConfigResult
       defaultModel: DEFAULT_MODEL,
     });
 
-    const primaryRef = parseModelRef(defaultModel, defaultProvider);
-    if (primaryRef) {
-      const status = getModelRefStatus({
-        cfg,
-        catalog,
-        ref: primaryRef,
-        defaultProvider,
-        defaultModel,
-      });
-      if (!status.inCatalog) {
-        results.push({
-          category: "model",
-          label: "Model catalog",
-          status: "warn",
-          message: `primary model "${status.key}" not in catalog (may fail at runtime)`,
-        });
-      } else {
-        results.push({
-          category: "model",
-          label: "Model catalog",
-          status: "ok",
-        });
-      }
-    } else {
+    // Use the already-resolved provider directly as the ref instead of re-parsing.
+    // Re-parsing breaks models whose IDs contain "/" (e.g., OpenRouter refs like
+    // "openrouter/anthropic/claude-sonnet-4-5" would be split incorrectly).
+    const ref = { provider: defaultProvider, model: defaultModel };
+    const status = getModelRefStatus({
+      cfg,
+      catalog,
+      ref,
+      defaultProvider,
+      defaultModel,
+    });
+    if (!status.inCatalog) {
       results.push({
         category: "model",
         label: "Model catalog",
         status: "warn",
-        message: "skipped — primary model ref could not be parsed",
+        message: `primary model "${status.key}" not in catalog (may fail at runtime)`,
+      });
+    } else {
+      results.push({
+        category: "model",
+        label: "Model catalog",
+        status: "ok",
       });
     }
   } catch (err) {

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -15,7 +15,7 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { resolveTtsConfig, isTtsProviderConfigured, TTS_PROVIDERS } from "../tts/tts.js";
+import { resolveTtsConfig, isTtsProviderConfigured, resolveTtsProviderOrder } from "../tts/tts.js";
 
 export type CheckConfigResult = {
   category: string;
@@ -316,12 +316,13 @@ function checkTtsConfig(cfg: OpenClawConfig, results: CheckConfigResult[]): void
 
     // TTS is enabled — check if the configured provider is actually available
     const configuredProvider = ttsConfig.provider;
-    const isConfigured = isTtsProviderConfigured(ttsConfig, configuredProvider);
+    const isConfigured = isTtsProviderConfigured(ttsConfig, configuredProvider, cfg);
 
     if (!isConfigured) {
       // Check if any fallback provider is available
-      const availableFallback = TTS_PROVIDERS.find(
-        (p) => p !== configuredProvider && isTtsProviderConfigured(ttsConfig, p),
+      const availableFallback = resolveTtsProviderOrder(configuredProvider, cfg).find(
+        (provider) =>
+          provider !== configuredProvider && isTtsProviderConfigured(ttsConfig, provider, cfg),
       );
 
       const reason =

--- a/src/commands/doctor-check-config.ts
+++ b/src/commands/doctor-check-config.ts
@@ -272,7 +272,7 @@ function checkFallbackModels(cfg: OpenClawConfig, results: CheckConfigResult[]):
   let hasIssue = false;
   for (const { source, fallbacks } of allFallbackSources) {
     for (const fallback of fallbacks) {
-      const raw = String(fallback).trim();
+      const raw = fallback.trim();
       if (!raw) {
         continue;
       }


### PR DESCRIPTION
## Summary

- Adds `openclaw doctor --check-config` for deep config validation that goes beyond schema parsing
- Two-layer approach: schema + plugin validation first, then subsystem dry-run checks (model resolution, model catalog, fallback chain, TTS provider, channel config)
- Catches silent config degradation where the gateway starts and looks healthy but features like TTS or model fallbacks are quietly broken
- Non-zero exit code on any failure for CI pipeline gating

Closes #45552
Closes #20909

## Motivation

Currently `openclaw doctor` validates auth profiles, gateway health, sandbox images, and more — but does not exercise config-dependent initialization paths. This means a user can upgrade OpenClaw, have the gateway start cleanly, and only discover that TTS stopped working (or model fallbacks broke) when they try to use the feature.

Real-world example from #45540: the `ANTHROPIC_MODEL_ALIASES` TDZ bug caused silent config degradation — gateway started, channels connected, cron fired normally — but TTS initialization was broken. Debugging took ~2 hours. `doctor --check-config` would have caught it immediately.

## What it checks

| Check | Category | Catches |
|-------|----------|---------|
| Config schema + plugins | Schema | Typos, structural errors, unknown keys, plugin config |
| Primary model resolution | Model | Broken model refs, unresolvable aliases |
| Model catalog lookup | Model | Models not in catalog (will fail at runtime) |
| Fallback model chain | Model | Unparseable fallback refs in global defaults and per-agent overrides |
| TTS provider availability | TTS | Missing API keys, disabled edge provider, silent fallback |
| Channel config | Channels | Enabled channels listing, all-disabled detection |

## Example output

```
✅ Config schema
✅ Primary model — anthropic/claude-opus-4-6
✅ Model catalog
✅ Model fallbacks — 2 fallbacks validated
⚠️  TTS provider — configured provider "openai" missing API key — will fall back to "edge"
✅ Channel: telegram — enabled
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (lint + format) passes
- [x] `pnpm test -- src/commands/doctor-check-config.test.ts` — 7 tests pass
- [ ] Manual test: `openclaw doctor --check-config` on a live config
- [ ] Manual test: verify non-zero exit code when config has failures

## Real behavior proof

Behavior or issue addressed:
`openclaw doctor --check-config` should load from the real CLI path and report config validation results instead of failing during TypeScript compilation.

Real environment tested:
Local macOS checkout of OpenClaw on branch `pr-47302-ci-fix`, Node 24.10.0, pnpm 11.1.0.

Exact steps or command run after this patch:
`pnpm tsgo:core`
`pnpm openclaw doctor --check-config`

Evidence after fix:
`pnpm tsgo:core` completed with `EXIT:0` after running `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`.
The real CLI command built the stale dist path, reached the new check-config command, and printed `Config file — config file not found` instead of crashing on the previous `TTS_PROVIDERS` import/type error.

Observed result after fix:
TypeScript production checking passes, and the real CLI reaches `doctor --check-config` runtime behavior. In a checkout without a configured OpenClaw config file, it fails closed with exit code 1 and a clear config-file diagnostic.

What was not tested:
A live configured OpenClaw installation with valid model/TTS credentials was not exercised locally; this pass verifies the compile-time regression and real CLI command path.

## Design decisions

- **Dynamic import** of the new module from `register.maintenance.ts` to avoid adding startup weight for the standard `doctor` path
- **Structured results** (`CheckConfigResult[]`) rather than direct console output, making it testable and extensible for JSON output later
- **Two-layer approach** as suggested in the issue discussion: fast schema check first, then subsystem dry-run
- **Every check always produces output** — no silent skips when a subsystem cannot be validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
