### PR TITLE
feat: add appliedTags support to channelEdit

### DIFF
--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const availableTags = parseAvailableTags(actionParams.availableTags);
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
     );

--- a/extensions/discord/src/send.channels.ts
+++ b/extensions/discord/src/send.channels.ts
@@ -79,7 +79,7 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
-  if (payload.appliedTags?.length) {
+  if (payload.appliedTags !== undefined) {
     body.applied_tags = payload.appliedTags;
   }
   return (await rest.patch(Routes.channel(payload.channelId), {

--- a/extensions/discord/src/send.channels.ts
+++ b/extensions/discord/src/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags?.length) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/extensions/discord/src/send.types.ts
+++ b/extensions/discord/src/send.types.ts
@@ -158,6 +158,8 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  /** Tag IDs to apply to a forum/media thread (Discord `applied_tags`). */
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -334,6 +334,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const editPayload = {
         channelId,
         name: name ?? undefined,
@@ -346,6 +347,7 @@ export async function handleDiscordGuildAction(
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       };
       const channel = accountId
         ? await editChannelDiscord(editPayload, { accountId })

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -468,6 +468,23 @@ describe("handleDiscordGuildAction - channel management", () => {
     });
   });
 
+  it("forwards appliedTags to channelEdit", async () => {
+    await handleDiscordGuildAction(
+      "channelEdit",
+      {
+        channelId: "C1",
+        appliedTags: ["tag1", "tag2"],
+      },
+      channelsEnabled,
+    );
+    expect(editChannelDiscord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "C1",
+        appliedTags: ["tag1", "tag2"],
+      }),
+    );
+  });
+
   it("deletes a channel", async () => {
     await handleDiscordGuildAction("channelDelete", { channelId: "C1" }, channelsEnabled);
     expect(deleteChannelDiscord).toHaveBeenCalledWith("C1");


### PR DESCRIPTION
## Summary
Add `appliedTags` parameter to the `channelEdit` tool, enabling agents to set `applied_tags` on Discord forum/media threads via `PATCH /channels/{thread_id}`.

Previously, `channelEdit` supported `availableTags` (channel-level tag definitions) but not `appliedTags` (per-thread tag assignment). This makes it impossible for agents to update which tags are applied to a specific forum post after creation.

## Changes
- **Type definition** (`send.types.ts`): Add `appliedTags?: string[]` to `DiscordChannelEdit`
- **REST body mapping** (`send.channels.ts`): Map `appliedTags` → `applied_tags` in PATCH body
- **Agent tool dispatcher** (`discord-actions-guild.ts`): Parse `appliedTags` param and pass to `editPayload`
- **Channel plugin handler** (`handle-action.guild-admin.ts`): Parse `appliedTags` and pass to `handleDiscordAction`
- **Test**: Verify `appliedTags` is forwarded through the dispatcher

## Use Case
Flywheel autonomous dev system uses forum posts to track issue execution. When session status changes (running → awaiting_review → completed), the agent needs to update the forum post's tag to reflect the current state. Without `appliedTags` on `channelEdit`, the agent can only set tags at thread creation time.

## Test Plan
- [x] Existing 38 discord-actions tests pass
- [x] New `appliedTags` dispatcher test passes (39 total)
- [x] `pnpm build` succeeds
- [x] E2E verified: agent successfully updates forum post tags via `channelEdit` with `appliedTags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)