### PR TITLE
fix(config): avoid failing startup on implicit memory slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - CLI: avoid loading provider discovery during startup model normalization. (#46522) Thanks @ItsAditya-xyz and @vincentkoc.
 - Tlon: honor explicit empty allowlists and defer cite expansion. (#46788) Thanks @zpbrent and @vincentkoc.
 - ACP: require admin scope for mutating internal actions. (#46789) Thanks @tdjackey and @vincentkoc.
+- Gateway/config validation: stop treating the implicit default memory slot as a required explicit plugin config, so startup no longer fails with `plugins.slots.memory: plugin not found: memory-core` when `memory-core` was only inferred. (#47494) Thanks @ngutman.
 
 ## 2026.3.13
 

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -173,6 +173,24 @@ describe("config plugin validation", () => {
     }
   });
 
+  it("does not fail validation for the implicit default memory slot when plugins config is explicit", async () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          entries: { acpx: { enabled: true } },
+        },
+      },
+      {
+        env: {
+          ...suiteEnv(),
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(suiteHome, "missing-bundled-plugins"),
+        },
+      },
+    );
+    expect(res.ok).toBe(true);
+  });
+
   it("warns for removed legacy plugin ids instead of failing validation", async () => {
     const removedId = "google-antigravity-auth";
     const res = validateInSuite({

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -528,8 +528,17 @@ function validateConfigObjectWithPluginsBase(
     }
   }
 
+  // The default memory slot is inferred; only a user-configured slot should block startup.
+  const hasExplicitMemorySlot =
+    Boolean(pluginsConfig?.slots) &&
+    Object.prototype.hasOwnProperty.call(pluginsConfig.slots, "memory");
   const memorySlot = normalizedPlugins.slots.memory;
-  if (typeof memorySlot === "string" && memorySlot.trim() && !knownIds.has(memorySlot)) {
+  if (
+    hasExplicitMemorySlot &&
+    typeof memorySlot === "string" &&
+    memorySlot.trim() &&
+    !knownIds.has(memorySlot)
+  ) {
     pushMissingPluginIssue("plugins.slots.memory", memorySlot);
   }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -529,9 +529,9 @@ function validateConfigObjectWithPluginsBase(
   }
 
   // The default memory slot is inferred; only a user-configured slot should block startup.
+  const pluginSlots = pluginsConfig?.slots;
   const hasExplicitMemorySlot =
-    Boolean(pluginsConfig?.slots) &&
-    Object.prototype.hasOwnProperty.call(pluginsConfig.slots, "memory");
+    pluginSlots !== undefined && Object.prototype.hasOwnProperty.call(pluginSlots, "memory");
   const memorySlot = normalizedPlugins.slots.memory;
   if (
     hasExplicitMemorySlot &&


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: config validation hard-fails `plugins.slots.memory: plugin not found: memory-core` even when the user never configured a memory slot and `memory-core` only came from the implicit default.
- Why it matters: any gateway config with an explicit `plugins` block can fail startup or restart if bundled plugin discovery misses `memory-core`, even though runtime treats the default memory plugin as optional.
- What changed: validation now only blocks on a missing memory plugin when `plugins.slots.memory` is explicitly configured; the implicit default path stays soft. Added a regression test for an explicit `plugins` config with no explicit memory slot.
- What did NOT change (scope boundary): this does not change plugin discovery/runtime loading behavior and does not address the separate slow WhatsApp startup regression.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Gateway startup/config validation no longer fails solely because the implicit default memory slot resolves to `memory-core` and that bundled plugin is unavailable. Explicit `plugins.slots.memory` misconfiguration still fails validation.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: `pnpm test`; `node --import tsx --input-type=module`
- Model/provider: N/A
- Integration/channel (if any): gateway config validation
- Relevant config (redacted): `plugins.entries.acpx.enabled=true`; no explicit `plugins.slots.memory`; `OPENCLAW_BUNDLED_PLUGINS_DIR` pointed at a missing directory

### Steps

1. Validate a config with an explicit `plugins` block but no explicit `plugins.slots.memory`, while forcing bundled plugin discovery to miss.
2. Observe the pre-fix result: validation fails with `plugins.slots.memory: plugin not found: memory-core`.
3. Apply this patch and re-run the same validation plus an explicit-slot variant.

### Expected

- Only an explicitly configured missing memory slot plugin should block validation/startup.

### Actual

- The implicit default `memory-core` also blocked validation/startup.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/config/config.plugin-validation.test.ts`; local repro with missing bundled plugins dir now returns `ok: true` when the memory slot is implicit.
- Edge cases checked: the same repro still returns `plugins.slots.memory: plugin not found: memory-core` when `plugins.slots.memory` is explicitly set to `memory-core`.
- What you did **not** verify: deploying this fix to the remote gateway host and re-testing daemon startup there.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8466d2f357`
- Files/config to restore: `src/config/validation.ts`; `src/config/config.plugin-validation.test.ts`
- Known bad symptoms reviewers should watch for: explicit `plugins.slots.memory` misconfigurations unexpectedly passing validation

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: explicit-vs-implicit detection could accidentally soften validation for user-provided memory slot settings.
- Mitigation: gate the relaxed path on `hasOwnProperty("memory")` and verify that explicit `plugins.slots.memory: memory-core` still fails when the plugin is missing.
