### PR TITLE
CLI: lazy-load auth choice provider fallback

### DIFF
--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -1,6 +1,4 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveProviderPluginChoice } from "../plugins/provider-wizard.js";
-import { resolvePluginProviders } from "../plugins/providers.js";
 import type { AuthChoice } from "./onboard-types.js";
 
 const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
@@ -53,17 +51,21 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   vllm: "vllm",
 };
 
-export function resolvePreferredProviderForAuthChoice(params: {
+export async function resolvePreferredProviderForAuthChoice(params: {
   choice: AuthChoice;
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): string | undefined {
+}): Promise<string | undefined> {
   const preferred = PREFERRED_PROVIDER_BY_AUTH_CHOICE[params.choice];
   if (preferred) {
     return preferred;
   }
 
+  const [{ resolveProviderPluginChoice }, { resolvePluginProviders }] = await Promise.all([
+    import("../plugins/provider-wizard.js"),
+    import("../plugins/providers.js"),
+  ]);
   const providers = resolvePluginProviders({
     config: params.config,
     workspaceDir: params.workspaceDir,

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1352,7 +1352,7 @@ describe("applyAuthChoice", () => {
 });
 
 describe("resolvePreferredProviderForAuthChoice", () => {
-  it("maps known and unknown auth choices", () => {
+  it("maps known and unknown auth choices", async () => {
     const scenarios = [
       { authChoice: "github-copilot" as const, expectedProvider: "github-copilot" },
       { authChoice: "qwen-portal" as const, expectedProvider: "qwen-portal" },
@@ -1361,9 +1361,9 @@ describe("resolvePreferredProviderForAuthChoice", () => {
       { authChoice: "unknown" as AuthChoice, expectedProvider: undefined },
     ] as const;
     for (const scenario of scenarios) {
-      expect(resolvePreferredProviderForAuthChoice({ choice: scenario.authChoice })).toBe(
-        scenario.expectedProvider,
-      );
+      await expect(
+        resolvePreferredProviderForAuthChoice({ choice: scenario.authChoice }),
+      ).resolves.toBe(scenario.expectedProvider);
     }
   });
 });

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -23,7 +23,7 @@ vi.mock("./auth-choice-prompt.js", () => ({
 
 vi.mock("./auth-choice.js", () => ({
   applyAuthChoice: mocks.applyAuthChoice,
-  resolvePreferredProviderForAuthChoice: vi.fn(() => undefined),
+  resolvePreferredProviderForAuthChoice: vi.fn(async () => undefined),
 }));
 
 vi.mock("./model-picker.js", async (importActual) => {

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -110,7 +110,7 @@ export async function promptAuthConfig(
       allowKeep: true,
       ignoreAllowlist: true,
       includeProviderPluginSetups: true,
-      preferredProvider: resolvePreferredProviderForAuthChoice({
+      preferredProvider: await resolvePreferredProviderForAuthChoice({
         choice: authChoice,
         config: next,
       }),

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
@@ -64,11 +64,11 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     : undefined;
   const preferredProviderId =
     prefixedProviderId ||
-    resolvePreferredProviderForAuthChoice({
+    (await resolvePreferredProviderForAuthChoice({
       choice: params.authChoice,
       config: params.nextConfig,
       workspaceDir,
-    });
+    }));
   const resolutionConfig = buildIsolatedProviderResolutionConfig(
     params.nextConfig,
     preferredProviderId,

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -11,7 +11,7 @@ import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
 const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => ({ profiles: {} })));
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn(async () => "skip"));
 const applyAuthChoice = vi.hoisted(() => vi.fn(async (args) => ({ config: args.config })));
-const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn(() => "openai"));
+const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn(async () => "openai"));
 const warnIfModelConfigLooksOff = vi.hoisted(() => vi.fn(async () => {}));
 const applyPrimaryModel = vi.hoisted(() => vi.fn((cfg) => cfg));
 const promptDefaultModel = vi.hoisted(() => vi.fn(async () => ({ config: null, model: null })));

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -464,7 +464,7 @@ export async function runOnboardingWizard(
       allowKeep: true,
       ignoreAllowlist: true,
       includeProviderPluginSetups: true,
-      preferredProvider: resolvePreferredProviderForAuthChoice({
+      preferredProvider: await resolvePreferredProviderForAuthChoice({
         choice: authChoice,
         config: nextConfig,
         workspaceDir,


### PR DESCRIPTION
## Summary

- Problem: `src/commands/auth-choice.preferred-provider.ts` used a static auth-choice map for most calls, but still eagerly imported `src/plugins/providers.ts` and `src/plugins/provider-wizard.ts` at module load.
- Why it matters: those modules lead into plugin loading, so common auth-choice paths were paying startup cost even when the static map could answer immediately.
- What changed: make `resolvePreferredProviderForAuthChoice()` async and lazy-load the plugin/provider helpers only when the static map misses.
- What did NOT change: fallback behavior for unknown/plugin-backed auth choices is unchanged; it still resolves via plugin providers when needed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] UI / DX
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45064
- Related #46522
- Related #46784
- Related #47467

## User-visible / Behavior Changes

- No user-facing behavior change intended.
- Common auth-choice selection paths no longer import plugin/provider resolution modules up front.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS 15.6.1 arm64
- Runtime/container: Node 22.20.0
- Model/provider: auth-choice helper path
- Integration/channel (if any): N/A
- Relevant config (redacted): default repo checkout

### Steps

1. Run `pnpm test -- src/commands/auth-choice.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts src/wizard/onboarding.test.ts`.
2. Run `pnpm build`.
3. Run `pnpm check`.
4. Probe helper import behavior with `node --import tsx`.

### Expected

- Known auth-choice lookups should resolve from the static map without importing plugin/provider resolution modules.
- Unknown/plugin-backed auth-choice lookups should still fall back to plugin resolution.
- Tests and repo checks should stay green.

### Actual

- `resolvePreferredProviderForAuthChoice()` now returns early for mapped choices and only imports plugin/provider helpers on fallback.
- `pnpm test -- src/commands/auth-choice.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts src/wizard/onboarding.test.ts`, `pnpm build`, and `pnpm check` passed.
- Probe results on this machine:
  - import helper + resolve mapped `github-copilot`: about `118 MB` to `123 MB` RSS
  - unknown-choice fallback call: about `970 MB` RSS

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted auth-choice/configure/onboarding tests, full build, full `pnpm check`, and direct import probes showing the static-map path stays light while fallback still performs the heavy plugin/provider work only when needed.
- Edge cases checked: all async callers were updated to await the helper; unknown choices still go through the same fallback resolution branch.
- What you did **not** verify: a dedicated low-memory host repro of the before/after impact on a full onboarding run.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/commands/auth-choice.preferred-provider.ts`, `src/commands/configure.gateway-auth.ts`, `src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts`, `src/wizard/onboarding.ts`
- Known bad symptoms reviewers should watch for: preferred provider selection becoming undefined for known auth choices, or async caller regressions in onboarding/configure flows.

## Risks and Mitigations

- Risk: converting the helper to async could miss a caller.
- Mitigation: updated all call sites found via `rg`, plus targeted tests for auth-choice, configure, and onboarding flows.

- Risk: plugin-backed fallback behavior could drift.
- Mitigation: fallback still calls the same `resolvePluginProviders` + `resolveProviderPluginChoice` logic, only behind a lazy boundary.
