### PR TITLE
feat: Add optional displayName argument to devices approve command

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3164,15 +3164,19 @@ public struct DevicePairListParams: Codable, Sendable {}
 
 public struct DevicePairApproveParams: Codable, Sendable {
     public let requestid: String
+    public let displayname: String?
 
     public init(
-        requestid: String)
+        requestid: String,
+        displayname: String?)
     {
         self.requestid = requestid
+        self.displayname = displayname
     }
 
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
+        case displayname = "displayName"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3164,15 +3164,19 @@ public struct DevicePairListParams: Codable, Sendable {}
 
 public struct DevicePairApproveParams: Codable, Sendable {
     public let requestid: String
+    public let displayname: String?
 
     public init(
-        requestid: String)
+        requestid: String,
+        displayname: String?)
     {
         self.requestid = requestid
+        self.displayname = displayname
     }
 
     private enum CodingKeys: String, CodingKey {
         case requestid = "requestId"
+        case displayname = "displayName"
     }
 }
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -10,6 +10,7 @@ const buildGatewayConnectionDetails = vi.fn(() => ({
 const listDevicePairing = vi.fn();
 const approveDevicePairing = vi.fn();
 const summarizeDeviceTokens = vi.fn();
+const updatePairedDeviceMetadata = vi.fn();
 const withProgress = vi.fn(async (_opts: unknown, fn: () => Promise<unknown>) => await fn());
 const runtime = {
   log: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock("../infra/device-pairing.js", () => ({
   listDevicePairing,
   approveDevicePairing,
   summarizeDeviceTokens,
+  updatePairedDeviceMetadata,
 }));
 
 vi.mock("../runtime.js", () => ({

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -160,12 +160,18 @@ async function approvePairingWithFallback(
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
     }
     const approved = await approveDevicePairing(requestId);
-    if (approved && displayName && approved.device) {
-      await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
-      approved.device.displayName = displayName;
-    }
     if (!approved) {
       return null;
+    }
+    if (displayName && approved.device) {
+      try {
+        await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
+        approved.device.displayName = displayName;
+      } catch (err) {
+        defaultRuntime.log(
+          theme.warn(`device pairing approved but displayName update failed device=${approved.device.deviceId}: ${err}`),
+        );
+      }
     }
     return {
       requestId,

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -384,7 +384,13 @@ export function registerDevicesCli(program: Command) {
       .option("--latest", "Approve the most recent pending request", false)
       .action(async (requestId: string | undefined, displayName: string | undefined, opts: DevicesRpcOpts) => {
         let resolvedRequestId = requestId?.trim();
-        if (!resolvedRequestId || opts.latest) {
+        // When --latest is used and requestId is provided but displayName is empty,
+        // it means the user passed displayName as first argument, promote it
+        if (opts.latest && resolvedRequestId && !displayName) {
+          displayName = resolvedRequestId;
+          resolvedRequestId = undefined;
+        }
+        if (!resolvedRequestId) {
           const latest = selectLatestPendingRequest((await listPairingWithFallback(opts)).pending);
           resolvedRequestId = latest?.requestId?.trim();
         }

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -168,9 +168,11 @@ async function approvePairingWithFallback(
         await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
         approved.device.displayName = displayName;
       } catch (err) {
-        defaultRuntime.log(
-          theme.warn(`device pairing approved but displayName update failed device=${approved.device.deviceId}: ${err}`),
-        );
+        if (!opts.json) {
+          defaultRuntime.log(
+            theme.warn(`device pairing approved but displayName update failed device=${approved.device.deviceId}: ${err}`),
+          );
+        }
       }
     }
     return {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -5,6 +5,7 @@ import {
   approveDevicePairing,
   listDevicePairing,
   summarizeDeviceTokens,
+  updatePairedDeviceMetadata,
   type PairedDevice as InfraPairedDevice,
 } from "../infra/device-pairing.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -147,9 +148,10 @@ async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePair
 async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
+  displayName?: string,
 ): Promise<Record<string, unknown> | null> {
   try {
-    return await callGatewayCli("device.pair.approve", opts, { requestId });
+    return await callGatewayCli("device.pair.approve", opts, { requestId, displayName });
   } catch (error) {
     if (!shouldUseLocalPairingFallback(opts, error)) {
       throw error;
@@ -158,6 +160,10 @@ async function approvePairingWithFallback(
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
     }
     const approved = await approveDevicePairing(requestId);
+    if (approved && displayName && approved.device) {
+      await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
+      approved.device.displayName = displayName;
+    }
     if (!approved) {
       return null;
     }
@@ -366,8 +372,9 @@ export function registerDevicesCli(program: Command) {
       .command("approve")
       .description("Approve a pending device pairing request")
       .argument("[requestId]", "Pending request id")
+      .argument("[displayName]", "Display name / 备注名称 (optional)", undefined)
       .option("--latest", "Approve the most recent pending request", false)
-      .action(async (requestId: string | undefined, opts: DevicesRpcOpts) => {
+      .action(async (requestId: string | undefined, displayName: string | undefined, opts: DevicesRpcOpts) => {
         let resolvedRequestId = requestId?.trim();
         if (!resolvedRequestId || opts.latest) {
           const latest = selectLatestPendingRequest((await listPairingWithFallback(opts)).pending);
@@ -378,7 +385,7 @@ export function registerDevicesCli(program: Command) {
           defaultRuntime.exit(1);
           return;
         }
-        const result = await approvePairingWithFallback(opts, resolvedRequestId);
+        const result = await approvePairingWithFallback(opts, resolvedRequestId, displayName);
         if (!result) {
           defaultRuntime.error("unknown requestId");
           defaultRuntime.exit(1);
@@ -389,8 +396,10 @@ export function registerDevicesCli(program: Command) {
           return;
         }
         const deviceId = (result as { device?: { deviceId?: string } })?.device?.deviceId;
+        const displayLabel = (result as { device?: { displayName?: string } })?.device?.displayName;
+        const display = displayLabel ? `${displayLabel} (${deviceId})` : (deviceId ?? "ok");
         defaultRuntime.log(
-          `${theme.success("Approved")} ${theme.command(deviceId ?? "ok")} ${theme.muted(`(${resolvedRequestId})`)}`,
+          `${theme.success("Approved")} ${theme.command(display)} ${theme.muted(`(${resolvedRequestId})`)}`,
         );
       }),
   );

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -27,6 +27,7 @@ type DevicesRpcOpts = {
   device?: string;
   role?: string;
   scope?: string[];
+  name?: string;
 };
 
 type DeviceTokenSummary = {
@@ -153,6 +154,21 @@ async function approvePairingWithFallback(
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId, displayName });
   } catch (error) {
+    // If displayName was provided and request failed due to schema validation,
+    // retry without displayName for backward compatibility with older gateways
+    if (displayName) {
+      try {
+        const result = await callGatewayCli("device.pair.approve", opts, { requestId });
+        if (!opts.json) {
+          defaultRuntime.log(
+            theme.warn("Gateway does not support displayName, device approved without naming"),
+          );
+        }
+        return result as Record<string, unknown> | null;
+      } catch {
+        // fall through to original error handling for local fallback
+      }
+    }
     if (!shouldUseLocalPairingFallback(opts, error)) {
       throw error;
     }
@@ -169,9 +185,8 @@ async function approvePairingWithFallback(
         approved.device.displayName = displayName;
       } catch (err) {
         if (!opts.json) {
-          defaultRuntime.log(
-            theme.warn(`device pairing approved but displayName update failed device=${approved.device.deviceId}: ${err}`),
-          );
+          const msg = `device pairing approved but displayName update failed device=${approved.device.deviceId}: ${String(err)}`;
+          defaultRuntime.log(theme.warn(msg));
         }
       }
     }
@@ -382,40 +397,64 @@ export function registerDevicesCli(program: Command) {
       .argument("[requestId]", "Pending request id")
       .argument("[displayName]", "Display name / 备注名称 (optional)", undefined)
       .option("--latest", "Approve the most recent pending request", false)
-      .action(async (requestId: string | undefined, displayName: string | undefined, opts: DevicesRpcOpts) => {
-        let resolvedRequestId = requestId?.trim();
-        // When --latest is used and requestId is provided but displayName is empty,
-        // it means the user passed displayName as first argument, promote it
-        if (opts.latest && resolvedRequestId && !displayName) {
-          displayName = resolvedRequestId;
-          resolvedRequestId = undefined;
-        }
-        if (!resolvedRequestId) {
-          const latest = selectLatestPendingRequest((await listPairingWithFallback(opts)).pending);
-          resolvedRequestId = latest?.requestId?.trim();
-        }
-        if (!resolvedRequestId) {
-          defaultRuntime.error("No pending device pairing requests to approve");
-          defaultRuntime.exit(1);
-          return;
-        }
-        const result = await approvePairingWithFallback(opts, resolvedRequestId, displayName);
-        if (!result) {
-          defaultRuntime.error("unknown requestId");
-          defaultRuntime.exit(1);
-          return;
-        }
-        if (opts.json) {
-          defaultRuntime.log(JSON.stringify(result, null, 2));
-          return;
-        }
-        const deviceId = (result as { device?: { deviceId?: string } })?.device?.deviceId;
-        const displayLabel = (result as { device?: { displayName?: string } })?.device?.displayName;
-        const display = displayLabel ? `${displayLabel} (${deviceId})` : (deviceId ?? "ok");
-        defaultRuntime.log(
-          `${theme.success("Approved")} ${theme.command(display)} ${theme.muted(`(${resolvedRequestId})`)}`,
-        );
-      }),
+      .option("--name <displayName>", "Display name for the paired device (optional)", undefined)
+      .action(
+        async (
+          requestId: string | undefined,
+          displayName: string | undefined,
+          opts: DevicesRpcOpts,
+        ) => {
+          let resolvedRequestId = requestId?.trim();
+          // Use --name option if provided for safer displayName setting with --latest
+          if (opts.name) {
+            displayName = opts.name.trim();
+          }
+          // When using --latest and NO requestId is provided (only displayName is given)
+          // User typed `devices approve --latest my-device-name` → promote the only positional to displayName
+          // This preserves backward compatibility for existing `devices approve req-old --latest`
+          // Original behavior: --latest always looks up the latest, even if a requestId is given
+          // So we need to lookup latest regardless of resolvedRequestId when --latest is set
+          if (opts.latest && !resolvedRequestId && typeof displayName === "string" && !opts.name) {
+            // Only promote if we actually got a string displayName and no requestId is provided
+            displayName = displayName.trim();
+            resolvedRequestId = undefined;
+          }
+          // --latest always resolves the latest pending request, ignoring any explicit requestId
+          // preserves original behavior
+          if (!resolvedRequestId || opts.latest) {
+            const latest = selectLatestPendingRequest(
+              (await listPairingWithFallback(opts)).pending,
+            );
+            resolvedRequestId = latest?.requestId?.trim();
+          }
+          if (!resolvedRequestId) {
+            defaultRuntime.error("No pending device pairing requests to approve");
+            defaultRuntime.exit(1);
+            return;
+          }
+          const result = await approvePairingWithFallback(
+            opts,
+            resolvedRequestId,
+            displayName?.trim(),
+          );
+          if (!result) {
+            defaultRuntime.error("unknown requestId");
+            defaultRuntime.exit(1);
+            return;
+          }
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            return;
+          }
+          const deviceId = (result as { device?: { deviceId?: string } })?.device?.deviceId;
+          const displayLabel = (result as { device?: { displayName?: string } })?.device
+            ?.displayName;
+          const display = displayLabel ? `${displayLabel} (${deviceId})` : (deviceId ?? "ok");
+          defaultRuntime.log(
+            `${theme.success("Approved")} ${theme.command(display)} ${theme.muted(`(${resolvedRequestId})`)}`,
+          );
+        },
+      ),
   );
 
   devicesCallOpts(

--- a/src/gateway/protocol/schema/devices.ts
+++ b/src/gateway/protocol/schema/devices.ts
@@ -4,7 +4,7 @@ import { NonEmptyString } from "./primitives.js";
 export const DevicePairListParamsSchema = Type.Object({}, { additionalProperties: false });
 
 export const DevicePairApproveParamsSchema = Type.Object(
-  { requestId: NonEmptyString },
+  { requestId: NonEmptyString, displayName: Type.Optional(NonEmptyString) },
   { additionalProperties: false },
 );
 

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -116,8 +116,14 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     if (displayName) {
-      await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
-      approved.device.displayName = displayName;
+      try {
+        await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
+        approved.device.displayName = displayName;
+      } catch (err) {
+        context.logGateway.warn(
+          `device pairing approved but displayName update failed device=${approved.device.deviceId}: ${err}`,
+        );
+      }
     }
     context.logGateway.info(
       `device pairing approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -3,6 +3,7 @@ import {
   getPairedDevice,
   listDevicePairing,
   removePairedDevice,
+  updatePairedDeviceMetadata,
   type DeviceAuthToken,
   type RotateDeviceTokenDenyReason,
   rejectDevicePairing,
@@ -108,11 +109,15 @@ export const deviceHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { requestId } = params as { requestId: string };
+    const { requestId, displayName } = params as { requestId: string; displayName?: string };
     const approved = await approveDevicePairing(requestId);
     if (!approved) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown requestId"));
       return;
+    }
+    if (displayName) {
+      await updatePairedDeviceMetadata(approved.device.deviceId, { displayName });
+      approved.device.displayName = displayName;
     }
     context.logGateway.info(
       `device pairing approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,


### PR DESCRIPTION
## Summary

This PR adds an optional second argument `displayName` to the `openclaw devices approve` command, allowing users to set a display name/remark for the paired device directly during approval, avoiding manual editing of `paired.json` afterwards.

### Changes
- Add optional `displayName` argument to CLI `approve` command
- Update JSON schema validation for `device.pair.approve` RPC to accept optional `displayName`
- Handle displayName in both remote gateway mode and local fallback mode
- Reuse existing `updatePairedDeviceMetadata` API, no new API needed
- Fully backward compatible, existing usage remains unchanged

### Usage Example
```bash
# Approve and set display name directly
openclaw devices approve <requestId> my-device-name

# Original usage still works
openclaw devices approve <requestId>
```

### Why this change
- When multiple devices are paired, it's hard to distinguish them only by deviceId
- Setting display name during approval is much more convenient than manual editing after approval
- No breaking changes, small footprint, adds useful functionality for multi-device management