### PR TITLE
Feishu: route feishu_chat tool via session accountId

### DIFF
--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 import { createTestPluginApi } from "../../../test/helpers/extensions/plugin-api.js";
 import { createPluginRuntimeMock } from "../../../test/helpers/extensions/plugin-runtime-mock.js";
 import type { OpenClawPluginApi } from "../runtime-api.js";
@@ -49,26 +50,20 @@ describe("registerFeishuChatTools", () => {
   });
 
   it("registers feishu_chat and handles info/members actions", async () => {
-    const registerTool = vi.fn();
-    registerFeishuChatTools(
-      createChatToolApi({
-        config: {
-          channels: {
-            feishu: {
-              enabled: true,
-              appId: "app_id",
-              appSecret: "app_secret", // pragma: allowlist secret
-              tools: { chat: true },
-            },
-          },
+    const { api, resolveTool } = createToolFactoryHarness({
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app_id",
+          appSecret: "app_secret", // pragma: allowlist secret
+          tools: { chat: true },
         },
-        registerTool,
-      }),
-    );
+      },
+    });
+    registerFeishuChatTools(api);
 
-    expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.name).toBe("feishu_chat");
+    const tool = resolveTool("feishu_chat");
+    expect(tool.name).toBe("feishu_chat");
 
     chatGetMock.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -2,8 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 function json(data: unknown) {
   return {
@@ -132,58 +131,68 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.chat) {
     api.logger.debug?.("feishu_chat: chat tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  // accountId is intentionally not in FeishuChatSchema — it is a programmatic-only
+  // override (same pattern as feishu_bitable, feishu_wiki, etc.). The LLM selects
+  // the account implicitly via the session's agentAccountId; callers that need to
+  // target a specific account pass it through ctx.agentAccountId before tool execution.
+  type FeishuChatExecuteParams = FeishuChatParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_chat",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info, member_info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuChatParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "members":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action members" });
-              }
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  p.page_size,
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action info" });
-              }
-              return json(await getChatInfo(client, p.chat_id));
-            case "member_info":
-              if (!p.member_id) {
-                return json({ error: "member_id is required for action member_info" });
-              }
-              return json(
-                await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
-              );
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_chat",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info, member_info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuChatExecuteParams;
+          try {
+              const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "members":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action members" });
+                }
+                return json(
+                  await getChatMembers(
+                    client,
+                    p.chat_id,
+                    p.page_size,
+                    p.page_token,
+                    p.member_id_type,
+                  ),
+                );
+              case "info":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action info" });
+                }
+                return json(await getChatInfo(client, p.chat_id));
+              case "member_info":
+                if (!p.member_id) {
+                  return json({ error: "member_id is required for action member_info" });
+                }
+                return json(
+                  await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
+                );
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_chat" },
   );

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -11,6 +11,7 @@ vi.mock("./client.js", () => ({
 }));
 
 let registerFeishuBitableTools: typeof import("./bitable.js").registerFeishuBitableTools;
+let registerFeishuChatTools: typeof import("./chat.js").registerFeishuChatTools;
 let registerFeishuDriveTools: typeof import("./drive.js").registerFeishuDriveTools;
 let registerFeishuPermTools: typeof import("./perm.js").registerFeishuPermTools;
 let registerFeishuWikiTools: typeof import("./wiki.js").registerFeishuWikiTools;
@@ -20,11 +21,13 @@ function createConfig(params: {
     wiki?: boolean;
     drive?: boolean;
     perm?: boolean;
+    chat?: boolean;
   };
   toolsB?: {
     wiki?: boolean;
     drive?: boolean;
     perm?: boolean;
+    chat?: boolean;
   };
   defaultAccount?: string;
 }): OpenClawPluginApi["config"] {
@@ -61,6 +64,7 @@ describe("feishu tool account routing", () => {
         ...(await import("./wiki.js")),
       })));
     ({ registerFeishuWikiTools } = await import("./wiki.js"));
+    ({ registerFeishuChatTools } = await import("./chat.js"));
     vi.clearAllMocks();
   });
 
@@ -120,6 +124,21 @@ describe("feishu tool account routing", () => {
     registerFeishuPermTools(api);
 
     const tool = resolveTool("feishu_perm", { agentAccountId: "b" });
+    await tool.execute("call", { action: "unknown_action" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
+  test("chat tool routes to agentAccountId", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { chat: false },
+        toolsB: { chat: true },
+      }),
+    );
+    registerFeishuChatTools(api);
+
+    const tool = resolveTool("feishu_chat", { agentAccountId: "b" });
     await tool.execute("call", { action: "unknown_action" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");


### PR DESCRIPTION
Refs #40691.

Background
- In multi-account Feishu setups, most Feishu tools route credentials per-session via `ctx.agentAccountId`.
- `feishu_chat` was still hard-wired to `accounts[0]` during tool registration, which could cause permission mismatches (wrong appId/appSecret) when accounts have different scopes.

What changed
- `feishu_chat` now:
  - registers if *any* enabled account has `tools.chat` enabled (merged tool config)
  - selects the Feishu client per execution using the current session account (`ctx.agentAccountId`) via `createFeishuToolClient` (with the standard `accountId` override)

Verification
- Added a regression test to `extensions/feishu/src/tool-account-routing.test.ts` ensuring `feishu_chat` routes to `agentAccountId`.
- Ran: `pnpm test -- extensions/feishu/src/tool-account-routing.test.ts`

Impact
- Multi-account Feishu deployments get consistent tool behavior: chat/doc/wiki/drive/perm/bitable all route by session account by default.
