### PR TITLE
fix: treat empty allowBundled array as block-all instead of allow-all (closes #21709)

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -44,7 +44,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
     return undefined;
   }
   const normalized = normalizeStringEntries(input);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -58,7 +58,7 @@ export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | und
 }
 
 export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+  if (!allowlist) {
     return true;
   }
   if (!isBundledSkill(entry)) {


### PR DESCRIPTION
## Summary
- Problem: Setting `skills.allowBundled: []` in config should block all bundled skills, but instead allows all of them. `normalizeAllowlist()` converts empty arrays to `undefined`, and `isBundledSkillAllowed()` treats both `undefined` and empty arrays as "no filter".
- Why it matters: Security-sensitive deployments cannot restrict bundled skills via the documented config option.
- What changed: (1) `normalizeAllowlist()` now returns `[]` for empty input arrays instead of `undefined`. (2) `isBundledSkillAllowed()` only treats `undefined` as "no filter" — an empty array now correctly blocks all bundled skills.
- What did NOT change (scope boundary): Non-bundled skills are unaffected. A populated allowlist works the same as before.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #21709

## User-visible / Behavior Changes
`skills.allowBundled: []` now correctly blocks all bundled skills instead of allowing all.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No (fixes existing security config to work as documented)

## Repro + Verification
### Steps
1. Set `skills.allowBundled: []` in openclaw.json
2. Run `openclaw skills list --eligible`
### Expected
- No bundled skills shown as ready
### Actual
- Before fix: All bundled skills shown as ready

## Evidence
- [x] Failing test/log before + passing after
- pnpm tsgo passes with no new errors
- filter tests pass

## Human Verification
- Verified scenarios: pnpm tsgo + filter tests pass; `undefined` still means allow-all, `[]` now means block-all
- Edge cases checked: Non-bundled skills unaffected; populated allowlist behavior unchanged
- What you did NOT verify: runtime end-to-end testing with actual skills list

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (fixes config to match documented behavior)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None