### PR TITLE
fix(github-copilot): add fetch timeout to device-code and token-poll requests

### DIFF
--- a/src/providers/github-copilot-auth.ts
+++ b/src/providers/github-copilot-auth.ts
@@ -95,10 +95,16 @@ async function pollForAccessToken(params: {
         body: bodyBase,
         signal: AbortSignal.timeout(15_000),
       });
-    } catch {
-      // Single-poll timeout — retry on next interval instead of aborting the flow.
-      await new Promise((r) => setTimeout(r, params.intervalMs));
-      continue;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        // Single-poll timeout — retry on next interval instead of aborting the flow.
+        await new Promise((r) => setTimeout(r, params.intervalMs));
+        continue;
+      }
+      throw new Error(
+        `GitHub token poll failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
 
     if (!res.ok) {

--- a/src/providers/github-copilot-auth.ts
+++ b/src/providers/github-copilot-auth.ts
@@ -43,14 +43,23 @@ async function requestDeviceCode(params: { scope: string }): Promise<DeviceCodeR
     scope: params.scope,
   });
 
-  const res = await fetch(DEVICE_CODE_URL, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body,
-  });
+  let res: Response;
+  try {
+    res = await fetch(DEVICE_CODE_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `GitHub device code request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!res.ok) {
     throw new Error(`GitHub device code failed: HTTP ${res.status}`);
@@ -75,14 +84,22 @@ async function pollForAccessToken(params: {
   });
 
   while (Date.now() < params.expiresAt) {
-    const res = await fetch(ACCESS_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: bodyBase,
-    });
+    let res: Response;
+    try {
+      res = await fetch(ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: bodyBase,
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch {
+      // Single-poll timeout — retry on next interval instead of aborting the flow.
+      await new Promise((r) => setTimeout(r, params.intervalMs));
+      continue;
+    }
 
     if (!res.ok) {
       throw new Error(`GitHub device token failed: HTTP ${res.status}`);


### PR DESCRIPTION
`requestDeviceCode()` and `pollForAccessToken()` issue bare `fetch()` calls to GitHub without a cancellation deadline. A stalled connection blocks the login flow indefinitely.

## Changes

- **`src/providers/github-copilot-auth.ts`**: Add `AbortSignal.timeout(15_000)` to both requests. For the device-code request, a timeout is fatal (re-throw with cause). For the token-poll loop, a single-poll timeout retries on the next interval instead of aborting the entire auth session.

lobster-biscuit
