### PR TITLE
fix(minimax-vlm): add fetch timeout to VLM image analysis call

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -73,18 +73,27 @@ export async function minimaxUnderstandImage(params: {
   });
   const url = new URL("/v1/coding_plan/vlm", host).toString();
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-      "MM-API-Source": "OpenClaw",
-    },
-    body: JSON.stringify({
-      prompt,
-      image_url: imageDataUrl,
-    }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "MM-API-Source": "OpenClaw",
+      },
+      body: JSON.stringify({
+        prompt,
+        image_url: imageDataUrl,
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `MiniMax VLM request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   const traceId = res.headers.get("Trace-Id") ?? "";
   if (!res.ok) {


### PR DESCRIPTION
`minimaxVlmImageAnalysis()` issues a bare `fetch()` to the MiniMax VLM endpoint without a cancellation deadline. A stalled connection blocks the event loop indefinitely.

## Changes

- **`src/agents/minimax-vlm.ts`**: Add `AbortSignal.timeout(120_000)` (2 min, appropriate for image inference payloads) and wrap in try/catch with `{ cause: err }`. The existing error-path body read already uses `.catch(() => "")`.

lobster-biscuit
