### PR TITLE
fix(bluebubbles): preserve group messages when sender identity is missing

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -145,7 +145,13 @@ export function createBlueBubblesDebounceRegistry(params: {
             msg.chatGuid?.trim() ??
             msg.chatIdentifier?.trim() ??
             (msg.chatId ? String(msg.chatId) : "dm");
-          return `bluebubbles:${account.accountId}:${chatKey}:${msg.senderId}`;
+          const senderKey = msg.senderId.trim();
+          if (senderKey) {
+            return `bluebubbles:${account.accountId}:${chatKey}:${senderKey}`;
+          }
+          const timestampKey =
+            typeof msg.timestamp === "number" ? `ts:${msg.timestamp}` : "unknown-sender";
+          return `bluebubbles:${account.accountId}:${chatKey}:${timestampKey}`;
         },
         shouldDebounce: (entry) => {
           const msg = entry.message;

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -120,6 +120,7 @@ export function createBlueBubblesDebounceRegistry(params: {
       }
 
       const { account, config, runtime, core } = target;
+      let fallbackSequence = 0;
       const debouncer = core.channel.debounce.createInboundDebouncer<BlueBubblesDebounceEntry>({
         debounceMs: resolveBlueBubblesDebounceMs(config, core),
         buildKey: (entry) => {
@@ -150,7 +151,9 @@ export function createBlueBubblesDebounceRegistry(params: {
             return `bluebubbles:${account.accountId}:${chatKey}:${senderKey}`;
           }
           const timestampKey =
-            typeof msg.timestamp === "number" ? `ts:${msg.timestamp}` : "unknown-sender";
+            typeof msg.timestamp === "number"
+              ? `ts:${msg.timestamp}`
+              : `unknown-sender:${fallbackSequence++}`;
           return `bluebubbles:${account.accountId}:${chatKey}:${timestampKey}`;
         },
         shouldDebounce: (entry) => {

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -150,9 +150,12 @@ export function createBlueBubblesDebounceRegistry(params: {
           if (senderKey) {
             return `bluebubbles:${account.accountId}:${chatKey}:${senderKey}`;
           }
+          // In the fully degraded unknown-sender path, favor keeping events distinct over
+          // coalescing by a weak timestamp heuristic. BlueBubbles payloads can fall back to
+          // second-resolution timestamps, which would otherwise merge unrelated messages.
           const timestampKey =
             typeof msg.timestamp === "number"
-              ? `ts:${msg.timestamp}`
+              ? `ts:${msg.timestamp}:${fallbackSequence++}`
               : `unknown-sender:${fallbackSequence++}`;
           return `bluebubbles:${account.accountId}:${chatKey}:${timestampKey}`;
         },

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -99,6 +99,22 @@ describe("normalizeWebhookMessage", () => {
     expect(result).toBeNull();
   });
 
+  it("drops degraded group messages when chatId is 0", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-chatid-zero",
+        text: "hello group",
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+        chatId: 0,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("falls back to me for fromMe messages when sender handle is missing", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",
@@ -184,6 +200,23 @@ describe("normalizeWebhookReaction", () => {
         isGroup: true,
         isFromMe: false,
         handle: null,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("drops degraded group reactions when chatId is 0", () => {
+    const result = normalizeWebhookReaction({
+      type: "updated-message",
+      data: {
+        guid: "msg-reaction-chatid-zero",
+        associatedMessageGuid: "p:0/msg-1",
+        associatedMessageType: 2000,
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+        chatId: 0,
       },
     });
 

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -64,6 +64,26 @@ describe("normalizeWebhookMessage", () => {
     expect(result?.isGroup).toBe(true);
   });
 
+  it("drops blank chatGuid and falls back to chatIdentifier for degraded groups", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-blank-chat-guid",
+        text: "hello group",
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+        chatGuid: "   ",
+        chatIdentifier: "group-fallback-id",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.chatGuid).toBeUndefined();
+    expect(result?.chatIdentifier).toBe("group-fallback-id");
+    expect(result?.senderId).toBe("");
+  });
+
   it("drops group messages with missing sender and no chat identity", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -64,6 +64,21 @@ describe("normalizeWebhookMessage", () => {
     expect(result?.isGroup).toBe(true);
   });
 
+  it("drops group messages with missing sender and no chat identity", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-no-chat-1",
+        text: "hello group",
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("falls back to me for fromMe messages when sender handle is missing", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",
@@ -137,5 +152,21 @@ describe("normalizeWebhookReaction", () => {
     expect(result?.senderId).toBe("");
     expect(result?.senderIdExplicit).toBe(false);
     expect(result?.messageId).toBe("p:0/msg-1");
+  });
+
+  it("drops group reactions with missing sender and no chat identity", () => {
+    const result = normalizeWebhookReaction({
+      type: "updated-message",
+      data: {
+        guid: "msg-no-chat-2",
+        associatedMessageGuid: "p:0/msg-1",
+        associatedMessageType: 2000,
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+      },
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -45,7 +45,7 @@ describe("normalizeWebhookMessage", () => {
     expect(result?.senderIdExplicit).toBe(true);
   });
 
-  it("does not infer sender from group chatGuid when sender handle is missing", () => {
+  it("preserves group messages when sender handle is missing", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",
       data: {
@@ -58,7 +58,28 @@ describe("normalizeWebhookMessage", () => {
       },
     });
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result?.senderId).toBe("");
+    expect(result?.senderIdExplicit).toBe(false);
+    expect(result?.isGroup).toBe(true);
+  });
+
+  it("falls back to me for fromMe messages when sender handle is missing", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-fromme-1",
+        text: "hello group",
+        isGroup: true,
+        isFromMe: true,
+        handle: null,
+        chatGuid: "iMessage;+;chat123456",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderId).toBe("me");
+    expect(result?.senderIdExplicit).toBe(false);
   });
 
   it("accepts array-wrapped payload data", () => {
@@ -96,5 +117,25 @@ describe("normalizeWebhookReaction", () => {
     expect(result?.senderIdExplicit).toBe(false);
     expect(result?.messageId).toBe("p:0/msg-1");
     expect(result?.action).toBe("added");
+  });
+
+  it("preserves group reactions when sender handle is missing", () => {
+    const result = normalizeWebhookReaction({
+      type: "updated-message",
+      data: {
+        guid: "msg-2",
+        associatedMessageGuid: "p:0/msg-1",
+        associatedMessageType: 2000,
+        isGroup: true,
+        isFromMe: false,
+        handle: null,
+        chatGuid: "iMessage;+;chat123456",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderId).toBe("");
+    expect(result?.senderIdExplicit).toBe(false);
+    expect(result?.messageId).toBe("p:0/msg-1");
   });
 });

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -678,6 +678,8 @@ function resolveNormalizedWebhookSender(params: {
   senderIdExplicit: boolean;
   isGroup: boolean;
   chatGuid?: string;
+  chatIdentifier?: string;
+  chatId?: number;
   fromMe?: boolean;
 }): string | null {
   const senderFallbackFromChatGuid =
@@ -693,9 +695,14 @@ function resolveNormalizedWebhookSender(params: {
   if (params.fromMe) {
     return "me";
   }
+  const hasStableGroupChatIdentity =
+    Boolean(params.chatGuid?.trim()) ||
+    Boolean(params.chatIdentifier?.trim()) ||
+    typeof params.chatId === "number";
   // Preserve group events with missing sender identity so processing can degrade
-  // gracefully instead of dropping the entire message or reaction.
-  return params.isGroup ? "" : null;
+  // gracefully instead of dropping the entire message or reaction. Still require
+  // a stable chat identity so unrelated degraded group events do not merge.
+  return params.isGroup && hasStableGroupChatIdentity ? "" : null;
 }
 
 export function normalizeWebhookMessage(
@@ -760,6 +767,8 @@ export function normalizeWebhookMessage(
     senderIdExplicit,
     isGroup,
     chatGuid,
+    chatIdentifier,
+    chatId,
     fromMe,
   });
   if (normalizedSender === null) {
@@ -841,6 +850,8 @@ export function normalizeWebhookReaction(
     senderIdExplicit,
     isGroup,
     chatGuid,
+    chatIdentifier,
+    chatId,
     fromMe,
   });
   if (normalizedSender === null) {

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -673,6 +673,31 @@ function extractMessagePayload(payload: Record<string, unknown>): Record<string,
   return null;
 }
 
+function resolveNormalizedWebhookSender(params: {
+  senderId: string;
+  senderIdExplicit: boolean;
+  isGroup: boolean;
+  chatGuid?: string;
+  fromMe?: boolean;
+}): string | null {
+  const senderFallbackFromChatGuid =
+    !params.senderIdExplicit && !params.isGroup && params.chatGuid
+      ? extractHandleFromChatGuid(params.chatGuid)
+      : null;
+  const normalizedSender = normalizeBlueBubblesHandle(
+    params.senderId || senderFallbackFromChatGuid || "",
+  );
+  if (normalizedSender) {
+    return normalizedSender;
+  }
+  if (params.fromMe) {
+    return "me";
+  }
+  // Preserve group events with missing sender identity so processing can degrade
+  // gracefully instead of dropping the entire message or reaction.
+  return params.isGroup ? "" : null;
+}
+
 export function normalizeWebhookMessage(
   payload: Record<string, unknown>,
 ): NormalizedWebhookMessage | null {
@@ -730,11 +755,14 @@ export function normalizeWebhookMessage(
         : timestampRaw * 1000
       : undefined;
 
-  // BlueBubbles may omit `handle` in webhook payloads; for DM chat GUIDs we can still infer sender.
-  const senderFallbackFromChatGuid =
-    !senderIdExplicit && !isGroup && chatGuid ? extractHandleFromChatGuid(chatGuid) : null;
-  const normalizedSender = normalizeBlueBubblesHandle(senderId || senderFallbackFromChatGuid || "");
-  if (!normalizedSender) {
+  const normalizedSender = resolveNormalizedWebhookSender({
+    senderId,
+    senderIdExplicit,
+    isGroup,
+    chatGuid,
+    fromMe,
+  });
+  if (normalizedSender === null) {
     return null;
   }
   const replyMetadata = extractReplyMetadata(message);
@@ -808,10 +836,14 @@ export function normalizeWebhookReaction(
         : timestampRaw * 1000
       : undefined;
 
-  const senderFallbackFromChatGuid =
-    !senderIdExplicit && !isGroup && chatGuid ? extractHandleFromChatGuid(chatGuid) : null;
-  const normalizedSender = normalizeBlueBubblesHandle(senderId || senderFallbackFromChatGuid || "");
-  if (!normalizedSender) {
+  const normalizedSender = resolveNormalizedWebhookSender({
+    senderId,
+    senderIdExplicit,
+    isGroup,
+    chatGuid,
+    fromMe,
+  });
+  if (normalizedSender === null) {
     return null;
   }
 

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -703,7 +703,7 @@ function resolveNormalizedWebhookSender(params: {
   const hasStableGroupChatIdentity =
     Boolean(params.chatGuid?.trim()) ||
     Boolean(params.chatIdentifier?.trim()) ||
-    typeof params.chatId === "number";
+    (typeof params.chatId === "number" && params.chatId > 0);
   // Preserve group events with missing sender identity so processing can degrade
   // gracefully instead of dropping the entire message or reaction. Still require
   // a stable chat identity so unrelated degraded group events do not merge.

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -39,6 +39,11 @@ function readNumberLike(record: Record<string, unknown> | null, key: string): nu
   return parseFiniteNumber(record[key]);
 }
 
+function trimOrUndefined(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function extractAttachments(message: Record<string, unknown>): BlueBubblesAttachment[] {
   const raw = message["attachments"];
   if (!Array.isArray(raw)) {
@@ -230,23 +235,23 @@ function extractChatContext(message: Record<string, unknown>): {
   const chat = asRecord(message.chat) ?? asRecord(message.conversation) ?? null;
   const chatFromList = readFirstChatRecord(message);
   const chatGuid =
-    readString(message, "chatGuid") ??
-    readString(message, "chat_guid") ??
-    readString(chat, "chatGuid") ??
-    readString(chat, "chat_guid") ??
-    readString(chat, "guid") ??
-    readString(chatFromList, "chatGuid") ??
-    readString(chatFromList, "chat_guid") ??
-    readString(chatFromList, "guid");
+    trimOrUndefined(readString(message, "chatGuid")) ??
+    trimOrUndefined(readString(message, "chat_guid")) ??
+    trimOrUndefined(readString(chat, "chatGuid")) ??
+    trimOrUndefined(readString(chat, "chat_guid")) ??
+    trimOrUndefined(readString(chat, "guid")) ??
+    trimOrUndefined(readString(chatFromList, "chatGuid")) ??
+    trimOrUndefined(readString(chatFromList, "chat_guid")) ??
+    trimOrUndefined(readString(chatFromList, "guid"));
   const chatIdentifier =
-    readString(message, "chatIdentifier") ??
-    readString(message, "chat_identifier") ??
-    readString(chat, "chatIdentifier") ??
-    readString(chat, "chat_identifier") ??
-    readString(chat, "identifier") ??
-    readString(chatFromList, "chatIdentifier") ??
-    readString(chatFromList, "chat_identifier") ??
-    readString(chatFromList, "identifier") ??
+    trimOrUndefined(readString(message, "chatIdentifier")) ??
+    trimOrUndefined(readString(message, "chat_identifier")) ??
+    trimOrUndefined(readString(chat, "chatIdentifier")) ??
+    trimOrUndefined(readString(chat, "chat_identifier")) ??
+    trimOrUndefined(readString(chat, "identifier")) ??
+    trimOrUndefined(readString(chatFromList, "chatIdentifier")) ??
+    trimOrUndefined(readString(chatFromList, "chat_identifier")) ??
+    trimOrUndefined(readString(chatFromList, "identifier")) ??
     extractChatIdentifierFromChatGuid(chatGuid);
   const chatId =
     readNumberLike(message, "chatId") ??

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -496,15 +496,17 @@ export async function processMessage(
     : text || placeholder;
   const isSelfChatMessage = isBlueBubblesSelfChatMessage(message, isGroup);
   const knownSenderId = resolveKnownBlueBubblesSenderId(message.senderId);
-  const selfChatLookup = {
-    accountId: account.accountId,
-    chatGuid: message.chatGuid,
-    chatIdentifier: message.chatIdentifier,
-    chatId: message.chatId,
-    senderId: knownSenderId,
-    body: rawBody,
-    timestamp: message.timestamp,
-  };
+  const selfChatLookup = knownSenderId
+    ? {
+        accountId: account.accountId,
+        chatGuid: message.chatGuid,
+        chatIdentifier: message.chatIdentifier,
+        chatId: message.chatId,
+        senderId: knownSenderId,
+        body: rawBody,
+        timestamp: message.timestamp,
+      }
+    : null;
 
   const cacheMessageId = message.messageId?.trim();
   const confirmedOutboundCacheEntry = cacheMessageId
@@ -544,7 +546,7 @@ export async function processMessage(
     const confirmedAssistantOutbound =
       confirmedOutboundCacheEntry?.senderLabel === "me" &&
       normalizeSnippet(confirmedOutboundCacheEntry.body ?? "") === normalizeSnippet(rawBody);
-    if (isSelfChatMessage && confirmedAssistantOutbound) {
+    if (isSelfChatMessage && confirmedAssistantOutbound && selfChatLookup) {
       rememberBlueBubblesSelfChatCopy(selfChatLookup);
     }
     if (cacheMessageId) {
@@ -570,7 +572,7 @@ export async function processMessage(
     return;
   }
 
-  if (isSelfChatMessage && hasBlueBubblesSelfChatCopy(selfChatLookup)) {
+  if (isSelfChatMessage && selfChatLookup && hasBlueBubblesSelfChatCopy(selfChatLookup)) {
     logVerbose(
       core,
       runtime,

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -89,6 +89,25 @@ function normalizeSnippet(value: string): string {
   return stripMarkdown(value).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+function resolveKnownBlueBubblesSenderId(senderId?: string | null): string | undefined {
+  return trimOrUndefined(senderId);
+}
+
+function resolveBlueBubblesSenderLabel(params: {
+  fromMe?: boolean;
+  senderName?: string;
+  senderId?: string | null;
+}): string {
+  if (params.fromMe) {
+    return "me";
+  }
+  return (
+    trimOrUndefined(params.senderName) ??
+    resolveKnownBlueBubblesSenderId(params.senderId) ??
+    "unknown sender"
+  );
+}
+
 function isBlueBubblesSelfChatMessage(
   message: NormalizedWebhookMessage,
   isGroup: boolean,
@@ -476,12 +495,13 @@ export async function processMessage(
       : `reacted with ${tapbackParsed.emoji}`
     : text || placeholder;
   const isSelfChatMessage = isBlueBubblesSelfChatMessage(message, isGroup);
+  const knownSenderId = resolveKnownBlueBubblesSenderId(message.senderId);
   const selfChatLookup = {
     accountId: account.accountId,
     chatGuid: message.chatGuid,
     chatIdentifier: message.chatIdentifier,
     chatId: message.chatId,
-    senderId: message.senderId,
+    senderId: knownSenderId,
     body: rawBody,
     timestamp: message.timestamp,
   };
@@ -507,7 +527,11 @@ export async function processMessage(
       chatGuid: message.chatGuid,
       chatIdentifier: message.chatIdentifier,
       chatId: message.chatId,
-      senderLabel: message.fromMe ? "me" : message.senderId,
+      senderLabel: resolveBlueBubblesSenderLabel({
+        fromMe: message.fromMe,
+        senderName: message.senderName,
+        senderId: message.senderId,
+      }),
       body: rawBody,
       timestamp: message.timestamp ?? Date.now(),
     });
@@ -547,18 +571,22 @@ export async function processMessage(
   }
 
   if (isSelfChatMessage && hasBlueBubblesSelfChatCopy(selfChatLookup)) {
-    logVerbose(core, runtime, `drop: reflected self-chat duplicate sender=${message.senderId}`);
+    logVerbose(
+      core,
+      runtime,
+      `drop: reflected self-chat duplicate sender=${knownSenderId ?? "unknown"}`,
+    );
     return;
   }
 
   if (!rawBody) {
-    logVerbose(core, runtime, `drop: empty text sender=${message.senderId}`);
+    logVerbose(core, runtime, `drop: empty text sender=${knownSenderId ?? "unknown"}`);
     return;
   }
   logVerbose(
     core,
     runtime,
-    `msg sender=${message.senderId} group=${isGroup} textLen=${text.length} attachments=${attachments.length} chatGuid=${message.chatGuid ?? ""} chatId=${message.chatId ?? ""}`,
+    `msg sender=${knownSenderId ?? "unknown"} group=${isGroup} textLen=${text.length} attachments=${attachments.length} chatGuid=${message.chatGuid ?? ""} chatId=${message.chatId ?? ""}`,
   );
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
@@ -623,12 +651,12 @@ export async function processMessage(
         logVerbose(
           core,
           runtime,
-          `Blocked BlueBubbles sender ${message.senderId} (not in groupAllowFrom)`,
+          `Blocked BlueBubbles sender ${knownSenderId ?? "unknown"} (not in groupAllowFrom)`,
         );
         logVerbose(
           core,
           runtime,
-          `drop: group sender not allowed sender=${message.senderId} allowFrom=${effectiveGroupAllowFrom.join(",")}`,
+          `drop: group sender not allowed sender=${knownSenderId ?? "unknown"} allowFrom=${effectiveGroupAllowFrom.join(",")}`,
         );
         logGroupAllowlistHint({
           runtime,
@@ -643,8 +671,8 @@ export async function processMessage(
     }
 
     if (accessDecision.reasonCode === DM_GROUP_ACCESS_REASON.DM_POLICY_DISABLED) {
-      logVerbose(core, runtime, `Blocked BlueBubbles DM from ${message.senderId}`);
-      logVerbose(core, runtime, `drop: dmPolicy disabled sender=${message.senderId}`);
+      logVerbose(core, runtime, `Blocked BlueBubbles DM from ${knownSenderId ?? "unknown"}`);
+      logVerbose(core, runtime, `drop: dmPolicy disabled sender=${knownSenderId ?? "unknown"}`);
       return;
     }
 
@@ -683,12 +711,12 @@ export async function processMessage(
     logVerbose(
       core,
       runtime,
-      `Blocked unauthorized BlueBubbles sender ${message.senderId} (dmPolicy=${dmPolicy})`,
+      `Blocked unauthorized BlueBubbles sender ${knownSenderId ?? "unknown"} (dmPolicy=${dmPolicy})`,
     );
     logVerbose(
       core,
       runtime,
-      `drop: dm sender not allowed sender=${message.senderId} allowFrom=${effectiveAllowFrom.join(",")}`,
+      `drop: dm sender not allowed sender=${knownSenderId ?? "unknown"} allowFrom=${effectiveAllowFrom.join(",")}`,
     );
     return;
   }
@@ -765,7 +793,7 @@ export async function processMessage(
       log: (msg) => logVerbose(core, runtime, msg),
       channel: "bluebubbles",
       reason: "control command (unauthorized)",
-      target: message.senderId,
+      target: knownSenderId ?? peerId,
     });
     return;
   }
@@ -891,17 +919,20 @@ export async function processMessage(
   // Build fromLabel the same way as iMessage/Signal (formatInboundFromLabel):
   // group label + id for groups, sender for DMs.
   // The sender identity is included in the envelope body via formatInboundEnvelope.
-  const senderLabel = message.senderName || `user:${message.senderId}`;
+  const senderLabel = resolveBlueBubblesSenderLabel({
+    senderName: message.senderName,
+    senderId: message.senderId,
+  });
   const fromLabel = isGroup
     ? `${message.chatName?.trim() || "Group"} id:${peerId}`
-    : senderLabel !== message.senderId
-      ? `${senderLabel} id:${message.senderId}`
+    : knownSenderId && senderLabel !== knownSenderId
+      ? `${senderLabel} id:${knownSenderId}`
       : senderLabel;
   const groupSubject = isGroup ? message.chatName?.trim() || undefined : undefined;
   const groupMembers = isGroup
     ? formatGroupMembers({
         participants: message.participants,
-        fallback: message.senderId ? { id: message.senderId, name: message.senderName } : undefined,
+        fallback: knownSenderId ? { id: knownSenderId, name: message.senderName } : undefined,
       })
     : undefined;
   const storePath = core.channel.session.resolveStorePath(config.session?.store, {
@@ -920,7 +951,7 @@ export async function processMessage(
     envelope: envelopeOptions,
     body: baseBody,
     chatType: isGroup ? "group" : "direct",
-    sender: { name: message.senderName || undefined, id: message.senderId },
+    sender: { name: message.senderName || undefined, id: knownSenderId },
   });
   let chatGuidForActions = chatGuid;
   if (!chatGuidForActions && baseUrl && password) {
@@ -1054,7 +1085,7 @@ export async function processMessage(
     chatGuid ||
     chatIdentifier ||
     (chatId ? String(chatId) : null) ||
-    (isGroup ? null : message.senderId) ||
+    (isGroup ? null : knownSenderId) ||
     "";
   const historyKey = historyIdentifier
     ? buildAccountScopedHistoryKey(account.accountId, historyIdentifier)
@@ -1063,7 +1094,11 @@ export async function processMessage(
   // Record the current message into rolling history
   if (historyKey && historyLimit > 0) {
     const nowMs = Date.now();
-    const senderLabel = message.fromMe ? "me" : message.senderName || message.senderId;
+    const senderLabel = resolveBlueBubblesSenderLabel({
+      fromMe: message.fromMe,
+      senderName: message.senderName,
+      senderId: message.senderId,
+    });
     const normalizedHistoryBody = truncateHistoryBody(text, MAX_STORED_HISTORY_ENTRY_CHARS);
     const currentEntries = recordPendingHistoryEntryIfEnabled({
       historyMap: chatHistories,
@@ -1181,7 +1216,7 @@ export async function processMessage(
     GroupSubject: groupSubject,
     GroupMembers: groupMembers,
     SenderName: message.senderName || undefined,
-    SenderId: message.senderId,
+    SenderId: knownSenderId,
     Provider: "bluebubbles",
     Surface: "bluebubbles",
     // Use short ID for token savings (agent can use this to reference the message)
@@ -1479,6 +1514,7 @@ export async function processReaction(
     return;
   }
 
+  const knownSenderId = resolveKnownBlueBubblesSenderId(reaction.senderId);
   const chatId = reaction.chatId ?? undefined;
   const chatGuid = reaction.chatGuid ?? undefined;
   const chatIdentifier = reaction.chatIdentifier ?? undefined;
@@ -1496,7 +1532,10 @@ export async function processReaction(
     },
   });
 
-  const senderLabel = reaction.senderName || reaction.senderId;
+  const senderLabel = resolveBlueBubblesSenderLabel({
+    senderName: reaction.senderName,
+    senderId: reaction.senderId,
+  });
   const chatLabel = reaction.isGroup ? ` in group:${peerId}` : "";
   // Use short ID for token savings
   const messageDisplayId = getShortIdForUuid(reaction.messageId) || reaction.messageId;
@@ -1507,7 +1546,7 @@ export async function processReaction(
       : `${senderLabel} reacted with ${reaction.emoji} [[reply_to:${messageDisplayId}]]${chatLabel}`;
   core.system.enqueueSystemEvent(text, {
     sessionKey: route.sessionKey,
-    contextKey: `bluebubbles:reaction:${reaction.action}:${peerId}:${reaction.messageId}:${reaction.senderId}:${reaction.emoji}`,
+    contextKey: `bluebubbles:reaction:${reaction.action}:${peerId}:${reaction.messageId}:${knownSenderId ?? "unknown"}:${reaction.emoji}`,
   });
   logVerbose(core, runtime, `reaction event enqueued: ${text}`);
 }

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1304,6 +1304,126 @@ describe("BlueBubbles webhook monitor", () => {
         vi.useRealTimers();
       }
     });
+
+    it("does not coalesce distinct group messages when sender identity and messageId are both missing", async () => {
+      vi.useFakeTimers();
+      try {
+        const account = createMockAccount({ dmPolicy: "open", groupPolicy: "open" });
+        const config: OpenClawConfig = {};
+        const core = createMockRuntime();
+
+        // Use a timing-aware debouncer test double that respects debounceMs/buildKey/shouldDebounce.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          type Item = any;
+          const buckets = new Map<
+            string,
+            { items: Item[]; timer: ReturnType<typeof setTimeout> | null }
+          >();
+
+          const flush = async (key: string) => {
+            const bucket = buckets.get(key);
+            if (!bucket) {
+              return;
+            }
+            if (bucket.timer) {
+              clearTimeout(bucket.timer);
+              bucket.timer = null;
+            }
+            const items = bucket.items;
+            bucket.items = [];
+            if (items.length > 0) {
+              try {
+                await params.onFlush(items);
+              } catch (err) {
+                params.onError?.(err);
+                throw err;
+              }
+            }
+          };
+
+          return {
+            enqueue: async (item: Item) => {
+              if (params.shouldDebounce && !params.shouldDebounce(item)) {
+                await params.onFlush([item]);
+                return;
+              }
+
+              const key = params.buildKey(item);
+              const existing = buckets.get(key);
+              const bucket = existing ?? { items: [], timer: null };
+              bucket.items.push(item);
+              if (bucket.timer) {
+                clearTimeout(bucket.timer);
+              }
+              bucket.timer = setTimeout(async () => {
+                await flush(key);
+              }, params.debounceMs);
+              buckets.set(key, bucket);
+            },
+            flushKey: vi.fn(async (key: string) => {
+              await flush(key);
+            }),
+          };
+        }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+
+        setBlueBubblesRuntime(core);
+
+        unregister = registerBlueBubblesWebhookTarget({
+          account,
+          config,
+          runtime: { log: vi.fn(), error: vi.fn() },
+          core,
+          path: "/bluebubbles-webhook",
+        });
+
+        const chatGuid = "iMessage;+;group-missing-sender";
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "first message",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+              date: 1_700_000_000,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "second message",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+              date: 1_700_000_005,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
+        const callBodies = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls.map(
+          (call) => call[0].ctx.Body,
+        );
+        expect(callBodies).toContain("first message");
+        expect(callBodies).toContain("second message");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("reply metadata", () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1425,6 +1425,126 @@ describe("BlueBubbles webhook monitor", () => {
       }
     });
 
+    it("does not coalesce distinct group messages when sender identity and timestamp fall in the same second", async () => {
+      vi.useFakeTimers();
+      try {
+        const account = createMockAccount({ dmPolicy: "open", groupPolicy: "open" });
+        const config: OpenClawConfig = {};
+        const core = createMockRuntime();
+
+        // Use a timing-aware debouncer test double that respects debounceMs/buildKey/shouldDebounce.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          type Item = any;
+          const buckets = new Map<
+            string,
+            { items: Item[]; timer: ReturnType<typeof setTimeout> | null }
+          >();
+
+          const flush = async (key: string) => {
+            const bucket = buckets.get(key);
+            if (!bucket) {
+              return;
+            }
+            if (bucket.timer) {
+              clearTimeout(bucket.timer);
+              bucket.timer = null;
+            }
+            const items = bucket.items;
+            bucket.items = [];
+            if (items.length > 0) {
+              try {
+                await params.onFlush(items);
+              } catch (err) {
+                params.onError?.(err);
+                throw err;
+              }
+            }
+          };
+
+          return {
+            enqueue: async (item: Item) => {
+              if (params.shouldDebounce && !params.shouldDebounce(item)) {
+                await params.onFlush([item]);
+                return;
+              }
+
+              const key = params.buildKey(item);
+              const existing = buckets.get(key);
+              const bucket = existing ?? { items: [], timer: null };
+              bucket.items.push(item);
+              if (bucket.timer) {
+                clearTimeout(bucket.timer);
+              }
+              bucket.timer = setTimeout(async () => {
+                await flush(key);
+              }, params.debounceMs);
+              buckets.set(key, bucket);
+            },
+            flushKey: vi.fn(async (key: string) => {
+              await flush(key);
+            }),
+          };
+        }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+
+        setBlueBubblesRuntime(core);
+
+        unregister = registerBlueBubblesWebhookTarget({
+          account,
+          config,
+          runtime: { log: vi.fn(), error: vi.fn() },
+          core,
+          path: "/bluebubbles-webhook",
+        });
+
+        const chatGuid = "iMessage;+;group-missing-sender-same-second";
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "first same second",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+              date: 1_700_000_000,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "second same second",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+              date: 1_700_000_000,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
+        const callBodies = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls.map(
+          (call) => call[0].ctx.Body,
+        );
+        expect(callBodies).toContain("first same second");
+        expect(callBodies).toContain("second same second");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not coalesce distinct group messages when sender identity, messageId, and timestamp are all missing", async () => {
       vi.useFakeTimers();
       try {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -621,6 +621,44 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     });
 
+    it("allows group messages without sender when groupPolicy=open", async () => {
+      const account = createMockAccount({
+        groupPolicy: "open",
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello from group",
+          handle: null,
+          isGroup: true,
+          isFromMe: false,
+          guid: "msg-missing-sender-1",
+          chatGuid: "iMessage;+;chat123456",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    });
+
     it("blocks group messages when groupPolicy=disabled", async () => {
       const account = createMockAccount({
         groupPolicy: "disabled",
@@ -723,6 +761,45 @@ describe("BlueBubbles webhook monitor", () => {
           isGroup: true,
           isFromMe: false,
           guid: "msg-1",
+          chatGuid: "iMessage;+;chat123456",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    });
+
+    it("allows group messages without sender when groupAllowFrom matches the chat", async () => {
+      const account = createMockAccount({
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["chat_guid:iMessage;+;chat123456"],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello from allowed group",
+          handle: null,
+          isGroup: true,
+          isFromMe: false,
+          guid: "msg-missing-sender-2",
           chatGuid: "iMessage;+;chat123456",
           date: Date.now(),
         },
@@ -996,6 +1073,53 @@ describe("BlueBubbles webhook monitor", () => {
           sender: { name: undefined, id: "+15551234567" },
         }),
       );
+    });
+
+    it("keeps group messages with missing sender identity and degrades sender metadata", async () => {
+      const account = createMockAccount({ groupPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello everyone",
+          handle: null,
+          isGroup: true,
+          isFromMe: false,
+          guid: "msg-unknown-sender-1",
+          chatGuid: "iMessage;+;chat123456",
+          chatName: "Family Chat",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockFormatInboundEnvelope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: "Family Chat id:iMessage;+;chat123456",
+          chatType: "group",
+          sender: { name: undefined, id: undefined },
+        }),
+      );
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.SenderId).toBeUndefined();
+      expect(callArgs.ctx.SenderName).toBeUndefined();
+      expect(callArgs.ctx.ConversationLabel).toBe("Family Chat id:iMessage;+;chat123456");
     });
 
     it("uses sender as from label for DM messages", async () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1424,6 +1424,124 @@ describe("BlueBubbles webhook monitor", () => {
         vi.useRealTimers();
       }
     });
+
+    it("does not coalesce distinct group messages when sender identity, messageId, and timestamp are all missing", async () => {
+      vi.useFakeTimers();
+      try {
+        const account = createMockAccount({ dmPolicy: "open", groupPolicy: "open" });
+        const config: OpenClawConfig = {};
+        const core = createMockRuntime();
+
+        // Use a timing-aware debouncer test double that respects debounceMs/buildKey/shouldDebounce.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          type Item = any;
+          const buckets = new Map<
+            string,
+            { items: Item[]; timer: ReturnType<typeof setTimeout> | null }
+          >();
+
+          const flush = async (key: string) => {
+            const bucket = buckets.get(key);
+            if (!bucket) {
+              return;
+            }
+            if (bucket.timer) {
+              clearTimeout(bucket.timer);
+              bucket.timer = null;
+            }
+            const items = bucket.items;
+            bucket.items = [];
+            if (items.length > 0) {
+              try {
+                await params.onFlush(items);
+              } catch (err) {
+                params.onError?.(err);
+                throw err;
+              }
+            }
+          };
+
+          return {
+            enqueue: async (item: Item) => {
+              if (params.shouldDebounce && !params.shouldDebounce(item)) {
+                await params.onFlush([item]);
+                return;
+              }
+
+              const key = params.buildKey(item);
+              const existing = buckets.get(key);
+              const bucket = existing ?? { items: [], timer: null };
+              bucket.items.push(item);
+              if (bucket.timer) {
+                clearTimeout(bucket.timer);
+              }
+              bucket.timer = setTimeout(async () => {
+                await flush(key);
+              }, params.debounceMs);
+              buckets.set(key, bucket);
+            },
+            flushKey: vi.fn(async (key: string) => {
+              await flush(key);
+            }),
+          };
+        }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+
+        setBlueBubblesRuntime(core);
+
+        unregister = registerBlueBubblesWebhookTarget({
+          account,
+          config,
+          runtime: { log: vi.fn(), error: vi.fn() },
+          core,
+          path: "/bluebubbles-webhook",
+        });
+
+        const chatGuid = "iMessage;+;group-missing-sender-no-timestamp";
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "first no timestamp",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", {
+            type: "new-message",
+            data: {
+              text: "second no timestamp",
+              handle: null,
+              isGroup: true,
+              isFromMe: false,
+              guid: null,
+              chatGuid,
+            },
+          }),
+          createMockResponse(),
+        );
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
+        const callBodies = mockDispatchReplyWithBufferedBlockDispatcher.mock.calls.map(
+          (call) => call[0].ctx.Body,
+        );
+        expect(callBodies).toContain("first no timestamp");
+        expect(callBodies).toContain("second no timestamp");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("reply metadata", () => {


### PR DESCRIPTION
## Summary
- preserve BlueBubbles group messages and reactions when webhook sender identity is missing
- keep the narrow `fromMe` fallback to `me`, but stop dropping non-self group events
- degrade sender metadata to unknown instead of fabricating a sender id

## Why
The previous fix only covered the `fromMe` sub-case. The user-visible bug is broader: when BlueBubbles omits sender identity for a group event, the message should still reach the agent so group context does not silently break.

This PR keeps the message path alive while avoiding false attribution.

Supersedes #44264.

## Tests
- `pnpm test -- extensions/bluebubbles/src/monitor-normalize.test.ts extensions/bluebubbles/src/monitor.test.ts`
