### PR TITLE
fix(discord): skip reaction listeners when all guilds disable reactions

### DIFF
--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -952,4 +952,29 @@ describe("monitorDiscordProvider", () => {
     expect(hasReactionListener).toBe(true);
     expect(hasReactionRemoveListener).toBe(true)
   });
+
+  it("registers reaction listeners when dm config is omitted (default dmEnabled=true)", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const { registerDiscordListener, DiscordReactionListener, DiscordReactionRemoveListener } =
+      await import("./listeners.js");
+
+    // No dm override — dmEnabled defaults to true.
+    mockResolvedDiscordAccountConfig({});
+    resolveDiscordAllowlistConfigMock.mockResolvedValue({
+      guildEntries: {
+        "guild-1": { reactionNotifications: "off" as const },
+      },
+      allowFrom: undefined,
+    });
+    vi.mocked(registerDiscordListener).mockClear();
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const registeredListeners = vi.mocked(registerDiscordListener).mock.calls.map((c) => c[1]);
+    expect(registeredListeners.some((l) => l instanceof DiscordReactionListener)).toBe(true);
+    expect(registeredListeners.some((l) => l instanceof DiscordReactionRemoveListener)).toBe(true);
+  });
 });

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -884,4 +884,72 @@ describe("monitorDiscordProvider", () => {
     const messages = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0]));
     expect(messages.some((msg) => msg.includes("discord startup ["))).toBe(false);
   });
+
+  it("skips reaction listeners when all guilds have reactionNotifications off and DMs disabled", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const { registerDiscordListener, DiscordReactionListener, DiscordReactionRemoveListener } =
+      await import("./listeners.js");
+
+    mockResolvedDiscordAccountConfig({
+      dm: { enabled: false, groupEnabled: false },
+    });
+    resolveDiscordAllowlistConfigMock.mockResolvedValue({
+      guildEntries: {
+        "guild-1": { reactionNotifications: "off" as const },
+        "guild-2": { reactionNotifications: "off" as const },
+      },
+      allowFrom: undefined,
+    });
+    vi.mocked(registerDiscordListener).mockClear();
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const registeredListeners = vi.mocked(registerDiscordListener).mock.calls.map((c) => c[1]);
+    const hasReactionListener = registeredListeners.some(
+      (l) => l instanceof DiscordReactionListener,
+    );
+    const hasReactionRemoveListener = registeredListeners.some(
+      (l) => l instanceof DiscordReactionRemoveListener,
+    );
+
+    expect(hasReactionListener).toBe(false);
+    expect(hasReactionRemoveListener).toBe(false);
+  });
+
+  it("registers reaction listeners when at least one guild allows reactions", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const { registerDiscordListener, DiscordReactionListener, DiscordReactionRemoveListener } =
+      await import("./listeners.js");
+
+    mockResolvedDiscordAccountConfig({
+      dm: { enabled: false, groupEnabled: false },
+    });
+    resolveDiscordAllowlistConfigMock.mockResolvedValue({
+      guildEntries: {
+        "guild-1": { reactionNotifications: "off" as const },
+        "guild-2": { reactionNotifications: "own" as const },
+      },
+      allowFrom: undefined,
+    });
+    vi.mocked(registerDiscordListener).mockClear();
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const registeredListeners = vi.mocked(registerDiscordListener).mock.calls.map((c) => c[1]);
+    const hasReactionListener = registeredListeners.some(
+      (l) => l instanceof DiscordReactionListener,
+    );
+    const hasReactionRemoveListener = registeredListeners.some(
+      (l) => l instanceof DiscordReactionRemoveListener,
+    );
+
+    expect(hasReactionListener).toBe(true);
+    expect(hasReactionRemoveListener).toBe(true)
+  });
 });

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -942,11 +942,30 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       logger,
       onEvent: trackInboundEvent,
     };
-    registerDiscordListener(client.listeners, new DiscordReactionListener(reactionListenerOptions));
-    registerDiscordListener(
-      client.listeners,
-      new DiscordReactionRemoveListener(reactionListenerOptions),
+    // Skip reaction listener registration when no guild can ever produce a
+    // reaction notification and DM/group-DM reactions are also disabled.
+    // This avoids queuing every reaction event only to early-return inside the
+    // handler (which also triggers spurious "Slow listener detected" warnings).
+    const guildKeys = Object.keys(guildEntries ?? {});
+    const allGuildsReactionsOff =
+      guildKeys.length > 0 &&
+      guildKeys.every((k) => guildEntries?.[k]?.reactionNotifications === "off");
+    const shouldRegisterReactionListeners = !(
+      allGuildsReactionsOff &&
+      !dmEnabled &&
+      !groupDmEnabled
     );
+
+    if (shouldRegisterReactionListeners) {
+      registerDiscordListener(
+        client.listeners,
+        new DiscordReactionListener(reactionListenerOptions),
+      );
+      registerDiscordListener(
+        client.listeners,
+        new DiscordReactionRemoveListener(reactionListenerOptions),
+      );
+    }
 
     registerDiscordListener(
       client.listeners,


### PR DESCRIPTION
## Summary

When every configured guild has `reactionNotifications: "off"` and DM/group-DM reactions are also disabled, the `DiscordReactionListener` and `DiscordReactionRemoveListener` are still registered unconditionally. This causes every reaction event to enter the Carbon event queue, go through guild config resolution and authorization checks, only to bail out with an early return — also triggering spurious "Slow listener detected" warnings.

This PR adds a guard that skips reaction listener registration when no configured path can ever produce a reaction notification:
- All guilds have `reactionNotifications: "off"`
- DMs are disabled (`dmEnabled === false`)
- Group DMs are disabled (`groupDmEnabled === false`)

When no guild entries exist (DM-only setup) or at least one guild allows reactions, listeners are registered as before.

Closes #47516

## Changes

- `extensions/discord/src/monitor/provider.ts`: add conditional guard around reaction listener registration
- `extensions/discord/src/monitor/provider.test.ts`: add tests for both skip and register paths

## Test plan

- [x] All 380 discord monitor tests pass (43 files)
- [x] New test: skips reaction listeners when all guilds have `reactionNotifications: "off"` and DMs disabled
- [x] New test: registers reaction listeners when at least one guild allows reactions