### PR TITLE
feat: add sessions_broadcast tool for cross-session system events

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -17,6 +17,7 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
+import { createSessionsBroadcastTool } from "./tools/sessions-broadcast-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
@@ -180,6 +181,12 @@ export function createOpenClawTools(
       config: options?.config,
     }),
     createSessionsSendTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentChannel: options?.agentChannel,
+      sandboxed: options?.sandboxed,
+      config: options?.config,
+    }),
+    createSessionsBroadcastTool({
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
       sandboxed: options?.sandboxed,

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -138,6 +138,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "sessions_broadcast",
+    label: "sessions_broadcast",
+    description: "Broadcast to all sessions",
+    sectionId: "sessions",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_spawn",
     label: "sessions_spawn",
     description: "Spawn sub-agent",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -142,7 +142,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "sessions_broadcast",
     description: "Broadcast to all sessions",
     sectionId: "sessions",
-    profiles: ["coding"],
+    profiles: ["coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/agents/tools/sessions-broadcast-tool.test.ts
+++ b/src/agents/tools/sessions-broadcast-tool.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      tools: {
+        sessions: { visibility: "all" },
+      },
+    }),
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import { createSessionsBroadcastTool } from "./sessions-broadcast-tool.js";
+
+const makeSessionsListResponse = (
+  sessions: Array<{
+    key: string;
+    kind?: string;
+    channel?: string;
+    lastChannel?: string;
+  }>,
+) => ({
+  sessions,
+  path: "/tmp/sessions.json",
+});
+
+describe("sessions_broadcast tool", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+  });
+
+  it("broadcasts to multiple sessions and skips self", async () => {
+    const agentKey = "agent:main:main";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([
+          { key: agentKey, kind: "direct", channel: "telegram" },
+          { key: "agent:main:telegram:group:123", kind: "group", channel: "telegram" },
+          { key: "agent:main:discord:group:456", kind: "group", channel: "discord" },
+        ]);
+      }
+      if (req.method === "agent") {
+        return { runId: "run-1" };
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({
+      agentSessionKey: agentKey,
+      agentChannel: "telegram",
+    });
+
+    const result = await tool.execute("call-1", { message: "System update ready" });
+    const details = result.details as {
+      status?: string;
+      sent?: number;
+      sessions?: string[];
+    };
+
+    expect(details.status).toBe("ok");
+    // Self is excluded, so only 2 sessions should receive the broadcast
+    expect(details.sent).toBe(2);
+    expect(details.sessions).toHaveLength(2);
+
+    // Verify self was not broadcast to
+    const agentCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string }).method === "agent",
+    );
+    const targets = agentCalls.map(
+      (call) => (call[0] as { params?: { sessionKey?: string } }).params?.sessionKey,
+    );
+    expect(targets).not.toContain(agentKey);
+  });
+
+  it("skips the current session (does not broadcast to self)", async () => {
+    const selfKey = "agent:main:main";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([{ key: selfKey, kind: "direct", channel: "telegram" }]);
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({ agentSessionKey: selfKey });
+
+    const result = await tool.execute("call-2", { message: "hello" });
+    const details = result.details as { status?: string; sent?: number; sessions?: string[] };
+
+    expect(details.status).toBe("ok");
+    expect(details.sent).toBe(0);
+    expect(details.sessions).toHaveLength(0);
+
+    // No agent calls should have been made
+    const agentCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string }).method === "agent",
+    );
+    expect(agentCalls).toHaveLength(0);
+  });
+
+  it("scope filtering only sends to matching channel sessions", async () => {
+    const selfKey = "agent:main:main";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([
+          { key: selfKey, kind: "direct", channel: "telegram" },
+          { key: "agent:main:telegram:group:111", kind: "group", channel: "telegram" },
+          { key: "agent:main:discord:group:222", kind: "group", channel: "discord" },
+          { key: "agent:main:whatsapp:group:333", kind: "group", channel: "whatsapp" },
+        ]);
+      }
+      if (req.method === "agent") {
+        return { runId: "run-scope" };
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({ agentSessionKey: selfKey });
+
+    // Broadcast only to discord
+    const result = await tool.execute("call-3", {
+      message: "discord only",
+      scope: "discord",
+    });
+    const details = result.details as { status?: string; sent?: number; sessions?: string[] };
+
+    expect(details.status).toBe("ok");
+    expect(details.sent).toBe(1);
+
+    const agentCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string }).method === "agent",
+    );
+    expect(agentCalls).toHaveLength(1);
+    expect(agentCalls[0]?.[0]).toMatchObject({
+      method: "agent",
+      params: {
+        sessionKey: "agent:main:discord:group:222",
+      },
+    });
+  });
+
+  it("returns correct count and session list", async () => {
+    const selfKey = "agent:main:main";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([
+          { key: selfKey, kind: "direct", channel: "telegram" },
+          { key: "agent:main:telegram:group:aaa", kind: "group", channel: "telegram" },
+          { key: "agent:main:telegram:group:bbb", kind: "group", channel: "telegram" },
+          { key: "agent:main:telegram:group:ccc", kind: "group", channel: "telegram" },
+        ]);
+      }
+      if (req.method === "agent") {
+        return { runId: "run-count" };
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({ agentSessionKey: selfKey });
+
+    const result = await tool.execute("call-4", { message: "count me" });
+    const details = result.details as { status?: string; sent?: number; sessions?: string[] };
+
+    expect(details.status).toBe("ok");
+    expect(details.sent).toBe(3);
+    expect(details.sessions).toHaveLength(3);
+  });
+
+  it("uses INTERNAL_MESSAGE_CHANNEL and fire-and-forget lane for all sends", async () => {
+    const selfKey = "agent:main:main";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([
+          { key: selfKey, kind: "direct", channel: "telegram" },
+          { key: "agent:main:telegram:group:x", kind: "group", channel: "telegram" },
+        ]);
+      }
+      if (req.method === "agent") {
+        return { runId: "run-ff" };
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({
+      agentSessionKey: selfKey,
+      agentChannel: "telegram",
+    });
+
+    await tool.execute("call-5", { message: "fire and forget" });
+
+    const agentCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string }).method === "agent",
+    );
+    expect(agentCalls).toHaveLength(1);
+    expect(agentCalls[0]?.[0]).toMatchObject({
+      method: "agent",
+      params: {
+        channel: "webchat",
+        lane: "nested",
+        deliver: false,
+        inputProvenance: {
+          kind: "broadcast",
+          sourceTool: "sessions_broadcast",
+        },
+      },
+    });
+  });
+
+  it("returns empty result when no sessions exist besides self", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "sessions.list") {
+        return makeSessionsListResponse([]);
+      }
+      return {};
+    });
+
+    const tool = createSessionsBroadcastTool({ agentSessionKey: "agent:main:main" });
+
+    const result = await tool.execute("call-6", { message: "nobody home" });
+    const details = result.details as {
+      status?: string;
+      sent?: number;
+      sessions?: string[];
+      message?: string;
+    };
+
+    expect(details.status).toBe("ok");
+    expect(details.sent).toBe(0);
+    expect(details.message).toBe("No sessions to broadcast to.");
+  });
+});

--- a/src/agents/tools/sessions-broadcast-tool.ts
+++ b/src/agents/tools/sessions-broadcast-tool.ts
@@ -1,0 +1,169 @@
+import crypto from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import {
+  type GatewayMessageChannel,
+  INTERNAL_MESSAGE_CHANNEL,
+} from "../../utils/message-channel.js";
+import { AGENT_LANE_NESTED } from "../lanes.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+import {
+  createAgentToAgentPolicy,
+  createSessionVisibilityGuard,
+  classifySessionKind,
+  deriveChannel,
+  resolveDisplaySessionKey,
+  resolveEffectiveSessionToolsVisibility,
+  resolveSandboxedSessionToolContext,
+  type SessionListRow,
+} from "./sessions-helpers.js";
+
+const SessionsBroadcastToolSchema = Type.Object({
+  message: Type.String(),
+  scope: Type.Optional(Type.String()),
+});
+
+export function createSessionsBroadcastTool(opts?: {
+  agentSessionKey?: string;
+  agentChannel?: GatewayMessageChannel;
+  sandboxed?: boolean;
+  config?: OpenClawConfig;
+}): AnyAgentTool {
+  return {
+    label: "Sessions Broadcast",
+    name: "sessions_broadcast",
+    description:
+      "Broadcast a system event to all active sessions. Use scope to target a specific channel (e.g. 'discord'), or omit (or use 'all') for all sessions.",
+    parameters: SessionsBroadcastToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const message = readStringParam(params, "message", { required: true });
+      const scopeRaw = readStringParam(params, "scope")?.trim().toLowerCase() || "all";
+
+      const cfg = opts?.config ?? loadConfig();
+      const { mainKey, alias, requesterInternalKey, restrictToSpawned } =
+        resolveSandboxedSessionToolContext({
+          cfg,
+          agentSessionKey: opts?.agentSessionKey,
+          sandboxed: opts?.sandboxed,
+        });
+      const effectiveRequesterKey = requesterInternalKey ?? alias;
+
+      const visibility = resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: opts?.sandboxed === true,
+      });
+
+      const a2aPolicy = createAgentToAgentPolicy(cfg);
+
+      // Fetch all sessions via gateway
+      const list = await callGateway<{ sessions: Array<SessionListRow> }>({
+        method: "sessions.list",
+        params: {
+          includeGlobal: !restrictToSpawned,
+          includeUnknown: !restrictToSpawned,
+          spawnedBy: restrictToSpawned ? effectiveRequesterKey : undefined,
+        },
+      });
+
+      const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
+
+      const visibilityGuard = await createSessionVisibilityGuard({
+        action: "send",
+        requesterSessionKey: effectiveRequesterKey,
+        visibility,
+        a2aPolicy,
+      });
+
+      // Build list of target sessions, filtering out self and applying scope
+      const targets: Array<{ internalKey: string; displayKey: string }> = [];
+
+      for (const entry of sessions) {
+        if (!entry || typeof entry !== "object") {
+          continue;
+        }
+        const key = typeof entry.key === "string" ? entry.key : "";
+        if (!key || key === "unknown" || key === "global") {
+          continue;
+        }
+
+        // Skip self
+        if (key === effectiveRequesterKey) {
+          continue;
+        }
+
+        // Visibility check
+        const access = visibilityGuard.check(key);
+        if (!access.allowed) {
+          continue;
+        }
+
+        // Derive display key (collapses alias/mainKey to "main")
+        const displayKey = resolveDisplaySessionKey({ key, alias, mainKey });
+
+        // Derive channel for scope filtering
+        const gatewayKind = typeof entry.kind === "string" ? entry.kind : undefined;
+        const kind = classifySessionKind({ key, gatewayKind, alias, mainKey });
+        const entryChannel = typeof entry.channel === "string" ? entry.channel : undefined;
+        const lastChannel = typeof entry.lastChannel === "string" ? entry.lastChannel : undefined;
+        const channel = deriveChannel({ key, kind, channel: entryChannel, lastChannel });
+
+        // Apply scope filter
+        if (scopeRaw !== "all" && channel !== scopeRaw) {
+          continue;
+        }
+
+        targets.push({ internalKey: key, displayKey });
+      }
+
+      if (targets.length === 0) {
+        return jsonResult({
+          status: "ok",
+          sent: 0,
+          sessions: [],
+          message: "No sessions to broadcast to.",
+        });
+      }
+
+      // Fire-and-forget: inject system event into each target session
+      const sentKeys: string[] = [];
+      const errors: Array<{ key: string; error: string }> = [];
+
+      for (const { internalKey, displayKey } of targets) {
+        try {
+          void callGateway({
+            method: "agent",
+            params: {
+              message,
+              sessionKey: internalKey,
+              idempotencyKey: crypto.randomUUID(),
+              deliver: false,
+              channel: INTERNAL_MESSAGE_CHANNEL,
+              lane: AGENT_LANE_NESTED,
+              inputProvenance: {
+                kind: "broadcast",
+                sourceSessionKey: opts?.agentSessionKey,
+                sourceChannel: opts?.agentChannel,
+                sourceTool: "sessions_broadcast",
+              },
+            },
+            timeoutMs: 10_000,
+          });
+          sentKeys.push(displayKey);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          errors.push({ key: displayKey, error: msg });
+        }
+      }
+
+      return jsonResult({
+        status: "ok",
+        sent: sentKeys.length,
+        sessions: sentKeys,
+        ...(errors.length > 0 ? { errors } : {}),
+      });
+    },
+  };
+}

--- a/src/agents/tools/sessions-broadcast-tool.ts
+++ b/src/agents/tools/sessions-broadcast-tool.ts
@@ -127,34 +127,49 @@ export function createSessionsBroadcastTool(opts?: {
         });
       }
 
-      // Fire-and-forget: inject system event into each target session
+      // Dispatch to all target sessions and await results for accurate delivery tracking
+      const promises = targets.map(({ internalKey, displayKey }) =>
+        callGateway({
+          method: "agent",
+          params: {
+            message,
+            sessionKey: internalKey,
+            idempotencyKey: crypto.randomUUID(),
+            deliver: false,
+            channel: INTERNAL_MESSAGE_CHANNEL,
+            lane: AGENT_LANE_NESTED,
+            inputProvenance: {
+              kind: "broadcast",
+              sourceSessionKey: opts?.agentSessionKey,
+              sourceChannel: opts?.agentChannel,
+              sourceTool: "sessions_broadcast",
+            },
+          },
+          timeoutMs: 10_000,
+        })
+          .then(() => ({ displayKey, ok: true as const }))
+          .catch((err: unknown) => ({
+            displayKey,
+            ok: false as const,
+            error: err instanceof Error ? err.message : String(err),
+          })),
+      );
+
+      const results = await Promise.allSettled(promises);
+
       const sentKeys: string[] = [];
       const errors: Array<{ key: string; error: string }> = [];
 
-      for (const { internalKey, displayKey } of targets) {
-        try {
-          void callGateway({
-            method: "agent",
-            params: {
-              message,
-              sessionKey: internalKey,
-              idempotencyKey: crypto.randomUUID(),
-              deliver: false,
-              channel: INTERNAL_MESSAGE_CHANNEL,
-              lane: AGENT_LANE_NESTED,
-              inputProvenance: {
-                kind: "broadcast",
-                sourceSessionKey: opts?.agentSessionKey,
-                sourceChannel: opts?.agentChannel,
-                sourceTool: "sessions_broadcast",
-              },
-            },
-            timeoutMs: 10_000,
-          });
-          sentKeys.push(displayKey);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          errors.push({ key: displayKey, error: msg });
+      for (const result of results) {
+        // allSettled never rejects individual items; each resolves to our shaped object
+        const value =
+          result.status === "fulfilled"
+            ? result.value
+            : { ok: false as const, displayKey: "unknown", error: String(result.reason) };
+        if (value.ok) {
+          sentKeys.push(value.displayKey);
+        } else {
+          errors.push({ key: value.displayKey, error: value.error });
         }
       }
 


### PR DESCRIPTION
## Summary

Adds a new `sessions_broadcast` tool that injects a system event message into all active sessions for the current agent. This enables cross-session state synchronization — when something fleet-wide changes in one session, all other sessions learn about it immediately.

## Motivation

Closes #47470.

When running multiple sessions across channels (Telegram, Discord, cron-spawned isolated sessions), each session operates in its own context. If something changes in one session (e.g., deploying a new agent, major config change), other active sessions have no way to learn about it until they read an updated file from disk.

**Real failure mode:** An agent deployed in a Telegram session at 12:30 AM. The Discord session, running on old context, had no idea the new agent existed — and repeatedly asked "who's that?" while the new agent was responding in the same channel.

## Implementation

### New tool: `sessions_broadcast`

**Parameters:**
- `message` (required, string) — system event text to inject
- `scope` (optional, string, default `"all"`) — `"all"` for all sessions, or a channel name (e.g. `"discord"`) to filter

**Behavior:**
1. Lists all active sessions via `sessions.list`
2. Filters out the current session (no self-broadcast)
3. Applies visibility guards and scope filtering
4. Fire-and-forget injects the message into each target session via `callGateway({ method: "agent" })`
5. Returns summary: count sent, session keys, any errors

Follows the same patterns as `sessions_send` — uses `INTERNAL_MESSAGE_CHANNEL`, `AGENT_LANE_NESTED`, visibility guards from `sessions-access.ts`, and TypeBox schema validation.

### Files changed
- `src/agents/tools/sessions-broadcast-tool.ts` — tool implementation
- `src/agents/tools/sessions-broadcast-tool.test.ts` — 6 tests
- `src/agents/tool-catalog.ts` — registered in CORE_TOOL_DEFINITIONS
- `src/agents/openclaw-tools.ts` — wired into createOpenClawTools

### Use cases
- Agent fleet changes (deploy/remove/config)
- Critical system events (auth expiry, service outage)
- State synchronization across channels
- Any change all session instances should know about immediately

## Testing
- `tsc --noEmit` passes clean
- 6 new tests pass
- All 21 existing session tests unaffected