### PR TITLE
fix: sessions_send announce drops threadId; child loggers bypass logging.level

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -47,8 +47,16 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    // threadId may be stored as a number in deliveryContext; coerce to string for the
+    // gateway send handler which expects typeof threadId === "string".
+    const rawThreadId =
+      deliveryContext?.threadId != null
+        ? deliveryContext.threadId
+        : (match as Record<string, unknown> | undefined)?.lastThreadId;
+    const threadId =
+      rawThreadId != null ? String(rawThreadId as string | number) : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -223,13 +223,20 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
   const name = bindings ? JSON.stringify(bindings) : undefined;
-  return base.getSubLogger({
+  // Only include minLevel when an explicit override is provided.
+  // Passing minLevel: undefined into getSubLogger() causes tslog's shallow
+  // merge to overwrite the parent's configured minLevel with undefined, which
+  // then falls back to 0 (SILLY) in the constructor — effectively bypassing
+  // the global logging.level setting for all child loggers.
+  const subSettings: Parameters<TsLogger<LogObj>["getSubLogger"]>[0] = {
     name,
-    minLevel,
     prefix: bindings ? [name ?? ""] : [],
-  });
+  };
+  if (opts?.level) {
+    subSettings.minLevel = levelToMinLevel(opts.level);
+  }
+  return base.getSubLogger(subSettings);
 }
 
 // Baileys expects a pino-like logger shape. Provide a lightweight adapter.


### PR DESCRIPTION
## Summary

Two related fixes for reported bugs in logging and sessions announce delivery.

---

## Fix 1: `sessions_send` announce delivery drops `threadId` (#47515)

**Problem:**
`resolveAnnounceTarget()` reads `channel`, `to`, and `accountId` from `deliveryContext` but never extracts `threadId`. For Telegram forum topics, the session stores `deliveryContext.threadId` as a **number**; the gateway `send` handler expects a **string**. Result: announce delivery for thread sessions fired without `message_thread_id`, causing Telegram 400 errors or silent delivery failures.

**Fix:**
Extract `threadId` from `deliveryContext` (or `lastThreadId` as fallback), coerce number→string to match gateway expectations, and include it in the returned `AnnounceTarget`.

**Side-effects:**
- `threadId` is `undefined` for non-topic sessions → no change in behavior
- Discord/Slack don't set `threadId` in `deliveryContext` → harmless
- Only one caller (`sessions_send` announce flow) → minimal blast radius

---

## Fix 2: Child loggers bypass `logging.level` due to `minLevel: undefined` (#47529)

**Problem:**
`getChildLogger()` unconditionally included `minLevel: undefined` in the settings passed to `getSubLogger()`. tslog's shallow merge (`{ ...this.settings, ...settings }`) means the child's explicit `undefined` overwrote the parent's correctly-configured `minLevel`. The tslog constructor then fell back to `settings?.minLevel ?? 0` (SILLY), allowing **all log levels** through for every child logger.

In practice: DEBUG lines (e.g. `cron: timer armed`) always appeared in `/tmp/openclaw/openclaw-*.log` even with `logging.level: "info"`.

**Fix:**
Only include `minLevel` in the sub-logger settings object when an explicit level override is provided. Without an override, the parent's `minLevel` is inherited correctly via tslog's merge behavior.

---

## Test notes

- No behavior change for non-topic sessions or non-Telegram channels
- Existing tests pass (`pnpm test` on local clone)

Fixes #47515, fixes #47529