### PR TITLE
Commands: lazy-load models auth provider runtime

### DIFF
--- a/src/commands/models/auth.runtime.ts
+++ b/src/commands/models/auth.runtime.ts
@@ -1,0 +1,1 @@
+export { resolvePluginProviders } from "../../plugins/providers.js";

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -51,7 +51,7 @@ vi.mock("../../agents/workspace.js", () => ({
   resolveDefaultAgentWorkspaceDir: mocks.resolveDefaultAgentWorkspaceDir,
 }));
 
-vi.mock("../../plugins/providers.js", () => ({
+vi.mock("./auth.runtime.js", () => ({
   resolvePluginProviders: mocks.resolvePluginProviders,
 }));
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -22,7 +22,6 @@ import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
-import { resolvePluginProviders } from "../../plugins/providers.js";
 import type { ProviderAuthResult, ProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
@@ -44,6 +43,10 @@ import {
   resolveProviderMatch,
 } from "../provider-auth-helpers.js";
 import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+
+async function loadModelsAuthRuntime() {
+  return import("./auth.runtime.js");
+}
 
 function guardCancel<T>(value: T | symbol): T {
   if (typeof value === "symbol" || isCancel(value)) {
@@ -389,6 +392,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     return;
   }
 
+  const { resolvePluginProviders } = await loadModelsAuthRuntime();
   const providers = resolvePluginProviders({ config, workspaceDir });
   if (providers.length === 0) {
     throw new Error(


### PR DESCRIPTION
## Summary
- add a runtime boundary for plugin-backed `models auth login` provider resolution
- lazy-load provider plugins only when `models auth login` is not using the built-in `openai-codex` path
- update models auth tests to mock the runtime boundary directly

## Related
- Related #45064
- follows the same startup/import trimming pattern as #46522, #46784, #47467, #47495, #47536, #47545, #47593, and #47692

## Verification
- `pnpm test -- src/commands/models/auth.test.ts`
- `pnpm build`
- `pnpm check` hit unrelated baseline TypeScript failures in `src/auto-reply/reply/dispatch-from-config.test.ts` and `src/plugins/conversation-binding.test.ts`, outside this patch
