### PR TITLE
fix(ui): shim fs module for browser bundle

### DIFF
--- a/ui/src/shims/fs.ts
+++ b/ui/src/shims/fs.ts
@@ -1,0 +1,11 @@
+// Browser shim for Node.js fs module to prevent accidental bundle crashes.
+// This should never be used for real file access in the Control UI.
+export const constants = {
+  W_OK: 2,
+  X_OK: 1,
+  O_RDONLY: 0,
+  O_NOFOLLOW: 0,
+};
+
+const fsShim = { constants };
+export default fsShim;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -21,11 +21,18 @@ function normalizeBase(input: string): string {
 export default defineConfig(() => {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
+  const fsShim = path.resolve(here, "src/shims/fs.ts");
   return {
     base,
     publicDir: path.resolve(here, "public"),
     optimizeDeps: {
       include: ["lit/directives/repeat.js"],
+    },
+    resolve: {
+      alias: {
+        fs: fsShim,
+        "node:fs": fsShim,
+      },
     },
     build: {
       outDir: path.resolve(here, "../dist/control-ui"),


### PR DESCRIPTION
## Summary\n- shim Node.js fs module for the Control UI bundle\n- alias fs/node:fs to the browser shim to prevent runtime crashes\n\n## Testing\n- not run (build-only change)\n\n## Notes\nThis is a safety net; ideally the underlying Node-only import is removed from the UI dependency graph.