### PR TITLE
fix: add node-addon-api to dependencies for sharp native build

### DIFF
--- a/package.json
+++ b/package.json
@@ -387,6 +387,7 @@
     "linkedom": "^0.18.12",
     "long": "^5.3.2",
     "markdown-it": "^14.1.1",
+    "node-addon-api": "^8.6.0",
     "node-edge-tts": "^1.2.10",
     "opusscript": "^0.1.1",
     "osc-progress": "^0.3.0",


### PR DESCRIPTION
## Summary
Adds `node-addon-api` to the root `dependencies` in `package.json` to fix sharp@0.34.5 native build failures on macOS arm64.

## Problem
On macOS arm64, when `openclaw update` runs and sharp@0.34.5 needs to build from source, it fails with:
```
sharp: Please add node-addon-api to your dependencies
```

## Solution
Add `node-addon-api@^8.6.0` to dependencies (not devDependencies) so it is available in the published package when sharp falls back to native build.

## Testing
- The version 8.6.0 matches what is already in pnpm-lock.yaml transitively
- This is a one-line change with minimal risk

Fixes #47563