### PR TITLE
feat(privacy): add redactInboundPII config to strip PII from LLM context

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -265,8 +265,10 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = sessionCtx.GroupSystemPrompt?.trim() ?? "";
+  const redactInboundPII = cfg.privacy?.redactInboundPII === true;
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
+    { redactPII: redactInboundPII },
   );
   const extraSystemPromptParts = [
     inboundMetaPrompt,
@@ -301,6 +303,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    { redactPII: redactInboundPII },
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -85,6 +85,40 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["flags"]).toBeUndefined();
   });
 
+  it("redacts chat_id when redactPII is true", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:5494292670",
+        AccountId: "work",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: true },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toBeUndefined();
+    expect(payload["account_id"]).toBe("work");
+  });
+
+  it("keeps chat_id when redactPII is false", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:5494292670",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: false },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toBe("telegram:5494292670");
+  });
+
   it("omits sender_id when blank", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "458",
@@ -320,6 +354,45 @@ describe("buildInboundUserContextPrefix", () => {
 
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender_id"]).toBe("289522496");
+  });
+
+  it("redacts sender_id, sender, and sender block when redactPII is true", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "group",
+        MessageSid: "msg-100",
+        SenderId: "289522496",
+        SenderName: "Tyler",
+        SenderUsername: "tylerg",
+        SenderTag: "Tyler#1234",
+        SenderE164: "+15551234567",
+      } as TemplateContext,
+      { redactPII: true },
+    );
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["sender_id"]).toBeUndefined();
+    expect(conversationInfo["sender"]).toBeUndefined();
+    expect(text).not.toContain("Sender (untrusted metadata):");
+    // non-PII fields should still be present
+    expect(conversationInfo["message_id"]).toBe("msg-100");
+  });
+
+  it("keeps sender fields when redactPII is false", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "group",
+        MessageSid: "msg-101",
+        SenderId: "289522496",
+        SenderName: "Tyler",
+      } as TemplateContext,
+      { redactPII: false },
+    );
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["sender_id"]).toBe("289522496");
+    expect(conversationInfo["sender"]).toBe("Tyler");
+    expect(text).toContain("Sender (untrusted metadata):");
   });
 
   it("falls back to SenderId when sender phone is missing", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -42,7 +42,10 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
-export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
+export function buildInboundMetaSystemPrompt(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
 
@@ -59,7 +62,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
 
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    chat_id: safeTrim(ctx.OriginatingTo),
+    chat_id: options?.redactPII ? undefined : safeTrim(ctx.OriginatingTo),
     account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
@@ -81,7 +84,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -96,17 +102,19 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const resolvedMessageId = messageId ?? messageIdFull;
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
+  const redactPII = options?.redactPII === true;
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
-    sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
+    sender_id: shouldIncludeConversationInfo && !redactPII ? safeTrim(ctx.SenderId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
-    sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ??
-        safeTrim(ctx.SenderE164) ??
-        safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername))
-      : undefined,
+    sender:
+      shouldIncludeConversationInfo && !redactPII
+        ? (safeTrim(ctx.SenderName) ??
+          safeTrim(ctx.SenderE164) ??
+          safeTrim(ctx.SenderId) ??
+          safeTrim(ctx.SenderUsername))
+        : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),
@@ -135,26 +143,31 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     );
   }
 
-  const senderInfo = {
-    label: resolveSenderLabel({
+  if (!redactPII) {
+    const senderInfo = {
+      label: resolveSenderLabel({
+        name: safeTrim(ctx.SenderName),
+        username: safeTrim(ctx.SenderUsername),
+        tag: safeTrim(ctx.SenderTag),
+        e164: safeTrim(ctx.SenderE164),
+        id: safeTrim(ctx.SenderId),
+      }),
+      id: safeTrim(ctx.SenderId),
       name: safeTrim(ctx.SenderName),
       username: safeTrim(ctx.SenderUsername),
       tag: safeTrim(ctx.SenderTag),
       e164: safeTrim(ctx.SenderE164),
-      id: safeTrim(ctx.SenderId),
-    }),
-    id: safeTrim(ctx.SenderId),
-    name: safeTrim(ctx.SenderName),
-    username: safeTrim(ctx.SenderUsername),
-    tag: safeTrim(ctx.SenderTag),
-    e164: safeTrim(ctx.SenderE164),
-  };
-  if (senderInfo?.label) {
-    blocks.push(
-      ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
-        "\n",
-      ),
-    );
+    };
+    if (senderInfo?.label) {
+      blocks.push(
+        [
+          "Sender (untrusted metadata):",
+          "```json",
+          JSON.stringify(senderInfo, null, 2),
+          "```",
+        ].join("\n"),
+      );
+    }
   }
 
   if (safeTrim(ctx.ThreadStarterBody)) {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -886,6 +886,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    privacy: z
+      .object({
+        redactInboundPII: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Add `privacy.redactInboundPII` config option (boolean, default `false`). When enabled, PII is stripped from the inbound metadata before it reaches the LLM provider.

## What's redacted

| Field | Location | Redacted? |
|-------|----------|-----------|
| `chat_id` | System prompt (`inbound_meta.v1`) | ✅ Omitted |
| `sender_id` | User context (conversation info) | ✅ Omitted |
| `sender` (name) | User context (conversation info) | ✅ Omitted |
| Sender block (id, name, username, tag, e164) | User context | ✅ Entire block omitted |
| `message_id`, `timestamp`, `group_subject`, etc. | User context | ❌ Preserved (functional) |

## Usage

```json
{
  "privacy": {
    "redactInboundPII": true
  }
}
```

## Changes

- `src/config/zod-schema.ts` — New `privacy.redactInboundPII` schema field
- `src/auto-reply/reply/inbound-meta.ts` — Both builder functions accept `{ redactPII?: boolean }`
- `src/auto-reply/reply/get-reply-run.ts` — Reads config, passes to builders
- `src/auto-reply/reply/inbound-meta.test.ts` — 4 new test cases (all passing)

Closes #47853