### PR TITLE
fix: make peer ID matching case-insensitive in binding resolution (closes #45296)

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -852,3 +852,49 @@ describe("binding evaluation cache scalability", () => {
     }
   });
 });
+
+describe("peer ID case-insensitive matching", () => {
+  test("matches binding with mixed-case peer ID against lowercased peer ID", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "signal-group-agent",
+          match: {
+            channel: "signal",
+            peer: { kind: "channel", id: "NPy/PPdwLKD996QtL3+0d2JdQgzPY3Ysf9NTY4P7BaE=" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "signal",
+      accountId: "default",
+      peer: { kind: "channel", id: "npy/ppdwlkd996qtl3+0d2jdqgzpy3ysf9nty4p7bae=" },
+    });
+    expect(route.agentId).toBe("signal-group-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("matches binding with lowercased peer ID against mixed-case peer ID", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "signal-group-agent",
+          match: {
+            channel: "signal",
+            peer: { kind: "channel", id: "npy/ppdwlkd996qtl3+0d2jdqgzpy3ysf9nty4p7bae=" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "signal",
+      accountId: "default",
+      peer: { kind: "channel", id: "NPy/PPdwLKD996QtL3+0d2JdQgzPY3Ysf9NTY4P7BaE=" },
+    });
+    expect(route.agentId).toBe("signal-group-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+});

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -332,13 +332,14 @@ function pushToIndexMap(
 }
 
 function peerLookupKeys(kind: ChatType, id: string): string[] {
+  const normalId = id.toLowerCase();
   if (kind === "group") {
-    return [`group:${id}`, `channel:${id}`];
+    return [`group:${normalId}`, `channel:${normalId}`];
   }
   if (kind === "channel") {
-    return [`channel:${id}`, `group:${id}`];
+    return [`channel:${normalId}`, `group:${normalId}`];
   }
-  return [`${kind}:${id}`];
+  return [`${kind}:${normalId}`];
 }
 
 function collectPeerIndexedBindings(
@@ -589,7 +590,7 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
     if (
       !scope.peer ||
       !peerKindMatches(match.peer.kind, scope.peer.kind) ||
-      scope.peer.id !== match.peer.id
+      scope.peer.id.toLowerCase() !== match.peer.id.toLowerCase()
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Problem: Signal group IDs contain mixed-case characters (e.g. base64-encoded), but session keys are lowercased. Peer binding matching in `peerLookupKeys` and `matchesBindingScope` compares IDs without normalizing case, so bindings never match the lowercased session key peer IDs.
- Why it matters: Signal group bindings silently fail — messages route to the default agent instead of the configured one, with no error.
- What changed: Added `.toLowerCase()` normalization in `peerLookupKeys()` for index key generation and in `matchesBindingScope()` for direct peer ID comparison.
- What did NOT change (scope boundary): Session key generation, `normalizeId()`, or any other routing logic.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #45296

## User-visible / Behavior Changes
Signal group bindings with mixed-case IDs now correctly match incoming messages, routing to the configured agent instead of falling through to the default.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure a Signal group binding with a mixed-case group ID like `NPy/PPdwLKD996QtL3+0d2JdQgzPY3Ysf9NTY4P7BaE=`
2. Send a message to the group
### Expected
- Message routes to the configured agent
### Actual (before fix)
- Message routes to the default agent because the lowercased session peer ID doesn't match the mixed-case binding ID

## Evidence
- [x] Failing test/log before + passing after
- Added 2 tests verifying case-insensitive matching in both directions (mixed→lower and lower→mixed)
- All 43 tests pass (41 existing + 2 new)

## Human Verification
- Verified scenarios: pnpm tsgo + vitest run resolve-route.test.ts all passing; reviewed diff matches issue description
- Edge cases checked: group/channel kind aliasing still works with lowercase IDs; existing tests unchanged
- What you did NOT verify: runtime end-to-end testing with actual Signal service

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None
