### PR TITLE
fix daemon parse Windows Last Result runtime field

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -23,6 +23,21 @@ describe("schtasks runtime parsing", () => {
       lastRunResult: "0x0",
     });
   });
+
+  it("parses Last Result output from schtasks list mode", () => {
+    const output = [
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Running",
+      "Last Run Time: 2026/3/16 8:34:15",
+      "Last Result: 267009",
+    ].join("\r\n");
+
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Running",
+      lastRunTime: "2026/3/16 8:34:15",
+      lastRunResult: "267009",
+    });
+  });
 });
 
 describe("scheduled task runtime derivation", () => {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -178,7 +178,7 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;
   }
-  const lastRunResult = entries["last run result"];
+  const lastRunResult = entries["last run result"] ?? entries["last result"];
   if (lastRunResult) {
     info.lastRunResult = lastRunResult;
   }


### PR DESCRIPTION
## Summary

- Problem: Windows scheduled task status parsing only read `Last Run Result`, but `schtasks /Query /V /FO LIST` commonly emits `Last Result`.
- Why it matters: `openclaw gateway status` can report `Runtime: unknown` even when the gateway task is running normally.
- What changed: `parseSchtasksQuery` now falls back to `Last Result`, and a regression test covers the real output shape.
- What did NOT change: runtime derivation rules and non-Windows service behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47726
- Related #

## User-visible / Behavior Changes

- Windows scheduled-task installs now report running status from `Last Result` output as expected.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 local dev shell
- Runtime/container: Node 22 plus pnpm
- Model/provider: N/A
- Integration/channel (if any): Windows scheduled task runtime inspection
- Relevant config (redacted): N/A

### Steps

1. Run `schtasks /Query /V /FO LIST` style parsing through `parseSchtasksQuery`.
2. Use output with `Last Result: 267009` and `Status: Running`.
3. Verify the parsed result includes `lastRunResult` so runtime derivation can mark the task as running.

### Expected

- `Last Result` is parsed the same as `Last Run Result`.

### Actual

- Added regression test now passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/daemon/schtasks.test.ts`
- Edge cases checked: both `Last Run Result` and `Last Result` parsing paths
- What you did **not** verify: real Windows `schtasks` invocation against a live installed task

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/daemon/schtasks.ts`, `src/daemon/schtasks.test.ts`
- Known bad symptoms reviewers should watch for: Windows task runtime incorrectly reported as stopped or unknown

## Risks and Mitigations

- Risk: unexpected localized output may still use another key name
- Mitigation: this change is additive and preserves the existing key path first
