### PR TITLE
WhatsApp: quote [[reply_to_current]] replies

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -143,7 +143,39 @@ describe("deliverWebReply", () => {
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (text)");
   });
 
-  it("quotes the current inbound message when replyToId matches msg.id", async () => {
+  it("quotes the current inbound message when replyToCurrent is set", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: { text: "hi", replyToCurrent: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", true);
+  });
+
+  it("quotes explicit reply tags only when they target the current inbound message", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: { text: "hi", replyToId: "msg-1", replyToTag: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", true);
+  });
+
+  it("does not quote implicit reply threading without an explicit reply directive", async () => {
     const msg = makeMsg();
 
     await deliverWebReply({
@@ -156,14 +188,14 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.reply).toHaveBeenCalledTimes(1);
-    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", true);
+    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", false);
   });
 
   it("does not try to quote older explicit reply ids", async () => {
     const msg = makeMsg();
 
     await deliverWebReply({
-      replyResult: { text: "hi", replyToId: "older-msg-123" },
+      replyResult: { text: "hi", replyToId: "older-msg-123", replyToTag: true },
       msg,
       maxMediaBytes: 1024 * 1024,
       textLimit: 200,
@@ -234,7 +266,11 @@ describe("deliverWebReply", () => {
     mockLoadedImageMedia();
 
     await deliverWebReply({
-      replyResult: { text: "cap", mediaUrl: "http://example.com/img.jpg", replyToId: "msg-1" },
+      replyResult: {
+        text: "cap",
+        mediaUrl: "http://example.com/img.jpg",
+        replyToCurrent: true,
+      },
       msg,
       maxMediaBytes: 1024 * 1024,
       textLimit: 200,

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -36,6 +36,18 @@ function makeMsg(): WebInboundMsg {
   } as unknown as WebInboundMsg;
 }
 
+function expectReplyCalledWithQuoteCurrent(
+  msg: WebInboundMsg,
+  callIndex: number,
+  text: string,
+  quoteCurrent: boolean,
+) {
+  expect((msg.reply as unknown as { mock: { calls: unknown[][] } }).mock.calls[callIndex]).toEqual([
+    text,
+    { quoteCurrent },
+  ]);
+}
+
 function mockLoadedImageMedia() {
   (
     loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
@@ -105,8 +117,11 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.reply).toHaveBeenCalledTimes(1);
-    expect(msg.reply).toHaveBeenCalledWith(
+    expectReplyCalledWithQuoteCurrent(
+      msg,
+      0,
       "Intro line\nReasoning: appears in content but is not a prefix",
+      false,
     );
   });
 
@@ -123,9 +138,41 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.reply).toHaveBeenCalledTimes(2);
-    expect(msg.reply).toHaveBeenNthCalledWith(1, "aaa");
-    expect(msg.reply).toHaveBeenNthCalledWith(2, "aaa");
+    expectReplyCalledWithQuoteCurrent(msg, 0, "aaa", false);
+    expectReplyCalledWithQuoteCurrent(msg, 1, "aaa", false);
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (text)");
+  });
+
+  it("quotes the current inbound message when replyToId matches msg.id", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: { text: "hi", replyToId: "msg-1" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", true);
+  });
+
+  it("does not try to quote older explicit reply ids", async () => {
+    const msg = makeMsg();
+
+    await deliverWebReply({
+      replyResult: { text: "hi", replyToId: "older-msg-123" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    expectReplyCalledWithQuoteCurrent(msg, 0, "hi", false);
   });
 
   it.each(["connection closed", "operation timed out"])(
@@ -175,10 +222,34 @@ describe("deliverWebReply", () => {
         caption: "aaa",
         mimetype: "image/jpeg",
       }),
+      { quoteCurrent: false },
     );
-    expect(msg.reply).toHaveBeenCalledWith("aaa");
+    expectReplyCalledWithQuoteCurrent(msg, 0, "aaa", false);
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (media)");
     expect(logVerbose).toHaveBeenCalled();
+  });
+
+  it("quotes media sends when replying to the current inbound message", async () => {
+    const msg = makeMsg();
+    mockLoadedImageMedia();
+
+    await deliverWebReply({
+      replyResult: { text: "cap", mediaUrl: "http://example.com/img.jpg", replyToId: "msg-1" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: expect.any(Buffer),
+        caption: "cap",
+        mimetype: "image/jpeg",
+      }),
+      { quoteCurrent: true },
+    );
   });
 
   it("retries media send on transient failure", async () => {
@@ -252,6 +323,7 @@ describe("deliverWebReply", () => {
         mimetype: "audio/ogg",
         caption: "cap",
       }),
+      { quoteCurrent: false },
     );
   });
 
@@ -280,6 +352,7 @@ describe("deliverWebReply", () => {
         caption: "cap",
         mimetype: "video/mp4",
       }),
+      { quoteCurrent: false },
     );
   });
 
@@ -310,6 +383,7 @@ describe("deliverWebReply", () => {
         caption: "cap",
         mimetype: "application/octet-stream",
       }),
+      { quoteCurrent: false },
     );
   });
 });

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -42,9 +42,13 @@ export async function deliverWebReply(params: {
 }) {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
   const replyStarted = Date.now();
-  // WhatsApp quoting needs the raw inbound message object, so only the current inbound
-  // message can be quoted here. Older explicit reply ids would need a lookup/cache layer.
-  const quoteCurrent = Boolean(replyResult.replyToId && msg.id && replyResult.replyToId === msg.id);
+  // WhatsApp quoting needs the raw inbound message object. Restrict this to explicit
+  // reply directives that target the current inbound message; older explicit reply ids
+  // would still need a lookup/cache layer to recover the original Baileys message.
+  const quoteCurrent = Boolean(
+    replyResult.replyToCurrent ||
+    (replyResult.replyToTag && replyResult.replyToId && msg.id && replyResult.replyToId === msg.id),
+  );
   if (shouldSuppressReasoningReply(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
     return;

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -42,6 +42,9 @@ export async function deliverWebReply(params: {
 }) {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
   const replyStarted = Date.now();
+  // WhatsApp quoting needs the raw inbound message object, so only the current inbound
+  // message can be quoted here. Older explicit reply ids would need a lookup/cache layer.
+  const quoteCurrent = Boolean(replyResult.replyToId && msg.id && replyResult.replyToId === msg.id);
   if (shouldSuppressReasoningReply(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
     return;
@@ -86,7 +89,7 @@ export async function deliverWebReply(params: {
     const totalChunks = textChunks.length;
     for (const [index, chunk] of textChunks.entries()) {
       const chunkStarted = Date.now();
-      await sendWithRetry(() => msg.reply(chunk), "text");
+      await sendWithRetry(() => msg.reply(chunk, { quoteCurrent }), "text");
       if (!skipLog) {
         const durationMs = Date.now() - chunkStarted;
         whatsappOutboundLog.debug(
@@ -130,32 +133,41 @@ export async function deliverWebReply(params: {
       if (media.kind === "image") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
-              image: media.buffer,
-              caption,
-              mimetype: media.contentType,
-            }),
+            msg.sendMedia(
+              {
+                image: media.buffer,
+                caption,
+                mimetype: media.contentType,
+              },
+              { quoteCurrent },
+            ),
           "media:image",
         );
       } else if (media.kind === "audio") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
-              audio: media.buffer,
-              ptt: true,
-              mimetype: media.contentType,
-              caption,
-            }),
+            msg.sendMedia(
+              {
+                audio: media.buffer,
+                ptt: true,
+                mimetype: media.contentType,
+                caption,
+              },
+              { quoteCurrent },
+            ),
           "media:audio",
         );
       } else if (media.kind === "video") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
-              video: media.buffer,
-              caption,
-              mimetype: media.contentType,
-            }),
+            msg.sendMedia(
+              {
+                video: media.buffer,
+                caption,
+                mimetype: media.contentType,
+              },
+              { quoteCurrent },
+            ),
           "media:video",
         );
       } else {
@@ -163,12 +175,15 @@ export async function deliverWebReply(params: {
         const mimetype = media.contentType ?? "application/octet-stream";
         await sendWithRetry(
           () =>
-            msg.sendMedia({
-              document: media.buffer,
-              fileName,
-              caption,
-              mimetype,
-            }),
+            msg.sendMedia(
+              {
+                document: media.buffer,
+                fileName,
+                caption,
+                mimetype,
+              },
+              { quoteCurrent },
+            ),
           "media:document",
         );
       }
@@ -199,7 +214,7 @@ export async function deliverWebReply(params: {
         const fallbackText = fallbackTextParts.join("\n");
         if (fallbackText) {
           whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
-          await msg.reply(fallbackText);
+          await msg.reply(fallbackText, { quoteCurrent });
         }
       }
     }
@@ -207,6 +222,6 @@ export async function deliverWebReply(params: {
 
   // Remaining text chunks after media
   for (const chunk of remainingText) {
-    await msg.reply(chunk);
+    await msg.reply(chunk, { quoteCurrent });
   }
 }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -327,11 +327,11 @@ export async function monitorWebInbox(options: {
         logVerbose(`Presence update failed: ${String(err)}`);
       }
     };
-    const reply = async (text: string) => {
-      await sock.sendMessage(chatJid, { text });
+    const reply = async (text: string, opts?: { quoteCurrent?: boolean }) => {
+      await sock.sendMessage(chatJid, { text }, opts?.quoteCurrent ? { quoted: msg } : undefined);
     };
-    const sendMedia = async (payload: AnyMessageContent) => {
-      await sock.sendMessage(chatJid, payload);
+    const sendMedia = async (payload: AnyMessageContent, opts?: { quoteCurrent?: boolean }) => {
+      await sock.sendMessage(chatJid, payload, opts?.quoteCurrent ? { quoted: msg } : undefined);
     };
     const timestamp = inbound.messageTimestampMs;
     const mentionedJids = extractMentionedJids(msg.message as proto.IMessage | undefined);

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -34,8 +34,8 @@ export type WebInboundMessage = {
   fromMe?: boolean;
   location?: NormalizedLocation;
   sendComposing: () => Promise<void>;
-  reply: (text: string) => Promise<void>;
-  sendMedia: (payload: AnyMessageContent) => Promise<void>;
+  reply: (text: string, opts?: { quoteCurrent?: boolean }) => Promise<void>;
+  sendMedia: (payload: AnyMessageContent, opts?: { quoteCurrent?: boolean }) => Promise<void>;
   mediaPath?: string;
   mediaType?: string;
   mediaFileName?: string;


### PR DESCRIPTION
## Summary
- quote WhatsApp auto-replies with Baileys `quoted` metadata when the reply target is the current inbound message
- keep the fix intentionally narrow for now: this covers `[[reply_to_current]]` and explicit reply ids only when they resolve to the current inbound message
- do not attempt older `[[reply_to:<id>]]` lookup in this PR; that still needs a message cache/lookup layer to recover the original Baileys message object

## Testing
- [x] `pnpm test -- extensions/whatsapp/src/auto-reply/deliver-reply.test.ts`
- [x] `pnpm build`
- [ ] `pnpm check` currently fails on `origin/main` due to pre-existing `extensions/signal/src/setup-surface.js` export/type errors in `src/channels/plugins/onboarding/signal.test.ts` and `src/channels/plugins/plugins-channel.test.ts`

## Notes
- AI-assisted: yes
- Testing degree: lightly tested
- Fixes #47611

Made with [Cursor](https://cursor.com)