### PR TITLE
Commands: lazy-load model picker provider runtime

### DIFF
--- a/src/commands/model-picker.runtime.ts
+++ b/src/commands/model-picker.runtime.ts
@@ -1,0 +1,7 @@
+export {
+  resolveProviderModelPickerEntries,
+  resolveProviderPluginChoice,
+  runProviderModelSelectedHook,
+} from "../plugins/provider-wizard.js";
+export { resolvePluginProviders } from "../plugins/providers.js";
+export { runProviderPluginAuthMethod } from "./auth-choice.apply.plugin-provider.js";

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyModelAllowlist,
@@ -37,19 +37,13 @@ vi.mock("../agents/model-auth.js", () => ({
 const resolveProviderModelPickerEntries = vi.hoisted(() => vi.fn(() => []));
 const resolveProviderPluginChoice = vi.hoisted(() => vi.fn());
 const runProviderModelSelectedHook = vi.hoisted(() => vi.fn(async () => {}));
-vi.mock("../plugins/provider-wizard.js", () => ({
+const resolvePluginProviders = vi.hoisted(() => vi.fn(() => []));
+const runProviderPluginAuthMethod = vi.hoisted(() => vi.fn());
+vi.mock("./model-picker.runtime.js", () => ({
   resolveProviderModelPickerEntries,
   resolveProviderPluginChoice,
   runProviderModelSelectedHook,
-}));
-
-const resolvePluginProviders = vi.hoisted(() => vi.fn(() => []));
-vi.mock("../plugins/providers.js", () => ({
   resolvePluginProviders,
-}));
-
-const runProviderPluginAuthMethod = vi.hoisted(() => vi.fn());
-vi.mock("./auth-choice.apply.plugin-provider.js", () => ({
   runProviderPluginAuthMethod,
 }));
 
@@ -76,6 +70,10 @@ function expectRouterModelFiltering(options: Array<{ value: string }>) {
 function createSelectAllMultiselect() {
   return vi.fn(async (params) => params.options.map((option: { value: string }) => option.value));
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("promptDefaultModel", () => {
   it("supports configuring vLLM during onboarding", async () => {
@@ -211,6 +209,7 @@ describe("router model filtering", () => {
     const allowlistCall = multiselect.mock.calls[0]?.[0];
     expectRouterModelFiltering(allowlistCall?.options as Array<{ value: string }>);
     expect(allowlistCall?.searchable).toBe(true);
+    expect(runProviderPluginAuthMethod).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -11,14 +11,8 @@ import {
 } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
-import {
-  resolveProviderPluginChoice,
-  resolveProviderModelPickerEntries,
-  runProviderModelSelectedHook,
-} from "../plugins/provider-wizard.js";
-import { resolvePluginProviders } from "../plugins/providers.js";
+import type { ProviderPlugin } from "../plugins/types.js";
 import type { WizardPrompter, WizardSelectOption } from "../wizard/prompts.js";
-import { runProviderPluginAuthMethod } from "./auth-choice.apply.plugin-provider.js";
 import { formatTokenK } from "./models/shared.js";
 import { OPENAI_CODEX_DEFAULT_MODEL } from "./openai-codex-model-default.js";
 
@@ -48,6 +42,10 @@ type PromptDefaultModelParams = {
 
 type PromptDefaultModelResult = { model?: string; config?: OpenClawConfig };
 type PromptModelAllowlistResult = { models?: string[] };
+
+async function loadModelPickerRuntime() {
+  return import("./model-picker.runtime.js");
+}
 
 function hasAuthForProvider(
   provider: string,
@@ -295,6 +293,7 @@ export async function promptDefaultModel(
     options.push({ value: MANUAL_VALUE, label: "Enter model manually" });
   }
   if (includeProviderPluginSetups && agentDir) {
+    const { resolveProviderModelPickerEntries } = await loadModelPickerRuntime();
     options.push(
       ...resolveProviderModelPickerEntries({
         config: cfg,
@@ -347,20 +346,24 @@ export async function promptDefaultModel(
       initialValue: configuredRaw || resolvedKey || undefined,
     });
   }
-  const pluginProviders = resolvePluginProviders({
-    config: cfg,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  const pluginResolution = selection.startsWith("provider-plugin:")
-    ? selection
-    : selection.includes("/")
-      ? null
-      : pluginProviders.some(
-            (provider) => normalizeProviderId(provider.id) === normalizeProviderId(selection),
-          )
-        ? selection
-        : null;
+
+  let pluginResolution: string | null = null;
+  let pluginProviders: ProviderPlugin[] = [];
+  if (selection.startsWith("provider-plugin:")) {
+    pluginResolution = selection;
+  } else if (!selection.includes("/")) {
+    const { resolvePluginProviders } = await loadModelPickerRuntime();
+    pluginProviders = resolvePluginProviders({
+      config: cfg,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    });
+    pluginResolution = pluginProviders.some(
+      (provider) => normalizeProviderId(provider.id) === normalizeProviderId(selection),
+    )
+      ? selection
+      : null;
+  }
   if (pluginResolution) {
     if (!agentDir || !params.runtime) {
       await params.prompter.note(
@@ -368,6 +371,19 @@ export async function promptDefaultModel(
         "Provider setup unavailable",
       );
       return {};
+    }
+    const {
+      resolvePluginProviders,
+      resolveProviderPluginChoice,
+      runProviderModelSelectedHook,
+      runProviderPluginAuthMethod,
+    } = await loadModelPickerRuntime();
+    if (pluginProviders.length === 0) {
+      pluginProviders = resolvePluginProviders({
+        config: cfg,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
     }
     const resolved = resolveProviderPluginChoice({
       providers: pluginProviders,
@@ -397,6 +413,7 @@ export async function promptDefaultModel(
     return { model: applied.defaultModel, config: applied.config };
   }
   const model = String(selection);
+  const { runProviderModelSelectedHook } = await loadModelPickerRuntime();
   await runProviderModelSelectedHook({
     config: cfg,
     model,


### PR DESCRIPTION
## Summary
- add a dedicated runtime boundary for model picker provider/plugin helpers
- lazy-load provider setup resolution only when the model picker actually needs plugin-backed entries or selections
- update model picker tests to mock the runtime boundary directly

## Related
- Related #45064
- follows the same startup-import trimming pattern as #46522, #46784, #47467, and #47495

## Verification
- `pnpm test -- src/commands/model-picker.test.ts`
- `pnpm build`
- `pnpm check`
- import-only RSS probe on `src/commands/model-picker.ts` versus `origin/main` was noisy and not a clear signal, so I am not claiming a measured RSS win from that narrow probe yet

