### PR TITLE
feat(privacy): strip SenderE164 (phone number) from LLM context

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -265,6 +265,7 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = sessionCtx.GroupSystemPrompt?.trim() ?? "";
+  const redactPIIOpts = cfg.privacy?.redactPII ? { redactPII: true } : undefined;
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
@@ -301,6 +302,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    redactPIIOpts,
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -331,4 +331,77 @@ describe("buildInboundUserContextPrefix", () => {
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender"]).toBe("user@example.com");
   });
+
+  describe("redactPII=true", () => {
+    it("omits e164 from senderInfo and falls back past it in sender field", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+          SenderUsername: "alice",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      // e164 skipped → falls back to SenderId
+      expect(conversationInfo["sender"]).toBe("user-123");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBeUndefined();
+      expect(senderInfo["id"]).toBe("user-123");
+      expect(senderInfo["username"]).toBe("alice");
+    });
+
+    it("still includes SenderName when redactPII=true", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderName: "Tyler",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("Tyler");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["name"]).toBe("Tyler");
+      expect(senderInfo["e164"]).toBeUndefined();
+    });
+
+    it("preserves e164 when redactPII=false", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: false },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
+
+    it("preserves e164 when no options passed", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        SenderE164: "+15551234567",
+        SenderId: "user-123",
+      } as TemplateContext);
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -81,7 +81,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -103,7 +106,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
       ? (safeTrim(ctx.SenderName) ??
-        safeTrim(ctx.SenderE164) ??
+        (options?.redactPII ? undefined : safeTrim(ctx.SenderE164)) ??
         safeTrim(ctx.SenderId) ??
         safeTrim(ctx.SenderUsername))
       : undefined,
@@ -135,19 +138,20 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     );
   }
 
+  const senderE164 = options?.redactPII ? undefined : safeTrim(ctx.SenderE164);
   const senderInfo = {
     label: resolveSenderLabel({
       name: safeTrim(ctx.SenderName),
       username: safeTrim(ctx.SenderUsername),
       tag: safeTrim(ctx.SenderTag),
-      e164: safeTrim(ctx.SenderE164),
+      e164: senderE164,
       id: safeTrim(ctx.SenderId),
     }),
     id: safeTrim(ctx.SenderId),
     name: safeTrim(ctx.SenderName),
     username: safeTrim(ctx.SenderUsername),
     tag: safeTrim(ctx.SenderTag),
-    e164: safeTrim(ctx.SenderE164),
+    e164: senderE164,
   };
   if (senderInfo?.label) {
     blocks.push(

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -886,6 +886,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    privacy: z
+      .object({
+        redactPII: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Add `privacy.redactPII` config option. When enabled, strips `SenderE164` (real phone numbers) from the inbound metadata sent to the LLM provider.

## Why

Phone numbers are genuine PII that the LLM has no functional need for — `SenderId` and `SenderUsername` already provide user identification. Signal and WhatsApp always include phone numbers, which currently get passed to the model provider.

## What's stripped

| Field | Stripped? |
|-------|-----------|
| `SenderE164` (phone number) | Yes |
| `SenderName` | No |
| `SenderId` | No |
| `SenderUsername` | No |
| `SenderTag` | No |

Intentionally minimal scope — only the field with no functional purpose and clear PII risk.

## Config

```json
{
  "privacy": {
    "redactPII": true
  }
}
```

## Changes

- `src/config/zod-schema.ts` — new `privacy.redactPII` field
- `src/auto-reply/reply/inbound-meta.ts` — `buildInboundUserContextPrefix` skips `SenderE164` when enabled
- `src/auto-reply/reply/get-reply-run.ts` — reads config, passes to builder
- `src/auto-reply/reply/inbound-meta.test.ts` — 4 new test cases (all passing)

Closes #47926