### PR TITLE
fix(cron): warn when cron edit --model is not in allowlist

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -211,18 +211,31 @@ export function registerCronEditCommand(cron: Command) {
           if (model) {
             try {
               const { loadConfig } = await import("../../config/config.js");
+              const { loadModelCatalog } = await import("../../agents/model-catalog.js");
+              const { buildAllowedModelSet, parseModelRef } =
+                await import("../../agents/model-selection.js");
+              const { DEFAULT_PROVIDER, DEFAULT_MODEL } = await import("../../agents/defaults.js");
               const cfg = loadConfig();
-              const modelsMap = cfg.agents?.defaults?.models ?? {};
-              const allowlistKeys = Object.keys(modelsMap);
-              if (allowlistKeys.length > 0 && !allowlistKeys.includes(model)) {
-                defaultRuntime.error(
-                  warn(
-                    `Warning: "${model}" is not in agents.defaults.models. This cron may fail at execution time.`,
-                  ),
-                );
+              const catalog = await loadModelCatalog({ config: cfg });
+              const { allowAny, allowedKeys } = buildAllowedModelSet({
+                cfg,
+                catalog,
+                defaultProvider: DEFAULT_PROVIDER,
+                defaultModel: DEFAULT_MODEL,
+              });
+              if (!allowAny) {
+                const ref = parseModelRef(model, DEFAULT_PROVIDER);
+                const key = ref ? `${ref.provider}/${ref.model}` : model;
+                if (!allowedKeys.has(key)) {
+                  defaultRuntime.error(
+                    warn(
+                      `Warning: "${model}" is not in the allowed model set. This cron may fail at execution time.`,
+                    ),
+                  );
+                }
               }
             } catch {
-              // Config loading can fail; don't block cron edit.
+              // Config/catalog loading can fail; don't block cron edit.
             }
           }
           const thinking =

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { CronJob } from "../../cron/types.js";
-import { danger } from "../../globals.js";
+import { danger, warn } from "../../globals.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
@@ -208,6 +208,23 @@ export function registerCronEditCommand(cron: Command) {
           const hasSystemEventPatch = typeof opts.systemEvent === "string";
           const model =
             typeof opts.model === "string" && opts.model.trim() ? opts.model.trim() : undefined;
+          if (model) {
+            try {
+              const { loadConfig } = await import("../../config/config.js");
+              const cfg = loadConfig();
+              const modelsMap = cfg.agents?.defaults?.models ?? {};
+              const allowlistKeys = Object.keys(modelsMap);
+              if (allowlistKeys.length > 0 && !allowlistKeys.includes(model)) {
+                defaultRuntime.error(
+                  warn(
+                    `Warning: "${model}" is not in agents.defaults.models. This cron may fail at execution time.`,
+                  ),
+                );
+              }
+            } catch {
+              // Config loading can fail; don't block cron edit.
+            }
+          }
           const thinking =
             typeof opts.thinking === "string" && opts.thinking.trim()
               ? opts.thinking.trim()


### PR DESCRIPTION
## Summary

`openclaw cron edit <id> --model` now warns when the specified model is not in the `agents.defaults.models` allowlist.

Closes #22006

## Problem

Setting a model via `cron edit --model "anthropic/claude-sonnet-4-6"` succeeded silently even when the model was not allowlisted. The failure only surfaced at cron execution time with "model not allowed", silently breaking all affected crons.

## Fix

After parsing the `--model` value, loads the config and checks if the model appears in the `agents.defaults.models` allowlist keys. If the allowlist is active (non-empty) and the model is not listed, prints a warning. The warning is non-blocking — the edit still proceeds.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)