### PR TITLE
fix agents classify bare 402 quota messages for fallback

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -252,6 +252,12 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
     expect(
       resolveFailoverReasonFromError({
+        message:
+          "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
         status: 402,
         message: `${"x".repeat(520)} insufficient credits. Monthly spend limit reached.`,
       }),

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -394,6 +394,16 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("falls back on bare leading 402 quota messages", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error(
+        "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
+      ),
+    });
+  });
+
   it("falls back on billing errors", async () => {
     await expectFallsBackToHaiku({
       provider: "openai",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -339,11 +339,30 @@ function classify402Message(message: string): PaymentRequiredFailoverReason {
   return "billing";
 }
 
+function hasBareLeading402Signal(raw: string): boolean {
+  const leading = extractLeadingHttpStatus(raw.trim());
+  if (leading?.code !== 402 || !leading.rest) {
+    return false;
+  }
+  const normalized = leading.rest.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    hasQuotaRefreshWindowSignal(normalized) ||
+    hasExplicit402BillingSignal(normalized) ||
+    hasRetryable402TransientSignal(normalized) ||
+    isRateLimitErrorMessage(normalized) ||
+    isBillingErrorMessage(normalized)
+  );
+}
+
 function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailoverReason | null {
-  if (!RAW_402_MARKER_RE.test(raw)) {
+  const trimmed = raw.trim();
+  if (!RAW_402_MARKER_RE.test(trimmed) && !hasBareLeading402Signal(trimmed)) {
     return null;
   }
-  return classify402Message(raw);
+  return classify402Message(trimmed);
 }
 
 function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {


### PR DESCRIPTION
## Summary

- Problem: bare assistant error strings that start with `402 ...` could bypass the existing 402 failover path.
- Why it matters: model fallback stops on the primary model instead of continuing after retryable quota-refresh errors.
- What changed: added a guarded leading-402 signal path and regression coverage for both failover classification and model fallback.
- What did NOT change: explicit billing 402 handling and existing wrapped `HTTP 402 Payment Required` logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47576
- Related #

## User-visible / Behavior Changes

- Retryable bare `402 ...` assistant errors now continue through model fallback instead of terminating the run on the primary model.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 local dev shell
- Runtime/container: Node 22 plus pnpm
- Model/provider: embedded model fallback tests
- Integration/channel (if any): agent failover classification
- Relevant config (redacted): default model fallback fixture

### Steps

1. Classify a bare error string that starts with `402 You have reached your subscription quota limit...`.
2. Run model fallback with the same error returned by the primary model.
3. Verify the primary error is classified as `rate_limit` and the fallback candidate runs.

### Expected

- bare leading `402 ...` quota-refresh messages enter the retryable 402 path.

### Actual

- Added regression tests now pass for both classification and fallback execution.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/agents/failover-error.test.ts src/agents/model-fallback.test.ts`
- Edge cases checked: bare leading 402 quota text still avoids broad regex widening and preserves wrapped 402 handling
- What you did **not** verify: live provider behavior against ZenMux or other external APIs

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/failover-error.test.ts`, `src/agents/model-fallback.test.ts`
- Known bad symptoms reviewers should watch for: non-error text that starts with `402` being misclassified as failover-worthy

## Risks and Mitigations

- Risk: broad leading-number parsing could overmatch non-error text
- Mitigation: the new path only activates when the remaining text contains existing rate-limit or billing signals
