### PR TITLE
feat: pluggable web search providers via plugin API

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -3,6 +3,8 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { logVerbose } from "../../globals.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { SearchProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -599,6 +601,54 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
     docs: "https://docs.openclaw.ai/tools/web",
   };
+}
+
+function resolvePluginSearchProvider(
+  search?: WebSearchConfig,
+  config?: OpenClawConfig,
+): SearchProviderPlugin | null {
+  const raw =
+    search && "provider" in search && typeof search.provider === "string"
+      ? search.provider.trim().toLowerCase()
+      : "";
+  const registry = getActivePluginRegistry();
+  if (!registry || registry.searchProviders.length === 0) {
+    return null;
+  }
+  // Explicit match by provider id (case-insensitive to match Zod-validated config)
+  if (raw) {
+    const match = registry.searchProviders.find(
+      (entry) => entry.provider.id.trim().toLowerCase() === raw,
+    );
+    if (match) {
+      return match.provider;
+    }
+    // Warn when a non-built-in provider id doesn't resolve to any plugin
+    const builtIn = new Set(SEARCH_PROVIDERS as readonly string[]);
+    if (!builtIn.has(raw)) {
+      logVerbose(
+        `web_search: provider "${raw}" is not registered as a plugin provider, falling back to built-in resolution`,
+      );
+    }
+  }
+  // Auto-detect: try each plugin provider's isAvailable()
+  if (!raw) {
+    for (const entry of registry.searchProviders) {
+      try {
+        if (entry.provider.isAvailable?.(config)) {
+          logVerbose(
+            `web_search: no provider configured, auto-detected plugin provider "${entry.provider.id}"`,
+          );
+          return entry.provider;
+        }
+      } catch {
+        logVerbose(
+          `web_search: plugin provider "${entry.provider.id}" isAvailable() threw, skipping`,
+        );
+      }
+    }
+  }
+  return null;
 }
 
 function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
@@ -1888,6 +1938,124 @@ async function runWebSearch(params: {
   return payload;
 }
 
+function sanitizeUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      // Strip embedded credentials (user:pass@host) to avoid leaking secrets.
+      parsed.username = "";
+      parsed.password = "";
+      return parsed.href;
+    }
+  } catch {}
+  return undefined;
+}
+
+const MAX_PLUGIN_DESCRIPTION_LENGTH = 200;
+
+/** Strip control chars and cap length so plugin descriptions stay safe for LLM tool metadata. */
+function sanitizePluginDescription(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const cleaned = raw.replace(/[\x00-\x1f\x7f]/g, " ").trim();
+  if (cleaned.length <= MAX_PLUGIN_DESCRIPTION_LENGTH) {
+    return cleaned;
+  }
+  return cleaned.slice(0, MAX_PLUGIN_DESCRIPTION_LENGTH).trimEnd() + "\u2026";
+}
+
+function createPluginSearchTool(
+  pluginProvider: SearchProviderPlugin,
+  search: WebSearchConfig | undefined,
+  config?: OpenClawConfig,
+): AnyAgentTool {
+  const cacheTtlMs = resolveCacheTtlMs(search?.cacheTtlMinutes);
+  const timeoutSeconds = resolveTimeoutSeconds(search?.timeoutSeconds);
+  const fallback = `Search the web using ${pluginProvider.name}. Returns titles, URLs, and descriptions for research.`;
+  const description = sanitizePluginDescription(pluginProvider.description ?? fallback);
+
+  return {
+    label: "Web Search",
+    name: "web_search",
+    description,
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      count: Type.Optional(
+        Type.Number({ description: "Number of results (1-10)", minimum: 1, maximum: 10 }),
+      ),
+    }),
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      if (!query) {
+        return jsonResult({ error: "missing_query", message: "query is required" });
+      }
+
+      const maxResults = readNumberParam(params, "count", { integer: true }) ??
+        search?.maxResults ?? DEFAULT_SEARCH_COUNT;
+      const cacheKey = normalizeCacheKey(`${pluginProvider.id}:${query}:${maxResults}`);
+      const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
+      if (cached) {
+        return jsonResult(cached.value);
+      }
+      const started = Date.now();
+
+      try {
+        const result = await pluginProvider.search({
+          query,
+          maxResults,
+          timeoutMs: timeoutSeconds * 1000,
+          config,
+        });
+
+        const payload = {
+          query,
+          provider: pluginProvider.id,
+          count: result.results?.length ?? 0,
+          tookMs: Date.now() - started,
+          externalContent: {
+            untrusted: true,
+            source: "web_search",
+            provider: pluginProvider.id,
+            wrapped: true,
+          },
+          ...(result.results && {
+            results: result.results
+              .filter((r) => sanitizeUrl(r.url))
+              .map((r) => ({
+                title: wrapWebContent(r.title),
+                url: sanitizeUrl(r.url)!,
+                description: r.description ? wrapWebContent(r.description) : undefined,
+                published: r.published,
+              })),
+          }),
+          ...(result.content && { content: wrapWebContent(result.content) }),
+          ...(result.citations && {
+            citations: result.citations
+              .map((c) => {
+                if (typeof c === "string") {
+                  return sanitizeUrl(c);
+                }
+                const url = sanitizeUrl(c.url);
+                return url
+                  ? { ...c, url, title: c.title ? wrapWebContent(c.title) : undefined }
+                  : undefined;
+              })
+              .filter(Boolean),
+          }),
+        };
+        writeCache(SEARCH_CACHE, cacheKey, payload, cacheTtlMs);
+        return jsonResult(payload);
+      } catch (err) {
+        return jsonResult({
+          error: "search_failed",
+          provider: pluginProvider.id,
+          message: String(err),
+        });
+      }
+    },
+  };
+}
+
 export function createWebSearchTool(options?: {
   config?: OpenClawConfig;
   sandboxed?: boolean;
@@ -1896,6 +2064,12 @@ export function createWebSearchTool(options?: {
   const search = resolveSearchConfig(options?.config);
   if (!resolveSearchEnabled({ search, sandboxed: options?.sandboxed })) {
     return null;
+  }
+
+  // Check plugin-registered search providers first.
+  const pluginProvider = resolvePluginSearchProvider(search, options?.config);
+  if (pluginProvider) {
+    return createPluginSearchTool(pluginProvider, search, options?.config);
   }
 
   const provider =

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -457,8 +457,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider. Built-in: "brave", "gemini", "grok", "kimi", "perplexity". Plugin providers use their registered id. */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | (string & {});
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -270,6 +270,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.string().regex(/^[a-z][a-z0-9_-]*$/, "custom provider id"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -309,6 +309,7 @@ function createPluginRecord(params: {
     cliCommands: [],
     services: [],
     commands: [],
+    searchProviderIds: [],
     httpRoutes: 0,
     hookCount: 0,
     configSchema: params.configSchema,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -42,6 +42,7 @@ import type {
   PluginHookName,
   PluginHookHandlerMap,
   PluginHookRegistration as TypedPluginHookRegistration,
+  SearchProviderPlugin,
 } from "./types.js";
 
 export type PluginToolRegistration = {
@@ -100,6 +101,12 @@ export type PluginCommandRegistration = {
   source: string;
 };
 
+export type PluginSearchProviderRegistration = {
+  pluginId: string;
+  provider: SearchProviderPlugin;
+  source: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -120,6 +127,7 @@ export type PluginRecord = {
   cliCommands: string[];
   services: string[];
   commands: string[];
+  searchProviderIds: string[];
   httpRoutes: number;
   hookCount: number;
   configSchema: boolean;
@@ -139,6 +147,7 @@ export type PluginRegistry = {
   cliRegistrars: PluginCliRegistration[];
   services: PluginServiceRegistration[];
   commands: PluginCommandRegistration[];
+  searchProviders: PluginSearchProviderRegistration[];
   diagnostics: PluginDiagnostic[];
 };
 
@@ -179,6 +188,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     cliRegistrars: [],
     services: [],
     commands: [],
+    searchProviders: [],
     diagnostics: [],
   };
 }
@@ -527,6 +537,47 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  // Built-in search provider IDs that plugins must not shadow.
+  const BUILTIN_SEARCH_PROVIDER_IDS = new Set(["brave", "gemini", "grok", "kimi", "perplexity"]);
+
+  const registerSearchProvider = (record: PluginRecord, provider: SearchProviderPlugin) => {
+    const id = typeof provider?.id === "string" ? provider.id.trim().toLowerCase() : "";
+    if (!id) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "search provider registration missing id",
+      });
+      return;
+    }
+    if (BUILTIN_SEARCH_PROVIDER_IDS.has(id)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `search provider id "${id}" conflicts with a built-in provider`,
+      });
+      return;
+    }
+    const existing = registry.searchProviders.find((entry) => entry.provider.id === id);
+    if (existing) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `search provider already registered: ${id} (${existing.pluginId})`,
+      });
+      return;
+    }
+    record.searchProviderIds.push(id);
+    registry.searchProviders.push({
+      pluginId: record.id,
+      provider: { ...provider, id },
+      source: record.source,
+    });
+  };
+
   const registerTypedHook = <K extends PluginHookName>(
     record: PluginRecord,
     hookName: K,
@@ -607,6 +658,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerHttpRoute: (params) => registerHttpRoute(record, params),
       registerChannel: (registration) => registerChannel(record, registration),
       registerProvider: (provider) => registerProvider(record, provider),
+      registerSearchProvider: (provider) => registerSearchProvider(record, provider),
       registerGatewayMethod: (method, handler) => registerGatewayMethod(record, method, handler),
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),
@@ -625,6 +677,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     registerTool,
     registerChannel,
     registerProvider,
+    registerSearchProvider,
     registerGatewayMethod,
     registerCli,
     registerService,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -234,6 +234,52 @@ export type ProviderPlugin = {
   onModelSelected?: (ctx: ProviderModelSelectedContext) => Promise<void>;
 };
 
+/**
+ * A plugin-provided web search backend. Registered via `api.registerSearchProvider()`.
+ * The built-in `web_search` tool will delegate to the first matching plugin provider
+ * when `tools.web.search.provider` matches the provider id.
+ */
+export type SearchProviderPlugin = {
+  /** Unique provider id used in config, e.g. "searxng" or "tavily". */
+  id: string;
+  /** Human-readable name shown in logs and tool descriptions. */
+  name: string;
+  /** Tool description override for the LLM (what the search tool does). */
+  description?: string;
+  /**
+   * Execute a search query. Must return normalized results.
+   * Throwing an error will surface it to the agent as a tool error.
+   */
+  search: (params: SearchProviderRequest) => Promise<SearchProviderResult>;
+  /**
+   * Optional auto-detection: return true if this provider is available
+   * (e.g. required env vars or config keys are set). Used when no
+   * explicit provider is configured and the system tries each in turn.
+   */
+  isAvailable?: (config?: OpenClawConfig) => boolean;
+};
+
+export type SearchProviderRequest = {
+  query: string;
+  maxResults?: number;
+  timeoutMs?: number;
+  config?: OpenClawConfig;
+};
+
+export type SearchProviderResult = {
+  /** Web result entries. */
+  results?: Array<{
+    title: string;
+    url: string;
+    description?: string;
+    published?: string;
+  }>;
+  /** AI-synthesized answer (for LLM-backed providers like Perplexity). */
+  content?: string;
+  /** Citation URLs or objects. */
+  citations?: Array<string | { url: string; title?: string }>;
+};
+
 export type OpenClawPluginGatewayMethod = {
   method: string;
   handler: GatewayRequestHandler;
@@ -388,6 +434,8 @@ export type OpenClawPluginApi = {
   registerCli: (registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;
   registerService: (service: OpenClawPluginService) => void;
   registerProvider: (provider: ProviderPlugin) => void;
+  /** Register a custom web search backend (SearXNG, Tavily, etc.). */
+  registerSearchProvider: (provider: SearchProviderPlugin) => void;
   /**
    * Register a custom command that bypasses the LLM agent.
    * Plugin commands are processed before built-in commands and before agent invocation.


### PR DESCRIPTION
## The problem

Users who need a different search backend — SearXNG, Tavily, Bing, a self-hosted engine — currently have no option short of forking the repo and patching `web-search.ts` by hand. Three separate issues have been open asking for this, with 43 combined 👍:

- #11399 — Extensible web_search providers via plugins (+13 👍)
- #2317 — Add SearXNG as fallback provider (+19 👍)
- #12034 — Add Tavily as configurable search provider (+11 👍)

**Before this PR**, adding a search provider means modifying core code.
**After this PR**, it's 5 lines in a plugin — no fork needed:

```typescript
api.registerSearchProvider({
  id: "searxng",
  name: "SearXNG",
  async search({ query, maxResults, timeoutMs }) {
    const res = await fetch(`https://my-searxng.example/search?q=${query}&format=json`);
    const data = await res.json();
    return data.results.slice(0, maxResults).map(r => ({
      title: r.title, url: r.url, content: r.content,
    }));
  },
});
```

## What this PR adds

**`SearchProviderPlugin` interface** — plugins register a provider with `id`, `name`, `search()`, and optional `isAvailable()`.

**Provider resolution** — when the user sets `tools.web.search.provider` to a plugin id, that plugin handles all web searches. If no provider is configured, plugins that return `true` from `isAvailable()` are auto-detected.

**Same security guarantees as built-in providers:**
- Plugin results go through `wrapWebContent` (content-security wrapping) and the shared `readCache`/`writeCache` pipeline
- Plugin descriptions are sanitized (200 char cap, control char stripping) to prevent prompt injection into tool metadata
- Raw error strings are redacted from LLM output — details are logged server-side only
- `maxResults` is clamped to `[1, 10]` to prevent resource exhaustion
- Embedded `user:pass@` credentials are stripped from result URLs
- Built-in provider IDs (`brave`, `gemini`, etc.) are reserved — plugins cannot shadow them

## Files changed

| File | What |
|------|------|
| `src/plugins/types.ts` | `SearchProviderPlugin` interface |
| `src/plugins/registry.ts` | `registerSearchProvider()` with collision guard |
| `src/plugins/loader.ts` | Wire up registration |
| `src/agents/tools/web-search.ts` | Plugin resolution, tool creation, security |
| `src/config/types.tools.ts` | Accept plugin provider ids in config |
| `src/config/zod-schema.agent-runtime.ts` | Validate custom provider id format |

Recreated from #41288 (auto-closed due to dirty branch).