### PR TITLE
fix(discord): include provider prefix in model picker values

### DIFF
--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -474,7 +474,9 @@ describe("Discord model picker rendering", () => {
     );
     expect(modelSelect).toBeTruthy();
     expect(modelSelect?.options?.length).toBe(3);
-    expect(modelSelect?.options?.find((option) => option.value === "o3")?.default).toBe(true);
+    expect(modelSelect?.options?.find((option) => option.value === "openai/o3")?.default).toBe(
+      true,
+    );
 
     const parsedModelSelectState = parseDiscordModelPickerCustomId(modelSelect?.custom_id ?? "");
     expect(parsedModelSelectState?.action).toBe("model");
@@ -654,5 +656,40 @@ describe("Discord model picker recents view", () => {
 
     const recentBtn = rows[1]?.components?.[0] as { label?: string };
     expect(recentBtn?.label).toContain("anthropic/claude-sonnet-4-5");
+  });
+});
+
+describe("Discord model picker nested provider IDs (#46975)", () => {
+  it("includes provider prefix in model dropdown values", () => {
+    const data = createModelsProviderData({
+      openrouter: ["deepseek/deepseek-v3.2", "anthropic/claude-3-opus", "gpt-4o"],
+    });
+
+    const rows = renderModelsViewRows({
+      command: "model",
+      userId: "42",
+      data,
+      provider: "openrouter",
+      page: 1,
+      providerPage: 1,
+    });
+
+    const modelSelect = rows
+      .flatMap((row) => row.components ?? [])
+      .find(
+        (c) =>
+          c.type === Number(ComponentType.StringSelect) &&
+          c.options?.some((opt) => opt.value?.includes("deepseek")),
+      );
+
+    expect(modelSelect).toBeDefined();
+
+    const deepseekOpt = modelSelect?.options?.find((o) =>
+      o.value?.includes("deepseek/deepseek-v3.2"),
+    );
+    expect(deepseekOpt?.value).toBe("openrouter/deepseek/deepseek-v3.2");
+
+    const gptOpt = modelSelect?.options?.find((o) => o.value?.includes("gpt-4o"));
+    expect(gptOpt?.value).toBe("openrouter/gpt-4o");
   });
 });

--- a/extensions/discord/src/monitor/model-picker.ts
+++ b/extensions/discord/src/monitor/model-picker.ts
@@ -431,7 +431,10 @@ function buildModelRows(params: {
   const selectedModelRef = parsedPendingModel ?? parsedCurrentModel;
   const modelOptions: APISelectMenuOption[] = params.modelPage.items.map((model) => ({
     label: model,
-    value: model,
+    // Include provider prefix so downstream handlers receive the full
+    // provider/model ref — prevents misparse when model IDs contain a slash
+    // (e.g., OpenRouter's "deepseek/deepseek-v3.2").
+    value: `${params.modelPage.provider}/${model}`,
     default: selectedModelRef
       ? selectedModelRef.provider === params.modelPage.provider && selectedModelRef.model === model
       : false,

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -787,9 +787,9 @@ async function handleDiscordModelPickerInteraction(
   }
 
   if (parsed.action === "model") {
-    const selectedModel = resolveModelPickerSelectionValue(interaction);
+    const selectedModelValue = resolveModelPickerSelectionValue(interaction);
     const provider = parsed.provider;
-    if (!provider || !selectedModel) {
+    if (!provider || !selectedModelValue) {
       await safeDiscordInteractionCall("model picker update", () =>
         interaction.update(
           buildDiscordModelPickerNoticePayload("Sorry, I couldn't read that model selection."),
@@ -797,6 +797,13 @@ async function handleDiscordModelPickerInteraction(
       );
       return;
     }
+
+    // Model dropdown values now include the provider prefix (provider/model).
+    // Strip the prefix to get the bare model ID for index lookup.
+    const providerPrefix = `${provider}/`;
+    const selectedModel = selectedModelValue.startsWith(providerPrefix)
+      ? selectedModelValue.slice(providerPrefix.length)
+      : selectedModelValue;
 
     const modelIndex = resolveDiscordModelPickerModelIndex({
       data: pickerData,


### PR DESCRIPTION
Fixes #46975

Model dropdown values in the Discord `/model` picker now include the provider prefix (e.g., `openrouter/deepseek/deepseek-v3.2` instead of bare `deepseek/deepseek-v3.2`). This prevents OpenRouter models with slashed IDs from being misinterpreted as a different provider when selected.

The `model` action handler in `native-command.ts` strips the provider prefix before the index lookup, with a fallback for any in-flight interactions carrying old-format values.

### Changes

- `model-picker.ts`: prefix model option `value` with the current provider
- `native-command.ts`: strip provider prefix from the selected value before index lookup
- `model-picker.test.ts`: add test for nested provider IDs and update existing assertion