### PR TITLE
fix(gateway): pin plugin webhook route registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config views: strip embedded credentials from URL-based endpoint fields before returning read-only account and config snapshots. Thanks @vincentkoc.
 - Tools/apply-patch: revalidate workspace-only delete and directory targets immediately before mutating host paths. Thanks @vincentkoc.
 - Webhooks/runtime: move auth earlier and tighten pre-auth body limits and timeouts across bundled webhook handlers, including slow-body handling for Mattermost slash commands. Thanks @vincentkoc.
+- Gateway/plugins: pin runtime webhook routes to the gateway startup registry so channel webhooks keep working across plugin-registry churn, and make plugin auth + dispatch resolve routes from the same live HTTP-route registry. Fixes #46924 and #47041.
 - Subagents/follow-ups: require the same controller ownership checks for `/subagents send` as other control actions, so leaf sessions cannot message nested child runs they do not control. Thanks @vincentkoc.
 - Inbound policy hardening: tighten callback and webhook sender checks across Mattermost and Google Chat, match Nextcloud Talk rooms by stable room token, and treat explicit empty Twitch allowlists as deny-all. (#46787) Thanks @zpbrent, @ijxpwastaken and @vincentkoc.
 - macOS/canvas actions: keep unattended local agent actions on trusted in-app canvas surfaces only, and stop exposing the deep-link fallback key to arbitrary page scripts. (#46790) Thanks @vincentkoc.

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -11,6 +11,7 @@ export function createGatewayCloseHandler(params: {
   tailscaleCleanup: (() => Promise<void>) | null;
   canvasHost: CanvasHostHandler | null;
   canvasHostServer: CanvasHostServer | null;
+  releasePluginRouteRegistry?: (() => void) | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
   cron: { stop: () => void };
@@ -33,106 +34,114 @@ export function createGatewayCloseHandler(params: {
   httpServers?: HttpServer[];
 }) {
   return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
-    const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
-    const reason = reasonRaw || "gateway stopping";
-    const restartExpectedMs =
-      typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
-        ? Math.max(0, Math.floor(opts.restartExpectedMs))
-        : null;
-    if (params.bonjourStop) {
-      try {
-        await params.bonjourStop();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (params.tailscaleCleanup) {
-      await params.tailscaleCleanup();
-    }
-    if (params.canvasHost) {
-      try {
-        await params.canvasHost.close();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (params.canvasHostServer) {
-      try {
-        await params.canvasHostServer.close();
-      } catch {
-        /* ignore */
-      }
-    }
-    for (const plugin of listChannelPlugins()) {
-      await params.stopChannel(plugin.id);
-    }
-    if (params.pluginServices) {
-      await params.pluginServices.stop().catch(() => {});
-    }
-    await stopGmailWatcher();
-    params.cron.stop();
-    params.heartbeatRunner.stop();
     try {
-      params.updateCheckStop?.();
-    } catch {
-      /* ignore */
-    }
-    for (const timer of params.nodePresenceTimers.values()) {
-      clearInterval(timer);
-    }
-    params.nodePresenceTimers.clear();
-    params.broadcast("shutdown", {
-      reason,
-      restartExpectedMs,
-    });
-    clearInterval(params.tickInterval);
-    clearInterval(params.healthInterval);
-    clearInterval(params.dedupeCleanup);
-    if (params.mediaCleanup) {
-      clearInterval(params.mediaCleanup);
-    }
-    if (params.agentUnsub) {
+      const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
+      const reason = reasonRaw || "gateway stopping";
+      const restartExpectedMs =
+        typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
+          ? Math.max(0, Math.floor(opts.restartExpectedMs))
+          : null;
+      if (params.bonjourStop) {
+        try {
+          await params.bonjourStop();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.tailscaleCleanup) {
+        await params.tailscaleCleanup();
+      }
+      if (params.canvasHost) {
+        try {
+          await params.canvasHost.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.canvasHostServer) {
+        try {
+          await params.canvasHostServer.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      for (const plugin of listChannelPlugins()) {
+        await params.stopChannel(plugin.id);
+      }
+      if (params.pluginServices) {
+        await params.pluginServices.stop().catch(() => {});
+      }
+      await stopGmailWatcher();
+      params.cron.stop();
+      params.heartbeatRunner.stop();
       try {
-        params.agentUnsub();
+        params.updateCheckStop?.();
       } catch {
         /* ignore */
       }
-    }
-    if (params.heartbeatUnsub) {
+      for (const timer of params.nodePresenceTimers.values()) {
+        clearInterval(timer);
+      }
+      params.nodePresenceTimers.clear();
+      params.broadcast("shutdown", {
+        reason,
+        restartExpectedMs,
+      });
+      clearInterval(params.tickInterval);
+      clearInterval(params.healthInterval);
+      clearInterval(params.dedupeCleanup);
+      if (params.mediaCleanup) {
+        clearInterval(params.mediaCleanup);
+      }
+      if (params.agentUnsub) {
+        try {
+          params.agentUnsub();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (params.heartbeatUnsub) {
+        try {
+          params.heartbeatUnsub();
+        } catch {
+          /* ignore */
+        }
+      }
+      params.chatRunState.clear();
+      for (const c of params.clients) {
+        try {
+          c.socket.close(1012, "service restart");
+        } catch {
+          /* ignore */
+        }
+      }
+      params.clients.clear();
+      await params.configReloader.stop().catch(() => {});
+      if (params.browserControl) {
+        await params.browserControl.stop().catch(() => {});
+      }
+      await new Promise<void>((resolve) => params.wss.close(() => resolve()));
+      const servers =
+        params.httpServers && params.httpServers.length > 0
+          ? params.httpServers
+          : [params.httpServer];
+      for (const server of servers) {
+        const httpServer = server as HttpServer & {
+          closeIdleConnections?: () => void;
+        };
+        if (typeof httpServer.closeIdleConnections === "function") {
+          httpServer.closeIdleConnections();
+        }
+        await new Promise<void>((resolve, reject) =>
+          httpServer.close((err) => (err ? reject(err) : resolve())),
+        );
+      }
+    } finally {
       try {
-        params.heartbeatUnsub();
+        params.releasePluginRouteRegistry?.();
       } catch {
         /* ignore */
       }
-    }
-    params.chatRunState.clear();
-    for (const c of params.clients) {
-      try {
-        c.socket.close(1012, "service restart");
-      } catch {
-        /* ignore */
-      }
-    }
-    params.clients.clear();
-    await params.configReloader.stop().catch(() => {});
-    if (params.browserControl) {
-      await params.browserControl.stop().catch(() => {});
-    }
-    await new Promise<void>((resolve) => params.wss.close(() => resolve()));
-    const servers =
-      params.httpServers && params.httpServers.length > 0
-        ? params.httpServers
-        : [params.httpServer];
-    for (const server of servers) {
-      const httpServer = server as HttpServer & {
-        closeIdleConnections?: () => void;
-      };
-      if (typeof httpServer.closeIdleConnections === "function") {
-        httpServer.closeIdleConnections();
-      }
-      await new Promise<void>((resolve, reject) =>
-        httpServer.close((err) => (err ? reject(err) : resolve())),
-      );
     }
   };
 }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,11 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  resolveActivePluginHttpRouteRegistry,
+} from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -70,6 +75,7 @@ export async function createGatewayRuntimeState(params: {
   getReadiness?: ReadinessChecker;
 }): Promise<{
   canvasHost: CanvasHostHandler | null;
+  releasePluginRouteRegistry: () => void;
   httpServer: HttpServer;
   httpServers: HttpServer[];
   httpBindHosts: string[];
@@ -91,147 +97,157 @@ export async function createGatewayRuntimeState(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   toolEventRecipients: ReturnType<typeof createToolEventRecipientRegistry>;
 }> {
-  let canvasHost: CanvasHostHandler | null = null;
-  if (params.canvasHostEnabled) {
-    try {
-      const handler = await createCanvasHostHandler({
-        runtime: params.canvasRuntime,
-        rootDir: params.cfg.canvasHost?.root,
-        basePath: CANVAS_HOST_PATH,
-        allowInTests: params.allowCanvasHostInTests,
-        liveReload: params.cfg.canvasHost?.liveReload,
-      });
-      if (handler.rootDir) {
-        canvasHost = handler;
-        params.logCanvas.info(
-          `canvas host mounted at http://${params.bindHost}:${params.port}${CANVAS_HOST_PATH}/ (root ${handler.rootDir})`,
-        );
+  pinActivePluginHttpRouteRegistry(params.pluginRegistry);
+  try {
+    let canvasHost: CanvasHostHandler | null = null;
+    if (params.canvasHostEnabled) {
+      try {
+        const handler = await createCanvasHostHandler({
+          runtime: params.canvasRuntime,
+          rootDir: params.cfg.canvasHost?.root,
+          basePath: CANVAS_HOST_PATH,
+          allowInTests: params.allowCanvasHostInTests,
+          liveReload: params.cfg.canvasHost?.liveReload,
+        });
+        if (handler.rootDir) {
+          canvasHost = handler;
+          params.logCanvas.info(
+            `canvas host mounted at http://${params.bindHost}:${params.port}${CANVAS_HOST_PATH}/ (root ${handler.rootDir})`,
+          );
+        }
+      } catch (err) {
+        params.logCanvas.warn(`canvas host failed to start: ${String(err)}`);
       }
-    } catch (err) {
-      params.logCanvas.warn(`canvas host failed to start: ${String(err)}`);
     }
-  }
 
-  const clients = new Set<GatewayWsClient>();
-  const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+    const clients = new Set<GatewayWsClient>();
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
-  const handleHooksRequest = createGatewayHooksRequestHandler({
-    deps: params.deps,
-    getHooksConfig: params.hooksConfig,
-    getClientIpConfig: params.getHookClientIpConfig,
-    bindHost: params.bindHost,
-    port: params.port,
-    logHooks: params.logHooks,
-  });
-
-  const handlePluginRequest = createGatewayPluginRequestHandler({
-    registry: params.pluginRegistry,
-    log: params.logPlugins,
-  });
-  const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
-    return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, pathContext);
-  };
-
-  const bindHosts = await resolveGatewayListenHosts(params.bindHost);
-  if (!isLoopbackHost(params.bindHost)) {
-    params.log.warn(
-      "⚠️  Gateway is binding to a non-loopback address. " +
-        "Ensure authentication is configured before exposing to public networks.",
-    );
-  }
-  if (params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true) {
-    params.log.warn(
-      "⚠️  gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true is enabled. " +
-        "Host-header origin fallback weakens origin checks and should only be used as break-glass.",
-    );
-  }
-  const httpServers: HttpServer[] = [];
-  const httpBindHosts: string[] = [];
-  for (const host of bindHosts) {
-    const httpServer = createGatewayHttpServer({
-      canvasHost,
-      clients,
-      controlUiEnabled: params.controlUiEnabled,
-      controlUiBasePath: params.controlUiBasePath,
-      controlUiRoot: params.controlUiRoot,
-      openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
-      openAiChatCompletionsConfig: params.openAiChatCompletionsConfig,
-      openResponsesEnabled: params.openResponsesEnabled,
-      openResponsesConfig: params.openResponsesConfig,
-      strictTransportSecurityHeader: params.strictTransportSecurityHeader,
-      handleHooksRequest,
-      handlePluginRequest,
-      shouldEnforcePluginGatewayAuth,
-      resolvedAuth: params.resolvedAuth,
-      rateLimiter: params.rateLimiter,
-      getReadiness: params.getReadiness,
-      tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
+    const handleHooksRequest = createGatewayHooksRequestHandler({
+      deps: params.deps,
+      getHooksConfig: params.hooksConfig,
+      getClientIpConfig: params.getHookClientIpConfig,
+      bindHost: params.bindHost,
+      port: params.port,
+      logHooks: params.logHooks,
     });
-    try {
-      await listenGatewayHttpServer({
-        httpServer,
-        bindHost: host,
-        port: params.port,
-      });
-      httpServers.push(httpServer);
-      httpBindHosts.push(host);
-    } catch (err) {
-      if (host === bindHosts[0]) {
-        throw err;
-      }
+
+    const handlePluginRequest = createGatewayPluginRequestHandler({
+      registry: params.pluginRegistry,
+      log: params.logPlugins,
+    });
+    const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
+      return shouldEnforceGatewayAuthForPluginPath(
+        resolveActivePluginHttpRouteRegistry(params.pluginRegistry),
+        pathContext,
+      );
+    };
+
+    const bindHosts = await resolveGatewayListenHosts(params.bindHost);
+    if (!isLoopbackHost(params.bindHost)) {
       params.log.warn(
-        `gateway: failed to bind loopback alias ${host}:${params.port} (${String(err)})`,
+        "⚠️  Gateway is binding to a non-loopback address. " +
+          "Ensure authentication is configured before exposing to public networks.",
       );
     }
-  }
-  const httpServer = httpServers[0];
-  if (!httpServer) {
-    throw new Error("Gateway HTTP server failed to start");
-  }
+    if (params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true) {
+      params.log.warn(
+        "⚠️  gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true is enabled. " +
+          "Host-header origin fallback weakens origin checks and should only be used as break-glass.",
+      );
+    }
+    const httpServers: HttpServer[] = [];
+    const httpBindHosts: string[] = [];
+    for (const host of bindHosts) {
+      const httpServer = createGatewayHttpServer({
+        canvasHost,
+        clients,
+        controlUiEnabled: params.controlUiEnabled,
+        controlUiBasePath: params.controlUiBasePath,
+        controlUiRoot: params.controlUiRoot,
+        openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
+        openAiChatCompletionsConfig: params.openAiChatCompletionsConfig,
+        openResponsesEnabled: params.openResponsesEnabled,
+        openResponsesConfig: params.openResponsesConfig,
+        strictTransportSecurityHeader: params.strictTransportSecurityHeader,
+        handleHooksRequest,
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth,
+        resolvedAuth: params.resolvedAuth,
+        rateLimiter: params.rateLimiter,
+        getReadiness: params.getReadiness,
+        tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
+      });
+      try {
+        await listenGatewayHttpServer({
+          httpServer,
+          bindHost: host,
+          port: params.port,
+        });
+        httpServers.push(httpServer);
+        httpBindHosts.push(host);
+      } catch (err) {
+        if (host === bindHosts[0]) {
+          throw err;
+        }
+        params.log.warn(
+          `gateway: failed to bind loopback alias ${host}:${params.port} (${String(err)})`,
+        );
+      }
+    }
+    const httpServer = httpServers[0];
+    if (!httpServer) {
+      throw new Error("Gateway HTTP server failed to start");
+    }
 
-  const wss = new WebSocketServer({
-    noServer: true,
-    maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
-  });
-  for (const server of httpServers) {
-    attachGatewayUpgradeHandler({
-      httpServer: server,
-      wss,
-      canvasHost,
-      clients,
-      resolvedAuth: params.resolvedAuth,
-      rateLimiter: params.rateLimiter,
+    const wss = new WebSocketServer({
+      noServer: true,
+      maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
     });
+    for (const server of httpServers) {
+      attachGatewayUpgradeHandler({
+        httpServer: server,
+        wss,
+        canvasHost,
+        clients,
+        resolvedAuth: params.resolvedAuth,
+        rateLimiter: params.rateLimiter,
+      });
+    }
+
+    const agentRunSeq = new Map<string, number>();
+    const dedupe = new Map<string, DedupeEntry>();
+    const chatRunState = createChatRunState();
+    const chatRunRegistry = chatRunState.registry;
+    const chatRunBuffers = chatRunState.buffers;
+    const chatDeltaSentAt = chatRunState.deltaSentAt;
+    const addChatRun = chatRunRegistry.add;
+    const removeChatRun = chatRunRegistry.remove;
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+
+    return {
+      canvasHost,
+      releasePluginRouteRegistry: () => releasePinnedPluginHttpRouteRegistry(params.pluginRegistry),
+      httpServer,
+      httpServers,
+      httpBindHosts,
+      wss,
+      clients,
+      broadcast,
+      broadcastToConnIds,
+      agentRunSeq,
+      dedupe,
+      chatRunState,
+      chatRunBuffers,
+      chatDeltaSentAt,
+      addChatRun,
+      removeChatRun,
+      chatAbortControllers,
+      toolEventRecipients,
+    };
+  } catch (err) {
+    releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
+    throw err;
   }
-
-  const agentRunSeq = new Map<string, number>();
-  const dedupe = new Map<string, DedupeEntry>();
-  const chatRunState = createChatRunState();
-  const chatRunRegistry = chatRunState.registry;
-  const chatRunBuffers = chatRunState.buffers;
-  const chatDeltaSentAt = chatRunState.deltaSentAt;
-  const addChatRun = chatRunRegistry.add;
-  const removeChatRun = chatRunRegistry.remove;
-  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
-  const toolEventRecipients = createToolEventRecipientRegistry();
-
-  return {
-    canvasHost,
-    httpServer,
-    httpServers,
-    httpBindHosts,
-    wss,
-    clients,
-    broadcast,
-    broadcastToConnIds,
-    agentRunSeq,
-    dedupe,
-    chatRunState,
-    chatRunBuffers,
-    chatDeltaSentAt,
-    addChatRun,
-    removeChatRun,
-    chatAbortControllers,
-    toolEventRecipients,
-  };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -583,6 +583,7 @@ export async function startGatewayServer(
   });
   const {
     canvasHost,
+    releasePluginRouteRegistry,
     httpServer,
     httpServers,
     httpBindHosts,
@@ -1041,6 +1042,7 @@ export async function startGatewayServer(
     tailscaleCleanup,
     canvasHost,
     canvasHostServer,
+    releasePluginRouteRegistry,
     stopChannel,
     pluginServices,
     cron,

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerPluginHttpRoute } from "../../plugins/http-registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
@@ -129,6 +136,11 @@ async function invokeSecureGatewayRoute(params: { gatewayAuthSatisfied: boolean 
 }
 
 describe("createGatewayPluginRequestHandler", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("caps unauthenticated plugin routes to non-admin subagent scopes", async () => {
     loadOpenClawPlugins.mockReset();
     handleGatewayRequest.mockReset();
@@ -281,6 +293,100 @@ describe("createGatewayPluginRequestHandler", () => {
     const handled = await handler({ url: "/API//demo" } as IncomingMessage, res);
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the provided registry when the pinned route registry is empty", async () => {
+    const explicitRouteHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 200;
+      return true;
+    });
+    const startupRegistry = createTestRegistry();
+    const explicitRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/demo", auth: "plugin", handler: explicitRouteHandler })],
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    const handler = createGatewayPluginRequestHandler({
+      registry: explicitRegistry,
+      log: createPluginLog(),
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/demo" } as IncomingMessage, res);
+    expect(handled).toBe(true);
+    expect(explicitRouteHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles routes registered into the pinned startup registry after the active registry changes", async () => {
+    const startupRegistry = createTestRegistry();
+    const laterActiveRegistry = createTestRegistry();
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 202;
+      return true;
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: startupRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("prefers the pinned route registry over a stale explicit registry", async () => {
+    const startupRegistry = createTestRegistry();
+    const staleExplicitRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/plugins/diffs", auth: "plugin" })],
+    });
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      return true;
+    });
+
+    setActivePluginRegistry(createTestRegistry());
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: routeHandler,
+    });
+
+    try {
+      const handler = createGatewayPluginRequestHandler({
+        registry: staleExplicitRegistry,
+        log: createPluginLog(),
+      });
+
+      const { res } = makeMockHttpResponse();
+      const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+      expect(handled).toBe(true);
+      expect(routeHandler).toHaveBeenCalledTimes(1);
+      expect(staleExplicitRegistry.httpRoutes).toHaveLength(1);
+      expect(startupRegistry.httpRoutes).toHaveLength(1);
+    } finally {
+      unregister();
+    }
   });
 
   it("logs and responds with 500 when a route throws", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { resolveActivePluginHttpRouteRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
@@ -63,8 +64,9 @@ export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
+    const registry = resolveActivePluginHttpRouteRegistry(params.registry);
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
 
 function expectRouteRegistrationDenied(params: {
   replaceExisting: boolean;
@@ -38,6 +43,11 @@ function expectRouteRegistrationDenied(params: {
 }
 
 describe("registerPluginHttpRoute", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("registers route and unregisters it", () => {
     const registry = createEmptyPluginRegistry();
     const handler = vi.fn();
@@ -163,5 +173,27 @@ describe("registerPluginHttpRoute", () => {
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(1);
+  });
+
+  it("uses the pinned route registry when the active registry changes later", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterActiveRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterActiveRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      handler: vi.fn(),
+    });
+
+    expect(startupRegistry.httpRoutes).toHaveLength(1);
+    expect(startupRegistry.httpRoutes[0]?.path).toBe("/bluebubbles-webhook");
+    expect(laterActiveRegistry.httpRoutes).toHaveLength(0);
+
+    unregister();
+    expect(startupRegistry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "./registry.js";
-import { requireActivePluginRegistry } from "./runtime.js";
+import { requireActivePluginHttpRouteRegistry } from "./runtime.js";
 
 export type PluginHttpRouteHandler = (
   req: IncomingMessage,
@@ -22,7 +22,7 @@ export function registerPluginHttpRoute(params: {
   log?: (message: string) => void;
   registry?: PluginRegistry;
 }): () => void {
-  const registry = params.registry ?? requireActivePluginRegistry();
+  const registry = params.registry ?? requireActivePluginHttpRouteRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
 

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  resolveActivePluginHttpRouteRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
+
+describe("plugin runtime route registry", () => {
+  afterEach(() => {
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("keeps the pinned route registry when the active plugin registry changes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(laterRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(laterRegistry)).toBe(startupRegistry);
+  });
+
+  it("falls back to the provided registry when the pinned route registry has no routes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const explicitRegistry = createEmptyPluginRegistry();
+    explicitRegistry.httpRoutes.push({
+      path: "/demo",
+      auth: "plugin",
+      match: "exact",
+      handler: () => true,
+      pluginId: "demo",
+      source: "test",
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(explicitRegistry);
+  });
+
+  it("prefers the pinned route registry when it already owns routes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const explicitRegistry = createEmptyPluginRegistry();
+    startupRegistry.httpRoutes.push({
+      path: "/bluebubbles-webhook",
+      auth: "plugin",
+      match: "exact",
+      handler: () => true,
+      pluginId: "bluebubbles",
+      source: "test",
+    });
+    explicitRegistry.httpRoutes.push({
+      path: "/plugins/diffs",
+      auth: "plugin",
+      match: "prefix",
+      handler: () => true,
+      pluginId: "diffs",
+      source: "test",
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(startupRegistry);
+  });
+});

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -4,6 +4,8 @@ const REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type RegistryState = {
   registry: PluginRegistry | null;
+  httpRouteRegistry: PluginRegistry | null;
+  httpRouteRegistryPinned: boolean;
   key: string | null;
   version: number;
 };
@@ -15,6 +17,8 @@ const state: RegistryState = (() => {
   if (!globalState[REGISTRY_STATE]) {
     globalState[REGISTRY_STATE] = {
       registry: createEmptyPluginRegistry(),
+      httpRouteRegistry: null,
+      httpRouteRegistryPinned: false,
       key: null,
       version: 0,
     };
@@ -24,6 +28,9 @@ const state: RegistryState = (() => {
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   state.registry = registry;
+  if (!state.httpRouteRegistryPinned) {
+    state.httpRouteRegistry = registry;
+  }
   state.key = cacheKey ?? null;
   state.version += 1;
 }
@@ -35,9 +42,52 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 export function requireActivePluginRegistry(): PluginRegistry {
   if (!state.registry) {
     state.registry = createEmptyPluginRegistry();
+    if (!state.httpRouteRegistryPinned) {
+      state.httpRouteRegistry = state.registry;
+    }
     state.version += 1;
   }
   return state.registry;
+}
+
+export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {
+  state.httpRouteRegistry = registry;
+  state.httpRouteRegistryPinned = true;
+}
+
+export function releasePinnedPluginHttpRouteRegistry(registry?: PluginRegistry) {
+  if (registry && state.httpRouteRegistry !== registry) {
+    return;
+  }
+  state.httpRouteRegistryPinned = false;
+  state.httpRouteRegistry = state.registry;
+}
+
+export function getActivePluginHttpRouteRegistry(): PluginRegistry | null {
+  return state.httpRouteRegistry ?? state.registry;
+}
+
+export function requireActivePluginHttpRouteRegistry(): PluginRegistry {
+  const existing = getActivePluginHttpRouteRegistry();
+  if (existing) {
+    return existing;
+  }
+  const created = requireActivePluginRegistry();
+  state.httpRouteRegistry = created;
+  return created;
+}
+
+export function resolveActivePluginHttpRouteRegistry(fallback: PluginRegistry): PluginRegistry {
+  const routeRegistry = getActivePluginHttpRouteRegistry();
+  if (!routeRegistry) {
+    return fallback;
+  }
+  const routeCount = routeRegistry.httpRoutes?.length ?? 0;
+  const fallbackRouteCount = fallback.httpRoutes?.length ?? 0;
+  if (routeCount === 0 && fallbackRouteCount > 0) {
+    return fallback;
+  }
+  return routeRegistry;
 }
 
 export function getActivePluginRegistryKey(): string | null {


### PR DESCRIPTION
## Summary

- fix plugin HTTP route desynchronization by pinning a dedicated HTTP-route registry for the gateway lifetime
- route runtime webhook registration through that pinned registry instead of the later active plugin registry pointer
- make plugin auth preflight and plugin request dispatch resolve routes from the same live HTTP-route registry
- add regression coverage for active-registry churn, explicit-registry fallback, and pinned-route registration

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #46924
- Fixes #47041
- Related #45598
- Related #45620
- Related #47468
- Supersedes #47676

## User-visible / Behavior Changes

- channel webhooks that register routes at runtime (for example BlueBubbles) remain reachable after plugin-registry churn instead of falling through to 404
- plugin HTTP auth preflight and dispatch now agree on the route registry they inspect

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Start the gateway with a channel that registers a webhook route at runtime.
2. Replace the active plugin registry during later plugin-loader activity.
3. POST to the webhook path.

### Before

- runtime route can be registered into a different registry object than the one the gateway auth/dispatch path reads
- webhook request falls through to 404 or mismatched auth behavior

### After

- runtime route stays in the pinned gateway route registry
- auth preflight and dispatch resolve the same route set

## Evidence

- `pnpm test -- src/plugins/runtime.test.ts src/plugins/http-registry.test.ts src/gateway/server/plugins-http.test.ts src/gateway/config-reload.test.ts`
- `pnpm tsgo`
- `pnpm build`
- `pnpm check`

## Human Verification

- verified the exact registry-churn failure mode with dedicated regression tests
- verified explicit-registry callers still work when the pinned route registry is empty
- verified route registration cleanup on shutdown/release path
