### PR TITLE
Fix browser.cdpUrl default profile to avoid DevToolsActivePort fallback

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -115,6 +115,26 @@ Notes:
 - `driver: "existing-session"` uses Chrome DevTools MCP instead of raw CDP. Do
   not set `cdpUrl` for that driver.
 
+### How `browser.cdpUrl` interacts with profiles
+
+When you set a top-level `browser.cdpUrl`, OpenClaw derives the default `openclaw`
+profile from that CDP endpoint. In this mode:
+
+- `openclaw` becomes a CDP-backed profile pointing at `browser.cdpUrl`.
+- If you **also** want a Chrome MCP attach profile, define an explicit `user`
+  profile under `browser.profiles` with `driver: "existing-session"`.
+
+Behavior when `browser.cdpUrl` is set:
+
+- If `defaultProfile` is omitted, the default stays `openclaw` (CDP).
+- If you set `defaultProfile: "user"` **and** define `profiles.user`, the
+  `user` profile is used (Chrome MCP / DevToolsActivePort).
+- If you set `defaultProfile: "user"` **but do not define `profiles.user`**,
+  OpenClaw rewrites the default back to `openclaw` so that the CDP endpoint
+  from `browser.cdpUrl` is used instead of falling back to Chrome MCP +
+  `DevToolsActivePort`. This matches the expectation that configuring
+  `browser.cdpUrl` should make the browser tool connect via CDP.
+
 ## Use Brave (or another Chromium-based browser)
 
 If your **system default** browser is Chromium-based (Chrome/Brave/Edge/etc),

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -343,6 +343,18 @@ describe("browser config", () => {
       expect(resolved.defaultProfile).toBe("user");
     });
 
+    it('rewrites defaultProfile "user" to "openclaw" when browser.cdpUrl is set without an explicit user profile', () => {
+      const resolved = resolveBrowserConfig({
+        cdpUrl: "http://localhost:9222",
+        defaultProfile: "user",
+      });
+      expect(resolved.defaultProfile).toBe("openclaw");
+      const profile = resolveProfile(resolved, resolved.defaultProfile);
+      expect(profile?.name).toBe("openclaw");
+      expect(profile?.driver).toBe("openclaw");
+      expect(profile?.cdpUrl).toBe("http://localhost:9222");
+    });
+
     it("allows custom profile as default even in headless mode", () => {
       const resolved = resolveBrowserConfig({
         headless: true,

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -178,24 +178,6 @@ function ensureDefaultProfile(
   return result;
 }
 
-/**
- * Ensure a built-in "user" profile exists for Chrome's existing-session attach flow.
- */
-function ensureDefaultUserBrowserProfile(
-  profiles: Record<string, BrowserProfileConfig>,
-): Record<string, BrowserProfileConfig> {
-  const result = { ...profiles };
-  if (result.user) {
-    return result;
-  }
-  result.user = {
-    driver: "existing-session",
-    attachOnly: true,
-    color: "#00AA00",
-  };
-  return result;
-}
-
 export function resolveBrowserConfig(
   cfg: BrowserConfig | undefined,
   rootConfig?: OpenClawConfig,
@@ -255,24 +237,57 @@ export function resolveBrowserConfig(
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;
   const isWsUrl = cdpInfo.parsed.protocol === "ws:" || cdpInfo.parsed.protocol === "wss:";
   const legacyCdpUrl = rawCdpUrl && isWsUrl ? cdpInfo.normalized : undefined;
-  const profiles = ensureDefaultUserBrowserProfile(
-    ensureDefaultProfile(
-      cfg?.profiles,
-      defaultColor,
-      legacyCdpPort,
-      cdpPortRangeStart,
-      legacyCdpUrl,
-    ),
+  const hasUserProfile = Boolean(cfg?.profiles && cfg.profiles.user);
+  let profiles = ensureDefaultProfile(
+    cfg?.profiles,
+    defaultColor,
+    legacyCdpPort,
+    cdpPortRangeStart,
+    legacyCdpUrl,
   );
+
+  /**
+   * Ensure a built-in "user" profile exists for Chrome's existing-session attach flow
+   * only when no legacy/global cdpUrl is configured.
+   *
+   * When browser.cdpUrl is set but no explicit "user" profile exists, we prefer to
+   * steer callers toward the default "openclaw" CDP profile so that remote CDP
+   * endpoints are actually used instead of falling back to Chrome MCP +
+   * DevToolsActivePort.
+   */
+  if (!rawCdpUrl && !hasUserProfile) {
+    profiles = {
+      ...profiles,
+      user: {
+        driver: "existing-session",
+        attachOnly: true,
+        color: "#00AA00",
+      },
+    };
+  }
   const cdpProtocol = cdpInfo.parsed.protocol === "https:" ? "https" : "http";
 
-  const defaultProfile =
+  let defaultProfile =
     defaultProfileFromConfig ??
     (profiles[DEFAULT_BROWSER_DEFAULT_PROFILE_NAME]
       ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
       : profiles[DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]
         ? DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME
         : "user");
+
+  // When browser.cdpUrl is set but the config does not define an explicit "user"
+  // profile, treat defaultProfile: "user" as a request to use the legacy CDP-backed
+  // "openclaw" profile instead of the Chrome MCP existing-session profile. This
+  // matches user expectations that setting browser.cdpUrl causes the browser tool
+  // to connect via CDP rather than relying on DevToolsActivePort.
+  if (
+    rawCdpUrl &&
+    defaultProfileFromConfig === "user" &&
+    !hasUserProfile &&
+    profiles[DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]
+  ) {
+    defaultProfile = DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME;
+  }
 
   const extraArgs = Array.isArray(cfg?.extraArgs)
     ? cfg.extraArgs.filter((a): a is string => typeof a === "string" && a.trim().length > 0)


### PR DESCRIPTION

## Summary

- Adjust browser config resolution so that `browser.cdpUrl` is honored even when `defaultProfile: "user"` is set without an explicit `profiles.user` entry.
- Stop auto-injecting the `user` existing-session (Chrome MCP) profile when a global `browser.cdpUrl` is configured, to avoid unintentionally routing through DevToolsActivePort.
- Add a regression test to cover the `browser.cdpUrl` + `defaultProfile: "user"` case and ensure the `openclaw` CDP profile is used by default.

## Details

Previously, when `browser.cdpUrl` was set but no explicit `profiles.user` existed, setting:

```jsonc
{
  "browser": {
    "enabled": true,
    "cdpUrl": "http://localhost:9222",
    "attachOnly": false,
    "defaultProfile": "user"
  }
}
```

would still resolve `user` as an implicit `existing-session` profile backed by Chrome MCP and DevToolsActivePort. In environments where Chrome is started with a custom `--user-data-dir` and does not write `DevToolsActivePort`, this caused the browser tool to fail even though the CDP endpoint at `http://localhost:9222` was reachable.

This PR makes two targeted changes in the browser config resolver:

- Auto-create the built-in `user` (existing-session) profile **only when**:
  - `browser.cdpUrl` is **not** set, and
  - there is no explicit `profiles.user` in the config.
- When:
  - `browser.cdpUrl` is set,
  - `defaultProfile` is explicitly `"user"`, and
  - there is no explicit `profiles.user`,
  
  we now rewrite the default profile to `"openclaw"` so that the legacy CDP-backed `openclaw` profile (derived from `browser.cdpUrl`) is used. This aligns with user expectations that configuring `browser.cdpUrl` should cause the browser tool to connect via CDP rather than relying on DevToolsActivePort.

## Testing

- `pnpm test -- src/browser/config.test.ts`

This includes a new test that validates:

- `browser.cdpUrl: "http://localhost:9222"` + `defaultProfile: "user"` with no explicit `profiles.user` resolves `defaultProfile` to `"openclaw"`.
- The `openclaw` profile uses `http://localhost:9222` as its `cdpUrl` and `openclaw` as the driver.

### Related

- #48042