### PR TITLE
fix(memory): remove QMD_CONFIG_DIR workaround, align with XDG spec

### DIFF
--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -29,4 +29,64 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
+
+  it("respects skillFilter from snapshot when building from entries", () => {
+    const entry1: SkillEntry = {
+      skill: {
+        name: "allowed-skill",
+        description: "Allowed",
+        filePath: "/app/skills/allowed-skill/SKILL.md",
+        baseDir: "/app/skills/allowed-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const entry2: SkillEntry = {
+      skill: {
+        name: "filtered-skill",
+        description: "Filtered",
+        filePath: "/app/skills/filtered-skill/SKILL.md",
+        baseDir: "/app/skills/filtered-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "",
+        skills: [],
+        skillFilter: ["allowed-skill"],
+      },
+      entries: [entry1, entry2],
+      workspaceDir: "/tmp/openclaw",
+    });
+    expect(prompt).toContain("allowed-skill");
+    expect(prompt).not.toContain("filtered-skill");
+  });
+
+  it("applies empty skillFilter correctly (no skills in prompt)", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "",
+        skills: [],
+        skillFilter: [],
+      },
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+    });
+    expect(prompt).toBe("");
+  });
 });

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -200,9 +200,6 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.env = {
       ...process.env,
       XDG_CONFIG_HOME: this.xdgConfigHome,
-      // workaround for upstream bug https://github.com/tobi/qmd/issues/132
-      // QMD doesn't respect XDG_CONFIG_HOME:
-      QMD_CONFIG_DIR: this.xdgConfigHome,
       XDG_CACHE_HOME: this.xdgCacheHome,
       NO_COLOR: "1",
     };


### PR DESCRIPTION
## Summary

Removes the obsolete `QMD_CONFIG_DIR` workaround now that the upstream bug (tobi/qmd#132) has been fixed.

## Problem

PR #27028 introduced a workaround because `qmd` was not respecting `XDG_CONFIG_HOME`. This workaround is now obsolete: the bug has been fixed upstream in [`tobi/qmd` — `src/collections.ts` L109](https://github.com/tobi/qmd/blob/2b8f329d7e4419af736a50e917057f685ad41110/src/collections.ts#L109).

Per the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), applications must store their configuration under:
```
$XDG_CONFIG_HOME/<appname>/
```

With the workaround, OpenClaw was setting both:
- `XDG_CONFIG_HOME = .openclaw/agents/main/qmd/xdg-config`
- `QMD_CONFIG_DIR = .openclaw/agents/main/qmd/xdg-config` (workaround)

This caused qmd to write config to:
```
.openclaw/agents/main/qmd/xdg-config/index.yml ❌  (missing qmd/ subdirectory)
```

## Solution

After removing the workaround, qmd now correctly resolves its config at:
```
.openclaw/agents/main/qmd/xdg-config/qmd/index.yml ✅  (XDG-compliant)
```

This aligns with both qmd's upstream behavior and the XDG Base Directory Specification.

## Changes

- Removed `QMD_CONFIG_DIR` environment variable override in `src/memory/qmd-manager.ts`
- Removed obsolete workaround comments

## Testing

- [ ] Verified qmd config is written to `xdg-config/qmd/index.yml` instead of `xdg-config/index.yml`
- [ ] Verified qmd collection operations still work correctly

Fixes #46943