### PR TITLE
fix: narrow reply-root dedupe to queued reruns

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -14,6 +14,11 @@ import {
   type FollowupRun,
   type QueueSettings,
 } from "./queue.js";
+import {
+  buildRecentSentReplyRootKeyForRun,
+  markRecentSentReplyRoot,
+  resetRecentSentReplyRootDedupe,
+} from "./reply-root-dedupe.js";
 import { createMockTypingController } from "./test-helpers.js";
 
 type AgentRunParams = {
@@ -96,6 +101,7 @@ beforeEach(() => {
   state.runCliAgentMock.mockClear();
   vi.mocked(enqueueFollowupRun).mockClear();
   vi.mocked(scheduleFollowupDrain).mockClear();
+  resetRecentSentReplyRootDedupe();
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
@@ -111,6 +117,7 @@ function createMinimalRun(params?: {
   isActive?: boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  replyRootId?: string;
   runOverrides?: Partial<FollowupRun["run"]>;
 }) {
   const typing = createMockTypingController();
@@ -127,6 +134,7 @@ function createMinimalRun(params?: {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
+    replyRootId: params?.replyRootId,
     run: {
       sessionId: "session",
       sessionKey,
@@ -153,6 +161,7 @@ function createMinimalRun(params?: {
 
   return {
     typing,
+    followupRun,
     opts,
     run: async () => {
       const runReplyAgent = await getRunReplyAgent();
@@ -318,6 +327,35 @@ describe("runReplyAgent heartbeat followup guard", () => {
 
     expect(result).toBeUndefined();
     expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("drops followups when the reply root was already sent recently", async () => {
+    const params = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+      replyRootId: "root-1",
+      runOverrides: {
+        agentId: "agent",
+      },
+    });
+    const recentKey = buildRecentSentReplyRootKeyForRun({
+      ...params.followupRun,
+      run: {
+        ...params.followupRun.run,
+        agentId: "agent",
+        sessionId: "session",
+        sessionKey: "main",
+      },
+    });
+    markRecentSentReplyRoot(recentKey);
+
+    const result = await params.run();
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -359,6 +359,37 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 
+  it("does not drop fresh inbound runs when the reply root was sent recently", async () => {
+    const params = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: false,
+      shouldFollowup: false,
+      replyRootId: "root-1",
+      runOverrides: {
+        agentId: "agent",
+      },
+    });
+    const recentKey = buildRecentSentReplyRootKeyForRun({
+      ...params.followupRun,
+      run: {
+        ...params.followupRun.run,
+        agentId: "agent",
+        sessionId: "session",
+        sessionKey: "main",
+      },
+    });
+    markRecentSentReplyRoot(recentKey);
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "fresh reply" }],
+      meta: {},
+    });
+
+    const result = await params.run();
+
+    expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({ text: "fresh reply" }));
+  });
+
   it("drains followup queue when an unexpected exception escapes the run path", async () => {
     const accounting = await import("./session-run-accounting.js");
     const persistSpy = vi

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -214,11 +214,6 @@ export async function runReplyAgent(params: {
     queueMode: resolvedQueue.mode,
   });
   const recentSentReplyRootKey = buildRecentSentReplyRootKeyForRun(followupRun);
-  if (hasRecentSentReplyRoot(recentSentReplyRootKey)) {
-    await touchActiveSessionEntry();
-    typing.cleanup();
-    return undefined;
-  }
 
   if (activeRunQueueAction === "drop") {
     typing.cleanup();
@@ -226,6 +221,11 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
+    if (hasRecentSentReplyRoot(recentSentReplyRootKey)) {
+      await touchActiveSessionEntry();
+      typing.cleanup();
+      return undefined;
+    }
     enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();
     typing.cleanup();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -52,6 +52,10 @@ import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-r
 import { readPostCompactionContext } from "./post-compaction-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  buildRecentSentReplyRootKeyForRun,
+  hasRecentSentReplyRoot,
+} from "./reply-root-dedupe.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
@@ -209,6 +213,12 @@ export async function runReplyAgent(params: {
     shouldFollowup,
     queueMode: resolvedQueue.mode,
   });
+  const recentSentReplyRootKey = buildRecentSentReplyRootKeyForRun(followupRun);
+  if (hasRecentSentReplyRoot(recentSentReplyRootKey)) {
+    await touchActiveSessionEntry();
+    typing.cleanup();
+    return undefined;
+  }
 
   if (activeRunQueueAction === "drop") {
     typing.cleanup();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -35,6 +35,7 @@ import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispat
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
+import { resolveReplyRootIdFromContext } from "./reply-root-dedupe.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 
@@ -241,6 +242,7 @@ export async function dispatchReplyFromConfig(params: {
   const shouldSuppressTyping =
     shouldRouteToOriginating || originatingChannel === INTERNAL_MESSAGE_CHANNEL;
   const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
+  const replyRootId = resolveReplyRootIdFromContext(ctx);
 
   /**
    * Helper to send a payload via route-reply (async).
@@ -266,8 +268,10 @@ export async function dispatchReplyFromConfig(params: {
       channel: originatingChannel,
       to: originatingTo,
       sessionKey: ctx.SessionKey,
+      replyRootScopeKey: ctx.SessionKey,
       accountId: ctx.AccountId,
       threadId: routeThreadId,
+      replyRootId,
       cfg,
       abortSignal,
       mirror,
@@ -295,8 +299,10 @@ export async function dispatchReplyFromConfig(params: {
           channel: originatingChannel,
           to: originatingTo,
           sessionKey: ctx.SessionKey,
+          replyRootScopeKey: ctx.SessionKey,
           accountId: ctx.AccountId,
           threadId: routeThreadId,
+          replyRootId,
           cfg,
           isGroup,
           groupId,
@@ -525,8 +531,10 @@ export async function dispatchReplyFromConfig(params: {
           channel: originatingChannel,
           to: originatingTo,
           sessionKey: ctx.SessionKey,
+          replyRootScopeKey: ctx.SessionKey,
           accountId: ctx.AccountId,
           threadId: routeThreadId,
+          replyRootId,
           cfg,
           isGroup,
           groupId,
@@ -577,8 +585,10 @@ export async function dispatchReplyFromConfig(params: {
               channel: originatingChannel,
               to: originatingTo,
               sessionKey: ctx.SessionKey,
+              replyRootScopeKey: ctx.SessionKey,
               accountId: ctx.AccountId,
               threadId: routeThreadId,
+              replyRootId,
               cfg,
               isGroup,
               groupId,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loadSessionStore, saveSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { FollowupRun } from "./queue.js";
+import {
+  buildRecentSentReplyRootKeyForRun,
+  markRecentSentReplyRoot,
+  resetRecentSentReplyRootDedupe,
+} from "./reply-root-dedupe.js";
 import { createMockFollowupRun, createMockTypingController } from "./test-helpers.js";
 
 const runEmbeddedPiAgentMock = vi.fn();
@@ -44,6 +49,7 @@ beforeEach(() => {
   routeReplyMock.mockReset();
   routeReplyMock.mockResolvedValue({ ok: true });
   isRoutableChannelMock.mockReset();
+  resetRecentSentReplyRootDedupe();
   isRoutableChannelMock.mockImplementation((ch: string | undefined) =>
     Boolean(ch?.trim() && ROUTABLE_TEST_CHANNELS.has(ch.trim().toLowerCase())),
   );
@@ -437,6 +443,25 @@ describe("createFollowupRunner messaging tool dedupe", () => {
         threadId: "1739142736.000100",
       }),
     );
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("skips queued runs when the reply root was already sent recently", async () => {
+    const queued = createQueuedRun({
+      replyRootId: "root-1",
+      run: {
+        agentId: "agent",
+        sessionKey: "main",
+      },
+    });
+    markRecentSentReplyRoot(buildRecentSentReplyRootKeyForRun(queued));
+    const onBlockReply = createAsyncReplySpy();
+    const runner = createMessagingDedupeRunner(onBlockReply);
+
+    await runner(queued);
+
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).not.toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -46,6 +46,7 @@ const ROUTABLE_TEST_CHANNELS = new Set([
 ]);
 
 beforeEach(() => {
+  runEmbeddedPiAgentMock.mockReset();
   routeReplyMock.mockReset();
   routeReplyMock.mockResolvedValue({ ok: true });
   isRoutableChannelMock.mockReset();

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -28,6 +28,10 @@ import {
   filterMessagingToolMediaDuplicates,
   shouldSuppressMessagingToolReplies,
 } from "./reply-payloads.js";
+import {
+  buildRecentSentReplyRootKeyForRun,
+  hasRecentSentReplyRoot,
+} from "./reply-root-dedupe.js";
 import { resolveReplyToMode } from "./reply-threading.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
@@ -100,8 +104,11 @@ export function createFollowupRunner(params: {
           channel: originatingChannel,
           to: originatingTo,
           sessionKey: queued.run.sessionKey,
+          replyRootScopeKey: queued.run.sessionKey ?? queued.run.sessionId,
+          replyRootAgentId: queued.run.agentId,
           accountId: queued.originatingAccountId,
           threadId: queued.originatingThreadId,
+          replyRootId: queued.replyRootId,
           cfg: queued.run.config,
         });
         if (!result.ok) {
@@ -131,6 +138,10 @@ export function createFollowupRunner(params: {
 
   return async (queued: FollowupRun) => {
     try {
+      const recentReplyRootKey = buildRecentSentReplyRootKeyForRun(queued);
+      if (hasRecentSentReplyRoot(recentReplyRootKey)) {
+        return;
+      }
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
         resolveOriginMessageProvider({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -44,6 +44,7 @@ import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
+import { resolveReplyRootIdFromContext } from "./reply-root-dedupe.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
@@ -472,6 +473,7 @@ export async function runPreparedReply(
   const followupRun = {
     prompt: queuedBody,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+    replyRootId: resolveReplyRootIdFromContext(sessionCtx),
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
     // Originating channel for reply routing.

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -18,9 +18,23 @@ const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalSingleton(RECENT_QUEUE_MESSAGE_IDS
   }),
 );
 
-function buildRecentMessageIdKey(run: FollowupRun, queueKey: string): string | undefined {
+function resolveRunDedupeIdentity(
+  run: FollowupRun,
+): { kind: "reply-root" | "message-id"; value: string } | undefined {
+  const replyRootId = run.replyRootId?.trim();
+  if (replyRootId) {
+    return { kind: "reply-root", value: replyRootId };
+  }
   const messageId = run.messageId?.trim();
-  if (!messageId) {
+  if (messageId) {
+    return { kind: "message-id", value: messageId };
+  }
+  return undefined;
+}
+
+function buildRecentMessageIdKey(run: FollowupRun, queueKey: string): string | undefined {
+  const identity = resolveRunDedupeIdentity(run);
+  if (!identity) {
     return undefined;
   }
   // Use JSON tuple serialization to avoid delimiter-collision edge cases when
@@ -32,7 +46,8 @@ function buildRecentMessageIdKey(run: FollowupRun, queueKey: string): string | u
     run.originatingTo ?? "",
     run.originatingAccountId ?? "",
     run.originatingThreadId == null ? "" : String(run.originatingThreadId),
-    messageId,
+    identity.kind,
+    identity.value,
   ]);
 }
 
@@ -47,9 +62,16 @@ function isRunAlreadyQueued(
     item.originatingAccountId === run.originatingAccountId &&
     item.originatingThreadId === run.originatingThreadId;
 
-  const messageId = run.messageId?.trim();
-  if (messageId) {
-    return items.some((item) => item.messageId?.trim() === messageId && hasSameRouting(item));
+  const identity = resolveRunDedupeIdentity(run);
+  if (identity) {
+    return items.some((item) => {
+      const itemIdentity = resolveRunDedupeIdentity(item);
+      return (
+        itemIdentity?.kind === identity.kind &&
+        itemIdentity.value === identity.value &&
+        hasSameRouting(item)
+      );
+    });
   }
   if (!allowPromptFallback) {
     return false;

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -23,6 +23,8 @@ export type FollowupRun = {
   prompt: string;
   /** Provider message ID, when available (for deduplication). */
   messageId?: string;
+  /** Stable reply/root target used to deduplicate retries across thread turns. */
+  replyRootId?: string;
   summaryLine?: string;
   enqueuedAt: number;
   /**

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -897,6 +897,7 @@ afterAll(() => {
 function createRun(params: {
   prompt: string;
   messageId?: string;
+  replyRootId?: string;
   originatingChannel?: FollowupRun["originatingChannel"];
   originatingTo?: string;
   originatingAccountId?: string;
@@ -905,6 +906,7 @@ function createRun(params: {
   return {
     prompt: params.prompt,
     messageId: params.messageId,
+    replyRootId: params.replyRootId,
     enqueuedAt: Date.now(),
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
@@ -1036,6 +1038,42 @@ describe("followup queue deduplication", () => {
 
     expect(redelivery).toBe(false);
     expect(calls).toHaveLength(1);
+  });
+
+  it("deduplicates different message ids when they share the same reply root", async () => {
+    const key = `test-dedup-reply-root-${Date.now()}`;
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    const first = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "first",
+        messageId: "m1",
+        replyRootId: "root-1",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(first).toBe(true);
+
+    const second = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "second",
+        messageId: "m2",
+        replyRootId: "root-1",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(second).toBe(false);
   });
 
   it("deduplicates same message_id across distinct enqueue module instances", async () => {

--- a/src/auto-reply/reply/reply-root-dedupe.test.ts
+++ b/src/auto-reply/reply/reply-root-dedupe.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveReplyRootId, resolveReplyRootIdFromContext } from "./reply-root-dedupe.js";
+
+describe("resolveReplyRootId", () => {
+  it("prefers explicit reply targets before thread roots", () => {
+    expect(
+      resolveReplyRootId({
+        rootMessageId: "thread-root",
+        replyToId: "reply-target",
+        messageId: "current-message",
+      }),
+    ).toBe("reply-target");
+  });
+
+  it("falls back to the thread root when reply-to metadata is unavailable", () => {
+    expect(
+      resolveReplyRootId({
+        rootMessageId: "thread-root",
+        messageId: "current-message",
+      }),
+    ).toBe("thread-root");
+  });
+});
+
+describe("resolveReplyRootIdFromContext", () => {
+  it("prefers ReplyToIdFull before RootMessageId", () => {
+    expect(
+      resolveReplyRootIdFromContext({
+        RootMessageId: "thread-root",
+        ReplyToId: "reply-short",
+        ReplyToIdFull: "reply-full",
+        MessageSid: "message-short",
+        MessageSidFull: "message-full",
+      }),
+    ).toBe("reply-full");
+  });
+});

--- a/src/auto-reply/reply/reply-root-dedupe.ts
+++ b/src/auto-reply/reply/reply-root-dedupe.ts
@@ -1,0 +1,114 @@
+import { createDedupeCache } from "../../infra/dedupe.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { FinalizedMsgContext, MsgContext, TemplateContext } from "../templating.js";
+import type { FollowupRun } from "./queue/types.js";
+
+const RECENT_SENT_REPLY_ROOTS_KEY = Symbol.for("openclaw.recentSentReplyRoots");
+const RECENT_SENT_REPLY_ROOTS = resolveGlobalSingleton(RECENT_SENT_REPLY_ROOTS_KEY, () =>
+  createDedupeCache({
+    ttlMs: 2 * 60 * 1000,
+    maxSize: 10_000,
+  }),
+);
+
+type ReplyRootIdentityParams = {
+  rootMessageId?: string;
+  replyToId?: string;
+  replyToIdFull?: string;
+  messageId?: string;
+  messageIdFull?: string;
+};
+
+type ReplyRootRouteKeyParams = {
+  scopeKey?: string;
+  agentId?: string;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  threadId?: string | number | null;
+  replyRootId?: string;
+};
+
+function clean(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveReplyRootId(params: ReplyRootIdentityParams): string | undefined {
+  return (
+    clean(params.rootMessageId) ??
+    clean(params.replyToIdFull) ??
+    clean(params.replyToId) ??
+    clean(params.messageIdFull) ??
+    clean(params.messageId)
+  );
+}
+
+export function resolveReplyRootIdFromContext(
+  ctx: Pick<
+    MsgContext | TemplateContext | FinalizedMsgContext,
+    "RootMessageId" | "ReplyToId" | "ReplyToIdFull" | "MessageSid" | "MessageSidFull"
+  >,
+): string | undefined {
+  return resolveReplyRootId({
+    rootMessageId: ctx.RootMessageId,
+    replyToId: ctx.ReplyToId,
+    replyToIdFull: ctx.ReplyToIdFull,
+    messageId: ctx.MessageSid,
+    messageIdFull: ctx.MessageSidFull,
+  });
+}
+
+export function buildRecentSentReplyRootKey(params: ReplyRootRouteKeyParams): string | undefined {
+  const replyRootId = clean(params.replyRootId);
+  if (!replyRootId) {
+    return undefined;
+  }
+  return JSON.stringify([
+    "sent-reply-root",
+    params.scopeKey ?? "",
+    params.agentId ?? "",
+    params.channel ?? "",
+    params.to ?? "",
+    params.accountId ?? "",
+    params.threadId == null ? "" : String(params.threadId),
+    replyRootId,
+  ]);
+}
+
+export function buildRecentSentReplyRootKeyForRun(
+  run: Pick<
+    FollowupRun,
+    | "originatingChannel"
+    | "originatingTo"
+    | "originatingAccountId"
+    | "originatingThreadId"
+    | "replyRootId"
+    | "run"
+  >,
+): string | undefined {
+  return buildRecentSentReplyRootKey({
+    scopeKey: run.run.sessionKey ?? run.run.sessionId,
+    agentId: run.run.agentId,
+    channel: run.originatingChannel,
+    to: run.originatingTo,
+    accountId: run.originatingAccountId,
+    threadId: run.originatingThreadId,
+    replyRootId: run.replyRootId,
+  });
+}
+
+export function hasRecentSentReplyRoot(key: string | undefined): boolean {
+  return Boolean(key && RECENT_SENT_REPLY_ROOTS.peek(key));
+}
+
+export function markRecentSentReplyRoot(key: string | undefined): void {
+  if (!key) {
+    return;
+  }
+  RECENT_SENT_REPLY_ROOTS.check(key);
+}
+
+export function resetRecentSentReplyRootDedupe(): void {
+  RECENT_SENT_REPLY_ROOTS.clear();
+}

--- a/src/auto-reply/reply/reply-root-dedupe.ts
+++ b/src/auto-reply/reply/reply-root-dedupe.ts
@@ -36,9 +36,9 @@ function clean(value: string | undefined | null): string | undefined {
 
 export function resolveReplyRootId(params: ReplyRootIdentityParams): string | undefined {
   return (
-    clean(params.rootMessageId) ??
     clean(params.replyToIdFull) ??
     clean(params.replyToId) ??
+    clean(params.rootMessageId) ??
     clean(params.messageIdFull) ??
     clean(params.messageId)
   );

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -13,6 +13,11 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import {
+  buildRecentSentReplyRootKey,
+  hasRecentSentReplyRoot,
+  resetRecentSentReplyRootDedupe,
+} from "./reply-root-dedupe.js";
 
 const mocks = vi.hoisted(() => ({
   sendMessageDiscord: vi.fn(async () => ({ messageId: "m1", channelId: "c1" })),
@@ -139,6 +144,7 @@ describe("routeReply", () => {
   beforeEach(() => {
     setActivePluginRegistry(defaultRegistry);
     mocks.deliverOutboundPayloads.mockImplementation(actualDeliver.deliverOutboundPayloads);
+    resetRecentSentReplyRootDedupe();
   });
 
   afterEach(() => {
@@ -204,6 +210,53 @@ describe("routeReply", () => {
       "channel:C123",
       "[openclaw] hi",
       expect.any(Object),
+    );
+  });
+
+  it("marks recently sent reply roots after a successful routed send", async () => {
+    const key = buildRecentSentReplyRootKey({
+      scopeKey: "session:1",
+      agentId: "main",
+      channel: "slack",
+      to: "channel:C123",
+      replyRootId: "root-1",
+    });
+    expect(hasRecentSentReplyRoot(key)).toBe(false);
+
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      sessionKey: "session:1",
+      replyRootAgentId: "main",
+      replyRootId: "root-1",
+      cfg: {} as never,
+    });
+
+    expect(hasRecentSentReplyRoot(key)).toBe(true);
+  });
+
+  it("passes reply root metadata into outbound delivery hooks", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValueOnce([{ messageId: "m1", channel: "slack" }]);
+
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      sessionKey: "session:2",
+      replyRootAgentId: "main",
+      replyRootId: "root-2",
+      cfg: {} as never,
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hookMetadata: expect.objectContaining({
+          sessionKey: "session:2",
+          replyRootId: "root-2",
+          replyRootKey: expect.any(String),
+        }),
+      }),
     );
   });
 

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -236,6 +236,29 @@ describe("routeReply", () => {
     expect(hasRecentSentReplyRoot(key)).toBe(true);
   });
 
+  it("does not mark reply roots when delivery produced no outbound messages", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValueOnce([]);
+    const key = buildRecentSentReplyRootKey({
+      scopeKey: "session:1",
+      agentId: "main",
+      channel: "slack",
+      to: "channel:C123",
+      replyRootId: "root-empty",
+    });
+
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      sessionKey: "session:1",
+      replyRootAgentId: "main",
+      replyRootId: "root-empty",
+      cfg: {} as never,
+    });
+
+    expect(hasRecentSentReplyRoot(key)).toBe(false);
+  });
+
   it("passes reply root metadata into outbound delivery hooks", async () => {
     mocks.deliverOutboundPayloads.mockResolvedValueOnce([{ messageId: "m1", channel: "slack" }]);
 

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -22,6 +22,10 @@ import {
   formatBtwTextForExternalDelivery,
   shouldSuppressReasoningPayload,
 } from "./reply-payloads.js";
+import {
+  buildRecentSentReplyRootKey,
+  markRecentSentReplyRoot,
+} from "./reply-root-dedupe.js";
 
 let deliverRuntimePromise: Promise<
   typeof import("../../infra/outbound/deliver-runtime.js")
@@ -55,6 +59,12 @@ export type RouteReplyParams = {
   isGroup?: boolean;
   /** Group or channel identifier for correlation with received events */
   groupId?: string;
+  /** Stable inbound reply/root target for duplicate suppression. */
+  replyRootId?: string;
+  /** Optional override for the reply-root dedupe scope key. */
+  replyRootScopeKey?: string;
+  /** Optional override for the reply-root dedupe agent identity. */
+  replyRootAgentId?: string;
 };
 
 export type RouteReplyResult = {
@@ -160,6 +170,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       ? String(threadId)
       : undefined);
   const resolvedThreadId = channelId === "slack" ? null : (threadId ?? null);
+  const recentReplyRootKey = buildRecentSentReplyRootKey({
+    scopeKey: params.replyRootScopeKey ?? params.sessionKey,
+    agentId: params.replyRootAgentId ?? resolvedAgentId,
+    channel: channelId,
+    to,
+    accountId: accountId ?? undefined,
+    threadId: threadId ?? null,
+    replyRootId: params.replyRootId,
+  });
 
   try {
     // Provider docking: this is an execution boundary (we're about to send).
@@ -180,6 +199,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       threadId: resolvedThreadId,
       session: outboundSession,
       abortSignal,
+      hookMetadata: {
+        sessionKey: params.sessionKey,
+        replyRootScopeKey: params.replyRootScopeKey ?? params.sessionKey,
+        agentId: params.replyRootAgentId ?? resolvedAgentId,
+        replyRootId: params.replyRootId,
+        replyRootKey: recentReplyRootKey,
+        replyToId: resolvedReplyToId,
+        threadId: threadId ?? null,
+      },
       mirror:
         params.mirror !== false && params.sessionKey
           ? {
@@ -194,6 +222,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     });
 
     const last = results.at(-1);
+    markRecentSentReplyRoot(recentReplyRootKey);
     return { ok: true, messageId: last?.messageId };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -222,7 +222,9 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     });
 
     const last = results.at(-1);
-    markRecentSentReplyRoot(recentReplyRootKey);
+    if (last) {
+      markRecentSentReplyRoot(recentReplyRootKey);
+    }
     return { ok: true, messageId: last?.messageId };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -89,6 +89,8 @@ export type MessageSentHookContext = {
   isGroup?: boolean;
   /** Group or channel identifier, if applicable */
   groupId?: string;
+  /** Additional provider-specific metadata */
+  metadata?: Record<string, unknown>;
 };
 
 export type MessageSentHookEvent = InternalHookEvent & {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -52,6 +52,7 @@ export type CanonicalSentMessageHookContext = {
   messageId?: string;
   isGroup?: boolean;
   groupId?: string;
+  metadata?: Record<string, unknown>;
 };
 
 export function deriveInboundMessageHookContext(
@@ -122,6 +123,7 @@ export function buildCanonicalSentMessageHookContext(params: {
   messageId?: string;
   isGroup?: boolean;
   groupId?: string;
+  metadata?: Record<string, unknown>;
 }): CanonicalSentMessageHookContext {
   return {
     to: params.to,
@@ -134,6 +136,7 @@ export function buildCanonicalSentMessageHookContext(params: {
     messageId: params.messageId,
     isGroup: params.isGroup,
     groupId: params.groupId,
+    metadata: params.metadata,
   };
 }
 
@@ -180,6 +183,7 @@ export function toPluginMessageSentEvent(
     content: canonical.content,
     success: canonical.success,
     ...(canonical.error ? { error: canonical.error } : {}),
+    ...(canonical.metadata ? { metadata: canonical.metadata } : {}),
   };
 }
 
@@ -269,5 +273,6 @@ export function toInternalMessageSentContext(
     messageId: canonical.messageId,
     ...(canonical.isGroup != null ? { isGroup: canonical.isGroup } : {}),
     ...(canonical.groupId ? { groupId: canonical.groupId } : {}),
+    ...(canonical.metadata ? { metadata: canonical.metadata } : {}),
   };
 }

--- a/src/infra/outbound/deliver.lifecycle.test.ts
+++ b/src/infra/outbound/deliver.lifecycle.test.ts
@@ -26,7 +26,10 @@ async function runChunkedWhatsAppDelivery(params?: {
   });
 }
 
-async function deliverSingleWhatsAppForHookTest(params?: { sessionKey?: string }) {
+async function deliverSingleWhatsAppForHookTest(params?: {
+  sessionKey?: string;
+  hookMetadata?: Record<string, unknown>;
+}) {
   const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
   await deliverOutboundPayloads({
     cfg: whatsappChunkConfig,
@@ -34,6 +37,7 @@ async function deliverSingleWhatsAppForHookTest(params?: { sessionKey?: string }
     to: "+1555",
     payloads: [{ text: "hello" }],
     deps: { sendWhatsApp },
+    hookMetadata: params?.hookMetadata,
     ...(params?.sessionKey ? { session: { key: params.sessionKey } } : {}),
   });
 }
@@ -251,6 +255,36 @@ describe("deliverOutboundPayloads lifecycle", () => {
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
       expect.objectContaining({ to: "+1555", content: "hello", success: true }),
       expect.objectContaining({ channelId: "whatsapp" }),
+    );
+  });
+
+  it("forwards hook metadata to message_sending and message_sent hooks", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    await deliverSingleWhatsAppForHookTest({
+      hookMetadata: {
+        replyRootId: "root-1",
+        replyRootKey: "dedupe-key-1",
+      },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          replyRootId: "root-1",
+          replyRootKey: "dedupe-key-1",
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          replyRootId: "root-1",
+          replyRootKey: "dedupe-key-1",
+        }),
+      }),
+      expect.any(Object),
     );
   });
 

--- a/src/infra/outbound/deliver.test-helpers.ts
+++ b/src/infra/outbound/deliver.test-helpers.ts
@@ -19,6 +19,7 @@ type DeliverMockState = {
   hooks: {
     runner: {
       hasHooks: (...args: unknown[]) => boolean;
+      runMessageSending: (...args: unknown[]) => Promise<unknown>;
       runMessageSent: (...args: unknown[]) => Promise<void>;
     };
   };
@@ -43,6 +44,7 @@ export const deliverMocks: DeliverMockState = {
   hooks: {
     runner: {
       hasHooks: () => false,
+      runMessageSending: async () => undefined,
       runMessageSent: async () => {},
     },
   },
@@ -68,6 +70,9 @@ const _mocks = vi.hoisted(() => ({
 const _hookMocks = vi.hoisted(() => ({
   runner: {
     hasHooks: vi.fn(() => deliverMocks.hooks.runner.hasHooks()),
+    runMessageSending: vi.fn(
+      async (...args: unknown[]) => await deliverMocks.hooks.runner.runMessageSending(...args),
+    ),
     runMessageSent: vi.fn(
       async (...args: unknown[]) => await deliverMocks.hooks.runner.runMessageSent(...args),
     ),
@@ -182,6 +187,7 @@ export const emptyRegistry = createTestRegistry([]);
 export function resetDeliverTestState() {
   setActivePluginRegistry(defaultRegistry);
   deliverMocks.hooks.runner.hasHooks = () => false;
+  deliverMocks.hooks.runner.runMessageSending = async () => undefined;
   deliverMocks.hooks.runner.runMessageSent = async () => {};
   deliverMocks.internalHooks.createInternalHookEvent = createInternalHookEventPayload;
   deliverMocks.internalHooks.triggerInternalHook = async () => {};
@@ -201,6 +207,7 @@ export function clearDeliverTestRegistry() {
 
 export function resetDeliverTestMocks(params?: { includeSessionMocks?: boolean }) {
   hookMocks.runner.hasHooks.mockClear();
+  hookMocks.runner.runMessageSending.mockClear();
   hookMocks.runner.runMessageSent.mockClear();
   internalHookMocks.createInternalHookEvent.mockClear();
   internalHookMocks.triggerInternalHook.mockClear();

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -256,6 +256,8 @@ type DeliverOutboundPayloadsCoreParams = {
   session?: OutboundSessionContext;
   mirror?: DeliveryMirror;
   silent?: boolean;
+  /** Optional metadata forwarded to message lifecycle hooks. */
+  hookMetadata?: Record<string, unknown>;
 };
 
 export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
@@ -351,6 +353,7 @@ function createMessageSentEmitter(params: {
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
+  hookMetadata?: Record<string, unknown>;
 }): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
@@ -369,6 +372,7 @@ function createMessageSentEmitter(params: {
       messageId: event.messageId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
+      metadata: params.hookMetadata,
     });
     if (hasMessageSentHooks) {
       fireAndForgetHook(
@@ -411,6 +415,7 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  hookMetadata?: Record<string, unknown>;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
@@ -432,6 +437,7 @@ async function applyMessageSendingHook(params: {
           channel: params.channel,
           accountId: params.accountId,
           mediaUrls: params.payloadSummary.mediaUrls,
+          ...params.hookMetadata,
         },
       },
       {
@@ -698,6 +704,7 @@ async function deliverOutboundPayloadsCore(
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
+    hookMetadata: params.hookMetadata,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
@@ -724,6 +731,7 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        hookMetadata: params.hookMetadata,
       });
       if (hookResult.cancelled) {
         continue;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -691,6 +691,7 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  metadata?: Record<string, unknown>;
 };
 
 // Tool context


### PR DESCRIPTION
## Summary
- dedupe queued reruns by explicit reply targets before falling back to thread roots
- keep recent reply-root suppression on queued/followup paths so fresh inbound messages still run normally
- only mark a reply root as sent after an outbound delivery actually returns a message result, and cover the behavior with new tests

## Test plan
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.config.ts src/auto-reply/reply/route-reply.test.ts
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.config.ts src/auto-reply/reply/reply-root-dedupe.test.ts
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.config.ts src/auto-reply/reply/followup-runner.test.ts
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.config.ts src/auto-reply/reply/reply-flow.test.ts
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.config.ts src/infra/outbound/deliver.lifecycle.test.ts
- [x] .\node_modules\.bin\vitest.cmd run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts