### PR TITLE
fix: sanitize prototype pollution keys from all JSON5 parse paths in config

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -660,12 +660,34 @@ function maybeLoadDotEnvForConfig(env: NodeJS.ProcessEnv): void {
   loadDotEnv({ quiet: true });
 }
 
+/**
+ * Recursively strip dangerous prototype-pollution keys (`__proto__`,
+ * `constructor`, `prototype`) from a parsed JSON5 value.
+ */
+function stripPrototypePollutionKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripPrototypePollutionKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    const clean: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      clean[key] = stripPrototypePollutionKeys((value as Record<string, unknown>)[key]);
+    }
+    return clean;
+  }
+  return value;
+}
+
 export function parseConfigJson5(
   raw: string,
   json5: { parse: (value: string) => unknown } = JSON5,
 ): ParseConfigJson5Result {
   try {
-    return { ok: true, parsed: json5.parse(raw) };
+    const parsed = json5.parse(raw);
+    return { ok: true, parsed: stripPrototypePollutionKeys(parsed) };
   } catch (err) {
     return { ok: false, error: String(err) };
   }
@@ -691,7 +713,7 @@ function resolveConfigIncludesForRead(
         rootRealDir,
         ioFs: deps.fs,
       }),
-    parseJson: (raw) => deps.json5.parse(raw),
+    parseJson: (raw) => stripPrototypePollutionKeys(deps.json5.parse(raw)),
   });
 }
 
@@ -747,7 +769,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         return {};
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
-      const parsed = deps.json5.parse(raw);
+      const parsed = stripPrototypePollutionKeys(deps.json5.parse(raw));
       const readResolution = resolveConfigForRead(
         resolveConfigIncludesForRead(parsed, configPath, deps),
         deps.env,
@@ -1102,7 +1124,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
               rootRealDir,
               ioFs: deps.fs,
             }),
-          parseJson: (raw) => deps.json5.parse(raw),
+          parseJson: (raw) => stripPrototypePollutionKeys(deps.json5.parse(raw)),
         });
         const collected = new Map<string, string>();
         collectEnvRefPaths(resolvedIncludes, "", collected);


### PR DESCRIPTION
## Summary

`src/config/io.ts` uses `JSON5.parse()` in multiple locations to parse user-controlled configuration. Unlike `JSON.parse()`, `JSON5.parse()` treats `__proto__` as a live prototype property, enabling Object.prototype pollution that can lead to privilege escalation or auth bypass.

## Changes

Add `stripPrototypePollutionKeys()` that recursively removes `__proto__`, `constructor`, and `prototype` keys (using the existing `isBlockedObjectKey` helper) and apply it consistently to **all four** JSON5 parse sites in `io.ts`:

1. **`parseConfigJson5()`** (line 690) — the `config.patch` endpoint path
2. **`loadConfig()`** (line 772) — the primary config file loading at boot
3. **`resolveConfigIncludesForRead`** (line 716) — `$include` file parsing during read
4. **write-path includes resolver** (line 1127) — `$include` resolution during config write

## Test plan

- [ ] Verify normal JSON5 config parsing still works (comments, trailing commas, etc.)
- [ ] Confirm `parseConfigJson5('{"__proto__": {"admin": true}}')` returns an object without `__proto__` key
- [ ] Confirm `Object.prototype` is not polluted after parsing malicious config at boot (`loadConfig`)
- [ ] Confirm `$include`-referenced files with `__proto__` keys are also sanitized
- [ ] Confirm `parseConfigJson5('{"constructor": {"prototype": {"x": 1}}}')` strips nested dangerous keys