### PR TITLE
fix(webchat): add missing operator.read and operator.write scopes

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -143,7 +143,7 @@ describe("GatewayBrowserClient", () => {
       deviceId: "device-1",
       role: "operator",
       token: "stored-device-token",
-      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"],
     });
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,7 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;


### PR DESCRIPTION
Fixes #46997

## Problem
WebChat clients get `missing scope: operator.write` errors when sending messages.

## Root Cause
`ui/src/ui/gateway.ts` was only requesting 3 scopes (`operator.admin`, `operator.approvals`, `operator.pairing`), missing `operator.read` and `operator.write` required by `chat.send`.

## Fix
Added `operator.read` and `operator.write` to the scope list.

*Note: Resubmission of #47359 which was auto-closed due to PR queue limit.*