### PR TITLE
fix: control UI model selector sends correct provider prefix

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -529,16 +529,24 @@ function resolveModelOverrideValue(state: AppViewState): string {
     return "";
   }
   // No local override recorded yet — fall back to server data.
+  // Include provider prefix so the value matches option keys (provider/model).
   const activeRow = resolveActiveSessionRow(state);
-  if (activeRow) {
-    return typeof activeRow.model === "string" ? activeRow.model.trim() : "";
+  if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
+    const provider = activeRow.modelProvider?.trim();
+    const model = activeRow.model.trim();
+    return provider ? `${provider}/${model}` : model;
   }
   return "";
 }
 
 function resolveDefaultModelValue(state: AppViewState): string {
-  const model = state.sessionsResult?.defaults?.model;
-  return typeof model === "string" ? model.trim() : "";
+  const defaults = state.sessionsResult?.defaults;
+  const model = defaults?.model;
+  if (typeof model !== "string" || !model.trim()) {
+    return "";
+  }
+  const provider = defaults?.modelProvider?.trim();
+  return provider ? `${provider}/${model.trim()}` : model.trim();
 }
 
 function buildChatModelOptions(
@@ -563,7 +571,8 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    const value = provider ? `${provider}/${entry.id}` : entry.id;
+    addOption(value, provider ? `${entry.id} · ${provider}` : entry.id);
   }
 
   if (currentOverride) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -592,7 +592,10 @@ function renderChatModelSelect(state: AppViewState) {
     currentOverride,
     defaultModel,
   );
-  const defaultLabel = defaultModel ? `Default (${defaultModel})` : "Default model";
+  const defaultDisplay = defaultModel.includes("/")
+    ? `${defaultModel.slice(defaultModel.indexOf("/") + 1)} · ${defaultModel.slice(0, defaultModel.indexOf("/"))}`
+    : defaultModel;
+  const defaultLabel = defaultModel ? `Default (${defaultDisplay})` : "Default model";
   const busy =
     state.chatLoading || state.chatSending || Boolean(state.chatRunId) || state.chatStream !== null;
   const disabled =

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -316,6 +316,7 @@ export type PresenceEntry = {
 };
 
 export type GatewaySessionsDefaults = {
+  modelProvider: string | null;
   model: string | null;
   contextTokens: number | null;
 };


### PR DESCRIPTION
## Summary

The Control UI model dropdown sends the wrong provider prefix when switching to a model from a different provider than the session's current one.

**Root cause:** `buildChatModelOptions()` in `ui/src/ui/app-render.helpers.ts` uses just `entry.id` (e.g. `gpt-5.2`) as the `<option>` value, while the label correctly shows `gpt-5.2 · openai`. When `switchChatModel` sends this bare model ID to `sessions.patch`, the server's `parseModelRef()` sees no `/` and falls back to the session's current `defaultProvider` (e.g. `anthropic`), yielding `anthropic/gpt-5.2` instead of `openai/gpt-5.2`.

**Fix:**
- `buildChatModelOptions`: use `provider/model` as option values (e.g. `openai/gpt-5.2`)
- `resolveModelOverrideValue`: return `provider/model` from server session data so selected state stays in sync
- `resolveDefaultModelValue`: same treatment for the default model value
- Add `modelProvider` to `GatewaySessionsDefaults` UI type (server already sends it)

**Reproduces when:** you have models from multiple providers (e.g. Anthropic + OpenAI, Anthropic + Ollama, OpenRouter models) and switch between them in the Control UI.

## Related issues

Closes #47559, closes #47352, closes #46764, closes #46577, closes #46453, closes #45938, closes #46859, closes #45630

All report the same root cause: the Control UI model dropdown strips or misassigns the provider prefix.

## Test plan

- [ ] Configure models from 2+ providers (e.g. `anthropic/claude-sonnet-4-5` and `openai/gpt-5.2`)
- [ ] Open Control UI, switch model via dropdown
- [ ] Verify `sessions.patch` sends `openai/gpt-5.2` (not `anthropic/gpt-5.2`)
- [ ] Verify switching back to default works
- [ ] Verify the selected model stays highlighted correctly after page refresh