### PR TITLE
fix(whatsapp): use globalThis singleton for active-listener Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 - Google Chat/runtime API: thin the private runtime barrel onto the curated public SDK surface while keeping public Google Chat exports intact. (#49504) Thanks @scoootscooob.
 - WhatsApp: stabilize inbound monitor and setup tests (#50007) Thanks @joshavant.
 - Matrix: make onboarding status runtime-safe (#49995) Thanks @joshavant.
+- WhatsApp/active-listener: pin the active listener registry to a `globalThis` singleton so split WhatsApp bundle chunks share one listener map and outbound sends stop missing the registered session. (#47433) Thanks @clawdia67.
 
 ### Breaking
 

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,9 +28,35 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
+// Use a process-level singleton to survive bundler code-splitting.
+// Rolldown duplicates this module across multiple output chunks, each with its
+// own module-scoped `listeners` Map. The WhatsApp provider writes to one chunk's
+// Map via setActiveWebListener(), but the outbound send path reads from a
+// different chunk's Map via requireActiveWebListener() — so the listener is
+// never found. Pinning the Map to globalThis ensures all chunks share one
+// instance.  See: https://github.com/openclaw/openclaw/issues/14406
+const GLOBAL_KEY = "__openclaw_wa_listeners" as const;
+const GLOBAL_CURRENT_KEY = "__openclaw_wa_current_listener" as const;
 
-const listeners = new Map<string, ActiveWebListener>();
+type GlobalWithListeners = typeof globalThis & {
+  [GLOBAL_KEY]?: Map<string, ActiveWebListener>;
+  [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
+};
+
+const _global = globalThis as GlobalWithListeners;
+
+_global[GLOBAL_KEY] ??= new Map<string, ActiveWebListener>();
+_global[GLOBAL_CURRENT_KEY] ??= null;
+
+const listeners = _global[GLOBAL_KEY];
+
+function getCurrentListener(): ActiveWebListener | null {
+  return _global[GLOBAL_CURRENT_KEY] ?? null;
+}
+
+function setCurrentListener(listener: ActiveWebListener | null): void {
+  _global[GLOBAL_CURRENT_KEY] = listener;
+}
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -74,7 +100,7 @@ export function setActiveWebListener(
     listeners.set(id, listener);
   }
   if (id === DEFAULT_ACCOUNT_ID) {
-    _currentListener = listener;
+    setCurrentListener(listener);
   }
 }
 


### PR DESCRIPTION
## Summary

- The `listeners` Map in `extensions/whatsapp/src/active-listener.ts` is duplicated across 7+ output chunks by Rolldown code-splitting
- `setActiveWebListener()` populates the Map in one chunk, but `requireActiveWebListener()` reads from a different chunk's copy
- Outbound sends via the `message` tool always fail with "No active WhatsApp Web listener" while auto-replies (which bypass the Map via direct socket references) work fine
- Pin both the `listeners` Map and `_currentListener` to `globalThis` so all chunk-local copies resolve to the same shared instance

## Test plan

- [ ] Verify existing `send.test.ts` passes
- [ ] Start gateway with WhatsApp linked
- [ ] Send media via `message` tool — should succeed instead of throwing "No active WhatsApp Web listener"
- [ ] Verify auto-reply path still works
- [ ] Verify `getActiveWebListener()` / `requireActiveWebListener()` return the listener registered by `setActiveWebListener()` even when called from a different chunk

Fixes #14406

🤖 Generated with [Claude Code](https://claude.com/claude-code)