### PR TITLE
fix(acpx): align pinned version with bundled acpx release

### DIFF
--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -8,7 +8,7 @@ export type AcpxPermissionMode = (typeof ACPX_PERMISSION_MODES)[number];
 export const ACPX_NON_INTERACTIVE_POLICIES = ["deny", "fail"] as const;
 export type AcpxNonInteractivePermissionPolicy = (typeof ACPX_NON_INTERACTIVE_POLICIES)[number];
 
-export const ACPX_PINNED_VERSION = "0.1.16";
+export const ACPX_PINNED_VERSION = "0.2.0";
 export const ACPX_VERSION_ANY = "any";
 const ACPX_BIN_NAME = process.platform === "win32" ? "acpx.cmd" : "acpx";
 export const ACPX_PLUGIN_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");


### PR DESCRIPTION
## Problem

OpenClaw 2026.3.11 bundles `acpx 0.2.0`, but the ACPX plugin still pins `0.1.16` as the expected version.

That makes the ACP backend version check fail and surfaces:

- `ACP runtime backend is currently unavailable.`

which blocks ACP session startup even when the bundled runtime is present.

## Fix

Update `ACPX_PINNED_VERSION` from `0.1.16` to `0.2.0` so the bundled ACPX runtime passes the expected-version gate again.

## Scope

Single-constant fix in `extensions/acpx/src/config.ts`.

Closes #43997
