### PR TITLE
CLI: trim onboarding provider startup imports

### DIFF
--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -10,7 +10,7 @@ import {
   buildXiaomiProvider,
   QIANFAN_DEFAULT_MODEL_ID,
   XIAOMI_DEFAULT_MODEL_ID,
-} from "../agents/models-config.providers.js";
+} from "../agents/models-config.providers.static.js";
 import {
   buildSyntheticModelDefinition,
   SYNTHETIC_BASE_URL,

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -1,4 +1,7 @@
-import { QIANFAN_BASE_URL, QIANFAN_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
+import {
+  QIANFAN_BASE_URL,
+  QIANFAN_DEFAULT_MODEL_ID,
+} from "../agents/models-config.providers.static.js";
 import type { ModelDefinitionConfig } from "../config/types.js";
 import {
   KILOCODE_DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## Summary

- Problem: onboarding model/config helpers were still importing `src/agents/models-config.providers.ts` for static constants and static provider builders.
- Why it matters: `src/agents/models-config.providers.ts` pulls `src/plugins/provider-discovery.ts`, which pulls `src/plugins/providers.ts`, which pulls `src/plugins/loader.ts`. That is the same eager startup pattern behind recent low-memory/OOM cleanup work.
- What changed: point onboarding imports at `src/agents/models-config.providers.static.ts` instead of the heavyweight provider-discovery entrypoint.
- What did NOT change: provider discovery behavior, onboarding behavior, model defaults, and plugin loading behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] UI / DX
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45064
- Related #46522
- Related #46784

## User-visible / Behavior Changes

- No user-facing behavior change intended.
- Onboarding startup avoids one unnecessary path through plugin/provider discovery.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS 15.6.1 arm64
- Runtime/container: Node 22.20.0
- Model/provider: onboarding config/model helpers
- Integration/channel (if any): N/A
- Relevant config (redacted): default repo checkout

### Steps

1. Build with `pnpm build`.
2. Run `pnpm test -- src/commands/onboard-auth.test.ts src/commands/onboard-auth.config-core.kilocode.test.ts`.
3. Run `pnpm check`.
4. Inspect the changed imports to verify onboarding no longer references `src/agents/models-config.providers.ts`.

### Expected

- Onboarding helper modules should depend only on static provider definitions when they only need static constants/builders.
- Tests and repo checks should stay green.

### Actual

- `src/commands/onboard-auth.models.ts` now imports Qianfan constants from `src/agents/models-config.providers.static.ts`.
- `src/commands/onboard-auth.config-core.ts` now imports static provider builders/default IDs from `src/agents/models-config.providers.static.ts`.
- `pnpm test -- src/commands/onboard-auth.test.ts src/commands/onboard-auth.config-core.kilocode.test.ts`, `pnpm build`, and `pnpm check` passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted onboarding tests, full build, full `pnpm check`, and import-path inspection confirming the onboarding files no longer import `src/agents/models-config.providers.ts`.
- Edge cases checked: static Qianfan/Xiaomi defaults and static provider builders remain sourced from the same underlying static module.
- What you did **not** verify: a dedicated before/after RSS measurement for a full onboarding command on a constrained host.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/commands/onboard-auth.models.ts`, `src/commands/onboard-auth.config-core.ts`
- Known bad symptoms reviewers should watch for: onboarding provider defaults not populating as expected.

## Risks and Mitigations

- Risk: a static onboarding path may have been implicitly relying on side effects from the heavyweight provider module.
- Mitigation: the changed imports now point at the underlying static module that actually defines these builders/constants, and targeted onboarding tests still pass.

- Risk: other constant/helper-only imports from heavyweight provider/plugin entrypoints may still exist elsewhere.
- Mitigation: this PR trims one confirmed onboarding edge and keeps the next memory follow-up easy to isolate.
