### PR TITLE
fix(gateway/discord): respect env proxy vars and prevent ECONNRESET

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -6,6 +6,7 @@ import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import WebSocket from "ws";
+import { resolveEnvHttpProxyUrl } from "../../../../src/infra/net/proxy-env.js";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
@@ -270,7 +271,7 @@ export function createDiscordGatewayPlugin(params: {
   runtime: RuntimeEnv;
 }): GatewayPlugin {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
-  const proxy = params.discordConfig?.proxy?.trim();
+  const proxy = params.discordConfig?.proxy?.trim() || resolveEnvHttpProxyUrl("https");
   const options = {
     reconnect: { maxAttempts: 50 },
     intents,
@@ -287,7 +288,7 @@ export function createDiscordGatewayPlugin(params: {
 
   try {
     const wsAgent = new HttpsProxyAgent<string>(proxy);
-    const fetchAgent = new ProxyAgent(proxy);
+    const fetchAgent = new ProxyAgent({ uri: proxy, connect: { keepAlive: false } });
 
     params.runtime.log?.("discord: gateway proxy enabled");
 

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -89,13 +89,18 @@ vi.mock("https-proxy-agent", () => ({
 vi.mock("undici", () => ({
   ProxyAgent: class {
     proxyUrl: string;
-    constructor(proxyUrl: string) {
+    constructor(opts: string | { uri: string }) {
+      const proxyUrl = typeof opts === "string" ? opts : opts.uri;
       this.proxyUrl = proxyUrl;
       undiciProxyAgentSpy(proxyUrl);
       restProxyAgentSpy(proxyUrl);
     }
   },
   fetch: undiciFetchMock,
+}));
+
+vi.mock("../../../../src/infra/net/proxy-env.js", () => ({
+  resolveEnvHttpProxyUrl: () => undefined,
 }));
 
 vi.mock("ws", () => ({

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -9,7 +9,8 @@ const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
 vi.mock("undici", () => {
   class ProxyAgent {
     proxyUrl: string;
-    constructor(proxyUrl: string) {
+    constructor(opts: string | { uri: string }) {
+      const proxyUrl = typeof opts === "string" ? opts : opts.uri;
       if (proxyUrl === "bad-proxy") {
         throw new Error("bad proxy");
       }

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -12,7 +12,7 @@ export function resolveDiscordRestFetch(
     return fetch;
   }
   try {
-    const agent = new ProxyAgent(proxy);
+    const agent = new ProxyAgent({ uri: proxy, connect: { keepAlive: false } });
     const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
         ...(init as Record<string, unknown>),

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -17,6 +17,10 @@ import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import {
+  ensureGlobalUndiciEnvProxyDispatcher,
+  ensureGlobalUndiciStreamTimeouts,
+} from "../../infra/net/undici-global-dispatcher.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
@@ -417,6 +421,11 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
           ...(opts.tailscaleResetOnExit ? { resetOnExit: true } : {}),
         }
       : undefined;
+
+  // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
+  // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
+  ensureGlobalUndiciEnvProxyDispatcher();
+  ensureGlobalUndiciStreamTimeouts();
 
   try {
     await runGatewayLoop({

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -203,8 +203,9 @@ export function isNodeCommandAllowed(params: {
   if (!params.allowlist.has(command)) {
     return { ok: false, reason: "command not allowlisted" };
   }
-  if (Array.isArray(params.declaredCommands) && params.declaredCommands.length > 0) {
-    if (!params.declaredCommands.includes(command)) {
+  const { declaredCommands } = params;
+  if (Array.isArray(declaredCommands) && declaredCommands.length > 0) {
+    if (!declaredCommands.includes(command)) {
       return { ok: false, reason: "command not declared by node" };
     }
   } else {

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1003,15 +1003,16 @@ export const nodeHandlers: GatewayRequestHandlers = {
           `node wake done node=${nodeId} req=${wakeReqId} connected=true totalMs=${totalDurationMs}`,
         );
       }
+      const session = nodeSession;
       const cfg = loadConfig();
-      const allowlist = resolveNodeCommandAllowlist(cfg, nodeSession);
+      const allowlist = resolveNodeCommandAllowlist(cfg, session);
       const allowed = isNodeCommandAllowed({
         command,
-        declaredCommands: nodeSession.commands,
+        declaredCommands: session.commands,
         allowlist,
       });
       if (!allowed.ok) {
-        const hint = buildNodeCommandRejectionHint(allowed.reason, command, nodeSession);
+        const hint = buildNodeCommandRejectionHint(allowed.reason, command, session);
         respond(
           false,
           undefined,

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -111,6 +111,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.connect).toEqual({
+      keepAlive: false,
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
     });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -93,7 +93,10 @@ export function ensureGlobalUndiciEnvProxyDispatcher(): void {
     return;
   }
   try {
-    setGlobalDispatcher(new EnvHttpProxyAgent());
+    // Many local proxies (Clash, Surge, etc.) close HTTP CONNECT tunnels after
+    // the first request, causing ECONNRESET on reuse. Disable keep-alive so
+    // undici opens a fresh tunnel per request instead of pooling.
+    setGlobalDispatcher(new EnvHttpProxyAgent({ connect: { keepAlive: false } }));
     lastAppliedProxyBootstrap = true;
   } catch {
     // Best-effort bootstrap only.
@@ -120,10 +123,11 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   const connect = resolveConnectOptions(autoSelectFamily);
   try {
     if (kind === "env-proxy") {
+      const proxyConnect = { keepAlive: false, ...connect };
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,
-        ...(connect ? { connect } : {}),
+        connect: proxyConnect,
       } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
       setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
     } else {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -123,7 +123,7 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   const connect = resolveConnectOptions(autoSelectFamily);
   try {
     if (kind === "env-proxy") {
-      const proxyConnect = { keepAlive: false, ...connect };
+      const proxyConnect = { ...connect, keepAlive: false };
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,


### PR DESCRIPTION
## Summary

- Bootstrap global `EnvHttpProxyAgent` in gateway startup so Node's `fetch()` honors `https_proxy`/`HTTP_PROXY` env vars — fixes Discord REST calls (command deployment, bot identity fetch) timing out behind local proxies
- Discord gateway plugin now falls back to env proxy vars for WebSocket connections when no explicit `channels.discord.proxy` is configured
- Disable `keepAlive` on all proxy `ProxyAgent` instances to prevent `ECONNRESET` from local proxies (Clash, Surge, etc.) that close HTTP CONNECT tunnels after one request

## Test plan

- [x] `pnpm test -- src/infra/net/undici-global-dispatcher.test.ts` passes (10/10)
- [x] `pnpm test -- extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts` passes (8/8)
- [ ] Manual: verify Discord gateway connects and responds to interactions behind a local proxy with `https_proxy` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)