### PR TITLE
fix(discord): route DM messages to user:<userId> instead of channel:<dmChannelId>

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -316,6 +316,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     message,
     messageChannelId,
     isGuildMessage,
+    isDirectMessage,
+    directUserId: isDirectMessage ? author.id : undefined,
     channelConfig,
     threadChannel,
     channelType: channelInfo?.type,

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -1261,4 +1261,33 @@ describe("resolveDiscordAutoThreadReplyPlan", () => {
       }
     }
   });
+
+  it("routes DM messages to user:<userId> instead of channel:<dmChannelId>", async () => {
+    // Regression test for issue #47500: DM messages were routed to
+    // channel:<dmChannelId> instead of user:<userId>, preventing bot replies.
+    const dmParams = {
+      client: { rest: { post: async () => ({ id: "thread" }) } } as unknown as Client,
+      message: {
+        id: "dm-msg-1",
+        channelId: "dm-channel-999",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      messageChannelId: "dm-channel-999",
+      isGuildMessage: false,
+      isDirectMessage: true,
+      directUserId: "user-123",
+      channelConfig: null,
+      threadChannel: null,
+      baseText: "hello from dm",
+      combinedBody: "hello from dm",
+      replyToMode: "all" as const,
+      agentId: "agent",
+      channel: "discord" as const,
+    };
+    const plan = await resolveDiscordAutoThreadReplyPlan(dmParams);
+    // Must route to user:userId, not channel:dmChannelId
+    expect(plan.deliverTarget).toBe("user:user-123");
+    expect(plan.replyTarget).toBe("user:user-123");
+    // DM messages never create auto-threads
+    expect(plan.autoThreadContext).toBeNull();
+  });
 });

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -502,4 +502,91 @@ describe("deliverDiscordReply", () => {
       expect.objectContaining({ token: "token", accountId: "default" }),
     );
   });
+
+  describe("DM target pre-resolution (user:<id>)", () => {
+    it("resolves DM channel once and uses fast path for all chunks", async () => {
+      const postMock = vi.fn().mockResolvedValue({ id: "dm-channel-99" });
+      const fakeRest = { post: postMock } as unknown as import("@buape/carbon").RequestClient;
+      const callOrder: string[] = [];
+      sendDiscordTextMock.mockImplementation(
+        async (_rest: unknown, _channelId: unknown, text: string) => {
+          callOrder.push(text);
+          return { id: `msg-${callOrder.length}`, channel_id: "dm-channel-99" };
+        },
+      );
+
+      await deliverDiscordReply({
+        replies: [{ text: "1234567890" }],
+        target: "user:user-42",
+        token: "token",
+        rest: fakeRest,
+        runtime,
+        cfg,
+        textLimit: 5,
+      });
+
+      // POST /users/@me/channels must be called exactly once regardless of chunk count.
+      expect(postMock).toHaveBeenCalledTimes(1);
+      expect(postMock).toHaveBeenCalledWith(
+        expect.stringContaining("channels"),
+        expect.objectContaining({ body: { recipient_id: "user-42" } }),
+      );
+
+      // All chunks sent via the fast path (sendDiscordText), not sendMessageDiscord.
+      expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+      expect(sendDiscordTextMock).toHaveBeenCalledTimes(2);
+      // Channel ID passed to sendDiscordText must be the resolved DM channel, not the user id.
+      expect(sendDiscordTextMock.mock.calls[0]?.[1]).toBe("dm-channel-99");
+      expect(sendDiscordTextMock.mock.calls[1]?.[1]).toBe("dm-channel-99");
+      expect(callOrder).toEqual(["12345", "67890"]);
+    });
+
+    it("falls back to sendMessageDiscord per-chunk when DM channel resolution fails", async () => {
+      const postMock = vi.fn().mockRejectedValue(new Error("network error"));
+      const fakeRest = { post: postMock } as unknown as import("@buape/carbon").RequestClient;
+      sendMessageDiscordMock.mockResolvedValue(undefined);
+
+      await deliverDiscordReply({
+        replies: [{ text: "hello DM" }],
+        target: "user:user-42",
+        token: "token",
+        rest: fakeRest,
+        runtime,
+        cfg,
+        textLimit: 2000,
+      });
+
+      // Resolution was attempted.
+      expect(postMock).toHaveBeenCalledTimes(1);
+      // Fast path unavailable — falls back to sendMessageDiscord.
+      expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+        "user:user-42",
+        "hello DM",
+        expect.objectContaining({ token: "token" }),
+      );
+      expect(sendDiscordTextMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to sendMessageDiscord when rest is not provided", async () => {
+      sendMessageDiscordMock.mockResolvedValue(undefined);
+
+      await deliverDiscordReply({
+        replies: [{ text: "hello DM" }],
+        target: "user:user-42",
+        token: "token",
+        runtime,
+        cfg,
+        textLimit: 2000,
+      });
+
+      expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+        "user:user-42",
+        "hello DM",
+        expect.objectContaining({ token: "token" }),
+      );
+      expect(sendDiscordTextMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -1,4 +1,5 @@
 import type { RequestClient } from "@buape/carbon";
+import { Routes } from "discord-api-types/v10";
 import { resolveAgentAvatar } from "../../../../src/agents/identity-avatar.js";
 import type { ChunkMode } from "../../../../src/auto-reply/chunk.js";
 import type { ReplyPayload } from "../../../../src/auto-reply/types.js";
@@ -81,6 +82,40 @@ function resolveTargetChannelId(target: string): string | undefined {
   }
   const channelId = target.slice("channel:".length).trim();
   return channelId || undefined;
+}
+
+/**
+ * For DM targets (`user:<userId>`), open (or reuse) the DM channel via the
+ * Discord API and return the resulting channel ID.  This lets the rest of the
+ * delivery pipeline treat DMs the same as guild channels — one POST
+ * /users/@me/channels at the start of the delivery call, then the fast-path
+ * `sendDiscordText` for every subsequent chunk/media send.
+ *
+ * Returns `undefined` when `rest` is absent or the API call fails, so callers
+ * can safely fall back to `sendMessageDiscord` per-chunk (the pre-existing
+ * behavior).
+ */
+async function resolveDmChannelId(
+  target: string,
+  rest: RequestClient | undefined,
+): Promise<string | undefined> {
+  if (!rest || !target.startsWith("user:")) {
+    return undefined;
+  }
+  const userId = target.slice("user:".length).trim();
+  if (!userId) {
+    return undefined;
+  }
+  try {
+    const dmChannel = (await rest.post(Routes.userChannels(), {
+      body: { recipient_id: userId },
+    })) as { id?: string };
+    const channelId = dmChannel?.id ? String(dmChannel.id).trim() : "";
+    return channelId || undefined;
+  } catch {
+    // Fall through — caller will use the per-chunk sendMessageDiscord path.
+    return undefined;
+  }
 }
 
 function resolveBoundThreadBinding(params: {
@@ -280,7 +315,11 @@ export async function deliverDiscordReply(params: {
   // Pre-resolve channel ID and retry runner once to avoid per-chunk overhead.
   // This eliminates redundant channel-type GET requests and client creation that
   // can cause ordering issues when multiple chunks share the RequestClient queue.
-  const channelId = resolveTargetChannelId(params.target);
+  // For DM targets (`user:<id>`), resolveDmChannelId opens the DM channel once
+  // so every subsequent chunk uses the fast sendDiscordText path instead of
+  // issuing a fresh POST /users/@me/channels per chunk.
+  const channelId =
+    resolveTargetChannelId(params.target) ?? (await resolveDmChannelId(params.target, params.rest));
   const account = resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId });
   const retryConfig = resolveDeliveryRetryConfig(account.config.retry);
   const request: RetryRunner | undefined = channelId

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -318,6 +318,8 @@ type MaybeCreateDiscordAutoThreadParams = {
   message: DiscordMessageEvent["message"];
   messageChannelId?: string;
   isGuildMessage: boolean;
+  isDirectMessage?: boolean;
+  directUserId?: string | null;
   channelConfig?: DiscordChannelConfigResolved | null;
   threadChannel?: DiscordThreadChannel | null;
   channelType?: ChannelType;
@@ -335,7 +337,13 @@ export async function resolveDiscordAutoThreadReplyPlan(
   const messageChannelId = resolveTrimmedDiscordMessageChannelId(params);
   // Prefer the resolved thread channel ID when available so replies stay in-thread.
   const targetChannelId = params.threadChannel?.id ?? (messageChannelId || "unknown");
-  const originalReplyTarget = `channel:${targetChannelId}`;
+  // DM messages must be routed to user:<userId> so the Discord API creates/opens
+  // the correct DM channel. Using channel:<dmChannelId> fails for DMs because
+  // reply delivery expects a guild/thread channel ID, not a DM channel ID.
+  const originalReplyTarget =
+    params.isDirectMessage && params.directUserId
+      ? `user:${params.directUserId}`
+      : `channel:${targetChannelId}`;
   const createdThreadId = await maybeCreateDiscordAutoThread({
     client: params.client,
     message: params.message,

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -319,7 +319,7 @@ type MaybeCreateDiscordAutoThreadParams = {
   messageChannelId?: string;
   isGuildMessage: boolean;
   isDirectMessage?: boolean;
-  directUserId?: string | null;
+  directUserId?: string;
   channelConfig?: DiscordChannelConfigResolved | null;
   threadChannel?: DiscordThreadChannel | null;
   channelType?: ChannelType;
@@ -341,7 +341,7 @@ export async function resolveDiscordAutoThreadReplyPlan(
   // the correct DM channel. Using channel:<dmChannelId> fails for DMs because
   // reply delivery expects a guild/thread channel ID, not a DM channel ID.
   const originalReplyTarget =
-    params.isDirectMessage && params.directUserId
+    params.isDirectMessage && params.directUserId != null && params.directUserId !== ""
       ? `user:${params.directUserId}`
       : `channel:${targetChannelId}`;
   const createdThreadId = await maybeCreateDiscordAutoThread({


### PR DESCRIPTION
## Summary

Fixes #47500

Discord DM messages were incorrectly routed to `channel:<dmChannelId>` instead of `user:<userId>`, causing the bot to receive DMs but fail to reply.

## Root Cause

`resolveDiscordAutoThreadReplyPlan` always built the `originalReplyTarget` as `channel:<channelId>` regardless of message type. For DMs, this must be `user:<userId>` so that `sendMessageDiscord` can open the correct DM channel via the Discord API (`POST /users/@me/channels`).

The bug manifests exactly as reported:
```
discord inbound: channel=1482379752743632967 deliver=channel:1482379752743632967 from=discord:channel:1482379752743632967
```
After fix, DM delivery will show `deliver=user:<userId>`.

## Changes

- **`extensions/discord/src/monitor/threading.ts`**: Add `isDirectMessage` and `directUserId` fields to `MaybeCreateDiscordAutoThreadParams`. When both are set, build `originalReplyTarget` as `user:<userId>` instead of `channel:<channelId>`.
- **`extensions/discord/src/monitor/message-handler.process.ts`**: Pass `isDirectMessage` and `directUserId: author.id` to `resolveDiscordAutoThreadReplyPlan` for DM messages.
- **`extensions/discord/src/monitor/monitor.test.ts`**: Add regression test asserting DM messages route to `user:<userId>`.

## Testing

- All existing Discord tests pass (638/639; the 1 pre-existing failure in `exec-approvals.test.ts` is unrelated to this change).
- New test `routes DM messages to user:<userId> instead of channel:<dmChannelId>` passes.