### PR TITLE
feat(telegram): add topic-edit action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/MiniMax: merge the bundled MiniMax API and MiniMax OAuth plugin surfaces into a single default-on `minimax` plugin, while keeping legacy `minimax-portal-auth` config ids aliased for compatibility.
 - Plugins/bundles: add compatible Codex, Claude, and Cursor bundle discovery/install support, map bundle skills into OpenClaw skills, and apply Claude bundle `settings.json` defaults to embedded Pi with shell overrides sanitized.
 - Plugins/agent integrations: broaden the plugin surface for app-server integrations with channel-aware commands, interactive callbacks, inbound claims, and Discord/Telegram conversation binding support. (#45318) Thanks @huntharo and @vincentkoc.
+- Telegram/actions: add `topic-edit` for forum-topic renames and icon updates while sharing the same Telegram topic-edit transport used by the plugin runtime. (#47798) Thanks @obviyus.
 
 ### Fixes
 

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -115,6 +115,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("createForumTopic")) {
       actions.add("topic-create");
     }
+    if (isEnabled("editForumTopic")) {
+      actions.add("topic-edit");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -282,6 +285,30 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           chatId,
           name,
           iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "topic-edit") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageThreadId =
+        readNumberParam(params, "messageThreadId", { integer: true }) ??
+        readNumberParam(params, "threadId", { integer: true });
+      if (typeof messageThreadId !== "number") {
+        throw new Error("messageThreadId or threadId is required.");
+      }
+      const name = readStringParam(params, "name");
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "editForumTopic",
+          chatId,
+          messageThreadId,
+          name: name ?? undefined,
           iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -15,6 +15,7 @@ const { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegr
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
+  editForumTopicTelegram,
   editMessageTelegram,
   pinMessageTelegram,
   reactMessageTelegram,
@@ -255,6 +256,42 @@ describe("sendMessageTelegram", () => {
     expect(botApi.editForumTopic).toHaveBeenCalledWith("-1001234567890", 271, {
       name: "Codex Thread",
     });
+  });
+
+  it("edits a Telegram forum topic name and icon via the shared helper", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          botToken: "tok",
+        },
+      },
+    });
+    botApi.editForumTopic.mockResolvedValue(true);
+
+    await editForumTopicTelegram("-1001234567890", 271, {
+      accountId: "default",
+      name: "Codex Thread",
+      iconCustomEmojiId: "emoji-123",
+    });
+
+    expect(botApi.editForumTopic).toHaveBeenCalledWith("-1001234567890", 271, {
+      name: "Codex Thread",
+      icon_custom_emoji_id: "emoji-123",
+    });
+  });
+
+  it("rejects empty topic edits", async () => {
+    await expect(
+      editForumTopicTelegram("-1001234567890", 271, {
+        accountId: "default",
+      }),
+    ).rejects.toThrow("Telegram forum topic update requires a name or iconCustomEmojiId");
+    await expect(
+      editForumTopicTelegram("-1001234567890", 271, {
+        accountId: "default",
+        iconCustomEmojiId: "   ",
+      }),
+    ).rejects.toThrow("Telegram forum topic icon custom emoji ID is required");
   });
 
   it("applies timeoutSeconds config precedence", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -280,6 +280,26 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("strips topic suffixes before editing a Telegram forum topic", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          botToken: "tok",
+        },
+      },
+    });
+    botApi.editForumTopic.mockResolvedValue(true);
+
+    await editForumTopicTelegram("telegram:group:-1001234567890:topic:271", 271, {
+      accountId: "default",
+      name: "Codex Thread",
+    });
+
+    expect(botApi.editForumTopic).toHaveBeenCalledWith("-1001234567890", 271, {
+      name: "Codex Thread",
+    });
+  });
+
   it("rejects empty topic edits", async () => {
     await expect(
       editForumTopicTelegram("-1001234567890", 271, {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1128,19 +1128,39 @@ export async function unpinMessageTelegram(
   };
 }
 
-export async function renameForumTopicTelegram(
+type TelegramEditForumTopicOpts = TelegramDeleteOpts & {
+  name?: string;
+  iconCustomEmojiId?: string;
+};
+
+export async function editForumTopicTelegram(
   chatIdInput: string | number,
   messageThreadIdInput: string | number,
-  name: string,
-  opts: TelegramDeleteOpts = {},
-): Promise<{ ok: true; chatId: string; messageThreadId: number; name: string }> {
-  const trimmedName = name.trim();
-  if (!trimmedName) {
+  opts: TelegramEditForumTopicOpts = {},
+): Promise<{
+  ok: true;
+  chatId: string;
+  messageThreadId: number;
+  name?: string;
+  iconCustomEmojiId?: string;
+}> {
+  const nameProvided = opts.name !== undefined;
+  const trimmedName = opts.name?.trim();
+  if (nameProvided && !trimmedName) {
     throw new Error("Telegram forum topic name is required");
   }
-  if (trimmedName.length > 128) {
+  if (trimmedName && trimmedName.length > 128) {
     throw new Error("Telegram forum topic name must be 128 characters or fewer");
   }
+  const iconProvided = opts.iconCustomEmojiId !== undefined;
+  const trimmedIconCustomEmojiId = opts.iconCustomEmojiId?.trim();
+  if (iconProvided && !trimmedIconCustomEmojiId) {
+    throw new Error("Telegram forum topic icon custom emoji ID is required");
+  }
+  if (!trimmedName && !trimmedIconCustomEmojiId) {
+    throw new Error("Telegram forum topic update requires a name or iconCustomEmojiId");
+  }
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const rawTarget = String(chatIdInput);
   const chatId = await resolveAndPersistChatId({
@@ -1157,16 +1177,39 @@ export async function renameForumTopicTelegram(
     retry: opts.retry,
     verbose: opts.verbose,
   });
+  const payload = {
+    ...(trimmedName ? { name: trimmedName } : {}),
+    ...(trimmedIconCustomEmojiId ? { icon_custom_emoji_id: trimmedIconCustomEmojiId } : {}),
+  };
   await requestWithDiag(
-    () => api.editForumTopic(chatId, messageThreadId, { name: trimmedName }),
+    () => api.editForumTopic(chatId, messageThreadId, payload),
     "editForumTopic",
   );
-  logVerbose(`[telegram] Renamed forum topic ${messageThreadId} in chat ${chatId}`);
+  logVerbose(`[telegram] Edited forum topic ${messageThreadId} in chat ${chatId}`);
   return {
     ok: true,
     chatId,
     messageThreadId,
-    name: trimmedName,
+    ...(trimmedName ? { name: trimmedName } : {}),
+    ...(trimmedIconCustomEmojiId ? { iconCustomEmojiId: trimmedIconCustomEmojiId } : {}),
+  };
+}
+
+export async function renameForumTopicTelegram(
+  chatIdInput: string | number,
+  messageThreadIdInput: string | number,
+  name: string,
+  opts: TelegramDeleteOpts = {},
+): Promise<{ ok: true; chatId: string; messageThreadId: number; name: string }> {
+  const result = await editForumTopicTelegram(chatIdInput, messageThreadIdInput, {
+    ...opts,
+    name,
+  });
+  return {
+    ok: true,
+    chatId: result.chatId,
+    messageThreadId: result.messageThreadId,
+    name: result.name ?? name.trim(),
   };
 }
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1163,10 +1163,11 @@ export async function editForumTopicTelegram(
 
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const rawTarget = String(chatIdInput);
+  const target = parseTelegramTarget(rawTarget);
   const chatId = await resolveAndPersistChatId({
     cfg,
     api,
-    lookupTarget: rawTarget,
+    lookupTarget: target.chatId,
     persistTarget: rawTarget,
     verbose: opts.verbose,
   });

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -23,6 +23,12 @@ const editMessageTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
 }));
+const editForumTopicTelegram = vi.fn(async () => ({
+  ok: true,
+  chatId: "123",
+  messageThreadId: 42,
+  name: "Renamed",
+}));
 const createForumTopicTelegram = vi.fn(async () => ({
   topicId: 99,
   name: "Topic",
@@ -42,6 +48,8 @@ vi.mock("../../../extensions/telegram/src/send.js", () => ({
     deleteMessageTelegram(...args),
   editMessageTelegram: (...args: Parameters<typeof editMessageTelegram>) =>
     editMessageTelegram(...args),
+  editForumTopicTelegram: (...args: Parameters<typeof editForumTopicTelegram>) =>
+    editForumTopicTelegram(...args),
   createForumTopicTelegram: (...args: Parameters<typeof createForumTopicTelegram>) =>
     createForumTopicTelegram(...args),
 }));
@@ -105,6 +113,7 @@ describe("handleTelegramAction", () => {
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editMessageTelegram.mockClear();
+    editForumTopicTelegram.mockClear();
     createForumTopicTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
@@ -456,6 +465,14 @@ describe("handleTelegramAction", () => {
       assertCall: (
         readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
       ) => readCallOpts(createForumTopicTelegram.mock.calls as unknown[][], 2),
+    },
+    {
+      name: "editForumTopic",
+      params: { action: "editForumTopic", chatId: "123", messageThreadId: 42, name: "New" },
+      cfg: telegramConfig({ actions: { editForumTopic: true } }),
+      assertCall: (
+        readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
+      ) => readCallOpts(editForumTopicTelegram.mock.calls as unknown[][], 2),
     },
   ])("forwards resolved cfg for $name action", async ({ params, cfg, assertCall }) => {
     const readCallOpts = (calls: unknown[][], argIndex: number): Record<string, unknown> => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -15,6 +15,7 @@ import { resolveTelegramReactionLevel } from "../../../extensions/telegram/src/r
 import {
   createForumTopicTelegram,
   deleteMessageTelegram,
+  editForumTopicTelegram,
   editMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
@@ -476,6 +477,37 @@ export async function handleTelegramAction(
       name: result.name,
       chatId: result.chatId,
     });
+  }
+
+  if (action === "editForumTopic") {
+    if (!isActionEnabled("editForumTopic")) {
+      throw new Error("Telegram editForumTopic is disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageThreadId =
+      readNumberParam(params, "messageThreadId", { integer: true }) ??
+      readNumberParam(params, "threadId", { integer: true });
+    if (typeof messageThreadId !== "number") {
+      throw new Error("messageThreadId or threadId is required.");
+    }
+    const name = readStringParam(params, "name");
+    const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await editForumTopicTelegram(chatId ?? "", messageThreadId, {
+      cfg,
+      token,
+      accountId: accountId ?? undefined,
+      name: name ?? undefined,
+      iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+    });
+    return jsonResult(result);
   }
 
   throw new Error(`Unsupported Telegram action: ${action}`);

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -540,6 +540,21 @@ describe("telegramMessageActions", () => {
     expect(actions).toContain("poll");
   });
 
+  it("lists topic-edit when telegram topic edits are enabled", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "tok",
+          actions: { editForumTopic: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const actions = telegramMessageActions.listActions?.({ cfg }) ?? [];
+
+    expect(actions).toContain("topic-edit");
+  });
+
   it("omits poll when sendMessage is disabled", () => {
     const cfg = {
       channels: {
@@ -790,6 +805,24 @@ describe("telegramMessageActions", () => {
           name: "Build Updates",
           iconColor: undefined,
           iconCustomEmojiId: undefined,
+          accountId: undefined,
+        },
+      },
+      {
+        name: "topic-edit maps to editForumTopic",
+        action: "topic-edit" as const,
+        params: {
+          to: "telegram:group:-1001234567890:topic:271",
+          threadId: 271,
+          name: "Build Updates",
+          iconCustomEmojiId: "emoji-123",
+        },
+        expectedPayload: {
+          action: "editForumTopic",
+          chatId: "telegram:group:-1001234567890:topic:271",
+          messageThreadId: 271,
+          name: "Build Updates",
+          iconCustomEmojiId: "emoji-123",
           accountId: undefined,
         },
       },

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -44,6 +44,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "category-edit",
   "category-delete",
   "topic-create",
+  "topic-edit",
   "voice-status",
   "event-list",
   "event-create",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -26,6 +26,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable forum topic editing (rename / change icon). */
+  editForumTopic?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -258,6 +258,7 @@ export const TelegramAccountSchemaBase = z
         editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
         createForumTopic: z.boolean().optional(),
+        editForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -49,6 +49,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     "category-edit": "none",
     "category-delete": "none",
     "topic-create": "to",
+    "topic-edit": "to",
     "voice-status": "none",
     "event-list": "none",
     "event-create": "none",


### PR DESCRIPTION
## Summary

- Add Telegram `topic-edit` message action support on top of the existing Telegram topic-edit transport.
- Reuse one shared `editForumTopicTelegram(...)` helper in `extensions/telegram/src/send.ts` instead of adding a second Telegram topic-edit path.
- Keep the newer plugin/runtime rename seam intact by making `renameForumTopicTelegram(...)` a thin wrapper over the shared helper.
- Wire the generic Telegram action/tool surfaces, action name/spec, and config gate for `editForumTopic`.
- Add focused tests for the raw Telegram helper, Telegram tool action, and channel message-action mapping.

## Why

PR #46407 had the right feature but predated the current Telegram/plugin surface shape. This replacement keeps the scope the same while collapsing the implementation onto the newer shared Telegram topic-edit seam.

Supersedes #46407.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible behavior

- Telegram action surfaces can now edit forum topics with `topic-edit`.
- Topic edits support rename and optional icon custom emoji updates.
- Plugins/runtime callers and generic action callers now share the same Telegram transport helper.

## Verification

- `pnpm test -- extensions/telegram/src/send.test.ts src/agents/tools/telegram-actions.test.ts src/channels/plugins/actions/actions.test.ts`

## Risks and mitigations

- Risk: duplicate Telegram topic-edit implementations drift over time.
  - Mitigation: this PR removes that split by making the generic action and plugin/runtime rename path share one helper.
- Risk: action/config surfaces expose topic editing when disabled.
  - Mitigation: the action is gated by `channels.telegram.actions.editForumTopic` and covered by focused tests.
