### PR TITLE
fix: report scope-limited gateway probes as reachable

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -28,6 +28,7 @@ import { checkUpdateStatus, formatGitInstallLabel } from "../infra/update-check.
 import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { VERSION } from "../version.js";
+import { isScopeLimitedProbeFailure } from "./gateway-status/helpers.ts";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
 import { getAgentLocalStatuses } from "./status-all/agents.js";
 import { buildChannelsTable } from "./status-all/channels.js";
@@ -253,9 +254,11 @@ export async function statusAllCommand(
     const gatewayTarget = remoteUrlMissing ? `fallback ${connection.url}` : connection.url;
     const gatewayStatus = gatewayReachable
       ? `reachable ${formatDurationPrecise(gatewayProbe?.connectLatencyMs ?? 0)}`
-      : gatewayProbe?.error
-        ? `unreachable (${gatewayProbe.error})`
-        : "unreachable";
+      : gatewayProbe && isScopeLimitedProbeFailure(gatewayProbe)
+        ? "reachable (diagnostics limited)"
+        : gatewayProbe?.error
+          ? `unreachable (${gatewayProbe.error})`
+          : "unreachable";
     const gatewayAuth = gatewayReachable ? ` · auth ${formatGatewayAuthUsed(probeAuth)}` : "";
     const gatewaySelfLine =
       gatewaySelf?.host || gatewaySelf?.ip || gatewaySelf?.version || gatewaySelf?.platform

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -17,6 +17,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
+import { isScopeLimitedProbeFailure } from "./gateway-status/helpers.ts";
 import { formatHealthChannelLines, type HealthSummary } from "./health.js";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
 import { statusAllCommand } from "./status-all.js";
@@ -270,7 +271,9 @@ export async function statusCommand(
       ? warn("misconfigured (remote.url missing)")
       : gatewayReachable
         ? ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)
-        : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
+        : gatewayProbe && isScopeLimitedProbeFailure(gatewayProbe)
+          ? warn("reachable (diagnostics limited)")
+          : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
     const auth =
       gatewayReachable && !remoteUrlMissing
         ? ` · auth ${formatGatewayAuthUsed(gatewayProbeAuth)}`

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -493,6 +493,23 @@ describe("statusCommand", () => {
     });
   });
 
+  it("treats missing operator.read as reachable with limited diagnostics", async () => {
+    mockProbeGatewayResult({
+      ok: false,
+      connectLatencyMs: 51,
+      error: "missing scope: operator.read",
+      health: null,
+      status: null,
+      presence: null,
+    });
+
+    const logs = await runStatusAndGetLogs();
+    expect(logs.some((line) => line.includes("reachable (diagnostics limited)"))).toBe(true);
+    expect(logs.some((line) => line.includes("unreachable (missing scope: operator.read)"))).toBe(
+      false,
+    );
+  });
+
   it("warns instead of crashing when gateway auth SecretRef is unresolved for probe auth", async () => {
     mocks.loadConfig.mockReturnValue({
       session: {},


### PR DESCRIPTION
## Summary

Treat gateway probes that connect successfully but lack `operator.read` as reachable-with-limited-diagnostics in the human-readable status output.

## Changes

- reuse the existing scope-limited probe detection in `status.command.ts`
- align `status-all.ts` with the same wording so it no longer says `unreachable`
- add a regression test covering the missing-scope path in `status.test.ts`

## Testing

- `pnpm exec vitest run src/commands/status.test.ts src/commands/gateway-status.test.ts src/commands/gateway-status/helpers.test.ts`

Fixes openclaw/openclaw#45908