### PR TITLE
docs(zalo): document current Marketplace bot behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/streaming: add `onReasoningStream` and `onReasoningEnd` support to streaming cards, so `/reasoning stream` renders thinking tokens as markdown blockquotes in the same card — matching the Telegram channel's reasoning lane behavior. (#46029)
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) thanks @scoootscooob.
 - Android/nodes: add `callLog.search` plus shared Call Log permission wiring so Android nodes can search recent call history through the gateway. (#44073) Thanks @lxk7280.
+- Docs/Zalo: clarify the Marketplace-bot support matrix and config guidance so the Zalo channel docs match current Bot Creator behavior more closely. (#47552) Thanks @No898.
 
 ### Fixes
 

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -7,7 +7,7 @@ title: "Zalo"
 
 # Zalo (Bot API)
 
-Status: experimental. DMs are supported; group handling is available with explicit group policy controls.
+Status: experimental. DMs are supported. For the currently tested Zalo Bot Creator / Marketplace bot flow, groups are not currently available.
 
 ## Plugin required
 
@@ -25,7 +25,7 @@ Zalo ships as a plugin and is not bundled with the core install.
    - Or pick **Zalo** in onboarding and confirm the install prompt
 2. Set the token:
    - Env: `ZALO_BOT_TOKEN=...`
-   - Or config: `channels.zalo.botToken: "..."`.
+   - Or config: `channels.zalo.accounts.default.botToken: "..."`.
 3. Restart the gateway (or finish onboarding).
 4. DM access is pairing by default; approve the pairing code on first contact.
 
@@ -36,8 +36,13 @@ Minimal config:
   channels: {
     zalo: {
       enabled: true,
-      botToken: "12345689:abc-xyz",
-      dmPolicy: "pairing",
+      accounts: {
+        default: {
+          botToken: "12345689:abc-xyz",
+          dmPolicy: "pairing",
+          groupPolicy: "disabled",
+        },
+      },
     },
   },
 }
@@ -48,10 +53,13 @@ Minimal config:
 Zalo is a Vietnam-focused messaging app; its Bot API lets the Gateway run a bot for 1:1 conversations.
 It is a good fit for support or notifications where you want deterministic routing back to Zalo.
 
+This page reflects the currently verified OpenClaw behavior for **Zalo Bot Creator / Marketplace bots**.
+**Zalo Official Account (OA) bots** are a different Zalo product surface and may behave differently.
+
 - A Zalo Bot API channel owned by the Gateway.
 - Deterministic routing: replies go back to Zalo; the model never chooses channels.
 - DMs share the agent's main session.
-- Groups are supported with policy controls (`groupPolicy` + `groupAllowFrom`) and default to fail-closed allowlist behavior.
+- For the currently tested Marketplace bot flow, groups are not currently available because the bot could not be added to a group in testing.
 
 ## Setup (fast path)
 
@@ -59,7 +67,7 @@ It is a good fit for support or notifications where you want deterministic routi
 
 1. Go to [https://bot.zaloplatforms.com](https://bot.zaloplatforms.com) and sign in.
 2. Create a new bot and configure its settings.
-3. Copy the bot token (format: `12345689:abc-xyz`).
+3. Copy the full bot token (typically `numeric_id:secret`). In current testing, the usable runtime token appeared in the bot's welcome message after creation.
 
 ### 2) Configure the token (env or config)
 
@@ -70,8 +78,13 @@ Example:
   channels: {
     zalo: {
       enabled: true,
-      botToken: "12345689:abc-xyz",
-      dmPolicy: "pairing",
+      accounts: {
+        default: {
+          botToken: "12345689:abc-xyz",
+          dmPolicy: "pairing",
+          groupPolicy: "disabled",
+        },
+      },
     },
   },
 }
@@ -109,13 +122,16 @@ Multi-account support: use `channels.zalo.accounts` with per-account tokens and 
 
 ## Access control (Groups)
 
+For the currently tested **Zalo Bot Creator / Marketplace bot** flow, group support was not available in practice because the bot could not be added to a group at all.
+
+That means the group-related config keys below exist in the schema, but were not usable in current Marketplace-bot testing:
+
 - `channels.zalo.groupPolicy` controls group inbound handling: `open | allowlist | disabled`.
-- Default behavior is fail-closed: `allowlist`.
 - `channels.zalo.groupAllowFrom` restricts which sender IDs can trigger the bot in groups.
 - If `groupAllowFrom` is unset, Zalo falls back to `allowFrom` for sender checks.
-- `groupPolicy: "disabled"` blocks all group messages.
-- `groupPolicy: "open"` allows any group member (mention-gated).
 - Runtime note: if `channels.zalo` is missing entirely, runtime still falls back to `groupPolicy="allowlist"` for safety.
+
+If you are using a different Zalo bot product surface and have verified working group behavior, document that separately rather than assuming it matches the Marketplace-bot flow.
 
 ## Long-polling vs webhook
 
@@ -134,22 +150,30 @@ Multi-account support: use `channels.zalo.accounts` with per-account tokens and 
 ## Supported message types
 
 - **Text messages**: Full support with 2000 character chunking.
-- **Image messages**: Download and process inbound images; send images via `sendPhoto`.
-- **Stickers**: Logged but not fully processed (no agent response).
-- **Unsupported types**: Logged (e.g., messages from protected users).
+- **Plain URLs in text**: Behave like normal text input.
+- **Link previews / rich link cards**: Did not reliably trigger a reply in current Marketplace-bot testing.
+- **Image messages**: Inbound image handling was not reliable in current Marketplace-bot testing (typing indicator without a final reply), so verify in your environment before relying on it.
+- **Stickers**: No normal agent response in current testing.
+- **Voice notes / audio files / video / generic file attachments**: No normal agent response in current testing.
+- **Unsupported types**: Logged (for example, messages from protected users).
 
 ## Capabilities
 
-| Feature         | Status                                                   |
-| --------------- | -------------------------------------------------------- |
-| Direct messages | ✅ Supported                                             |
-| Groups          | ⚠️ Supported with policy controls (allowlist by default) |
-| Media (images)  | ✅ Supported                                             |
-| Reactions       | ❌ Not supported                                         |
-| Threads         | ❌ Not supported                                         |
-| Polls           | ❌ Not supported                                         |
-| Native commands | ❌ Not supported                                         |
-| Streaming       | ⚠️ Blocked (2000 char limit)                             |
+| Feature                     | Status                                                                  |
+| --------------------------- | ----------------------------------------------------------------------- |
+| Direct messages             | ✅ Supported                                                            |
+| Groups                      | ❌ Not available in current Marketplace-bot testing                     |
+| Media (inbound images)      | ⚠️ Limited / verify in your environment                                 |
+| Plain URLs in text          | ✅ Supported                                                            |
+| Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing    |
+| Reactions                   | ❌ Not supported                                                        |
+| Stickers                    | ⚠️ Received but no normal agent reply observed                          |
+| Voice notes / audio / video | ❌ No normal agent reply observed in current Marketplace-bot testing    |
+| File attachments            | ❌ No normal agent reply observed in current Marketplace-bot testing    |
+| Threads                     | ❌ Not supported                                                        |
+| Polls                       | ❌ Not supported                                                        |
+| Native commands             | ❌ Not supported                                                        |
+| Streaming                   | ⚠️ Blocked (2000 char limit)                                            |
 
 ## Delivery targets (CLI/cron)
 
@@ -182,7 +206,7 @@ Provider options:
 - `channels.zalo.tokenFile`: read token from a regular file path. Symlinks are rejected.
 - `channels.zalo.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
 - `channels.zalo.allowFrom`: DM allowlist (user IDs). `open` requires `"*"`. The wizard will ask for numeric IDs.
-- `channels.zalo.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
+- `channels.zalo.groupPolicy`: `open | allowlist | disabled` (default: allowlist). Present in config, but not usable for the current Marketplace-bot flow when the bot cannot be added to groups.
 - `channels.zalo.groupAllowFrom`: group sender allowlist (user IDs). Falls back to `allowFrom` when unset.
 - `channels.zalo.mediaMaxMb`: inbound/outbound media cap (MB, default 5).
 - `channels.zalo.webhookUrl`: enable webhook mode (HTTPS required).

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -7,7 +7,7 @@ title: "Zalo"
 
 # Zalo (Bot API)
 
-Status: experimental. DMs are supported. For the currently tested Zalo Bot Creator / Marketplace bot flow, groups are not currently available.
+Status: experimental. DMs are supported. The [Capabilities](#capabilities) section below reflects current Marketplace-bot behavior.
 
 ## Plugin required
 
@@ -52,13 +52,13 @@ Minimal config:
 Zalo is a Vietnam-focused messaging app; its Bot API lets the Gateway run a bot for 1:1 conversations.
 It is a good fit for support or notifications where you want deterministic routing back to Zalo.
 
-This page reflects the currently verified OpenClaw behavior for **Zalo Bot Creator / Marketplace bots**.
+This page reflects current OpenClaw behavior for **Zalo Bot Creator / Marketplace bots**.
 **Zalo Official Account (OA) bots** are a different Zalo product surface and may behave differently.
 
 - A Zalo Bot API channel owned by the Gateway.
 - Deterministic routing: replies go back to Zalo; the model never chooses channels.
 - DMs share the agent's main session.
-- For the currently tested Marketplace bot flow, groups are not currently available because the bot could not be added to a group in testing.
+- The [Capabilities](#capabilities) section below shows current Marketplace-bot support.
 
 ## Setup (fast path)
 
@@ -66,7 +66,7 @@ This page reflects the currently verified OpenClaw behavior for **Zalo Bot Creat
 
 1. Go to [https://bot.zaloplatforms.com](https://bot.zaloplatforms.com) and sign in.
 2. Create a new bot and configure its settings.
-3. Copy the full bot token (typically `numeric_id:secret`). In current testing, the usable runtime token appeared in the bot's welcome message after creation.
+3. Copy the full bot token (typically `numeric_id:secret`). For Marketplace bots, the usable runtime token may appear in the bot's welcome message after creation.
 
 ### 2) Configure the token (env or config)
 
@@ -88,7 +88,7 @@ Example:
 }
 ```
 
-If you later move to a Zalo bot surface where groups are actually available, you can add group-specific config such as `groupPolicy` and `groupAllowFrom` explicitly.
+If you later move to a Zalo bot surface where groups are available, you can add group-specific config such as `groupPolicy` and `groupAllowFrom` explicitly. For current Marketplace-bot behavior, see [Capabilities](#capabilities).
 
 Env option: `ZALO_BOT_TOKEN=...` (works for the default account only).
 
@@ -122,9 +122,9 @@ Multi-account support: use `channels.zalo.accounts` with per-account tokens and 
 
 ## Access control (Groups)
 
-For the currently tested **Zalo Bot Creator / Marketplace bot** flow, group support was not available in practice because the bot could not be added to a group at all.
+For **Zalo Bot Creator / Marketplace bots**, group support was not available in practice because the bot could not be added to a group at all.
 
-That means the group-related config keys below exist in the schema, but were not usable in current Marketplace-bot testing:
+That means the group-related config keys below exist in the schema, but were not usable for Marketplace bots:
 
 - `channels.zalo.groupPolicy` controls group inbound handling: `open | allowlist | disabled`.
 - `channels.zalo.groupAllowFrom` restricts which sender IDs can trigger the bot in groups.
@@ -155,32 +155,36 @@ If you are using a different Zalo bot product surface and have verified working 
 
 ## Supported message types
 
+For a quick support snapshot, see [Capabilities](#capabilities). The notes below add detail where the behavior needs extra context.
+
 - **Text messages**: Full support with 2000 character chunking.
 - **Plain URLs in text**: Behave like normal text input.
-- **Link previews / rich link cards**: Did not reliably trigger a reply in current Marketplace-bot testing.
-- **Image messages**: Inbound image handling was not reliable in current Marketplace-bot testing (typing indicator without a final reply), so verify in your environment before relying on it.
-- **Stickers**: No normal agent response in current testing.
-- **Voice notes / audio files / video / generic file attachments**: No normal agent response in current testing.
+- **Link previews / rich link cards**: See the Marketplace-bot status in [Capabilities](#capabilities); they did not reliably trigger a reply.
+- **Image messages**: See the Marketplace-bot status in [Capabilities](#capabilities); inbound image handling was unreliable (typing indicator without a final reply).
+- **Stickers**: See the Marketplace-bot status in [Capabilities](#capabilities).
+- **Voice notes / audio files / video / generic file attachments**: See the Marketplace-bot status in [Capabilities](#capabilities).
 - **Unsupported types**: Logged (for example, messages from protected users).
 
 ## Capabilities
 
-| Feature                     | Status                                                               |
-| --------------------------- | -------------------------------------------------------------------- |
-| Direct messages             | ✅ Supported                                                         |
-| Groups                      | ❌ Not available in current Marketplace-bot testing                  |
-| Media (inbound images)      | ⚠️ Limited / verify in your environment                              |
-| Media (outbound images)     | ⚠️ Not re-tested in current Marketplace-bot testing                  |
-| Plain URLs in text          | ✅ Supported                                                         |
-| Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing |
-| Reactions                   | ❌ Not supported                                                     |
-| Stickers                    | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
-| Voice notes / audio / video | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
-| File attachments            | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
-| Threads                     | ❌ Not supported                                                     |
-| Polls                       | ❌ Not supported                                                     |
-| Native commands             | ❌ Not supported                                                     |
-| Streaming                   | ⚠️ Blocked (2000 char limit)                                         |
+This table summarizes current **Zalo Bot Creator / Marketplace bot** behavior in OpenClaw.
+
+| Feature                     | Status                                  |
+| --------------------------- | --------------------------------------- |
+| Direct messages             | ✅ Supported                            |
+| Groups                      | ❌ Not available for Marketplace bots   |
+| Media (inbound images)      | ⚠️ Limited / verify in your environment |
+| Media (outbound images)     | ⚠️ Not re-tested for Marketplace bots   |
+| Plain URLs in text          | ✅ Supported                            |
+| Link previews               | ⚠️ Unreliable for Marketplace bots      |
+| Reactions                   | ❌ Not supported                        |
+| Stickers                    | ⚠️ No agent reply for Marketplace bots  |
+| Voice notes / audio / video | ⚠️ No agent reply for Marketplace bots  |
+| File attachments            | ⚠️ No agent reply for Marketplace bots  |
+| Threads                     | ❌ Not supported                        |
+| Polls                       | ❌ Not supported                        |
+| Native commands             | ❌ Not supported                        |
+| Streaming                   | ⚠️ Blocked (2000 char limit)            |
 
 ## Delivery targets (CLI/cron)
 
@@ -215,7 +219,7 @@ Provider options:
 - `channels.zalo.tokenFile`: read token from a regular file path. Symlinks are rejected.
 - `channels.zalo.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
 - `channels.zalo.allowFrom`: DM allowlist (user IDs). `open` requires `"*"`. The wizard will ask for numeric IDs.
-- `channels.zalo.groupPolicy`: `open | allowlist | disabled` (default: allowlist). Present in config, but not usable for the current Marketplace-bot flow when the bot cannot be added to groups.
+- `channels.zalo.groupPolicy`: `open | allowlist | disabled` (default: allowlist). Present in config; see [Capabilities](#capabilities) and [Access control (Groups)](#access-control-groups) for current Marketplace-bot behavior.
 - `channels.zalo.groupAllowFrom`: group sender allowlist (user IDs). Falls back to `allowFrom` when unset.
 - `channels.zalo.mediaMaxMb`: inbound/outbound media cap (MB, default 5).
 - `channels.zalo.webhookUrl`: enable webhook mode (HTTPS required).
@@ -231,10 +235,9 @@ Multi-account options:
 - `channels.zalo.accounts.<id>.enabled`: enable/disable account.
 - `channels.zalo.accounts.<id>.dmPolicy`: per-account DM policy.
 - `channels.zalo.accounts.<id>.allowFrom`: per-account allowlist.
-- `channels.zalo.accounts.<id>.groupPolicy`: per-account group policy. Present in config, but not usable for the current Marketplace-bot flow when the bot cannot be added to groups.
+- `channels.zalo.accounts.<id>.groupPolicy`: per-account group policy. Present in config; see [Capabilities](#capabilities) and [Access control (Groups)](#access-control-groups) for current Marketplace-bot behavior.
 - `channels.zalo.accounts.<id>.groupAllowFrom`: per-account group sender allowlist.
 - `channels.zalo.accounts.<id>.webhookUrl`: per-account webhook URL.
 - `channels.zalo.accounts.<id>.webhookSecret`: per-account webhook secret.
 - `channels.zalo.accounts.<id>.webhookPath`: per-account webhook path.
 - `channels.zalo.accounts.<id>.proxy`: per-account proxy URL.
-  per-account proxy URL.

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -170,6 +170,7 @@ If you are using a different Zalo bot product surface and have verified working 
 | Direct messages             | ✅ Supported                                                         |
 | Groups                      | ❌ Not available in current Marketplace-bot testing                  |
 | Media (inbound images)      | ⚠️ Limited / verify in your environment                              |
+| Media (outbound images)     | ⚠️ Not re-tested in current Marketplace-bot testing                  |
 | Plain URLs in text          | ✅ Supported                                                         |
 | Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing |
 | Reactions                   | ❌ Not supported                                                     |
@@ -236,3 +237,4 @@ Multi-account options:
 - `channels.zalo.accounts.<id>.webhookSecret`: per-account webhook secret.
 - `channels.zalo.accounts.<id>.webhookPath`: per-account webhook path.
 - `channels.zalo.accounts.<id>.proxy`: per-account proxy URL.
+  per-account proxy URL.

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -131,6 +131,12 @@ That means the group-related config keys below exist in the schema, but were not
 - If `groupAllowFrom` is unset, Zalo falls back to `allowFrom` for sender checks.
 - Runtime note: if `channels.zalo` is missing entirely, runtime still falls back to `groupPolicy="allowlist"` for safety.
 
+The group policy values (when group access is available on your bot surface) are:
+
+- `groupPolicy: "disabled"` — blocks all group messages.
+- `groupPolicy: "open"` — allows any group member (mention-gated).
+- `groupPolicy: "allowlist"` — fail-closed default; only allowed senders are accepted.
+
 If you are using a different Zalo bot product surface and have verified working group behavior, document that separately rather than assuming it matches the Marketplace-bot flow.
 
 ## Long-polling vs webhook
@@ -159,21 +165,21 @@ If you are using a different Zalo bot product surface and have verified working 
 
 ## Capabilities
 
-| Feature                     | Status                                                                  |
-| --------------------------- | ----------------------------------------------------------------------- |
-| Direct messages             | ✅ Supported                                                            |
-| Groups                      | ❌ Not available in current Marketplace-bot testing                     |
-| Media (inbound images)      | ⚠️ Limited / verify in your environment                                 |
-| Plain URLs in text          | ✅ Supported                                                            |
-| Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing    |
-| Reactions                   | ❌ Not supported                                                        |
-| Stickers                    | ⚠️ Received but no normal agent reply observed                          |
-| Voice notes / audio / video | ❌ No normal agent reply observed in current Marketplace-bot testing    |
-| File attachments            | ❌ No normal agent reply observed in current Marketplace-bot testing    |
-| Threads                     | ❌ Not supported                                                        |
-| Polls                       | ❌ Not supported                                                        |
-| Native commands             | ❌ Not supported                                                        |
-| Streaming                   | ⚠️ Blocked (2000 char limit)                                            |
+| Feature                     | Status                                                               |
+| --------------------------- | -------------------------------------------------------------------- |
+| Direct messages             | ✅ Supported                                                         |
+| Groups                      | ❌ Not available in current Marketplace-bot testing                  |
+| Media (inbound images)      | ⚠️ Limited / verify in your environment                              |
+| Plain URLs in text          | ✅ Supported                                                         |
+| Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing |
+| Reactions                   | ❌ Not supported                                                     |
+| Stickers                    | ⚠️ Received but no normal agent reply observed                       |
+| Voice notes / audio / video | ❌ No normal agent reply observed in current Marketplace-bot testing |
+| File attachments            | ❌ No normal agent reply observed in current Marketplace-bot testing |
+| Threads                     | ❌ Not supported                                                     |
+| Polls                       | ❌ Not supported                                                     |
+| Native commands             | ❌ Not supported                                                     |
+| Streaming                   | ⚠️ Blocked (2000 char limit)                                         |
 
 ## Delivery targets (CLI/cron)
 
@@ -198,6 +204,8 @@ If you are using a different Zalo bot product surface and have verified working 
 ## Configuration reference (Zalo)
 
 Full configuration: [Configuration](/gateway/configuration)
+
+The flat top-level keys (`channels.zalo.botToken`, `channels.zalo.dmPolicy`, and similar) are a legacy single-account shorthand. Prefer `channels.zalo.accounts.<id>.*` for new configs. Both forms are still documented here because they exist in the schema.
 
 Provider options:
 

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -231,7 +231,7 @@ Multi-account options:
 - `channels.zalo.accounts.<id>.enabled`: enable/disable account.
 - `channels.zalo.accounts.<id>.dmPolicy`: per-account DM policy.
 - `channels.zalo.accounts.<id>.allowFrom`: per-account allowlist.
-- `channels.zalo.accounts.<id>.groupPolicy`: per-account group policy.
+- `channels.zalo.accounts.<id>.groupPolicy`: per-account group policy. Present in config, but not usable for the current Marketplace-bot flow when the bot cannot be added to groups.
 - `channels.zalo.accounts.<id>.groupAllowFrom`: per-account group sender allowlist.
 - `channels.zalo.accounts.<id>.webhookUrl`: per-account webhook URL.
 - `channels.zalo.accounts.<id>.webhookSecret`: per-account webhook secret.

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -40,7 +40,6 @@ Minimal config:
         default: {
           botToken: "12345689:abc-xyz",
           dmPolicy: "pairing",
-          groupPolicy: "disabled",
         },
       },
     },
@@ -82,13 +81,14 @@ Example:
         default: {
           botToken: "12345689:abc-xyz",
           dmPolicy: "pairing",
-          groupPolicy: "disabled",
         },
       },
     },
   },
 }
 ```
+
+If you later move to a Zalo bot surface where groups are actually available, you can add group-specific config such as `groupPolicy` and `groupAllowFrom` explicitly.
 
 Env option: `ZALO_BOT_TOKEN=...` (works for the default account only).
 
@@ -173,9 +173,9 @@ If you are using a different Zalo bot product surface and have verified working 
 | Plain URLs in text          | ✅ Supported                                                         |
 | Link previews               | ⚠️ Unreliable / no reply observed in current Marketplace-bot testing |
 | Reactions                   | ❌ Not supported                                                     |
-| Stickers                    | ⚠️ Received but no normal agent reply observed                       |
-| Voice notes / audio / video | ❌ No normal agent reply observed in current Marketplace-bot testing |
-| File attachments            | ❌ No normal agent reply observed in current Marketplace-bot testing |
+| Stickers                    | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
+| Voice notes / audio / video | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
+| File attachments            | ⚠️ No normal agent reply observed in current Marketplace-bot testing |
 | Threads                     | ❌ Not supported                                                     |
 | Polls                       | ❌ Not supported                                                     |
 | Native commands             | ❌ Not supported                                                     |


### PR DESCRIPTION
## Summary

Fixes #47550.

This PR updates `docs/channels/zalo.md` to match the currently verified behavior we observed while testing OpenClaw against a **Zalo Bot Creator / Marketplace bot**.

Main doc changes:
- clarify that the tested flow is **Zalo Bot Creator / Marketplace**, not OA
- change groups from effectively supported to **not currently available** for the tested Marketplace-bot flow
- prefer the modern `channels.zalo.accounts.default` config shape in examples
- document the practical token shape/use (`numeric_id:secret` from the bot welcome flow)
- separate **plain URL text** from **rich link preview** behavior
- document the observed limitations for inbound images and non-text media (stickers, voice, audio, video, files)

## Testing

- Manual local testing against a Zalo Bot Creator / Marketplace bot
- Refer to #47550 for the observed behavior matrix and evidence summary
- No automated tests run (docs-only change)

## AI disclosure

- [x] AI-assisted
- [x] Testing level noted (`manual local testing`; no automated tests run)
