### PR TITLE
feat: add ClawAPI as built-in provider — crypto-native multi-model gateway

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -241,6 +241,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/byteplus/**"
+"extensions: clawapi":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/clawapi/**"
 "extensions: deepseek":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1181,6 +1181,7 @@
                 "pages": [
                   "providers/anthropic",
                   "providers/bedrock",
+                  "providers/clawapi",
                   "providers/claude-max-api-proxy",
                   "providers/cloudflare-ai-gateway",
                   "providers/deepgram",

--- a/docs/providers/clawapi.md
+++ b/docs/providers/clawapi.md
@@ -1,0 +1,143 @@
+---
+summary: "ClawAPI setup (auth + model selection)"
+read_when:
+  - You want to use ClawAPI with OpenClaw
+  - You need the API key env var or CLI auth choice
+title: "ClawAPI"
+---
+
+# ClawAPI
+
+[ClawAPI](https://clawapi.org) is a crypto-native multi-model API gateway. One key, 8 models from 4 providers.
+
+Build for OPC (One Person Company) — Every human being is a Chairman.
+
+- Provider: `clawapi`
+- Auth: `CLAWAPI_KEY`
+- API: OpenAI-compatible
+- Free 10M tokens for new accounts
+
+## Quick start
+
+1. Get your API key at [clawapi.org](https://clawapi.org)
+2. Authenticate (recommended: store it for the Gateway):
+
+```bash
+openclaw onboard --auth-choice clawapi-api-key
+```
+
+3. Set a default model:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "clawapi/gpt-5.4" },
+    },
+  },
+}
+```
+
+## Non-interactive example
+
+```bash
+openclaw onboard --non-interactive --accept-risk \
+  --mode local \
+  --auth-choice clawapi-api-key \
+  --clawapi-api-key "$CLAWAPI_KEY"
+```
+
+This will set `clawapi/gpt-5.4` as the default model.
+
+## Environment variable
+
+```bash
+export CLAWAPI_KEY="sk-claw-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+If the Gateway runs as a daemon (launchd/systemd), make sure `CLAWAPI_KEY`
+is available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+
+## Available models
+
+ClawAPI provides access to 8 models across 4 providers, each with a role name:
+
+| Model ID                | Name                  | Role       | Reasoning | Context | Max Tokens | Cost (input/output per 1M) |
+| ----------------------- | --------------------- | ---------- | --------- | ------- | ---------- | -------------------------- |
+| `claude-opus-4-6`       | Claude Opus 4.6       | CEO        | Yes       | 1M      | 4,096      | $5.00 / $25.00             |
+| `gpt-5.4`               | GPT-5.4               | CTO        | Yes       | 1.05M   | 128,000    | $2.50 / $15.00             |
+| `claude-sonnet-4-6`     | Claude Sonnet 4.6     | CMO        | Yes       | 1M      | 4,096      | $3.00 / $15.00             |
+| `gemini-3.1-pro`        | Gemini 3.1 Pro        | Researcher | Yes       | 1M      | 16,384     | $2.00 / $12.00             |
+| `gpt-5-mini`            | GPT-5 Mini            | CFO        | Yes       | 400k    | 128,000    | $0.25 / $2.00              |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash-Lite | Secretary  | No        | 1M      | 32,768     | $0.25 / $1.50              |
+| `gpt-oss-120b`          | GPT-OSS-120B          | Engineer   | No        | 128k    | 8,192      | $0.05 / $0.45              |
+| `gpt-oss-20b`           | GPT-OSS-20B           | Intern     | No        | 128k    | 8,192      | $0.04 / $0.18              |
+
+All models support standard chat completions and are OpenAI API compatible.
+
+## Which model should I use
+
+| Use Case                     | Recommended Model       | Why                                        |
+| ---------------------------- | ----------------------- | ------------------------------------------ |
+| **General default**          | `gpt-5.4`               | Best balance of capability and cost        |
+| **Highest quality**          | `claude-opus-4-6`       | Strongest reasoning, largest context       |
+| **Fast and cheap**           | `gpt-oss-20b`           | Lowest cost, good for simple tasks         |
+| **Long context + reasoning** | `gemini-3.1-pro`        | 1M context with reasoning at moderate cost |
+| **Budget reasoning**         | `gpt-5-mini`            | Reasoning capability at low cost           |
+| **High throughput**          | `gemini-3.1-flash-lite` | 1M context, fast, no reasoning overhead    |
+
+## Usage examples
+
+```bash
+# Use the default model (GPT-5.4)
+openclaw agent --model clawapi/gpt-5.4 --message "Quick health check"
+
+# Use Claude Opus via ClawAPI
+openclaw agent --model clawapi/claude-opus-4-6 --message "Summarize this task"
+
+# Use the cheapest model for simple tasks
+openclaw agent --model clawapi/gpt-oss-20b --message "Format this list"
+```
+
+## Config file example
+
+```json5
+{
+  env: { CLAWAPI_KEY: "sk-claw-..." },
+  agents: { defaults: { model: { primary: "clawapi/gpt-5.4" } } },
+  models: {
+    mode: "merge",
+    providers: {
+      clawapi: {
+        baseUrl: "https://clawapi.org/api/v1",
+        apiKey: "${CLAWAPI_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "gpt-5.4",
+            name: "GPT-5.4 (CTO)",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 2.5, output: 15.0, cacheRead: 2.5, cacheWrite: 15.0 },
+            contextWindow: 1050000,
+            maxTokens: 128000,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Troubleshooting
+
+| Problem               | Fix                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Timeout with tools    | Must use `stream: true` when sending tool definitions. Without streaming, the gateway times out at 25s on complex requests |
+| 400 with tool results | Tool call IDs must use snake_case `tool_call_id`, not camelCase `toolCallId`. ClawAPI follows OpenAI format strictly       |
+
+## Links
+
+- [ClawAPI](https://clawapi.org)
+- [Feature Request](https://github.com/openclaw/openclaw/issues/47727)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 - [Amazon Bedrock](/providers/bedrock)
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
+- [ClawAPI (crypto-native multi-model gateway)](/providers/clawapi)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
 - [DeepSeek](/providers/deepseek)
 - [GitHub Copilot](/providers/github-copilot)

--- a/extensions/clawapi/index.ts
+++ b/extensions/clawapi/index.ts
@@ -1,0 +1,66 @@
+import { emptyPluginConfigSchema, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { applyClawApiConfig, CLAWAPI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildClawApiProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "clawapi";
+
+const clawapiPlugin = {
+  id: PROVIDER_ID,
+  name: "ClawAPI Provider",
+  description: "Bundled ClawAPI provider plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "ClawAPI",
+      docsPath: "/providers/clawapi",
+      envVars: ["CLAWAPI_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "ClawAPI API key",
+          hint: "Crypto-native multi-model gateway",
+          optionKey: "clawapiApiKey",
+          flagName: "--clawapi-api-key",
+          envVar: "CLAWAPI_KEY",
+          promptMessage: "Enter ClawAPI API key",
+          defaultModel: CLAWAPI_DEFAULT_MODEL_REF,
+          expectedProviders: ["clawapi"],
+          applyConfig: (cfg) => applyClawApiConfig(cfg),
+          noteMessage: [
+            "ClawAPI is a crypto-native multi-model API gateway.",
+            "One key gives you access to 8 models including GPT-5.4, Claude Opus 4.6, and Gemini 3.1 Pro.",
+            "Get your API key at: https://clawapi.org",
+          ].join("\n"),
+          noteTitle: "ClawAPI",
+          wizard: {
+            choiceId: "clawapi-api-key",
+            choiceLabel: "ClawAPI API key",
+            groupId: "clawapi",
+            groupLabel: "ClawAPI",
+            groupHint: "Crypto-native multi-model gateway",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildClawApiProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+    });
+  },
+};
+
+export default clawapiPlugin;

--- a/extensions/clawapi/onboard.ts
+++ b/extensions/clawapi/onboard.ts
@@ -1,0 +1,35 @@
+import {
+  buildClawApiModelDefinition,
+  CLAWAPI_BASE_URL,
+  CLAWAPI_DEFAULT_MODEL_REF,
+  CLAWAPI_MODEL_CATALOG,
+} from "openclaw/plugin-sdk/provider-models";
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+
+export { CLAWAPI_DEFAULT_MODEL_REF };
+
+export function applyClawApiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[CLAWAPI_DEFAULT_MODEL_REF] = {
+    ...models[CLAWAPI_DEFAULT_MODEL_REF],
+    alias: models[CLAWAPI_DEFAULT_MODEL_REF]?.alias ?? "ClawAPI",
+  };
+
+  const clawApiModels = CLAWAPI_MODEL_CATALOG.map(buildClawApiModelDefinition);
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "clawapi",
+    api: "openai-completions",
+    baseUrl: CLAWAPI_BASE_URL,
+    catalogModels: clawApiModels,
+  });
+}
+
+export function applyClawApiConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyClawApiProviderConfig(cfg);
+  return applyAgentDefaultModelPrimary(next, CLAWAPI_DEFAULT_MODEL_REF);
+}

--- a/extensions/clawapi/openclaw.plugin.json
+++ b/extensions/clawapi/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "clawapi",
+  "providers": ["clawapi"],
+  "providerAuthEnvVars": {
+    "clawapi": ["CLAWAPI_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "clawapi",
+      "method": "api-key",
+      "choiceId": "clawapi-api-key",
+      "choiceLabel": "ClawAPI API key",
+      "choiceHint": "Crypto-native multi-model gateway",
+      "groupId": "clawapi",
+      "groupLabel": "ClawAPI",
+      "groupHint": "Crypto-native multi-model gateway",
+      "optionKey": "clawapiApiKey",
+      "cliFlag": "--clawapi-api-key",
+      "cliOption": "--clawapi-api-key <key>",
+      "cliDescription": "ClawAPI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/clawapi/package.json
+++ b/extensions/clawapi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/clawapi-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw ClawAPI provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/clawapi/provider-catalog.ts
+++ b/extensions/clawapi/provider-catalog.ts
@@ -1,0 +1,14 @@
+import {
+  buildClawApiModelDefinition,
+  CLAWAPI_BASE_URL,
+  CLAWAPI_MODEL_CATALOG,
+} from "openclaw/plugin-sdk/provider-models";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
+
+export function buildClawApiProvider(): ModelProviderConfig {
+  return {
+    baseUrl: CLAWAPI_BASE_URL,
+    api: "openai-completions",
+    models: CLAWAPI_MODEL_CATALOG.map(buildClawApiModelDefinition),
+  };
+}

--- a/src/agents/clawapi-models.ts
+++ b/src/agents/clawapi-models.ts
@@ -1,0 +1,134 @@
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+
+export const CLAWAPI_BASE_URL = "https://clawapi.org/api/v1";
+
+export const CLAWAPI_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6 (CEO)",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 4096,
+    cost: {
+      input: 5.0,
+      output: 25.0,
+      cacheRead: 5.0,
+      cacheWrite: 25.0,
+    },
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4 (CTO)",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+    cost: {
+      input: 2.5,
+      output: 15.0,
+      cacheRead: 2.5,
+      cacheWrite: 15.0,
+    },
+  },
+  {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6 (CMO)",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 4096,
+    cost: {
+      input: 3.0,
+      output: 15.0,
+      cacheRead: 3.0,
+      cacheWrite: 15.0,
+    },
+  },
+  {
+    id: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro (Researcher)",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 16_384,
+    cost: {
+      input: 2.0,
+      output: 12.0,
+      cacheRead: 2.0,
+      cacheWrite: 12.0,
+    },
+  },
+  {
+    id: "gpt-5-mini",
+    name: "GPT-5 Mini (CFO)",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 400_000,
+    maxTokens: 128_000,
+    cost: {
+      input: 0.25,
+      output: 2.0,
+      cacheRead: 0.25,
+      cacheWrite: 2.0,
+    },
+  },
+  {
+    id: "gemini-3.1-flash-lite",
+    name: "Gemini 3.1 Flash-Lite (Secretary)",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 32_768,
+    cost: {
+      input: 0.25,
+      output: 1.5,
+      cacheRead: 0.25,
+      cacheWrite: 1.5,
+    },
+  },
+  {
+    id: "gpt-oss-120b",
+    name: "GPT-OSS-120B (Engineer)",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131_072,
+    maxTokens: 8192,
+    cost: {
+      input: 0.05,
+      output: 0.45,
+      cacheRead: 0.05,
+      cacheWrite: 0.45,
+    },
+  },
+  {
+    id: "gpt-oss-20b",
+    name: "GPT-OSS-20B (Intern)",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131_072,
+    maxTokens: 8192,
+    cost: {
+      input: 0.04,
+      output: 0.18,
+      cacheRead: 0.04,
+      cacheWrite: 0.18,
+    },
+  },
+];
+
+export function buildClawApiModelDefinition(
+  model: (typeof CLAWAPI_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    id: model.id,
+    name: model.name,
+    api: "openai-completions",
+    reasoning: model.reasoning,
+    input: model.input,
+    cost: model.cost,
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    compat: { supportsStore: false },
+  };
+}

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -6,6 +6,7 @@ export {
   buildBytePlusCodingProvider,
   buildBytePlusProvider,
 } from "../../extensions/byteplus/provider-catalog.js";
+export { buildClawApiProvider } from "../../extensions/clawapi/provider-catalog.js";
 export { buildDeepSeekProvider } from "../../extensions/deepseek/provider-catalog.js";
 export {
   buildKimiCodingProvider,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -10,6 +10,7 @@ export type BuiltInAuthChoice =
   | "claude-cli"
   | "token"
   | "chutes"
+  | "clawapi-api-key"
   | "deepseek-api-key"
   | "openai-codex"
   | "openai-api-key"
@@ -61,6 +62,7 @@ export type BuiltInAuthChoiceGroupId =
   | "openai"
   | "anthropic"
   | "chutes"
+  | "clawapi"
   | "deepseek"
   | "google"
   | "copilot"
@@ -119,6 +121,7 @@ export type OnboardOptions = {
   /** API key persistence mode for setup flows (default: plaintext). */
   secretInputMode?: SecretInputMode;
   anthropicApiKey?: string;
+  clawapiApiKey?: string;
   deepseekApiKey?: string;
   openaiApiKey?: string;
   mistralApiKey?: string;

--- a/src/plugin-sdk/provider-models.ts
+++ b/src/plugin-sdk/provider-models.ts
@@ -130,6 +130,12 @@ export {
   KILOCODE_MODEL_CATALOG,
 } from "../plugins/provider-model-kilocode.js";
 export {
+  buildClawApiModelDefinition,
+  CLAWAPI_BASE_URL,
+  CLAWAPI_MODEL_CATALOG,
+} from "../agents/clawapi-models.js";
+export { CLAWAPI_DEFAULT_MODEL_REF } from "../plugins/provider-auth-storage.js";
+export {
   discoverVercelAiGatewayModels,
   VERCEL_AI_GATEWAY_BASE_URL,
 } from "../agents/vercel-ai-gateway.js";

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -392,6 +392,48 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "clawapi",
+    idHint: "clawapi",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/clawapi-provider",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw ClawAPI provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "clawapi",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["clawapi"],
+      providerAuthEnvVars: {
+        clawapi: ["CLAWAPI_KEY"],
+      },
+      providerAuthChoices: [
+        {
+          provider: "clawapi",
+          method: "api-key",
+          choiceId: "clawapi-api-key",
+          choiceLabel: "ClawAPI API key",
+          choiceHint: "Crypto-native multi-model gateway",
+          groupId: "clawapi",
+          groupLabel: "ClawAPI",
+          groupHint: "Crypto-native multi-model gateway",
+          optionKey: "clawapiApiKey",
+          cliFlag: "--clawapi-api-key",
+          cliOption: "--clawapi-api-key <key>",
+          cliDescription: "ClawAPI API key",
+        },
+      ],
+    },
+  },
+  {
     dirName: "cloudflare-ai-gateway",
     idHint: "cloudflare-ai-gateway",
     source: {

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -5,6 +5,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   brave: ["BRAVE_API_KEY"],
   byteplus: ["BYTEPLUS_API_KEY"],
   chutes: ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"],
+  clawapi: ["CLAWAPI_KEY"],
   "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
   deepseek: ["DEEPSEEK_API_KEY"],
   exa: ["EXA_API_KEY"],

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -32,6 +32,7 @@ export const BUNDLED_ENABLED_BY_DEFAULT = new Set<string>([
   "amazon-bedrock",
   "anthropic",
   "byteplus",
+  "clawapi",
   "cloudflare-ai-gateway",
   "deepseek",
   "device-pair",

--- a/src/plugins/provider-auth-storage.ts
+++ b/src/plugins/provider-auth-storage.ts
@@ -31,6 +31,18 @@ export async function setAnthropicApiKey(
   });
 }
 
+export async function setClawApiKey(
+  key: SecretInput,
+  agentDir?: string,
+  options?: ApiKeyStorageOptions,
+) {
+  upsertAuthProfile({
+    profileId: "clawapi:default",
+    credential: buildApiKeyCredential("clawapi", key, undefined, options),
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
+
 export async function setOpenaiApiKey(
   key: SecretInput,
   agentDir?: string,
@@ -141,6 +153,7 @@ export async function setVeniceApiKey(
   });
 }
 
+export const CLAWAPI_DEFAULT_MODEL_REF = "clawapi/gpt-5.4";
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";


### PR DESCRIPTION
## Motivation

Add first-class support for ClawAPI so users can authenticate and use 8 models from 4 providers (Anthropic, OpenAI, Google, SiliconFlow) through one API key, without manual `models.providers` configuration.

Feature Request: #47727

## What is ClawAPI?

[ClawAPI](https://clawapi.org) is a crypto-native multi-model API gateway. One universal API key accesses all models via an OpenAI-compatible endpoint. Payments are in USDC/USDT on Ethereum — no credit card needed. New accounts get 10M free tokens on open-source models.

## Description

Changes follow the same patterns used by other API-key providers (Together, Venice, Hugging Face):

- Added model catalog (`src/agents/clawapi-models.ts`) with 8 models and `buildClawApiModelDefinition`
- Wired implicit provider discovery so `clawapi` is auto-registered when `CLAWAPI_KEY` env var or a `clawapi` auth profile exists
- Implemented provider config appliers and credential helper `setClawApiKey`
- Extended onboarding types, CLI flags, and command plumbing to accept `clawapi-api-key` / `--clawapi-api-key`
- Added ClawAPI to auth-choice UX: grouped option, preferred provider mapping, and interactive/non-interactive application flows
- Added documentation `docs/providers/clawapi.md` and linked from `docs/providers/index.md`

## Models

| Model | Role | Price (In/Out per 1M) | Context |
|---|---|---|---|
| `claude-opus-4-6` | CEO | $5 / $25 | 1M |
| `gpt-5.4` | CTO (default) | $2.50 / $15 | 1.05M |
| `claude-sonnet-4-6` | CMO | $3 / $15 | 1M |
| `gemini-3.1-pro` | Researcher | $2 / $12 | 1M |
| `gpt-5-mini` | CFO | $0.25 / $2 | 400K |
| `gemini-3.1-flash-lite` | Secretary | $0.25 / $1.50 | 1M |
| `gpt-oss-120b` | Engineer | $0.05 / $0.45 | 131K |
| `gpt-oss-20b` | Intern | $0.04 / $0.18 | 131K |

## Testing

- `pnpm tsgo` — TypeScript compilation passes (no new errors)
- `pnpm format` — formatting clean
- Changes are consistent with existing API-key provider patterns (Together, Venice, Hugging Face)

## Files changed (19)

**New files:**
- `src/agents/clawapi-models.ts` — model catalog
- `docs/providers/clawapi.md` — documentation

**Modified files:**
- `src/agents/model-auth-env-vars.ts` — env var mapping
- `src/agents/models-config.providers.static.ts` — static provider builder
- `src/agents/models-config.providers.ts` — implicit provider loader
- `src/commands/onboard-types.ts` — auth choice type + group + options
- `src/commands/onboard-provider-auth-flags.ts` — CLI flag registration
- `src/commands/auth-choice-options.static.ts` — UI option group
- `src/commands/auth-choice.apply.api-providers.ts` — token provider mapping
- `src/commands/auth-choice.apply.api-key-providers.ts` — full onboarding flow
- `src/commands/auth-choice.preferred-provider.ts` — preferred provider mapping
- `src/commands/onboard-auth.config-core.ts` — config appliers
- `src/commands/onboard-auth.credentials.ts` — credential helper
- `src/commands/onboard-auth.ts` — barrel re-exports
- `src/commands/onboard-non-interactive/local/auth-choice.api-key-providers.ts` — non-interactive flow
- `src/commands/onboard-non-interactive/local/auth-choice-inference.ts` — flag type
- `src/secrets/provider-env-vars.ts` — secret env var
- `docs/providers/index.md` — provider list
- `docs/docs.json` — navigation