### PR TITLE
Commands: lazy-load auth choice plugin provider runtime

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.runtime.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.runtime.ts
@@ -1,0 +1,5 @@
+export {
+  resolveProviderPluginChoice,
+  runProviderModelSelectedHook,
+} from "../plugins/provider-wizard.js";
+export { resolvePluginProviders } from "../plugins/providers.js";

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -9,15 +9,12 @@ import {
 } from "./auth-choice.apply.plugin-provider.js";
 
 const resolvePluginProviders = vi.hoisted(() => vi.fn<() => ProviderPlugin[]>(() => []));
-vi.mock("../plugins/providers.js", () => ({
-  resolvePluginProviders,
-}));
-
 const resolveProviderPluginChoice = vi.hoisted(() =>
   vi.fn<() => { provider: ProviderPlugin; method: ProviderAuthMethod } | null>(),
 );
 const runProviderModelSelectedHook = vi.hoisted(() => vi.fn(async () => {}));
-vi.mock("../plugins/provider-wizard.js", () => ({
+vi.mock("./auth-choice.apply.plugin-provider.runtime.js", () => ({
+  resolvePluginProviders,
   resolveProviderPluginChoice,
   runProviderModelSelectedHook,
 }));

--- a/src/commands/auth-choice.apply.plugin-provider.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.ts
@@ -7,11 +7,6 @@ import {
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
-import {
-  resolveProviderPluginChoice,
-  runProviderModelSelectedHook,
-} from "../plugins/provider-wizard.js";
-import { resolvePluginProviders } from "../plugins/providers.js";
 import type { ProviderAuthMethod } from "../plugins/types.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { isRemoteEnvironment } from "./oauth-env.js";
@@ -32,6 +27,10 @@ export type PluginProviderAuthChoiceOptions = {
   methodId?: string;
   label: string;
 };
+
+async function loadPluginProviderRuntime() {
+  return import("./auth-choice.apply.plugin-provider.runtime.js");
+}
 
 export async function runProviderPluginAuthMethod(params: {
   config: ApplyAuthChoiceParams["config"];
@@ -109,6 +108,8 @@ export async function applyAuthChoiceLoadedPluginProvider(
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const workspaceDir =
     resolveAgentWorkspaceDir(params.config, agentId) ?? resolveDefaultAgentWorkspaceDir();
+  const { resolvePluginProviders, resolveProviderPluginChoice, runProviderModelSelectedHook } =
+    await loadPluginProviderRuntime();
   const providers = resolvePluginProviders({ config: params.config, workspaceDir });
   const resolved = resolveProviderPluginChoice({
     providers,
@@ -177,6 +178,8 @@ export async function applyAuthChoicePluginProvider(
   const workspaceDir =
     resolveAgentWorkspaceDir(nextConfig, agentId) ?? resolveDefaultAgentWorkspaceDir();
 
+  const { resolvePluginProviders, runProviderModelSelectedHook } =
+    await loadPluginProviderRuntime();
   const providers = resolvePluginProviders({ config: nextConfig, workspaceDir });
   const provider = resolveProviderMatch(providers, options.providerId);
   if (!provider) {


### PR DESCRIPTION
## Summary
- add a runtime boundary for plugin-backed auth-choice apply helpers
- lazy-load provider resolution and model-selected hooks only when a plugin-provider branch is actually used
- update plugin-provider tests to mock the runtime boundary directly

## Related
- Related #45064
- follows the same startup/import trimming pattern as #46522, #46784, #47467, #47495, #47536, #47545, and #47593

## Verification
- `pnpm test -- src/commands/auth-choice.apply.plugin-provider.test.ts src/commands/auth-choice.test.ts`
- `pnpm build`
- `pnpm check` hit unrelated baseline TypeScript failures in `src/auto-reply/reply/dispatch-from-config.test.ts` and `src/plugins/conversation-binding.test.ts`, outside this patch
- `codex review --base origin/main` was started locally during prep; no issue in this patch surfaced before push
