### PR TITLE
fix: add operator.read and operator.write scopes to WebChat connection

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -143,7 +143,7 @@ describe("GatewayBrowserClient", () => {
       deviceId: "device-1",
       role: "operator",
       token: "stored-device-token",
-      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"],
     });
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,7 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;


### PR DESCRIPTION
Fixes #46997

## Problem
WebChat clients were missing `operator.read` and `operator.write` scopes when connecting to the gateway, causing `missing scope: operator.write` errors when attempting to send messages via `chat.send`.

## Root Cause
The WebChat client in `ui/src/ui/gateway.ts` was only requesting 3 scopes:
- `operator.admin`
- `operator.approvals`
- `operator.pairing`

But was missing:
- `operator.read` (required for read operations)
- `operator.write` (required for `chat.send` and other write operations)

## Solution
Added the missing scopes to the WebChat connection initialization. Now the client requests all 5 operator scopes:
- `operator.admin`
- `operator.read` ✨ (added)
- `operator.write` ✨ (added)
- `operator.approvals`
- `operator.pairing`

## Changes
- ✅ Added `operator.read` and `operator.write` to WebChat client scopes in `ui/src/ui/gateway.ts`
- ✅ Updated test in `ui/src/ui/gateway.node.test.ts` to reflect the complete scope list

## Testing
- [x] Existing tests updated to match new scope list
- [x] Verified against scope requirements in `src/gateway/method-scopes.ts`

## Impact
This fix enables WebChat to:
- ✅ Send messages via Control UI
- ✅ Use all read and write gateway methods
- ✅ Maintain full operator functionality

cc @openclaw/maintainers