### PR TITLE
Discord: fix RadioGroup modal field values lost on submission

### DIFF
--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -15,7 +15,7 @@ import {
   type StringSelectMenuInteraction,
   type UserSelectMenuInteraction,
 } from "@buape/carbon";
-import type { APIStringSelectComponent } from "discord-api-types/v10";
+import type { APIStringSelectComponent, ModalSubmitLabelComponent } from "discord-api-types/v10";
 import { ButtonStyle, ChannelType, ComponentType } from "discord-api-types/v10";
 import { resolveHumanDelayConfig } from "../../../../src/agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../../../src/auto-reply/chunk.js";
@@ -713,9 +713,7 @@ function resolveRadioGroupValueFromRaw(
 ): string | null {
   for (const component of interaction.rawData.data.components ?? []) {
     if (component.type === ComponentType.Label) {
-      const sub = (
-        component as { component?: { type: number; custom_id?: string; value?: string | null } }
-      ).component;
+      const sub = (component as ModalSubmitLabelComponent).component;
       if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
         return sub.value ?? null;
       }

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -16,7 +16,7 @@ import {
   type UserSelectMenuInteraction,
 } from "@buape/carbon";
 import type { APIStringSelectComponent } from "discord-api-types/v10";
-import { ButtonStyle, ChannelType } from "discord-api-types/v10";
+import { ButtonStyle, ChannelType, ComponentType } from "discord-api-types/v10";
 import { resolveHumanDelayConfig } from "../../../../src/agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../../../src/auto-reply/chunk.js";
 import {
@@ -701,6 +701,29 @@ function mapSelectValues(entry: DiscordComponentEntry, values: string[]): string
   return values;
 }
 
+/**
+ * Read a RadioGroup's selected value directly from the raw interaction payload.
+ * Carbon's FieldsHandler reads `.values` (array) for non-TextInput components,
+ * but Discord's RadioGroup submission uses `.value` (singular string | null).
+ * This bypasses Carbon to read the correct field.
+ */
+function resolveRadioGroupValueFromRaw(
+  interaction: ModalInteraction,
+  fieldId: string,
+): string | null {
+  for (const component of interaction.rawData.data.components ?? []) {
+    if (component.type === ComponentType.Label) {
+      const sub = (
+        component as { component?: { type: number; custom_id?: string; value?: string | null } }
+      ).component;
+      if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
+        return sub.value ?? null;
+      }
+    }
+  }
+  return null;
+}
+
 function resolveModalFieldValues(
   field: DiscordModalEntry["fields"][number],
   interaction: ModalInteraction,
@@ -717,9 +740,15 @@ function resolveModalFieldValues(
         const value = required ? fields.getText(field.id, true) : fields.getText(field.id);
         return value ? [value] : [];
       }
-      case "select":
-      case "checkbox":
       case "radio": {
+        const value = resolveRadioGroupValueFromRaw(interaction, field.id);
+        if (required && !value) {
+          throw new Error(`Missing required field: ${field.id}`);
+        }
+        return value ? mapOptionLabels(optionLabels, [value]) : [];
+      }
+      case "select":
+      case "checkbox": {
         const values = required
           ? fields.getStringSelect(field.id, true)
           : (fields.getStringSelect(field.id) ?? []);


### PR DESCRIPTION
## Summary

- Fix RadioGroup fields in Discord modals always failing with `Missing required field` errors on submission
- Carbon's `FieldsHandler` reads `.values` (array) for all non-TextInput modal components, but Discord's `APIModalSubmitRadioGroupComponent` uses `.value` (singular `string | null`)
- Add `resolveRadioGroupValueFromRaw()` that reads the raw interaction payload directly, bypassing Carbon's `FieldsHandler` for the `radio` case

## Root cause

When a modal with RadioGroup fields is submitted, Discord returns:
```json
{ "type": 21, "custom_id": "fld_xxx", "value": "selected_option" }
```

But Carbon's `FieldsHandler` constructor only reads `.values` (plural) for non-TextInput components, so the RadioGroup value is never stored in `rawData`. Subsequent calls to `getStringSelect()` then throw `Missing required field`.

This is confirmed by `discord-api-types` which defines `APIModalSubmitRadioGroupComponent` with `value: string | null` (not `values: string[]`).

## Fix

- New helper `resolveRadioGroupValueFromRaw()` iterates `interaction.rawData.data.components`, finds the Label-wrapped RadioGroup by `custom_id`, and reads `.value` directly
- Separate `radio` from `select`/`checkbox` in the `resolveModalFieldValues()` switch statement
- No Carbon dependency changes needed (reads raw interaction data)

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Existing tests pass (`pnpm test -- extensions/discord/src/monitor/agent-components extensions/discord/src/components`)
- [x] Manually verified: sent a Discord modal with RadioGroup fields via cron, submitted form, values read correctly with no errors (previously always failed with `Missing required field`)