### PR TITLE
fix(telegram): apply named-account session fallback to native commands

### DIFF
--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -185,6 +185,7 @@ function buildStatusTopicCommandContext() {
 
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   resolveTelegramGroupConfig?: RegisterTelegramHandlerParams["resolveTelegramGroupConfig"];
@@ -192,10 +193,11 @@ function registerAndResolveStatusHandler(params: {
   handler: TelegramCommandHandler;
   sendMessage: ReturnType<typeof vi.fn>;
 } {
-  const { cfg, allowFrom, groupAllowFrom, resolveTelegramGroupConfig } = params;
+  const { cfg, accountId, allowFrom, groupAllowFrom, resolveTelegramGroupConfig } = params;
   return registerAndResolveCommandHandlerBase({
     commandName: "status",
     cfg,
+    accountId: accountId ?? "default",
     allowFrom: allowFrom ?? ["*"],
     groupAllowFrom: groupAllowFrom ?? [],
     useAccessGroups: true,
@@ -206,6 +208,7 @@ function registerAndResolveStatusHandler(params: {
 function registerAndResolveCommandHandlerBase(params: {
   commandName: string;
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom: string[];
   groupAllowFrom: string[];
   useAccessGroups: boolean;
@@ -217,6 +220,7 @@ function registerAndResolveCommandHandlerBase(params: {
   const {
     commandName,
     cfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     useAccessGroups,
@@ -236,6 +240,7 @@ function registerAndResolveCommandHandlerBase(params: {
         }),
       } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
       cfg,
+      accountId: accountId ?? "default",
       allowFrom,
       groupAllowFrom,
       useAccessGroups,
@@ -251,6 +256,7 @@ function registerAndResolveCommandHandlerBase(params: {
 function registerAndResolveCommandHandler(params: {
   commandName: string;
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   useAccessGroups?: boolean;
@@ -262,6 +268,7 @@ function registerAndResolveCommandHandler(params: {
   const {
     commandName,
     cfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     useAccessGroups,
@@ -270,6 +277,7 @@ function registerAndResolveCommandHandler(params: {
   return registerAndResolveCommandHandlerBase({
     commandName,
     cfg,
+    accountId: accountId ?? "default",
     allowFrom: allowFrom ?? [],
     groupAllowFrom: groupAllowFrom ?? [],
     useAccessGroups: useAccessGroups ?? true,
@@ -474,6 +482,38 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       >
     )[0]?.[0];
     expect(sessionMetaCall?.sessionKey).toBe("agent:codex:telegram:slash:200");
+  });
+
+  it("routes Telegram native commands through named-account DM sessions", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {
+        session: { dmScope: "per-channel-peer" },
+      },
+      accountId: "knowledge",
+      allowFrom: ["200"],
+    });
+    await handler(buildStatusCommandContext());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:main:telegram:knowledge:direct:200",
+    );
+  });
+
+  it("blocks native commands in groups for named accounts without explicit binding", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      accountId: "knowledge",
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+    });
+    await handler(buildStatusTopicCommandContext());
+
+    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("routes Telegram native commands through topic-specific agent sessions", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -41,8 +41,12 @@ import {
   getPluginCommandSpecs,
   matchPluginCommand,
 } from "../../../src/plugins/commands.js";
-import { resolveAgentRoute } from "../../../src/routing/resolve-route.js";
-import { resolveThreadSessionKeys } from "../../../src/routing/session-key.js";
+import {
+  buildAgentSessionKey,
+  deriveLastRoutePolicy,
+  resolveAgentRoute,
+} from "../../../src/routing/resolve-route.js";
+import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "../../../src/routing/session-key.js";
 import type { RuntimeEnv } from "../../../src/runtime.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
@@ -59,6 +63,7 @@ import {
   buildTelegramThreadParams,
   buildSenderName,
   buildTelegramGroupFrom,
+  resolveTelegramDirectPeerId,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -506,6 +511,35 @@ export const registerTelegramNativeCommands = ({
         });
         return null;
       }
+    }
+    const isNamedAccountFallback =
+      route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default";
+    if (isNamedAccountFallback && isGroup) {
+      logVerbose(
+        `telegram native command: non-default account requires explicit binding (group ${chatId})`,
+      );
+      return null;
+    }
+    if (isNamedAccountFallback && !isGroup) {
+      const overriddenSessionKey = buildAgentSessionKey({
+        agentId: route.agentId,
+        channel: "telegram",
+        accountId: route.accountId,
+        peer: {
+          kind: "direct",
+          id: resolveTelegramDirectPeerId({ chatId, senderId }),
+        },
+        dmScope: "per-account-channel-peer",
+        identityLinks: cfg.session?.identityLinks,
+      }).toLowerCase();
+      route = {
+        ...route,
+        sessionKey: overriddenSessionKey,
+        lastRoutePolicy: deriveLastRoutePolicy({
+          sessionKey: overriddenSessionKey,
+          mainSessionKey: route.mainSessionKey,
+        }),
+      };
     }
     const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
     const tableMode = resolveMarkdownTableMode({


### PR DESCRIPTION

### 🐛 Problem

Native Telegram commands (`/status`, `/model`, etc.) resolve the wrong session key for non-default accounts without an explicit binding.

The inbound message path (`bot-message-context.ts`) already applies named-account fallback logic:
- **DMs**: overrides the session key to `per-account-channel-peer` scope, isolating sessions per account
- **Groups**: rejects the message with `logInboundDrop` when no explicit binding exists

However, `resolveCommandRuntimeContext` in `bot-native-commands.ts` does **not** apply this fallback. As a result, native commands can target a different session than normal messages sent in the same DM conversation.

### 📊 Impact

- `/status` in a named-account DM shows status for the **wrong session** (default account session instead of the named account session)
- `/model` switches models on the **wrong session**
- Any native command that reads or mutates session state operates on a mismatched session key
- Groups with named accounts could process native commands without an explicit binding, bypassing the safety guard that the inbound path enforces

### 🔍 Root Cause

This is **not** a config issue. Both paths call `resolveTelegramConversationRoute` with the same parameters and resolve the same base route. The divergence occurs **after** route resolution:

| Step | Inbound Message Path | Native Command Path (before fix) |
|------|---------------------|----------------------------------|
| Route resolution | `resolveTelegramConversationRoute` | `resolveTelegramConversationRoute` ✅ same |
| Named-account DM fallback | `buildAgentSessionKey` with `per-account-channel-peer` | ❌ **missing** |
| Named-account group guard | `logInboundDrop` → `return null` | ❌ **missing** |

### 🛠 Fix

Apply the same named-account fallback in `resolveCommandRuntimeContext` before returning the route:

1. **DMs** (`!isGroup`): Override session key using `buildAgentSessionKey` with `per-account-channel-peer` scope, then update `lastRoutePolicy` accordingly
2. **Groups** (`isGroup`): Return `null` to block the command, matching the inbound path behavior

#### Before

```
normal DM message  → agent:main:telegram:knowledge:direct:123
/status in same DM → agent:main:telegram:direct:123              ← WRONG
/status in group   → executes without explicit binding guard      ← WRONG
```

#### After

```
normal DM message  → agent:main:telegram:knowledge:direct:123
/status in same DM → agent:main:telegram:knowledge:direct:123    ← CORRECT
/status in group   → blocked (returns null)                       ← CORRECT
```

### ✅ Testing

Added 2 tests covering DM fallback and group rejection; existing tests unaffected.

### ⚠️ Limitation

This fix does not cover thread/topic-specific session isolation within named-account DMs. The inbound message path resolves `dmThreadId` via `resolveThreadSessionKeys` after the named-account fallback, but `resolveCommandRuntimeContext` does not have access to thread-level session logic. This is a pre-existing gap that applies to all native commands, not specific to named accounts.

### 🔗 Related

- #10407 — `fix(feishu): Remove incorrect oc_ prefix assumption in resolveFeishuSession` (merged, same contributor)
- `bot-message-context.ts` lines 96–247 — canonical implementation of named-account fallback for inbound messages
