### PR TITLE
fix: add default pidsLimit for sandbox containers (closes #38604)

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_PIDS_LIMIT,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -105,7 +106,7 @@ export function resolveSandboxDockerConfig(params: {
     capDrop: agentDocker?.capDrop ?? globalDocker?.capDrop ?? ["ALL"],
     env,
     setupCommand: agentDocker?.setupCommand ?? globalDocker?.setupCommand,
-    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,
+    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit ?? DEFAULT_SANDBOX_PIDS_LIMIT,
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,
     cpus: agentDocker?.cpus ?? globalDocker?.cpus,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(STATE_DIR, "sandboxes");
 export const DEFAULT_SANDBOX_IMAGE = "openclaw-sandbox:bookworm-slim";
 export const DEFAULT_SANDBOX_CONTAINER_PREFIX = "openclaw-sbx-";
 export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
+export const DEFAULT_SANDBOX_PIDS_LIMIT = 1024;
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 


### PR DESCRIPTION
## Summary
- Problem: Sandbox containers are created without a default `pidsLimit`, making them vulnerable to fork bomb attacks that can exhaust host PID slots and memory.
- Why it matters: Unlike other security options (`capDrop: ["ALL"]`, `readOnlyRoot: true`, `network: "none"`), `pidsLimit` had no fallback default, leaving containers unprotected against process exhaustion.
- What changed: Added `DEFAULT_SANDBOX_PIDS_LIMIT = 1024` constant and used it as the fallback in `resolveSandboxDockerConfig()`.
- What did NOT change (scope boundary): User-configured `pidsLimit` values are still respected; memory, CPU, and other resource limits are unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #38604

## User-visible / Behavior Changes
Sandbox containers now have a default `--pids-limit 1024` when no `pidsLimit` is configured at either the agent or global level. Users who already configure `pidsLimit` are not affected.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Run a sandbox container without configuring `pidsLimit`
2. Check `docker inspect` for `--pids-limit`
### Expected
- Container has `--pids-limit 1024`
### Actual (before fix)
- Container has no pids limit

## Evidence
- [x] Failing test/log before + passing after
- `sandbox-create-args.test.ts` — 15 tests pass
- `pnpm tsgo` passes (only pre-existing ui errors)
- `oxlint` passes on changed files

## Human Verification
- Verified scenarios: pnpm tsgo passes; sandbox-create-args.test.ts passes
- Edge cases checked: user-configured pidsLimit takes precedence; agent-level overrides global-level
- What you did NOT verify: runtime end-to-end Docker container testing

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (only adds a default where none existed)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None — 1024 is a generous default that accommodates normal workloads while preventing fork bombs.