### PR TITLE
fix(line): preserve underscores inside words in stripMarkdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - LINE/ACP: add current-conversation binding and inbound binding-routing parity so `/acp spawn ... --thread here`, configured ACP bindings, and active conversation-bound ACP sessions work on LINE like the other conversation channels.
+- LINE/markdown: preserve underscores inside Latin, Cyrillic, and CJK words when stripping markdown, while still removing standalone `_italic_` markers on the shared text-runtime path used by LINE and TTS. (#47465) Thanks @jackjin1997.
 - TTS/Microsoft: auto-switch the default Edge voice to Chinese for CJK-dominant text without overriding explicitly selected Microsoft voices. (#52355) Thanks @extrasmall0.
 - Agents/context pruning: count supplementary-plane CJK characters with the shared code-point-aware estimator so context pruning stops underestimating Japanese and Chinese text that uses Extension B ideographs. (#39985) Thanks @Edward-Qiang-2024.
 - macOS/local gateway: stop OpenClaw.app from killing healthy local gateway listeners after startup by recognizing the current `openclaw-gateway` process title and using the current `openclaw gateway` launch shape.

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -164,6 +164,12 @@ describe("stripMarkdown", () => {
     expect(stripMarkdown("foo_bar _italic_ baz_qux")).toBe("foo_bar italic baz_qux");
   });
 
+  it("preserves underscores inside non-Latin words", () => {
+    expect(stripMarkdown("привет_мир_тест")).toBe("привет_мир_тест");
+    expect(stripMarkdown("東京_駅_前")).toBe("東京_駅_前");
+    expect(stripMarkdown("var_123_end")).toBe("var_123_end");
+  });
+
   it("handles complex markdown", () => {
     const input = `# Title
 

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -148,6 +148,22 @@ describe("stripMarkdown", () => {
     }
   });
 
+  it("preserves underscores inside words", () => {
+    expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
+    expect(stripMarkdown("snake_case_var")).toBe("snake_case_var");
+    expect(stripMarkdown("use foo_bar_baz in code")).toBe("use foo_bar_baz in code");
+  });
+
+  it("still strips proper italic _text_", () => {
+    expect(stripMarkdown("This is _italic_ text")).toBe("This is italic text");
+    expect(stripMarkdown("_italic_ at start")).toBe("italic at start");
+    expect(stripMarkdown("end _italic_")).toBe("end italic");
+  });
+
+  it("strips italic between underscored words", () => {
+    expect(stripMarkdown("foo_bar _italic_ baz_qux")).toBe("foo_bar italic baz_qux");
+  });
+
   it("handles complex markdown", () => {
     const input = `# Title
 

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -170,6 +170,10 @@ describe("stripMarkdown", () => {
     expect(stripMarkdown("var_123_end")).toBe("var_123_end");
   });
 
+  it("strips standalone italic between non-Latin words", () => {
+    expect(stripMarkdown("こんにちは _italic_ テスト")).toBe("こんにちは italic テスト");
+  });
+
   it("handles complex markdown", () => {
     const input = `# Title
 

--- a/src/shared/text/strip-markdown.ts
+++ b/src/shared/text/strip-markdown.ts
@@ -9,7 +9,7 @@ export function stripMarkdown(text: string): string {
   result = result.replace(/__(.+?)__/g, "$1");
 
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
+  result = result.replace(/(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)/g, "$1");
 
   result = result.replace(/~~(.+?)~~/g, "$1");
   result = result.replace(/^#{1,6}\s+(.+)$/gm, "$1");

--- a/src/shared/text/strip-markdown.ts
+++ b/src/shared/text/strip-markdown.ts
@@ -9,7 +9,7 @@ export function stripMarkdown(text: string): string {
   result = result.replace(/__(.+?)__/g, "$1");
 
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)/g, "$1");
+  result = result.replace(/(?<![\p{L}\p{N}])_(?!_)(.+?)(?<!_)_(?![\p{L}\p{N}])/gu, "$1");
 
   result = result.replace(/~~(.+?)~~/g, "$1");
   result = result.replace(/^#{1,6}\s+(.+)$/gm, "$1");

--- a/src/tts/prepare-text.test.ts
+++ b/src/tts/prepare-text.test.ts
@@ -23,6 +23,8 @@ describe("TTS text preparation – stripMarkdown", () => {
 
   it("preserves underscores inside words while still stripping italic markers", () => {
     expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
+    expect(stripMarkdown("привет_мир_тест")).toBe("привет_мир_тест");
+    expect(stripMarkdown("東京_駅_前")).toBe("東京_駅_前");
     expect(stripMarkdown("use foo_bar_baz and _italic_ text")).toBe(
       "use foo_bar_baz and italic text",
     );

--- a/src/tts/prepare-text.test.ts
+++ b/src/tts/prepare-text.test.ts
@@ -21,6 +21,13 @@ describe("TTS text preparation – stripMarkdown", () => {
     );
   });
 
+  it("preserves underscores inside words while still stripping italic markers", () => {
+    expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
+    expect(stripMarkdown("use foo_bar_baz and _italic_ text")).toBe(
+      "use foo_bar_baz and italic text",
+    );
+  });
+
   it("strips inline code markers before TTS", () => {
     expect(stripMarkdown("Use `consistent hashing` for distribution")).toBe(
       "Use consistent hashing for distribution",


### PR DESCRIPTION
## Summary
- The italic-underscore regex in `stripMarkdown` incorrectly stripped underscores inside snake_case words (e.g. `here_is_a_message` → `herisamessage`).
- Tighten lookbehind/lookahead from `(?<!_)` / `(?!_)` to `(?<!\w)` / `(?!\w)` so only standalone `_italic_` markers are removed.
- Added 3 test cases covering underscore preservation and proper italic stripping.

Fixes #46185

## Test plan
- [x] `pnpm test src/line/markdown-to-line.test.ts` — 18/18 pass
- [x] New tests verify `snake_case_var`, `here_is_a_message` preserved
- [x] Existing italic stripping tests still pass