### PR TITLE
fix: fall back to auto tool_choice instead of disabling thinking for pinned Moonshot tool choice (closes #44896)

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1,73 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
-
-vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
-  const {
-    createOpenRouterSystemCacheWrapper,
-    createOpenRouterWrapper,
-    isProxyReasoningUnsupported,
-  } = await import("./pi-embedded-runner/proxy-stream-wrappers.js");
-
-  return {
-    ...actual,
-    prepareProviderExtraParams: (params: {
-      provider: string;
-      context: { extraParams?: Record<string, unknown> };
-    }) => {
-      if (params.provider !== "openai-codex") {
-        return undefined;
-      }
-      const transport = params.context.extraParams?.transport;
-      if (transport === "auto" || transport === "sse" || transport === "websocket") {
-        return params.context.extraParams;
-      }
-      return {
-        ...params.context.extraParams,
-        transport: "auto",
-      };
-    },
-    wrapProviderStreamFn: (params: {
-      provider: string;
-      context: {
-        modelId: string;
-        thinkingLevel?: import("../auto-reply/thinking.js").ThinkLevel;
-        extraParams?: Record<string, unknown>;
-        streamFn?: StreamFn;
-      };
-    }) => {
-      if (params.provider !== "openrouter") {
-        return params.context.streamFn;
-      }
-
-      const providerRouting =
-        params.context.extraParams?.provider != null &&
-        typeof params.context.extraParams.provider === "object"
-          ? (params.context.extraParams.provider as Record<string, unknown>)
-          : undefined;
-      let streamFn = params.context.streamFn;
-      if (providerRouting) {
-        const underlying = streamFn;
-        streamFn = (model, context, options) =>
-          (underlying as StreamFn)(
-            {
-              ...model,
-              compat: { ...model.compat, openRouterRouting: providerRouting },
-            },
-            context,
-            options,
-          );
-      }
-
-      const skipReasoningInjection =
-        params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
-      const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
-      return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
-    },
-  };
-});
-
 import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
 import { log } from "./pi-embedded-runner/logger.js";
 
@@ -765,7 +698,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
-  it("disables thinking instead of broadening pinned Moonshot tool_choice", () => {
+  it("falls back to auto tool_choice instead of disabling thinking for pinned Moonshot tool_choice", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -788,8 +721,8 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, {});
 
     expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
-    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
+    expect(payloads[0]?.thinking).toEqual({ type: "enabled" });
+    expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
   it("respects explicit Moonshot thinking param from model config", () => {
@@ -878,7 +811,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
-  it("disables thinking instead of broadening pinned Ollama Kimi cloud tool_choice", () => {
+  it("falls back to auto tool_choice instead of disabling thinking for pinned Ollama Kimi cloud tool_choice", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -901,11 +834,8 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, {});
 
     expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
-    expect(payloads[0]?.tool_choice).toEqual({
-      type: "function",
-      function: { name: "read" },
-    });
+    expect(payloads[0]?.thinking).toEqual({ type: "enabled" });
+    expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
   it("does not rewrite tool schema for kimi-coding (native Anthropic format)", () => {

--- a/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
@@ -132,10 +132,11 @@ export function createMoonshotThinkingWrapper(
             effectiveThinkingType === "enabled" &&
             !isMoonshotToolChoiceCompatible(payloadObj.tool_choice)
           ) {
-            if (payloadObj.tool_choice === "required") {
+            if (
+              payloadObj.tool_choice === "required" ||
+              isPinnedToolChoice(payloadObj.tool_choice)
+            ) {
               payloadObj.tool_choice = "auto";
-            } else if (isPinnedToolChoice(payloadObj.tool_choice)) {
-              payloadObj.thinking = { type: "disabled" };
             }
           }
         }


### PR DESCRIPTION
## Summary
- Problem: When `reasoning_effort` is set (e.g., "low") and `tool_choice` is a pinned function, `createMoonshotThinkingWrapper` sets `thinking.type` to `"disabled"`. This creates an invalid combination (`reasoning_effort=low` + `thinking=disabled`) that the API rejects with HTTP 400.
- Why it matters: Models like bailian/glm-5 and kimi-k2.5 fail with 400 errors when using pinned tool calls with reasoning enabled.
- What changed: Instead of disabling thinking when tool_choice is pinned, the code now falls back to `tool_choice: "auto"` (same as the existing `"required"` case). This preserves thinking/reasoning while making tool_choice compatible.
- What did NOT change (scope boundary): The `tool_choice === "required"` path already used auto fallback and is unchanged. thinkingLevel=off still correctly sets thinking to disabled.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #44896

## User-visible / Behavior Changes
Moonshot/Kimi models with reasoning enabled no longer fail with HTTP 400 when tool_choice is a pinned function. Tool choice falls back to "auto" instead.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Use kimi-k2.5 with reasoning_effort=low and a pinned tool_choice
### Expected
- Request succeeds with thinking enabled and tool_choice=auto
### Actual
- Before fix: HTTP 400 "Invalid combination of reasoning_effort and thinking type: low + disabled"

## Evidence
- [x] Failing test/log before + passing after
- All 79 extra-params tests pass with updated expectations
- pnpm tsgo passes with no new errors

## Human Verification
- Verified scenarios: Pinned tool_choice now falls back to auto; required tool_choice behavior unchanged; thinkingLevel=off still disables thinking
- Edge cases checked: Both Moonshot and Ollama Kimi cloud paths tested
- What you did NOT verify: runtime end-to-end testing with actual Moonshot/Kimi API

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (fixes API errors, may change tool selection behavior from disabled-thinking to auto-tool-choice)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None