### PR TITLE
fix: flush reply pipeline after compaction retry resolves

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2607,6 +2607,20 @@ export async function runEmbeddedAttempt(
           }
         }
 
+        // Flush reply pipeline again after compaction wait resolves.
+        // When compaction retries (willRetry=true), the SDK runs a new agent
+        // loop whose agent_end handler fires onBlockReplyFlush as
+        // fire-and-forget (void).  resolveCompactionRetry() then unblocks
+        // waitForCompactionRetryWithAggregateTimeout *synchronously* — before
+        // the async pipeline flush completes.  Without this second flush the
+        // retry's block replies may not reach the channel, and
+        // shouldDropFinalPayloads suppresses the final payloads because
+        // didStream() is already true from the first reply.  The call is
+        // idempotent; flushing twice is harmless.  (#35489 follow-up)
+        if (params.onBlockReplyFlush) {
+          await params.onBlockReplyFlush();
+        }
+
         // Check if ANY compaction occurred during the entire attempt (prompt + retry).
         // Using a cumulative count (> 0) instead of a delta check avoids missing
         // compactions that complete during activeSession.prompt() before the delta


### PR DESCRIPTION
## Summary

Fixes #47335

When auto-compaction retries (`willRetry=true`), the SDK runs a new agent loop whose `agent_end` handler fires `onBlockReplyFlush` as fire-and-forget (`void`). `resolveCompactionRetry()` then unblocks `waitForCompactionRetryWithAggregateTimeout` **synchronously** — before the async pipeline flush completes. Without a second flush after the wait resolves, the retry's block replies may not reach the channel, and `shouldDropFinalPayloads` suppresses the final payloads because `didStream()` is already true from the first reply.

## Changes

Add an idempotent `onBlockReplyFlush()` call after `waitForCompactionRetryWithAggregateTimeout` resolves in `attempt.ts`, ensuring both the original and retry reply pipelines are fully drained before the attempt returns.

The fix is minimal and surgical — a single flush call that follows the existing pattern. Flushing twice is harmless (the pipeline is idempotent).

## Root Cause

In the compaction retry path:

1. Retry's `agent_end` fires → `handleAgentEnd` calls `flushBlockReplyBuffer()` (sync) + `void onBlockReplyFlush()` (fire-and-forget)
2. `handleAgentEnd` calls `resolveCompactionRetry()` which **synchronously** resolves the compaction wait promise
3. `waitForCompactionRetryWithAggregateTimeout` in `attempt.ts` unblocks
4. The attempt continues and returns — but `onBlockReplyFlush()` from step 1 hasn't completed yet
5. `shouldDropFinalPayloads` is true (from first reply's `didStream()`), so final payloads are dropped
6. Result: reply in transcript (`stopReason: "stop"`) but never delivered

## Related

- Follow-up to `7a22b3fa0` (#35489) which covers in-run compaction but not the retry case
- The `void onBlockReplyFlush()` in `handleAgentEnd` is correct for the event handler context; the fix adds an explicit await at the callsite that needs the guarantee

## Testing

- Existing compaction-timeout tests pass ✅
- Compaction retry aggregate timeout tests pass ✅  
- Lifecycle handler tests pass ✅
- Block reply pipeline tests pass ✅
- Block reply rejection tests pass ✅