### PR TITLE
fix(msteams): add fetch timeout to Microsoft Graph API calls

### DIFF
--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -36,12 +36,21 @@ export async function fetchGraphJson<T>(params: {
   path: string;
   headers?: Record<string, string>;
 }): Promise<T> {
-  const res = await fetch(`${GRAPH_ROOT}${params.path}`, {
-    headers: {
-      Authorization: `Bearer ${params.token}`,
-      ...params.headers,
-    },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${GRAPH_ROOT}${params.path}`, {
+      headers: {
+        Authorization: `Bearer ${params.token}`,
+        ...params.headers,
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Graph ${params.path} request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`Graph ${params.path} failed (${res.status}): ${text || "unknown error"}`);


### PR DESCRIPTION
lobster-biscuit

## Problem

`fetchGraphJson()` in the MS Teams extension calls the Microsoft Graph API without any timeout. If the Graph endpoint hangs or is slow to respond, the entire extension stalls indefinitely.

## Solution

Add a 30-second `AbortSignal.timeout` to the central `fetchGraphJson()` wrapper. This single change protects every Graph API call in the MS Teams extension (list teams, list channels, etc.).

The fetch is wrapped in a try/catch that preserves the cause chain via `{ cause: err }`. The existing `!res.ok` error path already uses `.catch(() => "")` on the body read, so no change needed there.

## Changes

- `extensions/msteams/src/graph.ts` — add `AbortSignal.timeout(30_000)` to fetch + try/catch wrapper

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Existing MS Teams tests pass (no test file for graph.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)