### PR TITLE
fix(agents): add Mistral model hints to OpenRouter provider

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -130,6 +130,21 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
+  it("applies strict9 tool call ID mode for Mistral models through OpenRouter (#47707)", () => {
+    // OpenRouter routes to Mistral models which require strict9 format.
+    // Even when the plugin returns partial capabilities (without transcriptToolCallIdModelHints),
+    // the fallback hints should be merged in.
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/devstral-2512:free")).toBe(
+      "strict9",
+    );
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistral-large-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("openrouter", "codestral-latest")).toBe("strict9");
+    // Non-Mistral models should not get strict9
+    expect(
+      resolveTranscriptToolCallIdMode("openrouter", "anthropic/claude-3-opus"),
+    ).toBeUndefined();
+  });
+
   it("treats kimi aliases as native anthropic tool payload providers", () => {
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -51,6 +51,20 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
       "mistralai",
     ],
   },
+  openrouter: {
+    openAiCompatTurnValidation: false,
+    geminiThoughtSignatureSanitization: true,
+    geminiThoughtSignatureModelHints: ["gemini"],
+    transcriptToolCallIdModelHints: [
+      "mistral",
+      "mixtral",
+      "codestral",
+      "pixtral",
+      "devstral",
+      "ministral",
+      "mistralai",
+    ],
+  },
   opencode: {
     openAiCompatTurnValidation: false,
     geminiThoughtSignatureSanitization: true,

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -85,10 +85,14 @@ export function resolveProviderCapabilities(provider?: string | null): ProviderC
   const pluginCapabilities = normalized
     ? resolveProviderCapabilitiesWithPlugin({ provider: normalized })
     : undefined;
+  // Merge fallbacks first, then plugin capabilities on top. This ensures
+  // fallback hints (like transcriptToolCallIdModelHints) are applied even
+  // when the plugin provides partial capabilities.
   return {
     ...DEFAULT_PROVIDER_CAPABILITIES,
     ...CORE_PROVIDER_CAPABILITIES[normalized],
-    ...(pluginCapabilities ?? PLUGIN_CAPABILITIES_FALLBACKS[normalized]),
+    ...PLUGIN_CAPABILITIES_FALLBACKS[normalized],
+    ...pluginCapabilities,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #47707

OpenRouter routes to Mistral models which require `strict9` tool call ID format (alphanumeric only, length 9). Without this config, Mistral models through OpenRouter would not get proper tool call ID sanitization, causing failures when the Mistral backend rejects non-conforming tool call IDs.

## Changes

- **`provider-capabilities.ts`**: Add `openrouter` to `PLUGIN_CAPABILITIES_FALLBACKS` with:
  - `transcriptToolCallIdModelHints` for Mistral model families (mistral, mixtral, codestral, pixtral, devstral, ministral, mistralai)
  - `geminiThoughtSignatureSanitization` for Gemini model routes
  - `openAiCompatTurnValidation: false` (consistent with other routing providers)

## How it works

When a user routes to a Mistral model through OpenRouter (e.g., `mistralai/devstral-2512:free`), the `resolveTranscriptToolCallIdMode()` function will now check the model ID against these hints and return `strict9` mode, ensuring tool call IDs are properly sanitized.

## Test Plan

- [x] `pnpm test -- src/agents/provider-capabilities.test.ts` passes
- [x] `pnpm tsgo` passes

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
