### PR TITLE
fix(slack): instrument DM inbound pipeline with verbose drop logging

### DIFF
--- a/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
+++ b/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const logVerboseMock = vi.fn((_msg: string) => {});
+const shouldLogVerboseMock = vi.fn(() => false);
+
+vi.mock("../../../../src/globals.js", () => ({
+  logVerbose: (msg: string) => logVerboseMock(msg),
+  shouldLogVerbose: () => shouldLogVerboseMock(),
+  danger: (msg: string) => msg,
+}));
+
 const prepareSlackMessageMock =
   vi.fn<
     (params: {
@@ -120,6 +129,8 @@ describe("createSlackMessageHandler app_mention race handling", () => {
   beforeEach(() => {
     prepareSlackMessageMock.mockReset();
     dispatchPreparedSlackMessageMock.mockReset();
+    logVerboseMock.mockClear();
+    shouldLogVerboseMock.mockReset().mockReturnValue(false);
   });
 
   it("allows a single app_mention retry when message event was dropped before dispatch", async () => {
@@ -178,5 +189,33 @@ describe("createSlackMessageHandler app_mention race handling", () => {
 
     expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
     expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs unprepared drop in onFlush when verbose mode is enabled", async () => {
+    shouldLogVerboseMock.mockReturnValue(true);
+    prepareSlackMessageMock.mockResolvedValue(null);
+
+    const handler = createTestHandler();
+    await sendMessageEvent(handler, "1700000000.000300");
+
+    const dropCall = logVerboseMock.mock.calls.find((c) =>
+      c[0].includes("slack inbound: drop unprepared"),
+    );
+    expect(dropCall).toBeDefined();
+    expect(dropCall?.[0]).toContain("entries=1");
+    expect(dropCall?.[0]).toContain("source=message");
+    expect(dispatchPreparedSlackMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch when prepared is null for a DM batch", async () => {
+    prepareSlackMessageMock.mockResolvedValue(null);
+
+    const handler = createTestHandler();
+
+    // Simulate two DMs arriving (same channel/debounce key) — both should be dropped
+    await sendMessageEvent(handler, "1700000000.000400");
+    await sendMessageEvent(handler, "1700000000.000500");
+
+    expect(dispatchPreparedSlackMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -6,6 +6,8 @@ const flushKeyMock = vi.fn(async (_key: string) => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
 }));
+const logVerboseMock = vi.fn((_msg: string) => {});
+const shouldLogVerboseMock = vi.fn(() => false);
 
 vi.mock("../../../../src/auto-reply/inbound-debounce.js", () => ({
   resolveInboundDebounceMs: () => 10,
@@ -19,6 +21,12 @@ vi.mock("./thread-resolution.js", () => ({
   createSlackThreadTsResolver: () => ({
     resolve: (entry: { message: Record<string, unknown> }) => resolveThreadTsMock(entry),
   }),
+}));
+
+vi.mock("../../../../src/globals.js", () => ({
+  logVerbose: (msg: string) => logVerboseMock(msg),
+  shouldLogVerbose: () => shouldLogVerboseMock(),
+  danger: (msg: string) => msg,
 }));
 
 function createContext(overrides?: {
@@ -67,6 +75,8 @@ describe("createSlackMessageHandler", () => {
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
     resolveThreadTsMock.mockClear();
+    logVerboseMock.mockClear();
+    shouldLogVerboseMock.mockReset().mockReturnValue(false);
   });
 
   it("does not track invalid non-message events from the message stream", async () => {
@@ -145,5 +155,44 @@ describe("createSlackMessageHandler", () => {
     );
 
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+  });
+
+  it("logs DM trace when verbose mode is enabled", async () => {
+    shouldLogVerboseMock.mockReturnValue(true);
+    const { handler } = createHandlerWithTracker();
+
+    await handleDirectMessage(handler);
+
+    const dmTraceCall = logVerboseMock.mock.calls.find((c) =>
+      c[0].includes("slack inbound DM: channel=D1"),
+    );
+    expect(dmTraceCall).toBeDefined();
+    expect(dmTraceCall?.[0]).toContain("ts=123.456");
+    expect(dmTraceCall?.[0]).toContain("source=message");
+  });
+
+  it("logs dedup drop when verbose mode is enabled and message is already seen", async () => {
+    shouldLogVerboseMock.mockReturnValue(true);
+    const { handler } = createHandlerWithTracker({ markMessageSeen: () => true });
+
+    await handleDirectMessage(handler);
+
+    const dedupCall = logVerboseMock.mock.calls.find((c) =>
+      c[0].includes("slack inbound: dedup drop"),
+    );
+    expect(dedupCall).toBeDefined();
+    expect(dedupCall?.[0]).toContain("channel=D1");
+    expect(dedupCall?.[0]).toContain("ts=123.456");
+    expect(dedupCall?.[0]).toContain("source=message");
+  });
+
+  it("does not log DM trace when verbose mode is disabled", async () => {
+    shouldLogVerboseMock.mockReturnValue(false);
+    const { handler } = createHandlerWithTracker();
+
+    await handleDirectMessage(handler);
+
+    const dmTraceCall = logVerboseMock.mock.calls.find((c) => c[0].includes("slack inbound DM:"));
+    expect(dmTraceCall).toBeUndefined();
   });
 });

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -2,6 +2,7 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "../../../../src/channels/inbound-debounce-policy.js";
+import { logVerbose, shouldLogVerbose } from "../../../../src/globals.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
@@ -144,6 +145,14 @@ export function createSlackMessageHandler(params: {
       });
       const seenMessageKey = buildSeenMessageKey(last.message.channel, last.message.ts);
       if (!prepared) {
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `slack inbound: drop unprepared channel=${last.message.channel} ts=${last.message.ts ?? "unknown"} entries=${entries.length} source=${last.opts.source}`,
+          );
+        }
+        // Do NOT delete appMentionRetryKeys here: when a message is dropped by
+        // prepareSlackMessage (prepared=null), the retry key must stay alive so
+        // an in-flight app_mention for the same ts can still dispatch once.
         return;
       }
       if (seenMessageKey) {
@@ -152,9 +161,21 @@ export function createSlackMessageHandler(params: {
           // If app_mention wins the race and dispatches first, drop the later message dispatch.
           appMentionDispatchedKeys.set(seenMessageKey, Date.now() + APP_MENTION_RETRY_TTL_MS);
         } else if (last.opts.source === "message" && appMentionDispatchedKeys.has(seenMessageKey)) {
+          if (shouldLogVerbose()) {
+            logVerbose(
+              `slack inbound: app_mention race drop channel=${last.message.channel} ts=${last.message.ts ?? "unknown"}`,
+            );
+          }
           appMentionDispatchedKeys.delete(seenMessageKey);
           appMentionRetryKeys.delete(seenMessageKey);
           return;
+        }
+        // Clean up retry keys for all batched entries on successful dispatch.
+        for (const entry of entries) {
+          const entryKey = buildSeenMessageKey(entry.message.channel, entry.message.ts);
+          if (entryKey && entryKey !== seenMessageKey) {
+            appMentionRetryKeys.delete(entryKey);
+          }
         }
         appMentionRetryKeys.delete(seenMessageKey);
       }
@@ -218,6 +239,11 @@ export function createSlackMessageHandler(params: {
     ) {
       return;
     }
+    if (shouldLogVerbose() && isSlackDirectMessageChannel(message.channel)) {
+      logVerbose(
+        `slack inbound DM: channel=${message.channel} ts=${message.ts ?? "unknown"} source=${opts.source} user=${message.user ?? message.bot_id ?? "unknown"} subtype=${message.subtype ?? "none"}`,
+      );
+    }
     const seenMessageKey = buildSeenMessageKey(message.channel, message.ts);
     const wasSeen = seenMessageKey ? ctx.markMessageSeen(message.channel, message.ts) : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
@@ -229,6 +255,11 @@ export function createSlackMessageHandler(params: {
       // Allow exactly one app_mention retry if the same ts was previously dropped
       // from the message stream before it reached dispatch.
       if (opts.source !== "app_mention" || !consumeAppMentionRetryKey(seenMessageKey)) {
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `slack inbound: dedup drop channel=${message.channel} ts=${message.ts ?? "unknown"} source=${opts.source}`,
+          );
+        }
         return;
       }
     }

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -529,6 +529,9 @@ export async function prepareSlackMessage(params: {
     mediaMaxBytes: ctx.mediaMaxBytes,
   });
   if (!resolvedMessageContent) {
+    logVerbose(
+      `slack inbound: drop empty content channel=${message.channel} ts=${message.ts ?? "unknown"} isDirectMessage=${isDirectMessage} text_len=${(message.text ?? "").length} files=${message.files?.length ?? 0}`,
+    );
     return null;
   }
   const { rawBody, effectiveDirectMedia } = resolvedMessageContent;


### PR DESCRIPTION
## Summary

- Adds `logVerbose` trace points at every drop gate in the Slack DM inbound pipeline so intermittent message losses become diagnosable when verbose mode is enabled
- Fixes `appMentionRetryKeys` cleanup in `onFlush` to cover all batched entries on successful dispatch (not just the last entry), preventing stale map growth

## Root cause

DM messages were disappearing without any trace at default log levels. All drop decisions (`dedup drop`, `prepared=null`, `empty content`, `app_mention race`) were either silent or only logged via `logVerbose` from inside `prepare.ts`, making it impossible to distinguish authorization failures from content resolution failures from debounce issues.

## Changes

**`extensions/slack/src/monitor/message-handler.ts`**
- Import `logVerbose` / `shouldLogVerbose` from globals
- `slack inbound DM:` trace on every DM event entering the handler (channel, ts, source, user, subtype)
- `slack inbound: dedup drop` when `markMessageSeen` returns true
- `slack inbound: drop unprepared` in `onFlush` when `prepareSlackMessage` returns null; includes entry count and source so batched drops are attributable
- `slack inbound: app_mention race drop` when a message event is suppressed because app_mention already dispatched
- Fix: clean up `appMentionRetryKeys` for **all** entries in a batched flush on successful dispatch; the `!prepared` path leaves retry keys alive intentionally so in-flight app_mention events can retry once

**`extensions/slack/src/monitor/message-handler/prepare.ts`**
- `slack inbound: drop empty content` when `resolveSlackMessageContent` returns null; includes `isDirectMessage`, `text_len`, and `files` count for diagnosis

## Test plan

- [x] `pnpm test -- message-handler` — 7 tests pass (3 new: DM trace logged, dedup drop logged, no log when verbose off)
- [x] `pnpm test -- message-handler.app-mention-race` — 6 tests pass (2 new: onFlush unprepared drop logged, no dispatch for null prepared batch)
- [x] `pnpm test -- extensions/slack` — 386 tests pass (all pre-existing pass)
- [x] `pnpm tsgo` on changed files — no new errors
- [x] `pnpm format:fix` applied

## To test the fix in production

Enable verbose logging and reproduce a lost DM. The new trace points will show:
1. Whether the event reached the handler at all
2. Whether it was deduplicated
3. Whether `prepareSlackMessage` dropped it (and why via existing `logVerbose` inside prepare)
4. Whether content was empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)