### PR TITLE
fix: preserve thinking blocks in latest assistant message during compaction

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -6,6 +6,11 @@ import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
+import {
+  extractLatestAssistantThinkingBlocks,
+  restoreLatestAssistantThinkingBlocks,
+  type PreservedThinkingState,
+} from "./thinking-block-preservation.js";
 
 const log = createSubsystemLogger("compaction");
 
@@ -400,6 +405,8 @@ export function pruneHistoryForContextShare(params: {
   maxContextTokens: number;
   maxHistoryShare?: number;
   parts?: number;
+  /** Provider name for thinking block preservation (Anthropic-family providers). */
+  provider?: string;
 }): {
   messages: AgentMessage[];
   droppedMessagesList: AgentMessage[];
@@ -408,7 +415,16 @@ export function pruneHistoryForContextShare(params: {
   droppedTokens: number;
   keptTokens: number;
   budgetTokens: number;
+  /** Preserved thinking blocks from the latest assistant message (if any). */
+  preservedThinking?: PreservedThinkingState;
 } {
+  // CRITICAL: Extract thinking blocks from latest assistant BEFORE any modifications.
+  // Anthropic's API requires these blocks to remain byte-for-byte identical.
+  // See: https://github.com/openclaw/openclaw/issues/30157
+  const preservedThinking = params.provider
+    ? extractLatestAssistantThinkingBlocks(params.messages, params.provider)
+    : undefined;
+
   const maxHistoryShare = params.maxHistoryShare ?? 0.5;
   const budgetTokens = Math.max(1, Math.floor(params.maxContextTokens * maxHistoryShare));
   let keptMessages = params.messages;
@@ -448,6 +464,12 @@ export function pruneHistoryForContextShare(params: {
     keptMessages = repairedKept;
   }
 
+  // CRITICAL: Restore thinking blocks after all modifications.
+  // This ensures cryptographic signatures remain intact for Anthropic's API.
+  if (preservedThinking?.snapshot) {
+    keptMessages = restoreLatestAssistantThinkingBlocks(keptMessages, preservedThinking);
+  }
+
   return {
     messages: keptMessages,
     droppedMessagesList: allDroppedMessages,
@@ -456,6 +478,7 @@ export function pruneHistoryForContextShare(params: {
     droppedTokens,
     keptTokens: estimateMessagesTokens(keptMessages),
     budgetTokens,
+    preservedThinking,
   };
 }
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -79,6 +79,11 @@ import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
+import {
+  extractLatestAssistantThinkingBlocks,
+  restoreLatestAssistantThinkingBlocks,
+  validateThinkingBlockPreservation,
+} from "../thinking-block-preservation.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
@@ -923,6 +928,14 @@ export async function compactEmbeddedPiSessionDirect(
           };
         }
 
+        // CRITICAL: Preserve thinking blocks from latest assistant message.
+        // Anthropic's API requires these blocks to remain byte-for-byte identical.
+        // See: https://github.com/openclaw/openclaw/issues/30157
+        const preservedThinking = extractLatestAssistantThinkingBlocks(
+          session.messages,
+          provider
+        );
+
         const compactStartedAt = Date.now();
         // Measure compactedCount from the original pre-limiting transcript so compaction
         // lifecycle metrics represent total reduction through the compaction pipeline.
@@ -948,6 +961,27 @@ export async function compactEmbeddedPiSessionDirect(
             },
           },
         );
+
+        // CRITICAL: Restore thinking blocks after compaction.
+        // This ensures cryptographic signatures remain intact for Anthropic's API.
+        if (preservedThinking.snapshot) {
+          const currentMessages = session.messages;
+          const restored = restoreLatestAssistantThinkingBlocks(currentMessages, preservedThinking);
+          if (restored !== currentMessages) {
+            session.agent.replaceMessages(restored);
+            log.info(
+              `[compaction] restored ${preservedThinking.snapshot.blocks.length} thinking block(s) ` +
+                `after compaction (provider: ${provider})`
+            );
+          }
+
+          // Validate restoration succeeded
+          const validation = validateThinkingBlockPreservation(session.messages, preservedThinking);
+          if (!validation.valid) {
+            log.error(`[compaction] thinking block restoration failed: ${validation.error}`);
+          }
+        }
+
         await runPostCompactionSideEffects({
           config: params.config,
           sessionKey: params.sessionKey,

--- a/src/agents/thinking-block-preservation.test.ts
+++ b/src/agents/thinking-block-preservation.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for thinking block preservation utilities.
+ *
+ * These tests verify that thinking/redacted_thinking blocks are correctly
+ * preserved through compaction and other message modifications.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  extractLatestAssistantThinkingBlocks,
+  restoreLatestAssistantThinkingBlocks,
+  validateThinkingBlockPreservation,
+  requiresThinkingBlockPreservation,
+  withThinkingBlockPreservationSync,
+} from "./thinking-block-preservation.js";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createUserMessage(content: string): AgentMessage {
+  return {
+    role: "user",
+    content,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function createAssistantMessage(
+  content: Array<{ type: string; [key: string]: unknown }>,
+): AgentMessage {
+  return {
+    role: "assistant",
+    content,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function createThinkingBlock(thinking: string, signature: string) {
+  return { type: "thinking", thinking, signature };
+}
+
+function createRedactedThinkingBlock(data: string) {
+  return { type: "redacted_thinking", data };
+}
+
+function createTextBlock(text: string) {
+  return { type: "text", text };
+}
+
+// ============================================================================
+// Provider Detection Tests
+// ============================================================================
+
+describe("requiresThinkingBlockPreservation", () => {
+  it("returns true for anthropic provider", () => {
+    expect(requiresThinkingBlockPreservation("anthropic")).toBe(true);
+  });
+
+  it("returns true for amazon-bedrock provider", () => {
+    expect(requiresThinkingBlockPreservation("amazon-bedrock")).toBe(true);
+  });
+
+  it("returns true for bedrock provider", () => {
+    expect(requiresThinkingBlockPreservation("bedrock")).toBe(true);
+  });
+
+  it("returns true for anthropic-compatible providers", () => {
+    expect(requiresThinkingBlockPreservation("anthropic-proxy")).toBe(true);
+    expect(requiresThinkingBlockPreservation("my-anthropic-endpoint")).toBe(true);
+  });
+
+  it("returns false for openai provider", () => {
+    expect(requiresThinkingBlockPreservation("openai")).toBe(false);
+  });
+
+  it("returns false for google provider", () => {
+    expect(requiresThinkingBlockPreservation("google")).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(requiresThinkingBlockPreservation(null)).toBe(false);
+    expect(requiresThinkingBlockPreservation(undefined)).toBe(false);
+  });
+
+  it("handles case insensitivity", () => {
+    expect(requiresThinkingBlockPreservation("ANTHROPIC")).toBe(true);
+    expect(requiresThinkingBlockPreservation("Anthropic")).toBe(true);
+    expect(requiresThinkingBlockPreservation("AnThRoPiC")).toBe(true);
+  });
+});
+
+// ============================================================================
+// Extraction Tests
+// ============================================================================
+
+describe("extractLatestAssistantThinkingBlocks", () => {
+  it("extracts thinking blocks from last assistant message", () => {
+    const messages: AgentMessage[] = [
+      createUserMessage("Hello"),
+      createAssistantMessage([
+        createThinkingBlock("Let me think about this...", "sig_abc123"),
+        createTextBlock("Here's my response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot).not.toBeNull();
+    expect(result.snapshot!.blocks).toHaveLength(1);
+    expect(result.snapshot!.blocks[0].type).toBe("thinking");
+    expect(result.snapshot!.blocks[0].thinking).toBe("Let me think about this...");
+    expect(result.snapshot!.blocks[0].signature).toBe("sig_abc123");
+  });
+
+  it("extracts redacted_thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createRedactedThinkingBlock("encrypted_blob_data"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot).not.toBeNull();
+    expect(result.snapshot!.blocks[0].type).toBe("redacted_thinking");
+    expect(result.snapshot!.blocks[0].data).toBe("encrypted_blob_data");
+  });
+
+  it("extracts multiple thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("First thought", "sig1"),
+        createThinkingBlock("Second thought", "sig2"),
+        createRedactedThinkingBlock("redacted"),
+        createTextBlock("Final answer"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot!.blocks).toHaveLength(3);
+    expect(result.snapshot!.blocks[0].thinking).toBe("First thought");
+    expect(result.snapshot!.blocks[1].thinking).toBe("Second thought");
+    expect(result.snapshot!.blocks[2].type).toBe("redacted_thinking");
+  });
+
+  it("only extracts from the LAST assistant message", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Old thinking", "old_sig"),
+        createTextBlock("Old response"),
+      ]),
+      createUserMessage("Follow up"),
+      createAssistantMessage([
+        createThinkingBlock("New thinking", "new_sig"),
+        createTextBlock("New response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot!.blocks).toHaveLength(1);
+    expect(result.snapshot!.blocks[0].thinking).toBe("New thinking");
+    expect(result.snapshot!.blocks[0].signature).toBe("new_sig");
+    expect(result.snapshot!.messageIndex).toBe(2);
+  });
+
+  it("returns null snapshot for non-anthropic providers", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "openai");
+
+    expect(result.snapshot).toBeNull();
+    expect(result.provider).toBe("openai");
+  });
+
+  it("returns null snapshot when no assistant messages exist", () => {
+    const messages: AgentMessage[] = [
+      createUserMessage("Hello"),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot).toBeNull();
+  });
+
+  it("returns null snapshot when assistant has no thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createTextBlock("Just a simple response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot).toBeNull();
+  });
+
+  it("preserves additional/unknown fields in thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "Deep thought",
+          signature: "sig",
+          customField: "custom_value",
+          nestedObject: { a: 1, b: 2 },
+        },
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    expect(result.snapshot!.blocks[0].customField).toBe("custom_value");
+    expect(result.snapshot!.blocks[0].nestedObject).toEqual({ a: 1, b: 2 });
+  });
+
+  it("deep clones blocks to prevent mutation", () => {
+    const originalBlock = createThinkingBlock("Original", "sig");
+    const messages: AgentMessage[] = [
+      createAssistantMessage([originalBlock, createTextBlock("Response")]),
+    ];
+
+    const result = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    // Mutate the extracted block
+    result.snapshot!.blocks[0].thinking = "Modified";
+
+    // Original should be unchanged
+    expect(originalBlock.thinking).toBe("Original");
+  });
+});
+
+// ============================================================================
+// Restoration Tests
+// ============================================================================
+
+describe("restoreLatestAssistantThinkingBlocks", () => {
+  it("restores missing thinking blocks", () => {
+    // Original message with thinking
+    const originalMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Important reasoning", "crypto_sig_123"),
+        createTextBlock("My response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(originalMessages, "anthropic");
+
+    // Simulate compaction removing thinking blocks
+    const modifiedMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createTextBlock("My response"),
+      ]),
+    ];
+
+    const restored = restoreLatestAssistantThinkingBlocks(modifiedMessages, preserved);
+
+    expect(restored[0].content).toHaveLength(2);
+    expect(restored[0].content[0].type).toBe("thinking");
+    expect(restored[0].content[0].thinking).toBe("Important reasoning");
+    expect(restored[0].content[0].signature).toBe("crypto_sig_123");
+  });
+
+  it("returns same reference when blocks already match", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    // Pass the same messages through restoration
+    const result = restoreLatestAssistantThinkingBlocks(messages, preserved);
+
+    // Should be the same reference (no changes needed)
+    expect(result).toBe(messages);
+  });
+
+  it("restores blocks when signature was corrupted", () => {
+    const originalMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "original_signature"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(originalMessages, "anthropic");
+
+    // Simulate corruption of signature
+    const corruptedMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "corrupted_signature"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const restored = restoreLatestAssistantThinkingBlocks(corruptedMessages, preserved);
+
+    expect(restored[0].content[0].signature).toBe("original_signature");
+  });
+
+  it("handles null snapshot gracefully", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([createTextBlock("Response")]),
+    ];
+
+    const preserved = {
+      snapshot: null,
+      provider: "anthropic",
+      capturedAt: Date.now(),
+    };
+
+    const result = restoreLatestAssistantThinkingBlocks(messages, preserved);
+
+    expect(result).toBe(messages);
+  });
+
+  it("handles non-anthropic provider gracefully", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([createTextBlock("Response")]),
+    ];
+
+    const preserved = {
+      snapshot: {
+        messageIndex: 0,
+        blocks: [createThinkingBlock("Thinking", "sig") as any],
+        originalContentLength: 2,
+        hash: "tb-123",
+      },
+      provider: "openai",
+      capturedAt: Date.now(),
+    };
+
+    const result = restoreLatestAssistantThinkingBlocks(messages, preserved);
+
+    // Should not restore for non-anthropic provider
+    expect(result).toBe(messages);
+    expect(result[0].content).toHaveLength(1);
+  });
+
+  it("handles missing assistant message gracefully", () => {
+    const preserved = {
+      snapshot: {
+        messageIndex: 0,
+        blocks: [createThinkingBlock("Thinking", "sig") as any],
+        originalContentLength: 2,
+        hash: "tb-123",
+      },
+      provider: "anthropic",
+      capturedAt: Date.now(),
+    };
+
+    const messagesWithoutAssistant: AgentMessage[] = [
+      createUserMessage("Hello"),
+    ];
+
+    const result = restoreLatestAssistantThinkingBlocks(messagesWithoutAssistant, preserved);
+
+    // Should return unchanged (can't restore without assistant)
+    expect(result).toBe(messagesWithoutAssistant);
+  });
+
+  it("prepends thinking blocks before other content", () => {
+    const originalMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(originalMessages, "anthropic");
+
+    // Simulate modified message with extra content
+    const modifiedMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createTextBlock("Modified response"),
+        { type: "tool_use", id: "tool_1", name: "test" },
+      ]),
+    ];
+
+    const restored = restoreLatestAssistantThinkingBlocks(modifiedMessages, preserved);
+
+    // Thinking should be first
+    expect(restored[0].content[0].type).toBe("thinking");
+    expect(restored[0].content[1].type).toBe("text");
+    expect(restored[0].content[2].type).toBe("tool_use");
+  });
+});
+
+// ============================================================================
+// Validation Tests
+// ============================================================================
+
+describe("validateThinkingBlockPreservation", () => {
+  it("returns valid for null snapshot", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([createTextBlock("Response")]),
+    ];
+
+    const preserved = {
+      snapshot: null,
+      provider: "anthropic",
+      capturedAt: Date.now(),
+    };
+
+    const result = validateThinkingBlockPreservation(messages, preserved);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid when blocks match", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(messages, "anthropic");
+
+    const result = validateThinkingBlockPreservation(messages, preserved);
+
+    expect(result.valid).toBe(true);
+    expect(result.details?.hashMatch).toBe(true);
+  });
+
+  it("returns invalid when assistant message is missing", () => {
+    const preserved = {
+      snapshot: {
+        messageIndex: 0,
+        blocks: [createThinkingBlock("Thinking", "sig") as any],
+        originalContentLength: 2,
+        hash: "tb-123",
+      },
+      provider: "anthropic",
+      capturedAt: Date.now(),
+    };
+
+    const messages: AgentMessage[] = [
+      createUserMessage("Only user message"),
+    ];
+
+    const result = validateThinkingBlockPreservation(messages, preserved);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("removed");
+  });
+
+  it("returns invalid when thinking blocks were modified", () => {
+    const originalMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Original thinking", "original_sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const preserved = extractLatestAssistantThinkingBlocks(originalMessages, "anthropic");
+
+    const modifiedMessages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Modified thinking", "different_sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    const result = validateThinkingBlockPreservation(modifiedMessages, preserved);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("modified");
+    expect(result.details?.hashMatch).toBe(false);
+  });
+});
+
+// ============================================================================
+// Integration / Wrapper Tests
+// ============================================================================
+
+describe("withThinkingBlockPreservationSync", () => {
+  it("preserves thinking blocks through modification", () => {
+    const originalMessages: AgentMessage[] = [
+      createUserMessage("Hello"),
+      createAssistantMessage([
+        createThinkingBlock("Deep reasoning here", "crypto_sig_xyz"),
+        createTextBlock("My response"),
+      ]),
+    ];
+
+    // Simulate a compaction-like operation that removes thinking blocks
+    const result = withThinkingBlockPreservationSync(
+      originalMessages,
+      "anthropic",
+      (messages) => {
+        // Strip thinking blocks (simulating what compaction might do)
+        const modified = messages.map((msg) => {
+          if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+            return msg;
+          }
+          return {
+            ...msg,
+            content: msg.content.filter(
+              (block: any) => block.type !== "thinking" && block.type !== "redacted_thinking"
+            ),
+          };
+        }) as AgentMessage[];
+
+        return { messages: modified };
+      }
+    );
+
+    // Thinking blocks should be restored
+    const lastAssistant = result.messages.find((m) => m.role === "assistant");
+    expect(lastAssistant).toBeDefined();
+    expect(lastAssistant!.content).toHaveLength(2);
+    expect(lastAssistant!.content[0].type).toBe("thinking");
+    expect(lastAssistant!.content[0].signature).toBe("crypto_sig_xyz");
+  });
+
+  it("handles operations that don't modify thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    // Operation that doesn't touch thinking blocks
+    const result = withThinkingBlockPreservationSync(
+      messages,
+      "anthropic",
+      (msgs) => {
+        return { messages: msgs };
+      }
+    );
+
+    // Should return same reference
+    expect(result.messages).toBe(messages);
+  });
+
+  it("skips preservation for non-anthropic providers", () => {
+    const messages: AgentMessage[] = [
+      createAssistantMessage([
+        createThinkingBlock("Thinking", "sig"),
+        createTextBlock("Response"),
+      ]),
+    ];
+
+    let operationCalled = false;
+
+    const result = withThinkingBlockPreservationSync(
+      messages,
+      "openai",
+      (msgs) => {
+        operationCalled = true;
+        // Remove thinking blocks
+        const modified = msgs.map((msg) => {
+          if (msg.role !== "assistant") return msg;
+          return {
+            ...msg,
+            content: (msg.content as any[]).filter((b) => b.type !== "thinking"),
+          };
+        }) as AgentMessage[];
+        return { messages: modified };
+      }
+    );
+
+    expect(operationCalled).toBe(true);
+    // Thinking blocks should NOT be restored for OpenAI
+    expect(result.messages[0].content).toHaveLength(1);
+    expect(result.messages[0].content[0].type).toBe("text");
+  });
+});

--- a/src/agents/thinking-block-preservation.ts
+++ b/src/agents/thinking-block-preservation.ts
@@ -1,0 +1,467 @@
+/**
+ * Thinking Block Preservation for Anthropic API Compatibility
+ *
+ * Anthropic's API requires that `thinking` and `redacted_thinking` blocks in the
+ * LATEST assistant message remain byte-for-byte identical to the original response.
+ * These blocks contain cryptographic signatures that are validated server-side.
+ *
+ * This module provides utilities to:
+ * 1. Extract thinking blocks before compaction/modification
+ * 2. Restore them exactly after processing
+ * 3. Validate that preservation was successful
+ *
+ * @see https://github.com/openclaw/openclaw/issues/30157
+ * @see https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("thinking-block-preservation");
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A thinking or redacted_thinking content block from an assistant message.
+ * We preserve ALL fields to ensure byte-for-byte compatibility.
+ */
+export type ThinkingBlock = {
+  type: "thinking" | "redacted_thinking";
+  /** The visible thinking text (for `thinking` type) */
+  thinking?: string;
+  /** Cryptographic signature validating the block */
+  signature?: string;
+  /** Encrypted data (for `redacted_thinking` type) */
+  data?: string;
+  /** Preserve any additional/future fields */
+  [key: string]: unknown;
+};
+
+/**
+ * Snapshot of thinking blocks from the latest assistant message.
+ */
+export type ThinkingBlockSnapshot = {
+  /** Index of the assistant message in the original array */
+  messageIndex: number;
+  /** Complete thinking blocks, preserved exactly */
+  blocks: ThinkingBlock[];
+  /** Content array length for validation */
+  originalContentLength: number;
+  /** Hash of the serialized blocks for quick comparison */
+  hash: string;
+};
+
+/**
+ * State container for preserved thinking blocks.
+ */
+export type PreservedThinkingState = {
+  /** The snapshot, or null if nothing to preserve */
+  snapshot: ThinkingBlockSnapshot | null;
+  /** Provider that was active when snapshot was taken */
+  provider: string;
+  /** Timestamp for debugging */
+  capturedAt: number;
+};
+
+/**
+ * Result of validation check.
+ */
+export type ThinkingBlockValidation = {
+  valid: boolean;
+  error?: string;
+  details?: {
+    expectedBlocks: number;
+    actualBlocks: number;
+    hashMatch: boolean;
+  };
+};
+
+// ============================================================================
+// Provider Detection
+// ============================================================================
+
+/**
+ * Providers that require thinking block preservation.
+ * Anthropic-family providers validate thinking block signatures server-side.
+ */
+const ANTHROPIC_FAMILY_PROVIDERS = new Set([
+  "anthropic",
+  "amazon-bedrock",
+  "bedrock",
+]);
+
+const ANTHROPIC_FAMILY_PATTERNS = [
+  /anthropic/i,
+  /bedrock/i,
+  /claude/i, // Some providers use "claude" in the provider name
+];
+
+/**
+ * Check if a provider requires thinking block preservation.
+ */
+export function requiresThinkingBlockPreservation(provider: string | null | undefined): boolean {
+  if (!provider) return false;
+
+  const normalized = provider.toLowerCase().trim();
+
+  // Check exact matches first (fast path)
+  if (ANTHROPIC_FAMILY_PROVIDERS.has(normalized)) {
+    return true;
+  }
+
+  // Check patterns for derived/proxied providers
+  return ANTHROPIC_FAMILY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+// ============================================================================
+// Block Detection
+// ============================================================================
+
+/**
+ * Check if a content block is a thinking or redacted_thinking block.
+ */
+function isThinkingBlock(block: unknown): block is ThinkingBlock {
+  if (!block || typeof block !== "object") return false;
+
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
+/**
+ * Deep clone a thinking block to ensure we preserve the exact original.
+ * Using JSON parse/stringify for true isolation.
+ */
+function cloneThinkingBlock(block: ThinkingBlock): ThinkingBlock {
+  return JSON.parse(JSON.stringify(block));
+}
+
+/**
+ * Create a hash of thinking blocks for quick comparison.
+ * Uses JSON serialization - stable for our use case.
+ */
+function hashThinkingBlocks(blocks: ThinkingBlock[]): string {
+  const serialized = JSON.stringify(blocks);
+  // Simple hash for comparison (not cryptographic)
+  let hash = 0;
+  for (let i = 0; i < serialized.length; i++) {
+    const char = serialized.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return `tb-${Math.abs(hash).toString(36)}`;
+}
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Extract thinking blocks from the LATEST assistant message.
+ *
+ * This must be called BEFORE any compaction or message modification.
+ * The returned state should be passed to `restoreLatestAssistantThinkingBlocks`
+ * after processing is complete.
+ *
+ * @param messages - The current message array
+ * @param provider - The active provider (e.g., "anthropic")
+ * @returns State object containing the snapshot (or null if nothing to preserve)
+ */
+export function extractLatestAssistantThinkingBlocks(
+  messages: AgentMessage[],
+  provider: string,
+): PreservedThinkingState {
+  const result: PreservedThinkingState = {
+    snapshot: null,
+    provider,
+    capturedAt: Date.now(),
+  };
+
+  // Fast path: skip if provider doesn't need preservation
+  if (!requiresThinkingBlockPreservation(provider)) {
+    log.debug(`Skipping thinking block extraction: provider "${provider}" doesn't require it`);
+    return result;
+  }
+
+  // Find the LAST assistant message (working backwards)
+  let lastAssistantIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg && typeof msg === "object" && msg.role === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
+  if (lastAssistantIndex === -1) {
+    log.debug("No assistant message found for thinking block extraction");
+    return result;
+  }
+
+  const assistant = messages[lastAssistantIndex] as Extract<AgentMessage, { role: "assistant" }>;
+
+  // Check for content array
+  if (!Array.isArray(assistant.content)) {
+    log.debug("Assistant message has no content array");
+    return result;
+  }
+
+  // Extract all thinking/redacted_thinking blocks
+  const thinkingBlocks: ThinkingBlock[] = [];
+  for (const block of assistant.content) {
+    if (isThinkingBlock(block)) {
+      thinkingBlocks.push(cloneThinkingBlock(block));
+    }
+  }
+
+  if (thinkingBlocks.length === 0) {
+    log.debug("No thinking blocks found in latest assistant message");
+    return result;
+  }
+
+  const hash = hashThinkingBlocks(thinkingBlocks);
+
+  result.snapshot = {
+    messageIndex: lastAssistantIndex,
+    blocks: thinkingBlocks,
+    originalContentLength: assistant.content.length,
+    hash,
+  };
+
+  log.info(
+    `Extracted ${thinkingBlocks.length} thinking block(s) from message index ${lastAssistantIndex} ` +
+    `(hash: ${hash}, provider: ${provider})`
+  );
+
+  return result;
+}
+
+/**
+ * Restore preserved thinking blocks to the latest assistant message.
+ *
+ * This must be called AFTER compaction or message modification completes.
+ * It ensures the thinking blocks in the latest assistant message match
+ * the original exactly.
+ *
+ * @param messages - The (possibly modified) message array
+ * @param preserved - The state returned by `extractLatestAssistantThinkingBlocks`
+ * @returns The message array with thinking blocks restored (may be same reference if unchanged)
+ */
+export function restoreLatestAssistantThinkingBlocks(
+  messages: AgentMessage[],
+  preserved: PreservedThinkingState,
+): AgentMessage[] {
+  // Nothing to restore
+  if (!preserved.snapshot) {
+    return messages;
+  }
+
+  // Provider changed or doesn't need preservation
+  if (!requiresThinkingBlockPreservation(preserved.provider)) {
+    return messages;
+  }
+
+  // Find the LAST assistant message in the (possibly modified) array
+  let lastAssistantIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg && typeof msg === "object" && msg.role === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
+  if (lastAssistantIndex === -1) {
+    log.warn(
+      "Cannot restore thinking blocks: no assistant message found. " +
+      "The latest assistant message may have been removed during compaction."
+    );
+    return messages;
+  }
+
+  const assistant = messages[lastAssistantIndex] as Extract<AgentMessage, { role: "assistant" }>;
+
+  if (!Array.isArray(assistant.content)) {
+    log.warn("Cannot restore thinking blocks: assistant has no content array");
+    return messages;
+  }
+
+  // Check if current thinking blocks already match
+  const currentThinking = assistant.content.filter(isThinkingBlock);
+  const currentHash = hashThinkingBlocks(currentThinking as ThinkingBlock[]);
+
+  if (currentHash === preserved.snapshot.hash) {
+    log.debug("Thinking blocks already match preserved snapshot (hash: " + currentHash + ")");
+    return messages;
+  }
+
+  log.info(
+    `Restoring thinking blocks: current hash ${currentHash} differs from preserved ${preserved.snapshot.hash}`
+  );
+
+  // Remove any existing thinking blocks and prepend the preserved ones
+  // This ensures the preserved blocks come first (matching Anthropic's expected order)
+  const nonThinkingContent = assistant.content.filter((block) => !isThinkingBlock(block));
+
+  const restoredContent = [
+    // Deep clone preserved blocks to avoid mutations
+    ...preserved.snapshot.blocks.map(cloneThinkingBlock),
+    ...nonThinkingContent,
+  ];
+
+  const restoredAssistant = {
+    ...assistant,
+    content: restoredContent,
+  };
+
+  // Create new array with restored assistant
+  const result = [...messages];
+  result[lastAssistantIndex] = restoredAssistant as AgentMessage;
+
+  log.info(
+    `Restored ${preserved.snapshot.blocks.length} thinking block(s) to message index ${lastAssistantIndex}`
+  );
+
+  return result;
+}
+
+/**
+ * Validate that thinking blocks in the latest assistant message match the preserved state.
+ *
+ * @param messages - The message array to validate
+ * @param preserved - The original preserved state
+ * @returns Validation result with details
+ */
+export function validateThinkingBlockPreservation(
+  messages: AgentMessage[],
+  preserved: PreservedThinkingState,
+): ThinkingBlockValidation {
+  if (!preserved.snapshot) {
+    return { valid: true };
+  }
+
+  if (!requiresThinkingBlockPreservation(preserved.provider)) {
+    return { valid: true };
+  }
+
+  // Find latest assistant
+  let lastAssistantIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
+  if (lastAssistantIndex === -1) {
+    return {
+      valid: false,
+      error: "Latest assistant message was removed during processing",
+      details: {
+        expectedBlocks: preserved.snapshot.blocks.length,
+        actualBlocks: 0,
+        hashMatch: false,
+      },
+    };
+  }
+
+  const assistant = messages[lastAssistantIndex];
+  const content = (assistant as { content?: unknown[] }).content;
+
+  if (!Array.isArray(content)) {
+    return {
+      valid: false,
+      error: "Latest assistant message has no content array",
+      details: {
+        expectedBlocks: preserved.snapshot.blocks.length,
+        actualBlocks: 0,
+        hashMatch: false,
+      },
+    };
+  }
+
+  const currentThinking = content.filter(isThinkingBlock) as ThinkingBlock[];
+  const currentHash = hashThinkingBlocks(currentThinking);
+  const hashMatch = currentHash === preserved.snapshot.hash;
+
+  if (!hashMatch) {
+    return {
+      valid: false,
+      error: "Thinking blocks in latest assistant message were modified",
+      details: {
+        expectedBlocks: preserved.snapshot.blocks.length,
+        actualBlocks: currentThinking.length,
+        hashMatch: false,
+      },
+    };
+  }
+
+  return {
+    valid: true,
+    details: {
+      expectedBlocks: preserved.snapshot.blocks.length,
+      actualBlocks: currentThinking.length,
+      hashMatch: true,
+    },
+  };
+}
+
+/**
+ * Wrapper function for compaction operations.
+ *
+ * Automatically extracts thinking blocks before the operation and
+ * restores them after. Use this to wrap any function that might
+ * modify the message array in a way that could corrupt thinking blocks.
+ *
+ * @param messages - The input message array
+ * @param provider - The active provider
+ * @param operation - The async operation that may modify messages
+ * @returns The operation result with thinking blocks preserved
+ */
+export async function withThinkingBlockPreservation<T extends { messages: AgentMessage[] }>(
+  messages: AgentMessage[],
+  provider: string,
+  operation: (messages: AgentMessage[]) => Promise<T>,
+): Promise<T> {
+  const preserved = extractLatestAssistantThinkingBlocks(messages, provider);
+
+  const result = await operation(messages);
+
+  if (preserved.snapshot) {
+    result.messages = restoreLatestAssistantThinkingBlocks(result.messages, preserved);
+
+    // Validate restoration
+    const validation = validateThinkingBlockPreservation(result.messages, preserved);
+    if (!validation.valid) {
+      log.error(`Thinking block restoration failed: ${validation.error}`, validation.details);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Synchronous version of withThinkingBlockPreservation for operations
+ * that don't need async.
+ */
+export function withThinkingBlockPreservationSync<T extends { messages: AgentMessage[] }>(
+  messages: AgentMessage[],
+  provider: string,
+  operation: (messages: AgentMessage[]) => T,
+): T {
+  const preserved = extractLatestAssistantThinkingBlocks(messages, provider);
+
+  const result = operation(messages);
+
+  if (preserved.snapshot) {
+    result.messages = restoreLatestAssistantThinkingBlocks(result.messages, preserved);
+
+    const validation = validateThinkingBlockPreservation(result.messages, preserved);
+    if (!validation.valid) {
+      log.error(`Thinking block restoration failed: ${validation.error}`, validation.details);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem

Anthropic's API rejects requests when `thinking` or `redacted_thinking` blocks in the **latest assistant message** have been modified. These blocks contain cryptographic signatures that must remain byte-for-byte identical to the original response.

Currently, OpenClaw's compaction pipeline can modify or drop these blocks, causing:
```
LLM request rejected: messages.N.content.M: `thinking` or `redacted_thinking` blocks 
in the latest assistant message cannot be modified. These blocks must remain as they 
were in the original response.
```

**Fixes #30157**

## Solution

Added a thinking block preservation layer that:
1. **Extracts** thinking blocks from the latest assistant message BEFORE compaction
2. **Restores** them exactly AFTER compaction completes  
3. **Validates** the restoration succeeded

The fix only activates for Anthropic-family providers (anthropic, bedrock) and has no effect on other providers.

## Changes

### New files
- `src/agents/thinking-block-preservation.ts` — Core extraction/restoration utilities with full JSDoc
- `src/agents/thinking-block-preservation.test.ts` — 25+ unit tests covering extraction, restoration, validation, and edge cases

### Modified files
- `src/agents/compaction.ts` — Added preservation to `pruneHistoryForContextShare()`
- `src/agents/pi-embedded-runner/compact.ts` — Added preservation around `session.compact()`

## Testing

- Unit tests cover all extraction/restoration scenarios
- Integration tested with Claude Opus 4 sessions that hit compaction
- Verified no impact on non-Anthropic providers (OpenAI, Google)

## Notes

- Zero performance impact for non-Anthropic providers (early return)
- Minimal overhead for Anthropic (~JSON serialize/deserialize of thinking blocks)
- Deep clones blocks to prevent any mutation