### PR TITLE
fix(cron): default to system timezone when --tz is omitted

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -136,7 +136,10 @@ export function registerCronAddCommand(cron: Command) {
             return {
               kind: "cron" as const,
               expr: cronExpr,
-              tz: typeof opts.tz === "string" && opts.tz.trim() ? opts.tz.trim() : undefined,
+              tz:
+                typeof opts.tz === "string" && opts.tz.trim()
+                  ? opts.tz.trim()
+                  : Intl.DateTimeFormat().resolvedOptions().timeZone,
               staggerMs,
             };
           })();
@@ -281,6 +284,9 @@ export function registerCronAddCommand(cron: Command) {
 
           const res = await callGatewayFromCli("cron.add", opts, params);
           printCronJson(res);
+          if (schedule.kind === "cron" && !(typeof opts.tz === "string" && opts.tz.trim())) {
+            defaultRuntime.log(`note: timezone defaulted to ${schedule.tz} (use --tz to override)`);
+          }
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           handleCronCliError(err);

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -282,11 +282,13 @@ export function registerCronAddCommand(cron: Command) {
               : undefined,
           };
 
+          if (schedule.kind === "cron" && !(typeof opts.tz === "string" && opts.tz.trim())) {
+            defaultRuntime.error(
+              `note: timezone defaulted to ${schedule.tz} (use --tz to override)`,
+            );
+          }
           const res = await callGatewayFromCli("cron.add", opts, params);
           printCronJson(res);
-          if (schedule.kind === "cron" && !(typeof opts.tz === "string" && opts.tz.trim())) {
-            defaultRuntime.log(`note: timezone defaulted to ${schedule.tz} (use --tz to override)`);
-          }
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           handleCronCliError(err);

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -152,12 +152,61 @@ describe("printCronList", () => {
     expect(dataLine).toContain("opus");
   });
 
-  it("shows exact label for cron schedules with stagger disabled", () => {
+  it("shows (no tz) label for cron schedules without timezone", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "no-tz-job",
+      name: "No TZ",
+      schedule: { kind: "cron", expr: "30 2 * * *", staggerMs: 0 },
+      sessionTarget: "main",
+      state: {},
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    printCronList([job], runtime);
+    expect(logs.some((line) => line.includes("(no tz)"))).toBe(true);
+    expect(logs.some((line) => line.includes("(exact)"))).toBe(false);
+  });
+
+  it("shows (exact) label for cron schedules with explicit timezone", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "with-tz-job",
+      name: "With TZ",
+      schedule: { kind: "cron", expr: "30 2 * * *", tz: "UTC", staggerMs: 0 },
+      sessionTarget: "main",
+      state: {},
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    printCronList([job], runtime);
+    expect(logs.some((line) => line.includes("(exact)"))).toBe(true);
+    expect(logs.some((line) => line.includes("(no tz)"))).toBe(false);
+  });
+
+  it("shows stagger label without (no tz) for staggered cron schedules", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "stagger-no-tz-job",
+      name: "Stagger No TZ",
+      schedule: { kind: "cron", expr: "0 * * * *" },
+      sessionTarget: "main",
+      state: {},
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    printCronList([job], runtime);
+    // Staggered jobs show stagger label; (no tz) is only for exact schedules
+    expect(logs.some((line) => line.includes("stagger"))).toBe(true);
+    expect(logs.some((line) => line.includes("(no tz)"))).toBe(false);
+  });
+
+  it("shows exact label for cron schedules with stagger disabled and timezone set", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const job = createBaseJob({
       id: "exact-job",
       name: "Exact",
-      schedule: { kind: "cron", expr: "0 7 * * *", staggerMs: 0 },
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "UTC", staggerMs: 0 },
       sessionTarget: "main",
       state: {},
       payload: { kind: "systemEvent", text: "tick" },

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CronJob } from "../../cron/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { printCronList } from "./shared.js";
+import { formatSchedule, printCronList } from "./shared.js";
 
 function createRuntimeLogCapture(): { logs: string[]; runtime: RuntimeEnv } {
   const logs: string[] = [];
@@ -60,19 +60,15 @@ describe("printCronList", () => {
     expect(logs.some((line) => line.includes("isolated"))).toBe(true);
   });
 
-  it("shows stagger label for cron schedules", () => {
-    const { logs, runtime } = createRuntimeLogCapture();
-    const job = createBaseJob({
-      id: "staggered-job",
-      name: "Staggered",
-      schedule: { kind: "cron", expr: "0 * * * *", staggerMs: 5 * 60_000 },
-      sessionTarget: "main",
-      state: {},
-      payload: { kind: "systemEvent", text: "tick" },
+  it("shows stagger label for cron schedules with timezone", () => {
+    const label = formatSchedule({
+      kind: "cron",
+      expr: "0 * * * *",
+      tz: "UTC",
+      staggerMs: 5 * 60_000,
     });
-
-    printCronList([job], runtime);
-    expect(logs.some((line) => line.includes("(stagger 5m)"))).toBe(true);
+    expect(label).toContain("(stagger 5m)");
+    expect(label).not.toContain("no tz");
   });
 
   it("shows dash for unset agentId instead of default", () => {
@@ -184,21 +180,11 @@ describe("printCronList", () => {
     expect(logs.some((line) => line.includes("(no tz)"))).toBe(false);
   });
 
-  it("shows stagger label without (no tz) for staggered cron schedules", () => {
-    const { logs, runtime } = createRuntimeLogCapture();
-    const job = createBaseJob({
-      id: "stagger-no-tz-job",
-      name: "Stagger No TZ",
-      schedule: { kind: "cron", expr: "0 * * * *" },
-      sessionTarget: "main",
-      state: {},
-      payload: { kind: "systemEvent", text: "tick" },
-    });
-
-    printCronList([job], runtime);
-    // Staggered jobs show stagger label; (no tz) is only for exact schedules
-    expect(logs.some((line) => line.includes("stagger"))).toBe(true);
-    expect(logs.some((line) => line.includes("(no tz)"))).toBe(false);
+  it("shows stagger label with (no tz) for staggered cron schedules without timezone", () => {
+    const label = formatSchedule({ kind: "cron", expr: "0 * * * *" });
+    // Staggered jobs without tz show both stagger label and (no tz) warning
+    expect(label).toContain("stagger");
+    expect(label).toContain("no tz");
   });
 
   it("shows exact label for cron schedules with stagger disabled and timezone set", () => {

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -159,7 +159,7 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
-const formatSchedule = (schedule: CronSchedule) => {
+export const formatSchedule = (schedule: CronSchedule) => {
   if (schedule.kind === "at") {
     return `at ${formatIsoMinute(schedule.at)}`;
   }
@@ -171,7 +171,9 @@ const formatSchedule = (schedule: CronSchedule) => {
   if (staggerMs <= 0) {
     return schedule.tz ? `${base} (exact)` : `${base} (no tz)`;
   }
-  return `${base} (stagger ${formatDurationHuman(staggerMs)})`;
+  return schedule.tz
+    ? `${base} (stagger ${formatDurationHuman(staggerMs)})`
+    : `${base} (stagger ${formatDurationHuman(staggerMs)}, no tz)`;
 };
 
 const formatStatus = (job: CronJob) => {

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -169,7 +169,7 @@ const formatSchedule = (schedule: CronSchedule) => {
   const base = schedule.tz ? `cron ${schedule.expr} @ ${schedule.tz}` : `cron ${schedule.expr}`;
   const staggerMs = resolveCronStaggerMs(schedule);
   if (staggerMs <= 0) {
-    return `${base} (exact)`;
+    return schedule.tz ? `${base} (exact)` : `${base} (no tz)`;
   }
   return `${base} (stagger ${formatDurationHuman(staggerMs)})`;
 };

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -863,6 +863,20 @@ async function planStartupCatchup(
   );
   return locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
+
+    // Warn about cron jobs without explicit timezone (they default to the
+    // gateway process timezone which may differ from the user's intent).
+    if (state.store) {
+      for (const job of state.store.jobs) {
+        if (job.schedule.kind === "cron" && !job.schedule.tz && job.enabled) {
+          state.deps.log.warn(
+            { jobId: job.id, jobName: job.name, expr: job.schedule.expr },
+            "cron: job has no explicit timezone; schedule will use the gateway process timezone (use --tz to set)",
+          );
+        }
+      }
+    }
+
     if (!state.store) {
       return { candidates: [], deferredJobIds: [] };
     }


### PR DESCRIPTION
## Problem

When creating cron jobs via `openclaw cron add --cron "30 2 * * *"`, omitting `--tz` stores no timezone in the schedule. At runtime, `resolveCronTimezone()` falls back to the **gateway process timezone** (often UTC on servers), causing jobs intended for local time to fire at the wrong hour.

### Real-world impact (our instance)

We ran into this on our own OpenClaw deployment (`Asia/Shanghai`, UTC+8):

- **A nightly maintenance job** (`30 2 * * *`): intended for 2:30 AM local, actually ran at **10:30 AM** (UTC 2:30 = CST 10:30). Ran at the wrong time for **many days** before we noticed — because the job itself completed successfully, only the timing was wrong.
- **A daily update check** (`30 3 * * *`): intended for 3:30 AM, ran at 11:30 AM. A gateway restart triggered a catch-up run, causing duplicate reports in one day.
- 3 other cron jobs on the same instance correctly had `tz: "Asia/Shanghai"` — this is not a case of "user doesn't know about `--tz`", it's that **forgetting once** silently creates a broken schedule.
- `openclaw cron list` displayed these jobs as `(exact)`, which says nothing about timezone and gave no indication that anything was wrong.

### Root cause

In `register.cron-add.ts`, when `--tz` is not provided, `tz` is set to `undefined`:
```ts
tz: typeof opts.tz === "string" && opts.tz.trim() ? opts.tz.trim() : undefined,
```
The `(exact)` label in `formatSchedule` refers to stagger timing, not timezone — it provides zero signal that the schedule lacks an explicit timezone.

## Solution

Three minimal, backward-compatible changes:

### 1. Auto-fill system timezone in `cron add` CLI
When `--tz` is omitted, auto-detect the CLI host's timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and store it explicitly. A note is logged:
```
note: timezone defaulted to Asia/Shanghai (use --tz to override)
```

### 2. Show `(no tz)` in `cron list` for schedules without timezone
Changed `formatSchedule` to display `(no tz)` instead of `(exact)` when a cron schedule has no explicit timezone, making the gap immediately visible:
```
Before: cron 30 2 * * * (exact)      ← looks fine, actually runs in UTC
After:  cron 30 2 * * * (no tz)      ← clearly signals missing timezone
```
Jobs with an explicit timezone continue showing `(exact)` as before.

### 3. Startup warning for jobs without timezone
At gateway startup, emit a warning log for each enabled cron job that lacks an explicit timezone:
```
cron: job has no explicit timezone; schedule will use the gateway process timezone (use --tz to set)
```

### Backward compatibility
- Existing persisted jobs without `tz` continue to use the gateway process timezone at runtime — **no behavior change** for existing schedules.
- Only newly created jobs get the auto-detected timezone.
- The `(no tz)` label and startup warning make the implicit behavior visible without breaking anything.

## Testing

- Added 3 new test cases in `shared.test.ts` covering `(no tz)`, `(exact)` with tz, and stagger-without-tz display
- Updated 1 existing test to use explicit timezone (since `(exact)` now requires tz)
- All existing cron tests pass: `schedule.test.ts` (26), `stagger.test.ts` (4), `service.restart-catchup.test.ts` (8), `shared.test.ts` (12)

## Context

We are active contributors with 6 open PRs across openclaw and openclaw-lark (#42164, #42145, #32265, #90, #84, #72), covering Feishu multi-bot fixes, SSE error recovery, security hardening, and more.