### PR TITLE
fix(exec): add error handling for allowlist persistence failures

### DIFF
--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -497,7 +497,13 @@ async function executeSystemRunPhase(
       });
       for (const pattern of patterns) {
         if (pattern) {
-          addAllowlistEntry(phase.approvals.file, phase.agentId, pattern);
+          try {
+            addAllowlistEntry(phase.approvals.file, phase.agentId, pattern);
+          } catch (err) {
+            logWarn(
+              `exec approvals: failed to persist allow-always pattern "${pattern}" (runId=${phase.runId}): ${String(err)}`,
+            );
+          }
         }
       }
     }
@@ -510,13 +516,19 @@ async function executeSystemRunPhase(
         continue;
       }
       seen.add(match.pattern);
-      recordAllowlistUse(
-        phase.approvals.file,
-        phase.agentId,
-        match,
-        phase.commandText,
-        phase.segments[0]?.resolution?.resolvedPath,
-      );
+      try {
+        recordAllowlistUse(
+          phase.approvals.file,
+          phase.agentId,
+          match,
+          phase.commandText,
+          phase.segments[0]?.resolution?.resolvedPath,
+        );
+      } catch (err) {
+        logWarn(
+          `exec approvals: failed to record allowlist use for pattern "${match.pattern}" (runId=${phase.runId}): ${String(err)}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds error handling and logging when `addAllowlistEntry` or `recordAllowlistUse` fails during command execution, preventing silent failures that can leave users confused about why `allow-always` approvals don't persist.

## Problem

Issue #46929 Bug 2 reports: "When using allow-always to approve a command, the approval result cannot be correctly written to allowlist". The issue mentions that "when multiple channels are configured, approval callback loses channel context, causing allowlist update failure".

Currently, if `addAllowlistEntry` or `recordAllowlistUse` throws an error (e.g., file permissions, disk full, or other I/O errors), the exception bubbles up silently and users get no feedback about why their `allow-always` approval didn't persist.

## Solution

Wrap `addAllowlistEntry` and `recordAllowlistUse` calls in try-catch blocks and log warnings with:
- The pattern that failed to persist
- The runId for correlation
- The full error message

This allows:
1. Command execution to continue even if allowlist persistence fails
2. Clear diagnostics in logs for troubleshooting
3. Better observability for multi-channel or permission issues

## Testing

- Existing tests continue to pass
- Manual testing can verify log output by making exec-approvals.json read-only

## Partial Fix

This PR addresses **part of** issue #46929 (Bug 2) by improving error handling and diagnostics. The root cause of "channel context loss" may require additional investigation, but this change ensures failures are visible and don't break command execution.

Refs #46929