### PR TITLE
fix: classify Codex streaming server_error as failover-eligible (closes #35220)

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,10 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies Codex streaming server_error as timeout for failover", () => {
+    const codexError =
+      'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request.","param":null},"sequence_number":2}';
+    expect(classifyFailoverReason(codexError)).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -853,7 +853,15 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // Codex Responses API streaming errors use "server_error" as both type and code:
+  // {"type":"error","error":{"type":"server_error","code":"server_error","message":"..."}}
+  if (value.includes('"type":"server_error"') || value.includes('"code":"server_error"')) {
+    return true;
+  }
+  return false;
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary
- Problem: When the OpenAI Codex Responses API returns a `server_error` within a streaming response, the error message format (`"type":"server_error"`, `"code":"server_error"`) is not recognized by `classifyFailoverReason()`, so no fallback model is attempted despite a configured fallback chain.
- Why it matters: Agents using Codex as primary with fallbacks get no fallback protection against Codex server errors. Cron-scheduled tasks fail silently with no retry.
- What changed: Extended `isJsonApiInternalServerError()` to also recognize the Codex streaming error pattern (`"type":"server_error"` / `"code":"server_error"`), classifying it as `"timeout"` (transient) to trigger model fallback.
- What did NOT change (scope boundary): The existing Anthropic `api_error` detection is unchanged. No other failover classification logic was modified.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #35220

## User-visible / Behavior Changes
Codex Responses API streaming `server_error` events now trigger model fallback instead of terminating the session with an error.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Configure an agent with openai-codex/gpt-5.3-codex as primary and fallback models
2. Trigger a session that causes a Codex streaming server_error
3. Observe whether fallback models are attempted
### Expected
- The server_error is classified as transient and fallback models are tried
### Actual
- Before fix: Session terminates with stopReason: "error", no fallback attempted

## Evidence
- [x] Failing test/log before + passing after
- All 72 failover classification tests pass (71 existing + 1 new test for Codex server_error)
- pnpm tsgo passes with no new errors

## Human Verification
- Verified scenarios: pnpm tsgo + failover tests all passing; reviewed diff matches issue description
- Edge cases checked: Existing Anthropic api_error detection still works; only server_error type/code patterns added
- What you did NOT verify: runtime end-to-end testing with actual Codex streaming server error

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None