### PR TITLE
Fix/UI context notice icon overflow

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -314,7 +314,7 @@ function renderContextNotice(
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
   return html`
     <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
-      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      <svg class="context-notice__icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
       <span>${pct}% context used</span>
       <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
     </div>


### PR DESCRIPTION
## Summary

Fixes #47924 - Control UI context-notice SVG icon overflows and covers entire chat window

## Root Cause

The SVG element lacked explicit width and height attributes, causing it to expand to fill the parent container when the context usage warning appears (at ~85% token limit).

## Fix

Added `width="24" height="24"` attributes to the SVG element.

## Testing

- [x] Verified SVG icon displays at correct 24x24px size
- [x] Confirmed context notice no longer blocks chat interface
- [x] No other UI regressions

## Related Issue

Closes #47924