### PR TITLE
feat(tts): show provider, model, voice, and custom backend in /status command

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -406,7 +406,41 @@ const formatVoiceModeLine = (
   const provider = getTtsProvider(ttsConfig, prefsPath);
   const maxLength = getTtsMaxLength(prefsPath);
   const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
-  return `🔊 Voice: ${autoMode} · provider=${provider} · limit=${maxLength} · summary=${summarize}`;
+
+  // Build provider-specific details
+  const providerDetails: string[] = [];
+  
+  if (provider === "openai") {
+    const model = ttsConfig.openai.model;
+    const voice = ttsConfig.openai.voice;
+    const baseUrl = ttsConfig.openai.baseUrl;
+    const isCustomBackend = baseUrl && baseUrl !== "https://api.openai.com";
+    
+    providerDetails.push(`model=${model}`);
+    providerDetails.push(`voice=${voice}`);
+    
+    if (isCustomBackend) {
+      providerDetails.push(`backend=custom (${baseUrl})`);
+    }
+  } else if (provider === "elevenlabs") {
+    const model = ttsConfig.elevenlabs.modelId;
+    const voiceId = ttsConfig.elevenlabs.voiceId;
+    const baseUrl = ttsConfig.elevenlabs.baseUrl;
+    const isCustomBackend = baseUrl && baseUrl !== "https://api.elevenlabs.io";
+    
+    providerDetails.push(`model=${model}`);
+    providerDetails.push(`voice=${voiceId.slice(0, 8)}...`);
+    
+    if (isCustomBackend) {
+      providerDetails.push(`backend=custom (${baseUrl})`);
+    }
+  } else if (provider === "edge") {
+    const voice = ttsConfig.edge.voice;
+    providerDetails.push(`voice=${voice}`);
+  }
+
+  const details = providerDetails.length > 0 ? ` · ${providerDetails.join(" · ")}` : "";
+  return `🔊 Voice: ${autoMode} · provider=${provider}${details} · limit=${maxLength} · summary=${summarize}`;
 };
 
 export function buildStatusMessage(args: StatusArgs): string {


### PR DESCRIPTION
## Summary

Add TTS backend visibility to the `/status` slash command, including provider, model name, voice, and whether a custom `baseUrl` is in use.

## Changes

- Enhanced `formatVoiceModeLine` function in `src/auto-reply/status.ts` to display:
  - **OpenAI provider**: model, voice, and custom backend URL (if configured)
  - **ElevenLabs provider**: model, voice ID (first 8 chars), and custom backend URL (if configured)
  - **Edge TTS provider**: voice name

## Example Output

### With custom backend (e.g. NeuTTS local server)
```
🔊 Voice: always · provider=openai · model=neutts-nano · voice=alloy · backend=custom (http://127.0.0.1:18801) · limit=1500 · summary=on
```

### With standard OpenAI
```
🔊 Voice: always · provider=openai · model=gpt-4o-mini-tts · voice=alloy · limit=1500 · summary=on
```

### With ElevenLabs
```
🔊 Voice: inbound · provider=elevenlabs · model=eleven_multilingual_v2 · voice=pMsXgVXv... · limit=1500 · summary=on
```

### With Edge TTS
```
🔊 Voice: tagged · provider=edge · voice=en-US-MichelleNeural · limit=1500 · summary=on
```

## Impact

- Users can now confirm which TTS backend is active directly from `/status`
- No more confusion about whether a custom backend (like local NeuTTS) is being used
- Helps debugging TTS configuration issues

## Testing

- Code change is isolated to status display logic
- No service startup or port binding required
- Changes are display-only, no functional behavior modified

Closes #46602