### PR TITLE
fix: resolve gateway crash on second cron add

### DIFF
--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -8,6 +8,23 @@ const resolveChain = (promise: Promise<unknown>) =>
     () => undefined,
   );
 
+/**
+ * Clear the store lock for a given path.
+ * This should be called when the cron service is stopped to prevent
+ * stale promises from blocking subsequent operations.
+ */
+export function clearStoreLock(storePath: string): void {
+  storeLocks.delete(storePath);
+}
+
+/**
+ * Clear all store locks.
+ * This is primarily for testing purposes.
+ */
+export function clearAllStoreLocks(): void {
+  storeLocks.clear();
+}
+
 export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): Promise<T> {
   const storePath = state.deps.storePath;
   const storeOp = storeLocks.get(storePath) ?? Promise.resolve();

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -12,7 +12,7 @@ import {
   recomputeNextRuns,
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
-import { locked } from "./locked.js";
+import { clearStoreLock, locked } from "./locked.js";
 import type { CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import {
@@ -132,6 +132,9 @@ export async function start(state: CronServiceState) {
 
 export function stop(state: CronServiceState) {
   stopTimer(state);
+  // Clear the store lock to prevent stale promises from blocking
+  // subsequent operations if a new cron service is created for the same store.
+  clearStoreLock(state.deps.storePath);
 }
 
 export async function status(state: CronServiceState) {


### PR DESCRIPTION
## Summary

Fixes a gateway crash that occurred when executing openclaw cron add for the second time.

The issue was caused by the global storeLocks map in locked.ts not being cleaned up when the cron service was stopped. This could cause issues when the cron service was stopped and a new one was created for the same store path, as the old promise reference would still be in the map.

## Changes

- Added clearStoreLock function to clean up the store lock for a given path
- Added clearAllStoreLocks function for testing purposes
- Modified the stop function in ops.ts to call clearStoreLock when the cron service is stopped

## Testing

- All existing cron tests pass (65 test files, 517 tests)
- The fix ensures that stale promises do not block subsequent operations

Fixes openclaw/openclaw#47319