### PR TITLE
CI: cache workspace deps across jobs

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Whether pnpm store restore/save should use actions/cache.
     required: false
     default: "true"
+  use-workspace-deps-cache:
+    description: Whether to restore/save workspace node_modules via actions/cache.
+    required: false
+    default: "true"
   install-deps:
     description: Whether to run pnpm install after environment setup.
     required: false
@@ -67,7 +71,7 @@ runs:
         package-manager-cache: false
 
     - name: Restore workspace dependency cache
-      if: inputs.install-deps == 'true' || inputs.lookup-only == 'true'
+      if: (inputs.install-deps == 'true' || inputs.lookup-only == 'true') && inputs.use-workspace-deps-cache == 'true'
       id: workspace-deps-cache
       uses: actions/cache@v5
       with:

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -1,7 +1,8 @@
 name: Setup Node environment
 description: >
   Initialize submodules with retry, install Node 24 by default, pnpm, optionally Bun,
-  and optionally run pnpm install. Requires actions/checkout to run first.
+  and optionally run pnpm install. Restores cached workspace dependencies when available.
+  Requires actions/checkout to run first.
 inputs:
   node-version:
     description: Node.js version to install.
@@ -23,18 +24,64 @@ inputs:
     description: Request Blacksmith sticky-disk pnpm caching on trusted runs; pull_request runs fall back to actions/cache.
     required: false
     default: "false"
+  use-restore-keys:
+    description: Whether pnpm store restore should use fallback restore keys.
+    required: false
+    default: "true"
+  use-actions-cache:
+    description: Whether pnpm store restore/save should use actions/cache.
+    required: false
+    default: "true"
   install-deps:
     description: Whether to run pnpm install after environment setup.
     required: false
     default: "true"
+  lookup-only:
+    description: If true, only checks whether the workspace dependency cache exists before deciding whether install work is needed.
+    required: false
+    default: "false"
   frozen-lockfile:
     description: Whether to use --frozen-lockfile for install.
     required: false
     default: "true"
+  prefer-offline:
+    description: Whether to pass --prefer-offline to pnpm install.
+    required: false
+    default: "false"
+  side-effects-cache:
+    description: Whether to enable pnpm side-effects cache during install.
+    required: false
+    default: "false"
+outputs:
+  workspace-deps-cache-hit:
+    description: Whether the workspace dependency cache was restored by exact key.
+    value: ${{ steps.workspace-deps-cache.outputs.cache-hit }}
 runs:
   using: composite
   steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        check-latest: false
+        package-manager-cache: false
+
+    - name: Restore workspace dependency cache
+      if: inputs.install-deps == 'true' || inputs.lookup-only == 'true'
+      id: workspace-deps-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          node_modules
+          ui/node_modules
+          packages/*/node_modules
+          extensions/*/node_modules
+          !node_modules/.cache
+        key: workspace-deps-${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'ui/package.json', 'packages/*/package.json', 'extensions/*/package.json') }}
+        lookup-only: ${{ inputs.lookup-only }}
+
     - name: Checkout submodules (retry)
+      if: inputs.lookup-only != 'true' || steps.workspace-deps-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -48,18 +95,15 @@ runs:
         done
         exit 1
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.node-version }}
-        check-latest: false
-
     - name: Setup pnpm + cache store
+      if: inputs.lookup-only != 'true' || steps.workspace-deps-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/setup-pnpm-store-cache
       with:
         pnpm-version: ${{ inputs.pnpm-version }}
         cache-key-suffix: ${{ inputs.cache-key-suffix }}
         use-sticky-disk: ${{ inputs.use-sticky-disk }}
+        use-restore-keys: ${{ inputs.use-restore-keys }}
+        use-actions-cache: ${{ inputs.use-actions-cache }}
 
     - name: Setup Bun
       if: inputs.install-bun == 'true'
@@ -68,6 +112,7 @@ runs:
         bun-version: "1.3.9"
 
     - name: Runtime versions
+      if: inputs.lookup-only != 'true' || steps.workspace-deps-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         node -v
@@ -76,16 +121,18 @@ runs:
         if command -v bun &>/dev/null; then bun -v; fi
 
     - name: Capture node path
-      if: inputs.install-deps == 'true'
+      if: inputs.install-deps == 'true' && steps.workspace-deps-cache.outputs.cache-hit != 'true'
       shell: bash
       run: echo "NODE_BIN=$(dirname "$(node -p "process.execPath")")" >> "$GITHUB_ENV"
 
     - name: Install dependencies
-      if: inputs.install-deps == 'true'
+      if: inputs.install-deps == 'true' && steps.workspace-deps-cache.outputs.cache-hit != 'true'
       shell: bash
       env:
         CI: "true"
         FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
+        PREFER_OFFLINE: ${{ inputs.prefer-offline }}
+        SIDE_EFFECTS_CACHE: ${{ inputs.side-effects-cache }}
       run: |
         set -euo pipefail
         export PATH="$NODE_BIN:$PATH"
@@ -100,6 +147,22 @@ runs:
             exit 2
             ;;
         esac
+        case "$PREFER_OFFLINE" in
+          true) PREFER_OFFLINE_FLAG="--prefer-offline" ;;
+          false) PREFER_OFFLINE_FLAG="" ;;
+          *)
+            echo "::error::Invalid prefer-offline input: '$PREFER_OFFLINE' (expected true or false)"
+            exit 2
+            ;;
+        esac
+        case "$SIDE_EFFECTS_CACHE" in
+          true) SIDE_EFFECTS_CACHE_FLAG="--config.side-effects-cache=true" ;;
+          false) SIDE_EFFECTS_CACHE_FLAG="" ;;
+          *)
+            echo "::error::Invalid side-effects-cache input: '$SIDE_EFFECTS_CACHE' (expected true or false)"
+            exit 2
+            ;;
+        esac
 
         install_args=(
           install
@@ -109,5 +172,11 @@ runs:
         )
         if [ -n "$LOCKFILE_FLAG" ]; then
           install_args+=("$LOCKFILE_FLAG")
+        fi
+        if [ -n "$PREFER_OFFLINE_FLAG" ]; then
+          install_args+=("$PREFER_OFFLINE_FLAG")
+        fi
+        if [ -n "$SIDE_EFFECTS_CACHE_FLAG" ]; then
+          install_args+=("$SIDE_EFFECTS_CACHE_FLAG")
         fi
         pnpm "${install_args[@]}" || pnpm "${install_args[@]}"

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -120,11 +120,6 @@ runs:
         pnpm -v
         if command -v bun &>/dev/null; then bun -v; fi
 
-    - name: Capture node path
-      if: inputs.install-deps == 'true' && steps.workspace-deps-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: echo "NODE_BIN=$(dirname "$(node -p "process.execPath")")" >> "$GITHUB_ENV"
-
     - name: Install dependencies
       if: inputs.install-deps == 'true' && steps.workspace-deps-cache.outputs.cache-hit != 'true'
       shell: bash
@@ -135,7 +130,6 @@ runs:
         SIDE_EFFECTS_CACHE: ${{ inputs.side-effects-cache }}
       run: |
         set -euo pipefail
-        export PATH="$NODE_BIN:$PATH"
         which node
         node -v
         pnpm -v

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -55,7 +55,7 @@ runs:
       if: inputs.use-sticky-disk == 'true' && github.event_name != 'pull_request'
       uses: useblacksmith/stickydisk@v1
       with:
-        key: ${{ github.repository }}-pnpm-store-${{ runner.os }}-${{ github.ref_name }}-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ github.repository }}-pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
         path: ${{ steps.pnpm-store.outputs.path }}
 
     - name: Restore pnpm store cache (exact key only)
@@ -64,13 +64,13 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: ${{ runner.os }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Restore pnpm store cache (with fallback keys)
       if: inputs.use-actions-cache == 'true' && (inputs.use-sticky-disk != 'true' || github.event_name == 'pull_request') && inputs.use-restore-keys == 'true'
       uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: ${{ runner.os }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ inputs.cache-key-suffix }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-${{ inputs.cache-key-suffix }}-
+          ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ inputs.cache-key-suffix }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,49 @@ jobs:
 
           node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
 
+  # Seed the Linux dependency cache before fan-out jobs so a cold miss only installs once.
+  deps-linux:
+    needs: [docs-scope, changed-scope]
+    if: always() && (needs.docs-scope.outputs.docs_changed == 'true' || (needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'))
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Seed Linux dependency cache
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+          lookup-only: "true"
+
+  # Seed the Windows dependency cache before sharded jobs so only the first miss installs.
+  deps-windows:
+    needs: [docs-scope, changed-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'
+    runs-on: blacksmith-32vcpu-windows-2025
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Seed Windows dependency cache
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+          use-restore-keys: "false"
+          use-actions-cache: "true"
+          prefer-offline: "true"
+          side-effects-cache: "true"
+          lookup-only: "true"
+
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, deps-linux]
     if: github.event_name == 'push' && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -139,7 +179,7 @@ jobs:
         run: pnpm release:check
 
   checks:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, deps-linux]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     strategy:
@@ -208,7 +248,7 @@ jobs:
   # Types, lint, and format check.
   check:
     name: "check"
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, deps-linux]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -234,7 +274,7 @@ jobs:
 
   # Validate docs (format, lint, broken links) only when docs files changed.
   check-docs:
-    needs: [docs-scope]
+    needs: [docs-scope, deps-linux]
     if: needs.docs-scope.outputs.docs_changed == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -254,7 +294,7 @@ jobs:
 
   compat-node22:
     name: "compat-node22"
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, deps-linux]
     if: github.event_name == 'push' && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -380,7 +420,7 @@ jobs:
         run: pre-commit run --all-files pnpm-audit-prod
 
   checks-windows:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, deps-windows]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'
     runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 45
@@ -451,45 +491,20 @@ jobs:
             Write-Warning "Failed to apply Defender exclusions, continuing. $($_.Exception.Message)"
           }
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
         with:
-          node-version: 24.x
-          check-latest: false
-
-      - name: Setup pnpm + cache store
-        uses: ./.github/actions/setup-pnpm-store-cache
-        with:
-          pnpm-version: "10.23.0"
-          cache-key-suffix: "node24"
+          install-bun: "false"
           # Sticky disk mount currently retries/fails on every shard and adds ~50s
           # before install while still yielding zero pnpm store reuse.
-          # Try exact-key actions/cache restores instead to recover store reuse
-          # without the sticky-disk mount penalty.
+          # Keep exact-key actions/cache restores for the cold-miss path instead.
           use-sticky-disk: "false"
           use-restore-keys: "false"
           use-actions-cache: "true"
-
-      - name: Runtime versions
-        run: |
-          node -v
-          npm -v
-          pnpm -v
-
-      - name: Capture node path
-        run: echo "NODE_BIN=$(dirname \"$(node -p \"process.execPath\")\")" >> "$GITHUB_ENV"
-
-      - name: Install dependencies
-        env:
-          CI: true
-        run: |
-          export PATH="$NODE_BIN:$PATH"
-          which node
-          node -v
-          pnpm -v
+          prefer-offline: "true"
           # Persist Windows-native postinstall outputs in the pnpm store so restored
           # caches can skip repeated rebuild/download work on later shards/runs.
-          pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true || pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          side-effects-cache: "true"
 
       - name: Configure test shard (Windows)
         if: matrix.task == 'test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,28 +96,6 @@ jobs:
           use-sticky-disk: "false"
           lookup-only: "true"
 
-  # Seed the Windows dependency cache before sharded jobs so only the first miss installs.
-  deps-windows:
-    needs: [docs-scope, changed-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'
-    runs-on: blacksmith-32vcpu-windows-2025
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: false
-
-      - name: Seed Windows dependency cache
-        uses: ./.github/actions/setup-node-env
-        with:
-          install-bun: "false"
-          use-sticky-disk: "false"
-          use-restore-keys: "false"
-          use-actions-cache: "true"
-          prefer-offline: "true"
-          side-effects-cache: "true"
-          lookup-only: "true"
-
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:
     needs: [docs-scope, changed-scope, deps-linux]
@@ -420,7 +398,7 @@ jobs:
         run: pre-commit run --all-files pnpm-audit-prod
 
   checks-windows:
-    needs: [docs-scope, changed-scope, deps-windows]
+    needs: [docs-scope, changed-scope]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'
     runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 45
@@ -495,6 +473,7 @@ jobs:
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
+          use-workspace-deps-cache: "false"
           # Sticky disk mount currently retries/fails on every shard and adds ~50s
           # before install while still yielding zero pnpm store reuse.
           # Keep exact-key actions/cache restores for the cold-miss path instead.


### PR DESCRIPTION
## Summary

- Problem: CI restored the pnpm store but still ran `pnpm install` in every Node job and every Windows shard, so cache hits still paid install cost and parallel misses could race.
- Why it matters: the repo was not using the same lookup-only seed-job pattern as `ghcrawl`, so dependency setup work was repeated across jobs even when the dependency graph was unchanged.
- What changed: `setup-node-env` now restores an os/arch-aware workspace `node_modules` cache, supports lookup-only seeding, and skips `pnpm install` on exact cache hits; Linux and Windows CI now seed that cache in a blocking job before their fan-out jobs.
- What did NOT change (scope boundary): no product/runtime code changed, and I did not edit `codeql.yml` because that workflow is under secops ownership.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin arm64
- Runtime/container: local git worktree
- Model/provider: n/a
- Integration/channel (if any): GitHub Actions workflows
- Relevant config (redacted): n/a

### Steps

1. Read the existing `setup-node-env` and `setup-pnpm-store-cache` composite actions and the CI workflow.
2. Compare the repo's current behavior with `pwrdrvr/ghcrawl`'s `configure-nodejs` cache pattern.
3. Implement workspace dependency-cache restore + lookup-only seeding, then update the Linux and Windows CI lanes to depend on seed jobs.
4. Run the local workflow validation commands below.

### Expected

- Exact dependency-cache hits skip `pnpm install`.
- A cold miss installs once in the seed job, then dependent jobs restore the cache.
- Windows cache keys are os/arch-specific and still preserve the exact-key pnpm-store behavior used in this repo.

### Actual

- Matches expected based on the updated workflow graph and local lint/validation.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `python3 scripts/check-composite-action-input-interpolation.py`
  - `git diff --check`
  - `actionlint .github/workflows/ci.yml` using the same `v1.7.11` release used by the repo's workflow-sanity job
- Edge cases checked:
  - docs-only path still gets a Linux dependency seed for `check-docs`
  - Windows shards now use the shared setup action while preserving exact-key pnpm-store restores and side-effects cache on cold misses
  - pnpm store cache keys now include both OS and arch
- What you did **not** verify:
  - I did not run GitHub-hosted Actions end-to-end from this branch
  - I did not edit or validate `codeql.yml`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f45d7059d8`
- Files/config to restore:
  - `.github/actions/setup-node-env/action.yml`
  - `.github/actions/setup-pnpm-store-cache/action.yml`
  - `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for:
  - dependent jobs unexpectedly reinstalling on warm caches
  - seed jobs staying skipped when `check-docs` should run
  - Windows shards missing restored dependencies after the seed job populates cache

## Risks and Mitigations

- Risk: workspace `node_modules` cache invalidation misses a relevant package manifest and serves stale dependencies.
  - Mitigation: the cache key includes the lockfile, workspace file, root package manifest, `ui/package.json`, `packages/*/package.json`, and `extensions/*/package.json`.
- Risk: docs-only PRs could skip the new Linux seed job because `changed-scope` is intentionally skipped in that path.
  - Mitigation: the Linux seed job uses an explicit `always()` condition and a `docs_changed` branch so `check-docs` still gets its dependency cache.
