### PR TITLE
fix(memory): use FTS5 snippet() for keyword search instead of truncating chunk text from the beginning

### DIFF
--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -156,9 +156,14 @@ export async function searchKeyword(params: {
   const modelClause = params.providerModel ? " AND model = ?" : "";
   const modelParams = params.providerModel ? [params.providerModel] : [];
 
+  // SQLite FTS5 snippet() accepts at most 64 tokens for the column index.
+  // Clamp nTokens explicitly to avoid silent truncation by SQLite.
+  const snippetTokens = Math.min(64, Math.max(1, Math.floor(params.snippetMaxChars / 4)));
+
   const rows = params.db
     .prepare(
-      `SELECT id, path, source, start_line, end_line, text,\n` +
+      `SELECT id, path, source, start_line, end_line,\n` +
+        `       snippet(${params.ftsTable}, 0, '\u2026', '\u2026', '\u2026', ${snippetTokens}) AS snippet,\n` +
         `       bm25(${params.ftsTable}) AS rank\n` +
         `  FROM ${params.ftsTable}\n` +
         ` WHERE ${params.ftsTable} MATCH ?${modelClause}${params.sourceFilter.sql}\n` +
@@ -171,7 +176,7 @@ export async function searchKeyword(params: {
     source: SearchSource;
     start_line: number;
     end_line: number;
-    text: string;
+    snippet: string;
     rank: number;
   }>;
 
@@ -184,7 +189,7 @@ export async function searchKeyword(params: {
       endLine: row.end_line,
       score: textScore,
       textScore,
-      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
+      snippet: truncateUtf16Safe(row.snippet ?? "", params.snippetMaxChars),
       source: row.source,
     };
   });


### PR DESCRIPTION
## Problem

Keyword search results show the first N characters of the chunk text as the snippet (via ). When a match occurs deep in a chunk (e.g., line 50+ of a large chunk), the snippet only displays the beginning of the chunk — the match is invisible to the user.

Reported in #47730.

## Fix

Use SQLite FTS5's built-in `snippet()` function for keyword search, which extracts the relevant passage around the match with configurable ellipsis markers. This returns context centered on the actual match instead of the first lines of the chunk.

## Changes

- `src/memory/manager-search.ts`: Replace `SELECT ... text` with `SELECT ... snippet(table, 0, '…', '…', '', N) AS snippet` in the FTS query.

## Testing

- Existing tests should pass (the snippet column is just a different source for the same field)
- Manual test: index a file with content on line 50+, search for that content → snippet should show the relevant passage, not lines 1-15