### PR TITLE
Signal: inject reply context from dataMessage.quote

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -235,6 +235,56 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
 
+  it("injects reply context from dataMessage.quote", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "yes I agree",
+          attachments: [],
+          quote: {
+            id: 1700000099000,
+            text: "what do you think?",
+            authorNumber: "+15550002222",
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx!.ReplyToId).toBe("1700000099000");
+    expect(capture.ctx!.ReplyToBody).toBe("what do you think?");
+    expect(capture.ctx!.ReplyToSender).toBe("+15550002222");
+  });
+
+  it("omits reply context when no quote is present", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: { message: "hello", attachments: [] },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx!.ReplyToId).toBeUndefined();
+    expect(capture.ctx!.ReplyToBody).toBeUndefined();
+    expect(capture.ctx!.ReplyToSender).toBeUndefined();
+  });
+
   it("drops sync envelopes when syncMessage is present but null", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -113,6 +113,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    quoteBody?: string;
+    quoteId?: string;
+    quoteSender?: string;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -215,6 +218,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
+      ReplyToId: entry.quoteId,
+      ReplyToBody: entry.quoteBody,
+      ReplyToSender: entry.quoteSender,
     });
 
     await recordInboundSession({
@@ -796,6 +802,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      quoteBody: dataMessage.quote?.text?.trim() || undefined,
+      quoteId: dataMessage.quote?.id != null ? String(dataMessage.quote.id) : undefined,
+      quoteSender:
+        dataMessage.quote?.authorNumber ??
+        dataMessage.quote?.author ??
+        dataMessage.quote?.authorUuid ??
+        undefined,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -807,7 +807,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       quoteSender:
         dataMessage.quote?.authorNumber ??
         dataMessage.quote?.author ??
-        dataMessage.quote?.authorUuid,
+        dataMessage.quote?.authorUuid ??
+        undefined,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -807,8 +807,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       quoteSender:
         dataMessage.quote?.authorNumber ??
         dataMessage.quote?.author ??
-        dataMessage.quote?.authorUuid ??
-        undefined,
+        dataMessage.quote?.authorUuid,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -37,7 +37,14 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | null;
+    text?: string | null;
+    author?: string | null;
+    authorNumber?: string | null;
+    authorUuid?: string | null;
+    mentions?: Array<SignalMention> | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 


### PR DESCRIPTION
## Summary

- Wire Signal's `dataMessage.quote` fields (`id`, `authorNumber`/`author`/`authorUuid`, `text`) through to `ReplyToId`, `ReplyToBody`, and `ReplyToSender` in the inbound context payload, so `describeReplyContext()` produces the `[Replying to ...]` block for Signal replies — matching the behavior of every other channel (Discord, Telegram, iMessage, WhatsApp, Bluebubbles).
- Expand the `SignalDataMessage.quote` type to match what [signal-cli actually emits](https://github.com/AsamK/signal-cli/blob/master/src/main/java/org/asamk/signal/json/JsonQuote.java) (`id`, `author`, `authorNumber`, `authorUuid`, `mentions`).
- Add two test cases covering quote-present and quote-absent paths.

### Files changed

| File | Change |
|------|--------|
| `extensions/signal/src/monitor/event-handler.types.ts` | Expand `quote` type with `id`, `author`, `authorNumber`, `authorUuid`, `mentions` |
| `extensions/signal/src/monitor/event-handler.ts` | Add `quoteBody`/`quoteId`/`quoteSender` to entry type, extract at enqueue, set `ReplyTo*` in context |
| `extensions/signal/src/monitor/event-handler.inbound-contract.test.ts` | Two new test cases |

## Test plan

- [x] `pnpm test -- extensions/signal/src/monitor/event-handler` — all 24 tests pass
- [x] `pnpm tsgo` — no type errors
- [x] `pnpm check` — lint and format clean
- [ ] Manual: send a reply-to-message in Signal and verify the agent prompt contains `[Replying to ...]`