### PR TITLE
fix: handle flat number usage.cost from OpenRouter (closes #30204)

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -110,6 +110,35 @@ describe("session cost usage", () => {
     });
   });
 
+  it("handles flat number cost from OpenRouter", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-flat-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-flat.jsonl");
+
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openrouter",
+        model: "meta-llama/llama-3.3-70b-instruct",
+        usage: { input: 100, output: 50, totalTokens: 150, cost: 0.0042 },
+      },
+    };
+
+    await fs.writeFile(sessionFile, JSON.stringify(entry) + "\n", "utf-8");
+
+    const summary = await loadSessionCostUsage({
+      dataDir: root,
+      agentId: "main",
+      days: 7,
+    });
+
+    expect(summary.totals.totalCost).toBeCloseTo(0.0042, 6);
+    expect(summary.totals.totalTokens).toBe(150);
+  });
+
   it("summarizes a single session file", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-"));
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -82,11 +82,27 @@ const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | unde
     return undefined;
   }
   const record = usageRaw as Record<string, unknown>;
-  const cost = record.cost as Record<string, unknown> | undefined;
-  if (!cost) {
+  const costRaw = record.cost;
+  if (costRaw == null) {
     return undefined;
   }
 
+  // OpenRouter returns usage.cost as a flat number instead of an object.
+  if (typeof costRaw === "number") {
+    const total = toFiniteNumber(costRaw);
+    if (total === undefined || total < 0) {
+      return undefined;
+    }
+    return {
+      total,
+      input: undefined,
+      output: undefined,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    };
+  }
+
+  const cost = costRaw as Record<string, unknown>;
   const total = toFiniteNumber(cost.total);
   if (total === undefined || total < 0) {
     return undefined;


### PR DESCRIPTION
## Summary
- Problem: `extractCostBreakdown()` expects `usage.cost` to be an object `{total, input, output}`, but OpenRouter returns `usage.cost` as a flat number (e.g. `0.0045`). When `cost` is a number, `cost.total` is `undefined`, so cost is logged as $0.
- Why it matters: Cost tracking silently fails for all OpenRouter requests.
- What changed: Added a `typeof costRaw === "number"` check in `extractCostBreakdown()` to handle flat number costs, returning a `CostBreakdown` with the number as `total`.
- What did NOT change (scope boundary): Object-shaped cost handling remains unchanged; no other cost extraction paths were modified.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #30204

## User-visible / Behavior Changes
OpenRouter cost data is now correctly tracked and displayed instead of showing $0.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Use OpenRouter as provider
2. Send messages through the gateway
3. Check cost tracking in session usage
### Expected
- Cost shows actual value (e.g. $0.0045)
### Actual (before fix)
- Cost shows $0 for all OpenRouter requests

## Evidence
- [x] Failing test/log before + passing after
- `session-cost-usage.test.ts` — 9 tests pass
- `pnpm tsgo` passes (only pre-existing ui errors)
- `oxlint` passes on changed file

## Human Verification
- Verified scenarios: pnpm tsgo passes; reviewed diff matches issue description
- Edge cases checked: null/undefined cost still returns undefined; negative number cost still rejected; object cost unchanged
- What you did NOT verify: runtime end-to-end testing with actual OpenRouter API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None