### PR TITLE
fix ui send qualified model refs from chat picker

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { modelKey, normalizeProviderId } from "../../../src/agents/model-selection.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
@@ -541,6 +542,29 @@ function resolveDefaultModelValue(state: AppViewState): string {
   return typeof model === "string" ? model.trim() : "";
 }
 
+function resolveCatalogModelRef(entry: ModelCatalogEntry): string {
+  return modelKey(normalizeProviderId(entry.provider), entry.id);
+}
+
+function normalizeChatModelValue(value: string, catalog: ModelCatalogEntry[]): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalized = trimmed.toLowerCase();
+  const exactMatch = catalog.find(
+    (entry) => resolveCatalogModelRef(entry).toLowerCase() === normalized,
+  );
+  if (exactMatch) {
+    return resolveCatalogModelRef(exactMatch);
+  }
+  const idMatches = catalog.filter((entry) => entry.id.trim().toLowerCase() === normalized);
+  if (idMatches.length === 1) {
+    return resolveCatalogModelRef(idMatches[0]);
+  }
+  return trimmed;
+}
+
 function buildChatModelOptions(
   catalog: ModelCatalogEntry[],
   currentOverride: string,
@@ -563,7 +587,7 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    addOption(resolveCatalogModelRef(entry), provider ? `${entry.id} · ${provider}` : entry.id);
   }
 
   if (currentOverride) {
@@ -576,13 +600,10 @@ function buildChatModelOptions(
 }
 
 function renderChatModelSelect(state: AppViewState) {
-  const currentOverride = resolveModelOverrideValue(state);
-  const defaultModel = resolveDefaultModelValue(state);
-  const options = buildChatModelOptions(
-    state.chatModelCatalog ?? [],
-    currentOverride,
-    defaultModel,
-  );
+  const catalog = state.chatModelCatalog ?? [];
+  const currentOverride = normalizeChatModelValue(resolveModelOverrideValue(state), catalog);
+  const defaultModel = normalizeChatModelValue(resolveDefaultModelValue(state), catalog);
+  const options = buildChatModelOptions(catalog, currentOverride, defaultModel);
   const defaultLabel = defaultModel ? `Default (${defaultModel})` : "Default model";
   const busy =
     state.chatLoading || state.chatSending || Boolean(state.chatRunId) || state.chatStream !== null;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -565,16 +565,50 @@ describe("chat view", () => {
     expect(modelSelect).not.toBeNull();
     expect(modelSelect?.value).toBe("");
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
-    expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("openai/gpt-5-mini");
+    vi.unstubAllGlobals();
+  });
+
+  it("patches provider-qualified refs when switching to a model from another provider", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState({
+      model: "openai-codex/gpt-5.2",
+      models: [
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai-codex" },
+        { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", provider: "anthropic" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+
+    modelSelect!.value = "anthropic/claude-sonnet-4-5";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("anthropic/claude-sonnet-4-5");
     vi.unstubAllGlobals();
   });
 
@@ -593,7 +627,7 @@ describe("chat view", () => {
       'select[data-chat-model-select="true"]',
     );
     expect(modelSelect).not.toBeNull();
-    expect(modelSelect?.value).toBe("gpt-5-mini");
+    expect(modelSelect?.value).toBe("openai/gpt-5-mini");
 
     modelSelect!.value = "";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
@@ -637,7 +671,7 @@ describe("chat view", () => {
     );
     expect(modelSelect).not.toBeNull();
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
     render(renderChatSessionSelect(state), container);
@@ -645,7 +679,7 @@ describe("chat view", () => {
     const rerendered = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
     );
-    expect(rerendered?.value).toBe("gpt-5-mini");
+    expect(rerendered?.value).toBe("openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## Summary
- send provider-qualified model refs from the Control UI chat header model picker
- normalize existing selected values against the model catalog so current selections stay visible
- cover provider-qualified selection behavior in chat header tests

## Testing
- pnpm exec vitest run ui/src/ui/views/chat.test.ts

Closes #47620