### PR TITLE
Gateway: preserve arbiter subagent context and runtime

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -622,6 +622,24 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
+public struct AgentAbortParams: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String?
+
+    public init(
+        runid: String,
+        sessionkey: String?)
+    {
+        self.runid = runid
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+    }
+}
+
 public struct AgentIdentityParams: Codable, Sendable {
     public let agentid: String?
     public let sessionkey: String?

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -622,6 +622,24 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
+public struct AgentAbortParams: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String?
+
+    public init(
+        runid: String,
+        sessionkey: String?)
+    {
+        self.runid = runid
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+    }
+}
+
 public struct AgentIdentityParams: Codable, Sendable {
     public let agentid: String?
     public let sessionkey: String?

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -699,7 +699,7 @@ Then enable it in config:
 Plugins can register hooks at runtime. This lets a plugin bundle event-driven
 automation without a separate hook pack install.
 
-### Example
+### Hook registration example
 
 ```ts
 export default function register(api) {

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -19,6 +19,39 @@ const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("di
 export const listDiscordAccountIds = listAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 
+const managedDiscordAccountIdByBotUserId = new Map<string, string>();
+
+export function rememberDiscordManagedBotIdentity(params: {
+  botUserId: string;
+  accountId: string;
+}): void {
+  managedDiscordAccountIdByBotUserId.set(params.botUserId, params.accountId);
+}
+
+export function forgetDiscordManagedBotIdentity(params: {
+  botUserId?: string | null;
+  accountId?: string | null;
+}): void {
+  if (!params.botUserId) {
+    return;
+  }
+  if (
+    !params.accountId ||
+    managedDiscordAccountIdByBotUserId.get(params.botUserId) === params.accountId
+  ) {
+    managedDiscordAccountIdByBotUserId.delete(params.botUserId);
+  }
+}
+
+export function resolveDiscordManagedAccountIdByBotUserId(
+  botUserId?: string | null,
+): string | undefined {
+  if (!botUserId) {
+    return undefined;
+  }
+  return managedDiscordAccountIdByBotUserId.get(botUserId);
+}
+
 export function resolveDiscordAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,

--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -18,6 +18,7 @@ type DiscordInboundWorkerParams = {
 export type DiscordInboundWorker = {
   enqueue: (job: DiscordInboundJob) => void;
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 function formatDiscordRunContextSuffix(job: DiscordInboundJob): string {
@@ -101,5 +102,8 @@ export function createDiscordInboundWorker(
         });
     },
     deactivate: runState.deactivate,
+    waitForIdle: async () => {
+      await runQueue.waitForIdle();
+    },
   };
 }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -35,7 +35,10 @@ import { buildAgentSessionKey } from "../../../../src/routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../../src/routing/session-key.js";
 import { stripReasoningTagsFromText } from "../../../../src/shared/text/reasoning-tags.js";
 import { truncateUtf16Safe } from "../../../../src/utils.js";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import {
+  resolveDiscordManagedAccountIdByBotUserId,
+  resolveDiscordMaxLinesPerMessage,
+} from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -223,6 +226,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
+  const senderManagedAccountId = resolveDiscordManagedAccountIdByBotUserId(sender.id);
   const { groupSystemPrompt, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
     channelConfig,
     guildInfo,
@@ -363,6 +367,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
     SenderName: senderName,
+    SenderManagedAccountId: senderManagedAccountId,
     SenderId: sender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -28,6 +28,7 @@ type DiscordMessageHandlerParams = Omit<
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 export function createDiscordMessageHandler(
@@ -181,6 +182,7 @@ export function createDiscordMessageHandler(
   };
 
   handler.deactivate = inboundWorker.deactivate;
+  handler.waitForIdle = inboundWorker.waitForIdle;
 
   return handler;
 }

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -42,10 +42,12 @@ const {
   listNativeCommandSpecsForConfigMock,
   listSkillCommandsForAgentsMock,
   monitorLifecycleMock,
+  rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccountMock,
   resolveDiscordAllowlistConfigMock,
   resolveNativeCommandsEnabledMock,
   resolveNativeSkillsEnabledMock,
+  forgetDiscordManagedBotIdentityMock,
   voiceRuntimeModuleLoadedMock,
 } = vi.hoisted(() => {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
@@ -67,6 +69,7 @@ const {
         vi.fn(async () => undefined),
         {
           deactivate: vi.fn(),
+          waitForIdle: vi.fn(async () => undefined),
         },
       ),
     ),
@@ -99,6 +102,7 @@ const {
     monitorLifecycleMock: vi.fn(async (params: { threadBindings: { stop: () => void } }) => {
       params.threadBindings.stop();
     }),
+    rememberDiscordManagedBotIdentityMock: vi.fn(),
     resolveDiscordAccountMock: vi.fn(() => ({
       accountId: "default",
       token: "cfg-token",
@@ -108,6 +112,7 @@ const {
       guildEntries: undefined,
       allowFrom: undefined,
     })),
+    forgetDiscordManagedBotIdentityMock: vi.fn(),
     resolveNativeCommandsEnabledMock: vi.fn(() => true),
     resolveNativeSkillsEnabledMock: vi.fn(() => false),
     voiceRuntimeModuleLoadedMock: vi.fn(),
@@ -236,6 +241,8 @@ vi.mock("../../../../src/runtime.js", () => ({
 }));
 
 vi.mock("../accounts.js", () => ({
+  forgetDiscordManagedBotIdentity: forgetDiscordManagedBotIdentityMock,
+  rememberDiscordManagedBotIdentity: rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccount: resolveDiscordAccountMock,
 }));
 
@@ -405,6 +412,7 @@ describe("monitorDiscordProvider", () => {
         vi.fn(async () => undefined),
         {
           deactivate: vi.fn(),
+          waitForIdle: vi.fn(async () => undefined),
         },
       ),
     );
@@ -428,6 +436,8 @@ describe("monitorDiscordProvider", () => {
     monitorLifecycleMock.mockClear().mockImplementation(async (params) => {
       params.threadBindings.stop();
     });
+    rememberDiscordManagedBotIdentityMock.mockClear();
+    forgetDiscordManagedBotIdentityMock.mockClear();
     resolveDiscordAccountMock.mockClear();
     resolveDiscordAllowlistConfigMock.mockClear().mockResolvedValue({
       guildEntries: undefined,
@@ -807,6 +817,43 @@ describe("monitorDiscordProvider", () => {
     expect(monitorLifecycleMock).toHaveBeenCalledTimes(1);
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringContaining("native command deploy skipped"),
+    );
+  });
+
+  it("waits for inbound handler idle before forgetting managed bot identity", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const deactivate = vi.fn();
+    const waitForIdle = vi.fn(async () => undefined);
+    createDiscordMessageHandlerMock.mockImplementation(() =>
+      Object.assign(
+        vi.fn(async () => undefined),
+        {
+          deactivate,
+          waitForIdle,
+        },
+      ),
+    );
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(rememberDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate).toHaveBeenCalledTimes(1);
+    expect(waitForIdle).toHaveBeenCalledTimes(1);
+    expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate.mock.invocationCallOrder[0]).toBeLessThan(
+      waitForIdle.mock.invocationCallOrder[0],
+    );
+    expect(waitForIdle.mock.invocationCallOrder[0]).toBeLessThan(
+      forgetDiscordManagedBotIdentityMock.mock.invocationCallOrder[0],
     );
   });
 

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -857,6 +857,48 @@ describe("monitorDiscordProvider", () => {
     );
   });
 
+  it("bounds inbound handler idle wait during teardown", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitorDiscordProvider } = await import("./provider.js");
+      const deactivate = vi.fn();
+      const waitForIdle = vi.fn(() => new Promise<void>(() => undefined));
+      createDiscordMessageHandlerMock.mockImplementation(() =>
+        Object.assign(
+          vi.fn(async () => undefined),
+          {
+            deactivate,
+            waitForIdle,
+          },
+        ),
+      );
+      mockResolvedDiscordAccountConfig({
+        inboundWorker: { runTimeoutMs: 5_000 },
+      });
+      const runtime = baseRuntime();
+
+      const monitorPromise = monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      });
+
+      await vi.advanceTimersByTimeAsync(5_100);
+      await expect(monitorPromise).resolves.toBeUndefined();
+
+      expect(deactivate).toHaveBeenCalledTimes(1);
+      expect(waitForIdle).toHaveBeenCalledTimes(1);
+      expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+        botUserId: "bot-1",
+        accountId: "default",
+      });
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("inbound handler did not drain within 5000ms during teardown"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports connected status on startup and shutdown", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
     const setStatus = vi.fn();

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -862,7 +862,7 @@ describe("monitorDiscordProvider", () => {
     try {
       const { monitorDiscordProvider } = await import("./provider.js");
       const deactivate = vi.fn();
-      const waitForIdle = vi.fn(() => new Promise<void>(() => undefined));
+      const waitForIdle = vi.fn(() => new Promise<undefined>(() => undefined));
       createDiscordMessageHandlerMock.mockImplementation(() =>
         Object.assign(
           vi.fn(async () => undefined),

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -44,7 +44,11 @@ import { createSubsystemLogger } from "../../../../src/logging/subsystem.js";
 import { getPluginCommandSpecs } from "../../../../src/plugins/commands.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../../../src/runtime.js";
 import { summarizeStringEntries } from "../../../../src/shared/string-sample.js";
-import { resolveDiscordAccount } from "../accounts.js";
+import {
+  forgetDiscordManagedBotIdentity,
+  rememberDiscordManagedBotIdentity,
+  resolveDiscordAccount,
+} from "../accounts.js";
 import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
@@ -616,9 +620,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let lifecycleStarted = false;
   let releaseEarlyGatewayErrorGuard = () => {};
   let deactivateMessageHandler: (() => void) | undefined;
+  let waitForMessageHandlerIdle: (() => Promise<void>) | undefined;
   let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
   let earlyGatewayEmitter: ReturnType<typeof getDiscordGatewayEmitter> | undefined;
   let onEarlyGatewayDebug: ((msg: unknown) => void) | undefined;
+  let botUserId: string | undefined;
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -809,7 +815,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     const logger = createSubsystemLogger("discord/monitor");
     const guildHistories = new Map<string, HistoryEntry[]>();
-    let botUserId: string | undefined;
     let botUserName: string | undefined;
     let voiceManager: DiscordVoiceManager | null = null;
 
@@ -846,6 +851,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       const botUser = await client.fetchUser("@me");
       botUserId = botUser?.id;
       botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+      if (botUserId) {
+        rememberDiscordManagedBotIdentity({
+          botUserId,
+          accountId: account.accountId,
+        });
+      }
       logDiscordStartupPhase({
         runtime,
         accountId: account.accountId,
@@ -904,6 +915,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       discordRestFetch,
     });
     deactivateMessageHandler = messageHandler.deactivate;
+    waitForMessageHandlerIdle = messageHandler.waitForIdle;
     const trackInboundEvent = opts.setStatus
       ? () => {
           const at = Date.now();
@@ -978,6 +990,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
   } finally {
     deactivateMessageHandler?.();
+    await waitForMessageHandlerIdle?.();
+    forgetDiscordManagedBotIdentity({
+      botUserId,
+      accountId: account.accountId,
+    });
     autoPresenceController?.stop();
     opts.setStatus?.({ connected: false });
     if (onEarlyGatewayDebug) {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -44,6 +44,7 @@ import { createSubsystemLogger } from "../../../../src/logging/subsystem.js";
 import { getPluginCommandSpecs } from "../../../../src/plugins/commands.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../../../src/runtime.js";
 import { summarizeStringEntries } from "../../../../src/shared/string-sample.js";
+import { withTimeout } from "../../../../src/utils/with-timeout.js";
 import {
   forgetDiscordManagedBotIdentity,
   rememberDiscordManagedBotIdentity,
@@ -95,6 +96,7 @@ import {
   reconcileAcpThreadBindingsOnStartup,
 } from "./thread-bindings.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+import { normalizeDiscordInboundWorkerTimeoutMs } from "./timeouts.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -157,6 +159,15 @@ function appendPluginCommandSpecs(params: {
 
 const DISCORD_ACP_STATUS_PROBE_TIMEOUT_MS = 8_000;
 const DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS = 2 * 60 * 1000;
+const DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS = 15_000;
+
+function resolveDiscordMessageHandlerIdleTimeoutMs(raw: number | undefined): number {
+  const normalized = normalizeDiscordInboundWorkerTimeoutMs(raw);
+  if (!normalized) {
+    return DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS;
+  }
+  return Math.min(normalized, DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS);
+}
 
 function isLegacyMissingSessionError(message: string): boolean {
   return (
@@ -990,7 +1001,20 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
   } finally {
     deactivateMessageHandler?.();
-    await waitForMessageHandlerIdle?.();
+    if (waitForMessageHandlerIdle) {
+      const idleTimeoutMs = resolveDiscordMessageHandlerIdleTimeoutMs(
+        discordCfg.inboundWorker?.runTimeoutMs,
+      );
+      try {
+        await withTimeout(waitForMessageHandlerIdle(), idleTimeoutMs);
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message === "timeout"
+            ? `discord: inbound handler did not drain within ${idleTimeoutMs}ms during teardown; continuing shutdown`
+            : `discord: inbound handler idle wait failed during teardown: ${formatErrorMessage(error)}`;
+        runtime.log?.(warn(message));
+      }
+    }
     forgetDiscordManagedBotIdentity({
       botUserId,
       accountId: account.accountId,

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -260,6 +260,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     subagent: {
       run: vi.fn(),
+      enqueue: vi.fn(),
+      abort: vi.fn(),
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       getSession: vi.fn(),

--- a/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
@@ -151,4 +151,38 @@ describe("cacheRetention default behavior", () => {
     // Verify streamFn was set (override was applied)
     expect(agent.streamFn).toBeDefined();
   });
+
+  it("forwards toolChoice overrides to the wrapped stream options", async () => {
+    const baseStreamFn = vi.fn(async () => undefined);
+    const agent: { streamFn?: StreamFn } = { streamFn: baseStreamFn as unknown as StreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-4.1", {
+      toolChoice: {
+        type: "function",
+        function: {
+          name: "emit_structured_result",
+        },
+      },
+    });
+
+    expect(agent.streamFn).toBeDefined();
+    await agent.streamFn?.(
+      { api: "openai-responses", provider: "openai", id: "gpt-4.1", compat: {} } as never,
+      {} as never,
+      {},
+    );
+
+    expect(baseStreamFn).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        toolChoice: {
+          type: "function",
+          function: {
+            name: "emit_structured_result",
+          },
+        },
+      }),
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -78,6 +78,7 @@ export function resolveExtraParams(params: {
 type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: "none" | "short" | "long";
   openaiWsWarmup?: boolean;
+  toolChoice?: unknown;
 };
 
 function createStreamFnWithExtraParams(
@@ -95,6 +96,9 @@ function createStreamFnWithExtraParams(
   }
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;
+  }
+  if (extraParams.toolChoice !== undefined) {
+    streamParams.toolChoice = extraParams.toolChoice;
   }
   const transport = extraParams.transport;
   if (transport === "sse" || transport === "websocket" || transport === "auto") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1937,15 +1937,19 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = wrapOllamaCompatNumCtx(activeSession.agent.streamFn, numCtx);
       }
 
+      const effectiveStreamParams: Record<string, unknown> = {
+        ...params.streamParams,
+        fastMode: params.fastMode,
+      };
+      if (allowedToolNames.size === 0) {
+        effectiveStreamParams.toolChoice = undefined;
+      }
       applyExtraParamsToAgent(
         activeSession.agent,
         params.config,
         params.provider,
         params.modelId,
-        {
-          ...params.streamParams,
-          fastMode: params.fastMode,
-        },
+        effectiveStreamParams,
         params.thinkLevel,
         sessionAgentId,
       );

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/loader.js", () => ({
+  loadOpenClawPlugins,
+}));
+
+import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
+
+afterEach(() => {
+  loadOpenClawPlugins.mockReset();
+});
+
+describe("ensureRuntimePluginsLoaded", () => {
+  test("opts into shared runtime inheritance", () => {
+    const config = { plugins: { enabled: true } };
+
+    ensureRuntimePluginsLoaded({
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config,
+        inheritSharedRuntimeOptions: true,
+      }),
+    );
+  });
+});

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -14,5 +14,6 @@ export function ensureRuntimePluginsLoaded(params: {
   loadOpenClawPlugins({
     config: params.config,
     workspaceDir,
+    inheritSharedRuntimeOptions: true,
   });
 }

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -123,6 +123,8 @@ export type MsgContext = {
   /** Explicit owner allowlist overrides (trusted, configuration-derived). */
   OwnerAllowFrom?: Array<string | number>;
   SenderName?: string;
+  /** Provider-managed account id when the inbound sender is one of our configured bot accounts. */
+  SenderManagedAccountId?: string;
   SenderId?: string;
   SenderUsername?: string;
   SenderTag?: string;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -480,6 +480,7 @@ function runAgentAttempt(params: {
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,
     clientTools: params.opts.clientTools,
+    disableTools: params.opts.disableTools,
     provider: params.providerOverride,
     model: params.modelOverride,
     authProfileId,
@@ -1166,6 +1167,7 @@ async function agentCommandInternal(
             endedAt: Date.now(),
             aborted: result.meta.aborted ?? false,
             stopReason,
+            pendingToolCalls: result.meta.pendingToolCalls,
           },
         });
       }

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -17,6 +17,17 @@ export type AgentStreamParams = {
   maxTokens?: number;
   /** Provider fast-mode override (best-effort). */
   fastMode?: boolean;
+  /** Provider tool-choice override (best-effort). */
+  toolChoice?:
+    | "auto"
+    | "none"
+    | "required"
+    | {
+        type: "function";
+        function: {
+          name: string;
+        };
+      };
 };
 
 export type AgentRunContext = {
@@ -37,6 +48,8 @@ export type AgentCommandOpts = {
   images?: ImageContent[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
+  /** Disable built-in tools for this run while still allowing clientTools. */
+  disableTools?: boolean;
   /** Agent id override (must exist in config). */
   agentId?: string;
   to?: string;

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -28,6 +28,7 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const pluginRegistry = loadOpenClawPlugins({
     config: cfg,
     workspaceDir,
+    activateGlobalHookRunner: false,
     logger: {
       info: () => {},
       warn: () => {},

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -233,6 +233,7 @@ export function reloadOnboardingPluginRegistry(params: {
     config: params.cfg,
     workspaceDir,
     cache: false,
+    activateGlobalHookRunner: false,
     logger: createPluginLoaderLogger(log),
   });
 }

--- a/src/gateway/agent-abort.ts
+++ b/src/gateway/agent-abort.ts
@@ -1,0 +1,45 @@
+export type AgentAbortControllerEntry = {
+  controller: AbortController;
+  sessionKey?: string;
+  startedAtMs: number;
+  expiresAtMs: number;
+};
+
+export function resolveAgentRunExpiresAtMs(params: {
+  now: number;
+  timeoutMs?: number;
+  graceMs?: number;
+  minMs?: number;
+  maxMs?: number;
+}): number {
+  const {
+    now,
+    timeoutMs = 0,
+    graceMs = 60_000,
+    minMs = 2 * 60_000,
+    maxMs = 24 * 60 * 60_000,
+  } = params;
+  const boundedTimeoutMs = Math.max(0, timeoutMs);
+  const target = now + boundedTimeoutMs + graceMs;
+  const min = now + minMs;
+  const max = now + maxMs;
+  return Math.min(max, Math.max(min, target));
+}
+
+export function abortAgentRunById(params: {
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
+  runId: string;
+  sessionKey?: string;
+  reason?: unknown;
+}): { aborted: boolean } {
+  const active = params.agentAbortControllers.get(params.runId);
+  if (!active) {
+    return { aborted: false };
+  }
+  if (params.sessionKey && active.sessionKey && active.sessionKey !== params.sessionKey) {
+    return { aborted: false };
+  }
+  active.controller.abort(params.reason);
+  params.agentAbortControllers.delete(params.runId);
+  return { aborted: true };
+}

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -91,6 +91,8 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "send",
     "poll",
     "agent",
+    "agent.enqueue",
+    "agent.abort",
     "agent.wait",
     "wake",
     "talk.mode",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -1,6 +1,8 @@
 import AjvPkg, { type ErrorObject } from "ajv";
 import type { SessionsPatchResult } from "../session-utils.types.js";
 import {
+  type AgentAbortParams,
+  AgentAbortParamsSchema,
   type AgentEvent,
   AgentEventSchema,
   type AgentIdentityParams,
@@ -263,6 +265,7 @@ export const validateEventFrame = ajv.compile<EventFrame>(EventFrameSchema);
 export const validateSendParams = ajv.compile(SendParamsSchema);
 export const validatePollParams = ajv.compile<PollParams>(PollParamsSchema);
 export const validateAgentParams = ajv.compile(AgentParamsSchema);
+export const validateAgentAbortParams = ajv.compile<AgentAbortParams>(AgentAbortParamsSchema);
 export const validateAgentIdentityParams =
   ajv.compile<AgentIdentityParams>(AgentIdentityParamsSchema);
 export const validateAgentWaitParams = ajv.compile<AgentWaitParams>(AgentWaitParamsSchema);
@@ -469,6 +472,7 @@ export {
   ErrorShapeSchema,
   StateVersionSchema,
   AgentEventSchema,
+  AgentAbortParamsSchema,
   ChatEventSchema,
   SendParamsSchema,
   PollParamsSchema,
@@ -575,6 +579,7 @@ export type {
   ErrorShape,
   StateVersion,
   AgentEvent,
+  AgentAbortParams,
   AgentIdentityParams,
   AgentIdentityResult,
   AgentWaitParams,

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -29,6 +29,49 @@ export const AgentEventSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const ClientToolDefinitionSchema = Type.Object(
+  {
+    type: Type.Literal("function"),
+    function: Type.Object(
+      {
+        name: NonEmptyString,
+        description: Type.Optional(Type.String()),
+        parameters: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const AgentToolChoiceSchema = Type.Union([
+  Type.Literal("auto"),
+  Type.Literal("none"),
+  Type.Literal("required"),
+  Type.Object(
+    {
+      type: Type.Literal("function"),
+      function: Type.Object(
+        {
+          name: NonEmptyString,
+        },
+        { additionalProperties: false },
+      ),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+const AgentStreamParamsSchema = Type.Object(
+  {
+    temperature: Type.Optional(Type.Number()),
+    maxTokens: Type.Optional(Type.Number()),
+    fastMode: Type.Optional(Type.Boolean()),
+    toolChoice: Type.Optional(AgentToolChoiceSchema),
+  },
+  { additionalProperties: false },
+);
+
 export const SendParamsSchema = Type.Object(
   {
     to: NonEmptyString,
@@ -95,6 +138,9 @@ export const AgentParamsSchema = Type.Object(
     lane: Type.Optional(Type.String()),
     extraSystemPrompt: Type.Optional(Type.String()),
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
+    clientTools: Type.Optional(Type.Array(ClientToolDefinitionSchema)),
+    disableTools: Type.Optional(Type.Boolean()),
+    streamParams: Type.Optional(AgentStreamParamsSchema),
     inputProvenance: Type.Optional(InputProvenanceSchema),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -128,6 +128,14 @@ export const AgentWaitParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const AgentAbortParamsSchema = Type.Object(
+  {
+    runId: NonEmptyString,
+    sessionKey: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const WakeParamsSchema = Type.Object(
   {
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -1,5 +1,6 @@
 import type { TSchema } from "@sinclair/typebox";
 import {
+  AgentAbortParamsSchema,
   AgentEventSchema,
   AgentIdentityParamsSchema,
   AgentIdentityResultSchema,
@@ -174,6 +175,7 @@ export const ProtocolSchemas = {
   SendParams: SendParamsSchema,
   PollParams: PollParamsSchema,
   AgentParams: AgentParamsSchema,
+  AgentAbortParams: AgentAbortParamsSchema,
   AgentIdentityParams: AgentIdentityParamsSchema,
   AgentIdentityResult: AgentIdentityResultSchema,
   AgentWaitParams: AgentWaitParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -18,6 +18,7 @@ export type AgentEvent = SchemaType<"AgentEvent">;
 export type AgentIdentityParams = SchemaType<"AgentIdentityParams">;
 export type AgentIdentityResult = SchemaType<"AgentIdentityResult">;
 export type PollParams = SchemaType<"PollParams">;
+export type AgentAbortParams = SchemaType<"AgentAbortParams">;
 export type AgentWaitParams = SchemaType<"AgentWaitParams">;
 export type WakeParams = SchemaType<"WakeParams">;
 export type NodePairRequestParams = SchemaType<"NodePairRequestParams">;

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -22,6 +22,7 @@ function createMaintenanceTimerDeps() {
     refreshGatewayHealthSnapshot: async () => ({ ok: true }) as HealthSummary,
     logHealth: { error: () => {} },
     dedupe: new Map(),
+    agentAbortControllers: new Map(),
     chatAbortControllers: new Map(),
     chatRunState: { abortedRuns: new Map() },
     chatRunBuffers: new Map(),

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,5 +1,6 @@
 import type { HealthSummary } from "../commands/health.js";
 import { cleanOldMedia } from "../media/store.js";
+import { abortAgentRunById, type AgentAbortControllerEntry } from "./agent-abort.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
@@ -27,6 +28,7 @@ export function startGatewayMaintenanceTimers(params: {
   refreshGatewayHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   logHealth: { error: (msg: string) => void };
   dedupe: Map<string, DedupeEntry>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunState: { abortedRuns: Map<string, number> };
   chatRunBuffers: Map<string, string>;
@@ -100,6 +102,18 @@ export function startGatewayMaintenanceTimers(params: {
           break;
         }
       }
+    }
+
+    for (const [runId, entry] of params.agentAbortControllers) {
+      if (now <= entry.expiresAtMs) {
+        continue;
+      }
+      abortAgentRunById({
+        agentAbortControllers: params.agentAbortControllers,
+        runId,
+        sessionKey: entry.sessionKey,
+        reason: "timeout",
+      });
     }
 
     for (const [runId, entry] of params.chatAbortControllers) {

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -96,6 +96,8 @@ const BASE_METHODS = [
   "system-event",
   "send",
   "agent",
+  "agent.enqueue",
+  "agent.abort",
   "agent.identity.get",
   "agent.wait",
   "browser.request",

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -19,6 +19,12 @@ type AgentRunSnapshot = {
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  stopReason?: string;
+  pendingToolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: string;
+  }>;
   ts: number;
 };
 
@@ -86,12 +92,42 @@ function createSnapshotFromLifecycleEvent(params: {
     typeof data?.startedAt === "number" ? data.startedAt : agentRunStarts.get(runId);
   const endedAt = typeof data?.endedAt === "number" ? data.endedAt : undefined;
   const error = typeof data?.error === "string" ? data.error : undefined;
+  const stopReason = typeof data?.stopReason === "string" ? data.stopReason : undefined;
+  const pendingToolCalls = Array.isArray(data?.pendingToolCalls)
+    ? data.pendingToolCalls
+        .map((value) => {
+          if (!value || typeof value !== "object") {
+            return null;
+          }
+          const record = value as Record<string, unknown>;
+          return typeof record.id === "string" &&
+            typeof record.name === "string" &&
+            typeof record.arguments === "string"
+            ? {
+                id: record.id,
+                name: record.name,
+                arguments: record.arguments,
+              }
+            : null;
+        })
+        .filter(
+          (
+            value,
+          ): value is {
+            id: string;
+            name: string;
+            arguments: string;
+          } => value !== null,
+        )
+    : undefined;
   return {
     runId,
     status: phase === "error" ? "error" : data?.aborted ? "timeout" : "ok",
     startedAt,
     endedAt,
     error,
+    stopReason,
+    pendingToolCalls: pendingToolCalls?.length ? pendingToolCalls : undefined,
     ts: Date.now(),
   };
 }

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -258,6 +258,54 @@ describe("agent wait dedupe helper", () => {
     });
   });
 
+  it("extracts stopReason and pendingToolCalls from nested agent result metadata", () => {
+    const dedupe = new Map();
+    const runId = "run-structured-agent";
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "ok",
+        startedAt: 10,
+        endedAt: 20,
+        result: {
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              {
+                id: "call-1",
+                name: "emit_structured_result",
+                arguments: '{"entries":[]}',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "ok",
+      startedAt: 10,
+      endedAt: 20,
+      error: undefined,
+      stopReason: "tool_calls",
+      pendingToolCalls: [
+        {
+          id: "call-1",
+          name: "emit_structured_result",
+          arguments: '{"entries":[]}',
+        },
+      ],
+    });
+  });
+
   it("resolves multiple waiters for the same run id", async () => {
     const dedupe = new Map();
     const runId = "run-multi";

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -5,6 +5,12 @@ export type AgentWaitTerminalSnapshot = {
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  stopReason?: string;
+  pendingToolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: string;
+  }>;
 };
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
@@ -21,6 +27,44 @@ function parseRunIdFromDedupeKey(key: string): string | null {
 
 function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parsePendingToolCalls(value: unknown):
+  | Array<{
+      id: string;
+      name: string;
+      arguments: string;
+    }>
+  | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const calls = value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const record = entry as Record<string, unknown>;
+      return typeof record.id === "string" &&
+        typeof record.name === "string" &&
+        typeof record.arguments === "string"
+        ? {
+            id: record.id,
+            name: record.name,
+            arguments: record.arguments,
+          }
+        : null;
+    })
+    .filter(
+      (
+        entry,
+      ): entry is {
+        id: string;
+        name: string;
+        arguments: string;
+      } => entry !== null,
+    );
+  return calls.length > 0 ? calls : undefined;
 }
 
 function removeWaiter(runId: string, waiter: () => void): void {
@@ -72,6 +116,14 @@ export function readTerminalSnapshotFromDedupeEntry(
         endedAt?: unknown;
         error?: unknown;
         summary?: unknown;
+        stopReason?: unknown;
+        pendingToolCalls?: unknown;
+        result?: {
+          meta?: {
+            stopReason?: unknown;
+            pendingToolCalls?: unknown;
+          };
+        };
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -87,6 +139,15 @@ export function readTerminalSnapshotFromDedupeEntry(
       : typeof payload?.summary === "string"
         ? payload.summary
         : entry.error?.message;
+  const stopReason =
+    typeof payload?.result?.meta?.stopReason === "string"
+      ? payload.result.meta.stopReason
+      : typeof payload?.stopReason === "string"
+        ? payload.stopReason
+        : undefined;
+  const pendingToolCalls =
+    parsePendingToolCalls(payload?.result?.meta?.pendingToolCalls) ??
+    parsePendingToolCalls(payload?.pendingToolCalls);
 
   if (status === "ok" || status === "timeout") {
     return {
@@ -94,6 +155,8 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: status === "timeout" ? errorMessage : undefined,
+      stopReason,
+      pendingToolCalls,
     };
   }
   if (status === "error" || !entry.ok) {
@@ -102,6 +165,8 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: errorMessage,
+      stopReason,
+      pendingToolCalls,
     };
   }
   return null;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -406,6 +406,64 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
+  it("forwards structured subagent options to agentCommandFromIngress", async () => {
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "structured helper run",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        disableTools: true,
+        clientTools: [
+          {
+            type: "function",
+            function: {
+              name: "emit_structured_result",
+              description: "Return a structured result payload.",
+              parameters: {
+                type: "object",
+                properties: {
+                  entries: { type: "array" },
+                },
+              },
+            },
+          },
+        ],
+        streamParams: {
+          toolChoice: {
+            type: "function",
+            function: {
+              name: "emit_structured_result",
+            },
+          },
+        },
+        idempotencyKey: "test-structured-helper",
+      } as AgentParams,
+      { reqId: "structured-helper-1" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(callArgs.disableTools).toBe(true);
+    expect(callArgs.clientTools).toEqual([
+      {
+        type: "function",
+        function: expect.objectContaining({
+          name: "emit_structured_result",
+        }),
+      },
+    ]);
+    expect(callArgs.streamParams).toEqual({
+      toolChoice: {
+        type: "function",
+        function: {
+          name: "emit_structured_result",
+        },
+      },
+    });
+  });
+
   it("rejects public spawned-run metadata fields", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../utils/delivery-context.js", async () => {
 
 const makeContext = (): GatewayRequestContext =>
   ({
+    agentAbortControllers: new Map(),
     dedupe: new Map(),
     addChatRun: vi.fn(),
     logGateway: { info: vi.fn(), error: vi.fn() },
@@ -517,6 +518,31 @@ describe("gateway agent handler", () => {
     // Should be undefined, not cause an error
     expect(capturedEntry?.cliSessionIds).toBeUndefined();
     expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("aborts active agent runs by run id", () => {
+    const respond = vi.fn();
+    const controller = new AbortController();
+    const context = makeContext();
+    context.agentAbortControllers.set("run-1", {
+      controller,
+      sessionKey: "agent:main:main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    void agentHandlers["agent.abort"]({
+      params: { runId: "run-1", sessionKey: "agent:main:main" },
+      respond: respond as never,
+      context,
+      req: { type: "req", id: "agent-abort-1", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(context.agentAbortControllers.has("run-1")).toBe(false);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, aborted: true, runId: "run-1" });
   });
 
   it("prunes legacy main alias keys when writing a canonical session entry", async () => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -545,6 +545,70 @@ describe("gateway agent handler", () => {
     expect(respond).toHaveBeenCalledWith(true, { ok: true, aborted: true, runId: "run-1" });
   });
 
+  it("keeps a newer abort controller entry when an older run with the same id finishes", async () => {
+    mockMainSessionEntry({ sessionId: "existing-session-id" });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+
+    let resolveOlderRun:
+      | ((value: { payloads: Array<{ text: string }>; meta: { durationMs: number } }) => void)
+      | undefined;
+    mocks.agentCommand.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOlderRun = resolve;
+        }),
+    );
+
+    const context = makeContext();
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "older run",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "shared-run-id",
+      },
+      { respond, reqId: "shared-run-id", context },
+    );
+
+    const olderEntry = context.agentAbortControllers.get("shared-run-id");
+    expect(olderEntry).toBeDefined();
+
+    const newerController = new AbortController();
+    context.agentAbortControllers.set("shared-run-id", {
+      controller: newerController,
+      sessionKey: "agent:main:main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    resolveOlderRun?.({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await vi.waitFor(() => expect(respond).toHaveBeenCalledTimes(2));
+
+    expect(context.agentAbortControllers.get("shared-run-id")?.controller).toBe(newerController);
+
+    const abortRespond = vi.fn();
+    await agentHandlers["agent.abort"]({
+      params: { runId: "shared-run-id", sessionKey: "agent:main:main" },
+      respond: abortRespond as never,
+      context,
+      req: { type: "req", id: "agent-abort-shared", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(newerController.signal.aborted).toBe(true);
+    expect(context.agentAbortControllers.has("shared-run-id")).toBe(false);
+    expect(abortRespond).toHaveBeenCalledWith(true, {
+      ok: true,
+      aborted: true,
+      runId: "shared-run-id",
+    });
+  });
+
   it("prunes legacy main alias keys when writing a canonical session entry", async () => {
     mocks.loadSessionEntry.mockReturnValue({
       cfg: {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -5,7 +5,9 @@ import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -33,6 +35,7 @@ import {
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { abortAgentRunById, resolveAgentRunExpiresAtMs } from "../agent-abort.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
@@ -42,6 +45,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validateAgentAbortParams,
   validateAgentIdentityParams,
   validateAgentParams,
   validateAgentWaitParams,
@@ -142,7 +146,120 @@ function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         error: formatForLog(err),
       });
+    })
+    .finally(() => {
+      params.context.agentAbortControllers.delete(params.runId);
     });
+}
+
+function startAcceptedAgentRunFromGateway(params: {
+  request: {
+    thinking?: string;
+    timeout?: number;
+    lane?: string;
+    extraSystemPrompt?: string;
+    internalEvents?: AgentInternalEvent[];
+    deliver?: boolean;
+  };
+  message: string;
+  images: Array<{ type: "image"; data: string; mimeType: string }>;
+  resolvedTo: string | undefined;
+  resolvedSessionId: string | undefined;
+  resolvedSessionKey: string | undefined;
+  resolvedChannel: string;
+  resolvedAccountId: string | undefined;
+  resolvedThreadId: string | number | undefined;
+  resolvedGroupId: string | undefined;
+  resolvedGroupChannel: string | undefined;
+  resolvedGroupSpace: string | undefined;
+  deliveryTargetMode: ChannelOutboundTargetMode | undefined;
+  originMessageChannel: string;
+  spawnedByValue: string | undefined;
+  sessionEntry: SessionEntry | undefined;
+  senderIsOwner: boolean;
+  inputProvenance: InputProvenance | undefined;
+  bestEffortDeliver: boolean;
+  resolvedTimeoutMs: number;
+  runId: string;
+  idempotencyKey: string;
+  respond: GatewayRequestHandlerOptions["respond"];
+  context: GatewayRequestHandlerOptions["context"];
+}) {
+  const deliver =
+    params.request.deliver === true && params.resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+  const accepted = {
+    runId: params.runId,
+    status: "accepted" as const,
+    acceptedAt: Date.now(),
+  };
+  const agentAbortController = new AbortController();
+  params.context.agentAbortControllers.set(params.runId, {
+    controller: agentAbortController,
+    sessionKey: params.resolvedSessionKey,
+    startedAtMs: accepted.acceptedAt,
+    expiresAtMs: resolveAgentRunExpiresAtMs({
+      now: accepted.acceptedAt,
+      timeoutMs: params.resolvedTimeoutMs,
+    }),
+  });
+  setGatewayDedupeEntry({
+    dedupe: params.context.dedupe,
+    key: `agent:${params.idempotencyKey}`,
+    entry: {
+      ts: Date.now(),
+      ok: true,
+      payload: accepted,
+    },
+  });
+  params.respond(true, accepted, undefined, { runId: params.runId });
+
+  dispatchAgentRunFromGateway({
+    ingressOpts: {
+      message: params.message,
+      images: params.images,
+      to: params.resolvedTo,
+      sessionId: params.resolvedSessionId,
+      sessionKey: params.resolvedSessionKey,
+      thinking: params.request.thinking,
+      deliver,
+      deliveryTargetMode: params.deliveryTargetMode,
+      channel: params.resolvedChannel,
+      accountId: params.resolvedAccountId,
+      threadId: params.resolvedThreadId,
+      runContext: {
+        messageChannel: params.originMessageChannel,
+        accountId: params.resolvedAccountId,
+        groupId: params.resolvedGroupId,
+        groupChannel: params.resolvedGroupChannel,
+        groupSpace: params.resolvedGroupSpace,
+        currentThreadTs:
+          params.resolvedThreadId != null ? String(params.resolvedThreadId) : undefined,
+      },
+      groupId: params.resolvedGroupId,
+      groupChannel: params.resolvedGroupChannel,
+      groupSpace: params.resolvedGroupSpace,
+      spawnedBy: params.spawnedByValue,
+      timeout: params.request.timeout?.toString(),
+      bestEffortDeliver: params.bestEffortDeliver,
+      messageChannel: params.originMessageChannel,
+      runId: params.runId,
+      lane: params.request.lane,
+      extraSystemPrompt: params.request.extraSystemPrompt,
+      internalEvents: params.request.internalEvents,
+      inputProvenance: params.inputProvenance,
+      abortSignal: agentAbortController.signal,
+      // Internal-only: allow workspace override for spawned subagent runs.
+      workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
+        spawnedBy: params.spawnedByValue,
+        workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
+      }),
+      senderIsOwner: params.senderIsOwner,
+    },
+    runId: params.runId,
+    idempotencyKey: params.idempotencyKey,
+    respond: params.respond,
+    context: params.context,
+  });
 }
 
 export const agentHandlers: GatewayRequestHandlers = {
@@ -559,72 +676,67 @@ export const agentHandlers: GatewayRequestHandlers = {
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel);
 
-    const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
-
-    const accepted = {
-      runId,
-      status: "accepted" as const,
-      acceptedAt: Date.now(),
-    };
-    // Store an in-flight ack so retries do not spawn a second run.
-    setGatewayDedupeEntry({
-      dedupe: context.dedupe,
-      key: `agent:${idem}`,
-      entry: {
-        ts: Date.now(),
-        ok: true,
-        payload: accepted,
-      },
-    });
-    respond(true, accepted, undefined, { runId });
-
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
+    const resolvedTimeoutMs = resolveAgentTimeoutMs({
+      cfg: cfgForAgent ?? cfg,
+      overrideSeconds: request.timeout,
+    });
 
-    dispatchAgentRunFromGateway({
-      ingressOpts: {
-        message,
-        images,
-        to: resolvedTo,
-        sessionId: resolvedSessionId,
-        sessionKey: resolvedSessionKey,
-        thinking: request.thinking,
-        deliver,
-        deliveryTargetMode,
-        channel: resolvedChannel,
-        accountId: resolvedAccountId,
-        threadId: resolvedThreadId,
-        runContext: {
-          messageChannel: originMessageChannel,
-          accountId: resolvedAccountId,
-          groupId: resolvedGroupId,
-          groupChannel: resolvedGroupChannel,
-          groupSpace: resolvedGroupSpace,
-          currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
-        },
-        groupId: resolvedGroupId,
-        groupChannel: resolvedGroupChannel,
-        groupSpace: resolvedGroupSpace,
-        spawnedBy: spawnedByValue,
-        timeout: request.timeout?.toString(),
-        bestEffortDeliver,
-        messageChannel: originMessageChannel,
-        runId,
-        lane: request.lane,
-        extraSystemPrompt: request.extraSystemPrompt,
-        internalEvents: request.internalEvents,
-        inputProvenance,
-        // Internal-only: allow workspace override for spawned subagent runs.
-        workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
-          spawnedBy: spawnedByValue,
-          workspaceDir: sessionEntry?.spawnedWorkspaceDir,
-        }),
-        senderIsOwner,
-      },
+    startAcceptedAgentRunFromGateway({
+      request,
+      message,
+      images,
+      resolvedTo,
+      resolvedSessionId,
+      resolvedSessionKey,
+      resolvedChannel,
+      resolvedAccountId,
+      resolvedThreadId,
+      resolvedGroupId,
+      resolvedGroupChannel,
+      resolvedGroupSpace,
+      deliveryTargetMode,
+      originMessageChannel,
+      spawnedByValue,
+      sessionEntry,
+      senderIsOwner,
+      inputProvenance,
+      bestEffortDeliver,
+      resolvedTimeoutMs,
       runId,
       idempotencyKey: idem,
       respond,
       context,
     });
+  },
+  "agent.enqueue": async ({ req, params, respond, context, client, isWebchatConnect }) => {
+    await agentHandlers.agent({ req, params, respond, context, client, isWebchatConnect });
+  },
+  "agent.abort": ({ params, respond, context }) => {
+    if (!validateAgentAbortParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid agent.abort params: ${formatValidationErrors(validateAgentAbortParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const request = params as { runId: string; sessionKey?: string };
+    const runId = request.runId.trim();
+    const sessionKey =
+      typeof request.sessionKey === "string" && request.sessionKey.trim()
+        ? request.sessionKey.trim()
+        : undefined;
+    const result = abortAgentRunById({
+      agentAbortControllers: context.agentAbortControllers,
+      runId,
+      sessionKey,
+      reason: "rpc",
+    });
+    respond(true, { ok: true, aborted: result.aborted, runId });
   },
   "agent.identity.get": ({ params, respond }) => {
     if (!validateAgentIdentityParams(params)) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -9,6 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
+import type { AgentStreamParams } from "../../commands/agent/types.js";
 import { loadConfig } from "../../config/config.js";
 import {
   mergeSessionEntry,
@@ -164,6 +165,16 @@ function startAcceptedAgentRunFromGateway(params: {
     extraSystemPrompt?: string;
     internalEvents?: AgentInternalEvent[];
     deliver?: boolean;
+    clientTools?: Array<{
+      type: "function";
+      function: {
+        name: string;
+        description?: string;
+        parameters?: Record<string, unknown>;
+      };
+    }>;
+    disableTools?: boolean;
+    streamParams?: AgentStreamParams;
   };
   message: string;
   images: Array<{ type: "image"; data: string; mimeType: string }>;
@@ -250,6 +261,9 @@ function startAcceptedAgentRunFromGateway(params: {
       lane: params.request.lane,
       extraSystemPrompt: params.request.extraSystemPrompt,
       internalEvents: params.request.internalEvents,
+      clientTools: params.request.clientTools,
+      disableTools: params.request.disableTools,
+      streamParams: params.request.streamParams,
       inputProvenance: params.inputProvenance,
       abortSignal: agentAbortController.signal,
       // Internal-only: allow workspace override for spawned subagent runs.
@@ -307,6 +321,16 @@ export const agentHandlers: GatewayRequestHandlers = {
       lane?: string;
       extraSystemPrompt?: string;
       internalEvents?: AgentInternalEvent[];
+      clientTools?: Array<{
+        type: "function";
+        function: {
+          name: string;
+          description?: string;
+          parameters?: Record<string, unknown>;
+        };
+      }>;
+      disableTools?: boolean;
+      streamParams?: AgentStreamParams;
       idempotencyKey: string;
       timeout?: number;
       bestEffortDeliver?: boolean;
@@ -829,6 +853,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         startedAt: cachedGatewaySnapshot.startedAt,
         endedAt: cachedGatewaySnapshot.endedAt,
         error: cachedGatewaySnapshot.error,
+        stopReason: cachedGatewaySnapshot.stopReason,
+        pendingToolCalls: cachedGatewaySnapshot.pendingToolCalls,
       });
       return;
     }
@@ -883,6 +909,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      stopReason: snapshot.stopReason,
+      pendingToolCalls: snapshot.pendingToolCalls,
     });
   },
 };

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -101,6 +101,7 @@ function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
   idempotencyKey: string;
+  abortController: AbortController;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
 }) {
@@ -148,7 +149,10 @@ function dispatchAgentRunFromGateway(params: {
       });
     })
     .finally(() => {
-      params.context.agentAbortControllers.delete(params.runId);
+      const active = params.context.agentAbortControllers.get(params.runId);
+      if (active?.controller === params.abortController) {
+        params.context.agentAbortControllers.delete(params.runId);
+      }
     });
 }
 
@@ -257,6 +261,7 @@ function startAcceptedAgentRunFromGateway(params: {
     },
     runId: params.runId,
     idempotencyKey: params.idempotencyKey,
+    abortController: agentAbortController,
     respond: params.respond,
     context: params.context,
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -249,6 +249,8 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
     config: cfg,
     cache: true,
     workspaceDir,
+    inheritSharedRuntimeOptions: true,
+    activateGlobalHookRunner: false,
     logger: {
       info: () => {},
       warn: () => {},

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -4,6 +4,7 @@ import type { HealthSummary } from "../../commands/health.js";
 import type { CronService } from "../../cron/service.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
+import type { AgentAbortControllerEntry } from "../agent-abort.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { NodeRegistry } from "../node-registry.js";
@@ -53,6 +54,7 @@ export type GatewayRequestContext = {
   hasExecApprovalClients?: () => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -51,10 +51,21 @@ function getLastDispatchedContext(): GatewayRequestContext | undefined {
 }
 
 function getLastDispatchedRequest():
-  | (GatewayRequestOptions["req"] & { params?: Record<string, unknown> })
+  | { method: string; params?: Record<string, unknown> }
   | undefined {
   const call = handleGatewayRequest.mock.calls.at(-1)?.[0];
-  return call?.req;
+  const req = call?.req;
+  if (!req) {
+    return undefined;
+  }
+  const params =
+    "params" in req && req.params != null && typeof req.params === "object"
+      ? (req.params as Record<string, unknown>)
+      : undefined;
+  return {
+    method: req.method,
+    params,
+  };
 }
 
 async function importServerPluginsModule(): Promise<ServerPluginsModule> {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PluginRegistry } from "../plugins/registry.js";
+import {
+  clearSharedPluginRuntimeOptions,
+  getSharedPluginRuntimeOptions,
+} from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
@@ -98,6 +102,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearSharedPluginRuntimeOptions();
   vi.resetModules();
 });
 
@@ -158,6 +163,26 @@ describe("loadGatewayPlugins", () => {
     const subagent = call?.runtimeOptions?.subagent;
     expect(typeof subagent?.getSessionMessages).toBe("function");
     expect(typeof subagent?.getSession).toBe("function");
+  });
+
+  test("publishes shared runtime options for later plugin reloads", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+
+    expect(typeof getSharedPluginRuntimeOptions()?.subagent?.run).toBe("function");
   });
 
   test("shares fallback context across module reloads for existing runtimes", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -107,7 +107,17 @@ beforeEach(() => {
         opts.respond(true, { runId: "run-1" });
         return;
       case "agent.wait":
-        opts.respond(true, { status: "ok" });
+        opts.respond(true, {
+          status: "ok",
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call-1",
+              name: "emit_structured_result",
+              arguments: '{"entries":[]}',
+            },
+          ],
+        });
         return;
       case "sessions.get":
         opts.respond(true, { messages: [] });
@@ -355,5 +365,88 @@ describe("loadGatewayPlugins", () => {
       idempotencyKey: "plugin-enqueue-idem",
     });
     expect(getLastDispatchedRequest()?.params?.idempotencyKey).toBe("plugin-enqueue-idem");
+  });
+
+  test("forwards structured plugin subagent options to gateway agent methods", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+
+    await runtime.run({
+      sessionKey: "s-structured",
+      message: "extract memories",
+      disableTools: true,
+      clientTools: [
+        {
+          type: "function",
+          function: {
+            name: "emit_structured_result",
+            description: "Return a structured result payload.",
+            parameters: {
+              type: "object",
+              properties: {
+                entries: {
+                  type: "array",
+                },
+              },
+            },
+          },
+        },
+      ],
+      streamParams: {
+        toolChoice: {
+          type: "function",
+          function: {
+            name: "emit_structured_result",
+          },
+        },
+      },
+    });
+
+    expect(getLastDispatchedRequest()).toEqual({
+      method: "agent",
+      params: expect.objectContaining({
+        sessionKey: "s-structured",
+        message: "extract memories",
+        disableTools: true,
+        clientTools: [
+          {
+            type: "function",
+            function: expect.objectContaining({
+              name: "emit_structured_result",
+            }),
+          },
+        ],
+        streamParams: {
+          toolChoice: {
+            type: "function",
+            function: {
+              name: "emit_structured_result",
+            },
+          },
+        },
+      }),
+    });
+  });
+
+  test("returns pending tool calls from gateway agent.wait", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+
+    const result = await runtime.waitForRun({
+      runId: "run-1",
+      timeoutMs: 1_000,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      stopReason: "tool_calls",
+      pendingToolCalls: [
+        {
+          id: "call-1",
+          name: "emit_structured_result",
+          arguments: '{"entries":[]}',
+        },
+      ],
+    });
   });
 });

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -3,6 +3,7 @@ import type { PluginRegistry } from "../plugins/registry.js";
 import {
   clearSharedPluginRuntimeOptions,
   getSharedPluginRuntimeOptions,
+  setSharedPluginRuntimeOptions,
 } from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
@@ -202,6 +203,60 @@ describe("loadGatewayPlugins", () => {
     });
 
     expect(typeof getSharedPluginRuntimeOptions()?.subagent?.run).toBe("function");
+  });
+
+  test("rolls back shared runtime options when plugin loading fails", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("plugin load failed");
+    });
+
+    expect(() =>
+      loadGatewayPlugins({
+        cfg: {},
+        workspaceDir: "/tmp",
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        coreGatewayHandlers: {},
+        baseMethods: [],
+      }),
+    ).toThrow("plugin load failed");
+
+    expect(getSharedPluginRuntimeOptions()).toBeUndefined();
+  });
+
+  test("restores previous shared runtime options when plugin loading fails", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    const previousRuntime = {
+      subagent: {
+        run: vi.fn(),
+      },
+    } as unknown as NonNullable<ReturnType<typeof getSharedPluginRuntimeOptions>>;
+    setSharedPluginRuntimeOptions(previousRuntime);
+    loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("plugin load failed");
+    });
+
+    expect(() =>
+      loadGatewayPlugins({
+        cfg: {},
+        workspaceDir: "/tmp",
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        coreGatewayHandlers: {},
+        baseMethods: [],
+      }),
+    ).toThrow("plugin load failed");
+
+    expect(getSharedPluginRuntimeOptions()).toBe(previousRuntime);
   });
 
   test("shares fallback context across module reloads for existing runtimes", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -50,6 +50,13 @@ function getLastDispatchedContext(): GatewayRequestContext | undefined {
   return call?.context;
 }
 
+function getLastDispatchedRequest():
+  | (GatewayRequestOptions["req"] & { params?: Record<string, unknown> })
+  | undefined {
+  const call = handleGatewayRequest.mock.calls.at(-1)?.[0];
+  return call?.req;
+}
+
 async function importServerPluginsModule(): Promise<ServerPluginsModule> {
   return import("./server-plugins.js");
 }
@@ -84,6 +91,7 @@ beforeEach(() => {
   handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
     switch (opts.req.method) {
       case "agent":
+      case "agent.enqueue":
         opts.respond(true, { runId: "run-1" });
         return;
       case "agent.wait":
@@ -233,5 +241,53 @@ describe("loadGatewayPlugins", () => {
       | (GatewayRequestContext & { marker: string })
       | undefined;
     expect(dispatched?.marker).toBe("after-mutation");
+  });
+
+  test("mints idempotency keys for plugin subagent requests when absent", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+
+    await runtime.run({ sessionKey: "s-run", message: "hello" });
+    const runRequest = getLastDispatchedRequest();
+    expect(runRequest?.method).toBe("agent");
+    expect(runRequest?.params).toMatchObject({
+      sessionKey: "s-run",
+      message: "hello",
+      deliver: false,
+    });
+    expect(runRequest?.params?.idempotencyKey).toEqual(
+      expect.stringMatching(/^plugin-subagent:agent:s-run:/),
+    );
+
+    await runtime.enqueue({ sessionKey: "s-enqueue", message: "queued" });
+    const enqueueRequest = getLastDispatchedRequest();
+    expect(enqueueRequest?.method).toBe("agent.enqueue");
+    expect(enqueueRequest?.params).toMatchObject({
+      sessionKey: "s-enqueue",
+      message: "queued",
+      deliver: false,
+    });
+    expect(enqueueRequest?.params?.idempotencyKey).toEqual(
+      expect.stringMatching(/^plugin-subagent:agent\.enqueue:s-enqueue:/),
+    );
+  });
+
+  test("preserves caller-provided idempotency keys for plugin subagent requests", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = createSubagentRuntime(serverPlugins);
+
+    await runtime.run({
+      sessionKey: "s-run",
+      message: "hello",
+      idempotencyKey: "plugin-run-idem",
+    });
+    expect(getLastDispatchedRequest()?.params?.idempotencyKey).toBe("plugin-run-idem");
+
+    await runtime.enqueue({
+      sessionKey: "s-enqueue",
+      message: "queued",
+      idempotencyKey: "plugin-enqueue-idem",
+    });
+    expect(getLastDispatchedRequest()?.params?.idempotencyKey).toBe("plugin-enqueue-idem");
   });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -143,6 +143,9 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         }),
         ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
         ...(params.lane && { lane: params.lane }),
+        ...(params.clientTools && { clientTools: params.clientTools }),
+        ...(params.disableTools === true && { disableTools: true }),
+        ...(params.streamParams && { streamParams: params.streamParams }),
       });
       const runId = payload?.runId;
       if (typeof runId !== "string" || !runId) {
@@ -162,6 +165,9 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         }),
         ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
         ...(params.lane && { lane: params.lane }),
+        ...(params.clientTools && { clientTools: params.clientTools }),
+        ...(params.disableTools === true && { disableTools: true }),
+        ...(params.streamParams && { streamParams: params.streamParams }),
       });
       const runId = payload?.runId;
       if (typeof runId !== "string" || !runId) {
@@ -177,13 +183,19 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { aborted: payload?.aborted === true };
     },
     async waitForRun(params) {
-      const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-      );
+      const payload = await dispatchGatewayMethod<{
+        status?: string;
+        error?: string;
+        stopReason?: string;
+        pendingToolCalls?: Array<{
+          id: string;
+          name: string;
+          arguments: string;
+        }>;
+      }>("agent.wait", {
+        runId: params.runId,
+        ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
+      });
       const status = payload?.status;
       if (status !== "ok" && status !== "error" && status !== "timeout") {
         throw new Error(`Gateway agent.wait returned unexpected status: ${status}`);
@@ -191,6 +203,12 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return {
         status,
         ...(typeof payload?.error === "string" && payload.error && { error: payload.error }),
+        ...(typeof payload?.stopReason === "string" &&
+          payload.stopReason && { stopReason: payload.stopReason }),
+        ...(Array.isArray(payload?.pendingToolCalls) &&
+          payload.pendingToolCalls.length > 0 && {
+            pendingToolCalls: payload.pendingToolCalls,
+          }),
       };
     },
     getSessionMessages,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import type { loadConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
-import { setSharedPluginRuntimeOptions } from "../plugins/runtime/shared-runtime-options.js";
+import {
+  clearSharedPluginRuntimeOptions,
+  getSharedPluginRuntimeOptions,
+  setSharedPluginRuntimeOptions,
+} from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import type { ErrorShape } from "./protocol/index.js";
@@ -217,23 +221,34 @@ export function loadGatewayPlugins(params: {
   baseMethods: string[];
 }) {
   const gatewaySubagentRuntime = createGatewaySubagentRuntime();
+  const previousSharedRuntimeOptions = getSharedPluginRuntimeOptions();
   setSharedPluginRuntimeOptions({
     subagent: gatewaySubagentRuntime,
   });
-  const pluginRegistry = loadOpenClawPlugins({
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    logger: {
-      info: (msg) => params.log.info(msg),
-      warn: (msg) => params.log.warn(msg),
-      error: (msg) => params.log.error(msg),
-      debug: (msg) => params.log.debug(msg),
-    },
-    coreGatewayHandlers: params.coreGatewayHandlers,
-    runtimeOptions: {
-      subagent: gatewaySubagentRuntime,
-    },
-  });
+  let pluginRegistry;
+  try {
+    pluginRegistry = loadOpenClawPlugins({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      logger: {
+        info: (msg) => params.log.info(msg),
+        warn: (msg) => params.log.warn(msg),
+        error: (msg) => params.log.error(msg),
+        debug: (msg) => params.log.debug(msg),
+      },
+      coreGatewayHandlers: params.coreGatewayHandlers,
+      runtimeOptions: {
+        subagent: gatewaySubagentRuntime,
+      },
+    });
+  } catch (error) {
+    if (previousSharedRuntimeOptions) {
+      setSharedPluginRuntimeOptions(previousSharedRuntimeOptions);
+    } else {
+      clearSharedPluginRuntimeOptions();
+    }
+    throw error;
+  }
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);
   const gatewayMethods = Array.from(new Set([...params.baseMethods, ...pluginMethods]));
   if (pluginRegistry.diagnostics.length > 0) {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { loadConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { setSharedPluginRuntimeOptions } from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import type { ErrorShape } from "./protocol/index.js";
@@ -129,6 +130,28 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       }
       return { runId };
     },
+    async enqueue(params) {
+      const payload = await dispatchGatewayMethod<{ runId?: string }>("agent.enqueue", {
+        sessionKey: params.sessionKey,
+        message: params.message,
+        deliver: params.deliver ?? false,
+        ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+        ...(params.lane && { lane: params.lane }),
+        ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
+      });
+      const runId = payload?.runId;
+      if (typeof runId !== "string" || !runId) {
+        throw new Error("Gateway agent.enqueue method returned an invalid runId.");
+      }
+      return { runId };
+    },
+    async abort(params) {
+      const payload = await dispatchGatewayMethod<{ aborted?: boolean }>("agent.abort", {
+        runId: params.runId,
+        ...(params.sessionKey && { sessionKey: params.sessionKey }),
+      });
+      return { aborted: payload?.aborted === true };
+    },
     async waitForRun(params) {
       const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
         "agent.wait",
@@ -173,6 +196,10 @@ export function loadGatewayPlugins(params: {
   coreGatewayHandlers: Record<string, GatewayRequestHandler>;
   baseMethods: string[];
 }) {
+  const gatewaySubagentRuntime = createGatewaySubagentRuntime();
+  setSharedPluginRuntimeOptions({
+    subagent: gatewaySubagentRuntime,
+  });
   const pluginRegistry = loadOpenClawPlugins({
     config: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -184,7 +211,7 @@ export function loadGatewayPlugins(params: {
     },
     coreGatewayHandlers: params.coreGatewayHandlers,
     runtimeOptions: {
-      subagent: createGatewaySubagentRuntime(),
+      subagent: gatewaySubagentRuntime,
     },
   });
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -110,8 +110,7 @@ function resolvePluginSubagentIdempotencyKey(params: {
   sessionKey: string;
   method: "agent" | "agent.enqueue";
 }): string {
-  const provided =
-    typeof params.idempotencyKey === "string" ? params.idempotencyKey.trim() : "";
+  const provided = typeof params.idempotencyKey === "string" ? params.idempotencyKey.trim() : "";
   if (provided) {
     return provided;
   }

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -105,6 +105,19 @@ async function dispatchGatewayMethod<T>(
   return result.payload as T;
 }
 
+function resolvePluginSubagentIdempotencyKey(params: {
+  idempotencyKey?: string;
+  sessionKey: string;
+  method: "agent" | "agent.enqueue";
+}): string {
+  const provided =
+    typeof params.idempotencyKey === "string" ? params.idempotencyKey.trim() : "";
+  if (provided) {
+    return provided;
+  }
+  return `plugin-subagent:${params.method}:${params.sessionKey}:${randomUUID()}`;
+}
+
 function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
   const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
     const payload = await dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
@@ -120,9 +133,13 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         sessionKey: params.sessionKey,
         message: params.message,
         deliver: params.deliver ?? false,
+        idempotencyKey: resolvePluginSubagentIdempotencyKey({
+          idempotencyKey: params.idempotencyKey,
+          sessionKey: params.sessionKey,
+          method: "agent",
+        }),
         ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
         ...(params.lane && { lane: params.lane }),
-        ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
       });
       const runId = payload?.runId;
       if (typeof runId !== "string" || !runId) {
@@ -135,9 +152,13 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         sessionKey: params.sessionKey,
         message: params.message,
         deliver: params.deliver ?? false,
+        idempotencyKey: resolvePluginSubagentIdempotencyKey({
+          idempotencyKey: params.idempotencyKey,
+          sessionKey: params.sessionKey,
+          method: "agent.enqueue",
+        }),
         ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
         ...(params.lane && { lane: params.lane }),
-        ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
       });
       const runId = payload?.runId;
       if (typeof runId !== "string" || !runId) {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -6,6 +6,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { AgentAbortControllerEntry } from "./agent-abort.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
@@ -78,6 +79,7 @@ export async function createGatewayRuntimeState(params: {
   broadcast: GatewayBroadcastFn;
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   agentRunSeq: Map<string, number>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   dedupe: Map<string, DedupeEntry>;
   chatRunState: ReturnType<typeof createChatRunState>;
   chatRunBuffers: Map<string, string>;
@@ -205,6 +207,7 @@ export async function createGatewayRuntimeState(params: {
   }
 
   const agentRunSeq = new Map<string, number>();
+  const agentAbortControllers = new Map<string, AgentAbortControllerEntry>();
   const dedupe = new Map<string, DedupeEntry>();
   const chatRunState = createChatRunState();
   const chatRunRegistry = chatRunState.registry;
@@ -225,6 +228,7 @@ export async function createGatewayRuntimeState(params: {
     broadcast,
     broadcastToConnIds,
     agentRunSeq,
+    agentAbortControllers,
     dedupe,
     chatRunState,
     chatRunBuffers,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -48,6 +48,7 @@ import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { clearSharedPluginRuntimeOptions } from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -591,6 +592,7 @@ export async function startGatewayServer(
     broadcast,
     broadcastToConnIds,
     agentRunSeq,
+    agentAbortControllers,
     dedupe,
     chatRunState,
     chatRunBuffers,
@@ -714,6 +716,7 @@ export async function startGatewayServer(
       refreshGatewayHealthSnapshot,
       logHealth,
       dedupe,
+      agentAbortControllers,
       chatAbortControllers,
       chatRunState,
       chatRunBuffers,
@@ -853,6 +856,7 @@ export async function startGatewayServer(
     },
     nodeRegistry,
     agentRunSeq,
+    agentAbortControllers,
     chatAbortControllers,
     chatAbortedRuns: chatRunState.abortedRuns,
     chatRunBuffers: chatRunState.buffers,
@@ -1082,6 +1086,7 @@ export async function startGatewayServer(
       authRateLimiter?.dispose();
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
+      clearSharedPluginRuntimeOptions();
       clearSecretsRuntimeSnapshot();
       await close(opts);
     },

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -123,6 +123,9 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       messageId: "out-1",
+      threadId: "thread-1",
+      sessionKey: "agent:agent-1:telegram:chat:456",
+      agentId: "agent-1",
       isGroup: true,
       groupId: "telegram:chat:456",
     });
@@ -137,6 +140,17 @@ describe("message hook mappers", () => {
       content: "reply",
       success: false,
       error: "network error",
+      metadata: {
+        channel: "telegram",
+        accountId: "acc-1",
+        conversationId: "telegram:chat:456",
+        messageId: "out-1",
+        threadId: "thread-1",
+        sessionKey: "agent:agent-1:telegram:chat:456",
+        agentId: "agent-1",
+        isGroup: true,
+        groupId: "telegram:chat:456",
+      },
     });
     expect(toInternalMessageSentContext(canonical)).toEqual({
       to: "telegram:chat:456",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -26,6 +26,7 @@ export type CanonicalInboundMessageHookContext = {
   messageId?: string;
   senderId?: string;
   senderName?: string;
+  senderManagedAccountId?: string;
   senderUsername?: string;
   senderE164?: string;
   provider?: string;
@@ -50,6 +51,9 @@ export type CanonicalSentMessageHookContext = {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 };
@@ -95,6 +99,7 @@ export function deriveInboundMessageHookContext(
       ctx.MessageSidLast,
     senderId: ctx.SenderId,
     senderName: ctx.SenderName,
+    senderManagedAccountId: ctx.SenderManagedAccountId,
     senderUsername: ctx.SenderUsername,
     senderE164: ctx.SenderE164,
     provider: ctx.Provider,
@@ -120,6 +125,9 @@ export function buildCanonicalSentMessageHookContext(params: {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 }): CanonicalSentMessageHookContext {
@@ -132,6 +140,9 @@ export function buildCanonicalSentMessageHookContext(params: {
     accountId: params.accountId,
     conversationId: params.conversationId ?? params.to,
     messageId: params.messageId,
+    threadId: params.threadId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     isGroup: params.isGroup,
     groupId: params.groupId,
   };
@@ -164,6 +175,7 @@ export function toPluginMessageReceivedEvent(
       messageId: canonical.messageId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
@@ -180,6 +192,17 @@ export function toPluginMessageSentEvent(
     content: canonical.content,
     success: canonical.success,
     ...(canonical.error ? { error: canonical.error } : {}),
+    metadata: {
+      channel: canonical.channelId,
+      accountId: canonical.accountId,
+      conversationId: canonical.conversationId,
+      messageId: canonical.messageId,
+      threadId: canonical.threadId,
+      sessionKey: canonical.sessionKey,
+      agentId: canonical.agentId,
+      isGroup: canonical.isGroup,
+      groupId: canonical.groupId,
+    },
   };
 }
 
@@ -201,6 +224,7 @@ export function toInternalMessageReceivedContext(
       threadId: canonical.threadId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -124,7 +124,6 @@ describe("outbound channel resolution", () => {
       config: { autoEnabled: true },
       workspaceDir: "/tmp/workspace",
       inheritSharedRuntimeOptions: true,
-      activateGlobalHookRunner: false,
     });
 
     getChannelPluginMock.mockReturnValue(undefined);

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -123,6 +123,8 @@ describe("outbound channel resolution", () => {
     expect(loadOpenClawPluginsMock).toHaveBeenCalledWith({
       config: { autoEnabled: true },
       workspaceDir: "/tmp/workspace",
+      inheritSharedRuntimeOptions: true,
+      activateGlobalHookRunner: false,
     });
 
     getChannelPluginMock.mockReturnValue(undefined);

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -51,6 +51,8 @@ function maybeBootstrapChannelPlugin(params: {
     loadOpenClawPlugins({
       config: autoEnabled,
       workspaceDir,
+      inheritSharedRuntimeOptions: true,
+      activateGlobalHookRunner: false,
     });
   } catch {
     // Allow a follow-up resolution attempt if bootstrap failed transiently.

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -52,7 +52,6 @@ function maybeBootstrapChannelPlugin(params: {
       config: autoEnabled,
       workspaceDir,
       inheritSharedRuntimeOptions: true,
-      activateGlobalHookRunner: false,
     });
   } catch {
     // Allow a follow-up resolution attempt if bootstrap failed transiently.

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -18,7 +18,8 @@ const mocks = vi.hoisted(() => ({
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => false),
+    hasHooks: vi.fn<(name: string) => boolean>((_name) => false),
+    runMessageSending: vi.fn(async () => undefined),
     runMessageSent: vi.fn(async () => {}),
   },
 }));
@@ -201,6 +202,8 @@ describe("deliverOutboundPayloads", () => {
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
     hookMocks.runner.hasHooks.mockClear();
     hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSending.mockClear();
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
     hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
     internalHookMocks.createInternalHookEvent.mockClear();
@@ -942,6 +945,167 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("uses the same resolved sessionKey in message_sending and message_sent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello" }],
+      replyToId: "1741719181.247349",
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses payload-level replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-2" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello", replyToId: "1741719181.999999" }],
+      replyToId: undefined,
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to mirror metadata for message_sending when session is absent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+      skipQueue: true,
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
@@ -1156,6 +1320,47 @@ describe("deliverOutboundPayloads", () => {
         error: "downstream failed",
       }),
       expect.objectContaining({ channelId: "whatsapp" }),
+    );
+  });
+
+  it("emits payload-level threadId in message_sent failure metadata for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi.fn().mockRejectedValue(new Error("downstream failed"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "slack",
+        to: "C123",
+        payloads: [{ text: "hi", replyToId: "1741719181.424242" }],
+        threadId: null,
+        session: { key: "agent:sender:session", agentId: "sender-agent" },
+      }),
+    ).rejects.toThrow("downstream failed");
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.424242",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+        success: false,
+        error: "downstream failed",
+      }),
+      expect.anything(),
     );
   });
 });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -308,13 +308,23 @@ function createMessageSentEmitter(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  conversationId?: string;
+  agentId?: string;
+  sessionKey?: string;
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
-}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+}): {
+  emitMessageSent: (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => void;
+  hasMessageSentHooks: boolean;
+} {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
-  const emitMessageSent = (event: MessageSentEvent) => {
+  const emitMessageSent = (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => {
     if (!hasMessageSentHooks && !canEmitInternalHook) {
       return;
     }
@@ -325,8 +335,11 @@ function createMessageSentEmitter(params: {
       error: event.error,
       channelId: params.channel,
       accountId: params.accountId ?? undefined,
-      conversationId: params.to,
+      conversationId: event.conversationId ?? params.conversationId ?? params.to,
       messageId: event.messageId,
+      threadId: event.threadId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -363,6 +376,31 @@ function createMessageSentEmitter(params: {
   return { emitMessageSent, hasMessageSentHooks };
 }
 
+function resolveOutboundHookMetadata(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  conversationId?: string;
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  session?: OutboundSessionContext;
+  mirror?: DeliverOutboundPayloadsCoreParams["mirror"];
+}): {
+  conversationId: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
+} {
+  const resolvedThreadId =
+    params.threadId ??
+    (params.channel === "slack" && params.replyToId ? params.replyToId : undefined);
+  return {
+    conversationId: params.conversationId ?? params.to,
+    threadId: resolvedThreadId,
+    sessionKey: params.mirror?.sessionKey ?? params.session?.key,
+    agentId: params.mirror?.agentId ?? params.session?.agentId,
+  };
+}
+
 async function applyMessageSendingHook(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
@@ -371,6 +409,10 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  conversationId?: string;
+  threadId?: string | number | null;
+  sessionKey?: string;
+  agentId?: string;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
@@ -391,12 +433,17 @@ async function applyMessageSendingHook(params: {
         metadata: {
           channel: params.channel,
           accountId: params.accountId,
+          conversationId: params.conversationId ?? params.to,
+          threadId: params.threadId ?? undefined,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
           mediaUrls: params.payloadSummary.mediaUrls,
         },
       },
       {
         channelId: params.channel,
         accountId: params.accountId ?? undefined,
+        conversationId: params.conversationId ?? params.to,
       },
     );
     if (sendingResult?.cancel) {
@@ -647,7 +694,16 @@ async function deliverOutboundPayloadsCore(
     accountId,
   );
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
+  const hookMetadata = resolveOutboundHookMetadata({
+    channel,
+    to,
+    conversationId: to,
+    replyToId: params.replyToId,
+    threadId: params.threadId,
+    session: params.session,
+    mirror: params.mirror,
+  });
+  const sessionKeyForInternalHooks = hookMetadata.sessionKey;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
@@ -655,23 +711,35 @@ async function deliverOutboundPayloadsCore(
     channel,
     to,
     accountId,
+    conversationId: hookMetadata.conversationId,
+    agentId: hookMetadata.agentId,
+    sessionKey: hookMetadata.sessionKey,
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
+  if (hasMessageSentHooks && hookMetadata.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
         channel,
         to,
-        agentId: params.session.agentId,
+        agentId: hookMetadata.agentId,
       },
     );
   }
   for (const payload of normalizedPayloads) {
     let payloadSummary = buildPayloadSummary(payload);
+    let payloadHookMetadata = resolveOutboundHookMetadata({
+      channel,
+      to,
+      conversationId: to,
+      replyToId: payload.replyToId ?? params.replyToId,
+      threadId: params.threadId,
+      session: params.session,
+      mirror: params.mirror,
+    });
     try {
       throwIfAborted(abortSignal);
 
@@ -684,6 +752,10 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
+        sessionKey: payloadHookMetadata.sessionKey,
+        agentId: payloadHookMetadata.agentId,
       });
       if (hookResult.cancelled) {
         continue;
@@ -697,6 +769,15 @@ async function deliverOutboundPayloadsCore(
         threadId: params.threadId ?? undefined,
         forceDocument: params.forceDocument,
       };
+      payloadHookMetadata = resolveOutboundHookMetadata({
+        channel,
+        to,
+        conversationId: to,
+        replyToId: sendOverrides.replyToId,
+        threadId: sendOverrides.threadId,
+        session: params.session,
+        mirror: params.mirror,
+      });
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
@@ -704,6 +785,8 @@ async function deliverOutboundPayloadsCore(
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -719,6 +802,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -745,6 +830,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -769,12 +856,16 @@ async function deliverOutboundPayloadsCore(
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
     } catch (err) {
       emitMessageSent({
         success: false,
         content: payloadSummary.text,
         error: err instanceof Error ? err.message : String(err),
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
       if (!params.bestEffort) {
         throw err;

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -38,9 +38,8 @@ async function readJsonFile(filePath: string): Promise<unknown> {
 }
 
 function expectedBuildSpawn(platform: NodeJS.Platform = process.platform) {
-  return platform === "win32"
-    ? ["cmd.exe", "/d", "/s", "/c", "pnpm", "exec", "tsdown", "--no-clean"]
-    : ["pnpm", "exec", "tsdown", "--no-clean"];
+  void platform;
+  return [process.execPath, "scripts/tsdown-build.mjs", "--no-clean"];
 }
 
 describe("run-node script", () => {
@@ -513,16 +512,9 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
-<<<<<<< HEAD
-      await expect(
-        fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({
-        id: "demo",
-=======
       await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
         id: "demo",
         configSchema: { type: "object" },
->>>>>>> 77582aa1a (Test run-node plugin metadata semantically.)
       });
     });
   });
@@ -589,16 +581,9 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
-<<<<<<< HEAD
-      await expect(
-        fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({
-        id: "demo",
-=======
       await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
         id: "demo",
         configSchema: { type: "object" },
->>>>>>> 77582aa1a (Test run-node plugin metadata semantically.)
       });
     });
   });

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -33,8 +33,14 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
   await fs.utimes(pluginSdkAliasPath, baselineTime, baselineTime);
 }
 
-function expectedBuildSpawn() {
-  return [process.execPath, "scripts/tsdown-build.mjs", "--no-clean"];
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf-8"));
+}
+
+function expectedBuildSpawn(platform: NodeJS.Platform = process.platform) {
+  return platform === "win32"
+    ? ["cmd.exe", "/d", "/s", "/c", "pnpm", "exec", "tsdown", "--no-clean"]
+    : ["pnpm", "exec", "tsdown", "--no-clean"];
 }
 
 describe("run-node script", () => {
@@ -154,10 +160,11 @@ describe("run-node script", () => {
         fs.readFile(path.join(tmp, "dist", "plugin-sdk", "root-alias.cjs"), "utf-8"),
       ).resolves.toContain("module.exports = {};");
       await expect(
-        fs
-          .readFile(path.join(tmp, "dist", "extensions", "demo", "openclaw.plugin.json"), "utf-8")
-          .then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({ id: "demo" });
+        readJsonFile(path.join(tmp, "dist", "extensions", "demo", "openclaw.plugin.json")),
+      ).resolves.toMatchObject({
+        id: "demo",
+        configSchema: { type: "object" },
+      });
       await expect(
         fs.readFile(path.join(tmp, "dist", "extensions", "demo", "package.json"), "utf-8"),
       ).resolves.toContain(
@@ -506,10 +513,16 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
+<<<<<<< HEAD
       await expect(
         fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
       ).resolves.toMatchObject({
         id: "demo",
+=======
+      await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
+        id: "demo",
+        configSchema: { type: "object" },
+>>>>>>> 77582aa1a (Test run-node plugin metadata semantically.)
       });
     });
   });
@@ -576,10 +589,16 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
+<<<<<<< HEAD
       await expect(
         fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
       ).resolves.toMatchObject({
         id: "demo",
+=======
+      await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
+        id: "demo",
+        configSchema: { type: "object" },
+>>>>>>> 77582aa1a (Test run-node plugin metadata semantically.)
       });
     });
   });

--- a/src/plugin-sdk/keyed-async-queue.ts
+++ b/src/plugin-sdk/keyed-async-queue.ts
@@ -45,4 +45,12 @@ export class KeyedAsyncQueue {
       ...(hooks ? { hooks } : {}),
     });
   }
+
+  async waitForIdle(): Promise<void> {
+    const tails = [...this.tails.values()];
+    if (tails.length === 0) {
+      return;
+    }
+    await Promise.allSettled(tails);
+  }
 }

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -25,6 +25,7 @@ export function registerPluginCliCommands(
     config,
     workspaceDir,
     env,
+    activateGlobalHookRunner: false,
     logger,
   });
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -14,25 +14,29 @@ async function importFreshPluginTestModules() {
   vi.unmock("./hooks.js");
   vi.unmock("./loader.js");
   vi.unmock("jiti");
-  const [loader, hookRunnerGlobal, hooks] = await Promise.all([
+  const [loader, hookRunnerGlobal, hooks, sharedRuntimeOptions] = await Promise.all([
     import("./loader.js"),
     import("./hook-runner-global.js"),
     import("./hooks.js"),
+    import("./runtime/shared-runtime-options.js"),
   ]);
   return {
     ...loader,
     ...hookRunnerGlobal,
     ...hooks,
+    ...sharedRuntimeOptions,
   };
 }
 
 const {
   __testing,
   clearPluginLoaderCache,
+  clearSharedPluginRuntimeOptions,
   createHookRunner,
   getGlobalHookRunner,
   loadOpenClawPlugins,
   resetGlobalHookRunner,
+  setSharedPluginRuntimeOptions,
 } = await importFreshPluginTestModules();
 
 type TempPlugin = { dir: string; file: string; id: string };
@@ -302,6 +306,8 @@ function createExtensionApiAliasFixture(params?: { srcBody?: string; distBody?: 
 
 afterEach(() => {
   clearPluginLoaderCache();
+  clearSharedPluginRuntimeOptions();
+  resetGlobalHookRunner();
   if (prevBundledDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -484,6 +490,236 @@ describe("loadOpenClawPlugins", () => {
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("does not reuse cached registries across runtime capability changes", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "runtime-capability-cache",
+      filename: "runtime-capability-cache.cjs",
+      body: `module.exports = {
+        id: "runtime-capability-cache",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "runtime-capability", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["runtime-capability-cache"],
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    await expect(
+      createHookRunner(first, { catchErrors: false }).runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).rejects.toThrow(
+      "Plugin runtime subagent methods are only available during a gateway request.",
+    );
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-1" })),
+      enqueue: vi.fn(async () => ({ runId: "run-1" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const second = loadOpenClawPlugins({
+      ...options,
+      runtimeOptions: { subagent },
+    });
+
+    expect(second).not.toBe(first);
+    await expect(
+      createHookRunner(second).runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).resolves.toBeUndefined();
+    expect(subagent.run).toHaveBeenCalledWith({
+      sessionKey: "runtime-capability",
+      message: "hello",
+    });
+  });
+
+  it("does not inherit shared runtime options without explicit opt-in", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options-no-inherit",
+      filename: "shared-runtime-options-no-inherit.cjs",
+      body: `module.exports = {
+        id: "shared-runtime-options-no-inherit",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "shared-runtime-no-inherit", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    setSharedPluginRuntimeOptions({ subagent });
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-inherit"],
+        },
+      },
+    });
+
+    await expect(
+      createHookRunner(registry, { catchErrors: false }).runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).rejects.toThrow(
+      "Plugin runtime subagent methods are only available during a gateway request.",
+    );
+    expect(subagent.run).not.toHaveBeenCalled();
+  });
+
+  it("does not replace the global hook runner when activation is disabled", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options-no-global-replace",
+      filename: "shared-runtime-options-no-global-replace.cjs",
+      body: `module.exports = {
+        id: "shared-runtime-options-no-global-replace",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "shared-runtime-preserved", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const first = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      runtimeOptions: { subagent },
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-global-replace"],
+        },
+      },
+    });
+    const globalHookRunner = getGlobalHookRunner();
+
+    expect(globalHookRunner).not.toBeNull();
+
+    const second = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      activateGlobalHookRunner: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-global-replace"],
+        },
+      },
+    });
+
+    expect(second).not.toBe(first);
+    expect(getGlobalHookRunner()).toBe(globalHookRunner);
+    await expect(
+      createHookRunner(second, { catchErrors: false }).runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).rejects.toThrow(
+      "Plugin runtime subagent methods are only available during a gateway request.",
+    );
+    await expect(
+      globalHookRunner?.runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).resolves.toBeUndefined();
+    expect(subagent.run).toHaveBeenCalledWith({
+      sessionKey: "shared-runtime-preserved",
+      message: "hello",
+    });
+  });
+  it("uses shared runtime options when explicit runtime options are absent and inheritance is enabled", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options",
+      filename: "shared-runtime-options.cjs",
+      body: `module.exports = {
+        id: "shared-runtime-options",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "shared-runtime", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    setSharedPluginRuntimeOptions({ subagent });
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      inheritSharedRuntimeOptions: true,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options"],
+        },
+      },
+    });
+
+    await expect(
+      createHookRunner(registry).runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).resolves.toBeUndefined();
+    expect(subagent.run).toHaveBeenCalledWith({
+      sessionKey: "shared-runtime",
+      message: "hello",
+    });
   });
 
   it("does not reuse cached bundled plugin registries across env changes", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -14,17 +14,19 @@ async function importFreshPluginTestModules() {
   vi.unmock("./hooks.js");
   vi.unmock("./loader.js");
   vi.unmock("jiti");
-  const [loader, hookRunnerGlobal, hooks, sharedRuntimeOptions] = await Promise.all([
+  const [loader, hookRunnerGlobal, hooks, sharedRuntimeOptions, tools] = await Promise.all([
     import("./loader.js"),
     import("./hook-runner-global.js"),
     import("./hooks.js"),
     import("./runtime/shared-runtime-options.js"),
+    import("./tools.js"),
   ]);
   return {
     ...loader,
     ...hookRunnerGlobal,
     ...hooks,
     ...sharedRuntimeOptions,
+    ...tools,
   };
 }
 
@@ -36,6 +38,7 @@ const {
   getGlobalHookRunner,
   loadOpenClawPlugins,
   resetGlobalHookRunner,
+  resolvePluginTools,
   setSharedPluginRuntimeOptions,
 } = await importFreshPluginTestModules();
 
@@ -673,6 +676,79 @@ describe("loadOpenClawPlugins", () => {
       message: "hello",
     });
   });
+
+  it("preserves the gateway hook runner when resolving plugin tools", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "tool-resolution-preserves-hook-runner",
+      filename: "tool-resolution-preserves-hook-runner.cjs",
+      body: `module.exports = {
+        id: "tool-resolution-preserves-hook-runner",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "tool-resolution-preserved", message: "hello" });
+          });
+          api.registerTool({
+            name: "echo",
+            description: "echo",
+            parameters: { type: "object", properties: {} },
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      runtimeOptions: { subagent },
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["tool-resolution-preserves-hook-runner"],
+        },
+      },
+    });
+    const globalHookRunner = getGlobalHookRunner();
+
+    expect(globalHookRunner).not.toBeNull();
+
+    const tools = resolvePluginTools({
+      context: {
+        config: {
+          plugins: {
+            enabled: true,
+            load: { paths: [plugin.file] },
+            allow: ["tool-resolution-preserves-hook-runner"],
+          },
+        },
+        workspaceDir: plugin.dir,
+      } as never,
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(getGlobalHookRunner()).toBe(globalHookRunner);
+    await expect(
+      globalHookRunner?.runAgentEnd(
+        { messages: [], success: true, durationMs: 1 },
+        { workspaceDir: plugin.dir },
+      ),
+    ).resolves.toBeUndefined();
+    expect(subagent.run).toHaveBeenCalledWith({
+      sessionKey: "tool-resolution-preserved",
+      message: "hello",
+    });
+  });
+
   it("uses shared runtime options when explicit runtime options are absent and inheritance is enabled", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -25,6 +25,10 @@ import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./
 import { resolvePluginCacheInputs } from "./roots.js";
 import { setActivePluginRegistry } from "./runtime.js";
 import { createPluginRuntime, type CreatePluginRuntimeOptions } from "./runtime/index.js";
+import {
+  getPluginRuntimeCapabilityKey,
+  getSharedPluginRuntimeOptions,
+} from "./runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
 import type {
@@ -45,6 +49,8 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   runtimeOptions?: CreatePluginRuntimeOptions;
+  inheritSharedRuntimeOptions?: boolean;
+  activateGlobalHookRunner?: boolean;
   cache?: boolean;
   mode?: "full" | "validate";
 };
@@ -238,6 +244,7 @@ function buildCacheKey(params: {
   plugins: NormalizedPluginsConfig;
   installs?: Record<string, PluginInstallRecord>;
   env: NodeJS.ProcessEnv;
+  runtimeOptions?: CreatePluginRuntimeOptions;
 }): string {
   const { roots, loadPaths } = resolvePluginCacheInputs({
     workspaceDir: params.workspaceDir,
@@ -264,6 +271,7 @@ function buildCacheKey(params: {
     ...params.plugins,
     installs,
     loadPaths,
+    runtimeCapabilities: getPluginRuntimeCapabilityKey(params.runtimeOptions),
   })}`;
 }
 
@@ -623,9 +631,15 @@ function warnAboutUntrackedLoadedPlugins(params: {
   }
 }
 
-function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): void {
+function activatePluginRegistry(
+  registry: PluginRegistry,
+  cacheKey: string,
+  activateGlobalHookRunner: boolean,
+): void {
   setActivePluginRegistry(registry, cacheKey);
-  initializeGlobalHookRunner(registry);
+  if (activateGlobalHookRunner) {
+    initializeGlobalHookRunner(registry);
+  }
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
@@ -636,17 +650,22 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const logger = options.logger ?? defaultLogger();
   const validateOnly = options.mode === "validate";
   const normalized = normalizePluginsConfig(cfg.plugins);
+  const effectiveRuntimeOptions =
+    options.runtimeOptions ??
+    (options.inheritSharedRuntimeOptions ? getSharedPluginRuntimeOptions() : undefined);
+  const shouldActivateGlobalHookRunner = options.activateGlobalHookRunner !== false;
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
     installs: cfg.plugins?.installs,
     env,
+    runtimeOptions: effectiveRuntimeOptions,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
-      activatePluginRegistry(cached, cacheKey);
+      activatePluginRegistry(cached, cacheKey, shouldActivateGlobalHookRunner);
       return cached;
     }
   }
@@ -658,7 +677,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   // not eagerly load every channel runtime dependency.
   let resolvedRuntime: PluginRuntime | null = null;
   const resolveRuntime = (): PluginRuntime => {
-    resolvedRuntime ??= createPluginRuntime(options.runtimeOptions);
+    resolvedRuntime ??= createPluginRuntime(effectiveRuntimeOptions);
     return resolvedRuntime;
   };
   const runtime = new Proxy({} as PluginRuntime, {
@@ -1016,7 +1035,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (cacheEnabled) {
     setCachedPluginRegistry(cacheKey, registry);
   }
-  activatePluginRegistry(registry, cacheKey);
+  activatePluginRegistry(registry, cacheKey, shouldActivateGlobalHookRunner);
   return registry;
 }
 

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -15,6 +15,7 @@ export function resolvePluginProviders(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    activateGlobalHookRunner: false,
     logger: createPluginLoaderLogger(log),
   });
 

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -70,4 +70,30 @@ describe("plugin runtime command execution", () => {
     // Wrappers should NOT be the same reference as the raw functions
     expect(runtime.modelAuth.getApiKeyForModel).not.toBe(rawGetApiKey);
   });
+
+  it("uses the provided subagent runtime when available", async () => {
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-1" })),
+      enqueue: vi.fn(async () => ({ runId: "run-1" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const runtime = createPluginRuntime({ subagent });
+    await expect(runtime.subagent.run({ sessionKey: "s", message: "hi" })).resolves.toEqual({
+      runId: "run-1",
+    });
+    await expect(runtime.subagent.enqueue({ sessionKey: "s", message: "hi" })).resolves.toEqual({
+      runId: "run-1",
+    });
+    await expect(runtime.subagent.abort({ runId: "run-1" })).resolves.toEqual({
+      aborted: true,
+    });
+    expect(subagent.run).toHaveBeenCalledWith({ sessionKey: "s", message: "hi" });
+    expect(subagent.enqueue).toHaveBeenCalledWith({ sessionKey: "s", message: "hi" });
+    expect(subagent.abort).toHaveBeenCalledWith({ runId: "run-1" });
+  });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -38,6 +38,8 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   };
   return {
     run: unavailable,
+    enqueue: unavailable,
+    abort: unavailable,
     waitForRun: unavailable,
     getSessionMessages: unavailable,
     getSession: unavailable,

--- a/src/plugins/runtime/shared-runtime-options.ts
+++ b/src/plugins/runtime/shared-runtime-options.ts
@@ -1,0 +1,42 @@
+import type { CreatePluginRuntimeOptions } from "./index.js";
+
+const SHARED_PLUGIN_RUNTIME_OPTIONS_KEY: unique symbol = Symbol.for(
+  "openclaw.sharedPluginRuntimeOptions",
+);
+
+type SharedPluginRuntimeOptionsState = {
+  options?: CreatePluginRuntimeOptions;
+};
+
+function getSharedPluginRuntimeOptionsState(): SharedPluginRuntimeOptionsState {
+  const globalState = globalThis as typeof globalThis & {
+    [SHARED_PLUGIN_RUNTIME_OPTIONS_KEY]?: SharedPluginRuntimeOptionsState;
+  };
+  const existing = globalState[SHARED_PLUGIN_RUNTIME_OPTIONS_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created: SharedPluginRuntimeOptionsState = {};
+  globalState[SHARED_PLUGIN_RUNTIME_OPTIONS_KEY] = created;
+  return created;
+}
+
+export function setSharedPluginRuntimeOptions(options: CreatePluginRuntimeOptions): void {
+  getSharedPluginRuntimeOptionsState().options = options;
+}
+
+export function getSharedPluginRuntimeOptions(): CreatePluginRuntimeOptions | undefined {
+  return getSharedPluginRuntimeOptionsState().options;
+}
+
+export function clearSharedPluginRuntimeOptions(): void {
+  getSharedPluginRuntimeOptionsState().options = undefined;
+}
+
+export function getPluginRuntimeCapabilityKey(
+  options?: CreatePluginRuntimeOptions,
+): Record<string, boolean> {
+  return {
+    subagent: Boolean(options?.subagent),
+  };
+}

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -18,6 +18,10 @@ export type SubagentRunResult = {
   runId: string;
 };
 
+export type SubagentEnqueueParams = SubagentRunParams;
+
+export type SubagentEnqueueResult = SubagentRunResult;
+
 export type SubagentWaitParams = {
   runId: string;
   timeoutMs?: number;
@@ -26,6 +30,15 @@ export type SubagentWaitParams = {
 export type SubagentWaitResult = {
   status: "ok" | "error" | "timeout";
   error?: string;
+};
+
+export type SubagentAbortParams = {
+  runId: string;
+  sessionKey?: string;
+};
+
+export type SubagentAbortResult = {
+  aborted: boolean;
 };
 
 export type SubagentGetSessionMessagesParams = {
@@ -51,6 +64,8 @@ export type SubagentDeleteSessionParams = {
 export type PluginRuntime = PluginRuntimeCore & {
   subagent: {
     run: (params: SubagentRunParams) => Promise<SubagentRunResult>;
+    enqueue: (params: SubagentEnqueueParams) => Promise<SubagentEnqueueResult>;
+    abort: (params: SubagentAbortParams) => Promise<SubagentAbortResult>;
     waitForRun: (params: SubagentWaitParams) => Promise<SubagentWaitResult>;
     getSessionMessages: (
       params: SubagentGetSessionMessagesParams,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,3 +1,5 @@
+import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
+import type { AgentStreamParams } from "../../commands/agent/types.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
@@ -12,6 +14,9 @@ export type SubagentRunParams = {
   lane?: string;
   deliver?: boolean;
   idempotencyKey?: string;
+  clientTools?: ClientToolDefinition[];
+  disableTools?: boolean;
+  streamParams?: AgentStreamParams;
 };
 
 export type SubagentRunResult = {
@@ -30,6 +35,12 @@ export type SubagentWaitParams = {
 export type SubagentWaitResult = {
   status: "ok" | "error" | "timeout";
   error?: string;
+  stopReason?: string;
+  pendingToolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: string;
+  }>;
 };
 
 export type SubagentAbortParams = {

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -28,6 +28,7 @@ export function buildPluginStatusReport(params?: {
     config,
     workspaceDir,
     env: params?.env,
+    activateGlobalHookRunner: false,
     logger: createPluginLoaderLogger(log),
   });
 

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -154,6 +154,21 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics).toHaveLength(0);
   });
 
+  it("loads plugin tools without re-initializing the global hook runner", () => {
+    setOptionalDemoRegistry();
+
+    resolvePluginTools({
+      context: createContext() as never,
+      toolAllowlist: ["optional_tool"],
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inheritSharedRuntimeOptions: true,
+        activateGlobalHookRunner: false,
+      }),
+    );
+  });
   it("forwards an explicit env to plugin loading", () => {
     setOptionalDemoRegistry();
     const env = { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv;

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -62,6 +62,8 @@ export function resolvePluginTools(params: {
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
     env,
+    inheritSharedRuntimeOptions: true,
+    activateGlobalHookRunner: false,
     logger: createPluginLoaderLogger(log),
   });
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -691,6 +691,7 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  metadata?: Record<string, unknown>;
 };
 
 // Tool context


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway-driven plugin orchestration could lose subagent runtime capabilities after later plugin loads, and hook/outbound events were missing sender and thread metadata needed to correlate follow-up runs.
- Why it matters: plugins that coordinate follow-up agent work can stop enqueuing or aborting runs after reloads, or misattribute outbound events to the wrong conversation or agent.
- What changed: preserved inbound/outbound sender, thread, session, and agent metadata; restored `agent.enqueue` and `agent.abort`; and kept gateway-provided subagent runtime support available across gateway-aware reload paths without leaking it into non-gateway plugin loads.
- What did NOT change (scope boundary): no end-user config changes, no new external integrations, and no plugin behavior changes outside gateway-scoped subagent/runtime metadata handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Plugin hook payloads now preserve sender-managed-account and thread metadata for inbound/outbound message correlation.
- Gateway plugin runtimes expose `subagent.enqueue(...)` and `subagent.abort(...)` again.
- Gateway-aware plugin reload paths keep subagent runtime support after later plugin loads without enabling it for unrelated non-gateway plugin loads.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  Gateway-scoped plugin runtimes regain `enqueue` and `abort` subagent controls. The risk is accidental capability bleed into unrelated plugin loads; mitigation is explicit shared-runtime opt-in plus regression coverage for non-gateway loads.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js + pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): gateway plugin runtime, Discord plugin tests
- Relevant config (redacted): plugin hooks enabled; gateway plugin registry loaded from workspace

### Steps

1. Load a plugin that calls `api.runtime.subagent.*` from gateway-scoped hooks and another plugin load path that refreshes the registry later.
2. Trigger agent execution, outbound delivery, and a later plugin/schema load.
3. Verify subagent runtime support remains available for gateway-scoped plugin hooks and that outbound events retain enough metadata to correlate the correct conversation/agent.

### Expected

- Gateway-scoped plugin hooks keep working after later plugin loads.
- Outbound hook payloads retain the conversation, thread, session, and agent identifiers needed for orchestration.
- Non-gateway plugin loads do not inherit gateway-only subagent runtime capabilities.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: loader cache split across runtime capabilities; shared-runtime inheritance only on explicit gateway-aware loads; gateway subagent enqueue/abort handlers; message hook metadata preservation through outbound delivery.
- Edge cases checked: later non-gateway plugin loads do not inherit shared runtime; gateway schema loads still reuse the shared runtime path; runtime helper paths used by agent run/compaction/context-engine notifications keep inheriting gateway runtime when present.
- What you did **not** verify: full end-to-end live gateway traffic against a real production plugin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c5e6548c6`
- Files/config to restore: `src/gateway/server-methods/agent.ts`, `src/gateway/server-plugins.ts`, `src/hooks/message-hook-mappers.ts`, `src/infra/outbound/deliver.ts`, `src/plugins/loader.ts`, `src/agents/runtime-plugins.ts`
- Known bad symptoms reviewers should watch for: plugin hooks losing thread/agent correlation, `api.runtime.subagent.enqueue/abort` unavailable after gateway reloads, or gateway-only runtime capabilities appearing in unrelated plugin loads.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: another gateway-adjacent plugin load path might miss shared-runtime opt-in and still downgrade the active registry.
  - Mitigation: explicit `inheritSharedRuntimeOptions` wiring in gateway-aware loaders plus regression coverage for the agent runtime helper and loader cache behavior.