### PR TITLE
fix(daemon): accept Last Result key from schtasks on Windows (#47726)

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -23,6 +23,20 @@ describe("schtasks runtime parsing", () => {
       lastRunResult: "0x0",
     });
   });
+
+  it("parses Last Result (Windows locale variant without Run)", () => {
+    const output = [
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Running",
+      "Last Run Time: 2026/3/16 8:34:15",
+      "Last Result: 267009",
+    ].join("\r\n");
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Running",
+      lastRunTime: "2026/3/16 8:34:15",
+      lastRunResult: "267009",
+    });
+  });
 });
 
 describe("scheduled task runtime derivation", () => {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -178,7 +178,8 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;
   }
-  const lastRunResult = entries["last run result"];
+  // Windows schtasks /Query /V /FO LIST may output "Last Result" (no "Run") in some locales
+  const lastRunResult = entries["last run result"] ?? entries["last result"];
   if (lastRunResult) {
     info.lastRunResult = lastRunResult;
   }


### PR DESCRIPTION
- Problem: On Windows, openclaw gateway status shows Runtime: unknown even when gateway is running (RPC probe: ok).
- Root cause: parseSchtasksQuery expects last run result, but some Windows locales output Last Result (no Run).
- What changed: Accept both keys when parsing schtasks output.
- What did NOT change: Linux/macOS behavior; only Windows schtasks parsing.

## Change Type
- [x] Bug fix

## Scope
- [x] Daemon / Windows service

## Linked Issue/PR
- Closes #47726

## User-visible / Behavior Changes
On Windows: openclaw gateway status now correctly derives runtime status when schtasks outputs Last Result instead of Last Run Result.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
- pnpm test src/daemon/schtasks.test.ts - all pass.
- See docs/pr-47726-schtasks-last-result.md for full details.