### PR TITLE
fix: strip [[reply_to:ID]] tags from iMessage outbound text (closes #41576)

### DIFF
--- a/extensions/imessage/src/monitor/sanitize-outbound.test.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test.ts
@@ -61,4 +61,16 @@ describe("sanitizeOutboundText", () => {
     expect(result).not.toMatch(/assistant to=final/i);
     expect(result).toContain("Actual reply");
   });
+
+  it("strips [[reply_to:ID]] tags", () => {
+    expect(sanitizeOutboundText("[[reply_to:1578]] Hey Matt.")).toBe("Hey Matt.");
+  });
+
+  it("strips [[reply_to_current]] tags", () => {
+    expect(sanitizeOutboundText("[[reply_to_current]] Hello!")).toBe("Hello!");
+  });
+
+  it("strips [[reply_to:ID]] with whitespace inside brackets", () => {
+    expect(sanitizeOutboundText("[[ reply_to: 42 ]] Hi there")).toBe("Hi there");
+  });
 });

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -7,6 +7,7 @@ import { stripAssistantInternalScaffolding } from "../../../../src/shared/text/a
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
 const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
+const REPLY_TO_TAG_RE = /\[\[\s*reply_to[\s_:]+(?:current|[^\]]+)\s*\]\]\s*/gi;
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
@@ -23,6 +24,7 @@ export function sanitizeOutboundText(text: string): string {
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
   cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
+  cleaned = cleaned.replace(REPLY_TO_TAG_RE, "");
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();


### PR DESCRIPTION
## Summary
- Problem: `sanitizeOutboundText()` in the iMessage channel does not strip `[[reply_to:<id>]]` directive tags before delivery, causing raw metadata like `[[reply_to:1578]]` to appear in user-visible iMessage replies.
- Why it matters: Users see raw internal directive tags in their iMessage conversations, which is confusing and looks broken.
- What changed: Added a `REPLY_TO_TAG_RE` regex pattern to `sanitizeOutboundText()` that strips all `[[reply_to:*]]` and `[[reply_to_current]]` tags (with flexible whitespace handling) from outbound text. Added 3 test cases.
- What did NOT change (scope boundary): No changes to other channel sanitization or the `parseInlineDirectives` function. Only the iMessage outbound path is affected.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #41576

## User-visible / Behavior Changes
iMessage replies no longer contain raw `[[reply_to:ID]]` tag prefixes.
- Before: `[[reply_to:1578]] Hey Matt.`
- After: `Hey Matt.`

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure iMessage channel
2. Agent replies with a `[[reply_to:<id>]]` tag
### Expected
- Tag is stripped; user sees clean text
### Actual (before fix)
- Raw `[[reply_to:1578]]` visible in iMessage

## Evidence
- [x] Failing test/log before + passing after
- `npx vitest run extensions/imessage/src/monitor/sanitize-outbound.test.ts` — 14 tests passed (3 new)

## Human Verification
- Verified scenarios: vitest tests all passing; reviewed diff matches issue description
- Edge cases checked: `[[reply_to:ID]]`, `[[reply_to_current]]`, `[[ reply_to: 42 ]]` with whitespace
- What you did NOT verify: runtime end-to-end testing with actual iMessage

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None