### PR TITLE
feat: pass modelId to context engine assemble()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Web tools/Tavily: add Tavily as a bundled web-search provider with dedicated `tavily_search` and `tavily_extract` tools, using canonical plugin-owned config under `plugins.entries.tavily.config.webSearch.*`. (#49200) thanks @lakshyaag-tavily.
 - Docs/plugins: add the community DingTalk plugin listing to the docs catalog. (#29913) Thanks @sliverp.
 - Docs/plugins: add the community QQbot plugin listing to the docs catalog. (#29898) Thanks @sliverp.
+- Plugins/context engines: pass the embedded runner `modelId` into context-engine `assemble()` so plugins can adapt context formatting per model. (#47437) thanks @jscianna.
 
 ### Fixes
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -39,6 +39,7 @@ const hoisted = vi.hoisted(() => {
     contextFiles: [],
   }));
   const getGlobalHookRunnerMock = vi.fn<() => unknown>(() => undefined);
+  const initializeGlobalHookRunnerMock = vi.fn();
   const sessionManager = {
     getLeafEntry: vi.fn(() => null),
     branch: vi.fn(),
@@ -55,6 +56,7 @@ const hoisted = vi.hoisted(() => {
     acquireSessionWriteLockMock,
     resolveBootstrapContextForRunMock,
     getGlobalHookRunnerMock,
+    initializeGlobalHookRunnerMock,
     sessionManager,
   };
 });
@@ -94,6 +96,7 @@ vi.mock("../../pi-embedded-subscribe.js", () => ({
 
 vi.mock("../../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: hoisted.getGlobalHookRunnerMock,
+  initializeGlobalHookRunner: hoisted.initializeGlobalHookRunnerMock,
 }));
 
 vi.mock("../../../infra/machine-name.js", () => ({
@@ -214,6 +217,16 @@ vi.mock("../../anthropic-payload-log.js", () => ({
 
 vi.mock("../../cache-trace.js", () => ({
   createCacheTrace: () => undefined,
+}));
+
+vi.mock("../../pi-tools.js", () => ({
+  createOpenClawCodingTools: () => [],
+  resolveToolLoopDetectionConfig: () => undefined,
+}));
+
+vi.mock("../../../image-generation/runtime.js", () => ({
+  generateImage: vi.fn(),
+  listRuntimeImageGenerationProviders: () => [],
 }));
 
 vi.mock("../../model-selection.js", async (importOriginal) => {
@@ -346,10 +359,12 @@ function createDefaultEmbeddedSession(params?: {
 function createContextEngineBootstrapAndAssemble() {
   return {
     bootstrap: vi.fn(async (_params: { sessionKey?: string }) => ({ bootstrapped: true })),
-    assemble: vi.fn(async ({ messages }: { messages: AgentMessage[]; sessionKey?: string }) => ({
-      messages,
-      estimatedTokens: 1,
-    })),
+    assemble: vi.fn(
+      async ({ messages }: { messages: AgentMessage[]; sessionKey?: string; model?: string }) => ({
+        messages,
+        estimatedTokens: 1,
+      }),
+    ),
   };
 }
 
@@ -677,6 +692,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       sessionKey?: string;
       messages: AgentMessage[];
       tokenBudget?: number;
+      model?: string;
     }) => Promise<AssembleResult>;
     afterTurn?: (params: {
       sessionId: string;
@@ -781,6 +797,22 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expectCalledWithSessionKey(bootstrap, sessionKey);
     expectCalledWithSessionKey(assemble, sessionKey);
     expectCalledWithSessionKey(afterTurn, sessionKey);
+  });
+
+  it("forwards modelId to assemble", async () => {
+    const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
+
+    const result = await runAttemptWithContextEngine({
+      bootstrap,
+      assemble,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(assemble).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-test",
+      }),
+    );
   });
 
   it("forwards sessionKey to ingestBatch when afterTurn is absent", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2167,6 +2167,7 @@ export async function runEmbeddedAttempt(
               sessionKey: params.sessionKey,
               messages: activeSession.messages,
               tokenBudget: params.contextTokenBudget,
+              model: params.modelId,
             });
             if (assembled.messages !== activeSession.messages) {
               activeSession.agent.replaceMessages(assembled.messages);

--- a/src/context-engine/legacy.ts
+++ b/src/context-engine/legacy.ts
@@ -40,6 +40,7 @@ export class LegacyContextEngine implements ContextEngine {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    model?: string;
   }): Promise<AssembleResult> {
     // Pass-through: the existing sanitize -> validate -> limit -> repair pipeline
     // in attempt.ts handles context assembly for the legacy engine.

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -131,6 +131,9 @@ export interface ContextEngine {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    /** Current model identifier (e.g. "claude-opus-4", "gpt-4o", "qwen2.5-7b").
+     *  Allows context engine plugins to adapt formatting per model. */
+    model?: string;
   }): Promise<AssembleResult>;
 
   /**


### PR DESCRIPTION
## Summary

Context engine plugins currently receive `sessionId`, `messages`, and `tokenBudget` in `assemble()` — but not which model is being used. This means plugins can't adapt their output format per model.

## Change

Adds an optional `model?: string` parameter to the `assemble()` interface and passes `params.modelId` from the embedded runner's attempt call site.

**3 files changed, 5 insertions:**
- `src/context-engine/types.ts` — add `model?: string` to assemble params
- `src/agents/pi-embedded-runner/run/attempt.ts` — pass `params.modelId` 
- `src/context-engine/legacy.ts` — accept new param (unused, backward-compatible)

## Why

Different models benefit from different context formatting:
- **Claude** prefers XML-structured context
- **GPT** works best with markdown
- **Small local models (7B)** need terse, compressed context to stay within limited windows
- **Gemini** has 1M+ context but still benefits from structured formatting

Without the model identifier, context engine plugins have to guess or use a one-size-fits-all approach.

## Backward Compatibility

Fully backward-compatible. The `model` param is optional — existing plugins that don't use it are completely unaffected.