### PR TITLE
feat(privacy): redact PII from LLM context when privacy.redactPII is enabled

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -265,8 +265,10 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = sessionCtx.GroupSystemPrompt?.trim() ?? "";
+  const redactPIIOpts = cfg.privacy?.redactPII ? { redactPII: true } : undefined;
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
+    redactPIIOpts,
   );
   const extraSystemPromptParts = [
     inboundMetaPrompt,
@@ -301,6 +303,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    redactPIIOpts,
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal
@@ -496,6 +499,9 @@ export async function runPreparedReply(
       groupId: resolveGroupSessionKey(sessionCtx)?.id ?? undefined,
       groupChannel: sessionCtx.GroupChannel?.trim() ?? sessionCtx.GroupSubject?.trim(),
       groupSpace: sessionCtx.GroupSpace?.trim() ?? undefined,
+      // Raw sender fields are intentional here: they are used for internal auth/routing
+      // and policy checks, not injected into the LLM prompt. PII redaction is applied
+      // separately in buildInboundUserContextPrefix above.
       senderId: sessionCtx.SenderId?.trim() || undefined,
       senderName: sessionCtx.SenderName?.trim() || undefined,
       senderUsername: sessionCtx.SenderUsername?.trim() || undefined,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -85,6 +85,39 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["flags"]).toBeUndefined();
   });
 
+  it("hashes chat_id when redactPII=true", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:1657377165",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: true },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toMatch(/^telegram:[a-f0-9]{12}$/);
+    expect(payload["chat_id"]).not.toContain("1657377165");
+  });
+
+  it("preserves chat_id when redactPII=false", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:1657377165",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: false },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toBe("telegram:1657377165");
+  });
+
   it("omits sender_id when blank", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "458",
@@ -330,5 +363,95 @@ describe("buildInboundUserContextPrefix", () => {
 
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender"]).toBe("user@example.com");
+  });
+
+  describe("redactPII", () => {
+    it("omits e164 and hashes SenderId", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+          SenderUsername: "alice",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender"]).not.toBe("user-123");
+      expect(conversationInfo["sender_id"]).toMatch(/^user_[a-f0-9]{12}$/);
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBeUndefined();
+      expect(senderInfo["id"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(senderInfo["username"]).toBe("alice");
+    });
+
+    it("hashes phone-like SenderId on WhatsApp/Signal", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "+15551234567",
+          SenderName: "Alice",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender_id"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender_id"]).not.toContain("15551234567");
+      expect(conversationInfo["sender"]).toBe("Alice");
+    });
+
+    it("still includes SenderName when redactPII=true", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderName: "Tyler",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("Tyler");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["name"]).toBe("Tyler");
+      expect(senderInfo["e164"]).toBeUndefined();
+    });
+
+    it("preserves e164 when redactPII=false", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: false },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
+
+    it("preserves e164 when no options passed", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        SenderE164: "+15551234567",
+        SenderId: "user-123",
+      } as TemplateContext);
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -453,5 +453,66 @@ describe("buildInboundUserContextPrefix", () => {
       const senderInfo = parseSenderInfoPayload(text);
       expect(senderInfo["e164"]).toBe("+15551234567");
     });
+
+    it("redacts phone-like sender in InboundHistory", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          InboundHistory: [
+            { sender: "+15559876543", timestamp: 1000, body: "hello" },
+            { sender: "Alice", timestamp: 2000, body: "hi" },
+          ],
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toContain("Alice");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts phone-like ReplyToSender", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "+15559876543",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts phone-like ForwardedFrom", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ForwardedFrom: "+15559876543",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("keeps non-phone ReplyToSender unchanged", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "Bob",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).toContain("Bob");
+    });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -501,6 +501,21 @@ describe("buildInboundUserContextPrefix", () => {
       expect(text).toMatch(/user_[a-f0-9]{12}/);
     });
 
+    it("hashes SenderE164 as fallback when SenderId is absent", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      // E164 should be hashed as fallback, not undefined
+      expect(conversationInfo["sender"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender"]).not.toContain("15551234567");
+    });
+
     it("keeps non-phone ReplyToSender unchanged", () => {
       const text = buildInboundUserContextPrefix(
         {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -1,7 +1,26 @@
+import { createHash } from "node:crypto";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import type { TemplateContext } from "../templating.js";
+
+function hashId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function hashSenderId(value: string): string {
+  return `user_${hashId(value)}`;
+}
+
+function hashChatId(value: string): string {
+  const colonIdx = value.indexOf(":");
+  if (colonIdx > 0) {
+    const prefix = value.slice(0, colonIdx);
+    const id = value.slice(colonIdx + 1);
+    return `${prefix}:${hashId(id)}`;
+  }
+  return hashId(value);
+}
 
 function safeTrim(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -42,7 +61,10 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
-export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
+export function buildInboundMetaSystemPrompt(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
 
@@ -59,7 +81,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
 
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    chat_id: safeTrim(ctx.OriginatingTo),
+    chat_id:
+      options?.redactPII && safeTrim(ctx.OriginatingTo)
+        ? hashChatId(safeTrim(ctx.OriginatingTo)!)
+        : safeTrim(ctx.OriginatingTo),
     account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
@@ -81,7 +106,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -96,16 +124,17 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const resolvedMessageId = messageId ?? messageIdFull;
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
+  const senderE164 = options?.redactPII ? undefined : safeTrim(ctx.SenderE164);
+  const rawSenderId = safeTrim(ctx.SenderId);
+  const senderId = options?.redactPII && rawSenderId ? hashSenderId(rawSenderId) : rawSenderId;
+
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
-    sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
+    sender_id: shouldIncludeConversationInfo ? senderId : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ??
-        safeTrim(ctx.SenderE164) ??
-        safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername))
+      ? (safeTrim(ctx.SenderName) ?? senderE164 ?? senderId ?? safeTrim(ctx.SenderUsername))
       : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
@@ -140,14 +169,14 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
       name: safeTrim(ctx.SenderName),
       username: safeTrim(ctx.SenderUsername),
       tag: safeTrim(ctx.SenderTag),
-      e164: safeTrim(ctx.SenderE164),
-      id: safeTrim(ctx.SenderId),
+      e164: senderE164,
+      id: senderId,
     }),
-    id: safeTrim(ctx.SenderId),
+    id: senderId,
     name: safeTrim(ctx.SenderName),
     username: safeTrim(ctx.SenderUsername),
     tag: safeTrim(ctx.SenderTag),
-    e164: safeTrim(ctx.SenderE164),
+    e164: senderE164,
   };
   if (senderInfo?.label) {
     blocks.push(

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -132,7 +132,13 @@ export function buildInboundUserContextPrefix(
   const resolvedMessageId = messageId ?? messageIdFull;
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
-  const senderE164 = options?.redactPII ? undefined : safeTrim(ctx.SenderE164);
+  const rawE164 = safeTrim(ctx.SenderE164);
+  // When redacting, hash E.164 as fallback pseudonym if no other sender ID exists; otherwise strip.
+  const senderE164 = options?.redactPII
+    ? rawE164 && !safeTrim(ctx.SenderId)
+      ? hashSenderId(rawE164)
+      : undefined
+    : rawE164;
   const rawSenderId = safeTrim(ctx.SenderId);
   const senderId = options?.redactPII && rawSenderId ? hashSenderId(rawSenderId) : rawSenderId;
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -12,8 +12,8 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
-/** E.164 phone number pattern: optional +, 7-15 digits, optionally followed by @... (WhatsApp JID) */
-const E164_PATTERN = /^\+?\d{7,15}(?:@.*)?$/;
+/** E.164 phone number or WhatsApp JID pattern: requires + prefix for bare numbers, or digits followed by @ for JIDs */
+const E164_PATTERN = /^(?:\+\d{7,15}|\d{7,15}@.+)$/;
 
 function redactSenderLabel(value: string | undefined): string | undefined {
   if (!value) {
@@ -88,13 +88,11 @@ export function buildInboundMetaSystemPrompt(
   // For webchat/Hub Chat sessions (when Surface is 'webchat' or undefined with no real channel),
   // omit the channel field entirely rather than falling back to an unrelated provider.
   const channelValue = resolveInboundChannel(ctx);
+  const chatId = safeTrim(ctx.OriginatingTo);
 
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    chat_id:
-      options?.redactPII && safeTrim(ctx.OriginatingTo)
-        ? hashChatId(safeTrim(ctx.OriginatingTo)!)
-        : safeTrim(ctx.OriginatingTo),
+    chat_id: options?.redactPII && chatId ? hashChatId(chatId) : chatId,
     account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -12,6 +12,16 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
+/** E.164 phone number pattern: optional +, 7-15 digits, optionally followed by @... (WhatsApp JID) */
+const E164_PATTERN = /^\+?\d{7,15}(?:@.*)?$/;
+
+function redactSenderLabel(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return E164_PATTERN.test(value) ? hashSenderId(value) : value;
+}
+
 function hashChatId(value: string): string {
   const colonIdx = value.indexOf(":");
   if (colonIdx > 0) {
@@ -204,7 +214,9 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           {
-            sender_label: safeTrim(ctx.ReplyToSender),
+            sender_label: options?.redactPII
+              ? redactSenderLabel(safeTrim(ctx.ReplyToSender))
+              : safeTrim(ctx.ReplyToSender),
             is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
             body: ctx.ReplyToBody,
           },
@@ -223,7 +235,9 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           {
-            from: safeTrim(ctx.ForwardedFrom),
+            from: options?.redactPII
+              ? redactSenderLabel(safeTrim(ctx.ForwardedFrom))
+              : safeTrim(ctx.ForwardedFrom),
             type: safeTrim(ctx.ForwardedFromType),
             username: safeTrim(ctx.ForwardedFromUsername),
             title: safeTrim(ctx.ForwardedFromTitle),
@@ -246,7 +260,7 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           ctx.InboundHistory.map((entry) => ({
-            sender: entry.sender,
+            sender: options?.redactPII ? redactSenderLabel(entry.sender) : entry.sender,
             timestamp_ms: entry.timestamp,
             body: entry.body,
           })),

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -133,14 +133,12 @@ export function buildInboundUserContextPrefix(
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
   const rawE164 = safeTrim(ctx.SenderE164);
-  // When redacting, hash E.164 as fallback pseudonym if no other sender ID exists; otherwise strip.
-  const senderE164 = options?.redactPII
-    ? rawE164 && !safeTrim(ctx.SenderId)
-      ? hashSenderId(rawE164)
-      : undefined
-    : rawE164;
   const rawSenderId = safeTrim(ctx.SenderId);
   const senderId = options?.redactPII && rawSenderId ? hashSenderId(rawSenderId) : rawSenderId;
+  const senderE164 = options?.redactPII ? undefined : rawE164;
+  // When redacting, hash E.164 as fallback pseudonym if no other sender ID exists; otherwise strip.
+  const senderFallback =
+    options?.redactPII && rawE164 && !senderId ? hashSenderId(rawE164) : senderE164;
 
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
@@ -148,7 +146,7 @@ export function buildInboundUserContextPrefix(
     sender_id: shouldIncludeConversationInfo ? senderId : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ?? senderE164 ?? senderId ?? safeTrim(ctx.SenderUsername))
+      ? (safeTrim(ctx.SenderName) ?? senderFallback ?? senderId ?? safeTrim(ctx.SenderUsername))
       : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -887,6 +887,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    privacy: z
+      .object({
+        redactPII: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Add `privacy.redactPII` config option (boolean, default `false`). When enabled, redacts personally identifiable information from the prompt context sent to the LLM provider.

## What's redacted

| Field | Treatment |
|-------|-----------|
| `SenderE164` (phone number) | Stripped entirely |
| `SenderId` (platform user ID) | Deterministic hash (`user_` + 12-char sha256) |
| `chat_id` | ID portion hashed, channel prefix preserved |
| `SenderName` | Not affected (user-chosen, publicly visible) |
| `SenderUsername` | Not affected (user-chosen public handle) |
| `SenderTag` | Not affected (platform identifier) |

## Why

Phone numbers (`SenderE164`) and user IDs (`SenderId`, `chat_id`) are PII that the LLM has no functional need for. Auth and routing happen at the gateway layer before the LLM call. Signal/WhatsApp always include phone numbers, and Telegram private chat `chat_id` equals the user ID.

## Config

```json
{
  "privacy": {
    "redactPII": true
  }
}
```

## Design decisions

- **Deterministic hash (no salt)**: same user always maps to same pseudonym, consistent across sessions. Aligns with existing `formatOwnerDisplayId` (12-char sha256).
- **Strip vs hash**: `SenderE164` is stripped (redundant field). `SenderId` and `chat_id` are hashed (needed for speaker differentiation and context identification).
- **Public fields preserved**: `SenderName`, `SenderUsername`, `SenderTag` are user-chosen and publicly visible — not treated as PII.
- **Raw PII in followupRun**: intentionally preserved for internal auth/routing/policy checks; not injected into LLM prompt. Clarifying comment added.

## Changes

- `src/config/zod-schema.ts` — new `privacy.redactPII` field
- `src/auto-reply/reply/inbound-meta.ts` — hash/strip PII in both builder functions, pre-computed variables to avoid duplication
- `src/auto-reply/reply/get-reply-run.ts` — reads config, passes to builder, documents raw PII scope
- `src/auto-reply/reply/inbound-meta.test.ts` — 7 new test cases (30 total, all passing)

Closes #47958