### PR TITLE
fix(qwen-portal): add fetch timeout to OAuth device-code and token flows

### DIFF
--- a/extensions/qwen-portal-auth/oauth.ts
+++ b/extensions/qwen-portal-auth/oauth.ts
@@ -35,23 +35,32 @@ type DeviceTokenResult =
   | { status: "error"; message: string };
 
 async function requestDeviceCode(params: { challenge: string }): Promise<QwenDeviceAuthorization> {
-  const response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-      "x-request-id": randomUUID(),
-    },
-    body: toFormUrlEncoded({
-      client_id: QWEN_OAUTH_CLIENT_ID,
-      scope: QWEN_OAUTH_SCOPE,
-      code_challenge: params.challenge,
-      code_challenge_method: "S256",
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "x-request-id": randomUUID(),
+      },
+      body: toFormUrlEncoded({
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        scope: QWEN_OAUTH_SCOPE,
+        code_challenge: params.challenge,
+        code_challenge_method: "S256",
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Qwen device code request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
-    const text = await response.text();
+    const text = await response.text().catch(() => "");
     throw new Error(`Qwen device authorization failed: ${text || response.statusText}`);
   }
 
@@ -69,26 +78,39 @@ async function pollDeviceToken(params: {
   deviceCode: string;
   verifier: string;
 }): Promise<DeviceTokenResult> {
-  const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    body: toFormUrlEncoded({
-      grant_type: QWEN_OAUTH_GRANT_TYPE,
-      client_id: QWEN_OAUTH_CLIENT_ID,
-      device_code: params.deviceCode,
-      code_verifier: params.verifier,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: toFormUrlEncoded({
+        grant_type: QWEN_OAUTH_GRANT_TYPE,
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        device_code: params.deviceCode,
+        code_verifier: params.verifier,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      // Single-poll timeout — treat as pending so the caller retries on next interval.
+      return { status: "pending" };
+    }
+    throw new Error(
+      `Qwen token poll failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
     let payload: { error?: string; error_description?: string } | undefined;
     try {
       payload = (await response.json()) as { error?: string; error_description?: string };
     } catch {
-      const text = await response.text();
+      const text = await response.text().catch(() => "");
       return { status: "error", message: text || response.statusText };
     }
 

--- a/src/providers/qwen-portal-oauth.ts
+++ b/src/providers/qwen-portal-oauth.ts
@@ -13,21 +13,30 @@ export async function refreshQwenPortalCredentials(
     throw new Error("Qwen OAuth refresh token missing; re-authenticate.");
   }
 
-  const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: QWEN_OAUTH_CLIENT_ID,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: QWEN_OAUTH_CLIENT_ID,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Qwen OAuth refresh request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
-    const text = await response.text();
+    const text = await response.text().catch(() => "");
     if (response.status === 400) {
       throw new Error(
         `Qwen OAuth refresh token expired or invalid. Re-authenticate with \`${formatCliCommand("openclaw models auth login --provider qwen-portal")}\`.`,


### PR DESCRIPTION
lobster-biscuit

## Problem

Three bare `fetch()` calls in the Qwen portal OAuth flow have no timeout:

1. **`src/providers/qwen-portal-oauth.ts`** — refresh token exchange
2. **`extensions/qwen-portal-auth/oauth.ts`** — device-code request
3. **`extensions/qwen-portal-auth/oauth.ts`** — token poll

If the Qwen endpoint hangs, authentication stalls indefinitely.

## Solution

Add `AbortSignal.timeout(15_000)` to all three fetch calls with proper error handling:

- **Device-code request**: fatal on timeout (15 s). Wrapped in try/catch with `{ cause: err }`.
- **Token poll**: timeout returns `{ status: "pending" }` so the caller retries on the next interval. Only `DOMException TimeoutError` is caught; DNS/TLS/other errors are re-thrown immediately.
- **Refresh token**: fatal on timeout (15 s). Same try/catch pattern.

Also guarded error-path body reads with `.catch(() => "")` to prevent a late timeout from producing an unwrapped error.

## Changes

- `src/providers/qwen-portal-oauth.ts` — add timeout to refresh token fetch
- `extensions/qwen-portal-auth/oauth.ts` — add timeout to device-code + poll fetches

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Qwen OAuth login flow works end-to-end (requires Qwen account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)