### PR TITLE
fix(whatsapp): use old timestamp in append test to respect grace window

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-120_000),
           pushName: "History Sender",
         },
       ],


### PR DESCRIPTION
## Summary
- The refactored monitor added a 60s grace period for append messages — recent append messages are now processed instead of skipped
- The "handles append messages by marking them read but skipping auto-reply" test was using `nowSeconds()` which falls within the grace window, causing `onMessage` to fire unexpectedly
- Fixed by using a 2-minute-old timestamp (`nowSeconds(-120_000)`) so the message is treated as stale history and correctly skipped

## Test plan
- [x] `extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts` — all 7 tests pass locally
- [ ] CI green on `pnpm test:extensions` and `pnpm test:channels`