### PR TITLE
Fix stale TTS summarizeText mock for resolveModelAsync

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -2,7 +2,7 @@ import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
-import { resolveModel } from "../agents/pi-embedded-runner/model.js";
+import { resolveModelAsync } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnv } from "../test-utils/env.js";
 import * as tts from "./tts.js";
@@ -21,7 +21,7 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 }));
 
 vi.mock("../agents/pi-embedded-runner/model.js", () => ({
-  resolveModel: vi.fn((provider: string, modelId: string) => ({
+  resolveModelAsync: vi.fn(async (provider: string, modelId: string) => ({
     model: {
       provider,
       id: modelId,
@@ -411,11 +411,11 @@ describe("tts", () => {
         timeoutMs: 30_000,
       });
 
-      expect(resolveModel).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
+      expect(resolveModelAsync).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
     });
 
     it("registers the Ollama api before direct summarization", async () => {
-      vi.mocked(resolveModel).mockReturnValue({
+      vi.mocked(resolveModelAsync).mockResolvedValue({
         model: {
           provider: "ollama",
           id: "qwen3:8b",


### PR DESCRIPTION
## Summary
Update the  mock to match the current  implementation.

## Problem
 now resolves the summary model via , but  was still mocking and asserting against .

That causes the Windows CI shard to fail with:



## Change
- mock  instead of 
- update the summarizeText assertions to expect the async resolver
- keep the fix scoped to the test layer only

## Verification
 ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace

Closes no issue. Independent of #47073.