### PR TITLE
fix(logging): rotate log file when date changes in rolling-path mode

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -146,9 +146,28 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   let currentFileBytes = getCurrentLogFileBytes(settings.file);
   let warnedAboutSizeCap = false;
 
+  let lastLogDate = new Date();
+
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
+      const logTime = logObj.date ?? new Date();
+      const time = formatLocalIsoWithOffset(logTime);
+      
+      // Check if date has changed for rolling log files
+      let currentFile = settings.file;
+      if (isRollingPath(settings.file)) {
+        const lastLogDateStr = formatLocalDate(lastLogDate);
+        const currentLogDateStr = formatLocalDate(logTime);
+        if (lastLogDateStr !== currentLogDateStr) {
+          // Date has changed, recalculate the file path
+          currentFile = defaultRollingPathForToday();
+          fs.mkdirSync(path.dirname(currentFile), { recursive: true });
+          currentFileBytes = getCurrentLogFileBytes(currentFile);
+          warnedAboutSizeCap = false;
+          lastLogDate = logTime;
+        }
+      }
+      
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");
@@ -160,16 +179,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             time: formatLocalIsoWithOffset(new Date()),
             level: "warn",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            message: `log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          appendLogLine(currentFile, `${warningLine}\n`);
           process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            `[openclaw] log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}\n`,
           );
         }
         return;
       }
-      if (appendLogLine(settings.file, payload)) {
+      if (appendLogLine(currentFile, payload)) {
         currentFileBytes = nextBytes;
       }
     } catch {


### PR DESCRIPTION
## Fixes
Fixes #47266

## Description
When OpenClaw uses the default rolling log file naming scheme (with date in the filename), loggers would continue writing to the old file even after midnight. The file path was only determined once at logger creation time, not on each log write.

## Changes
- Track the last log date in the transport closure
- On each log write, check if the date has changed (only for rolling paths)
- If date changed, recalculate the file path for the new day using `defaultRollingPathForToday()`
- Update `currentFileBytes` and reset warning flag for the new file to avoid false positives

## How to Test
1. Set up OpenClaw with default rolling log files enabled
2. Wait for midnight (or manually manipulate system time)
3. Check that logs from after midnight are written to the new dated file, not the old one
4. Verify both old and new files exist with appropriate content