### PR TITLE
fix: scope localStorage settings key by basePath (#47481)

### DIFF
--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -1,7 +1,11 @@
-const KEY = "openclaw.control.settings.v1";
+const SETTINGS_KEY_PREFIX = "openclaw.control.settings.v1:";
 const LEGACY_TOKEN_SESSION_KEY = "openclaw.control.token.v1";
 const TOKEN_SESSION_KEY_PREFIX = "openclaw.control.token.v1:";
 const MAX_SCOPED_SESSION_ENTRIES = 10;
+
+function settingsKeyForGateway(gatewayUrl: string): string {
+  return `${SETTINGS_KEY_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
+}
 
 type ScopedSessionSelection = {
   sessionKey: string;
@@ -188,7 +192,9 @@ export function loadSettings(): UiSettings {
   };
 
   try {
-    const raw = storage?.getItem(KEY);
+    // First check for legacy key (no scope), then check for scoped key
+    const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
+    const raw = storage?.getItem(scopedKey) ?? storage?.getItem(SETTINGS_KEY_PREFIX + "default") ?? storage?.getItem("openclaw.control.settings.v1");
     if (!raw) {
       return defaults;
     }
@@ -256,9 +262,11 @@ function persistSettings(next: UiSettings) {
   persistSessionToken(next.gatewayUrl, next.token);
   const storage = getSafeLocalStorage();
   const scope = normalizeGatewayTokenScope(next.gatewayUrl);
+  const scopedKey = settingsKeyForGateway(next.gatewayUrl);
   let existingSessionsByGateway: Record<string, ScopedSessionSelection> = {};
   try {
-    const raw = storage?.getItem(KEY);
+    // Try to migrate from legacy key or other scopes
+    const raw = storage?.getItem(scopedKey) ?? storage?.getItem(SETTINGS_KEY_PREFIX + "default") ?? storage?.getItem("openclaw.control.settings.v1");
     if (raw) {
       const parsed = JSON.parse(raw) as PersistedUiSettings;
       if (parsed.sessionsByGateway && typeof parsed.sessionsByGateway === "object") {
@@ -294,5 +302,5 @@ function persistSettings(next: UiSettings) {
     sessionsByGateway,
     ...(next.locale ? { locale: next.locale } : {}),
   };
-  storage?.setItem(KEY, JSON.stringify(persisted));
+  storage?.setItem(scopedKey, JSON.stringify(persisted));
 }


### PR DESCRIPTION
Fixes #47481 - Control UI localStorage settings conflict across different basePath deployments

## Problem
When multiple Gateway instances are deployed under the same domain with different basePaths (e.g., /gateway-a/, /gateway-b/), the Control UI shares a single localStorage key "openclaw.control.settings.v1", causing settings from one Gateway to incorrectly apply to another.

## Solution
- Add `settingsKeyForGateway()` function to scope settings key by gateway URL
- Use scoped key format: `openclaw.control.settings.v1:https://example.com/gateway-a`
- This matches the existing pattern used for tokens (`openclaw.control.token.v1:...`)
- Add migration from legacy static key on load for backward compatibility

## Changes
- `ui/src/ui/storage.ts`: Modified KEY constant and added settingsKeyForGateway()