### PR TITLE
CLI: respect full timeout for loopback gateway probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/context engines: retry strict legacy `assemble()` calls without the new `prompt` field when older engines reject it, preserving prompt-aware retrieval compatibility for pre-prompt plugins. (#50848) thanks @danhdoan.
 - Agents/embedded transport errors: distinguish common network failures like connection refused, DNS lookup failure, and interrupted sockets from true timeouts in embedded-run user messaging and lifecycle diagnostics. (#51419) Thanks @scoootscooob.
 - Discord/startup logging: report client initialization while the gateway is still connecting instead of claiming Discord is logged in before readiness is reached. (#51425) Thanks @scoootscooob.
+- Gateway/probe: honor caller `--timeout` for active local loopback probes in `gateway status`, keep inactive remote-mode loopback probes fast, and clamp probe timers to JS-safe bounds so slow local/container gateways stop reporting false timeouts. (#47533) Thanks @MonkeyLeeT.
 
 ### Breaking
 

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -567,6 +567,26 @@ describe("gateway-status command", () => {
     expect(targets.some((t) => t.kind === "sshTunnel")).toBe(true);
   });
 
+  it("passes the full caller timeout through to local loopback probes", async () => {
+    const { runtime } = createRuntimeCapture();
+    probeGateway.mockClear();
+    readBestEffortConfig.mockResolvedValueOnce({
+      gateway: {
+        mode: "local",
+        auth: { mode: "token", token: "ltok" },
+      },
+    } as never);
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 15_000,
+      }),
+    );
+  });
+
   it("skips invalid ssh-auto discovery targets", async () => {
     const { runtime } = createRuntimeCapture();
     await withEnvAsync({ USER: "steipete" }, async () => {

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -587,6 +587,27 @@ describe("gateway-status command", () => {
     );
   });
 
+  it("keeps inactive local loopback probes on the short timeout in remote mode", async () => {
+    const { runtime } = createRuntimeCapture();
+    probeGateway.mockClear();
+    readBestEffortConfig.mockResolvedValueOnce({
+      gateway: {
+        mode: "remote",
+        auth: { mode: "token", token: "ltok" },
+        remote: {},
+      },
+    } as never);
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 800,
+      }),
+    );
+  });
+
   it("skips invalid ssh-auto discovery targets", async () => {
     const { runtime } = createRuntimeCapture();
     await withEnvAsync({ USER: "steipete" }, async () => {

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -176,7 +176,7 @@ export async function gatewayStatusCommand(
               token: authResolution.token,
               password: authResolution.password,
             };
-            const timeoutMs = resolveProbeBudgetMs(overallTimeoutMs, target.kind);
+            const timeoutMs = resolveProbeBudgetMs(overallTimeoutMs, target);
             const probe = await probeGateway({
               url: target.url,
               auth,

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   isScopeLimitedProbeFailure,
   renderProbeSummaryLine,
   resolveAuthForTarget,
+  resolveProbeBudgetMs,
 } from "./helpers.js";
 
 describe("extractConfigSummary", () => {
@@ -271,5 +272,17 @@ describe("probe reachability classification", () => {
     expect(isScopeLimitedProbeFailure(probe)).toBe(false);
     expect(isProbeReachable(probe)).toBe(false);
     expect(renderProbeSummaryLine(probe, false)).toContain("RPC: failed");
+  });
+});
+
+describe("resolveProbeBudgetMs", () => {
+  it("lets local loopback probes use the full caller budget", () => {
+    expect(resolveProbeBudgetMs(15_000, "localLoopback")).toBe(15_000);
+    expect(resolveProbeBudgetMs(3_000, "localLoopback")).toBe(3_000);
+  });
+
+  it("keeps non-local probe caps unchanged", () => {
+    expect(resolveProbeBudgetMs(15_000, "configRemote")).toBe(1_500);
+    expect(resolveProbeBudgetMs(15_000, "sshTunnel")).toBe(2_000);
   });
 });

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -276,13 +276,19 @@ describe("probe reachability classification", () => {
 });
 
 describe("resolveProbeBudgetMs", () => {
-  it("lets local loopback probes use the full caller budget", () => {
-    expect(resolveProbeBudgetMs(15_000, "localLoopback")).toBe(15_000);
-    expect(resolveProbeBudgetMs(3_000, "localLoopback")).toBe(3_000);
+  it("lets active local loopback probes use the full caller budget", () => {
+    expect(resolveProbeBudgetMs(15_000, { kind: "localLoopback", active: true })).toBe(15_000);
+    expect(resolveProbeBudgetMs(3_000, { kind: "localLoopback", active: true })).toBe(3_000);
+  });
+
+  it("keeps inactive local loopback probes on the short cap", () => {
+    expect(resolveProbeBudgetMs(15_000, { kind: "localLoopback", active: false })).toBe(800);
+    expect(resolveProbeBudgetMs(500, { kind: "localLoopback", active: false })).toBe(500);
   });
 
   it("keeps non-local probe caps unchanged", () => {
-    expect(resolveProbeBudgetMs(15_000, "configRemote")).toBe(1_500);
-    expect(resolveProbeBudgetMs(15_000, "sshTunnel")).toBe(2_000);
+    expect(resolveProbeBudgetMs(15_000, { kind: "configRemote", active: true })).toBe(1_500);
+    expect(resolveProbeBudgetMs(15_000, { kind: "explicit", active: true })).toBe(1_500);
+    expect(resolveProbeBudgetMs(15_000, { kind: "sshTunnel", active: true })).toBe(2_000);
   });
 });

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -118,7 +118,9 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
 
 export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
   if (kind === "localLoopback") {
-    return Math.min(800, overallMs);
+    // Let the local probe use the caller's full budget. Slow local shells/containers can
+    // exceed the old fixed cap and produce false "unreachable" results.
+    return overallMs;
   }
   if (kind === "sshTunnel") {
     return Math.min(2000, overallMs);

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -14,8 +14,6 @@ const MISSING_SCOPE_PATTERN = /\bmissing scope:\s*[a-z0-9._-]+/i;
 type TargetKind = "explicit" | "configRemote" | "localLoopback" | "sshTunnel";
 
 const INACTIVE_LOOPBACK_PROBE_BUDGET_MS = 800;
-const REMOTE_PROBE_BUDGET_MS = 1_500;
-const SSH_TUNNEL_PROBE_BUDGET_MS = 2_000;
 
 export type GatewayStatusTarget = {
   id: string;
@@ -131,9 +129,9 @@ export function resolveProbeBudgetMs(
       // remote-mode status checks do not stall on an expected local miss.
       return target.active ? overallMs : Math.min(INACTIVE_LOOPBACK_PROBE_BUDGET_MS, overallMs);
     case "sshTunnel":
-      return Math.min(SSH_TUNNEL_PROBE_BUDGET_MS, overallMs);
+      return Math.min(2_000, overallMs);
     default:
-      return Math.min(REMOTE_PROBE_BUDGET_MS, overallMs);
+      return Math.min(1_500, overallMs);
   }
 }
 

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -13,8 +13,6 @@ const MISSING_SCOPE_PATTERN = /\bmissing scope:\s*[a-z0-9._-]+/i;
 
 type TargetKind = "explicit" | "configRemote" | "localLoopback" | "sshTunnel";
 
-const INACTIVE_LOOPBACK_PROBE_BUDGET_MS = 800;
-
 export type GatewayStatusTarget = {
   id: string;
   kind: TargetKind;
@@ -127,7 +125,7 @@ export function resolveProbeBudgetMs(
       // Active loopback probes should honor the caller budget because local shells/containers
       // can legitimately take longer to connect. Inactive loopback probes stay bounded so
       // remote-mode status checks do not stall on an expected local miss.
-      return target.active ? overallMs : Math.min(INACTIVE_LOOPBACK_PROBE_BUDGET_MS, overallMs);
+      return target.active ? overallMs : Math.min(800, overallMs);
     case "sshTunnel":
       return Math.min(2_000, overallMs);
     default:

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -13,6 +13,9 @@ const MISSING_SCOPE_PATTERN = /\bmissing scope:\s*[a-z0-9._-]+/i;
 
 type TargetKind = "explicit" | "configRemote" | "localLoopback" | "sshTunnel";
 
+const REMOTE_PROBE_BUDGET_MS = 1_500;
+const SSH_TUNNEL_PROBE_BUDGET_MS = 2_000;
+
 export type GatewayStatusTarget = {
   id: string;
   kind: TargetKind;
@@ -117,15 +120,16 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
 }
 
 export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
-  if (kind === "localLoopback") {
-    // Let the local probe use the caller's full budget. Slow local shells/containers can
-    // exceed the old fixed cap and produce false "unreachable" results.
-    return overallMs;
+  switch (kind) {
+    case "localLoopback":
+      // Let the local probe use the caller's full budget. Slow local shells/containers can
+      // exceed the old fixed cap and produce false "unreachable" results.
+      return overallMs;
+    case "sshTunnel":
+      return Math.min(SSH_TUNNEL_PROBE_BUDGET_MS, overallMs);
+    default:
+      return Math.min(REMOTE_PROBE_BUDGET_MS, overallMs);
   }
-  if (kind === "sshTunnel") {
-    return Math.min(2000, overallMs);
-  }
-  return Math.min(1500, overallMs);
 }
 
 export function sanitizeSshTarget(value: unknown): string | null {

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -13,6 +13,7 @@ const MISSING_SCOPE_PATTERN = /\bmissing scope:\s*[a-z0-9._-]+/i;
 
 type TargetKind = "explicit" | "configRemote" | "localLoopback" | "sshTunnel";
 
+const INACTIVE_LOOPBACK_PROBE_BUDGET_MS = 800;
 const REMOTE_PROBE_BUDGET_MS = 1_500;
 const SSH_TUNNEL_PROBE_BUDGET_MS = 2_000;
 
@@ -119,12 +120,16 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
   return targets;
 }
 
-export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
-  switch (kind) {
+export function resolveProbeBudgetMs(
+  overallMs: number,
+  target: Pick<GatewayStatusTarget, "kind" | "active">,
+): number {
+  switch (target.kind) {
     case "localLoopback":
-      // Let the local probe use the caller's full budget. Slow local shells/containers can
-      // exceed the old fixed cap and produce false "unreachable" results.
-      return overallMs;
+      // Active loopback probes should honor the caller budget because local shells/containers
+      // can legitimately take longer to connect. Inactive loopback probes stay bounded so
+      // remote-mode status checks do not stall on an expected local miss.
+      return target.active ? overallMs : Math.min(INACTIVE_LOOPBACK_PROBE_BUDGET_MS, overallMs);
     case "sshTunnel":
       return Math.min(SSH_TUNNEL_PROBE_BUDGET_MS, overallMs);
     default:

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -40,9 +40,15 @@ vi.mock("./client.js", () => ({
   GatewayClient: MockGatewayClient,
 }));
 
-const { probeGateway } = await import("./probe.js");
+const { clampProbeTimeoutMs, probeGateway } = await import("./probe.js");
 
 describe("probeGateway", () => {
+  it("clamps probe timeout to timer-safe bounds", () => {
+    expect(clampProbeTimeoutMs(1)).toBe(250);
+    expect(clampProbeTimeoutMs(2_000)).toBe(2_000);
+    expect(clampProbeTimeoutMs(3_000_000_000)).toBe(2_147_483_647);
+  });
+
   it("connects with operator.read scope", async () => {
     const result = await probeGateway({
       url: "ws://127.0.0.1:18789",

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -29,6 +29,13 @@ export type GatewayProbeResult = {
   configSnapshot: unknown;
 };
 
+export const MIN_PROBE_TIMEOUT_MS = 250;
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function clampProbeTimeoutMs(timeoutMs: number): number {
+  return Math.min(MAX_TIMER_DELAY_MS, Math.max(MIN_PROBE_TIMEOUT_MS, timeoutMs));
+}
+
 export async function probeGateway(opts: {
   url: string;
   auth?: GatewayProbeAuth;
@@ -144,21 +151,18 @@ export async function probeGateway(opts: {
       },
     });
 
-    const timer = setTimeout(
-      () => {
-        settle({
-          ok: false,
-          connectLatencyMs,
-          error: connectError ? `connect failed: ${connectError}` : "timeout",
-          close,
-          health: null,
-          status: null,
-          presence: null,
-          configSnapshot: null,
-        });
-      },
-      Math.max(250, opts.timeoutMs),
-    );
+    const timer = setTimeout(() => {
+      settle({
+        ok: false,
+        connectLatencyMs,
+        error: connectError ? `connect failed: ${connectError}` : "timeout",
+        close,
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      });
+    }, clampProbeTimeoutMs(opts.timeoutMs));
 
     client.start();
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway probe --timeout <ms>` advertised an overall budget, but local loopback probes were silently hard-capped to 800ms.
- Why it matters: on slower local/containerized setups this produced false "Reachable: no" / timeout results while other gateway commands (`logs`, `gateway call health`) still worked.
- What changed: local loopback probes now use the caller's full requested budget; remote and SSH probe caps stay unchanged.
- What did NOT change (scope boundary): this PR does not change gateway auth, handshake semantics, or remote probe budgeting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #46130
- This PR does not directly fix #46130; it fixes a separate loopback `gateway probe` false-negative uncovered while investigating that issue.

## User-visible / Behavior Changes

`openclaw gateway probe --timeout <ms>` now lets local loopback probes use the full caller-provided budget instead of silently capping them at 800ms.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host, plus live Docker container
- Runtime/container: `openclaw:local` container running OpenClaw 2026.3.13
- Model/provider: n/a
- Integration/channel (if any): container had Telegram + WhatsApp configured
- Relevant config (redacted): local loopback gateway inside the container

### Steps

1. Run `openclaw gateway status` in the container.
2. Run `openclaw logs --limit 1 --timeout 15000 --plain` and `openclaw gateway call health --json` in the same container.
3. Run `openclaw gateway probe --timeout 15000 --json` in the same container.

### Expected

- A healthy local loopback gateway should not time out under `gateway probe` when other local gateway commands succeed.

### Actual

- `gateway status`, `logs`, and `gateway call health` succeeded.
- `gateway probe --timeout 15000 --json` still failed with local loopback `connect.error: "timeout"`.
- Code path showed the local probe budget was still capped to 800ms.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the false-negative manually in the live container; verified `logs` and `gateway call health` succeeded while `gateway probe` timed out; updated tests to cover helper-level and command-level timeout forwarding.
- Edge cases checked: remote and SSH probe caps remain unchanged in tests.
- What you did **not** verify: I did not run a patched build inside the live container; manual repro there was against the existing 2026.3.13 container image.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `551e3d38cc346c004216fe81bfde63fa4554f2d8`
- Files/config to restore: `src/commands/gateway-status/helpers.ts`
- Known bad symptoms reviewers should watch for: loopback `gateway probe` taking longer when a caller explicitly passes a large timeout

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `gateway probe` can wait longer on loopback when the caller explicitly requests a larger budget.
  - Mitigation: default timeout remains 3000ms, and remote/SSH caps are unchanged.
