### PR TITLE
fix: share WhatsApp listeners Map across ESM chunks (fixes #38734)

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -32,8 +32,8 @@ declare global {
   var __openclaw_wa_listeners: Map<string, ActiveWebListener> | undefined;
 }
 
-const listeners: Map<string, ActiveWebListener> =
-  (globalThis.__openclaw_wa_listeners ??= new Map());
+const listeners: Map<string, ActiveWebListener> = (globalThis.__openclaw_wa_listeners ??=
+  new Map());
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,9 +28,12 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-let _currentListener: ActiveWebListener | null = null;
+declare global {
+  var __openclaw_wa_listeners: Map<string, ActiveWebListener> | undefined;
+}
 
-const listeners: Map<string, ActiveWebListener> = (globalThis as any).__openclaw_wa_listeners ??= new Map();
+const listeners: Map<string, ActiveWebListener> =
+  (globalThis.__openclaw_wa_listeners ??= new Map());
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -72,9 +75,6 @@ export function setActiveWebListener(
     listeners.delete(id);
   } else {
     listeners.set(id, listener);
-  }
-  if (id === DEFAULT_ACCOUNT_ID) {
-    _currentListener = listener;
   }
 }
 

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -30,7 +30,7 @@ export type ActiveWebListener = {
 
 let _currentListener: ActiveWebListener | null = null;
 
-const listeners = new Map<string, ActiveWebListener>();
+const listeners: Map<string, ActiveWebListener> = (globalThis as any).__openclaw_wa_listeners ??= new Map();
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;


### PR DESCRIPTION
## Bug
WhatsApp proactive outbound (message tool + cron delivery) fails with
`No active WhatsApp Web listener` while session auto-replies work fine.

## Root Cause
Vite/Rollup duplicates the active listener module across multiple ESM chunks.
Each chunk creates its own Map instance. The gateway populates one chunk's Map
via `setActiveWebListener()`, but cron delivery and the message tool call
`requireActiveWebListener()` from a different chunk — which has an empty Map.

## Fix
- Use `globalThis` with `??=` to share a single `listeners` Map across all chunks
- Add `declare global` type augmentation for type safety (no `as any`)
- Remove unused `_currentListener` variable (dead code, never read)

Tested in production — cron delivery and message tool work correctly after this change.

Closes #38734
Partially addresses #46192, #46659, #45994, #46190, #41950, #46884, #46991, #47313, #45511, #45387, #47369, #48126

---

## AI Disclosure
- [x] Marked as AI-assisted in PR description
- [x] Degree of testing: **fully tested** (validated in production, cron delivery works)
- [x] I understand what the code does
- [ ] Codex review: no access

Built with [Antigravity](https://github.com/google-deepmind/antigravity) (Google DeepMind AI coding agent). 🤖

---

> ⚠️ **CI Note:** Failing Windows test shards and `extension-fast (whatsapp)` are pre-existing on `main` — unrelated to this PR which only modifies `extensions/whatsapp/src/active-listener.ts`. The `check` job (format + lint + typecheck) passes.
