### PR TITLE
fix(ui): send full provider/model-id from Control UI model dropdown [AI-assisted]

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -529,9 +529,19 @@ function resolveModelOverrideValue(state: AppViewState): string {
     return "";
   }
   // No local override recorded yet — fall back to server data.
+  // Build the full provider/model reference so it matches catalog option values.
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow) {
-    return typeof activeRow.model === "string" ? activeRow.model.trim() : "";
+    const model = typeof activeRow.model === "string" ? activeRow.model.trim() : "";
+    const provider =
+      typeof activeRow.modelProvider === "string" ? activeRow.modelProvider.trim() : "";
+    if (model && provider) {
+      const firstSegment = model.split("/")[0];
+      if (!model.includes("/") || firstSegment !== provider) {
+        return `${provider}/${model}`;
+      }
+    }
+    return model;
   }
   return "";
 }
@@ -563,7 +573,12 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    // Use the full provider/model-id as the option value so the correct
+    // provider is always sent to sessions.patch — never assembled from stale
+    // UI state.  The label keeps the human-readable model name up front.
+    const fullId =
+      provider && !entry.id.startsWith(`${provider}/`) ? `${provider}/${entry.id}` : entry.id;
+    addOption(fullId, provider ? `${entry.id} · ${provider}` : entry.id);
   }
 
   if (currentOverride) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -541,7 +541,25 @@ function resolveModelOverrideValue(state: AppViewState): string {
         return `${provider}/${model}`;
       }
     }
-    return model;
+    // modelProvider absent — scan the catalog to infer provider so the
+    // returned value matches the `provider/model` option values that
+    // buildChatModelOptions now emits.  Without this, legacy sessions that
+    // the server returns without modelProvider would silently fall back to
+    // the "Default model" placeholder because no bare-id option exists.
+    if (model) {
+      const catalog = state.chatModelCatalog ?? [];
+      const match = catalog.find(
+        (entry) => entry.id === model || `${entry.provider}/${entry.id}` === model,
+      );
+      if (match?.provider) {
+        const inferredProvider = match.provider.trim();
+        const firstSegment = model.split("/")[0];
+        if (!model.includes("/") || firstSegment !== inferredProvider) {
+          return `${inferredProvider}/${model}`;
+        }
+      }
+      return model;
+    }
   }
   return "";
 }
@@ -585,7 +603,19 @@ function buildChatModelOptions(
     addOption(currentOverride);
   }
   if (defaultModel) {
-    addOption(defaultModel);
+    // Qualify the default model value using the catalog so it matches the
+    // provider/model-id format of the catalog options above.  Without this,
+    // an OpenRouter default like `anthropic/claude-…` (provider=openrouter)
+    // would be added as a bare `anthropic/claude-…` option, reintroducing
+    // an ambiguous value that the gateway would reject as "model not allowed".
+    const defaultMatch = catalog.find(
+      (entry) => entry.id === defaultModel || `${entry.provider}/${entry.id}` === defaultModel,
+    );
+    const qualifiedDefault =
+      defaultMatch?.provider && !defaultModel.startsWith(`${defaultMatch.provider}/`)
+        ? `${defaultMatch.provider}/${defaultModel}`
+        : defaultModel;
+    addOption(qualifiedDefault);
   }
   return options;
 }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -48,7 +48,15 @@ function createChatHeaderState(
         defaults: { model: "gpt-5", contextTokens: null },
         sessions: omitSessionFromList
           ? []
-          : [{ key: "main", kind: "direct", updatedAt: null, model: currentModel }],
+          : [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                model: currentModel,
+                modelProvider: "openai",
+              },
+            ],
       };
     }
     if (method === "models.list") {
@@ -67,7 +75,15 @@ function createChatHeaderState(
       defaults: { model: "gpt-5", contextTokens: null },
       sessions: omitSessionFromList
         ? []
-        : [{ key: "main", kind: "direct", updatedAt: null, model: currentModel }],
+        : [
+            {
+              key: "main",
+              kind: "direct",
+              updatedAt: null,
+              model: currentModel,
+              modelProvider: "openai",
+            },
+          ],
     },
     chatModelOverrides: {},
     chatModelCatalog: catalog,
@@ -565,16 +581,16 @@ describe("chat view", () => {
     expect(modelSelect).not.toBeNull();
     expect(modelSelect?.value).toBe("");
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
-    expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 
@@ -593,7 +609,9 @@ describe("chat view", () => {
       'select[data-chat-model-select="true"]',
     );
     expect(modelSelect).not.toBeNull();
-    expect(modelSelect?.value).toBe("gpt-5-mini");
+    // Session was initialized with model="gpt-5-mini" and modelProvider="openai";
+    // the picker should pre-select the full "openai/gpt-5-mini" catalog entry.
+    expect(modelSelect?.value).toBe("openai/gpt-5-mini");
 
     modelSelect!.value = "";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
@@ -637,7 +655,7 @@ describe("chat view", () => {
     );
     expect(modelSelect).not.toBeNull();
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
     render(renderChatSessionSelect(state), container);
@@ -645,7 +663,7 @@ describe("chat view", () => {
     const rerendered = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
     );
-    expect(rerendered?.value).toBe("gpt-5-mini");
+    expect(rerendered?.value).toBe("openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -625,6 +625,30 @@ describe("chat view", () => {
     vi.unstubAllGlobals();
   });
 
+  it("pre-selects model from catalog when session row has no modelProvider", () => {
+    // Simulate a legacy session row returned by the server without modelProvider
+    // (valid per GatewaySessionRow where modelProvider?: string).
+    // resolveModelOverrideValue should infer the provider from the catalog so
+    // the dropdown pre-selects the correct "provider/model" option instead of
+    // silently falling back to "Default model".
+    const { state } = createChatHeaderState({ model: "gpt-5-mini" });
+    // Strip modelProvider from the session row to simulate a legacy server response.
+    const sessionRow = state.sessionsResult?.sessions[0];
+    if (sessionRow) {
+      delete (sessionRow as Partial<typeof sessionRow>).modelProvider;
+    }
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+    // Catalog has { id: "gpt-5-mini", provider: "openai" } so the inferred
+    // value should be "openai/gpt-5-mini", matching the catalog option value.
+    expect(modelSelect?.value).toBe("openai/gpt-5-mini");
+  });
+
   it("disables the chat header model picker while a run is active", () => {
     const { state } = createChatHeaderState();
     state.chatRunId = "run-123";


### PR DESCRIPTION
## Summary

Fixes the Control UI model dropdown stripping the `openrouter/` provider prefix before submitting to the gateway, causing `GatewayRequestError: model not allowed` for all openrouter-backed models.

## Root cause

`buildChatModelOptions` used `entry.id` as the `<option>` value. For openrouter-backed models, `entry.provider` is `openrouter` and `entry.id` is the bare `anthropic/claude-haiku-4.5` — the provider prefix was silently dropped before the value reached `sessions.patch`.

Additionally, `resolveModelOverrideValue` fell back to `activeRow.model` (bare id) when no local override was cached, so the dropdown pre-selection also failed to match any catalog option after a session switch.

## Fix

**`buildChatModelOptions`** now uses `${provider}/${entry.id}` as the option value for every catalog entry (when the id doesn't already start with the provider prefix). The full registered `provider/model-id` string is always sent to `sessions.patch`, making the provider explicit.

**`resolveModelOverrideValue`** now builds the full `provider/model` reference from `activeRow.modelProvider + "/" + activeRow.model` when falling back to session data, so the dropdown pre-selects the correct catalog entry after a session switch.

## Files changed

- `ui/src/ui/app-render.helpers.ts` — core fix in `buildChatModelOptions` and `resolveModelOverrideValue`
- `ui/src/ui/views/chat.test.ts` — updated tests to use full `provider/model` values and include `modelProvider` in test session fixtures

## Testing

- `pnpm build` passes ✓
- `pnpm test` passes (544/544 tests) ✓

## Relationship to #47522

PR #47522 (fix/issue-47352) addressed a similar issue where the stale server-side `defaultProvider` was used to construct model IDs. This PR fixes the same root cause in the same functions but targets the specific `openrouter/` provider prefix case reported in #47559.

## AI disclosure

This PR was generated with Claude (Sonnet) via OpenClaw. The fix was reviewed and understood before submission.

Fixes #47559