### PR TITLE
fix(ci): restore check baseline after pairing auth changes

### DIFF
--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -389,6 +389,9 @@ export default function register(api: OpenClawPluginApi) {
         if (!approved) {
           return { text: "Pairing request not found." };
         }
+        if (approved.status === "forbidden") {
+          return { text: `Missing scope: ${approved.missingScope}` };
+        }
         const label = approved.device.displayName?.trim() || approved.device.deviceId;
         const platform = approved.device.platform?.trim();
         const platformLabel = platform ? ` (${platform})` : "";

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -385,7 +385,7 @@ export default function register(api: OpenClawPluginApi) {
         if (!pending) {
           return { text: "Pairing request not found." };
         }
-        const approved = await approveDevicePairing(pending.requestId);
+        const approved = await approveDevicePairing(pending.requestId, {});
         if (!approved) {
           return { text: "Pairing request not found." };
         }

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -260,6 +260,7 @@ describe("devices cli local fallback", () => {
       paired: [],
     });
     approveDevicePairing.mockResolvedValueOnce({
+      status: "approved",
       requestId: "req-latest",
       device: {
         deviceId: "device-1",
@@ -275,6 +276,22 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).toHaveBeenCalledWith("req-latest");
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
+  it("surfaces missing scope from local approve fallback", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"))
+      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "forbidden",
+      missingScope: "operator.admin",
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("missing scope: operator.admin");
   });
 
   it("does not use local fallback when an explicit --url is provided", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -273,7 +273,7 @@ describe("devices cli local fallback", () => {
 
     await runDevicesApprove(["--latest"]);
 
-    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest");
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {});
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
   });

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -161,6 +161,9 @@ async function approvePairingWithFallback(
     if (!approved) {
       return null;
     }
+    if (approved.status === "forbidden") {
+      throw new Error(`missing scope: ${approved.missingScope}`);
+    }
     return {
       requestId,
       device: redactLocalPairedDevice(approved.device),

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -157,12 +157,12 @@ async function approvePairingWithFallback(
     if (opts.json !== true) {
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
     }
-    const approved = await approveDevicePairing(requestId);
+    const approved = await approveDevicePairing(requestId, {});
     if (!approved) {
       return null;
     }
     if (approved.status === "forbidden") {
-      throw new Error(`missing scope: ${approved.missingScope}`);
+      throw new Error(`missing scope: ${approved.missingScope}`, { cause: error });
     }
     return {
       requestId,

--- a/src/gateway/server.device-pair-approve-authz.test.ts
+++ b/src/gateway/server.device-pair-approve-authz.test.ts
@@ -57,17 +57,21 @@ async function issuePairingScopedOperator(name: string): Promise<{
     clientId: GATEWAY_CLIENT_NAMES.TEST,
     clientMode: GATEWAY_CLIENT_MODES.TEST,
   });
-  await approveDevicePairing(request.request.requestId);
+  const approveResult = await approveDevicePairing(request.request.requestId);
+  expect(approveResult?.status).toBe("approved");
   const rotated = await rotateDeviceToken({
     deviceId: loaded.identity.deviceId,
     role: "operator",
     scopes: ["operator.pairing"],
   });
-  expect(rotated.ok ? rotated.entry.token : "").toBeTruthy();
+  expect(rotated.ok).toBe(true);
+  if (!rotated.ok) {
+    throw new Error("expected rotated pairing token");
+  }
   return {
     identityPath: loaded.identityPath,
     deviceId: loaded.identity.deviceId,
-    token: rotated.ok ? rotated.entry.token : "",
+    token: rotated.entry.token,
   };
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -751,7 +751,7 @@ export function attachGatewayWsMessageHandler(params: {
             const context = buildRequestContext();
             if (pairing.request.silent === true) {
               const approved = await approveDevicePairing(pairing.request.requestId);
-              if (approved) {
+              if (approved?.status === "approved") {
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
                 );


### PR DESCRIPTION
## Summary
This restores the shared `check` baseline on `main` after the device-pair approval/token result shapes changed and the generated config baseline drifted out of formatter compliance.

## Changes
- reformat `docs/.generated/config-baseline.json` so `pnpm check` no longer fails on formatting drift
- update device-pair fallback and auto-approve callers to handle the current `approveDevicePairing()` result union
- update the device token authz test and CLI fallback test to match the current return shapes

## Testing
- [x] `pnpm build`
- [x] `pnpm check`
- [x] `pnpm exec vitest run src/cli/devices-cli.test.ts src/gateway/server.device-pair-approve-authz.test.ts`


Made with [Cursor](https://cursor.com)