### PR TITLE
fix: flush pending requests before closing WebSocket on tick timeout (closes #45468)

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -675,6 +675,9 @@ export class GatewayClient {
       }
       const gap = Date.now() - this.lastTick;
       if (gap > this.tickIntervalMs * 2) {
+        clearInterval(this.tickTimer!);
+        this.tickTimer = null;
+        this.flushPendingErrors(new Error("tick timeout — gateway unresponsive"));
         this.ws?.close(4000, "tick timeout");
       }
     }, interval);


### PR DESCRIPTION
## Summary
- Problem: When `startTickWatch()` detects a tick timeout, it closes the WebSocket but does not flush pending requests. Those requests hang until the close event eventually fires `flushPendingErrors`, creating a window where requests accumulate without being rejected.
- Why it matters: Pending requests experience delayed error propagation during gateway disconnects, adding latency and potential memory leaks.
- What changed: Added `this.flushPendingErrors(new Error("tick timeout — gateway unresponsive"))` before `this.ws?.close()` in the tick watch handler.
- What did NOT change (scope boundary): The close event handler still calls `flushPendingErrors` as before (idempotent). No other reconnect logic was modified.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #45468

## User-visible / Behavior Changes
Pending gateway requests are immediately rejected with a clear error message on tick timeout instead of hanging.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Connect to gateway with pending requests
2. Gateway becomes unresponsive (tick gap > 2x interval)
### Expected
- Pending requests immediately rejected with error
### Actual
- Before fix: Pending requests hang until close event fires

## Evidence
- [x] Failing test/log before + passing after
- pnpm tsgo passes with no new errors

## Human Verification
- Verified scenarios: flushPendingErrors called before ws.close; close event still calls flush (idempotent)
- Edge cases checked: Double flush is safe (pending map is cleared)
- What you did NOT verify: runtime end-to-end testing with actual gateway disconnect

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None