### PR TITLE
feishu: add structured card actions and interactive approval flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - secrets: harden read-only SecretRef command paths and diagnostics. (#47794) Thanks @joshavant.
 - Sandbox/runtime: add pluggable sandbox backends, ship an OpenShell backend with `mirror` and `remote` workspace modes, and make sandbox list/recreate/prune backend-aware instead of Docker-only.
 - Sandbox/SSH: add a core SSH sandbox backend with secret-backed key, certificate, and known_hosts inputs, move shared remote exec/filesystem tooling into core, and keep OpenShell focused on sandbox lifecycle plus optional `mirror` mode.
+- Feishu/cards: add structured interactive approval and quick-action launcher cards, preserve callback user and conversation context through routing, and keep legacy card-action fallback behavior so common actions can run without typing raw commands. (#47873)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/runtime: add pluggable sandbox backends, ship an OpenShell backend with `mirror` and `remote` workspace modes, and make sandbox list/recreate/prune backend-aware instead of Docker-only.
 - Sandbox/SSH: add a core SSH sandbox backend with secret-backed key, certificate, and known_hosts inputs, move shared remote exec/filesystem tooling into core, and keep OpenShell focused on sandbox lifecycle plus optional `mirror` mode.
 - Feishu/cards: add structured interactive approval and quick-action launcher cards, preserve callback user and conversation context through routing, and keep legacy card-action fallback behavior so common actions can run without typing raw commands. (#47873)
+- Feishu/ACP: add current-conversation ACP and subagent session binding for supported DMs and topic conversations, including completion delivery back to the originating Feishu conversation. (#46819)
 
 ### Fixes
 

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+import {
+  handleFeishuCardAction,
+  resetProcessedFeishuCardActionTokensForTests,
+  type FeishuCardActionEvent,
+} from "./card-action.js";
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import {
   FEISHU_APPROVAL_CANCEL_ACTION,
@@ -33,6 +37,7 @@ describe("Feishu Card Action Handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetProcessedFeishuCardActionTokensForTests();
   });
 
   it("handles card action with text payload", async () => {
@@ -128,7 +133,13 @@ describe("Feishu Card Action Handler", () => {
             command: "/new",
             prompt: "Start a fresh session?",
           },
-          c: { u: "u123", h: "chat1", t: "group", s: "agent:codex:feishu:chat:chat1", e: Date.now() + 60_000 },
+          c: {
+            u: "u123",
+            h: "chat1",
+            t: "group",
+            s: "agent:codex:feishu:chat:chat1",
+            e: Date.now() + 60_000,
+          },
         }),
         tag: "button",
       },
@@ -327,5 +338,30 @@ describe("Feishu Card Action Handler", () => {
     await handleFeishuCardAction({ cfg, event, runtime });
 
     expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a claimed token when dispatch fails so retries can succeed", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok11",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+    vi.mocked(handleFeishuMessage)
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(undefined as never);
+
+    await expect(handleFeishuCardAction({ cfg, event, runtime })).rejects.toThrow("transient");
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -364,4 +364,40 @@ describe("Feishu Card Action Handler", () => {
 
     expect(handleFeishuMessage).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps an in-flight token claimed while a slow dispatch is still running", async () => {
+    vi.useFakeTimers();
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok12",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    let resolveDispatch: (() => void) | undefined;
+    vi.mocked(handleFeishuMessage).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDispatch = resolve;
+        }) as never,
+    );
+
+    const first = handleFeishuCardAction({ cfg, event, runtime });
+    await vi.advanceTimersByTimeAsync(61_000);
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
+
+    resolveDispatch?.();
+    await first;
+    vi.useRealTimers();
+  });
 });

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+import {
+  FEISHU_APPROVAL_CANCEL_ACTION,
+  FEISHU_APPROVAL_CONFIRM_ACTION,
+  FEISHU_APPROVAL_REQUEST_ACTION,
+} from "./card-ux-approval.js";
 
 // Mock resolveFeishuAccount
 vi.mock("./accounts.js", () => ({
@@ -11,11 +17,23 @@ vi.mock("./bot.js", () => ({
   handleFeishuMessage: vi.fn(),
 }));
 
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendCardFeishu: sendCardFeishuMock,
+  sendMessageFeishu: sendMessageFeishuMock,
+}));
+
 import { handleFeishuMessage } from "./bot.js";
 
 describe("Feishu Card Action Handler", () => {
   const cfg = {} as any; // Minimal mock
   const runtime = { log: vi.fn(), error: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("handles card action with text payload", async () => {
     const event: FeishuCardActionEvent = {
@@ -59,5 +77,255 @@ describe("Feishu Card Action Handler", () => {
         }),
       }),
     );
+  });
+
+  it("routes quick command actions with operator and conversation context", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok3",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          sender: expect.objectContaining({
+            sender_id: expect.objectContaining({
+              open_id: "u123",
+              user_id: "uid1",
+              union_id: "un1",
+            }),
+          }),
+          message: expect.objectContaining({
+            chat_id: "chat1",
+            content: '{"text":"/help"}',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("opens an approval card for metadata actions", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok4",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "meta",
+          a: FEISHU_APPROVAL_REQUEST_ACTION,
+          m: {
+            command: "/new",
+            prompt: "Start a fresh session?",
+          },
+          c: { u: "u123", h: "chat1", t: "group", s: "agent:codex:feishu:chat:chat1", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime, accountId: "main" });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:chat1",
+        accountId: "main",
+        card: expect.objectContaining({
+          header: expect.objectContaining({
+            title: expect.objectContaining({ content: "Confirm action" }),
+          }),
+          body: expect.objectContaining({
+            elements: expect.arrayContaining([
+              expect.objectContaining({
+                tag: "action",
+                actions: expect.arrayContaining([
+                  expect.objectContaining({
+                    value: expect.objectContaining({
+                      c: expect.objectContaining({
+                        u: "u123",
+                        h: "chat1",
+                        t: "group",
+                        s: "agent:codex:feishu:chat:chat1",
+                      }),
+                    }),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+  });
+
+  it("runs approval confirmation through the normal message path", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok5",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: FEISHU_APPROVAL_CONFIRM_ACTION,
+          q: "/new",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"/new"}',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("safely rejects stale structured actions", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok6",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() - 1 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:chat1",
+        text: expect.stringContaining("expired"),
+      }),
+    );
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+  });
+
+  it("safely rejects wrong-user structured actions", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u999", user_id: "uid1", union_id: "un1" },
+      token: "tok7",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u999", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("different user"),
+      }),
+    );
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends a lightweight cancellation notice", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok8",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "button",
+          a: FEISHU_APPROVAL_CANCEL_ACTION,
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:chat1",
+        text: "Cancelled.",
+      }),
+    );
+  });
+
+  it("preserves p2p callbacks for DM quick actions", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok9",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "p2p-chat-1", t: "p2p", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "p2p-chat-1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_id: "p2p-chat-1",
+            chat_type: "p2p",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("drops duplicate structured callback tokens", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok10",
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+        }),
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -30,17 +30,24 @@ export type FeishuCardActionEvent = {
 
 const FEISHU_APPROVAL_CARD_TTL_MS = 5 * 60_000;
 const FEISHU_CARD_ACTION_TOKEN_TTL_MS = 15 * 60_000;
-const processedCardActionTokens = new Map<string, number>();
+const processedCardActionTokens = new Map<
+  string,
+  { status: "inflight" | "completed"; expiresAt: number }
+>();
+
+export function resetProcessedFeishuCardActionTokensForTests(): void {
+  processedCardActionTokens.clear();
+}
 
 function pruneProcessedCardActionTokens(now: number): void {
-  for (const [key, expireAt] of processedCardActionTokens.entries()) {
-    if (expireAt <= now) {
+  for (const [key, entry] of processedCardActionTokens.entries()) {
+    if (entry.expiresAt <= now) {
       processedCardActionTokens.delete(key);
     }
   }
 }
 
-function claimFeishuCardActionToken(params: {
+function beginFeishuCardActionToken(params: {
   token: string;
   accountId: string;
   now?: number;
@@ -53,11 +60,35 @@ function claimFeishuCardActionToken(params: {
   }
   const key = `${params.accountId}:${normalizedToken}`;
   const existing = processedCardActionTokens.get(key);
-  if (existing && existing > now) {
+  if (existing && existing.expiresAt > now) {
     return false;
   }
-  processedCardActionTokens.set(key, now + FEISHU_CARD_ACTION_TOKEN_TTL_MS);
+  processedCardActionTokens.set(key, { status: "inflight", expiresAt: now + 60_000 });
   return true;
+}
+
+function completeFeishuCardActionToken(params: {
+  token: string;
+  accountId: string;
+  now?: number;
+}): void {
+  const now = params.now ?? Date.now();
+  const normalizedToken = params.token.trim();
+  if (!normalizedToken) {
+    return;
+  }
+  processedCardActionTokens.set(`${params.accountId}:${normalizedToken}`, {
+    status: "completed",
+    expiresAt: now + FEISHU_CARD_ACTION_TOKEN_TTL_MS,
+  });
+}
+
+function releaseFeishuCardActionToken(params: { token: string; accountId: string }): void {
+  const normalizedToken = params.token.trim();
+  if (!normalizedToken) {
+    return;
+  }
+  processedCardActionTokens.delete(`${params.accountId}:${normalizedToken}`);
 }
 
 function buildSyntheticMessageEvent(
@@ -143,7 +174,7 @@ export async function handleFeishuCardAction(params: {
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
   const decoded = decodeFeishuCardAction({ event });
-  const claimedToken = claimFeishuCardActionToken({
+  const claimedToken = beginFeishuCardActionToken({
     token: event.token,
     accountId: account.accountId,
   });
@@ -152,112 +183,125 @@ export async function handleFeishuCardAction(params: {
     return;
   }
 
-  if (decoded.kind === "invalid") {
-    log(
-      `feishu[${account.accountId}]: rejected card action from ${event.operator.open_id}: ${decoded.reason}`,
-    );
-    await sendInvalidInteractionNotice({
-      cfg,
-      event,
-      reason: decoded.reason,
-      accountId,
-    });
-    return;
-  }
-
-  if (decoded.kind === "structured") {
-    const { envelope } = decoded;
-    log(
-      `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
-    );
-
-    if (envelope.a === FEISHU_APPROVAL_REQUEST_ACTION) {
-      const command = typeof envelope.m?.command === "string" ? envelope.m.command.trim() : "";
-      if (!command) {
-        await sendInvalidInteractionNotice({
-          cfg,
-          event,
-          reason: "malformed",
-          accountId,
-        });
-        return;
-      }
-      const prompt =
-        typeof envelope.m?.prompt === "string" && envelope.m.prompt.trim()
-          ? envelope.m.prompt
-          : `Run \`${command}\` in this Feishu conversation?`;
-      await sendCardFeishu({
-        cfg,
-        to: resolveCallbackTarget(event),
-        card: createApprovalCard({
-          operatorOpenId: event.operator.open_id,
-          chatId: event.context.chat_id || undefined,
-          command,
-          prompt,
-          sessionKey: envelope.c?.s,
-          expiresAt: Date.now() + FEISHU_APPROVAL_CARD_TTL_MS,
-          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
-          confirmLabel: command === "/reset" ? "Reset" : "Confirm",
-        }),
-        accountId,
-      });
-      return;
-    }
-
-    if (envelope.a === FEISHU_APPROVAL_CANCEL_ACTION) {
-      await sendMessageFeishu({
-        cfg,
-        to: resolveCallbackTarget(event),
-        text: "Cancelled.",
-        accountId,
-      });
-      return;
-    }
-
-    if (envelope.a === FEISHU_APPROVAL_CONFIRM_ACTION || envelope.k === "quick") {
-      const command = envelope.q?.trim();
-      if (!command) {
-        await sendInvalidInteractionNotice({
-          cfg,
-          event,
-          reason: "malformed",
-          accountId,
-        });
-        return;
-      }
-      await dispatchSyntheticCommand({
+  try {
+    if (decoded.kind === "invalid") {
+      log(
+        `feishu[${account.accountId}]: rejected card action from ${event.operator.open_id}: ${decoded.reason}`,
+      );
+      await sendInvalidInteractionNotice({
         cfg,
         event,
-        command,
-        botOpenId: params.botOpenId,
-        runtime,
+        reason: decoded.reason,
         accountId,
-        chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
       });
+      completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
       return;
     }
 
-    await sendInvalidInteractionNotice({
+    if (decoded.kind === "structured") {
+      const { envelope } = decoded;
+      log(
+        `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
+      );
+
+      if (envelope.a === FEISHU_APPROVAL_REQUEST_ACTION) {
+        const command = typeof envelope.m?.command === "string" ? envelope.m.command.trim() : "";
+        if (!command) {
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+        const prompt =
+          typeof envelope.m?.prompt === "string" && envelope.m.prompt.trim()
+            ? envelope.m.prompt
+            : `Run \`${command}\` in this Feishu conversation?`;
+        await sendCardFeishu({
+          cfg,
+          to: resolveCallbackTarget(event),
+          card: createApprovalCard({
+            operatorOpenId: event.operator.open_id,
+            chatId: event.context.chat_id || undefined,
+            command,
+            prompt,
+            sessionKey: envelope.c?.s,
+            expiresAt: Date.now() + FEISHU_APPROVAL_CARD_TTL_MS,
+            chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+            confirmLabel: command === "/reset" ? "Reset" : "Confirm",
+          }),
+          accountId,
+        });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      if (envelope.a === FEISHU_APPROVAL_CANCEL_ACTION) {
+        await sendMessageFeishu({
+          cfg,
+          to: resolveCallbackTarget(event),
+          text: "Cancelled.",
+          accountId,
+        });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      if (envelope.a === FEISHU_APPROVAL_CONFIRM_ACTION || envelope.k === "quick") {
+        const command = envelope.q?.trim();
+        if (!command) {
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+        await dispatchSyntheticCommand({
+          cfg,
+          event,
+          command,
+          botOpenId: params.botOpenId,
+          runtime,
+          accountId,
+          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+        });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      await sendInvalidInteractionNotice({
+        cfg,
+        event,
+        reason: "malformed",
+        accountId,
+      });
+      completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+      return;
+    }
+
+    const content = buildFeishuCardActionTextFallback(event);
+
+    log(
+      `feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`,
+    );
+
+    await dispatchSyntheticCommand({
       cfg,
       event,
-      reason: "malformed",
+      command: content,
+      botOpenId: params.botOpenId,
+      runtime,
       accountId,
     });
-    return;
+    completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+  } catch (err) {
+    releaseFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+    throw err;
   }
-
-  const content = buildFeishuCardActionTextFallback(event);
-
-  log(
-    `feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`,
-  );
-
-  await dispatchSyntheticCommand({
-    cfg,
-    event,
-    command: content,
-    botOpenId: params.botOpenId,
-    runtime,
-    accountId,
-  });
 }

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -63,7 +63,10 @@ function beginFeishuCardActionToken(params: {
   if (existing && existing.expiresAt > now) {
     return false;
   }
-  processedCardActionTokens.set(key, { status: "inflight", expiresAt: now + 60_000 });
+  processedCardActionTokens.set(key, {
+    status: "inflight",
+    expiresAt: now + FEISHU_CARD_ACTION_TOKEN_TTL_MS,
+  });
   return true;
 }
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,6 +1,14 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
+import { decodeFeishuCardAction, buildFeishuCardActionTextFallback } from "./card-interaction.js";
+import {
+  createApprovalCard,
+  FEISHU_APPROVAL_CANCEL_ACTION,
+  FEISHU_APPROVAL_CONFIRM_ACTION,
+  FEISHU_APPROVAL_REQUEST_ACTION,
+} from "./card-ux-approval.js";
+import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -20,18 +28,108 @@ export type FeishuCardActionEvent = {
   };
 };
 
-function buildCardActionTextFallback(event: FeishuCardActionEvent): string {
-  const actionValue = event.action.value;
-  if (typeof actionValue === "object" && actionValue !== null) {
-    if ("text" in actionValue && typeof actionValue.text === "string") {
-      return actionValue.text;
+const FEISHU_APPROVAL_CARD_TTL_MS = 5 * 60_000;
+const FEISHU_CARD_ACTION_TOKEN_TTL_MS = 15 * 60_000;
+const processedCardActionTokens = new Map<string, number>();
+
+function pruneProcessedCardActionTokens(now: number): void {
+  for (const [key, expireAt] of processedCardActionTokens.entries()) {
+    if (expireAt <= now) {
+      processedCardActionTokens.delete(key);
     }
-    if ("command" in actionValue && typeof actionValue.command === "string") {
-      return actionValue.command;
-    }
-    return JSON.stringify(actionValue);
   }
-  return String(actionValue);
+}
+
+function claimFeishuCardActionToken(params: {
+  token: string;
+  accountId: string;
+  now?: number;
+}): boolean {
+  const now = params.now ?? Date.now();
+  pruneProcessedCardActionTokens(now);
+  const normalizedToken = params.token.trim();
+  if (!normalizedToken) {
+    return true;
+  }
+  const key = `${params.accountId}:${normalizedToken}`;
+  const existing = processedCardActionTokens.get(key);
+  if (existing && existing > now) {
+    return false;
+  }
+  processedCardActionTokens.set(key, now + FEISHU_CARD_ACTION_TOKEN_TTL_MS);
+  return true;
+}
+
+function buildSyntheticMessageEvent(
+  event: FeishuCardActionEvent,
+  content: string,
+  chatType?: "p2p" | "group",
+): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: {
+        open_id: event.operator.open_id,
+        user_id: event.operator.user_id,
+        union_id: event.operator.union_id,
+      },
+    },
+    message: {
+      message_id: `card-action-${event.token}`,
+      chat_id: event.context.chat_id || event.operator.open_id,
+      chat_type: chatType ?? (event.context.chat_id ? "group" : "p2p"),
+      message_type: "text",
+      content: JSON.stringify({ text: content }),
+    },
+  };
+}
+
+function resolveCallbackTarget(event: FeishuCardActionEvent): string {
+  const chatId = event.context.chat_id?.trim();
+  if (chatId) {
+    return `chat:${chatId}`;
+  }
+  return `user:${event.operator.open_id}`;
+}
+
+async function dispatchSyntheticCommand(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuCardActionEvent;
+  command: string;
+  botOpenId?: string;
+  runtime?: RuntimeEnv;
+  accountId?: string;
+  chatType?: "p2p" | "group";
+}): Promise<void> {
+  await handleFeishuMessage({
+    cfg: params.cfg,
+    event: buildSyntheticMessageEvent(params.event, params.command, params.chatType),
+    botOpenId: params.botOpenId,
+    runtime: params.runtime,
+    accountId: params.accountId,
+  });
+}
+
+async function sendInvalidInteractionNotice(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuCardActionEvent;
+  reason: "malformed" | "stale" | "wrong_user" | "wrong_conversation";
+  accountId?: string;
+}): Promise<void> {
+  const reasonText =
+    params.reason === "stale"
+      ? "This card action has expired. Open a fresh launcher card and try again."
+      : params.reason === "wrong_user"
+        ? "This card action belongs to a different user."
+        : params.reason === "wrong_conversation"
+          ? "This card action belongs to a different conversation."
+          : "This card action payload is invalid.";
+
+  await sendMessageFeishu({
+    cfg: params.cfg,
+    to: resolveCallbackTarget(params.event),
+    text: `⚠️ ${reasonText}`,
+    accountId: params.accountId,
+  });
 }
 
 export async function handleFeishuCardAction(params: {
@@ -44,34 +142,120 @@ export async function handleFeishuCardAction(params: {
   const { cfg, event, runtime, accountId } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
-  const content = buildCardActionTextFallback(event);
+  const decoded = decodeFeishuCardAction({ event });
+  const claimedToken = claimFeishuCardActionToken({
+    token: event.token,
+    accountId: account.accountId,
+  });
+  if (!claimedToken) {
+    log(`feishu[${account.accountId}]: skipping duplicate card action token ${event.token}`);
+    return;
+  }
 
-  // Construct a synthetic message event
-  const messageEvent: FeishuMessageEvent = {
-    sender: {
-      sender_id: {
-        open_id: event.operator.open_id,
-        user_id: event.operator.user_id,
-        union_id: event.operator.union_id,
-      },
-    },
-    message: {
-      message_id: `card-action-${event.token}`,
-      chat_id: event.context.chat_id || event.operator.open_id,
-      chat_type: event.context.chat_id ? "group" : "p2p",
-      message_type: "text",
-      content: JSON.stringify({ text: content }),
-    },
-  };
+  if (decoded.kind === "invalid") {
+    log(
+      `feishu[${account.accountId}]: rejected card action from ${event.operator.open_id}: ${decoded.reason}`,
+    );
+    await sendInvalidInteractionNotice({
+      cfg,
+      event,
+      reason: decoded.reason,
+      accountId,
+    });
+    return;
+  }
+
+  if (decoded.kind === "structured") {
+    const { envelope } = decoded;
+    log(
+      `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
+    );
+
+    if (envelope.a === FEISHU_APPROVAL_REQUEST_ACTION) {
+      const command = typeof envelope.m?.command === "string" ? envelope.m.command.trim() : "";
+      if (!command) {
+        await sendInvalidInteractionNotice({
+          cfg,
+          event,
+          reason: "malformed",
+          accountId,
+        });
+        return;
+      }
+      const prompt =
+        typeof envelope.m?.prompt === "string" && envelope.m.prompt.trim()
+          ? envelope.m.prompt
+          : `Run \`${command}\` in this Feishu conversation?`;
+      await sendCardFeishu({
+        cfg,
+        to: resolveCallbackTarget(event),
+        card: createApprovalCard({
+          operatorOpenId: event.operator.open_id,
+          chatId: event.context.chat_id || undefined,
+          command,
+          prompt,
+          sessionKey: envelope.c?.s,
+          expiresAt: Date.now() + FEISHU_APPROVAL_CARD_TTL_MS,
+          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+          confirmLabel: command === "/reset" ? "Reset" : "Confirm",
+        }),
+        accountId,
+      });
+      return;
+    }
+
+    if (envelope.a === FEISHU_APPROVAL_CANCEL_ACTION) {
+      await sendMessageFeishu({
+        cfg,
+        to: resolveCallbackTarget(event),
+        text: "Cancelled.",
+        accountId,
+      });
+      return;
+    }
+
+    if (envelope.a === FEISHU_APPROVAL_CONFIRM_ACTION || envelope.k === "quick") {
+      const command = envelope.q?.trim();
+      if (!command) {
+        await sendInvalidInteractionNotice({
+          cfg,
+          event,
+          reason: "malformed",
+          accountId,
+        });
+        return;
+      }
+      await dispatchSyntheticCommand({
+        cfg,
+        event,
+        command,
+        botOpenId: params.botOpenId,
+        runtime,
+        accountId,
+        chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+      });
+      return;
+    }
+
+    await sendInvalidInteractionNotice({
+      cfg,
+      event,
+      reason: "malformed",
+      accountId,
+    });
+    return;
+  }
+
+  const content = buildFeishuCardActionTextFallback(event);
 
   log(
     `feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`,
   );
 
-  // Dispatch as normal message
-  await handleFeishuMessage({
+  await dispatchSyntheticCommand({
     cfg,
-    event: messageEvent,
+    event,
+    command: content,
     botOpenId: params.botOpenId,
     runtime,
     accountId,

--- a/extensions/feishu/src/card-interaction.test.ts
+++ b/extensions/feishu/src/card-interaction.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFeishuCardActionTextFallback,
+  createFeishuCardInteractionEnvelope,
+  decodeFeishuCardAction,
+} from "./card-interaction.js";
+
+describe("feishu card interaction decoder", () => {
+  it("decodes valid structured payloads", () => {
+    const result = decodeFeishuCardAction({
+      now: 1_700_000_000_000,
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+            c: { u: "u123", h: "chat1", t: "group", e: 1_700_000_060_000 },
+          }),
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        envelope: expect.objectContaining({
+          q: "/help",
+        }),
+      }),
+    );
+  });
+
+  it("falls back for legacy text-like payloads", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: { value: { text: "/ping" } },
+      },
+    });
+
+    expect(result).toEqual({ kind: "legacy", text: "/ping" });
+    expect(
+      buildFeishuCardActionTextFallback({
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: { value: { command: "/new" } },
+      }),
+    ).toBe("/new");
+  });
+
+  it("rejects malformed structured payloads", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: {
+            oc: "ocf1",
+            k: "quick",
+            a: "broken",
+            m: { bad: { nested: true } },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({ kind: "invalid", reason: "malformed" });
+  });
+
+  it("rejects stale payloads", () => {
+    const result = decodeFeishuCardAction({
+      now: 100,
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "button",
+            a: "stale",
+            c: { e: 99, t: "group" },
+          }),
+        },
+      },
+    });
+
+    expect(result).toEqual({ kind: "invalid", reason: "stale" });
+  });
+
+  it("rejects wrong-conversation payloads when chat context is enforced", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat2" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "button",
+            a: "scoped",
+            c: { u: "u123", h: "chat1", t: "group", e: Date.now() + 60_000 },
+          }),
+        },
+      },
+    });
+
+    expect(result).toEqual({ kind: "invalid", reason: "wrong_conversation" });
+  });
+
+  it("rejects malformed chat-type context", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: {
+            oc: "ocf1",
+            k: "button",
+            a: "bad",
+            c: { t: "private" },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({ kind: "invalid", reason: "malformed" });
+  });
+});

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -61,9 +61,7 @@ function isInteractionKind(value: unknown): value is FeishuCardInteractionKind {
   return value === "button" || value === "quick" || value === "meta";
 }
 
-function isMetadataValue(
-  value: unknown,
-): value is string | number | boolean | null | undefined {
+function isMetadataValue(value: unknown): value is string | number | boolean | null | undefined {
   return (
     value === null ||
     value === undefined ||
@@ -144,11 +142,7 @@ export function decodeFeishuCardAction(params: {
     if (actionValue.c.e !== undefined && !Number.isFinite(actionValue.c.e)) {
       return { kind: "invalid", reason: "malformed" };
     }
-    if (
-      actionValue.c.t !== undefined &&
-      actionValue.c.t !== "p2p" &&
-      actionValue.c.t !== "group"
-    ) {
+    if (actionValue.c.t !== undefined && actionValue.c.t !== "p2p" && actionValue.c.t !== "group") {
       return { kind: "invalid", reason: "malformed" };
     }
 

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -1,0 +1,174 @@
+export const FEISHU_CARD_INTERACTION_VERSION = "ocf1";
+
+export type FeishuCardInteractionKind = "button" | "quick" | "meta";
+export type FeishuCardInteractionReason =
+  | "malformed"
+  | "stale"
+  | "wrong_user"
+  | "wrong_conversation";
+
+export type FeishuCardInteractionMetadata = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export type FeishuCardInteractionEnvelope = {
+  oc: typeof FEISHU_CARD_INTERACTION_VERSION;
+  k: FeishuCardInteractionKind;
+  a: string;
+  q?: string;
+  m?: FeishuCardInteractionMetadata;
+  c?: {
+    u?: string;
+    h?: string;
+    s?: string;
+    e?: number;
+    t?: "p2p" | "group";
+  };
+};
+
+export type FeishuCardActionEventLike = {
+  operator: {
+    open_id?: string;
+  };
+  action: {
+    value: unknown;
+  };
+  context: {
+    chat_id?: string;
+  };
+};
+
+export type DecodedFeishuCardAction =
+  | {
+      kind: "structured";
+      envelope: FeishuCardInteractionEnvelope;
+    }
+  | {
+      kind: "legacy";
+      text: string;
+    }
+  | {
+      kind: "invalid";
+      reason: FeishuCardInteractionReason;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isInteractionKind(value: unknown): value is FeishuCardInteractionKind {
+  return value === "button" || value === "quick" || value === "meta";
+}
+
+function isMetadataValue(
+  value: unknown,
+): value is string | number | boolean | null | undefined {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+export function createFeishuCardInteractionEnvelope(
+  envelope: Omit<FeishuCardInteractionEnvelope, "oc">,
+): FeishuCardInteractionEnvelope {
+  return {
+    oc: FEISHU_CARD_INTERACTION_VERSION,
+    ...envelope,
+  };
+}
+
+export function buildFeishuCardActionTextFallback(event: FeishuCardActionEventLike): string {
+  const actionValue = event.action.value;
+  if (isRecord(actionValue)) {
+    if (typeof actionValue.text === "string") {
+      return actionValue.text;
+    }
+    if (typeof actionValue.command === "string") {
+      return actionValue.command;
+    }
+    return JSON.stringify(actionValue);
+  }
+  return String(actionValue);
+}
+
+export function decodeFeishuCardAction(params: {
+  event: FeishuCardActionEventLike;
+  now?: number;
+}): DecodedFeishuCardAction {
+  const { event, now = Date.now() } = params;
+  const actionValue = event.action.value;
+  if (!isRecord(actionValue) || actionValue.oc !== FEISHU_CARD_INTERACTION_VERSION) {
+    return {
+      kind: "legacy",
+      text: buildFeishuCardActionTextFallback(event),
+    };
+  }
+
+  if (!isInteractionKind(actionValue.k) || typeof actionValue.a !== "string" || !actionValue.a) {
+    return { kind: "invalid", reason: "malformed" };
+  }
+
+  if (actionValue.q !== undefined && typeof actionValue.q !== "string") {
+    return { kind: "invalid", reason: "malformed" };
+  }
+
+  if (actionValue.m !== undefined) {
+    if (!isRecord(actionValue.m)) {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    for (const value of Object.values(actionValue.m)) {
+      if (!isMetadataValue(value)) {
+        return { kind: "invalid", reason: "malformed" };
+      }
+    }
+  }
+
+  if (actionValue.c !== undefined) {
+    if (!isRecord(actionValue.c)) {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    if (actionValue.c.u !== undefined && typeof actionValue.c.u !== "string") {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    if (actionValue.c.h !== undefined && typeof actionValue.c.h !== "string") {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    if (actionValue.c.s !== undefined && typeof actionValue.c.s !== "string") {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    if (actionValue.c.e !== undefined && !Number.isFinite(actionValue.c.e)) {
+      return { kind: "invalid", reason: "malformed" };
+    }
+    if (
+      actionValue.c.t !== undefined &&
+      actionValue.c.t !== "p2p" &&
+      actionValue.c.t !== "group"
+    ) {
+      return { kind: "invalid", reason: "malformed" };
+    }
+
+    if (typeof actionValue.c.e === "number" && actionValue.c.e < now) {
+      return { kind: "invalid", reason: "stale" };
+    }
+
+    const expectedUser = actionValue.c.u?.trim();
+    if (expectedUser && expectedUser !== (event.operator.open_id ?? "").trim()) {
+      return { kind: "invalid", reason: "wrong_user" };
+    }
+
+    const expectedChat = actionValue.c.h?.trim();
+    if (expectedChat && expectedChat !== (event.context.chat_id ?? "").trim()) {
+      return { kind: "invalid", reason: "wrong_conversation" };
+    }
+  }
+
+  return {
+    kind: "structured",
+    envelope: actionValue as FeishuCardInteractionEnvelope,
+  };
+}

--- a/extensions/feishu/src/card-ux-approval.ts
+++ b/extensions/feishu/src/card-ux-approval.ts
@@ -1,27 +1,9 @@
-import {
-  createFeishuCardInteractionEnvelope,
-  type FeishuCardInteractionEnvelope,
-} from "./card-interaction.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+import { buildFeishuCardButton, buildFeishuCardInteractionContext } from "./card-ux-shared.js";
 
 export const FEISHU_APPROVAL_REQUEST_ACTION = "feishu.quick_actions.request_approval";
 export const FEISHU_APPROVAL_CONFIRM_ACTION = "feishu.approval.confirm";
 export const FEISHU_APPROVAL_CANCEL_ACTION = "feishu.approval.cancel";
-
-function buildButton(params: {
-  label: string;
-  value: FeishuCardInteractionEnvelope;
-  type?: "default" | "primary" | "danger";
-}) {
-  return {
-    tag: "button",
-    text: {
-      tag: "plain_text",
-      content: params.label,
-    },
-    type: params.type ?? "default",
-    value: params.value,
-  };
-}
 
 export function createApprovalCard(params: {
   operatorOpenId: string;
@@ -34,13 +16,7 @@ export function createApprovalCard(params: {
   confirmLabel?: string;
   cancelLabel?: string;
 }): Record<string, unknown> {
-  const context = {
-    u: params.operatorOpenId,
-    ...(params.chatId ? { h: params.chatId } : {}),
-    ...(params.sessionKey ? { s: params.sessionKey } : {}),
-    e: params.expiresAt,
-    ...(params.chatType ? { t: params.chatType } : {}),
-  };
+  const context = buildFeishuCardInteractionContext(params);
 
   return {
     schema: "2.0",
@@ -63,7 +39,7 @@ export function createApprovalCard(params: {
         {
           tag: "action",
           actions: [
-            buildButton({
+            buildFeishuCardButton({
               label: params.confirmLabel ?? "Confirm",
               type: "primary",
               value: createFeishuCardInteractionEnvelope({
@@ -73,7 +49,7 @@ export function createApprovalCard(params: {
                 c: context,
               }),
             }),
-            buildButton({
+            buildFeishuCardButton({
               label: params.cancelLabel ?? "Cancel",
               value: createFeishuCardInteractionEnvelope({
                 k: "button",

--- a/extensions/feishu/src/card-ux-approval.ts
+++ b/extensions/feishu/src/card-ux-approval.ts
@@ -1,0 +1,89 @@
+import {
+  createFeishuCardInteractionEnvelope,
+  type FeishuCardInteractionEnvelope,
+} from "./card-interaction.js";
+
+export const FEISHU_APPROVAL_REQUEST_ACTION = "feishu.quick_actions.request_approval";
+export const FEISHU_APPROVAL_CONFIRM_ACTION = "feishu.approval.confirm";
+export const FEISHU_APPROVAL_CANCEL_ACTION = "feishu.approval.cancel";
+
+function buildButton(params: {
+  label: string;
+  value: FeishuCardInteractionEnvelope;
+  type?: "default" | "primary" | "danger";
+}) {
+  return {
+    tag: "button",
+    text: {
+      tag: "plain_text",
+      content: params.label,
+    },
+    type: params.type ?? "default",
+    value: params.value,
+  };
+}
+
+export function createApprovalCard(params: {
+  operatorOpenId: string;
+  chatId?: string;
+  command: string;
+  prompt: string;
+  expiresAt: number;
+  chatType?: "p2p" | "group";
+  sessionKey?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}): Record<string, unknown> {
+  const context = {
+    u: params.operatorOpenId,
+    ...(params.chatId ? { h: params.chatId } : {}),
+    ...(params.sessionKey ? { s: params.sessionKey } : {}),
+    e: params.expiresAt,
+    ...(params.chatType ? { t: params.chatType } : {}),
+  };
+
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: "Confirm action",
+      },
+      template: "orange",
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: params.prompt,
+        },
+        {
+          tag: "action",
+          actions: [
+            buildButton({
+              label: params.confirmLabel ?? "Confirm",
+              type: "primary",
+              value: createFeishuCardInteractionEnvelope({
+                k: "quick",
+                a: FEISHU_APPROVAL_CONFIRM_ACTION,
+                q: params.command,
+                c: context,
+              }),
+            }),
+            buildButton({
+              label: params.cancelLabel ?? "Cancel",
+              value: createFeishuCardInteractionEnvelope({
+                k: "button",
+                a: FEISHU_APPROVAL_CANCEL_ACTION,
+                c: context,
+              }),
+            }),
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/extensions/feishu/src/card-ux-launcher.test.ts
+++ b/extensions/feishu/src/card-ux-launcher.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  createQuickActionLauncherCard,
+  isFeishuQuickActionMenuEventKey,
+  maybeHandleFeishuQuickActionMenu,
+} from "./card-ux-launcher.js";
+
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendCardFeishu: sendCardFeishuMock,
+}));
+
+describe("feishu quick-action launcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recognizes the quick-actions bot menu key", () => {
+    expect(isFeishuQuickActionMenuEventKey("quick-actions")).toBe(true);
+    expect(isFeishuQuickActionMenuEventKey("other")).toBe(false);
+  });
+
+  it("builds a launcher card with interactive actions", () => {
+    const card = createQuickActionLauncherCard({
+      operatorOpenId: "u123",
+      chatId: "chat1",
+      expiresAt: 123,
+      sessionKey: "agent:codex:feishu:chat:chat1",
+    }) as {
+      body: {
+        elements: Array<{
+          tag: string;
+          actions?: Array<{ value?: { oc?: string; c?: { s?: string; t?: string } } }>;
+        }>;
+      };
+    };
+
+    const actionBlock = card.body.elements.find((entry) => entry.tag === "action");
+    expect(actionBlock?.actions).toHaveLength(3);
+    expect(actionBlock?.actions?.[0]?.value?.oc).toBe("ocf1");
+    expect(actionBlock?.actions?.[0]?.value?.c?.s).toBe("agent:codex:feishu:chat:chat1");
+    expect(actionBlock?.actions?.[0]?.value?.c?.t).toBeUndefined();
+  });
+
+  it("opens the launcher from a supported bot menu event", async () => {
+    sendCardFeishuMock.mockResolvedValue({ messageId: "m1", chatId: "c1" });
+
+    const handled = await maybeHandleFeishuQuickActionMenu({
+      cfg: {} as any,
+      eventKey: "quick-actions",
+      operatorOpenId: "u123",
+      accountId: "main",
+      now: 100,
+    });
+
+    expect(handled).toBe(true);
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:u123",
+        accountId: "main",
+        card: expect.objectContaining({
+          body: expect.objectContaining({
+            elements: expect.arrayContaining([
+              expect.objectContaining({
+                tag: "action",
+                actions: expect.arrayContaining([
+                  expect.objectContaining({
+                    value: expect.objectContaining({
+                      c: expect.objectContaining({
+                        t: "p2p",
+                      }),
+                    }),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("falls back to legacy menu handling when launcher send fails", async () => {
+    sendCardFeishuMock.mockRejectedValueOnce(new Error("network"));
+
+    const handled = await maybeHandleFeishuQuickActionMenu({
+      cfg: {} as any,
+      eventKey: "quick-actions",
+      operatorOpenId: "u123",
+      accountId: "main",
+      runtime: { log: vi.fn() } as any,
+      now: 100,
+    });
+
+    expect(handled).toBe(false);
+  });
+});

--- a/extensions/feishu/src/card-ux-launcher.ts
+++ b/extensions/feishu/src/card-ux-launcher.ts
@@ -1,46 +1,12 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
-import { sendCardFeishu } from "./send.js";
-import {
-  createFeishuCardInteractionEnvelope,
-  type FeishuCardInteractionEnvelope,
-} from "./card-interaction.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { FEISHU_APPROVAL_REQUEST_ACTION } from "./card-ux-approval.js";
+import { buildFeishuCardButton, buildFeishuCardInteractionContext } from "./card-ux-shared.js";
+import { sendCardFeishu } from "./send.js";
 
 export const FEISHU_QUICK_ACTION_CARD_TTL_MS = 10 * 60_000;
 
 const QUICK_ACTION_MENU_KEYS = new Set(["quick-actions", "quick_actions", "launcher"]);
-
-function buildButton(params: {
-  label: string;
-  value: FeishuCardInteractionEnvelope;
-  type?: "default" | "primary" | "danger";
-}) {
-  return {
-    tag: "button",
-    text: {
-      tag: "plain_text",
-      content: params.label,
-    },
-    type: params.type ?? "default",
-    value: params.value,
-  };
-}
-
-function buildInteractionContext(params: {
-  operatorOpenId: string;
-  chatId?: string;
-  expiresAt: number;
-  chatType?: "p2p" | "group";
-  sessionKey?: string;
-}) {
-  return {
-    u: params.operatorOpenId,
-    ...(params.chatId ? { h: params.chatId } : {}),
-    ...(params.sessionKey ? { s: params.sessionKey } : {}),
-    e: params.expiresAt,
-    ...(params.chatType ? { t: params.chatType } : {}),
-  };
-}
 
 export function isFeishuQuickActionMenuEventKey(eventKey: string): boolean {
   return QUICK_ACTION_MENU_KEYS.has(eventKey.trim().toLowerCase());
@@ -53,7 +19,7 @@ export function createQuickActionLauncherCard(params: {
   chatType?: "p2p" | "group";
   sessionKey?: string;
 }): Record<string, unknown> {
-  const context = buildInteractionContext(params);
+  const context = buildFeishuCardInteractionContext(params);
   return {
     schema: "2.0",
     config: {
@@ -75,7 +41,7 @@ export function createQuickActionLauncherCard(params: {
         {
           tag: "action",
           actions: [
-            buildButton({
+            buildFeishuCardButton({
               label: "Help",
               value: createFeishuCardInteractionEnvelope({
                 k: "quick",
@@ -84,7 +50,7 @@ export function createQuickActionLauncherCard(params: {
                 c: context,
               }),
             }),
-            buildButton({
+            buildFeishuCardButton({
               label: "New session",
               type: "primary",
               value: createFeishuCardInteractionEnvelope({
@@ -97,7 +63,7 @@ export function createQuickActionLauncherCard(params: {
                 c: context,
               }),
             }),
-            buildButton({
+            buildFeishuCardButton({
               label: "Reset",
               type: "danger",
               value: createFeishuCardInteractionEnvelope({

--- a/extensions/feishu/src/card-ux-launcher.ts
+++ b/extensions/feishu/src/card-ux-launcher.ts
@@ -1,0 +1,154 @@
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
+import { sendCardFeishu } from "./send.js";
+import {
+  createFeishuCardInteractionEnvelope,
+  type FeishuCardInteractionEnvelope,
+} from "./card-interaction.js";
+import { FEISHU_APPROVAL_REQUEST_ACTION } from "./card-ux-approval.js";
+
+export const FEISHU_QUICK_ACTION_CARD_TTL_MS = 10 * 60_000;
+
+const QUICK_ACTION_MENU_KEYS = new Set(["quick-actions", "quick_actions", "launcher"]);
+
+function buildButton(params: {
+  label: string;
+  value: FeishuCardInteractionEnvelope;
+  type?: "default" | "primary" | "danger";
+}) {
+  return {
+    tag: "button",
+    text: {
+      tag: "plain_text",
+      content: params.label,
+    },
+    type: params.type ?? "default",
+    value: params.value,
+  };
+}
+
+function buildInteractionContext(params: {
+  operatorOpenId: string;
+  chatId?: string;
+  expiresAt: number;
+  chatType?: "p2p" | "group";
+  sessionKey?: string;
+}) {
+  return {
+    u: params.operatorOpenId,
+    ...(params.chatId ? { h: params.chatId } : {}),
+    ...(params.sessionKey ? { s: params.sessionKey } : {}),
+    e: params.expiresAt,
+    ...(params.chatType ? { t: params.chatType } : {}),
+  };
+}
+
+export function isFeishuQuickActionMenuEventKey(eventKey: string): boolean {
+  return QUICK_ACTION_MENU_KEYS.has(eventKey.trim().toLowerCase());
+}
+
+export function createQuickActionLauncherCard(params: {
+  operatorOpenId: string;
+  chatId?: string;
+  expiresAt: number;
+  chatType?: "p2p" | "group";
+  sessionKey?: string;
+}): Record<string, unknown> {
+  const context = buildInteractionContext(params);
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: "Quick actions",
+      },
+      template: "indigo",
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: "Run common actions without typing raw commands.",
+        },
+        {
+          tag: "action",
+          actions: [
+            buildButton({
+              label: "Help",
+              value: createFeishuCardInteractionEnvelope({
+                k: "quick",
+                a: "feishu.quick_actions.help",
+                q: "/help",
+                c: context,
+              }),
+            }),
+            buildButton({
+              label: "New session",
+              type: "primary",
+              value: createFeishuCardInteractionEnvelope({
+                k: "meta",
+                a: FEISHU_APPROVAL_REQUEST_ACTION,
+                m: {
+                  command: "/new",
+                  prompt: "Start a fresh session? This will reset the current chat context.",
+                },
+                c: context,
+              }),
+            }),
+            buildButton({
+              label: "Reset",
+              type: "danger",
+              value: createFeishuCardInteractionEnvelope({
+                k: "meta",
+                a: FEISHU_APPROVAL_REQUEST_ACTION,
+                m: {
+                  command: "/reset",
+                  prompt: "Reset this session now? Any active conversation state will be cleared.",
+                },
+                c: context,
+              }),
+            }),
+          ],
+        },
+      ],
+    },
+  };
+}
+
+export async function maybeHandleFeishuQuickActionMenu(params: {
+  cfg: ClawdbotConfig;
+  eventKey: string;
+  operatorOpenId: string;
+  runtime?: RuntimeEnv;
+  accountId?: string;
+  now?: number;
+}): Promise<boolean> {
+  if (!isFeishuQuickActionMenuEventKey(params.eventKey)) {
+    return false;
+  }
+
+  const expiresAt = (params.now ?? Date.now()) + FEISHU_QUICK_ACTION_CARD_TTL_MS;
+  try {
+    await sendCardFeishu({
+      cfg: params.cfg,
+      to: `user:${params.operatorOpenId}`,
+      card: createQuickActionLauncherCard({
+        operatorOpenId: params.operatorOpenId,
+        expiresAt,
+        chatType: "p2p",
+      }),
+      accountId: params.accountId,
+    });
+  } catch (err) {
+    params.runtime?.log?.(
+      `feishu[${params.accountId ?? "default"}]: failed to open quick-action launcher for ${params.operatorOpenId}: ${String(err)}`,
+    );
+    return false;
+  }
+  params.runtime?.log?.(
+    `feishu[${params.accountId ?? "default"}]: opened quick-action launcher for ${params.operatorOpenId}`,
+  );
+  return true;
+}

--- a/extensions/feishu/src/card-ux-shared.ts
+++ b/extensions/feishu/src/card-ux-shared.ts
@@ -1,0 +1,33 @@
+import type { FeishuCardInteractionEnvelope } from "./card-interaction.js";
+
+export function buildFeishuCardButton(params: {
+  label: string;
+  value: FeishuCardInteractionEnvelope;
+  type?: "default" | "primary" | "danger";
+}) {
+  return {
+    tag: "button",
+    text: {
+      tag: "plain_text",
+      content: params.label,
+    },
+    type: params.type ?? "default",
+    value: params.value,
+  };
+}
+
+export function buildFeishuCardInteractionContext(params: {
+  operatorOpenId: string;
+  chatId?: string;
+  expiresAt: number;
+  chatType?: "p2p" | "group";
+  sessionKey?: string;
+}) {
+  return {
+    u: params.operatorOpenId,
+    ...(params.chatId ? { h: params.chatId } : {}),
+    ...(params.sessionKey ? { s: params.sessionKey } : {}),
+    e: params.expiresAt,
+    ...(params.chatType ? { t: params.chatType } : {}),
+  };
+}

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -525,16 +525,6 @@ function registerEventHandlers(
         if (!operatorOpenId || !eventKey) {
           return;
         }
-        const handledMenu = await maybeHandleFeishuQuickActionMenu({
-          cfg,
-          eventKey,
-          operatorOpenId,
-          runtime,
-          accountId,
-        });
-        if (handledMenu) {
-          return;
-        }
         const syntheticEvent: FeishuMessageEvent = {
           sender: {
             sender_id: {
@@ -554,14 +544,28 @@ function registerEventHandlers(
             }),
           },
         };
-        const promise = handleFeishuMessage({
+        const handleLegacyMenu = () =>
+          handleFeishuMessage({
+            cfg,
+            event: syntheticEvent,
+            botOpenId: botOpenIds.get(accountId),
+            botName: botNames.get(accountId),
+            runtime,
+            chatHistories,
+            accountId,
+          });
+
+        const promise = maybeHandleFeishuQuickActionMenu({
           cfg,
-          event: syntheticEvent,
-          botOpenId: botOpenIds.get(accountId),
-          botName: botNames.get(accountId),
+          eventKey,
+          operatorOpenId,
           runtime,
-          chatHistories,
           accountId,
+        }).then((handledMenu) => {
+          if (handledMenu) {
+            return;
+          }
+          return handleLegacyMenu();
         });
         if (fireAndForget) {
           promise.catch((err) => {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -10,6 +10,7 @@ import {
   type FeishuBotAddedEvent,
 } from "./bot.js";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { createEventDispatcher } from "./client.js";
 import {
   hasProcessedFeishuMessage,
@@ -19,7 +20,6 @@ import {
   warmupDedupFromDisk,
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
-import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
@@ -514,7 +514,7 @@ function registerEventHandlers(
       try {
         const event = data as {
           event_key?: string;
-          timestamp?: number;
+          timestamp?: string | number;
           operator?: {
             operator_name?: string;
             operator_id?: { open_id?: string; user_id?: string; union_id?: string };

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -19,6 +19,7 @@ import {
   warmupDedupFromDisk,
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
+import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
@@ -522,6 +523,16 @@ function registerEventHandlers(
         const operatorOpenId = event.operator?.operator_id?.open_id?.trim();
         const eventKey = event.event_key?.trim();
         if (!operatorOpenId || !eventKey) {
+          return;
+        }
+        const handledMenu = await maybeHandleFeishuQuickActionMenu({
+          cfg,
+          eventKey,
+          operatorOpenId,
+          runtime,
+          accountId,
+        });
+        if (handledMenu) {
           return;
         }
         const syntheticEvent: FeishuMessageEvent = {

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -138,6 +138,39 @@ describe("Feishu bot menu handler", () => {
     expect(handleFeishuMessageMock).not.toHaveBeenCalled();
   });
 
+  it("does not block bot-menu handling on quick-action launcher send", async () => {
+    const onBotMenu = await registerHandlers();
+    let resolveSend: (() => void) | undefined;
+    sendCardFeishuMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = () => resolve({ messageId: "m1", chatId: "c1" });
+        }),
+    );
+
+    const pending = onBotMenu({
+      event_key: "quick-actions",
+      timestamp: "1700000000000",
+      operator: {
+        operator_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+    });
+    let settled = false;
+    pending.finally(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(true);
+
+    resolveSend?.();
+    await pending;
+  });
+
   it("falls back to the legacy /menu synthetic message path for unrelated bot menu keys", async () => {
     const onBotMenu = await registerHandlers();
 
@@ -181,14 +214,16 @@ describe("Feishu bot menu handler", () => {
       },
     });
 
-    expect(handleFeishuMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: expect.objectContaining({
-          message: expect.objectContaining({
-            content: '{"text":"/menu quick-actions"}',
+    await vi.waitFor(() => {
+      expect(handleFeishuMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            message: expect.objectContaining({
+              content: '{"text":"/menu quick-actions"}',
+            }),
           }),
         }),
-      }),
-    );
+      );
+    });
   });
 });

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -1,0 +1,194 @@
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hasControlCommand } from "../../../src/auto-reply/command-detection.js";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "../../../src/auto-reply/inbound-debounce.js";
+import { createPluginRuntimeMock } from "../../test-utils/plugin-runtime-mock.js";
+import { monitorSingleAccount } from "./monitor.account.js";
+import { setFeishuRuntime } from "./runtime.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
+const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+const handleFeishuMessageMock = vi.hoisted(() => vi.fn(async () => {}));
+const sendCardFeishuMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "m1", chatId: "c1" })));
+const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
+
+let handlers: Record<string, (data: unknown) => Promise<void>> = {};
+
+vi.mock("./client.js", () => ({
+  createEventDispatcher: createEventDispatcherMock,
+}));
+
+vi.mock("./monitor.transport.js", () => ({
+  monitorWebSocket: monitorWebSocketMock,
+  monitorWebhook: monitorWebhookMock,
+}));
+
+vi.mock("./bot.js", async () => {
+  const actual = await vi.importActual<typeof import("./bot.js")>("./bot.js");
+  return {
+    ...actual,
+    handleFeishuMessage: handleFeishuMessageMock,
+  };
+});
+
+vi.mock("./send.js", async () => {
+  const actual = await vi.importActual<typeof import("./send.js")>("./send.js");
+  return {
+    ...actual,
+    sendCardFeishu: sendCardFeishuMock,
+  };
+});
+
+vi.mock("./thread-bindings.js", () => ({
+  createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
+}));
+
+function buildAccount(): ResolvedFeishuAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    appId: "cli_test",
+    appSecret: "secret_test", // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+async function registerHandlers() {
+  setFeishuRuntime(
+    createPluginRuntimeMock({
+      channel: {
+        debounce: {
+          createInboundDebouncer,
+          resolveInboundDebounceMs,
+        },
+        text: {
+          hasControlCommand,
+        },
+      },
+    }),
+  );
+  const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
+    handlers = registered;
+  });
+  createEventDispatcherMock.mockReturnValue({ register });
+
+  await monitorSingleAccount({
+    cfg: {} as ClawdbotConfig,
+    account: buildAccount(),
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as RuntimeEnv,
+    botOpenIdSource: {
+      kind: "prefetched",
+      botOpenId: "ou_bot",
+      botName: "Bot",
+    },
+  });
+
+  const onBotMenu = handlers["application.bot.menu_v6"];
+  if (!onBotMenu) {
+    throw new Error("missing application.bot.menu_v6 handler");
+  }
+  return onBotMenu;
+}
+
+describe("Feishu bot menu handler", () => {
+  beforeEach(() => {
+    handlers = {};
+    vi.clearAllMocks();
+  });
+
+  it("opens the quick-action launcher card at the webhook/event layer", async () => {
+    const onBotMenu = await registerHandlers();
+
+    await onBotMenu({
+      event_key: "quick-actions",
+      timestamp: "1700000000000",
+      operator: {
+        operator_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+    });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou_user1",
+        card: expect.objectContaining({
+          header: expect.objectContaining({
+            title: expect.objectContaining({ content: "Quick actions" }),
+          }),
+        }),
+      }),
+    );
+    expect(handleFeishuMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy /menu synthetic message path for unrelated bot menu keys", async () => {
+    const onBotMenu = await registerHandlers();
+
+    await onBotMenu({
+      event_key: "custom-key",
+      timestamp: "1700000000000",
+      operator: {
+        operator_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+    });
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"/menu custom-key"}',
+          }),
+        }),
+      }),
+    );
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy /menu path when launcher rendering fails", async () => {
+    const onBotMenu = await registerHandlers();
+    sendCardFeishuMock.mockRejectedValueOnce(new Error("boom"));
+
+    await onBotMenu({
+      event_key: "quick-actions",
+      timestamp: "1700000000000",
+      operator: {
+        operator_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+    });
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"/menu quick-actions"}',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1250,13 +1250,16 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     }
   }
 
-  if (context.includeChannelSecurity && hasPotentialConfiguredChannels(cfg, env)) {
-    const plugins = context.plugins ?? (await loadChannelPlugins()).listChannelPlugins();
+  const shouldAuditChannelSecurity =
+    context.includeChannelSecurity &&
+    (context.plugins !== undefined || hasPotentialConfiguredChannels(cfg, env));
+  if (shouldAuditChannelSecurity) {
+    const channelPlugins = context.plugins ?? (await loadChannelPlugins()).listChannelPlugins();
     findings.push(
       ...(await collectChannelSecurityFindings({
         cfg,
         sourceConfig: context.sourceConfig,
-        plugins,
+        plugins: channelPlugins,
       })),
     );
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu card callbacks only flowed through ad hoc text extraction, so interactive cards could not safely carry structured actions or robust callback context.
- Why it matters: card-driven UX was brittle, hard to extend, and required users to fall back to raw typed commands for actions that should be clickable.
- What changed: added a structured Feishu card interaction envelope and callback decoder/router, shipped approval-confirm cards and a quick-action launcher card, wired launcher opening into Feishu bot menu events, preserved legacy fallback behavior, and added stale/wrong-context/token-dedup safeguards.
- What did NOT change (scope boundary): no polls/vote cards, no generic modal framework, no search/admin workflows, and no broader channel capability expansion beyond the implemented approval and launcher flows.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Feishu card callbacks now support structured button, quick-command, and metadata actions with context validation.
- Users can open a Feishu quick-action launcher card from supported bot menu events instead of typing raw commands.
- Destructive/confirm-style actions now use an approval card flow before dispatching `/new` or `/reset`.
- Legacy text-like card payload behavior remains available as a fallback.
- Stale, malformed, duplicate, or wrong-context interactions now degrade safely with a user-visible notice or no-op.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vitest worktree run
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): default Feishu test harness / mocked Feishu runtime

### Steps

1. Trigger a supported Feishu bot menu event such as `quick-actions`.
2. Open the quick-action launcher card and click a quick action or a confirm-gated action.
3. Exercise invalid, stale, duplicate, or wrong-context callback payloads through tests.

### Expected

- Structured callbacks route correctly, DM callbacks stay DM-scoped, confirm flows preserve callback context, and malformed/stale/wrong-context/duplicate callbacks do not execute unsafe actions.

### Actual

- Verified by targeted and adjacent Feishu test suites passing after the change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: structured callback decoding, quick command routing, approval-card generation, DM callback preservation, duplicate-token suppression, bot-menu launcher open path, and launcher failure fallback to legacy `/menu` handling.
- Edge cases checked: legacy text-like fallback, malformed payload rejection, stale payload rejection, wrong-user rejection, wrong-conversation rejection, cancel path, and launcher send failure.
- What you did **not** verify: live Feishu UI interaction against a real workspace/account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `508978a00d` or switch callers back to the legacy synthetic `/menu` and text-only card-action path.
- Files/config to restore: `extensions/feishu/src/card-action.ts`, `extensions/feishu/src/monitor.account.ts`, and the new `card-interaction` / `card-ux-*` helpers.
- Known bad symptoms reviewers should watch for: quick-action menu clicks doing nothing, DM launcher actions being treated like group commands, duplicate approval cards, or missing fallback when launcher send fails.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: structured callback envelope fields could drift from handler expectations in later edits.
  - Mitigation: dedicated decode/routing tests assert envelope validation, callback scoping, and approval-card context propagation.
- Risk: Feishu callback retries or double taps could replay actions.
  - Mitigation: callback tokens are deduplicated before approval-card emission or command dispatch.
