### PR TITLE
feat(telegram): bi-directional custom emoji reactions

### DIFF
--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -1,4 +1,4 @@
-import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import type { Message, ReactionTypeCustomEmoji, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../../../src/agents/agent-scope.js";
 import { resolveDefaultModelForAgent } from "../../../src/agents/model-selection.js";
 import {
@@ -811,17 +811,25 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      // Detect added reactions.
+      // Detect added reactions (both standard emoji and custom emoji).
       const oldEmojis = new Set(
         reaction.old_reaction
           .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
           .map((r) => r.emoji),
       );
+      const oldCustomEmojis = new Set(
+        reaction.old_reaction
+          .filter((r): r is ReactionTypeCustomEmoji => r.type === "custom_emoji")
+          .map((r) => r.custom_emoji_id),
+      );
       const addedReactions = reaction.new_reaction
         .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
         .filter((r) => !oldEmojis.has(r.emoji));
+      const addedCustomReactions = reaction.new_reaction
+        .filter((r): r is ReactionTypeCustomEmoji => r.type === "custom_emoji")
+        .filter((r) => !oldCustomEmojis.has(r.custom_emoji_id));
 
-      if (addedReactions.length === 0) {
+      if (addedReactions.length === 0 && addedCustomReactions.length === 0) {
         return;
       }
 
@@ -868,6 +876,15 @@ export const registerTelegramHandlers = ({
           contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);
+      }
+      for (const r of addedCustomReactions) {
+        const customEmojiId = r.custom_emoji_id;
+        const text = `Telegram custom emoji reaction added: custom_emoji_id=${customEmojiId} by ${senderLabel} on msg ${messageId}`;
+        enqueueSystemEvent(text, {
+          sessionKey,
+          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:custom_emoji:${customEmojiId}`,
+        });
+        logVerbose(`telegram: custom emoji reaction event enqueued: ${text}`);
       }
     } catch (err) {
       runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1997,4 +1997,92 @@ describe("createTelegramBot", () => {
     const sessionKey = eventOptions.sessionKey ?? "";
     expect(sessionKey).not.toContain(":topic:");
   });
+
+  it("enqueues system event for custom emoji reactions", async () => {
+    enqueueSystemEventSpy.mockReset();
+    wasSentByBotSpy.mockReturnValue(true);
+
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 508 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "custom_emoji", custom_emoji_id: "5368324170671202286" }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+      "Telegram custom emoji reaction added: custom_emoji_id=5368324170671202286 by Ada (@ada_bot) on msg 42",
+      expect.objectContaining({
+        contextKey: expect.stringContaining(
+          "telegram:reaction:add:1234:42:9:custom_emoji:5368324170671202286",
+        ),
+      }),
+    );
+  });
+
+  it("handles mixed emoji and custom emoji reactions in same update", async () => {
+    enqueueSystemEventSpy.mockReset();
+    wasSentByBotSpy.mockReturnValue(true);
+
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 509 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [
+          { type: "emoji", emoji: "👍" },
+          { type: "custom_emoji", custom_emoji_id: "5368324170671202286" },
+        ],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(2);
+    expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Telegram reaction added: 👍"),
+      expect.any(Object),
+    );
+    expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+      expect.stringContaining("custom_emoji_id=5368324170671202286"),
+      expect.any(Object),
+    );
+  });
+
+  it("does not enqueue event when only custom emoji is removed (not added)", async () => {
+    enqueueSystemEventSpy.mockReset();
+    wasSentByBotSpy.mockReturnValue(true);
+
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 510 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [{ type: "custom_emoji", custom_emoji_id: "5368324170671202286" }],
+        new_reaction: [],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1565,6 +1565,56 @@ describe("reactMessageTelegram", () => {
       }),
     );
   });
+
+  it("sends custom emoji reaction when customEmojiId is provided", async () => {
+    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
+    const api = { setMessageReaction } as unknown as {
+      setMessageReaction: typeof setMessageReaction;
+    };
+
+    await reactMessageTelegram("123", 456, "", {
+      token: "tok",
+      api,
+      customEmojiId: "5368324170671202286",
+    });
+
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [
+      { type: "custom_emoji", custom_emoji_id: "5368324170671202286" },
+    ]);
+  });
+
+  it("prefers customEmojiId over emoji when both are provided", async () => {
+    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
+    const api = { setMessageReaction } as unknown as {
+      setMessageReaction: typeof setMessageReaction;
+    };
+
+    await reactMessageTelegram("123", 456, "👍", {
+      token: "tok",
+      api,
+      customEmojiId: "5368324170671202286",
+    });
+
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, [
+      { type: "custom_emoji", custom_emoji_id: "5368324170671202286" },
+    ]);
+  });
+
+  it("removes reaction even when customEmojiId is provided with remove flag", async () => {
+    const setMessageReaction = vi.fn().mockResolvedValue(undefined);
+    const api = { setMessageReaction } as unknown as {
+      setMessageReaction: typeof setMessageReaction;
+    };
+
+    await reactMessageTelegram("123", 456, "", {
+      token: "tok",
+      api,
+      customEmojiId: "5368324170671202286",
+      remove: true,
+    });
+
+    expect(setMessageReaction).toHaveBeenCalledWith("123", 456, []);
+  });
 });
 
 describe("sendStickerTelegram", () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -93,6 +93,7 @@ type TelegramReactionOpts = {
   remove?: boolean;
   verbose?: boolean;
   retry?: RetryConfig;
+  customEmojiId?: string;
 };
 
 type TelegramTypingOpts = {
@@ -1010,12 +1011,15 @@ export async function reactMessageTelegram(
   });
   const remove = opts.remove === true;
   const trimmedEmoji = emoji.trim();
-  // Build the reaction array. We cast emoji to the grammY union type since
-  // Telegram validates emoji server-side; invalid emojis fail gracefully.
+  const customEmojiId = opts.customEmojiId?.trim();
+  // Build the reaction array. Custom emoji takes priority when provided.
+  // We cast emoji to the grammY union type since Telegram validates server-side.
   const reactions: ReactionType[] =
-    remove || !trimmedEmoji
+    remove || (!trimmedEmoji && !customEmojiId)
       ? []
-      : [{ type: "emoji", emoji: trimmedEmoji as ReactionTypeEmoji["emoji"] }];
+      : customEmojiId
+        ? [{ type: "custom_emoji", custom_emoji_id: customEmojiId }]
+        : [{ type: "emoji", emoji: trimmedEmoji as ReactionTypeEmoji["emoji"] }];
   if (typeof api.setMessageReaction !== "function") {
     throw new Error("Telegram reactions are unavailable in this bot API.");
   }
@@ -1024,7 +1028,8 @@ export async function reactMessageTelegram(
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (/REACTION_INVALID/i.test(msg)) {
-      return { ok: false as const, warning: `Reaction unavailable: ${trimmedEmoji}` };
+      const label = customEmojiId ? `custom_emoji:${customEmojiId}` : trimmedEmoji;
+      return { ok: false as const, warning: `Reaction unavailable: ${label}` };
     }
     throw err;
   }

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -146,6 +146,7 @@ export async function handleTelegramAction(
     const { emoji, remove, isEmpty } = readReactionParams(params, {
       removeErrorMessage: "Emoji is required to remove a Telegram reaction.",
     });
+    const customEmojiId = readStringParam(params, "customEmojiId");
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       return jsonResult({
@@ -161,6 +162,7 @@ export async function handleTelegramAction(
         token,
         remove,
         accountId: accountId ?? undefined,
+        customEmojiId: customEmojiId ?? undefined,
       });
     } catch (err) {
       const isInvalid = String(err).includes("REACTION_INVALID");
@@ -181,7 +183,11 @@ export async function handleTelegramAction(
       });
     }
     if (!remove && !isEmpty) {
-      return jsonResult({ ok: true, added: emoji });
+      return jsonResult({
+        ok: true,
+        added: customEmojiId ? `custom_emoji:${customEmojiId}` : emoji,
+        ...(customEmojiId ? { customEmojiId } : {}),
+      });
     }
     return jsonResult({ ok: true, removed: true });
   }

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -182,7 +182,7 @@ export async function handleTelegramAction(
         ...(remove || isEmpty ? { removed: true } : { added: emoji }),
       });
     }
-    if (!remove && !isEmpty) {
+    if (!remove && (!isEmpty || !!customEmojiId)) {
       return jsonResult({
         ok: true,
         added: customEmojiId ? `custom_emoji:${customEmojiId}` : emoji,


### PR DESCRIPTION
## Summary

Adds support for Telegram custom emoji reactions in both directions:

### Inbound — Receive custom emoji reactions
- `bot-handlers.ts`: Now detects `type: "custom_emoji"` reactions alongside standard emoji reactions
- Custom emoji reactions surface as system events with the `custom_emoji_id` in event text
- Context key format: `telegram:reaction:add:{chatId}:{msgId}:{userId}:custom_emoji:{customEmojiId}`
- Mixed updates (both emoji + custom emoji in one reaction update) are handled correctly

### Outbound — Send custom emoji reactions
- `reactMessageTelegram()` accepts optional `customEmojiId` parameter
- When `customEmojiId` is provided, sends `{type: "custom_emoji", custom_emoji_id: "..."}` instead of `{type: "emoji", emoji: "..."}`
- `customEmojiId` takes priority when both emoji and customEmojiId are provided
- `telegram-actions.ts`: The `react` action now accepts `customEmojiId` parameter

### Tests
- 3 new `send.test.ts` cases: custom emoji send, priority over standard emoji, remove with custom emoji
- 3 new `bot.test.ts` cases: custom emoji inbound event, mixed emoji+custom_emoji, removal (no event)

### Notes on Custom Emoji IDs
- Custom emoji reactions require **Telegram Premium** on the reacting user's account
- Custom emoji IDs are numeric strings (e.g., `"5368324170671202286"`)
- To find a custom emoji ID: receive a custom emoji reaction inbound (it will appear in the system event), or use the Telegram Bot API `getCustomEmojiStickers` method
- The bot itself does NOT need Premium to set custom emoji reactions, but the chat must allow them

### Quality
- `npx tsc --noEmit`: No new errors (pre-existing errors in device-pair/chrome-mcp unchanged)
- `npx vitest run extensions/telegram/src/send.test.ts`: 68/68 pass (3 new)
- `npm run build`: Succeeds