### PR TITLE
discord: respect channel ownership while allowing explicit cross-bot mentions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -2,9 +2,44 @@ import { ChannelType } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
+const hasControlCommandMock = vi.hoisted(() => vi.fn(() => false));
+const loadConfigMock = vi.hoisted(() => vi.fn());
+const shouldHandleTextCommandsMock = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("../../../../src/media-understanding/audio-preflight.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+}));
+vi.mock("../../../../src/auto-reply/command-detection.js", () => ({
+  hasControlCommand: (...args: unknown[]) => hasControlCommandMock(...args),
+}));
+vi.mock("../../../../src/auto-reply/commands-registry.js", () => ({
+  shouldHandleTextCommands: (...args: unknown[]) => shouldHandleTextCommandsMock(...args),
+}));
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: () => [],
+}));
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class Client {
+    async connect() {
+      return undefined;
+    }
+    async listTools() {
+      return { tools: [] };
+    }
+    async close() {
+      return undefined;
+    }
+  },
+}));
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: class StdioClientTransport {
+    pid: number | null = null;
+  },
+}));
+vi.mock("../../../../src/config/config.js", () => ({
+  loadConfig: loadConfigMock,
+  getRuntimeConfigSnapshot: () => loadConfigMock(),
 }));
 import {
   __testing as sessionBindingTesting,
@@ -224,6 +259,184 @@ describe("preflightDiscordMessage", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
     transcribeFirstAudioMock.mockReset();
+    hasControlCommandMock.mockReset();
+    hasControlCommandMock.mockReturnValue(false);
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue(DEFAULT_PREFLIGHT_CFG);
+    shouldHandleTextCommandsMock.mockReset();
+    shouldHandleTextCommandsMock.mockReturnValue(true);
+  });
+
+  it("allows an explicitly mentioned alternate bot account to route via its account binding", async () => {
+    const channelId = "channel-polymarket";
+    const guildId = "guild-1";
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            name: "Kakashi",
+            workspace: "/tmp/main-workspace",
+            agentDir: "/tmp/main-agent",
+          },
+          {
+            id: "monitor",
+            name: "Hinata",
+            workspace: "/tmp/monitor-workspace",
+            agentDir: "/tmp/monitor-agent",
+          },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            guildId,
+            peer: {
+              kind: "channel",
+              id: channelId,
+            },
+          },
+        },
+        {
+          agentId: "monitor",
+          match: {
+            channel: "discord",
+            accountId: "notifier",
+          },
+        },
+      ],
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    } as import("../../../../src/config/config.js").OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const client = createGuildTextClient(channelId);
+    const message = createDiscordMessage({
+      id: "m-explicit-alt-bot",
+      channelId,
+      content: "<@notifier-bot> hello",
+      mentionedUsers: [{ id: "notifier-bot" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "aphrodite44444",
+      },
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg,
+        discordConfig: {
+          allowBots: true,
+        } as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      accountId: "notifier",
+      botUserId: "notifier-bot",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.route.agentId).toBe("monitor");
+    expect(result?.route.accountId).toBe("notifier");
+    expect(result?.route.matchedBy).toBe("binding.account");
+    expect(result?.wasMentioned).toBe(true);
+  });
+
+  it("allows a text mention of the alternate bot name to route via its account binding", async () => {
+    const channelId = "channel-yelp";
+    const guildId = "guild-1";
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            name: "Kakashi",
+            workspace: "/tmp/main-workspace",
+            agentDir: "/tmp/main-agent",
+          },
+          {
+            id: "monitor",
+            name: "Hinata",
+            workspace: "/tmp/monitor-workspace",
+            agentDir: "/tmp/monitor-agent",
+          },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "monitor",
+          match: {
+            channel: "discord",
+            accountId: "notifier",
+            guildId,
+            peer: {
+              kind: "channel",
+              id: channelId,
+            },
+          },
+        },
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "default",
+          },
+        },
+      ],
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    } as import("../../../../src/config/config.js").OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const client = createGuildTextClient(channelId);
+    const message = createDiscordMessage({
+      id: "m-text-alt-bot",
+      channelId,
+      content: "@旗木卡卡西 你可以说话吗？",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "aphrodite44444",
+      },
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg,
+        discordConfig: {
+          allowBots: true,
+        } as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      accountId: "default",
+      botUserId: "kakashi-bot",
+      botUserName: "旗木卡卡西",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.route.agentId).toBe("main");
+    expect(result?.route.accountId).toBe("default");
+    expect(result?.route.matchedBy).toBe("binding.account");
+    expect(result?.wasMentioned).toBe(true);
   });
 
   it("drops bound-thread bot system messages to prevent ACP self-loop", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildMentionRegexes,
   matchesMentionWithExplicit,
+  normalizeMentionText,
 } from "../../../../src/auto-reply/reply/mentions.js";
 import { formatAllowlistMatchMeta } from "../../../../src/channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../../../src/channels/command-gating.js";
@@ -59,6 +60,7 @@ import {
   resolveDiscordMessageText,
 } from "./message-utils.js";
 import { resolveDiscordPreflightAudioMentionContext } from "./preflight-audio.js";
+import { resolveDiscordRouteOwner } from "./route-owner.js";
 import {
   buildDiscordRoutePeer,
   resolveDiscordConversationRoute,
@@ -75,6 +77,44 @@ export type {
 } from "./message-handler.preflight.types.js";
 
 const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildBotNameMentionRegexes(botUserName?: string): RegExp[] {
+  const name = botUserName?.trim();
+  if (!name) {
+    return [];
+  }
+  const parts = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => escapeRegexLiteral(part));
+  if (parts.length === 0) {
+    return [];
+  }
+  try {
+    return [
+      new RegExp(
+        String.raw`(?:^|\s)@?${parts.join(String.raw`\s+`)}(?=$|\s|[!?,.;:，。！？；：、】【（）()<>《》"'“”‘’])`,
+        "i",
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+function mergeMentionRegexes(primary: RegExp[], fallback: RegExp[]): RegExp[] {
+  if (fallback.length === 0) {
+    return primary;
+  }
+  if (primary.length === 0) {
+    return fallback;
+  }
+  return [...primary, ...fallback];
+}
 
 function isPreflightAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
@@ -289,6 +329,10 @@ export async function preflightDiscordMessage(
   const messageText = resolveDiscordMessageText(message, {
     includeForwarded: true,
   });
+  const botNameMentionRegexes = buildBotNameMentionRegexes(params.botUserName);
+  const explicitlyMentioned = Boolean(
+    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
+  );
 
   // Intercept text-only slash commands (e.g. user typing "/reset" instead of using Discord's slash command picker)
   // These should not be forwarded to the agent; proper slash command interactions are handled elsewhere
@@ -337,17 +381,18 @@ export async function preflightDiscordMessage(
     ? params.data.rawMember.roles.map((roleId: string) => String(roleId))
     : [];
   const freshCfg = loadConfig();
+  const routePeer = buildDiscordRoutePeer({
+    isDirectMessage,
+    isGroupDm,
+    directUserId: author.id,
+    conversationId: messageChannelId,
+  });
   const route = resolveDiscordConversationRoute({
     cfg: freshCfg,
     accountId: params.accountId,
     guildId: params.data.guild_id ?? undefined,
     memberRoleIds,
-    peer: buildDiscordRoutePeer({
-      isDirectMessage,
-      isGroupDm,
-      directUserId: author.id,
-      conversationId: messageChannelId,
-    }),
+    peer: routePeer,
     parentConversationId: earlyThreadParentId,
   });
   let threadBinding: SessionBindingRecord | undefined;
@@ -372,6 +417,52 @@ export async function preflightDiscordMessage(
   const configuredBinding = configuredRoute?.configuredBinding ?? null;
   if (!threadBinding && configuredBinding) {
     threadBinding = configuredBinding.record;
+  }
+  const hasAnyMention = Boolean(
+    !isDirectMessage &&
+    ((message.mentionedUsers?.length ?? 0) > 0 ||
+      (message.mentionedRoles?.length ?? 0) > 0 ||
+      (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
+  );
+  const ownerBypassMentionRegexes = mergeMentionRegexes(
+    buildMentionRegexes(freshCfg, route.agentId),
+    botNameMentionRegexes,
+  );
+  const bypassOwnerBecauseMentioned =
+    !isDirectMessage &&
+    matchesMentionWithExplicit({
+      text: normalizeMentionText(baseText),
+      mentionRegexes: ownerBypassMentionRegexes,
+      explicit: {
+        hasAnyMention,
+        isExplicitlyMentioned: explicitlyMentioned,
+        canResolveExplicit: Boolean(botId),
+      },
+    });
+  if (!threadBinding && !configuredBinding) {
+    const owner = resolveDiscordRouteOwner({
+      cfg: freshCfg,
+      currentAccountId: params.accountId,
+      currentRoute: route,
+      guildId: params.data.guild_id ?? undefined,
+      memberRoleIds,
+      peer: routePeer,
+      parentPeer: earlyThreadParentId ? { kind: "channel", id: earlyThreadParentId } : undefined,
+    });
+    if (owner && !bypassOwnerBecauseMentioned) {
+      logInboundDrop({
+        log: logVerbose,
+        channel: "discord",
+        target: messageChannelId,
+        reason: `owned by account=${owner.accountId} agent=${owner.route.agentId} via ${owner.route.matchedBy}`,
+      });
+      return null;
+    }
+    if (owner && bypassOwnerBecauseMentioned) {
+      logVerbose(
+        `discord: bypass route owner account=${owner.accountId} because current bot ${params.botUserName ?? botId ?? "unknown"} was explicitly mentioned`,
+      );
+    }
   }
   if (
     shouldIgnoreBoundThreadWebhookMessage({
@@ -403,15 +494,9 @@ export async function preflightDiscordMessage(
     logVerbose(`discord: drop bound-thread bot system message ${message.id}`);
     return null;
   }
-  const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
-  const explicitlyMentioned = Boolean(
-    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
-  );
-  const hasAnyMention = Boolean(
-    !isDirectMessage &&
-    ((message.mentionedUsers?.length ?? 0) > 0 ||
-      (message.mentionedRoles?.length ?? 0) > 0 ||
-      (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
+  const mentionRegexes = mergeMentionRegexes(
+    buildMentionRegexes(params.cfg, effectiveRoute.agentId),
+    botNameMentionRegexes,
   );
   const hasUserOrRoleMention = Boolean(
     !isDirectMessage &&
@@ -785,6 +870,7 @@ export async function preflightDiscordMessage(
     token: params.token,
     runtime: params.runtime,
     botUserId: params.botUserId,
+    botUserName: params.botUserName,
     abortSignal: params.abortSignal,
     guildHistories: params.guildHistories,
     historyLimit: params.historyLimit,

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -25,6 +25,7 @@ type DiscordMessagePreflightSharedFields = {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  botUserName?: string;
   abortSignal?: AbortSignal;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -700,6 +700,27 @@ describe("monitorDiscordProvider", () => {
     expect(eventQueue?.listenerTimeout).toBe(120_000);
   });
 
+  it("keeps the application id as botUserId when fetchUser(@me) fails", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const runtime = baseRuntime();
+    clientFetchUserMock.mockRejectedValueOnce(new Error("fetch failed"));
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime,
+    });
+
+    const params = getFirstDiscordMessageHandlerParams<{
+      botUserId?: string;
+      botUserName?: string;
+    }>();
+    expect(params?.botUserId).toBe("app-1");
+    expect(params?.botUserName).toBeUndefined();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "discord: failed to fetch bot identity: Error: fetch failed",
+    );
+  });
+
   it("forwards custom eventQueue config from discord config to Carbon Client", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -809,7 +809,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     const logger = createSubsystemLogger("discord/monitor");
     const guildHistories = new Map<string, HistoryEntry[]>();
-    let botUserId: string | undefined;
+    // Discord application id is also the bot user id, so keep it as a
+    // fallback when fetchUser("@me") is temporarily unavailable.
+    let botUserId: string | undefined = applicationId;
     let botUserName: string | undefined;
     let voiceManager: DiscordVoiceManager | null = null;
 
@@ -844,7 +846,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
     try {
       const botUser = await client.fetchUser("@me");
-      botUserId = botUser?.id;
+      botUserId = botUser?.id || applicationId;
       botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
       logDiscordStartupPhase({
         runtime,
@@ -890,6 +892,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       abortSignal: opts.abortSignal,
       workerRunTimeoutMs: discordCfg.inboundWorker?.runTimeoutMs,
       botUserId,
+      botUserName,
       guildHistories,
       historyLimit,
       mediaMaxBytes,

--- a/extensions/discord/src/monitor/route-owner.test.ts
+++ b/extensions/discord/src/monitor/route-owner.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../../src/config/config.js";
+import { resolveAgentRoute } from "../../../../src/routing/resolve-route.js";
+import { resolveDiscordRouteOwner } from "./route-owner.js";
+
+describe("resolveDiscordRouteOwner", () => {
+  it("prefers another account when the current account only falls back to default", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: "/ws/main" },
+          { id: "monitor", workspace: "/ws/monitor" },
+        ],
+      },
+      channels: {
+        discord: {
+          accounts: {
+            default: {},
+            notifier: {},
+          },
+        },
+      },
+      bindings: [
+        {
+          agentId: "monitor",
+          match: {
+            channel: "discord",
+            accountId: "notifier",
+            peer: { kind: "channel", id: "channel-monitor" },
+          },
+        },
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: "channel-main" },
+          },
+        },
+      ],
+    };
+
+    const currentRoute = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "channel-monitor" },
+      guildId: "guild-1",
+    });
+
+    const owner = resolveDiscordRouteOwner({
+      cfg,
+      currentAccountId: "default",
+      currentRoute,
+      guildId: "guild-1",
+      peer: { kind: "channel", id: "channel-monitor" },
+    });
+
+    expect(currentRoute.matchedBy).toBe("default");
+    expect(owner).toEqual({
+      accountId: "notifier",
+      route: expect.objectContaining({
+        agentId: "monitor",
+        accountId: "notifier",
+        matchedBy: "binding.peer",
+      }),
+    });
+  });
+
+  it("prefers a more specific peer binding on another account over an account-wide match", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            default: {},
+            notifier: {},
+          },
+        },
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "default",
+          },
+        },
+        {
+          agentId: "monitor",
+          match: {
+            channel: "discord",
+            accountId: "notifier",
+            peer: { kind: "channel", id: "channel-monitor" },
+          },
+        },
+      ],
+    };
+
+    const currentRoute = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "channel-monitor" },
+      guildId: "guild-1",
+    });
+
+    const owner = resolveDiscordRouteOwner({
+      cfg,
+      currentAccountId: "default",
+      currentRoute,
+      guildId: "guild-1",
+      peer: { kind: "channel", id: "channel-monitor" },
+    });
+
+    expect(currentRoute.matchedBy).toBe("binding.account");
+    expect(owner).toEqual({
+      accountId: "notifier",
+      route: expect.objectContaining({
+        agentId: "monitor",
+        accountId: "notifier",
+        matchedBy: "binding.peer",
+      }),
+    });
+  });
+
+  it("keeps the current account when it already has the most specific binding", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            default: {},
+            notifier: {},
+          },
+        },
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: "channel-main" },
+          },
+        },
+        {
+          agentId: "monitor",
+          match: {
+            channel: "discord",
+            accountId: "notifier",
+          },
+        },
+      ],
+    };
+
+    const currentRoute = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "channel-main" },
+      guildId: "guild-1",
+    });
+
+    const owner = resolveDiscordRouteOwner({
+      cfg,
+      currentAccountId: "default",
+      currentRoute,
+      guildId: "guild-1",
+      peer: { kind: "channel", id: "channel-main" },
+    });
+
+    expect(currentRoute.matchedBy).toBe("binding.peer");
+    expect(owner).toBeNull();
+  });
+});

--- a/extensions/discord/src/monitor/route-owner.ts
+++ b/extensions/discord/src/monitor/route-owner.ts
@@ -1,0 +1,75 @@
+import type { OpenClawConfig } from "../../../../src/config/config.js";
+import { listBoundAccountIds } from "../../../../src/routing/bindings.js";
+import {
+  resolveAgentRoute,
+  type ResolveAgentRouteInput,
+  type ResolvedAgentRoute,
+} from "../../../../src/routing/resolve-route.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../../src/routing/session-key.js";
+import { listDiscordAccountIds } from "../accounts.js";
+
+const ROUTE_PRIORITY: Record<ResolvedAgentRoute["matchedBy"], number> = {
+  "binding.peer": 0,
+  "binding.peer.parent": 1,
+  "binding.guild+roles": 2,
+  "binding.guild": 3,
+  "binding.team": 4,
+  "binding.account": 5,
+  "binding.channel": 6,
+  default: 7,
+};
+
+export type DiscordRouteOwner = {
+  accountId: string;
+  route: ResolvedAgentRoute;
+};
+
+type DiscordRouteOwnerInput = Pick<
+  ResolveAgentRouteInput,
+  "cfg" | "guildId" | "memberRoleIds" | "peer" | "parentPeer"
+> & {
+  currentAccountId?: string | null;
+  currentRoute: ResolvedAgentRoute;
+};
+
+function listDiscordCandidateAccountIds(cfg: OpenClawConfig): string[] {
+  return Array.from(
+    new Set([
+      DEFAULT_ACCOUNT_ID,
+      ...listDiscordAccountIds(cfg),
+      ...listBoundAccountIds(cfg, "discord"),
+    ]),
+  )
+    .map((accountId) => normalizeAccountId(accountId))
+    .filter(Boolean);
+}
+
+export function resolveDiscordRouteOwner(params: DiscordRouteOwnerInput): DiscordRouteOwner | null {
+  const currentAccountId = normalizeAccountId(params.currentAccountId);
+  const currentPriority = ROUTE_PRIORITY[params.currentRoute.matchedBy];
+  let owner: { accountId: string; route: ResolvedAgentRoute; priority: number } | null = null;
+
+  for (const accountId of listDiscordCandidateAccountIds(params.cfg)) {
+    if (accountId === currentAccountId) {
+      continue;
+    }
+    const route = resolveAgentRoute({
+      cfg: params.cfg,
+      channel: "discord",
+      accountId,
+      guildId: params.guildId ?? undefined,
+      memberRoleIds: params.memberRoleIds,
+      peer: params.peer,
+      parentPeer: params.parentPeer ?? undefined,
+    });
+    const priority = ROUTE_PRIORITY[route.matchedBy];
+    if (priority >= currentPriority) {
+      continue;
+    }
+    if (!owner || priority < owner.priority) {
+      owner = { accountId, route, priority };
+    }
+  }
+
+  return owner ? { accountId: owner.accountId, route: owner.route } : null;
+}


### PR DESCRIPTION
## Summary

- Problem: account-wide Discord bindings could still consume messages in channels that were more specifically owned by another Discord account, and explicitly mentioning the non-owner bot could still fail in production when bot identity lookup was unavailable.
- Why it matters: the intended "one default bot per channel" model was not enforced consistently, while users also could not reliably call the alternate bot on demand with an explicit mention.
- What changed: added Discord route-owner resolution so a more specific channel owner wins by default, but allow the current bot/account to bypass that owner guard when it is explicitly mentioned. Also keep `botUserId` stable by falling back to the Discord application id when `fetchUser("@me")` fails.
- What did NOT change (scope boundary): no slash-command ownership blocking was included in this PR, and no Discord config defaults were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- In a Discord channel owned by one bot/account, only that owner responds by default.
- If a user explicitly mentions the alternate bot in that channel, the alternate bot can still respond.
- Explicit Discord `<@bot>` mentions continue to work even if provider startup cannot resolve `fetchUser("@me")`.
- No config migration is required.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/OpenClaw dev environment
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Discord
- Relevant config (redacted): two Discord accounts, channel-specific owner bindings plus account-wide fallback bindings

### Steps

1. Bind one Discord channel to account A with a more specific channel binding.
2. Keep account B available through a broader account-wide binding.
3. Send a normal message in the channel, then explicitly mention the alternate bot.
4. Simulate provider startup with `fetchUser("@me")` failing.

### Expected

- Normal channel traffic goes only to the owner account.
- Explicit mention of the alternate bot bypasses the owner guard and routes to that bot.
- Explicit `<@bot>` mention detection still works when the bot identity fetch fails.

### Actual

- Verified locally after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: route-owner precedence, explicit alternate-bot mention routing, text-form bot-name mention routing, provider startup fallback when `fetchUser("@me")` fails, local build, gateway restart, and a live Discord re-test in the local environment after restart.
- Edge cases checked: account-wide fallback bindings losing to more specific owner bindings; explicit mention bypass; missing bot username with preserved bot id.
- What you did **not** verify: GitHub-hosted CI, slash-command ownership semantics, unrelated Discord command flows.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `9650ab829` and `a162d01c5`, rebuild, and restart the gateway.
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`, `src/discord/monitor/message-handler.preflight.types.ts`, `src/discord/monitor/provider.ts`, `src/discord/monitor/route-owner.ts`, and related tests.
- Known bad symptoms reviewers should watch for: non-owner bots responding to default channel traffic again, or explicit alternate-bot mentions no longer routing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: owner resolution could suppress messages for an account that used to rely on a broader binding in a channel now owned by another account.
  - Mitigation: owner precedence is covered by focused route-owner tests, and explicit mentions still bypass the owner guard.
- Risk: provider startup identity fallback could preserve bot id without bot username when Discord REST calls are degraded.
  - Mitigation: explicit `<@bot>` mentions still work because they only require the bot id; username matching remains best-effort.
