### PR TITLE
feat(plugins): add trust tier classification for plugin security model

### DIFF
--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -252,6 +252,9 @@ This makes bundle support safer by default than native plugin modules, but you
 should still treat third-party bundles as trusted content for the features they
 do expose.
 
+All bundle plugins are classified as **content** trust tier. See
+[Plugin trust tiers](/plugins/trust-tiers) for the full trust model.
+
 ## Install examples
 
 ```bash

--- a/docs/plugins/trust-tiers.md
+++ b/docs/plugins/trust-tiers.md
@@ -1,0 +1,102 @@
+---
+summary: "Plugin trust tier classification — content, sandboxed, and native security boundaries"
+read_when:
+  - You want to understand the security model for plugins
+  - You are building a plugin and need to know what capabilities each tier grants
+  - You are evaluating whether a third-party plugin is safe to install
+title: "Plugin Trust Tiers"
+---
+
+# Plugin trust tiers
+
+OpenClaw classifies every plugin into one of three **trust tiers**. The tier
+determines the maximum set of capabilities a plugin can access at runtime.
+
+## Tier definitions
+
+| Tier | Format | Runtime access | Example |
+|------|--------|---------------|---------|
+| **content** | `bundle` (Codex, Claude, Cursor) | Metadata, skills, commands, hook-packs. No in-process code execution. | Community prompt packs, skill bundles |
+| **sandboxed** | _(reserved)_ | Future — ACP/subprocess-isolated tool execution with explicit capability grants. | _(not yet available)_ |
+| **native** | `openclaw` | Full `api.runtime` access: tools, hooks, providers, HTTP routes, services, channels. | First-party and community TypeScript plugins |
+
+## How tiers are assigned
+
+Trust tier is resolved automatically when a plugin is loaded, based on its
+`format` field in the manifest:
+
+| `format` | Tier |
+|----------|------|
+| `"bundle"` | `content` |
+| `"openclaw"` | `native` |
+| _(undefined)_ | `content` (safe fallback) |
+
+The resolution logic lives in `src/plugins/trust.ts` (`resolveTrustTier()`).
+The `bundleFormat` (codex/claude/cursor) and `origin` (bundled/global/workspace/config)
+parameters are accepted for forward compatibility but do not currently affect
+tier assignment.
+
+## Current capabilities by tier
+
+### Content tier
+
+- Skill definitions (prompt templates, workflows)
+- Command definitions
+- Hook-packs (declarative hook configurations)
+- Settings files
+- All paths boundary-checked to stay inside the plugin root
+
+Content-tier plugins **cannot**:
+
+- Execute arbitrary TypeScript/JavaScript in-process
+- Register tools, providers, or HTTP routes
+- Access `api.runtime`
+
+### Native tier
+
+Native plugins have full access to the OpenClaw plugin API:
+
+- `registerTool` — agent tools with schemas
+- `registerHook` — lifecycle hooks (26 hook points)
+- `registerProvider` — LLM provider backends
+- `registerHttpRoute` — HTTP endpoints
+- `registerChannel` — messaging channels
+- `registerService` — background services
+- `registerCommand` — CLI commands
+- `registerContextEngine` — context engines
+
+### Sandboxed tier (reserved)
+
+The sandboxed tier is reserved for future use. It will enable plugins to
+execute tools in an isolated subprocess with explicit capability grants,
+using the Agent Communication Protocol (ACP). This tier bridges the gap
+between content-only bundles and full native access.
+
+## CLI output
+
+Trust tier appears in both `plugins list --verbose` and `plugins info`:
+
+```
+$ openclaw plugins list --verbose
+my-bundle (loaded)
+  format: bundle
+  source: ~/.openclaw/extensions/my-bundle
+  origin: global
+  trust: content
+
+$ openclaw plugins info my-native-plugin
+Trust tier: native
+```
+
+## Security rationale
+
+The tier system follows the principle of **least privilege**:
+
+- Bundle content is safe by default — no code execution, boundary-checked paths
+- Native plugins are explicitly trusted — they run in-process with full API access
+- The safe fallback for unknown formats is `content`, not `native`
+- The reserved `sandboxed` tier will allow expanding bundle capabilities
+  without granting full native access
+
+This classification makes the implicit trust boundary between bundles and
+native plugins explicit in the type system, CLI output, and documentation.

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -108,6 +108,7 @@ function formatPluginLine(plugin: PluginRecord, verbose = false): string {
     `  format: ${format}`,
     `  source: ${theme.muted(shortenHomeInString(plugin.source))}`,
     `  origin: ${plugin.origin}`,
+    `  trust: ${plugin.trustTier}`,
   ];
   if (plugin.bundleFormat) {
     parts.push(`  bundle format: ${plugin.bundleFormat}`);
@@ -512,6 +513,7 @@ export function registerPluginsCli(program: Command) {
       }
       lines.push(`${theme.muted("Source:")} ${shortenHomeInString(plugin.source)}`);
       lines.push(`${theme.muted("Origin:")} ${plugin.origin}`);
+      lines.push(`${theme.muted("Trust tier:")} ${plugin.trustTier}`);
       if (plugin.version) {
         lines.push(`${theme.muted("Version:")} ${plugin.version}`);
       }

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -329,6 +329,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       name: "loaded",
       source: "/tmp/loaded.cjs",
       origin: "bundled",
+      trustTier: "native",
       enabled: true,
       status: "loaded",
       toolNames: [],

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -28,6 +28,7 @@ import { setActivePluginRegistry } from "./runtime.js";
 import { createPluginRuntime, type CreatePluginRuntimeOptions } from "./runtime/index.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
+import { resolveTrustTier } from "./trust.js";
 import type {
   OpenClawPluginDefinition,
   OpenClawPluginModule,
@@ -35,6 +36,7 @@ import type {
   PluginBundleFormat,
   PluginFormat,
   PluginLogger,
+  PluginTrustTier,
 } from "./types.js";
 
 export type PluginLoadResult = PluginRegistry;
@@ -337,6 +339,7 @@ function createPluginRecord(params: {
   source: string;
   rootDir?: string;
   origin: PluginRecord["origin"];
+  trustTier: PluginTrustTier;
   workspaceDir?: string;
   enabled: boolean;
   configSchema: boolean;
@@ -352,6 +355,7 @@ function createPluginRecord(params: {
     source: params.source,
     rootDir: params.rootDir,
     origin: params.origin,
+    trustTier: params.trustTier,
     workspaceDir: params.workspaceDir,
     enabled: params.enabled,
     status: params.enabled ? "loaded" : "disabled",
@@ -842,6 +846,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         source: candidate.source,
         rootDir: candidate.rootDir,
         origin: candidate.origin,
+        trustTier: resolveTrustTier({
+          format: manifestRecord.format,
+          bundleFormat: manifestRecord.bundleFormat,
+          origin: candidate.origin,
+        }),
         workspaceDir: candidate.workspaceDir,
         enabled: false,
         configSchema: Boolean(manifestRecord.configSchema),
@@ -870,6 +879,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       source: candidate.source,
       rootDir: candidate.rootDir,
       origin: candidate.origin,
+      trustTier: resolveTrustTier({
+        format: manifestRecord.format,
+        bundleFormat: manifestRecord.bundleFormat,
+        origin: candidate.origin,
+      }),
       workspaceDir: candidate.workspaceDir,
       enabled: enableState.enabled,
       configSchema: Boolean(manifestRecord.configSchema),

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -42,6 +42,7 @@ import type {
   PluginFormat,
   PluginLogger,
   PluginOrigin,
+  PluginTrustTier,
   PluginKind,
   PluginRegistrationMode,
   PluginHookName,
@@ -148,6 +149,7 @@ export type PluginRecord = {
   source: string;
   rootDir?: string;
   origin: PluginOrigin;
+  trustTier: PluginTrustTier;
   workspaceDir?: string;
   enabled: boolean;
   status: "loaded" | "disabled" | "error";

--- a/src/plugins/trust.test.ts
+++ b/src/plugins/trust.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrustTier } from "./trust.js";
+import type { PluginBundleFormat, PluginOrigin } from "./types.js";
+
+const ALL_ORIGINS: PluginOrigin[] = ["bundled", "global", "workspace", "config"];
+const BUNDLE_FORMATS: PluginBundleFormat[] = ["codex", "claude", "cursor"];
+
+describe("resolveTrustTier", () => {
+  describe("bundle format plugins", () => {
+    for (const origin of ALL_ORIGINS) {
+      it(`returns "content" for bundle format with origin "${origin}"`, () => {
+        expect(resolveTrustTier({ format: "bundle", origin })).toBe("content");
+      });
+    }
+
+    for (const bundleFormat of BUNDLE_FORMATS) {
+      it(`returns "content" for bundleFormat "${bundleFormat}"`, () => {
+        expect(
+          resolveTrustTier({ format: "bundle", bundleFormat, origin: "global" }),
+        ).toBe("content");
+      });
+    }
+
+    it('returns "content" for bundle without bundleFormat', () => {
+      expect(resolveTrustTier({ format: "bundle", origin: "workspace" })).toBe(
+        "content",
+      );
+    });
+  });
+
+  describe("openclaw format plugins", () => {
+    for (const origin of ALL_ORIGINS) {
+      it(`returns "native" for openclaw format with origin "${origin}"`, () => {
+        expect(resolveTrustTier({ format: "openclaw", origin })).toBe("native");
+      });
+    }
+  });
+
+  describe("undefined format (safe fallback)", () => {
+    it('returns "content" when format is undefined', () => {
+      expect(resolveTrustTier({ origin: "global" })).toBe("content");
+    });
+
+    for (const origin of ALL_ORIGINS) {
+      it(`returns "content" for undefined format with origin "${origin}"`, () => {
+        expect(resolveTrustTier({ format: undefined, origin })).toBe("content");
+      });
+    }
+  });
+});

--- a/src/plugins/trust.ts
+++ b/src/plugins/trust.ts
@@ -1,0 +1,23 @@
+import type { PluginBundleFormat, PluginFormat, PluginOrigin, PluginTrustTier } from "./types.js";
+
+/**
+ * Resolves the trust tier for a plugin based on its format and origin.
+ *
+ * `bundleFormat` and `origin` are accepted but unused today — forward-compatible
+ * for when the sandboxed tier lands and certain origins/subformats need
+ * different treatment.
+ */
+export function resolveTrustTier(params: {
+  format?: PluginFormat;
+  bundleFormat?: PluginBundleFormat;
+  origin: PluginOrigin;
+}): PluginTrustTier {
+  if (params.format === "bundle") {
+    return "content";
+  }
+  if (params.format === "openclaw") {
+    return "native";
+  }
+  // Safe fallback for unknown or undefined formats
+  return "content";
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1013,6 +1013,16 @@ export type PluginFormat = "openclaw" | "bundle";
 
 export type PluginBundleFormat = "codex" | "claude" | "cursor";
 
+/**
+ * Trust boundary classification for plugins.
+ *
+ * - "content": Bundle plugins (Claude, Codex, Cursor). Safe metadata/skill/command packs.
+ *   No runtime code execution.
+ * - "sandboxed": Reserved — future tier for ACP/subprocess-isolated tool execution.
+ * - "native": TypeScript plugins with full api.runtime access. Existing in-process model.
+ */
+export type PluginTrustTier = "content" | "sandboxed" | "native";
+
 export type PluginDiagnostic = {
   level: "warn" | "error";
   message: string;


### PR DESCRIPTION
## Summary

- Formalizes the implicit native vs bundle trust boundary into explicit **trust tiers** (`content` | `sandboxed` | `native`)
- Adds `PluginTrustTier` type, `resolveTrustTier()` pure function, and wires it into the plugin loader
- Surfaces trust tier in `plugins list --verbose` and `plugins info` CLI output
- Reserves `sandboxed` tier for future ACP-backed tool execution
- No behavior change — pure metadata addition + documentation

## Motivation

Today OpenClaw has an implicit trust boundary: native plugins get full in-process `api.runtime` access, bundles get content-only access. This PR makes that boundary explicit in the type system, CLI output, and documentation — creating the foundation for safely expanding bundle capabilities (especially the future sandboxed tier).

## Changes

| File | What |
|------|------|
| `src/plugins/types.ts` | `PluginTrustTier` type union |
| `src/plugins/trust.ts` | `resolveTrustTier()` — format → tier mapping |
| `src/plugins/registry.ts` | `trustTier` field on `PluginRecord` |
| `src/plugins/loader.ts` | Wire `resolveTrustTier()` at both `createPluginRecord` call sites |
| `src/cli/plugins-cli.ts` | Show trust tier in `plugins info` + verbose list |
| `src/plugins/trust.test.ts` | 17 unit tests — all format × origin combos |
| `docs/plugins/trust-tiers.md` | Design doc with tier definitions, assignment rules, security rationale |
| `docs/plugins/bundles.md` | Cross-reference to trust tiers doc |
| `src/commands/onboarding/plugin-install.test.ts` | Add required `trustTier` to mock record |

## Test plan

- [x] `tsc --noEmit` passes (non-optional `trustTier` caught everywhere)
- [x] 17/17 new unit tests pass (all format × origin × bundleFormat combos)
- [x] Existing test suite unaffected (no regressions)
- [ ] Manual: `openclaw plugins list --verbose` shows trust tier
- [ ] Manual: `openclaw plugins info <bundle-id>` shows "Trust tier: content"
- [ ] Manual: `openclaw plugins info <native-id>` shows "Trust tier: native"

[AI-assisted]

🤖 Generated with [Claude Code](https://claude.com/claude-code)