### PR TITLE
fix(failover): treat bare leading 402 assistant error strings as 402 markers (#47576)

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -467,4 +467,18 @@ describe("failover-error", () => {
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
   });
+
+  it("coerces bare leading 402 assistant error string to FailoverError (#47576)", () => {
+    // ZenMux quota-refresh 402 arrives as a bare assistant error string — must coerce to FailoverError
+    // so the embedded runner can enter model fallback.
+    const zenmuxQuota402 =
+      "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.";
+    const err = coerceToFailoverError(new Error(zenmuxQuota402), {
+      provider: "zenmux",
+      model: "gpt-4o",
+    });
+    expect(err).not.toBeNull();
+    expect(err?.reason).toBe("rate_limit");
+    expect(err?.provider).toBe("zenmux");
+  });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,19 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies bare leading 402 assistant error strings as rate_limit (#47576)", () => {
+    // ZenMux quota-refresh 402 surfaces as a bare assistant error string — must enter model fallback.
+    expect(
+      classifyFailoverReason(
+        "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
+      ),
+    ).toBe("rate_limit");
+    // Bare 402 with generic text should be treated as a 402 marker.
+    expect(classifyFailoverReason("402 Quota exceeded")).toBe("rate_limit");
+    // Bare 402 with typical billing text should classify as billing.
+    expect(
+      classifyFailoverReason("402 Please add more credits to continue using this service."),
+    ).toBe("billing");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -270,7 +270,7 @@ const RETRYABLE_402_SCOPED_RESULT_HINTS = [
   "exhausted",
 ] as const;
 const RAW_402_MARKER_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b/i;
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b|^\s*402\s+\S/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -270,7 +270,7 @@ const RETRYABLE_402_SCOPED_RESULT_HINTS = [
   "exhausted",
 ] as const;
 const RAW_402_MARKER_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b|^\s*402\s+\S/i;
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+\S/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
 


### PR DESCRIPTION
## Summary

Fixes #47576.

ZenMux quota-refresh 402s can surface to the embedded runner as a bare assistant error string like:

```
402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.
```

The existing `RAW_402_MARKER_RE` only matched forms like `status: 402`, `HTTP 402`, `402 Payment Required`, etc. A bare leading `402 <text>` was not recognised, so `classifyFailoverReasonFrom402Text()` returned `null` and the run ended without entering model fallback.

## Fix

Add a branch `|^\s*402\s+\S` to `RAW_402_MARKER_RE` to catch any bare leading `402 <non-whitespace>` string, then delegate sub-classification to the existing `classify402Message()` path, which already recognises the quota-refresh window signal and returns `rate_limit`.

## Tests

- `classifyFailoverReason('402 You have reached your subscription quota limit...')` === `'rate_limit'`
- `classifyFailoverReason('402 Quota exceeded')` === `'rate_limit'`  
- `classifyFailoverReason('402 Please add more credits...')` === `'billing'`
- `coerceToFailoverError(new Error('402 ...'))` is non-null with `reason === 'rate_limit'`

All 105 existing tests continue to pass.