### PR TITLE
fix: mount sandbox workspace as read-write when workspaceAccess is none (closes #46026)

### DIFF
--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -5,7 +5,7 @@ describe("appendWorkspaceMountArgs", () => {
   it.each([
     { access: "rw" as const, expected: "/tmp/workspace:/workspace" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro" },
-    { access: "none" as const, expected: "/tmp/workspace:/workspace:ro" },
+    { access: "none" as const, expected: "/tmp/workspace:/workspace" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
     const args: string[] = [];
     appendWorkspaceMountArgs({
@@ -30,7 +30,7 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:ro"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace"]);
   });
 
   it("omits agent workspace mount when paths are identical", () => {

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -2,7 +2,7 @@ import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 function mainWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
-  return access === "rw" ? "" : ":ro";
+  return access === "ro" ? ":ro" : "";
 }
 
 function agentWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {


### PR DESCRIPTION
## Summary
- Problem: When `workspaceAccess` is set to `"none"`, the sandbox workspace is mounted as read-only (`:ro`) instead of read-write. The `"none"` mode uses an isolated `sandboxWorkspaceDir`, which should be writable for the session to store its own data.
- Why it matters: Sandboxed sessions with `workspaceAccess: "none"` cannot write to their own workspace directory, breaking tool execution and file operations.
- What changed: Changed the condition in `mainWorkspaceMountSuffix()` from `access === "rw" ? "" : ":ro"` to `access === "ro" ? ":ro" : ""` so only explicit read-only mode adds the `:ro` suffix. Updated corresponding test expectations.
- What did NOT change (scope boundary): `agentWorkspaceMountSuffix()` logic is unchanged. The `"rw"` and `"ro"` modes behave identically to before.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #46026

## User-visible / Behavior Changes
Sandbox sessions with `workspaceAccess: "none"` now have a writable workspace directory, matching the documented behavior.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No (sandbox workspace was already an isolated per-session directory)

## Repro + Verification
### Steps
1. Configure a sandbox with `workspaceAccess: "none"`, `scope: "session"`
2. Start a sandboxed session
3. Attempt to write a file in the workspace
### Expected
- File write succeeds (sandbox workspace is read-write)
### Actual
- Before fix: File write fails (workspace mounted as `:ro`)

## Evidence
- [x] Failing test/log before + passing after
- All 5 workspace-mounts tests pass with updated expectations
- pnpm tsgo passes with no new errors

## Human Verification
- Verified scenarios: pnpm tsgo + workspace-mounts tests all passing; reviewed diff matches issue description
- Edge cases checked: "rw" still mounts without suffix, "ro" still mounts with `:ro`, "none" now mounts without suffix
- What you did NOT verify: runtime end-to-end testing with actual Docker sandbox

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration
- Backward compatible? Yes (fixes incorrect restrictive behavior)
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: revert this commit

## Risks and Mitigations
None