### PR TITLE
fix(context): fall back to path basename for unnamed bootstrap files

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -48,6 +48,32 @@ describe("buildBootstrapInjectionStats", () => {
       truncated: true,
     });
   });
+
+  it("falls back to basename of path when name is missing (#47941)", () => {
+    const bootstrapFiles = [
+      {
+        name: undefined as unknown as string,
+        path: "/workspace/SELF_IMPROVEMENT_REMINDER.md",
+        content: "reminder text",
+        missing: false,
+      },
+      {
+        name: "" as unknown as string,
+        path: "/workspace/NOTES.md",
+        content: "notes",
+        missing: false,
+      },
+    ] as unknown as WorkspaceBootstrapFile[];
+
+    const injectedFiles = [
+      { path: "/workspace/SELF_IMPROVEMENT_REMINDER.md", content: "reminder text" },
+      { path: "/workspace/NOTES.md", content: "notes" },
+    ];
+
+    const stats = buildBootstrapInjectionStats({ bootstrapFiles, injectedFiles });
+    expect(stats[0]?.name).toBe("SELF_IMPROVEMENT_REMINDER.md");
+    expect(stats[1]?.name).toBe("NOTES.md");
+  });
 });
 
 describe("analyzeBootstrapBudget", () => {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -150,9 +150,11 @@ export function buildBootstrapInjectionStats(params: {
       injectedByBaseName.get(file.name);
     const injectedChars = injected ? injected.length : 0;
     const truncated = !file.missing && injectedChars < rawChars;
+    const name =
+      file.name || path.posix.basename(pathValue.replace(/\\/g, "/")) || "(virtual file)";
     return {
-      name: file.name,
-      path: pathValue || file.name,
+      name,
+      path: pathValue || name,
       missing: file.missing,
       rawChars,
       injectedChars,


### PR DESCRIPTION
Fixes #47941

Hook-injected virtual bootstrap files may omit the `name` field. `buildBootstrapInjectionStats` now falls back to `path.basename(file.path)` (then a `"(virtual file)"` placeholder) so `/context breakdown` never renders a literal `undefined` label.

### Changes

- `bootstrap-budget.ts`: derive `name` from `file.name || basename(path) || "(virtual file)"`
- `bootstrap-budget.test.ts`: add test covering missing/empty `name` with a valid `path`