### PR TITLE
fix(discord): include provider prefix in model dropdown values (closes #46975)

### DIFF
--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -655,4 +655,53 @@ describe("Discord model picker recents view", () => {
     const recentBtn = rows[1]?.components?.[0] as { label?: string };
     expect(recentBtn?.label).toContain("anthropic/claude-sonnet-4-5");
   });
+
+  it("includes provider prefix in model dropdown values for nested provider IDs", () => {
+    // Test case for issue #46975: OpenRouter models with nested provider IDs
+    // (e.g., deepseek/deepseek-v3.2) should have full provider/model format in values
+    const data = createModelsProviderData({
+      openrouter: ["deepseek/deepseek-v3.2", "anthropic/claude-3-opus", "gpt-4o"],
+    });
+
+    const rendered = renderDiscordModelPickerModelsView({
+      command: "model",
+      userId: "42",
+      data,
+      provider: "openrouter",
+      page: 1,
+      providerPage: 1,
+    });
+
+    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+      components?: SerializedComponent[];
+    };
+
+    const rows = extractContainerRows(payload.components);
+    const modelSelectRow = rows?.find(
+      (row) =>
+        row.components?.[0]?.type === ComponentType.StringSelect &&
+        row.components?.[0]?.options?.some((opt) => opt.value?.includes("deepseek")),
+    );
+
+    expect(modelSelectRow).toBeDefined();
+    const modelSelect = modelSelectRow?.components?.[0];
+    expect(modelSelect?.options).toBeDefined();
+
+    // Verify that the dropdown options include the provider prefix in their values
+    const deepseekOption = modelSelect?.options?.find((opt) =>
+      opt.value?.includes("deepseek/deepseek-v3.2"),
+    );
+    expect(deepseekOption).toBeDefined();
+    expect(deepseekOption?.value).toBe("openrouter/deepseek/deepseek-v3.2");
+    expect(deepseekOption?.label).toBe("deepseek/deepseek-v3.2"); // Label stays bare for readability
+
+    // Verify other models also have provider prefix
+    const anthropicOption = modelSelect?.options?.find((opt) =>
+      opt.value?.includes("anthropic/claude"),
+    );
+    expect(anthropicOption?.value).toBe("openrouter/anthropic/claude-3-opus");
+
+    const gptOption = modelSelect?.options?.find((opt) => opt.value?.includes("gpt-4o"));
+    expect(gptOption?.value).toBe("openrouter/gpt-4o");
+  });
 });

--- a/extensions/discord/src/monitor/model-picker.ts
+++ b/extensions/discord/src/monitor/model-picker.ts
@@ -431,7 +431,10 @@ function buildModelRows(params: {
   const selectedModelRef = parsedPendingModel ?? parsedCurrentModel;
   const modelOptions: APISelectMenuOption[] = params.modelPage.items.map((model) => ({
     label: model,
-    value: model,
+    // Include provider prefix in the value so downstream handlers receive the full
+    // provider/model string and don't need to re-attach the provider manually.
+    // This prevents issues with nested provider IDs (e.g., OpenRouter's deepseek/model).
+    value: `${params.modelPage.provider}/${model}`,
     default: selectedModelRef
       ? selectedModelRef.provider === params.modelPage.provider && selectedModelRef.model === model
       : false,

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -780,9 +780,9 @@ async function handleDiscordModelPickerInteraction(
   }
 
   if (parsed.action === "model") {
-    const selectedModel = resolveModelPickerSelectionValue(interaction);
+    const selectedModelValue = resolveModelPickerSelectionValue(interaction);
     const provider = parsed.provider;
-    if (!provider || !selectedModel) {
+    if (!provider || !selectedModelValue) {
       await safeDiscordInteractionCall("model picker update", () =>
         interaction.update(
           buildDiscordModelPickerNoticePayload("Sorry, I couldn't read that model selection."),
@@ -790,6 +790,13 @@ async function handleDiscordModelPickerInteraction(
       );
       return;
     }
+
+    // Model dropdown values now include provider prefix (provider/model format).
+    // Strip the provider prefix to get the bare model ID for index lookup.
+    const providerPrefix = `${provider}/`;
+    const selectedModel = selectedModelValue.startsWith(providerPrefix)
+      ? selectedModelValue.slice(providerPrefix.length)
+      : selectedModelValue;
 
     const modelIndex = resolveDiscordModelPickerModelIndex({
       data: pickerData,
@@ -805,6 +812,7 @@ async function handleDiscordModelPickerInteraction(
       return;
     }
 
+    // Reconstruct the full model ref for display and submission.
     const modelRef = `${provider}/${selectedModel}`;
     const rendered = renderDiscordModelPickerModelsView({
       command: parsed.command,


### PR DESCRIPTION
Fixes #46975

## Problem
The Discord model picker was sending bare model IDs (e.g., `deepseek/deepseek-v3.2`) without the top-level provider prefix when the model ID itself contained a slash. This caused issues with nested provider IDs like OpenRouter's models, where the backend would incorrectly parse `deepseek/deepseek-v3.2` as provider=deepseek instead of provider=openrouter, resulting in "model not allowed" errors.

## Solution
Updated the Discord model picker to include the provider prefix in dropdown option values (e.g., `openrouter/deepseek/deepseek-v3.2`), mirroring the approach used in #47295 for the webchat model picker.

## Changes
- **model-picker.ts**: Updated `modelOptions` to include provider prefix in the `value` field while keeping `label` unchanged for readability
- **native-command.ts**: Added logic to strip the provider prefix from the selected value before performing index lookup
- **model-picker.test.ts**: Added test case for nested provider IDs to ensure values include the full `provider/model` format

## Testing
- Added test case that verifies OpenRouter models with nested IDs (e.g., `deepseek/deepseek-v3.2`) have correct `provider/model` format in dropdown values
- Verified that labels remain user-friendly (bare model ID only)
- Backward compatible with existing model selection flow