### PR TITLE
fix: reduce API key exposure in maskApiKey to 4 chars max (closes #34452)

### DIFF
--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -7,14 +7,16 @@ describe("maskApiKey", () => {
     expect(maskApiKey("   ")).toBe("missing");
   });
 
-  it("masks short and medium values without returning raw secrets", () => {
-    expect(maskApiKey(" abcdefghijklmnop ")).toBe("ab...op");
-    expect(maskApiKey(" short ")).toBe("s...t");
-    expect(maskApiKey(" a ")).toBe("a...a");
-    expect(maskApiKey(" ab ")).toBe("a...b");
+  it("masks short keys without revealing any characters", () => {
+    expect(maskApiKey(" short ")).toBe("****");
+    expect(maskApiKey(" a ")).toBe("****");
+    expect(maskApiKey(" ab ")).toBe("****");
+    expect(maskApiKey("12345678")).toBe("****");
   });
 
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop"); // pragma: allowlist secret
+  it("masks longer keys with only first 4 characters", () => {
+    expect(maskApiKey("123456789")).toBe("1234****");
+    expect(maskApiKey(" abcdefghijklmnop ")).toBe("abcd****");
+    expect(maskApiKey("sk-ant-api03-abcdefghijklmnop")).toBe("sk-a****");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -3,11 +3,8 @@ export const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 6) {
-    return `${trimmed.slice(0, 1)}...${trimmed.slice(-1)}`;
+  if (trimmed.length <= 8) {
+    return "****";
   }
-  if (trimmed.length <= 16) {
-    return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 4)}****`;
 };


### PR DESCRIPTION
## Summary
- Problem: `maskApiKey()` exposes up to 16 characters of API keys (first 8 + last 8) in chat messages displayed via `/models list`. This masked value is sent as plaintext in Telegram, Discord, etc.
- Why it matters: For shorter provider keys, the "masked" output can reveal the entire key. Even for longer keys, 16 revealed characters significantly reduces brute-force complexity.
- What changed: `maskApiKey()` now reveals at most 4 prefix characters (`sk-a****`), and fully masks keys ≤ 8 characters as `****`. This is consistent with the approach taken in #24409 for `formatApiKeySnippet()`.
- What did NOT change (scope boundary): The `"missing"` return for empty values is unchanged. No changes to `formatApiKeySnippet()` or other masking utilities.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #34452

## User-visible / Behavior Changes
Masked API key output changes:
- Before: `sk-ant-a...xyz12345` (16 chars exposed)
- After: `sk-a****` (4 chars max)

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — significantly less key material exposed
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run `/models list` in any chat channel
### Expected
- API keys show at most 4 prefix characters + `****`
### Actual (before fix)
- API keys show 8 prefix + 8 suffix characters

## Evidence
- [x] Failing test/log before + passing after
- `npx vitest run src/utils/mask-api-key.test.ts` — 3 tests passed (updated)
- `pnpm tsgo` — no new type errors

## Human Verification
- Verified scenarios: pnpm tsgo + vitest tests all passing; reviewed diff matches issue description
- Edge cases checked: empty/whitespace → "missing"; short keys (≤8) → "****"; longer keys → first 4 + "****"
- What you did NOT verify: runtime end-to-end testing with actual chat channels

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (output format change only, no API contract)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None