### PR TITLE
fix(whatsapp): share listener map and add monitor timeouts

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -30,7 +30,14 @@ export type ActiveWebListener = {
 
 let _currentListener: ActiveWebListener | null = null;
 
-const listeners = new Map<string, ActiveWebListener>();
+type GlobalWithWaListeners = typeof globalThis & {
+  __openclawWaListeners?: Map<string, ActiveWebListener>;
+};
+
+const globalWithWaListeners = globalThis as GlobalWithWaListeners;
+const listeners =
+  globalWithWaListeners.__openclawWaListeners ??
+  (globalWithWaListeners.__openclawWaListeners = new Map<string, ActiveWebListener>());
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -22,6 +22,9 @@ import { downloadInboundMedia } from "./media.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
+const WA_CONNECT_TIMEOUT_MS = 15_000;
+const WA_PRESENCE_UPDATE_TIMEOUT_MS = 5_000;
+
 export async function monitorWebInbox(options: {
   verbose: boolean;
   accountId: string;
@@ -40,7 +43,29 @@ export async function monitorWebInbox(options: {
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
   });
-  await waitForWaConnection(sock);
+  {
+    let connectTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        waitForWaConnection(sock),
+        new Promise<never>((_, reject) => {
+          connectTimer = setTimeout(
+            () => reject(new Error("waitForWaConnection timeout")),
+            WA_CONNECT_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } catch (err) {
+      try {
+        sock.ws?.close();
+      } catch {
+        /* ignore close errors */
+      }
+      throw err;
+    } finally {
+      if (connectTimer !== undefined) clearTimeout(connectTimer);
+    }
+  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
@@ -56,13 +81,26 @@ export async function monitorWebInbox(options: {
     resolver(reason);
   };
 
-  try {
-    await sock.sendPresenceUpdate("available");
-    if (shouldLogVerbose()) {
-      logVerbose("Sent global 'available' presence on connect");
+  {
+    let presenceTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        sock.sendPresenceUpdate("available"),
+        new Promise<never>((_, reject) => {
+          presenceTimer = setTimeout(
+            () => reject(new Error("presence update timeout")),
+            WA_PRESENCE_UPDATE_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (shouldLogVerbose()) {
+        logVerbose("Sent global 'available' presence on connect");
+      }
+    } catch (err) {
+      logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+    } finally {
+      if (presenceTimer !== undefined) clearTimeout(presenceTimer);
     }
-  } catch (err) {
-    logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
   }
 
   const selfJid = sock.user?.id;


### PR DESCRIPTION
﻿## Summary
- Use a shared global WhatsApp listener map to avoid cross-bundle listener mismatch.
- Add timeout guards around connection wait and initial presence update in WhatsApp inbound monitor.
- Port runtime dist patch behavior into source TypeScript.

## Bug Reference
- #47173
- https://github.com/openclaw/openclaw/issues/47173

## Failure Before

Tool output message

```json
{
  "status": "error",
  "tool": "message",
  "error": "Error: No active WhatsApp Web listener (account: default). Start the gateway, then link WhatsApp with: openclaw channels login --channel whatsapp --account default."
}
```

## Success After

Tool output message

```json
{
  "channel": "whatsapp",
  "to": "123456789012345678@g.us",
  "via": "gateway",
  "mediaUrl": null,
  "result": {
    "runId": "7b97f4e4-a395-4fc9-bf91-211376fffb85",
    "messageId": "3EB0AE4382D0D8121F5534",
    "channel": "whatsapp",
    "toJid": "123456789012345678@g.us"
  }
}
```

## Validation
- pnpm test -- extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
- Result: 2 files passed, 21 tests passed
