### PR TITLE
docs(showcase): add CrewClaw deployment platform

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -365,9 +365,9 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 </Card>
 
 <Card title="CrewClaw" icon="rocket" href="https://crewclaw.com">
-  **@mergisi** • `deployment` `templates` `telegram` `docker`
+  **@mergisi** • `deployment` `templates` `docker`
 
-  Agent deployment platform with 162 templates across 24 categories. Generates complete workspaces (SOUL.md, Dockerfile, bot scripts) for single and multi-agent setups.
+  Agent deployment platform with ready-to-use templates. Generates complete workspaces (SOUL.md, Dockerfile, bot scripts) for single and multi-agent setups.
 </Card>
 
 </CardGroup>

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -360,8 +360,14 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 
 <Card title="CalDAV Calendar" icon="calendar" href="https://clawhub.com/skills/caldav-calendar">
   **ClawHub** • `calendar` `caldav` `skill`
-  
+
   Calendar skill using khal/vdirsyncer. Self-hosted calendar integration.
+</Card>
+
+<Card title="CrewClaw" icon="rocket" href="https://crewclaw.com">
+  **@mergisi** • `deployment` `templates` `telegram` `docker`
+
+  Agent deployment platform with 162 templates across 24 categories. Generates complete workspaces (SOUL.md, Dockerfile, bot scripts) for single and multi-agent setups.
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
## What

Adds [CrewClaw](https://crewclaw.com) to the **Infrastructure & Deployment** section of the community showcase.

CrewClaw is an agent deployment platform with 162 templates across 24 categories. It generates complete OpenClaw agent workspaces (SOUL.md, Dockerfile, bot scripts, docker-compose) for single and multi-agent setups.

## Why

Makes it easier for new OpenClaw users to go from zero to deployed agent. Complements existing deployment tools (Home Assistant Add-on, Nix Packaging) in the showcase.

- Live at https://crewclaw.com
- Open-source templates: https://github.com/mergisi/awesome-openclaw-agents (362 stars)

Re-submission of #14016 (auto-closed by stale bot, Greptile reviewed 5/5 confidence).

## Checklist

- [x] Follows existing Card component format
- [x] Placed in relevant section (Infrastructure & Deployment)
- [x] Single-file docs change (7 additions, 1 deletion)