### PR TITLE
fix(auth): don't pass ADC marker as literal API key for google-vertex

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -467,4 +467,38 @@ describe("getApiKeyForModel", () => {
       },
     );
   });
+
+  it("resolveEnvApiKey('google-vertex') returns undefined apiKey when ADC marker is returned (#48033)", async () => {
+    // When GOOGLE_APPLICATION_CREDENTIALS + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION
+    // are all set, pi-ai's getEnvApiKey("google-vertex") returns "<authenticated>".
+    // We must NOT pass this marker as a literal API key — return undefined so the SDK
+    // uses ADC token exchange instead.
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const tempDir = os.tmpdir();
+    const fakeCredPath = path.join(tempDir, "test-gcloud-adc-creds.json");
+    // Create a fake service account file (pi-ai checks existence)
+    fs.writeFileSync(fakeCredPath, JSON.stringify({ type: "service_account" }), "utf-8");
+    try {
+      await withEnvAsync(
+        {
+          GOOGLE_APPLICATION_CREDENTIALS: fakeCredPath,
+          GOOGLE_CLOUD_PROJECT: "test-project",
+          GOOGLE_CLOUD_LOCATION: "us-central1",
+          GEMINI_API_KEY: undefined,
+          GOOGLE_API_KEY: undefined,
+          GOOGLE_CLOUD_API_KEY: undefined,
+        },
+        async () => {
+          const resolved = resolveEnvApiKey("google-vertex");
+          // apiKey should be undefined (not "<authenticated>") so the SDK uses ADC
+          expect(resolved?.apiKey).toBeUndefined();
+          expect(resolved?.source).toBe("gcloud adc");
+        },
+      );
+    } finally {
+      fs.unlinkSync(fakeCredPath);
+    }
+  });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -426,6 +426,12 @@ export function resolveEnvApiKey(
     if (!envKey) {
       return null;
     }
+    // pi-ai returns "<authenticated>" when ADC is configured (GOOGLE_APPLICATION_CREDENTIALS
+    // + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION). Don't pass this marker as a literal
+    // API key — return undefined so the SDK uses ADC token exchange instead. See #48033.
+    if (envKey === "<authenticated>") {
+      return { apiKey: undefined, source: "gcloud adc" };
+    }
     return { apiKey: envKey, source: "gcloud adc" };
   }
   return null;


### PR DESCRIPTION
## Summary

When pi-ai's `getEnvApiKey('google-vertex')` returns `<authenticated>` (signaling that `GOOGLE_APPLICATION_CREDENTIALS` + `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION` are configured for ADC), we must not pass this marker string as a literal API key.

## Problem

Previously, `<authenticated>` was passed to the `@google/genai` SDK as `apiKey`, which:
1. Made the SDK send `<authenticated>` as the `x-goog-api-key` header
2. Caused the SDK to clear project/location (thinking an API key was provided)
3. Resulted in 401 UNAUTHENTICATED errors because ADC credential resolution was bypassed

## Solution

Return `{ apiKey: undefined, source: 'gcloud adc' }` when the marker is detected, so the SDK properly uses Application Default Credentials token exchange instead.

## Test

Added test case that verifies the behavior when ADC env vars are configured.

Fixes #48033