### PR TITLE
fix(message): make channel capability probing secret-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Docs: https://docs.openclaw.ai
 - Node/startup: remove leftover debug `console.log("node host PATH: ...")` that printed the resolved PATH on every `openclaw node run` invocation. (#46411)
 - CLI/completion: reduce recursive completion-script string churn and fix nested PowerShell command-path matching so generated nested completions resolve on PowerShell too. (#45537) Thanks @yiShanXin and @vincentkoc.
 
+### Fixes
+
+- Message/tool schema: make channel capability probing secret-safe so unresolved Telegram or Slack SecretRefs no longer crash the whole `message` tool or block explicit sends on other channels.
+
 ## 2026.3.13
 
 ### Changes

--- a/src/channels/plugins/message-actions.test.ts
+++ b/src/channels/plugins/message-actions.test.ts
@@ -1,13 +1,16 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { defaultRuntime } from "../../runtime.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
 import {
+  _resetActionProbeErrorLogForTest,
   channelSupportsMessageCapability,
   channelSupportsMessageCapabilityForChannel,
+  listChannelMessageActions,
   listChannelMessageCapabilities,
   listChannelMessageCapabilitiesForChannel,
 } from "./message-actions.js";
@@ -58,6 +61,8 @@ function activateMessageActionTestRegistry() {
 describe("message action capability checks", () => {
   afterEach(() => {
     setActivePluginRegistry(emptyRegistry);
+    _resetActionProbeErrorLogForTest();
+    vi.restoreAllMocks();
   });
 
   it("aggregates capabilities across plugins", () => {
@@ -121,5 +126,118 @@ describe("message action capability checks", () => {
     expect(channelSupportsMessageCapabilityForChannel({ cfg: {} as OpenClawConfig }, "cards")).toBe(
       false,
     );
+  });
+
+  it("ignores SecretRef probe failures while aggregating capabilities", () => {
+    const brokenPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group"] },
+        config: {
+          listAccountIds: () => ["default"],
+        },
+      }),
+      actions: {
+        listActions: () => {
+          throw new Error("unresolved SecretRef");
+        },
+        getCapabilities: () => {
+          throw new Error("unresolved SecretRef");
+        },
+      },
+    };
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "discord", source: "test", plugin: buttonsPlugin },
+        { pluginId: "telegram", source: "test", plugin: brokenPlugin },
+      ]),
+    );
+
+    expect(listChannelMessageActions({} as OpenClawConfig)).toEqual(["send", "broadcast"]);
+    expect(listChannelMessageCapabilities({} as OpenClawConfig).toSorted()).toEqual([
+      "buttons",
+      "interactive",
+    ]);
+    expect(channelSupportsMessageCapability({} as OpenClawConfig, "cards")).toBe(false);
+    expect(
+      listChannelMessageCapabilitiesForChannel({
+        cfg: {} as OpenClawConfig,
+        channel: "telegram",
+      }),
+    ).toEqual([]);
+    expect(
+      channelSupportsMessageCapabilityForChannel(
+        { cfg: {} as OpenClawConfig, channel: "telegram" },
+        "cards",
+      ),
+    ).toBe(false);
+  });
+
+  it("rethrows non-SecretRef probe failures", () => {
+    const brokenPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group"] },
+        config: {
+          listAccountIds: () => ["default"],
+        },
+      }),
+      actions: {
+        listActions: () => {
+          throw new TypeError("cannot read properties of undefined");
+        },
+      },
+    };
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: brokenPlugin }]),
+    );
+
+    expect(() => listChannelMessageActions({} as OpenClawConfig)).toThrow(
+      "cannot read properties of undefined",
+    );
+  });
+
+  it("resets deduped SecretRef probe logging between checks", () => {
+    const errorSpy = vi.fn();
+    const previousError = defaultRuntime.error;
+    defaultRuntime.error = errorSpy;
+
+    try {
+      const brokenPlugin: ChannelPlugin = {
+        ...createChannelTestPluginBase({
+          id: "telegram",
+          label: "Telegram",
+          capabilities: { chatTypes: ["direct", "group"] },
+          config: {
+            listAccountIds: () => ["default"],
+          },
+        }),
+        actions: {
+          listActions: () => {
+            throw new Error("unresolved SecretRef");
+          },
+        },
+      };
+
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "telegram", source: "test", plugin: brokenPlugin }]),
+      );
+
+      expect(listChannelMessageActions({} as OpenClawConfig)).toEqual(["send", "broadcast"]);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      expect(listChannelMessageActions({} as OpenClawConfig)).toEqual(["send", "broadcast"]);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      _resetActionProbeErrorLogForTest();
+      expect(listChannelMessageActions({} as OpenClawConfig)).toEqual(["send", "broadcast"]);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      defaultRuntime.error = previousError;
+    }
   });
 });

--- a/src/channels/plugins/message-actions.ts
+++ b/src/channels/plugins/message-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { defaultRuntime } from "../../runtime.js";
 import { getChannelPlugin, listChannelPlugins } from "./index.js";
 import type { ChannelMessageCapability } from "./message-capabilities.js";
 import type { ChannelMessageActionContext, ChannelMessageActionName } from "./types.js";
@@ -19,10 +20,12 @@ function requiresTrustedRequesterSender(ctx: ChannelMessageActionContext): boole
 export function listChannelMessageActions(cfg: OpenClawConfig): ChannelMessageActionName[] {
   const actions = new Set<ChannelMessageActionName>(["send", "broadcast"]);
   for (const plugin of listChannelPlugins()) {
-    const list = plugin.actions?.listActions?.({ cfg });
-    if (!list) {
-      continue;
-    }
+    const list = runSafeActionProbe({
+      pluginId: plugin.id,
+      probe: "listActions",
+      fn: () => plugin.actions?.listActions?.({ cfg }) ?? [],
+      fallback: [] as ChannelMessageActionName[],
+    });
     for (const action of list) {
       actions.add(action);
     }
@@ -40,10 +43,13 @@ function listCapabilities(
 export function listChannelMessageCapabilities(cfg: OpenClawConfig): ChannelMessageCapability[] {
   const capabilities = new Set<ChannelMessageCapability>();
   for (const plugin of listChannelPlugins()) {
-    if (!plugin.actions) {
-      continue;
-    }
-    for (const capability of listCapabilities(plugin.actions, cfg)) {
+    const list = runSafeActionProbe({
+      pluginId: plugin.id,
+      probe: "getCapabilities",
+      fn: () => (plugin.actions ? listCapabilities(plugin.actions, cfg) : []),
+      fallback: [] as readonly ChannelMessageCapability[],
+    });
+    for (const capability of list) {
       capabilities.add(capability);
     }
   }
@@ -58,7 +64,13 @@ export function listChannelMessageCapabilitiesForChannel(params: {
     return [];
   }
   const plugin = getChannelPlugin(params.channel as Parameters<typeof getChannelPlugin>[0]);
-  return plugin?.actions ? Array.from(listCapabilities(plugin.actions, params.cfg)) : [];
+  const capabilities = runSafeActionProbe({
+    pluginId: plugin?.id ?? params.channel,
+    probe: "getCapabilitiesForChannel",
+    fn: () => (plugin?.actions ? listCapabilities(plugin.actions, params.cfg) : []),
+    fallback: [] as readonly ChannelMessageCapability[],
+  });
+  return Array.from(capabilities);
 }
 
 export function channelSupportsMessageCapability(
@@ -76,6 +88,46 @@ export function channelSupportsMessageCapabilityForChannel(
   capability: ChannelMessageCapability,
 ): boolean {
   return listChannelMessageCapabilitiesForChannel(params).includes(capability);
+}
+
+const loggedActionProbeErrors = new Set<string>();
+
+export function _resetActionProbeErrorLogForTest(): void {
+  loggedActionProbeErrors.clear();
+}
+
+function isToleratedActionProbeError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("SecretRef");
+}
+
+function runSafeActionProbe<T>(params: {
+  pluginId: string;
+  probe: string;
+  fn: () => T;
+  fallback: T;
+}): T {
+  try {
+    return params.fn();
+  } catch (err) {
+    if (!isToleratedActionProbeError(err)) {
+      throw err;
+    }
+    logActionProbeError(params.pluginId, params.probe, err);
+    return params.fallback;
+  }
+}
+
+function logActionProbeError(pluginId: string, probe: string, err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  const key = `${pluginId}:${probe}:${message}`;
+  if (loggedActionProbeErrors.has(key)) {
+    return;
+  }
+  loggedActionProbeErrors.add(key);
+  const stack = err instanceof Error && err.stack ? err.stack : null;
+  const details = stack ?? message;
+  defaultRuntime.error?.(`[channel-tools] ${pluginId}.actions.${probe} failed: ${details}`);
 }
 
 export async function dispatchChannelMessageAction(

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -141,6 +141,50 @@ describe("resolveMessageChannelSelection", () => {
     });
   });
 
+  it("does not inspect unrelated plugins when channel is explicit", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      makePlugin({
+        id: "telegram",
+        isConfigured: () => {
+          throw new Error("telegram should not be inspected for explicit whatsapp sends");
+        },
+      }),
+    ]);
+
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).resolves.toEqual({
+      channel: "whatsapp",
+      configured: [],
+      source: "explicit",
+    });
+  });
+
+  it("does not inspect unrelated plugins when falling back to tool context channel", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      makePlugin({
+        id: "telegram",
+        isConfigured: () => {
+          throw new Error("telegram should not be inspected for fallback slack sends");
+        },
+      }),
+    ]);
+
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        fallbackChannel: "slack",
+      }),
+    ).resolves.toEqual({
+      channel: "slack",
+      configured: [],
+      source: "tool-context-fallback",
+    });
+  });
+
   it("selects single configured channel when no explicit/fallback channel exists", async () => {
     mocks.listChannelPlugins.mockReturnValue([
       makePlugin({ id: "discord", isConfigured: async () => true }),

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -123,7 +123,7 @@ export async function resolveMessageChannelSelection(params: {
       if (fallback) {
         return {
           channel: fallback,
-          configured: await listConfiguredMessageChannels(params.cfg),
+          configured: [],
           source: "tool-context-fallback",
         };
       }
@@ -134,7 +134,7 @@ export async function resolveMessageChannelSelection(params: {
     }
     return {
       channel: availableExplicit,
-      configured: await listConfiguredMessageChannels(params.cfg),
+      configured: [],
       source: "explicit",
     };
   }
@@ -146,7 +146,7 @@ export async function resolveMessageChannelSelection(params: {
   if (fallback) {
     return {
       channel: fallback,
-      configured: await listConfiguredMessageChannels(params.cfg),
+      configured: [],
       source: "tool-context-fallback",
     };
   }


### PR DESCRIPTION
## Summary

- Problem: the `message` tool could crash during schema construction when an unrelated channel plugin eagerly resolved account secrets and hit an unresolved `SecretRef`.
- Why it matters: an explicit send like `channel=whatsapp` could fail because Telegram/Slack capability probing ran first and threw before the send path.
- What changed: explicit sends now skip unrelated channel inspection, and message capability probing now degrades safely when a plugin cannot resolve secrets.
- What did NOT change (scope boundary): actual message dispatch still throws real send-time errors; this PR only hardens capability/schema probing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47519
- Related #47519

## User-visible / Behavior Changes

- Explicit `message` sends no longer fail just because another configured channel has an unresolved token SecretRef.
- The `message` tool schema/capability probing now falls back safely instead of crashing the tool.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This changes how unresolved secret-backed channel capability probes fail: instead of crashing the whole tool, probing falls back safely and logs once per key. Actual dispatch remains strict, so real send-time errors are still surfaced.

## Repro + Verification

### Environment

- OS: macOS 15.2 (arm64)
- Runtime/container: local OpenClaw dev build
- Model/provider: N/A
- Integration/channel (if any): WhatsApp explicit send with unrelated Telegram/Slack SecretRef failures present
- Relevant config (redacted): Telegram/Slack tokens resolved through `file:localcache:` refs that were unresolved in the active runtime snapshot

### Steps

1. Configure an unrelated channel account with an unresolved `SecretRef` token.
2. Keep another channel (for example WhatsApp) otherwise working.
3. Invoke the `message` tool for an explicit send on the healthy channel.

### Expected

- Explicit sends should not inspect unrelated channel configs.
- Capability probing should not crash the whole `message` tool.

### Actual

- Tool/schema construction probed unrelated channel plugins first and crashed with unresolved SecretRef errors.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/infra/outbound/channel-selection.test.ts src/channels/plugins/message-actions.test.ts`
  - `pnpm build`
  - restarted the local gateway after rebuild
  - `message.send` WhatsApp dry-run succeeded after the fix while unresolved SecretRef warnings remained on unrelated channels
- Edge cases checked:
  - explicit sends skip unrelated channel inspection
  - capability probing falls back safely instead of throwing
  - real dispatch path was left strict
- What you did **not** verify:
  - end-to-end live sends on every channel plugin
  - full repo test suite clean pass; `pnpm test` currently hits an unrelated existing failure in `src/media/store.redirect.test.ts` on file-mode expectations (`384` vs `420`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit
- Files/config to restore: `src/channels/plugins/message-actions.ts`, `src/infra/outbound/channel-selection.ts`
- Known bad symptoms reviewers should watch for: message tool capability lists missing optional actions for a misconfigured channel instead of surfacing probe-time errors

## Risks and Mitigations

- Risk: safe capability fallback could hide a misconfigured channel during schema generation.
  - Mitigation: probe failures are still logged, and actual dispatch remains strict.
