### PR TITLE
fix: increase handshake timeout to 10s and add file label fallback

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -21,7 +21,7 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
     maxChatHistoryMessagesBytes = value;
   }
 };
-export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 3_000;
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -25,6 +25,21 @@ function pct(part: number, total: number): number {
   return (part / total) * 100;
 }
 
+/** Get display label for a bootstrap file with fallback chain. */
+function getFileLabel(file: { name?: string; path?: string }): string {
+  // Fallback chain: name -> path -> basename of path -> generic placeholder
+  if (file.name && file.name.trim()) {
+    return file.name.trim();
+  }
+  if (file.path && file.path.trim()) {
+    const path = file.path.trim();
+    // Extract basename from path (handle both / and \)
+    const baseName = path.includes("/") ? path.split("/").pop() : path.includes("\\") ? path.split("\\").pop() : path;
+    return baseName || path;
+  }
+  return "(virtual bootstrap file)";
+}
+
 function renderEmptyDetailState() {
   return nothing;
 }
@@ -857,7 +872,7 @@ function renderContextPanel(
                       ${filesTop.map(
                         (f) => html`
                           <div class="context-breakdown-item">
-                            <span class="mono">${f.name}</span>
+                            <span class="mono">${getFileLabel(f)}</span>
                             <span class="muted">~${formatTokens(charsToTokens(f.injectedChars))}</span>
                           </div>
                         `,


### PR DESCRIPTION
## Summary

This PR fixes two bugs:

### Fix #47931: Increase DEFAULT_HANDSHAKE_TIMEOUT_MS to 10s

**Problem**: The 3-second handshake timeout was too aggressive, causing spurious disconnects during busy gateway periods (plugin loading, compaction, multiple concurrent sessions).

**Solution**: Increased `DEFAULT_HANDSHAKE_TIMEOUT_MS` from 3,000ms to 10,000ms in `src/gateway/server-constants.ts`.

**Impact**:
- Prevents "gateway closed (1000)" errors during normal gateway activity
- Accommodates plugin loading (3-7s on some systems)
- Still catches genuinely broken connections within reasonable UX budget

**Related issues**: #47889, #47874

### Fix #47941: Add file label fallback for context breakdown

**Problem**: Context breakdown (`/context breakdown`) could display literal `undefined` for virtual bootstrap files when the `name` field was not set, even though the content was present and counted.

**Solution**: Added `getFileLabel()` helper function with fallback chain:
1. `file.name` (if non-empty)
2. `file.path` (if non-empty)
3. Basename of `file.path` (extracted from path separators)
4. Generic placeholder: `'(virtual bootstrap file)'`

**Files changed**:
- `ui/src/ui/views/usage-render-details.ts`: Added `getFileLabel()` helper and updated file display to use it

## Testing

- Both changes are minimal and well-scoped
- Handshake timeout change affects all gateway connections
- File label fallback is defensive - handles edge cases gracefully

## Checklist

- [x] Fixes are minimal and focused
- [x] Related issues are referenced
- [x] No unrelated changes or refactoring
- [x] Code follows existing style and conventions