### PR TITLE
Telegram: handle unresolved SecretRefs gracefully in token resolution

### DIFF
--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -188,7 +188,7 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("none");
   });
 
-  it("throws when botToken is an unresolved SecretRef object", () => {
+  it("returns empty token with config source when botToken is an unresolved SecretRef object", () => {
     const cfg = {
       channels: {
         telegram: {
@@ -197,9 +197,31 @@ describe("resolveTelegramToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
-      /channels\.telegram\.botToken: unresolved SecretRef/i,
-    );
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("");
+    expect(res.source).toBe("config");
+  });
+
+  it("returns empty token with config source when account botToken is an unresolved file SecretRef", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              botToken: {
+                source: "file",
+                provider: "filemain",
+                id: "/channels/telegram/accounts/default/botToken",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg, { accountId: "default" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("config");
   });
 });
 

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -1,6 +1,9 @@
 import type { BaseTokenResolution } from "../../../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
-import { normalizeResolvedSecretInputString } from "../../../src/config/types.secrets.js";
+import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+} from "../../../src/config/types.secrets.js";
 import type { TelegramAccountConfig } from "../../../src/config/types.telegram.js";
 import { tryReadSecretFileSync } from "../../../src/infra/secret-file.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../src/routing/session-key.js";
@@ -60,12 +63,12 @@ export function resolveTelegramToken(
     return { token: "", source: "none" };
   }
 
-  const accountToken = normalizeResolvedSecretInputString({
-    value: accountCfg?.botToken,
-    path: `channels.telegram.accounts.${accountId}.botToken`,
-  });
+  const accountToken = normalizeSecretInputString(accountCfg?.botToken);
   if (accountToken) {
     return { token: accountToken, source: "config" };
+  }
+  if (hasConfiguredSecretInput(accountCfg?.botToken, cfg?.secrets?.defaults)) {
+    return { token: "", source: "config" };
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
@@ -81,12 +84,12 @@ export function resolveTelegramToken(
     return { token: "", source: "none" };
   }
 
-  const configToken = normalizeResolvedSecretInputString({
-    value: telegramCfg?.botToken,
-    path: "channels.telegram.botToken",
-  });
+  const configToken = normalizeSecretInputString(telegramCfg?.botToken);
   if (configToken) {
     return { token: configToken, source: "config" };
+  }
+  if (hasConfiguredSecretInput(telegramCfg?.botToken, cfg?.secrets?.defaults)) {
+    return { token: "", source: "config" };
   }
 
   const envToken = allowEnv ? (opts.envToken ?? process.env.TELEGRAM_BOT_TOKEN)?.trim() : "";


### PR DESCRIPTION
## Summary

- `resolveTelegramToken` threw on unresolved SecretRef objects (e.g. file-based providers), causing `openclaw doctor --fix` to fail even though the gateway runtime resolved the same ref correctly.
- Replaced `normalizeResolvedSecretInputString` (throws on unresolved refs) with `normalizeSecretInputString` + `hasConfiguredSecretInput` (returns configured-unavailable result), matching the existing pattern in `account-inspect.ts`.

Fixes #47686

## Test plan

- [x] `extensions/telegram/src/token.test.ts` — 14/14 passed (updated existing throw test, added file SecretRef test)
- [x] `extensions/telegram/src/accounts.test.ts` — 23/23 passed
- [x] `src/commands/doctor-config-flow.test.ts` — 24/24 passed
- [x] `pnpm build` passes
- [x] `pnpm format:check` passes
- [ ] Manual: configure Telegram botToken as a file SecretRef, run `openclaw doctor --fix`, verify no throw

- [x] AI-assisted (Claude)
- [x] Fully tested locally