### PR TITLE
fix: restore export-html template placeholders to single-line format (closes #43620)

### DIFF
--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,12 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <script>{{JS}}</script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Problem: The `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` placeholders in `template.html` were split across multiple lines by a code formatter, causing `.replace("{{MARKED_JS}}", ...)` calls to silently fail. Exported HTML files then throw `ReferenceError: MARKED_JS is not defined`.
- Why it matters: Session HTML export is completely broken — exported files cannot be opened in a browser.
- What changed: Restored the three script placeholders to single-line `<script>{{PLACEHOLDER}}</script>` format in `template.html`.
- What did NOT change (scope boundary): The replacement logic in `commands-export-session.ts`; no formatter config changes needed since `oxfmt` does not process HTML files.

## Change Type
- [x] Bug fix

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #43620

## User-visible / Behavior Changes
Exported session HTML files now correctly include vendored JavaScript libraries (marked.js, highlight.js) and the main application code, allowing the files to open and render properly in a browser.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Export a session with `/export-session`
2. Open the generated HTML file in a browser
### Expected
- Page renders correctly with syntax-highlighted code blocks
### Actual (before fix)
- Browser console shows `ReferenceError: MARKED_JS is not defined`, `HIGHLIGHT_JS is not defined`, `JS is not defined`

## Evidence
- [x] Failing test/log before + passing after
- `template.security.test.ts` — 5 tests pass
- `pnpm tsgo` passes (only pre-existing ui errors)

## Human Verification
- Verified scenarios: template.security.test.ts passes; replacement strings `{{MARKED_JS}}` etc. now match the patterns used in commands-export-session.ts
- Edge cases checked: `{{CSS}}` and `{{SESSION_DATA}}` were already on single lines (unaffected)
- What you did NOT verify: runtime end-to-end HTML export testing

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None