### PR TITLE
fix(doctor): show per-step progress spinners during update

### DIFF
--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -6,9 +6,14 @@ import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
 const originalStdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 const mocks = vi.hoisted(() => ({
+  createUpdateProgress: vi.fn(),
   note: vi.fn(),
   runCommandWithTimeout: vi.fn(),
   runGatewayUpdate: vi.fn(),
+}));
+
+vi.mock("../cli/update-cli/progress.js", () => ({
+  createUpdateProgress: mocks.createUpdateProgress,
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -38,6 +43,8 @@ async function runOffer(params?: {
 }
 
 beforeEach(async () => {
+  mocks.createUpdateProgress.mockReset();
+  mocks.createUpdateProgress.mockReturnValue({ progress: {}, stop: vi.fn() });
   mocks.note.mockReset();
   mocks.runCommandWithTimeout.mockReset();
   mocks.runGatewayUpdate.mockReset();
@@ -86,6 +93,29 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
       expect.stringContaining("This install is not a git checkout."),
       "Update",
     );
+  });
+
+  it("passes step progress to the updater and stops the spinner when the update throws", async () => {
+    const stop = vi.fn();
+    const progress = {};
+    mocks.createUpdateProgress.mockReturnValue({ progress, stop });
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => String(candidate));
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "/repo/link\n",
+      stderr: "",
+      code: 0,
+      killed: false,
+      signal: null,
+      termination: "exit",
+      noOutputTimedOut: false,
+    });
+    mocks.runGatewayUpdate.mockRejectedValue(new Error("update exploded"));
+
+    const confirm = vi.fn().mockResolvedValue(true);
+    await expect(runOffer({ root: "/repo/link", confirm })).rejects.toThrow("update exploded");
+
+    expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(expect.objectContaining({ progress }));
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   it("keeps package-manager guidance when git reports a different checkout", async () => {

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
 
 const originalStdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const originalStdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 const mocks = vi.hoisted(() => ({
   createUpdateProgress: vi.fn(),
@@ -52,6 +53,10 @@ beforeEach(async () => {
     configurable: true,
     value: true,
   });
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: true,
+  });
 });
 
 afterEach(() => {
@@ -60,6 +65,11 @@ afterEach(() => {
     Object.defineProperty(process.stdin, "isTTY", originalStdinIsTtyDescriptor);
   } else {
     delete (process.stdin as Partial<typeof process.stdin>).isTTY;
+  }
+  if (originalStdoutIsTtyDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", originalStdoutIsTtyDescriptor);
+  } else {
+    delete (process.stdout as Partial<typeof process.stdout>).isTTY;
   }
 });
 
@@ -115,7 +125,40 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     await expect(runOffer({ root: "/repo/link", confirm })).rejects.toThrow("update exploded");
 
     expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(expect.objectContaining({ progress }));
+    expect(mocks.createUpdateProgress).toHaveBeenCalledWith(true);
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables update progress when stdout is not a TTY", async () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => String(candidate));
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "/repo/link\n",
+      stderr: "",
+      code: 0,
+      killed: false,
+      signal: null,
+      termination: "exit",
+      noOutputTimedOut: false,
+    });
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "skipped",
+      mode: "git",
+      root: "/repo/link",
+      steps: [],
+      durationMs: 0,
+    });
+
+    const confirm = vi.fn().mockResolvedValue(true);
+    await expect(runOffer({ root: "/repo/link", confirm })).resolves.toEqual({
+      updated: true,
+      handled: false,
+    });
+
+    expect(mocks.createUpdateProgress).toHaveBeenCalledWith(false);
   });
 
   it("keeps package-manager guidance when git reports a different checkout", async () => {

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -1,4 +1,5 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { createUpdateProgress } from "../cli/update-cli/progress.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -51,11 +52,18 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     if (!shouldUpdate) {
       return { updated: false };
     }
-    note("Running update (fetch/rebase/build/ui:build/doctor)…", "Update");
-    const result = await runGatewayUpdate({
-      cwd: params.root,
-      argv1: process.argv[1],
-    });
+    note("Running update…", "Update");
+    const { progress, stop } = createUpdateProgress(Boolean(process.stdout.isTTY));
+    let result;
+    try {
+      result = await runGatewayUpdate({
+        cwd: params.root,
+        argv1: process.argv[1],
+        progress,
+      });
+    } finally {
+      stop();
+    }
     note(
       [
         `Status: ${result.status}`,

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -65,7 +65,7 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
       return { updated: false };
     }
     note("Running update…", "Update");
-    const { progress, stop } = createUpdateProgress(Boolean(process.stdout.isTTY));
+    const { progress, stop } = createUpdateProgress(process.stdout.isTTY);
     let result;
     try {
       result = await runGatewayUpdate({

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -7,6 +7,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { createUpdateProgress } from "../cli/update-cli/progress.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
+import type { UpdateRunResult } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
@@ -66,7 +67,7 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     }
     note("Running update…", "Update");
     const { progress, stop } = createUpdateProgress(process.stdout.isTTY);
-    let result;
+    let result: UpdateRunResult;
     try {
       result = await runGatewayUpdate({
         cwd: params.root,

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { createUpdateProgress } from "../cli/update-cli/progress.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -63,11 +64,18 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     if (!shouldUpdate) {
       return { updated: false };
     }
-    note("Running update (fetch/rebase/build/ui:build/doctor)…", "Update");
-    const result = await runGatewayUpdate({
-      cwd: params.root,
-      argv1: process.argv[1],
-    });
+    note("Running update…", "Update");
+    const { progress, stop } = createUpdateProgress(Boolean(process.stdout.isTTY));
+    let result;
+    try {
+      result = await runGatewayUpdate({
+        cwd: params.root,
+        argv1: process.argv[1],
+        progress,
+      });
+    } finally {
+      stop();
+    }
     note(
       [
         `Status: ${result.status}`,


### PR DESCRIPTION
## Summary

- `openclaw doctor` offers a git update before running checks, but the update (fetch/rebase/build/ui:build/doctor) ran behind a single static note with zero progress indication for several minutes — it looked frozen, and users couldn't tell progress from a hang.
- This PR wires the existing `createUpdateProgress()` controller (already used by `openclaw update`) into the doctor pre-update call site, so each update step shows a live spinner and a completion line with duration.
- Spinners are disabled when stdout is not a TTY (`Boolean(process.stdout.isTTY)`), and `stop()` runs in a `finally` block so an updater error cannot leave an orphaned spinner.
- Intentionally out of scope: the npm/package-manager (non-git) update path and the update runner/progress controller themselves — call-site wiring only, no new progress implementation.
- Reviewers should focus on `src/commands/doctor-update.ts`; the runner already accepted optional `UpdateStepProgress`, so no contract changed.

## Linked context

Which issue does this close?

Closes # — N/A (observed during normal usage; no tracking issue)

Which issues, PRs, or discussions are related?

Related # — N/A

Was this requested by a maintainer or owner?

No — contributor UX fix for a confusing silent wait.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the `openclaw doctor` git update ran fetch/rebase/build/ui:build/doctor with no progress output after one static note, so a multi-minute update looked frozen.
- Real environment tested: macOS (Darwin 25.5.0, arm64), Node v22.22.1, real git source checkout of openclaw (built `dist`, run via `node openclaw.mjs`), starting at commit `fe4c48d` = this patch on top of `origin/main~4` (4 commits behind), pristine `OPENCLAW_STATE_DIR`; the update resolved its target to `418d7e1e` (the then-current `origin/main` tip).
- Exact steps or command run after this patch: in that checkout, ran `node openclaw.mjs doctor` in a real terminal session, answered Yes to "Update OpenClaw from git before running doctor?", and let the full git update run through completion.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): redacted terminal capture from the live session (spinner completion lines with per-step durations):

```text
┌  OpenClaw doctor
◆  Update OpenClaw from git before running doctor?
│  ● Yes / ○ No
└
◇  Update OpenClaw from git before running doctor?
│  Yes
◇  Update ──────────╮
│                   │
│  Running update…  │
│                   │
├───────────────────╯
◇  ✓ Working directory is clean (188ms)
◇  ✓ Fetching latest changes (8.51s)
◇  ✓ Upstream branch exists (31ms)
◇  ✓ Resolving upstream commit (39ms)
◇  ✓ Enumerating candidate commits (36ms)
◇  ✓ Preparing preflight worktree (6.59s)
◇  ✓ preflight checkout (418d7e1e) (188ms)
◇  ✓ preflight deps install (418d7e1e) (34.22s)
◇  ✓ preflight build (418d7e1e) (542.6s)
◇  ✓ Cleaning preflight worktree (39.96s)
◇  ✓ Rebasing onto target commit (904ms)
◇  ✓ Installing dependencies (911ms)
◇  ✓ Building (662.23s)
◇  ✓ Building UI assets (4.16s)
◇  ✓ Running doctor checks (93.53s)
◇  ✓ Verifying update (31ms)
◇  Update result ─────────────────────╮
│                                     │
│  Status: ok                         │
│  Mode: git                          │
│  Root: /private/tmp/openclaw-proof  │
│                                     │
├─────────────────────────────────────╯
└  Update completed (doctor already ran as part of the update).
```

- Observed result after fix: every update step rendered a live spinner while running and finished with a ✓ line and its duration; the previous silent multi-minute gap between the update note and the result note is gone.
- What was not tested: the npm/package-manager (non-git) update path — this change does not touch it.
- Proof limitations or environment constraints: capture is copied live output from the pty session with ANSI control sequences stripped for readability; absolute durations vary with machine load.
- Before evidence (optional but encouraged): on current main the same flow prints only `Running update (fetch/rebase/build/ui:build/doctor)…` and then nothing until the final result note (see `src/commands/doctor-update.ts` on `main`).

## Tests and validation

Which commands did you run?

- `pnpm test src/commands/doctor-update.test.ts` — 3 passed (commands project).
- `pnpm check` and `pnpm build` on the refreshed branch.

What regression coverage was added or updated?

- New test in `src/commands/doctor-update.test.ts`: asserts `runGatewayUpdate` receives the progress callbacks and that the spinner `stop()` runs exactly once when the updater throws (the failure mode flagged in review).

What failed before this fix, if known?

- No automated failure — the gap was UX-only (silent multi-minute update). The new test guards the spinner-cleanup contract going forward.

If no test was added, why not?

- N/A (test added).

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — doctor's git update now shows per-step spinners with durations instead of a single static note.

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Spinner lifecycle when stdout is not a TTY or when the updater throws mid-run.

How is that risk mitigated?

Spinner creation is gated on `Boolean(process.stdout.isTTY)`; `stop()` is called in `finally`; a regression test covers the throw path; the happy path is shown in the real terminal capture above.

## Current review state

What is the next action?

Maintainer review / ClawSweeper re-review of the refreshed head (rebased onto current main, proof attached).

What is still waiting on author, maintainer, CI, or external proof?

Nothing on the author side.

Which bot or reviewer comments were addressed?

- Greptile: hardcoded `createUpdateProgress(true)` → now `Boolean(process.stdout.isTTY)` (resolved).
- Greptile + Codex P2: `stop()` not called if `runGatewayUpdate` throws → `try/finally` plus regression test (resolved).
- Codex P2 on `src/plugin-sdk/subpaths.test.ts`: outdated thread — this PR only touches `src/commands/doctor-update.ts`, and that test file was since replaced on `main` (resolved with explanation).

---

AI-assisted (Claude). Real behavior proof captured by running the patched CLI in a live terminal session as described above.
