### PR TITLE
docker: fix docker-setup.sh .env handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ ui/src/ui/__screenshots__
 ui/src/ui/views/__screenshots__
 ui/.vitest-attachments
 docs/superpowers
+docker-compose.override.yml

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load .env if present so variables like OPENCLAW_DOCKER_APT_PACKAGES are available
+if [[ -f "$ROOT_DIR/.env" ]]; then
+set -a
+# shellcheck source=/dev/null
+source "$ROOT_DIR/.env"
+set +a
+fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
 IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
@@ -382,6 +389,14 @@ upsert_env() {
   # Use a delimited string instead of an associative array so the script
   # works with Bash 3.2 (macOS default) which lacks `declare -A`.
   local seen=" "
+  _write_kv() {
+    local _k="$1" _v="$2"
+    if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
+      printf '%s="%s"\n' "$_k" "$_v" >>"$tmp"
+    else
+      printf '%s=%s\n' "$_k" "$_v" >>"$tmp"
+    fi
+  }
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -389,7 +404,7 @@ upsert_env() {
       local replaced=false
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
-          printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
+          _write_kv "$k" "${!k-}"
           seen="$seen$k "
           replaced=true
           break
@@ -403,7 +418,7 @@ upsert_env() {
 
   for k in "${keys[@]}"; do
     if [[ "$seen" != *" $k "* ]]; then
-      printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
+      _write_kv "$k" "${!k-}"
     fi
   done
 

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -2,12 +2,28 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Load .env if present so variables like OPENCLAW_DOCKER_APT_PACKAGES are available
+# Load .env if present so variables like OPENCLAW_DOCKER_APT_PACKAGES are available.
+# Only sets variables not already in the environment so explicit CLI overrides
+# (e.g. OPENCLAW_IMAGE=foo ./docker-setup.sh) take precedence over .env defaults.
+# Parses the file manually to avoid executing unquoted words as shell commands.
 if [[ -f "$ROOT_DIR/.env" ]]; then
-  set -a
-  # shellcheck source=/dev/null
-  source "$ROOT_DIR/.env"
-  set +a
+  while IFS= read -r _env_line || [[ -n "$_env_line" ]]; do
+    _env_line="${_env_line%$'\r'}"
+    [[ -z "$_env_line" || "$_env_line" == '#'* ]] && continue
+    _env_key="${_env_line%%=*}"
+    _env_val="${_env_line#*=}"
+    if [[ "$_env_val" == '"'*'"' ]]; then
+      _env_val="${_env_val%'"'}"
+      _env_val="${_env_val#'"'}"
+    elif [[ "$_env_val" == "'"*"'" ]]; then
+      _env_val="${_env_val%"'"}"
+      _env_val="${_env_val#"'"}"
+    fi
+    if [[ -n "$_env_key" && -z "${!_env_key+x}" ]]; then
+      export "$_env_key=$_env_val"
+    fi
+  done < "$ROOT_DIR/.env"
+  unset _env_line _env_key _env_val
 fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -19,7 +19,8 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
       _env_val="${_env_val%"'"}"
       _env_val="${_env_val#"'"}"
     fi
-    if [[ -n "$_env_key" && -z "${!_env_key+x}" ]]; then
+    # Skip invalid identifiers (indented comments, "export KEY=val" lines, keys with hyphens, etc.)
+    if [[ "$_env_key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ && -z "${!_env_key+x}" ]]; then
       export "$_env_key=$_env_val"
     fi
   done < "$ROOT_DIR/.env"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -25,6 +25,7 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
       _env_val="${_env_val%'"'}"
       _env_val="${_env_val#'"'}"
       _env_val="${_env_val//\\"/"}"
+      _env_val="${_env_val//\\\\/\\}"
     elif [[ "$_env_val" == "'"*"'" ]]; then
       _env_val="${_env_val%"'"}"
       _env_val="${_env_val#"'"}"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -23,7 +23,7 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
     if [[ "$_env_val" == '"'*'"' ]]; then
       _env_val="${_env_val%'"'}"
       _env_val="${_env_val#'"'}"
-      _env_val="${_env_val//\"/"}"
+      _env_val="${_env_val//\\"/"}"
     elif [[ "$_env_val" == "'"*"'" ]]; then
       _env_val="${_env_val%"'"}"
       _env_val="${_env_val#"'"}"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Load .env if present so variables like OPENCLAW_DOCKER_APT_PACKAGES are available
 if [[ -f "$ROOT_DIR/.env" ]]; then
-set -a
-# shellcheck source=/dev/null
-source "$ROOT_DIR/.env"
-set +a
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
 fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
@@ -392,7 +392,7 @@ upsert_env() {
   _write_kv() {
     local _k="$1" _v="$2"
     if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
-      printf '%s="%s"\n' "$_k" "$_v" >>"$tmp"
+      printf '%s="%s"\n' "$_k" "${_v//"/\\"}" >>"$tmp"
     else
       printf '%s=%s\n' "$_k" "$_v" >>"$tmp"
     fi

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -410,7 +410,7 @@ done
 ENV_FILE="$ROOT_DIR/.env"
 _write_kv() {
   local _k="$1" _v="$2" _file="$3"
-  if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
+  if [[ "$_v" == *' '* || "$_v" == *$'\t'* || "$_v" == *'"'* ]]; then
     _v="${_v//\\/\\\\}"
     printf '%s="%s"\n' "$_k" "${_v//"/\\"}" >>"$_file"
   else

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -11,6 +11,7 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
     _env_line="${_env_line%$'\r'}"
     [[ -z "$_env_line" || "$_env_line" == '#'* ]] && continue
     _env_key="${_env_line%%=*}"
+    [[ "$_env_line" != *'='* ]] && continue
     _env_val="${_env_line#*=}"
     # Strip unquoted inline comments BEFORE removing surrounding quotes.
     # A comment marker outside quotes (KEY=val # note) is removed here.
@@ -409,6 +410,7 @@ ENV_FILE="$ROOT_DIR/.env"
 _write_kv() {
   local _k="$1" _v="$2" _file="$3"
   if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
+    _v="${_v//\\/\\\\}"
     printf '%s="%s"\n' "$_k" "${_v//"/\\"}" >>"$_file"
   else
     printf '%s=%s\n' "$_k" "$_v" >>"$_file"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -20,6 +20,9 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
       _env_val="${_env_val#"'"}"
     fi
     # Skip invalid identifiers (indented comments, "export KEY=val" lines, keys with hyphens, etc.)
+    # Strip inline comments (e.g. KEY=val # note) and trailing whitespace.
+    _env_val="${_env_val%%\ \#*}"
+    _env_val="${_env_val%"${_env_val##*[! ]}"}"
     if [[ "$_env_key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ && -z "${!_env_key+x}" ]]; then
       export "$_env_key=$_env_val"
     fi
@@ -397,6 +400,14 @@ for compose_file in "${COMPOSE_FILES[@]}"; do
 done
 
 ENV_FILE="$ROOT_DIR/.env"
+_write_kv() {
+  local _k="$1" _v="$2" _file="$3"
+  if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
+    printf '%s="%s"\n' "$_k" "${_v//"/\\"}" >>"$_file"
+  else
+    printf '%s=%s\n' "$_k" "$_v" >>"$_file"
+  fi
+}
 upsert_env() {
   local file="$1"
   shift
@@ -406,14 +417,7 @@ upsert_env() {
   # Use a delimited string instead of an associative array so the script
   # works with Bash 3.2 (macOS default) which lacks `declare -A`.
   local seen=" "
-  _write_kv() {
-    local _k="$1" _v="$2"
-    if [[ "$_v" == *' '* || "$_v" == *$'\t'* ]]; then
-      printf '%s="%s"\n' "$_k" "${_v//"/\\"}" >>"$tmp"
-    else
-      printf '%s=%s\n' "$_k" "$_v" >>"$tmp"
-    fi
-  }
+
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -421,7 +425,7 @@ upsert_env() {
       local replaced=false
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
-          _write_kv "$k" "${!k-}"
+          _write_kv "$k" "${!k-}" "$tmp"
           seen="$seen$k "
           replaced=true
           break
@@ -435,7 +439,7 @@ upsert_env() {
 
   for k in "${keys[@]}"; do
     if [[ "$seen" != *" $k "* ]]; then
-      _write_kv "$k" "${!k-}"
+      _write_kv "$k" "${!k-}" "$tmp"
     fi
   done
 

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -12,17 +12,23 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
     [[ -z "$_env_line" || "$_env_line" == '#'* ]] && continue
     _env_key="${_env_line%%=*}"
     _env_val="${_env_line#*=}"
+    # Strip unquoted inline comments BEFORE removing surrounding quotes.
+    # A comment marker outside quotes (KEY=val # note) is removed here.
+    # A marker inside quotes (KEY="val # not-a-comment") is protected.
+    if [[ "$_env_val" != '"'*'"' && "$_env_val" != "'"*"'" ]]; then
+      _env_val="${_env_val%%' #'*}"
+      _env_val="${_env_val%"${_env_val##*[! ]}"}"
+    fi
+    # Strip surrounding quotes and unescape any escaped double-quotes.
     if [[ "$_env_val" == '"'*'"' ]]; then
       _env_val="${_env_val%'"'}"
       _env_val="${_env_val#'"'}"
+      _env_val="${_env_val//\"/"}"
     elif [[ "$_env_val" == "'"*"'" ]]; then
       _env_val="${_env_val%"'"}"
       _env_val="${_env_val#"'"}"
     fi
-    # Skip invalid identifiers (indented comments, "export KEY=val" lines, keys with hyphens, etc.)
-    # Strip inline comments (e.g. KEY=val # note) and trailing whitespace.
-    _env_val="${_env_val%%\ \#*}"
-    _env_val="${_env_val%"${_env_val##*[! ]}"}"
+    # Skip invalid bash identifiers (indented comments, "export KEY=val", hyphens, etc.)
     if [[ "$_env_key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ && -z "${!_env_key+x}" ]]; then
       export "$_env_key=$_env_val"
     fi

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -480,6 +480,7 @@ if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
     --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
     --build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}" \
     --build-arg "OPENCLAW_INSTALL_DOCKER_CLI=${OPENCLAW_INSTALL_DOCKER_CLI:-}" \
+    --build-arg "OPENCLAW_INSTALL_BROWSER=${OPENCLAW_INSTALL_BROWSER:-}" \
     -t "$IMAGE_NAME" \
     -f "$ROOT_DIR/Dockerfile" \
     "$ROOT_DIR"


### PR DESCRIPTION
## Problem

Two related issues with `docker-setup.sh` and `.env` handling:

### 1. `docker-setup.sh` does not source `.env`

Variables defined in `.env` (e.g. `OPENCLAW_DOCKER_APT_PACKAGES`, `OPENCLAW_INSTALL_BROWSER`) were silently ignored unless the caller manually ran `source .env` before invoking `docker-setup.sh`. This is a common footgun — the file exists and looks authoritative, but has no effect on the build.

### 2. `upsert_env()` strips quotes from whitespace-containing values

`upsert_env()` rewrites `.env` using bare `printf '%s=%s\n'`, which drops quotes. After a `docker-setup.sh` run, a value like:

```
OPENCLAW_DOCKER_APT_PACKAGES="jq ripgrep"
```

becomes:

```
OPENCLAW_DOCKER_APT_PACKAGES=jq ripgrep
```

On the next invocation, `source .env` fails with `command not found: ripgrep`, silently breaking multi-package build args.

## Fix

- **Source `.env` at startup** using `set -a / source / set +a` so all `.env` variables are exported before the script proceeds.
- **Add `_write_kv()` helper** in `upsert_env()` that wraps values containing spaces or tabs in double quotes when writing back to `.env`.

## Testing

```bash
echo 'OPENCLAW_DOCKER_APT_PACKAGES="jq ripgrep"' >> .env
echo 'OPENCLAW_INSTALL_BROWSER=1' >> .env
./docker-setup.sh
grep -E 'APT_PACKAGES|INSTALL_BROWSER' .env
# Expected: values preserved with quotes intact
```