### PR TITLE
feat(skills): compact format fallback for skill catalog truncation

### DIFF
--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -5,12 +5,12 @@ import { getSessionBindingService } from "../../../src/infra/outbound/session-bi
 import {
   buildAgentSessionKey,
   deriveLastRoutePolicy,
-  pickFirstExistingAgentId,
   resolveAgentRoute,
 } from "../../../src/routing/resolve-route.js";
 import {
   buildAgentMainSessionKey,
   resolveAgentIdFromSessionKey,
+  sanitizeAgentId,
 } from "../../../src/routing/session-key.js";
 import {
   buildTelegramGroupPeerId,
@@ -56,7 +56,10 @@ export function resolveTelegramConversationRoute(params: {
 
   const rawTopicAgentId = params.topicAgentId?.trim();
   if (rawTopicAgentId) {
-    const topicAgentId = pickFirstExistingAgentId(params.cfg, rawTopicAgentId);
+    // Preserve the configured topic agentId as-is — even if it doesn't match
+    // a known agent — so operators can route topics to agents that may be
+    // registered later or managed externally.
+    const topicAgentId = sanitizeAgentId(rawTopicAgentId);
     route = {
       ...route,
       agentId: topicAgentId,

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,0 +1,139 @@
+import { formatSkillsForPrompt, type Skill } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { SkillEntry } from "./types.js";
+import { formatSkillsCompact, buildWorkspaceSkillsPrompt } from "./workspace.js";
+
+function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/SKILL.md`): Skill {
+  return {
+    name,
+    description: desc,
+    filePath,
+    baseDir: `/skills/${name}`,
+    source: "workspace",
+    disableModelInvocation: false,
+  };
+}
+
+function makeEntry(skill: Skill): SkillEntry {
+  return { skill, frontmatter: {} };
+}
+
+function buildPrompt(
+  skills: Skill[],
+  limits: { maxChars?: number; maxCount?: number } = {},
+): string {
+  return buildWorkspaceSkillsPrompt("/fake", {
+    entries: skills.map(makeEntry),
+    config: {
+      skills: {
+        limits: {
+          ...(limits.maxChars !== undefined && { maxSkillsPromptChars: limits.maxChars }),
+          ...(limits.maxCount !== undefined && { maxSkillsInPrompt: limits.maxCount }),
+        },
+      },
+    } as any,
+  });
+}
+
+describe("formatSkillsCompact", () => {
+  it("returns empty string for no skills", () => {
+    expect(formatSkillsCompact([])).toBe("");
+  });
+
+  it("omits description, keeps name and location", () => {
+    const out = formatSkillsCompact([makeSkill("weather", "Get weather data")]);
+    expect(out).toContain("<name>weather</name>");
+    expect(out).toContain("<location>/skills/weather/SKILL.md</location>");
+    expect(out).not.toContain("Get weather data");
+    expect(out).not.toContain("<description>");
+  });
+
+  it("filters out disableModelInvocation skills", () => {
+    const hidden: Skill = { ...makeSkill("hidden"), disableModelInvocation: true };
+    const out = formatSkillsCompact([makeSkill("visible"), hidden]);
+    expect(out).toContain("visible");
+    expect(out).not.toContain("hidden");
+  });
+
+  it("escapes XML special characters", () => {
+    const out = formatSkillsCompact([makeSkill("a<b&c")]);
+    expect(out).toContain("a&lt;b&amp;c");
+  });
+
+  it("is significantly smaller than full format", () => {
+    const skills = Array.from({ length: 50 }, (_, i) =>
+      makeSkill(`skill-${i}`, "A moderately long description that takes up space in the prompt"),
+    );
+    const compact = formatSkillsCompact(skills);
+    expect(compact.length).toBeLessThan(6000);
+  });
+});
+
+describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
+  it("tier 1: uses full format when under budget", () => {
+    const skills = [makeSkill("weather", "Get weather data")];
+    const prompt = buildPrompt(skills, { maxChars: 50_000 });
+    expect(prompt).toContain("<description>");
+    expect(prompt).toContain("Get weather data");
+    expect(prompt).not.toContain("⚠️");
+  });
+
+  it("tier 2: compact when full exceeds budget but compact fits", () => {
+    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const fullLen = formatSkillsForPrompt(skills).length;
+    const compactLen = formatSkillsCompact(skills).length;
+    const budget = Math.floor((fullLen + compactLen) / 2);
+    const prompt = buildPrompt(skills, { maxChars: budget });
+    expect(prompt).not.toContain("<description>");
+    // All skills preserved — distinct message, no "included X of Y"
+    expect(prompt).toContain("compact format (descriptions omitted)");
+    expect(prompt).not.toContain("included");
+    expect(prompt).toContain("skill-0");
+    expect(prompt).toContain("skill-19");
+  });
+
+  it("tier 3: compact + binary search when compact also exceeds budget", () => {
+    const skills = Array.from({ length: 100 }, (_, i) => makeSkill(`skill-${i}`, "description"));
+    const prompt = buildPrompt(skills, { maxChars: 2000 });
+    expect(prompt).toContain("compact format, descriptions omitted");
+    expect(prompt).not.toContain("<description>");
+    expect(prompt).toContain("skill-0");
+    const match = prompt.match(/included (\d+) of (\d+)/);
+    expect(match).toBeTruthy();
+    expect(Number(match![1])).toBeLessThan(Number(match![2]));
+    expect(Number(match![1])).toBeGreaterThan(0);
+  });
+
+  it("compact preserves all skills where full format would drop some", () => {
+    const skills = Array.from({ length: 50 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const compactLen = formatSkillsCompact(skills).length;
+    const prompt = buildPrompt(skills, { maxChars: compactLen + 100 });
+    // All 50 fit in compact — no truncation, just compact notice
+    expect(prompt).toContain("compact format");
+    expect(prompt).not.toContain("included");
+    expect(prompt).toContain("skill-0");
+    expect(prompt).toContain("skill-49");
+  });
+
+  it("count truncation + compact: shows included X of Y with compact note", () => {
+    // 30 skills but maxCount=10, and full format of 10 exceeds budget
+    const skills = Array.from({ length: 30 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const tenSkills = skills.slice(0, 10);
+    const fullLen = formatSkillsForPrompt(tenSkills).length;
+    const compactLen = formatSkillsCompact(tenSkills).length;
+    const budget = Math.floor((fullLen + compactLen) / 2);
+    const prompt = buildPrompt(skills, { maxChars: budget, maxCount: 10 });
+    // Count-truncated (30→10) AND compact
+    expect(prompt).toContain("included 10 of 30");
+    expect(prompt).toContain("compact format, descriptions omitted");
+    expect(prompt).not.toContain("<description>");
+  });
+
+  it("count truncation only: shows included X of Y without compact note", () => {
+    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "short"));
+    const prompt = buildPrompt(skills, { maxChars: 50_000, maxCount: 5 });
+    expect(prompt).toContain("included 5 of 20");
+    expect(prompt).not.toContain("compact");
+    expect(prompt).toContain("<description>");
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -526,10 +526,45 @@ function loadSkillEntries(
   return skillEntries;
 }
 
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Compact skill catalog: name + location only (no description).
+ * Used as a fallback when the full format exceeds the char budget,
+ * preserving awareness of all skills before resorting to dropping.
+ */
+export function formatSkillsCompact(skills: Skill[]): string {
+  const visible = skills.filter((s) => !s.disableModelInvocation);
+  if (visible.length === 0) return "";
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    "Use the read tool to load a skill's file when the task matches its name.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of visible) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}
+
 function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawConfig }): {
   skillsForPrompt: Skill[];
   truncated: boolean;
   truncatedReason: "count" | "chars" | null;
+  compact: boolean;
 } {
   const limits = resolveSkillsLimits(params.config);
   const total = params.skills.length;
@@ -538,30 +573,40 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
   let skillsForPrompt = byCount;
   let truncated = total > byCount.length;
   let truncatedReason: "count" | "chars" | null = truncated ? "count" : null;
+  let compact = false;
 
-  const fits = (skills: Skill[]): boolean => {
-    const block = formatSkillsForPrompt(skills);
-    return block.length <= limits.maxSkillsPromptChars;
-  };
+  const fitsFull = (skills: Skill[]): boolean =>
+    formatSkillsForPrompt(skills).length <= limits.maxSkillsPromptChars;
 
-  if (!fits(skillsForPrompt)) {
-    // Binary search the largest prefix that fits in the char budget.
-    let lo = 0;
-    let hi = skillsForPrompt.length;
-    while (lo < hi) {
-      const mid = Math.ceil((lo + hi) / 2);
-      if (fits(skillsForPrompt.slice(0, mid))) {
-        lo = mid;
-      } else {
-        hi = mid - 1;
+  const fitsCompact = (skills: Skill[]): boolean =>
+    formatSkillsCompact(skills).length <= limits.maxSkillsPromptChars;
+
+  if (!fitsFull(skillsForPrompt)) {
+    // Full format exceeds budget. Try compact (name + location, no description)
+    // to preserve awareness of all skills before dropping any.
+    if (fitsCompact(skillsForPrompt)) {
+      compact = true;
+      // No skills dropped — only format downgraded. Preserve existing truncated state.
+    } else {
+      // Compact still too large — binary search the largest prefix that fits.
+      compact = true;
+      let lo = 0;
+      let hi = skillsForPrompt.length;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(skillsForPrompt.slice(0, mid))) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
       }
+      skillsForPrompt = skillsForPrompt.slice(0, lo);
+      truncated = true;
+      truncatedReason = "chars";
     }
-    skillsForPrompt = skillsForPrompt.slice(0, lo);
-    truncated = true;
-    truncatedReason = "chars";
   }
 
-  return { skillsForPrompt, truncated, truncatedReason };
+  return { skillsForPrompt, truncated, truncatedReason, compact };
 }
 
 export function buildWorkspaceSkillSnapshot(
@@ -620,17 +665,20 @@ function resolveWorkspaceSkillPromptState(
   );
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
-  const { skillsForPrompt, truncated } = applySkillsPromptLimits({
+  const { skillsForPrompt, truncated, compact } = applySkillsPromptLimits({
     skills: resolvedSkills,
     config: opts?.config,
   });
   const truncationNote = truncated
-    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}. Run \`openclaw skills check\` to audit.`
-    : "";
+    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}${compact ? " (compact format, descriptions omitted)" : ""}. Run \`openclaw skills check\` to audit.`
+    : compact
+      ? `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`
+      : "";
+  const compacted = compactSkillPaths(skillsForPrompt);
   const prompt = [
     remoteNote,
     truncationNote,
-    formatSkillsForPrompt(compactSkillPaths(skillsForPrompt)),
+    compact ? formatSkillsCompact(compacted) : formatSkillsForPrompt(compacted),
   ]
     .filter(Boolean)
     .join("\n");


### PR DESCRIPTION
## Summary

- Problem: When the skill catalog exceeds `maxSkillsPromptChars` (default 30K), `applySkillsPromptLimits` uses binary search to find the largest prefix that fits, silently dropping skills at the end. Users have no visibility into which skills were cut, and the agent loses all awareness of dropped skills.
- Why it matters: Users with many skills (50+) lose skill coverage without knowing it. The agent cannot even discover dropped skills exist, let alone read their SKILL.md on demand. This defeats the progressive disclosure pattern where the catalog is a lightweight index and full instructions are loaded on demand.
- What changed: Added a compact format fallback (name + location only, no description) that is tried before binary-search truncation. This preserves awareness of all skills while saving ~63% chars per skill. Three-tier strategy: (1) full format fits → use full, (2) full exceeds budget but compact fits → use compact with all skills, (3) compact still too large → compact + binary search.
- What did NOT change (scope boundary): No new config options, no new tools, no changes to `formatSkillsForPrompt` in pi-coding-agent. Default behavior is unchanged when skills fit in full format.

### Additional fix: Telegram topic routing regression (#46817)

This PR also includes a one-line fix for a pre-existing test regression introduced in #46817. The `resolveTelegramConversationRoute` function used `pickFirstExistingAgentId` for topic-based agent routing, which falls back to the default agent (`main`) when the configured topic agentId isn't in the known agent list. This broke the design intent: operators should be able to route topics to agents that may be registered later or managed externally. The fix replaces `pickFirstExistingAgentId` with `sanitizeAgentId`, which preserves the configured agentId as-is (only sanitizing format). All 6 existing topic routing tests pass with this fix; they fail on current `main`.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #26301
- Related #29267
- Fixes test regression from #46817

## User-visible / Behavior Changes

- When skill catalog exceeds char budget, the truncation warning now includes "(compact format, descriptions omitted)" to indicate the fallback was used.
- In compact mode, skill entries show name + location only (no description). The agent can still read any skill's SKILL.md via the read tool.
- More skills are preserved in the prompt before any are dropped.
- Telegram topic routing now preserves unknown agentIds instead of falling back to the default agent.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Model/provider: Any
- Relevant config: `maxSkillsPromptChars: 30000` (default)

### Steps

1. Configure 100+ skills (or set `maxSkillsPromptChars` to a low value like 5000)
2. Start a session and observe the skills prompt

### Expected

- All skills appear in compact format (name + location) when full format exceeds budget
- Truncation warning includes "(compact format, descriptions omitted)"

### Actual (before this PR)

- Skills at the end of the list are silently dropped entirely

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Token savings measured:
- 33 skills full: 7138 chars → compact: 2660 chars (63% reduction)
- 50 skills compact format: < 6000 chars (verified by test)

## Human Verification (required)

- Verified scenarios: Full format under budget (no change), full over budget but compact fits (all skills preserved), both over budget (compact + binary search)
- Edge cases checked: Empty skills list, `disableModelInvocation` filtering, XML special characters in skill names
- What you did **not** verify: Integration test with live gateway (unit tests only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## AI-Assisted

- [x] This PR was AI-assisted (Kiro CLI agent)
- Testing: fully tested (11 unit/integration tests for compact format, 6 telegram topic routing tests)
- I understand what the code does

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/skills/workspace.ts`
- Known bad symptoms reviewers should watch for: Skills prompt missing descriptions when it shouldn't be (would indicate the char budget check is wrong)

## Risks and Mitigations

- Risk: Compact format (no descriptions) may reduce skill matching accuracy for the agent.
  - Mitigation: This only activates when the alternative is dropping skills entirely. Having name + location with no description is strictly better than not having the skill at all. The agent can still read the SKILL.md to discover what the skill does.