### PR TITLE
feat(ui): preserve chat draft per session on switch

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -26,6 +26,30 @@ type SessionDefaultsSnapshot = {
   mainKey?: string;
 };
 
+/**
+ * Per-session chat draft cache.
+ *
+ * When the user switches sessions, the current unsent message is saved here
+ * keyed by the *old* session key, and the draft for the *new* session (if any)
+ * is restored into `chatMessage`.  This keeps each session's work-in-progress
+ * text across switches without persisting to disk.
+ */
+const chatDraftCache = new Map<string, string>();
+
+export function saveChatDraft(state: AppViewState): void {
+  const key = state.sessionKey;
+  const draft = state.chatMessage;
+  if (draft) {
+    chatDraftCache.set(key, draft);
+  } else {
+    chatDraftCache.delete(key);
+  }
+}
+
+export function restoreChatDraft(state: AppViewState): void {
+  state.chatMessage = chatDraftCache.get(state.sessionKey) ?? "";
+}
+
 function resolveSidebarChatSessionKey(state: AppViewState): string {
   const snapshot = state.hello?.snapshot as
     | { sessionDefaults?: SessionDefaultsSnapshot }
@@ -42,8 +66,9 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 }
 
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
+  saveChatDraft(state);
   state.sessionKey = sessionKey;
-  state.chatMessage = "";
+  restoreChatDraft(state);
   state.chatStream = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
@@ -488,8 +513,9 @@ export function renderChatMobileToggle(state: AppViewState) {
 }
 
 function switchChatSession(state: AppViewState, nextSessionKey: string) {
+  saveChatDraft(state);
   state.sessionKey = nextSessionKey;
-  state.chatMessage = "";
+  restoreChatDraft(state);
   state.chatStream = null;
   // P1: Clear queued chat items from the previous session
   (state as unknown as { chatQueue: unknown[] }).chatQueue = [];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -14,6 +14,8 @@ import {
   renderTab,
   renderSidebarConnectionStatus,
   renderTopbarThemeModeToggle,
+  saveChatDraft,
+  restoreChatDraft,
 } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
@@ -637,8 +639,9 @@ export function renderApp(state: AppViewState) {
                 onSettingsChange: (next) => state.applySettings(next),
                 onPasswordChange: (next) => (state.password = next),
                 onSessionKeyChange: (next) => {
+                  saveChatDraft(state);
                   state.sessionKey = next;
-                  state.chatMessage = "";
+                  restoreChatDraft(state);
                   state.resetToolStream();
                   state.applySettings({
                     ...state.settings,
@@ -1332,8 +1335,9 @@ export function renderApp(state: AppViewState) {
             ? renderChat({
                 sessionKey: state.sessionKey,
                 onSessionKeyChange: (next) => {
+                  saveChatDraft(state);
                   state.sessionKey = next;
-                  state.chatMessage = "";
+                  restoreChatDraft(state);
                   state.chatAttachments = [];
                   state.chatStream = null;
                   state.chatStreamStartedAt = null;
@@ -1412,7 +1416,9 @@ export function renderApp(state: AppViewState) {
                 agentsList: state.agentsList,
                 currentAgentId: resolvedAgentId ?? "main",
                 onAgentChange: (agentId: string) => {
+                  saveChatDraft(state);
                   state.sessionKey = buildAgentMainSessionKey({ agentId });
+                  restoreChatDraft(state);
                   state.chatMessages = [];
                   state.chatStream = null;
                   state.chatRunId = null;


### PR DESCRIPTION
When switching sessions (via session dropdown, agent dropdown, or sidebar chat button), the unsent message in the chat input is now saved per session key and restored when switching back.

Previously the draft was unconditionally cleared to empty string, causing users to lose their work-in-progress messages.

- Add module-level chatDraftCache (Map\<string, string\>)
- Export saveChatDraft / restoreChatDraft helpers
- Patch all 5 session-switch code paths:
  - resetChatStateForSessionSwitch()
  - switchChatSession()
  - onSessionKeyChange in overview tab
  - onSessionKeyChange in chat tab
  - onAgentChange in chat tab

## Summary

- Problem: Switching sessions clears unsent chat input text
- Why it matters: Users lose work-in-progress messages
- What changed: Added in-memory draft cache that saves/restores chatMessage per session key
- What did NOT change: No persistence to disk, no new UI elements, no config changes

## Change Type

- [x] Feature

## Scope

- [x] UI / DX

## User-visible Changes

Chat input text is preserved when switching sessions/agents and restored when switching back.

## Security Impact

All No. Pure client-side in-memory cache, no network/permission/data changes.

## Compatibility

- Backward compatible: Yes
- Config changes: No
- Migration: No