### PR TITLE
feat(exec): allow agents to opt into sandbox exec when configured host is gateway

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -309,13 +309,37 @@ export function createExecTool(
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
-        // Allow agents to opt into a more isolated host than the configured default.
-        // Specifically: gateway → sandbox is permitted (sandbox is stricter, not an escape).
-        // The reverse (sandbox → gateway) is blocked: that would be a container escape.
-        // Node is excluded from this hierarchy — it is a separate topology concern.
-        const sandboxOverrideAllowed =
-          configuredHost === "gateway" && requestedHost === "sandbox";
-        if (!sandboxOverrideAllowed) {
+        // tools.exec.allowedHosts: optional explicit allowlist of hosts the agent may request.
+        // When absent, only the configured host is allowed (backward-compatible).
+        // Validation rules enforced at runtime (schema validation catches config errors at load):
+        //   host=sandbox → allowedHosts must not include "gateway" or "node" (container escape)
+        //   host=gateway → allowedHosts must not include "node" (unknown trust boundary)
+        //   host=node    → allowedHosts may only include "node"
+        const allowedHosts = defaults?.allowedHosts;
+        if (allowedHosts) {
+          // Guard against misconfigured allowedHosts that would permit privilege escalation.
+          if (configuredHost === "sandbox" && allowedHosts.some((h) => h !== "sandbox")) {
+            throw new Error(
+              `exec: tools.exec.allowedHosts cannot include less-isolated hosts when host=sandbox (container escape prevention).`,
+            );
+          }
+          if (configuredHost === "gateway" && allowedHosts.some((h) => h === "node")) {
+            throw new Error(
+              `exec: tools.exec.allowedHosts cannot include "node" when host=gateway (unknown trust boundary).`,
+            );
+          }
+          if (configuredHost === "node" && allowedHosts.some((h) => h !== "node")) {
+            throw new Error(
+              `exec: tools.exec.allowedHosts can only include "node" when host=node.`,
+            );
+          }
+          if (!allowedHosts.includes(requestedHost)) {
+            throw new Error(
+              `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
+                `add to tools.exec.allowedHosts to allow).`,
+            );
+          }
+        } else {
           throw new Error(
             `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
               `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -309,10 +309,18 @@ export function createExecTool(
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
-        throw new Error(
-          `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
-            `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,
-        );
+        // Allow agents to opt into a more isolated host than the configured default.
+        // Specifically: gateway → sandbox is permitted (sandbox is stricter, not an escape).
+        // The reverse (sandbox → gateway) is blocked: that would be a container escape.
+        // Node is excluded from this hierarchy — it is a separate topology concern.
+        const sandboxOverrideAllowed =
+          configuredHost === "gateway" && requestedHost === "sandbox";
+        if (!sandboxOverrideAllowed) {
+          throw new Error(
+            `exec host not allowed (requested ${renderExecHostLabel(requestedHost)}; ` +
+              `configure tools.exec.host=${renderExecHostLabel(configuredHost)} to allow).`,
+          );
+        }
       }
       if (elevatedRequested) {
         host = "gateway";

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -228,6 +228,15 @@ export type GroupToolPolicyBySenderConfig = Record<string, GroupToolPolicyConfig
 export type ExecToolConfig = {
   /** Exec host routing (default: sandbox). */
   host?: "sandbox" | "gateway" | "node";
+  /**
+   * Optional allowlist of hosts agents may request at runtime.
+   * When absent, only the configured host is allowed (current behavior).
+   * Validation rules:
+   *   - host=sandbox → allowedHosts cannot include "gateway" or "node" (escape prevention)
+   *   - host=gateway → allowedHosts cannot include "node" (unknown trust boundary)
+   *   - host=node    → allowedHosts can only include "node"
+   */
+  allowedHosts?: Array<"sandbox" | "gateway" | "node">;
   /** Exec security mode (default: deny). */
   security?: "deny" | "allowlist" | "full";
   /** Exec ask mode (default: on-miss). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -423,6 +423,7 @@ const ToolExecSafeBinProfileSchema = z
 
 const ToolExecBaseShape = {
   host: z.enum(["sandbox", "gateway", "node"]).optional(),
+  allowedHosts: z.array(z.enum(["sandbox", "gateway", "node"])).optional(),
   security: z.enum(["deny", "allowlist", "full"]).optional(),
   ask: z.enum(["off", "on-miss", "always"]).optional(),
   node: z.string().optional(),


### PR DESCRIPTION
feat(exec): allow agents to opt into sandbox exec when configured host is gateway

**Problem**

`tools.exec.host` is currently both a default and a hard restriction. An agent configured with `host: "gateway"` cannot request `host: "sandbox"` even though sandbox is strictly more isolated. This prevents legitimate use cases where an agent needs gateway-only tools (e.g. `gh`, `xurl` on host PATH) and sandbox tools (e.g. `curl`, `python3` in container) in the same session.

Related: #12405

**Solution**

Add an optional `tools.exec.allowedHosts` config field — an explicit allowlist of hosts agents may request at runtime. When absent, only the configured host is allowed (backward-compatible). When present, agents may pass `host=<value>` for any listed host.

The rule: **you can always go more isolated, never less** — enforced via validation rules on `allowedHosts`:

- `host: "sandbox"` → `allowedHosts` cannot include `"gateway"` or `"node"` (container escape prevention)
- `host: "gateway"` → `allowedHosts` cannot include `"node"` (unknown trust boundary)
- `host: "node"` → `allowedHosts` can only include `"node"`

Node is intentionally excluded from cross-host promotion — it is a separate topology concern, not an isolation level.

**Example config**

```json
{
  "tools": {
    "exec": {
      "host": "gateway",
      "allowedHosts": ["gateway", "sandbox"]
    }
  }
}
```

**Changes**

- `src/config/types.tools.ts`: add optional `allowedHosts` field to `ExecToolConfig`
- `src/config/zod-schema.agent-runtime.ts`: add `allowedHosts` to exec schema
- `src/agents/bash-tools.exec.ts`: runtime check uses `allowedHosts` when present; validation guards against misconfigured escalation paths; error messages updated to mention `allowedHosts` for discoverability

**Security**

- Existing sandbox confinement is preserved: `host: "sandbox"` agents cannot reach gateway or node
- Allowlist still applies per-host (no change)
- No new attack surface when `allowedHosts` is absent (default behavior unchanged)
- Config validation errors are thrown early to prevent silent misconfigurations