### PR TITLE
fix(plugins): preserve channel webhook routes across registry replacements

### DIFF
--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -61,10 +61,11 @@ export type PluginHttpRequestHandler = (
 ) => Promise<boolean>;
 
 export function createGatewayPluginRequestHandler(params: {
-  registry: PluginRegistry;
+  /** @deprecated Routes are now read from the active plugin registry at request time. */
+  registry?: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry: _registry, log } = params;
+  const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
     // Use the CURRENT active registry to find routes.
     // Channel plugins (like BlueBubbles) register webhook routes via requireActivePluginRegistry()

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -63,9 +64,14 @@ export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { registry: _registry, log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
-    const routes = registry.httpRoutes ?? [];
+    // Use the CURRENT active registry to find routes.
+    // Channel plugins (like BlueBubbles) register webhook routes via requireActivePluginRegistry()
+    // after the HTTP handler is created. The handler's captured `registry` may be stale
+    // because setActivePluginRegistry() replaces it during per-agent plugin loading.
+    const effectiveRegistry = requireActivePluginRegistry();
+    const routes = effectiveRegistry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;
     }
@@ -76,7 +82,7 @@ export function createGatewayPluginRequestHandler(params: {
         const url = new URL(req.url ?? "/", "http://localhost");
         return resolvePluginRoutePathContext(url.pathname);
       })();
-    const matchedRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
+    const matchedRoutes = findMatchingPluginHttpRoutes(effectiveRegistry, pathContext);
     if (matchedRoutes.length === 0) {
       return false;
     }

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -23,6 +23,16 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+  // Preserve httpRoutes from the previous registry so channel-registered webhook routes
+  // (e.g. BlueBubbles) survive per-agent plugin loader cycles that replace the registry.
+  const prevRoutes = state.registry?.httpRoutes;
+  if (
+    prevRoutes &&
+    prevRoutes.length > 0 &&
+    (!registry.httpRoutes || registry.httpRoutes.length === 0)
+  ) {
+    registry.httpRoutes = prevRoutes;
+  }
   state.registry = registry;
   state.key = cacheKey ?? null;
   state.version += 1;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -23,9 +23,13 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
-  // Preserve httpRoutes from the previous registry so channel-registered webhook routes
-  // (e.g. BlueBubbles) survive per-agent plugin loader cycles that replace the registry.
-  // Clone to avoid mutating the caller's object (the loader may retain a reference).
+  // Preserve the httpRoutes reference across registry replacements. Channel plugins
+  // (e.g. BlueBubbles) register webhook routes into the active registry's httpRoutes
+  // during channel startup. The per-agent plugin loader replaces the registry with a
+  // fresh one, but channels are not re-started, so their routes would be lost.
+  // By sharing the same httpRoutes array, channel-registered routes survive loader cycles.
+  // When a channel is disabled and its provider stops, it calls its own unregister()
+  // teardown which removes its entries from this shared array.
   const prevRoutes = state.registry?.httpRoutes;
   if (
     prevRoutes &&

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -25,13 +25,14 @@ const state: RegistryState = (() => {
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   // Preserve httpRoutes from the previous registry so channel-registered webhook routes
   // (e.g. BlueBubbles) survive per-agent plugin loader cycles that replace the registry.
+  // Clone to avoid mutating the caller's object (the loader may retain a reference).
   const prevRoutes = state.registry?.httpRoutes;
   if (
     prevRoutes &&
     prevRoutes.length > 0 &&
     (!registry.httpRoutes || registry.httpRoutes.length === 0)
   ) {
-    registry.httpRoutes = prevRoutes;
+    registry = { ...registry, httpRoutes: prevRoutes };
   }
   state.registry = registry;
   state.key = cacheKey ?? null;


### PR DESCRIPTION
## Problem

Channel plugins (e.g. BlueBubbles) register HTTP webhook routes via `requireActivePluginRegistry()` during channel startup. However, the per-agent plugin loader calls `setActivePluginRegistry()` with a fresh registry for each agent, orphaning previously registered `httpRoutes`. The gateway HTTP handler then reads from the latest registry and finds zero routes, returning 404 for all webhook POSTs.

This breaks inbound message delivery for any channel that relies on webhook HTTP routes (BlueBubbles being the primary one).

## Root Cause

1. `createGatewayPluginRequestHandler()` captures a registry snapshot at creation time
2. Channel startup (e.g. BlueBubbles `monitorBlueBubblesProvider`) registers webhook routes into `requireActivePluginRegistry()`
3. Subsequent per-agent plugin loader cycles call `setActivePluginRegistry()` with a new empty registry
4. The captured snapshot and the current active registry diverge — both lose the webhook routes

## Fix

Two changes:

1. **`setActivePluginRegistry()`** now carries forward `httpRoutes` from the previous registry when the new one has none, preserving channel-registered webhook routes across loader cycles.
2. **`createGatewayPluginRequestHandler()`** reads routes from `requireActivePluginRegistry()` (current) instead of the stale snapshot captured at handler creation time.

## Testing

- Verified webhook POST returns 200 and messages are delivered after the fix
- Confirmed routes persist across multiple agent session initializations

Fixes #32275