### PR TITLE
fix(whatsapp): use globalThis singleton for active-listener registry

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -1,6 +1,7 @@
 import { formatCliCommand } from "../../../src/cli/command-format.js";
 import type { PollInput } from "../../../src/polls.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
+import { resolveGlobalMap } from "../../../src/shared/global-singleton.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
@@ -28,9 +29,8 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
-
-const listeners = new Map<string, ActiveWebListener>();
+const WA_LISTENERS_KEY = Symbol.for("openclaw.whatsappActiveListeners");
+const listeners = resolveGlobalMap<string, ActiveWebListener>(WA_LISTENERS_KEY);
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -72,9 +72,6 @@ export function setActiveWebListener(
     listeners.delete(id);
   } else {
     listeners.set(id, listener);
-  }
-  if (id === DEFAULT_ACCOUNT_ID) {
-    _currentListener = listener;
   }
 }
 


### PR DESCRIPTION
## Summary

- Apply the `resolveGlobalMap()` singleton pattern to the WhatsApp active-listener `Map`, fixing proactive message sends that fail with `No active WhatsApp Web listener`
- Remove dead `_currentListener` variable (written but never read)

## Problem

`extensions/whatsapp/src/active-listener.ts` maintains a module-scoped `Map<string, ActiveWebListener>` to track active WhatsApp listeners. Rollup duplicates this module into **6 separate chunks** (reply, model-selection ×2, auth-profiles ×2, discord), each with its own copy of the Map.

When `monitorWebChannel` calls `setActiveWebListener()`, it populates the Map in one chunk. But when the `message` tool calls `requireActiveWebListener()`, it resolves to a different chunk's Map — empty — causing the error.

**Auto-reply works** because it uses `msg.reply()` on the received message object (direct socket reference, bypasses the Map).

## Solution

One-line change: replace the module-scoped `new Map()` with `resolveGlobalMap()` from `src/shared/global-singleton.ts`, keyed by `Symbol.for("openclaw.whatsappActiveListeners")`.

This is the same pattern applied to Telegram, Slack, Feishu, and other extensions in PR #43683 — WhatsApp was missed in that sweep.

```diff
-let _currentListener: ActiveWebListener | null = null;
-
-const listeners = new Map<string, ActiveWebListener>();
+const WA_LISTENERS_KEY = Symbol.for("openclaw.whatsappActiveListeners");
+const listeners = resolveGlobalMap<string, ActiveWebListener>(WA_LISTENERS_KEY);
```

## Test plan

- [ ] Existing `outbound.test.ts` passes (calls `setActiveWebListener`/`requireActiveWebListener`)
- [ ] Send a proactive WhatsApp message via the `message` tool after gateway start
- [ ] Force a WhatsApp reconnection → proactive sends still work
- [ ] Auto-reply still works (no regression)

Fixes #47313
Partially addresses #38734, #46192, #46659, #45994, #46190, #41950, #46884, #46991, #45511, #45387, #47369, #48126
Relates to #14406, #47389, #43683

🤖 Generated with [Claude Code](https://claude.com/claude-code)