### PR TITLE
fix(webchat): allow configurable chunk limit, increase default

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -108,6 +108,24 @@ describe("resolveTextChunkLimit", () => {
     ).toBe(2000);
   });
 
+  it("uses higher default for webchat", () => {
+    // Webchat uses higher default since there's no upstream API limit
+    expect(resolveTextChunkLimit(undefined, "webchat")).toBe(20000);
+    expect(resolveTextChunkLimit(undefined)).toBe(20000); // undefined provider = webchat
+  });
+
+  it("supports webchat config override", () => {
+    const cfg = { webchat: { textChunkLimit: 50000 } };
+    expect(resolveTextChunkLimit(cfg, "webchat")).toBe(50000);
+    expect(resolveTextChunkLimit(cfg)).toBe(50000);
+  });
+
+  it("supports webchat chunkMode config", () => {
+    const cfg = { webchat: { chunkMode: "newline" as const } };
+    expect(resolveChunkMode(cfg, "webchat")).toBe("newline");
+    expect(resolveChunkMode(cfg)).toBe("newline");
+  });
+
   it("supports provider overrides", () => {
     const cfg = { channels: { telegram: { textChunkLimit: 1234 } } };
     expect(resolveTextChunkLimit(cfg, "whatsapp")).toBe(4000);

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -22,12 +22,19 @@ export type TextChunkProvider = ChannelId | typeof INTERNAL_MESSAGE_CHANNEL;
 export type ChunkMode = "length" | "newline";
 
 const DEFAULT_CHUNK_LIMIT = 4000;
+/** Webchat default is higher since there's no upstream API limit. */
+const DEFAULT_WEBCHAT_CHUNK_LIMIT = 20000;
 const DEFAULT_CHUNK_MODE: ChunkMode = "length";
 
 type ProviderChunkConfig = {
   textChunkLimit?: number;
   chunkMode?: ChunkMode;
   accounts?: Record<string, { textChunkLimit?: number; chunkMode?: ChunkMode }>;
+};
+
+type WebchatChunkConfig = {
+  textChunkLimit?: number;
+  chunkMode?: ChunkMode;
 };
 
 function resolveChunkLimitForProvider(
@@ -54,19 +61,26 @@ export function resolveTextChunkLimit(
   accountId?: string | null,
   opts?: { fallbackLimit?: number },
 ): number {
+  const isWebchat = !provider || provider === INTERNAL_MESSAGE_CHANNEL;
+  const defaultLimit = isWebchat ? DEFAULT_WEBCHAT_CHUNK_LIMIT : DEFAULT_CHUNK_LIMIT;
   const fallback =
     typeof opts?.fallbackLimit === "number" && opts.fallbackLimit > 0
       ? opts.fallbackLimit
-      : DEFAULT_CHUNK_LIMIT;
-  const providerOverride = (() => {
-    if (!provider || provider === INTERNAL_MESSAGE_CHANNEL) {
-      return undefined;
+      : defaultLimit;
+
+  // Check for webchat-specific config override
+  if (isWebchat) {
+    const webchatConfig = cfg?.webchat as WebchatChunkConfig | undefined;
+    if (typeof webchatConfig?.textChunkLimit === "number" && webchatConfig.textChunkLimit > 0) {
+      return webchatConfig.textChunkLimit;
     }
-    const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
-    const providerConfig = (channelsConfig?.[provider] ??
-      (cfg as Record<string, unknown> | undefined)?.[provider]) as ProviderChunkConfig | undefined;
-    return resolveChunkLimitForProvider(providerConfig, accountId);
-  })();
+    return fallback;
+  }
+
+  const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
+  const providerConfig = (channelsConfig?.[provider] ??
+    (cfg as Record<string, unknown> | undefined)?.[provider]) as ProviderChunkConfig | undefined;
+  const providerOverride = resolveChunkLimitForProvider(providerConfig, accountId);
   if (typeof providerOverride === "number" && providerOverride > 0) {
     return providerOverride;
   }
@@ -96,9 +110,17 @@ export function resolveChunkMode(
   provider?: TextChunkProvider,
   accountId?: string | null,
 ): ChunkMode {
-  if (!provider || provider === INTERNAL_MESSAGE_CHANNEL) {
+  const isWebchat = !provider || provider === INTERNAL_MESSAGE_CHANNEL;
+
+  // Check for webchat-specific config override
+  if (isWebchat) {
+    const webchatConfig = cfg?.webchat as WebchatChunkConfig | undefined;
+    if (webchatConfig?.chunkMode) {
+      return webchatConfig.chunkMode;
+    }
     return DEFAULT_CHUNK_MODE;
   }
+
   const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
   const providerConfig = (channelsConfig?.[provider] ??
     (cfg as Record<string, unknown> | undefined)?.[provider]) as ProviderChunkConfig | undefined;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -351,6 +351,12 @@ export const FIELD_HELP: Record<string, string> = {
     "Randomization factor (0-1) applied to reconnect delays to desynchronize clients after outage events. Keep non-zero jitter in multi-client deployments to reduce synchronized spikes.",
   "web.reconnect.maxAttempts":
     "Maximum reconnect attempts before giving up for the current failure sequence (0 means no retries). Use finite caps for controlled failure handling in automation-sensitive environments.",
+  webchat:
+    "Webchat configuration for control UI message chunking. Webchat has no upstream API limits, so defaults are higher than external channels.",
+  "webchat.textChunkLimit":
+    "Max characters per message chunk for webchat/control-UI (default: 20000). Increase for longer responses or decrease for slower clients.",
+  "webchat.chunkMode":
+    'Chunking mode for webchat: "length" (default) splits by size limit; "newline" splits on paragraph boundaries for more natural breaks.',
   canvasHost:
     "Canvas host settings for serving canvas assets and local live-reload behavior used by canvas-enabled workflows. Keep disabled unless canvas-hosted assets are actively used.",
   "canvasHost.enabled":

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -28,6 +28,14 @@ import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
+/** Webchat configuration for control UI message chunking. */
+export type WebchatConfig = {
+  /** Max characters per message chunk for webchat (default: 20000). */
+  textChunkLimit?: number;
+  /** Chunking mode: "length" (default) splits by size; "newline" splits on paragraph boundaries. */
+  chunkMode?: "length" | "newline";
+};
+
 export type OpenClawConfig = {
   meta?: {
     /** Last OpenClaw version that wrote this config. */
@@ -112,6 +120,8 @@ export type OpenClawConfig = {
   approvals?: ApprovalsConfig;
   session?: SessionConfig;
   web?: WebConfig;
+  /** Webchat configuration for control UI message chunking. */
+  webchat?: WebchatConfig;
   channels?: ChannelsConfig;
   cron?: CronConfig;
   hooks?: HooksConfig;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -334,6 +334,17 @@ export const ReplyRuntimeConfigSchemaShape = {
   mediaMaxMb: z.number().positive().optional(),
 };
 
+/** Webchat configuration for control UI message chunking. */
+export const WebchatConfigSchema = z
+  .object({
+    /** Max characters per message chunk for webchat (default: 20000). */
+    textChunkLimit: z.number().int().positive().optional(),
+    /** Chunking mode: "length" (default) splits by size; "newline" splits on paragraph boundaries. */
+    chunkMode: z.enum(["length", "newline"]).optional(),
+  })
+  .strict()
+  .optional();
+
 export const BlockStreamingChunkSchema = z
   .object({
     minChars: z.number().int().positive().optional(),


### PR DESCRIPTION
Fixes #47123

Problem: Long assistant responses in webchat control-UI were silently truncated at ~4000 characters with no configuration option.

Solution: 
- Increased default for webchat from 4000 to 20000 characters
- Added webchat config section with textChunkLimit and chunkMode options
- Updated resolveTextChunkLimit and resolveChunkMode to check for webchat-specific config