### PR TITLE
WhatsApp: add composing-aware inbound debounce extension

### DIFF
--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -29,6 +29,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  composingDebounceMs?: number;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -146,6 +147,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    composingDebounceMs: accountCfg?.composingDebounceMs ?? rootCfg?.composingDebounceMs,
   };
 }
 

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -199,6 +199,7 @@ export async function monitorWebChannel(
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
+      composingDebounceMs: account.composingDebounceMs,
       shouldDebounce,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -32,6 +32,10 @@ export async function monitorWebInbox(options: {
   sendReadReceipts?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
+  /** Extend the debounce window (ms) while the sender is typing (default: 0 — disabled).
+   *  Recommended value: 15000. WhatsApp emits composing indicators roughly every 10 s,
+   *  so the configured value should exceed that interval. */
+  composingDebounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
 }) {
@@ -67,6 +71,12 @@ export async function monitorWebInbox(options: {
 
   const selfJid = sock.user?.id;
   const selfE164 = selfJid ? jidToE164(selfJid) : null;
+
+  // WhatsApp presence events use internal LID format instead of phone-number JIDs.
+  // Cache the LID→E164 mapping from inbound messages so composing events can be
+  // matched to the correct debounce buffer.
+  const jidToE164Cache = new Map<string, string>();
+
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
     buildKey: (msg) => {
@@ -382,6 +392,18 @@ export async function monitorWebInbox(options: {
       mediaType: enriched.mediaType,
       mediaFileName: enriched.mediaFileName,
     };
+    // Subscribe to presence events for this chat so we receive "composing"
+    // indicators that can extend the debounce window while the sender types.
+    if (composingExtendMs > 0 && typeof sock.presenceSubscribe === "function") {
+      const { remoteJid } = inbound;
+      if (inbound.from && remoteJid && remoteJid !== inbound.from) {
+        jidToE164Cache.set(remoteJid, inbound.from);
+      }
+      sock.presenceSubscribe(remoteJid).catch((err) => {
+        logVerbose(`presenceSubscribe failed for ${remoteJid}: ${String(err)}`);
+      });
+    }
+
     try {
       const task = Promise.resolve(debouncer.enqueue(inboundMessage));
       void task.catch((err) => {
@@ -432,6 +454,51 @@ export async function monitorWebInbox(options: {
   };
   sock.ev.on("messages.upsert", handleMessagesUpsert);
 
+  // Extend the inbound debounce window while the sender is actively typing.
+  // WhatsApp emits "composing" presence events roughly every 10 seconds, so the
+  // default of 15 s bridges the gap between consecutive events.
+  // Set composingDebounceMs to 0 to disable this feature entirely.
+  const composingExtendMs = options.composingDebounceMs ?? 0;
+
+  const handlePresenceUpdate = (update: {
+    id: string;
+    presences: Record<string, { lastKnownPresence?: string } | undefined>;
+  }) => {
+    try {
+      if (!update?.id) {
+        return;
+      }
+      const { presences } = update;
+      if (!presences) {
+        return;
+      }
+      for (const [jid, presence] of Object.entries(presences)) {
+        if (presence?.lastKnownPresence !== "composing") {
+          continue;
+        }
+        const e164 =
+          jidToE164(jid, { authDir: options.authDir }) ??
+          jidToE164Cache.get(jid) ??
+          jidToE164Cache.get(update.id);
+        if (!e164) {
+          continue;
+        }
+        const chatJid = update.id;
+        const group = isJidGroup(chatJid) === true;
+        const conversationKey = group ? chatJid : e164;
+        const prefix = `${options.accountId}:${conversationKey}:${e164}`;
+        debouncer.touchByPrefix(prefix, composingExtendMs);
+      }
+    } catch (err) {
+      logVerbose(`presence.update handler error: ${String(err)}`);
+    }
+  };
+
+  // Only subscribe to presence events when both debounce and composing extension are enabled.
+  if (composingExtendMs > 0 && (options.debounceMs ?? 0) > 0) {
+    sock.ev.on("presence.update", handlePresenceUpdate);
+  }
+
   const handleConnectionUpdate = (
     update: Partial<import("@whiskeysockets/baileys").ConnectionState>,
   ) => {
@@ -478,6 +545,17 @@ export async function monitorWebInbox(options: {
         } else if (typeof ev.removeListener === "function") {
           ev.removeListener("messages.upsert", messagesUpsertHandler);
           ev.removeListener("connection.update", connectionUpdateHandler);
+        }
+        // Remove presence listener only if it was registered.
+        if (composingExtendMs > 0 && (options.debounceMs ?? 0) > 0) {
+          const presenceUpdateHandler = handlePresenceUpdate as unknown as (
+            ...args: unknown[]
+          ) => void;
+          if (typeof ev.off === "function") {
+            ev.off("presence.update", presenceUpdateHandler);
+          } else if (typeof ev.removeListener === "function") {
+            ev.removeListener("presence.update", presenceUpdateHandler);
+          }
         }
         sock.ws?.close();
       } catch (err) {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -124,5 +124,45 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  /**
+   * Reset the flush timer for an existing buffer without adding a new item.
+   * Useful for extending the debounce window when the sender is still typing.
+   * @param extendMs — if provided and greater than the buffer's current debounceMs,
+   *   temporarily use this value for the scheduled flush.
+   */
+  const touch = (key: string, extendMs?: number): boolean => {
+    const existing = buffers.get(key);
+    if (!existing) {
+      return false;
+    }
+    const origMs = existing.debounceMs;
+    if (typeof extendMs === "number" && extendMs > origMs) {
+      existing.debounceMs = extendMs;
+    }
+    scheduleFlush(key, existing);
+    existing.debounceMs = origMs;
+    return true;
+  };
+
+  /**
+   * Like {@link touch}, but matches all buffer keys starting with `prefix`.
+   * Returns true if at least one buffer was touched.
+   */
+  const touchByPrefix = (prefix: string, extendMs?: number): boolean => {
+    let touched = false;
+    for (const [key, buffer] of buffers) {
+      if (key.startsWith(prefix)) {
+        const origMs = buffer.debounceMs;
+        if (typeof extendMs === "number" && extendMs > origMs) {
+          buffer.debounceMs = extendMs;
+        }
+        scheduleFlush(key, buffer);
+        buffer.debounceMs = origMs;
+        touched = true;
+      }
+    }
+    return touched;
+  };
+
+  return { enqueue, flushKey, touch, touchByPrefix };
 }

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -79,6 +79,10 @@ type WhatsAppSharedConfig = {
   ackReaction?: WhatsAppAckReactionConfig;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
+  /** Extend the debounce window (ms) while the sender is typing (default: 0 — disabled).
+   *  Recommended value: 15000. WhatsApp emits composing indicators roughly every 10 seconds,
+   *  so the configured value should exceed that interval. */
+  composingDebounceMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Channel health monitor overrides for this channel/account. */


### PR DESCRIPTION
Extend the inbound debounce window while the sender is actively typing by subscribing to WhatsApp presence (composing) events. Adds a new composingDebounceMs config option (default 0/disabled) and touch/touchByPrefix helpers to the inbound debouncer.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: If someone sends "Hey" and starts writing a longer follow-up, the bot processes and responds to "Hey" alone.
- Why it matters: Allowing claws to wait for the user to stop typing enables more human-like interactions.
- What changed: New opt-in config composingDebounceMs on the WhatsApp channel. When set, the gateway subscribes to Baileys presence.update events and resets the debounce timer while the sender's status is "composing". 
- What did NOT change (scope boundary): Default behavior is unchanged (composingDebounceMs defaults to 0 — disabled). No changes to other channels, the debounce core logic, or the config schema beyond the new optional field. 

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

## User-visible / Behavior Changes

New opt-in config composingDebounceMs on the WhatsApp channel

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No


## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None
