### PR TITLE
feat(signal): reply context, reaction wake, and outbound quoted reply

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -35,6 +35,9 @@ import { getSignalRuntime } from "./runtime.js";
 import { signalSetupAdapter } from "./setup-core.js";
 import { createSignalPluginBase, signalConfigAccessors, signalSetupWizard } from "./shared.js";
 
+/** Default text chunk size for Signal outbound messages (chars). */
+const SIGNAL_TEXT_CHUNK_LIMIT = 4000;
+
 const signalMessageActions: ChannelMessageActionAdapter = {
   listActions: (ctx) => getSignalRuntime().channel.signal.messageActions?.listActions?.(ctx) ?? [],
   supportsAction: (ctx) =>
@@ -67,6 +70,30 @@ function resolveSignalSendContext(params: {
   return { send, maxBytes };
 }
 
+function resolveSignalQuoteParams(
+  to: string,
+  replyToId: string | null | undefined,
+  accountPhone: string | undefined,
+): { quoteTimestamp?: number; quoteAuthor?: string } {
+  if (!replyToId) {
+    return {};
+  }
+  const quoteTimestamp = Number(replyToId);
+  if (!Number.isFinite(quoteTimestamp) || quoteTimestamp <= 0) {
+    return {};
+  }
+  const normalizedTo = to.replace(/^signal:/i, "").trim();
+  const isGroup = normalizedTo.toLowerCase().startsWith("group:");
+  if (isGroup) {
+    return {};
+  }
+  const quoteAuthor = normalizedTo || accountPhone;
+  if (!quoteAuthor) {
+    return {};
+  }
+  return { quoteTimestamp, quoteAuthor };
+}
+
 async function sendSignalOutbound(params: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
   to: string;
@@ -74,15 +101,23 @@ async function sendSignalOutbound(params: {
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   accountId?: string;
+  replyToId?: string | null;
   deps?: { [channelId: string]: unknown };
 }) {
   const { send, maxBytes } = resolveSignalSendContext(params);
+  const accountInfo = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId });
+  const quoteParams = resolveSignalQuoteParams(
+    params.to,
+    params.replyToId,
+    accountInfo.config.account ?? undefined,
+  );
   return await send(params.to, params.text, {
     cfg: params.cfg,
     ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
     ...(params.mediaLocalRoots?.length ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
     maxBytes,
     accountId: params.accountId ?? undefined,
+    ...quoteParams,
   });
 }
 
@@ -350,7 +385,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     deliveryMode: "direct",
     chunker: (text, limit) => getSignalRuntime().channel.text.chunkText(text, limit),
     chunkerMode: "text",
-    textChunkLimit: 4000,
+    textChunkLimit: SIGNAL_TEXT_CHUNK_LIMIT,
     sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
       await sendFormattedSignalText({
         cfg,
@@ -380,17 +415,66 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         deps,
         abortSignal,
       }),
-    sendText: async ({ cfg, to, text, accountId, deps }) => {
+    sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
+      const urls: string[] = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (!text && urls.length === 0) {
+        return { channel: "signal", messageId: "" };
+      }
+      if (urls.length > 0) {
+        let lastResult: { channel: string; messageId: string } | undefined;
+        for (let i = 0; i < urls.length; i++) {
+          const mediaUrl = urls[i];
+          if (!mediaUrl) continue;
+          const result = await sendSignalOutbound({
+            cfg: ctx.cfg,
+            to: ctx.to,
+            text: i === 0 ? text : "",
+            mediaUrl,
+            mediaLocalRoots: ctx.mediaLocalRoots,
+            accountId: ctx.accountId ?? undefined,
+            replyToId: i === 0 ? (ctx.replyToId ?? undefined) : undefined,
+            deps: ctx.deps,
+          });
+          lastResult = { channel: "signal", ...result };
+        }
+        return lastResult ?? { channel: "signal", messageId: "" };
+      }
+      // Text-only: chunk and send; only first chunk carries the quote.
+      const limit = SIGNAL_TEXT_CHUNK_LIMIT;
+      const chunks = getSignalRuntime().channel.text.chunkText(text, limit);
+      let lastResult: { channel: string; messageId: string } | undefined;
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        if (!chunk) continue;
+        const result = await sendSignalOutbound({
+          cfg: ctx.cfg,
+          to: ctx.to,
+          text: chunk,
+          accountId: ctx.accountId ?? undefined,
+          replyToId: i === 0 ? (ctx.replyToId ?? undefined) : undefined,
+          deps: ctx.deps,
+        });
+        lastResult = { channel: "signal", ...result };
+      }
+      return lastResult ?? { channel: "signal", messageId: "" };
+    },
+    sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       const result = await sendSignalOutbound({
         cfg,
         to,
         text,
         accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
         deps,
       });
       return { channel: "signal", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
       const result = await sendSignalOutbound({
         cfg,
         to,
@@ -398,6 +482,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         mediaUrl,
         mediaLocalRoots,
         accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
         deps,
       });
       return { channel: "signal", ...result };

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -13,6 +13,7 @@ import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
 import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/config-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+import { requestHeartbeatNow } from "openclaw/plugin-sdk/infra-runtime";
 import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { hasControlCommand } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
@@ -113,6 +114,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
+    replyToBody?: string;
+    replyToSender?: string;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -213,6 +217,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
@@ -459,6 +466,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       .filter(Boolean)
       .join(":");
     enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+    requestHeartbeatNow({ coalesceMs: 500, sessionKey: route.sessionKey });
     return true;
   }
 
@@ -778,6 +786,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const senderName = envelope.sourceName ?? senderDisplay;
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+    const quoteId = dataMessage.quote?.id;
+    const quoteAuthor =
+      dataMessage.quote?.author?.trim() ||
+      dataMessage.quote?.authorNumber?.trim() ||
+      undefined;
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,
@@ -796,6 +809,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId: typeof quoteId === "number" ? String(quoteId) : undefined,
+      replyToBody: quoteText || undefined,
+      replyToSender: quoteAuthor,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -37,7 +37,12 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | null;
+    text?: string | null;
+    author?: string | null;
+    authorNumber?: string | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 

--- a/extensions/signal/src/outbound-adapter.ts
+++ b/extensions/signal/src/outbound-adapter.ts
@@ -91,7 +91,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "signal", ...result };
   },
-  sendText: async ({ cfg, to, text, accountId, deps }) => {
+  sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
     const send = resolveSignalSender(deps);
     const maxBytes = resolveSignalMaxBytes({
       cfg,
@@ -101,10 +101,11 @@ export const signalOutbound: ChannelOutboundAdapter = {
       cfg,
       maxBytes,
       accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
     });
     return { channel: "signal", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
     const send = resolveSignalSender(deps);
     const maxBytes = resolveSignalMaxBytes({
       cfg,
@@ -115,6 +116,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       maxBytes,
       accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
       mediaLocalRoots,
     });
     return { channel: "signal", ...result };

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -18,6 +18,16 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  /**
+   * Message ID (timestamp string) to quote/reply-to. When provided and quoteTimestamp
+   * is not set, this is parsed as the quote timestamp and `to` is used as quote-author
+   * (best-effort; works for DM inbound replies, skipped for groups).
+   */
+  replyToId?: string;
+  /** Timestamp of the message being quoted (from replyToId). Takes precedence over replyToId. */
+  quoteTimestamp?: number;
+  /** Author of the quoted message (UUID for inbound, phone number for outbound). */
+  quoteAuthor?: string;
 };
 
 export type SignalSendResult = {
@@ -169,6 +179,35 @@ export async function sendMessageSignal(
   }
   if (attachments && attachments.length > 0) {
     params.attachments = attachments;
+  }
+  // Resolve quote params: prefer explicit quoteTimestamp/quoteAuthor, fall back to replyToId.
+  let resolvedQuoteTimestamp = opts.quoteTimestamp;
+  let resolvedQuoteAuthor = opts.quoteAuthor?.trim();
+  if (
+    (typeof resolvedQuoteTimestamp !== "number" || !resolvedQuoteAuthor) &&
+    opts.replyToId?.trim()
+  ) {
+    const parsedTs = Number(opts.replyToId.trim());
+    if (Number.isFinite(parsedTs) && parsedTs > 0) {
+      // Best-effort: use `to` as quote-author for DM cases; skip for groups.
+      const normalizedTo = to.replace(/^signal:/i, "").trim();
+      const isGroup = normalizedTo.toLowerCase().startsWith("group:");
+      if (!isGroup) {
+        if (typeof resolvedQuoteTimestamp !== "number") {
+          resolvedQuoteTimestamp = parsedTs;
+        }
+        resolvedQuoteAuthor = resolvedQuoteAuthor || normalizedTo;
+      }
+    }
+  }
+  if (
+    typeof resolvedQuoteTimestamp === "number" &&
+    Number.isFinite(resolvedQuoteTimestamp) &&
+    resolvedQuoteTimestamp > 0 &&
+    resolvedQuoteAuthor
+  ) {
+    params["quote-timestamp"] = resolvedQuoteTimestamp;
+    params["quote-author"] = resolvedQuoteAuthor;
   }
 
   const targetParams = buildTargetParams(target, {

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -17,6 +17,7 @@ export * from "../infra/format-time/format-duration.ts";
 export * from "../infra/fs-safe.ts";
 export * from "../infra/heartbeat-events.ts";
 export * from "../infra/heartbeat-visibility.ts";
+export { requestHeartbeatNow } from "../infra/heartbeat-wake.ts";
 export * from "../infra/home-dir.js";
 export * from "../infra/http-body.js";
 export * from "../infra/json-files.js";


### PR DESCRIPTION
## Summary

Three improvements to Signal channel support, focusing on reply/quote functionality:

---

### 1. Inbound reply/quote context

When a Signal user replies to a message (quote), the agent now sees the quoted message context via `ReplyToId`, `ReplyToBody`, and `ReplyToSender` — matching the pattern already used by Discord, Slack, and BlueBubbles.

**Changes:**
- `event-handler.types.ts`: Extended `SignalDataMessage.quote` type to include `id` (number), `author` (string), and `authorNumber` (string) — the fields signal-cli provides in the envelope
- `event-handler.ts`: Added `replyToId`/`replyToBody`/`replyToSender` to `SignalInboundEntry`; populated from quote fields on enqueue; set `ReplyToId`, `ReplyToBody`, `ReplyToSender` on the inbound context payload

---

### 2. Reaction immediate wake

When a Signal reaction arrives, the agent now wakes immediately (via `requestHeartbeatNow`) instead of waiting for the next heartbeat interval.

**Changes:**
- `event-handler.ts`: After `enqueueSystemEvent` in the reaction notification path, call `requestHeartbeatNow({ coalesceMs: 500, sessionKey })`. The 500ms coalesce window batches rapid reactions into a single agent turn.

---

### 3. Outbound quoted reply support

When the agent sends a reply with `replyToId` (from `[[reply_to_current]]` or the message tool), Signal messages now include the quote context so recipients see the reply in thread.

**Changes:**
- `send.ts`: Added `replyToId`, `quoteTimestamp`, and `quoteAuthor` to `SignalSendOpts`. Resolves quote params (prefers explicit values, falls back to parsing `replyToId` as timestamp with `to` as best-effort quote-author). Appends `quote-timestamp` and `quote-author` to the signal-cli RPC call.
- `channel.ts`: Added `resolveSignalQuoteParams()` helper that normalises the contact identifier from `to`, skips groups (quote-author for groups requires the original sender UUID which is not available in the outbound path), and falls back to the bot account phone number. Added a custom `sendPayload` override that handles chunking manually so **only the first chunk carries the quote** — subsequent chunks of a multi-part message are sent without redundant quote headers.
- `src/channels/plugins/outbound/signal.ts`: Updated `buildTextOptions`/`buildMediaOptions` to forward `replyToId` into `SignalSendOpts` for consistency with the iMessage plugin pattern.

---

## Notes

- Group outbound quotes are intentionally skipped: signal-cli requires `quote-author` as the original sender's UUID, which is not present in the outbound context. DM replies (the common case) work correctly.
- All changes are TypeScript source only; no compiled JS files modified.