### PR TITLE
fix(gateway): guard tailscale serve cleanup ownership

### DIFF
--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -19,28 +19,42 @@ vi.mock("../infra/tailscale.js", () => ({
 import { startGatewayTailscaleExposure } from "./server-tailscale.js";
 
 function createOwnerStore() {
-  let currentToken: string | null = null;
+  let currentOwner: null | {
+    token: string;
+    mode: "serve" | "funnel";
+    port: number;
+    pid: number;
+    claimedAt: string;
+  } = null;
   let nextId = 0;
 
   return {
     async claim(mode: "serve" | "funnel", port: number) {
-      const record = {
+      const previousOwner = currentOwner;
+      const owner = {
         token: `owner-${++nextId}`,
         mode,
         port,
         pid: nextId,
         claimedAt: new Date(0).toISOString(),
       };
-      currentToken = record.token;
-      return record;
+      currentOwner = owner;
+      return { owner, previousOwner };
     },
-    async isCurrentOwner(token: string) {
-      return currentToken === token;
-    },
-    async clearIfCurrentOwner(token: string) {
-      if (currentToken === token) {
-        currentToken = null;
+    async replaceIfCurrent(token: string, nextOwner: typeof currentOwner | null) {
+      if (currentOwner?.token !== token) {
+        return false;
       }
+      currentOwner = nextOwner;
+      return true;
+    },
+    async runCleanupIfCurrentOwner(token: string, cleanup: () => Promise<void>) {
+      if (currentOwner?.token !== token) {
+        return false;
+      }
+      await cleanup();
+      currentOwner = null;
+      return true;
     },
   };
 }
@@ -74,23 +88,20 @@ describe("startGatewayTailscaleExposure", () => {
 
     await cleanupA?.();
     expect(tailscaleState.disableServe).not.toHaveBeenCalled();
-    expect(logTailscale.info).toHaveBeenCalledWith(
-      "serve cleanup skipped: newer gateway owns Tailscale exposure",
-    );
+    expect(logTailscale.info).toHaveBeenCalledWith("serve cleanup skipped: not the current owner");
 
     await cleanupB?.();
     expect(tailscaleState.disableServe).toHaveBeenCalledTimes(1);
   });
 
-  it("clears ownership after a startup failure", async () => {
+  it("restores the previous owner after a takeover startup failure", async () => {
     const ownerStore = createOwnerStore();
     const logTailscale = {
       info: vi.fn(),
       warn: vi.fn(),
     };
-    tailscaleState.enableServe.mockRejectedValueOnce(new Error("boom"));
 
-    const cleanup = await startGatewayTailscaleExposure({
+    const cleanupA = await startGatewayTailscaleExposure({
       tailscaleMode: "serve",
       resetOnExit: true,
       port: 18789,
@@ -98,10 +109,24 @@ describe("startGatewayTailscaleExposure", () => {
       ownerStore,
     });
 
-    expect(cleanup).not.toBeNull();
+    tailscaleState.enableServe.mockRejectedValueOnce(new Error("boom"));
+
+    const cleanupB = await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      resetOnExit: true,
+      port: 18789,
+      logTailscale,
+      ownerStore,
+    });
+
+    expect(cleanupB).not.toBeNull();
     expect(logTailscale.warn).toHaveBeenCalledWith("serve failed: boom");
 
-    await cleanup?.();
+    await cleanupB?.();
     expect(tailscaleState.disableServe).not.toHaveBeenCalled();
+    expect(logTailscale.info).toHaveBeenCalledWith("serve cleanup skipped: not the current owner");
+
+    await cleanupA?.();
+    expect(tailscaleState.disableServe).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -73,7 +73,7 @@ const modeCases = [
 ];
 
 describe.each(modeCases)(
-  "startGatewayTailscaleExposure (%s)",
+  "startGatewayTailscaleExposure ($mode)",
   ({ mode, enableMock, disableMock }) => {
     beforeEach(() => {
       vi.restoreAllMocks();
@@ -193,6 +193,40 @@ describe.each(modeCases)(
       );
 
       await cleanupB?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to unguarded cleanup when the ownership guard cannot claim", async () => {
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const cleanup = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore: {
+          async claim() {
+            throw new Error("lock dir unavailable");
+          },
+          async replaceIfCurrent() {
+            return false;
+          },
+          async runCleanupIfCurrentOwner() {
+            return false;
+          },
+        },
+      });
+
+      expect(cleanup).not.toBeNull();
+      expect(enableMock).toHaveBeenCalledTimes(1);
+      expect(logTailscale.warn).toHaveBeenCalledWith(
+        `${mode} ownership guard unavailable: lock dir unavailable`,
+      );
+
+      await cleanup?.();
       expect(disableMock).toHaveBeenCalledTimes(1);
     });
   },

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -59,74 +59,141 @@ function createOwnerStore() {
   };
 }
 
-describe("startGatewayTailscaleExposure", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+const modeCases = [
+  {
+    mode: "serve" as const,
+    enableMock: tailscaleState.enableServe,
+    disableMock: tailscaleState.disableServe,
+  },
+  {
+    mode: "funnel" as const,
+    enableMock: tailscaleState.enableFunnel,
+    disableMock: tailscaleState.disableFunnel,
+  },
+];
 
-  it("skips stale serve cleanup after a newer gateway takes ownership", async () => {
-    const ownerStore = createOwnerStore();
-    const logTailscale = {
-      info: vi.fn(),
-      warn: vi.fn(),
-    };
-
-    const cleanupA = await startGatewayTailscaleExposure({
-      tailscaleMode: "serve",
-      resetOnExit: true,
-      port: 18789,
-      logTailscale,
-      ownerStore,
-    });
-    const cleanupB = await startGatewayTailscaleExposure({
-      tailscaleMode: "serve",
-      resetOnExit: true,
-      port: 18789,
-      logTailscale,
-      ownerStore,
+describe.each(modeCases)(
+  "startGatewayTailscaleExposure (%s)",
+  ({ mode, enableMock, disableMock }) => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.clearAllMocks();
     });
 
-    await cleanupA?.();
-    expect(tailscaleState.disableServe).not.toHaveBeenCalled();
-    expect(logTailscale.info).toHaveBeenCalledWith("serve cleanup skipped: not the current owner");
+    it("skips stale cleanup after a newer gateway takes ownership", async () => {
+      const ownerStore = createOwnerStore();
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
 
-    await cleanupB?.();
-    expect(tailscaleState.disableServe).toHaveBeenCalledTimes(1);
-  });
+      const cleanupA = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+      const cleanupB = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
 
-  it("restores the previous owner after a takeover startup failure", async () => {
-    const ownerStore = createOwnerStore();
-    const logTailscale = {
-      info: vi.fn(),
-      warn: vi.fn(),
-    };
+      await cleanupA?.();
+      expect(disableMock).not.toHaveBeenCalled();
+      expect(logTailscale.info).toHaveBeenCalledWith(
+        `${mode} cleanup skipped: not the current owner`,
+      );
 
-    const cleanupA = await startGatewayTailscaleExposure({
-      tailscaleMode: "serve",
-      resetOnExit: true,
-      port: 18789,
-      logTailscale,
-      ownerStore,
+      await cleanupB?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
     });
 
-    tailscaleState.enableServe.mockRejectedValueOnce(new Error("boom"));
+    it("restores the previous live owner after a takeover startup failure", async () => {
+      const ownerStore = createOwnerStore();
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
 
-    const cleanupB = await startGatewayTailscaleExposure({
-      tailscaleMode: "serve",
-      resetOnExit: true,
-      port: 18789,
-      logTailscale,
-      ownerStore,
+      const cleanupA = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+
+      enableMock.mockRejectedValueOnce(new Error("boom"));
+
+      const cleanupB = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+
+      expect(cleanupB).not.toBeNull();
+      expect(logTailscale.warn).toHaveBeenCalledWith(`${mode} failed: boom`);
+
+      await cleanupB?.();
+      expect(disableMock).not.toHaveBeenCalled();
+      expect(logTailscale.info).toHaveBeenCalledWith(
+        `${mode} cleanup skipped: not the current owner`,
+      );
+
+      await cleanupA?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
     });
 
-    expect(cleanupB).not.toBeNull();
-    expect(logTailscale.warn).toHaveBeenCalledWith("serve failed: boom");
+    it("keeps the failed owner when the previous owner is already gone", async () => {
+      const ownerStore = createOwnerStore();
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
 
-    await cleanupB?.();
-    expect(tailscaleState.disableServe).not.toHaveBeenCalled();
-    expect(logTailscale.info).toHaveBeenCalledWith("serve cleanup skipped: not the current owner");
+      const cleanupA = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
 
-    await cleanupA?.();
-    expect(tailscaleState.disableServe).toHaveBeenCalledTimes(1);
-  });
-});
+      vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+        if (pid === 1) {
+          const err = new Error("gone") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      }) as typeof process.kill);
+      enableMock.mockRejectedValueOnce(new Error("boom"));
+
+      const cleanupB = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+
+      expect(cleanupB).not.toBeNull();
+      expect(logTailscale.warn).toHaveBeenCalledWith(`${mode} failed: boom`);
+
+      await cleanupA?.();
+      expect(disableMock).not.toHaveBeenCalled();
+      expect(logTailscale.info).toHaveBeenCalledWith(
+        `${mode} cleanup skipped: not the current owner`,
+      );
+
+      await cleanupB?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
+    });
+  },
+);

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -25,18 +25,21 @@ function createOwnerStore() {
     port: number;
     pid: number;
     claimedAt: string;
+    phase: "active" | "cleaning";
+    cleanupStartedAt?: string;
   } = null;
-  let nextId = 0;
+  let nextPid = process.pid - 1;
 
   return {
     async claim(mode: "serve" | "funnel", port: number) {
       const previousOwner = currentOwner;
       const owner = {
-        token: `owner-${++nextId}`,
+        token: `owner-${++nextPid}`,
         mode,
         port,
-        pid: nextId,
+        pid: nextPid,
         claimedAt: new Date(0).toISOString(),
+        phase: "active" as const,
       };
       currentOwner = owner;
       return { owner, previousOwner };
@@ -52,6 +55,11 @@ function createOwnerStore() {
       if (currentOwner?.token !== token) {
         return false;
       }
+      currentOwner = {
+        ...currentOwner,
+        phase: "cleaning",
+        cleanupStartedAt: new Date(0).toISOString(),
+      };
       await cleanup();
       currentOwner = null;
       return true;
@@ -166,7 +174,7 @@ describe.each(modeCases)(
       });
 
       vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
-        if (pid === 1) {
+        if (pid === process.pid) {
           const err = new Error("gone") as NodeJS.ErrnoException;
           err.code = "ESRCH";
           throw err;
@@ -228,6 +236,40 @@ describe.each(modeCases)(
 
       await cleanup?.();
       expect(disableMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips unguarded fallback while a previous cleanup is still in progress", async () => {
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const cleanup = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore: {
+          async claim() {
+            const err = new Error("busy");
+            err.name = "TailscaleExposureCleanupInProgressError";
+            throw err;
+          },
+          async replaceIfCurrent() {
+            return false;
+          },
+          async runCleanupIfCurrentOwner() {
+            return false;
+          },
+        },
+      });
+
+      expect(cleanup).toBeNull();
+      expect(enableMock).not.toHaveBeenCalled();
+      expect(disableMock).not.toHaveBeenCalled();
+      expect(logTailscale.warn).toHaveBeenCalledWith(
+        `${mode} ownership cleanup still in progress; skipping external exposure`,
+      );
     });
   },
 );

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tailscaleState = vi.hoisted(() => ({
+  enableServe: vi.fn(async (_port: number) => {}),
+  disableServe: vi.fn(async () => {}),
+  enableFunnel: vi.fn(async (_port: number) => {}),
+  disableFunnel: vi.fn(async () => {}),
+  getHost: vi.fn(async () => "gateway.tailnet.ts.net"),
+}));
+
+vi.mock("../infra/tailscale.js", () => ({
+  enableTailscaleServe: (port: number) => tailscaleState.enableServe(port),
+  disableTailscaleServe: () => tailscaleState.disableServe(),
+  enableTailscaleFunnel: (port: number) => tailscaleState.enableFunnel(port),
+  disableTailscaleFunnel: () => tailscaleState.disableFunnel(),
+  getTailnetHostname: () => tailscaleState.getHost(),
+}));
+
+import { startGatewayTailscaleExposure } from "./server-tailscale.js";
+
+function createOwnerStore() {
+  let currentToken: string | null = null;
+  let nextId = 0;
+
+  return {
+    async claim(mode: "serve" | "funnel", port: number) {
+      const record = {
+        token: `owner-${++nextId}`,
+        mode,
+        port,
+        pid: nextId,
+        claimedAt: new Date(0).toISOString(),
+      };
+      currentToken = record.token;
+      return record;
+    },
+    async isCurrentOwner(token: string) {
+      return currentToken === token;
+    },
+    async clearIfCurrentOwner(token: string) {
+      if (currentToken === token) {
+        currentToken = null;
+      }
+    },
+  };
+}
+
+describe("startGatewayTailscaleExposure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips stale serve cleanup after a newer gateway takes ownership", async () => {
+    const ownerStore = createOwnerStore();
+    const logTailscale = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const cleanupA = await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      resetOnExit: true,
+      port: 18789,
+      logTailscale,
+      ownerStore,
+    });
+    const cleanupB = await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      resetOnExit: true,
+      port: 18789,
+      logTailscale,
+      ownerStore,
+    });
+
+    await cleanupA?.();
+    expect(tailscaleState.disableServe).not.toHaveBeenCalled();
+    expect(logTailscale.info).toHaveBeenCalledWith(
+      "serve cleanup skipped: newer gateway owns Tailscale exposure",
+    );
+
+    await cleanupB?.();
+    expect(tailscaleState.disableServe).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears ownership after a startup failure", async () => {
+    const ownerStore = createOwnerStore();
+    const logTailscale = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    tailscaleState.enableServe.mockRejectedValueOnce(new Error("boom"));
+
+    const cleanup = await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      resetOnExit: true,
+      port: 18789,
+      logTailscale,
+      ownerStore,
+    });
+
+    expect(cleanup).not.toBeNull();
+    expect(logTailscale.warn).toHaveBeenCalledWith("serve failed: boom");
+
+    await cleanup?.();
+    expect(tailscaleState.disableServe).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -27,6 +27,7 @@ function createOwnerStore() {
     claimedAt: string;
     phase: "active" | "cleaning";
     cleanupStartedAt?: string;
+    alive: boolean;
   } = null;
   let nextPid = process.pid - 1;
 
@@ -40,6 +41,7 @@ function createOwnerStore() {
         pid: nextPid,
         claimedAt: new Date(0).toISOString(),
         phase: "active" as const,
+        alive: true,
       };
       currentOwner = owner;
       return { owner, previousOwner };
@@ -52,7 +54,10 @@ function createOwnerStore() {
       return true;
     },
     async runCleanupIfCurrentOwner(token: string, cleanup: () => Promise<void>) {
-      if (currentOwner?.token !== token) {
+      if (!currentOwner) {
+        return false;
+      }
+      if (currentOwner.token !== token && currentOwner.alive) {
         return false;
       }
       currentOwner = {
@@ -63,6 +68,11 @@ function createOwnerStore() {
       await cleanup();
       currentOwner = null;
       return true;
+    },
+    markCurrentOwnerDead() {
+      if (currentOwner) {
+        currentOwner = { ...currentOwner, alive: false };
+      }
     },
   };
 }
@@ -204,6 +214,36 @@ describe.each(modeCases)(
       expect(disableMock).toHaveBeenCalledTimes(1);
     });
 
+    it("reclaims cleanup from a dead newer owner before exit", async () => {
+      const ownerStore = createOwnerStore();
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const cleanupA = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+      await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore,
+      });
+      ownerStore.markCurrentOwnerDead();
+
+      await cleanupA?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
+      expect(logTailscale.info).not.toHaveBeenCalledWith(
+        `${mode} cleanup skipped: not the current owner`,
+      );
+    });
+
     it("falls back to unguarded cleanup when the ownership guard cannot claim", async () => {
       const logTailscale = {
         info: vi.fn(),
@@ -269,6 +309,50 @@ describe.each(modeCases)(
       expect(disableMock).not.toHaveBeenCalled();
       expect(logTailscale.warn).toHaveBeenCalledWith(
         `${mode} ownership cleanup still in progress; skipping external exposure`,
+      );
+    });
+
+    it("falls back to a direct reset when guarded cleanup bookkeeping fails", async () => {
+      const logTailscale = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const cleanup = await startGatewayTailscaleExposure({
+        tailscaleMode: mode,
+        resetOnExit: true,
+        port: 18789,
+        logTailscale,
+        ownerStore: {
+          async claim() {
+            return {
+              owner: {
+                token: "owner-1",
+                mode,
+                port: 18789,
+                pid: process.pid,
+                claimedAt: new Date(0).toISOString(),
+                phase: "active" as const,
+              },
+              previousOwner: null,
+            };
+          },
+          async replaceIfCurrent() {
+            return true;
+          },
+          async runCleanupIfCurrentOwner() {
+            throw new Error("lock dir unavailable");
+          },
+        },
+      });
+
+      await cleanup?.();
+      expect(disableMock).toHaveBeenCalledTimes(1);
+      expect(logTailscale.warn).toHaveBeenCalledWith(
+        `${mode} cleanup failed: lock dir unavailable`,
+      );
+      expect(logTailscale.warn).toHaveBeenCalledWith(
+        `${mode} cleanup guard failed; applied direct reset fallback`,
       );
     });
   },

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -32,6 +32,15 @@ type TailscaleExposureOwnerStore = {
   runCleanupIfCurrentOwner(token: string, cleanup: () => Promise<void>): Promise<boolean>;
 };
 
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException | undefined)?.code !== "ESRCH";
+  }
+}
+
 function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
   const ownerFilePath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.json");
   const ownerLockPath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.lock");
@@ -64,29 +73,15 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  function isPidAlive(pid: number): boolean {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch (err) {
-      return (err as NodeJS.ErrnoException | undefined)?.code !== "ESRCH";
-    }
-  }
-
   async function breakStaleLock() {
     try {
-      const [raw, stat] = await Promise.all([
-        fs.readFile(ownerLockPath, "utf8").catch(() => null),
-        fs.stat(ownerLockPath),
-      ]);
+      const stat = await fs.stat(ownerLockPath);
       if (Date.now() - stat.mtimeMs < lockStaleMs) {
         return;
       }
-      const parsed = raw ? JSON.parse(raw) : null;
-      const pid = typeof parsed?.pid === "number" ? parsed.pid : null;
-      if (pid !== null && isPidAlive(pid)) {
-        return;
-      }
+      // All lock holders only perform short file I/O plus the Tailscale CLI calls,
+      // and those helpers already time out after 15s. If the lock still exists after
+      // the wider stale window, assume the holder is wedged and break it.
       await fs.unlink(ownerLockPath).catch(() => {});
     } catch (err) {
       if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
@@ -202,7 +197,13 @@ export async function startGatewayTailscaleExposure(params: {
       params.logTailscale.info(`${params.tailscaleMode} enabled`);
     }
   } catch (err) {
-    await ownerStore.replaceIfCurrent(owner.token, previousOwner).catch(() => {});
+    const nextOwner =
+      previousOwner && isPidAlive(previousOwner.pid)
+        ? previousOwner
+        : params.resetOnExit
+          ? owner
+          : null;
+    await ownerStore.replaceIfCurrent(owner.token, nextOwner).catch(() => {});
     params.logTailscale.warn(
       `${params.tailscaleMode} failed: ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -79,9 +79,15 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
       if (Date.now() - stat.mtimeMs < lockStaleMs) {
         return;
       }
-      // All lock holders only perform short file I/O plus the Tailscale CLI calls,
-      // and those helpers already time out after 15s. If the lock still exists after
-      // the wider stale window, assume the holder is wedged and break it.
+      try {
+        const raw = await fs.readFile(ownerLockPath, "utf8");
+        const parsed = JSON.parse(raw) as { pid?: unknown };
+        if (typeof parsed.pid === "number" && isPidAlive(parsed.pid)) {
+          return;
+        }
+      } catch {
+        // Unreadable lock state is treated as stale so a dead holder cannot block recovery.
+      }
       await fs.unlink(ownerLockPath).catch(() => {});
     } catch (err) {
       if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
@@ -153,15 +159,19 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
       });
     },
     async runCleanupIfCurrentOwner(token, cleanup) {
-      return await withOwnerLock(async () => {
+      const shouldRunCleanup = await withOwnerLock(async () => {
         const current = await readOwner();
         if (current?.token !== token) {
           return false;
         }
-        await cleanup();
         await deleteOwnerFile();
         return true;
       });
+      if (!shouldRunCleanup) {
+        return false;
+      }
+      await cleanup();
+      return true;
     },
   };
 }
@@ -179,7 +189,16 @@ export async function startGatewayTailscaleExposure(params: {
   }
 
   const ownerStore = params.ownerStore ?? createTailscaleExposureOwnerStore();
-  const { owner, previousOwner } = await ownerStore.claim(params.tailscaleMode, params.port);
+  let owner: TailscaleExposureOwnerRecord | null = null;
+  let previousOwner: TailscaleExposureOwnerRecord | null = null;
+
+  try {
+    ({ owner, previousOwner } = await ownerStore.claim(params.tailscaleMode, params.port));
+  } catch (err) {
+    params.logTailscale.warn(
+      `${params.tailscaleMode} ownership guard unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   try {
     if (params.tailscaleMode === "serve") {
@@ -197,13 +216,15 @@ export async function startGatewayTailscaleExposure(params: {
       params.logTailscale.info(`${params.tailscaleMode} enabled`);
     }
   } catch (err) {
-    const nextOwner =
-      previousOwner && isPidAlive(previousOwner.pid)
-        ? previousOwner
-        : params.resetOnExit
-          ? owner
-          : null;
-    await ownerStore.replaceIfCurrent(owner.token, nextOwner).catch(() => {});
+    if (owner) {
+      const nextOwner =
+        previousOwner && isPidAlive(previousOwner.pid)
+          ? previousOwner
+          : params.resetOnExit
+            ? owner
+            : null;
+      await ownerStore.replaceIfCurrent(owner.token, nextOwner).catch(() => {});
+    }
     params.logTailscale.warn(
       `${params.tailscaleMode} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -215,15 +236,26 @@ export async function startGatewayTailscaleExposure(params: {
 
   return async () => {
     try {
-      const cleanedUp = await ownerStore.runCleanupIfCurrentOwner(owner.token, async () => {
-        if (params.tailscaleMode === "serve") {
-          await disableTailscaleServe();
-        } else {
-          await disableTailscaleFunnel();
+      if (owner) {
+        const cleanedUp = await ownerStore.runCleanupIfCurrentOwner(owner.token, async () => {
+          if (params.tailscaleMode === "serve") {
+            await disableTailscaleServe();
+          } else {
+            await disableTailscaleFunnel();
+          }
+        });
+        if (!cleanedUp) {
+          params.logTailscale.info(
+            `${params.tailscaleMode} cleanup skipped: not the current owner`,
+          );
         }
-      });
-      if (!cleanedUp) {
-        params.logTailscale.info(`${params.tailscaleMode} cleanup skipped: not the current owner`);
+        return;
+      }
+
+      if (params.tailscaleMode === "serve") {
+        await disableTailscaleServe();
+      } else {
+        await disableTailscaleFunnel();
       }
     } catch (err) {
       params.logTailscale.warn(

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -24,13 +24,19 @@ type TailscaleExposureOwnerStore = {
   claim(
     mode: Exclude<GatewayTailscaleMode, "off">,
     port: number,
-  ): Promise<TailscaleExposureOwnerRecord>;
-  isCurrentOwner(token: string): Promise<boolean>;
-  clearIfCurrentOwner(token: string): Promise<void>;
+  ): Promise<{
+    owner: TailscaleExposureOwnerRecord;
+    previousOwner: TailscaleExposureOwnerRecord | null;
+  }>;
+  replaceIfCurrent(token: string, nextOwner: TailscaleExposureOwnerRecord | null): Promise<boolean>;
+  runCleanupIfCurrentOwner(token: string, cleanup: () => Promise<void>): Promise<boolean>;
 };
 
 function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
   const ownerFilePath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.json");
+  const ownerLockPath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.lock");
+  const lockRetryMs = 25;
+  const lockStaleMs = 60_000;
 
   async function readOwner(): Promise<TailscaleExposureOwnerRecord | null> {
     try {
@@ -47,42 +53,120 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
       ) {
         return parsed as TailscaleExposureOwnerRecord;
       }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
-        // Ignore malformed or unreadable ownership state and continue.
-      }
+    } catch {
+      // ENOENT means the file does not exist yet. Any other parse/read error is
+      // also ignored so the ownership guard remains best-effort and non-fatal.
     }
     return null;
   }
 
-  return {
-    async claim(mode, port) {
-      const record: TailscaleExposureOwnerRecord = {
-        token: randomUUID(),
-        mode,
-        port,
-        pid: process.pid,
-        claimedAt: new Date().toISOString(),
-      };
-      await fs.mkdir(path.dirname(ownerFilePath), { recursive: true });
-      await fs.writeFile(ownerFilePath, JSON.stringify(record), "utf8");
-      return record;
-    },
-    async isCurrentOwner(token) {
-      const current = await readOwner();
-      return current?.token === token;
-    },
-    async clearIfCurrentOwner(token) {
-      if (!(await this.isCurrentOwner(token))) {
+  async function sleep(ms: number) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      return (err as NodeJS.ErrnoException | undefined)?.code !== "ESRCH";
+    }
+  }
+
+  async function breakStaleLock() {
+    try {
+      const [raw, stat] = await Promise.all([
+        fs.readFile(ownerLockPath, "utf8").catch(() => null),
+        fs.stat(ownerLockPath),
+      ]);
+      if (Date.now() - stat.mtimeMs < lockStaleMs) {
         return;
       }
+      const parsed = raw ? JSON.parse(raw) : null;
+      const pid = typeof parsed?.pid === "number" ? parsed.pid : null;
+      if (pid !== null && isPidAlive(pid)) {
+        return;
+      }
+      await fs.unlink(ownerLockPath).catch(() => {});
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+        // Ignore malformed or unreadable lock state and retry.
+      }
+    }
+  }
+
+  async function withOwnerLock<T>(fn: () => Promise<T>): Promise<T> {
+    await fs.mkdir(path.dirname(ownerLockPath), { recursive: true });
+
+    while (true) {
       try {
-        await fs.unlink(ownerFilePath);
+        const handle = await fs.open(ownerLockPath, "wx");
+        try {
+          await handle.writeFile(
+            JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }),
+          );
+          return await fn();
+        } finally {
+          await handle.close().catch(() => {});
+          await fs.unlink(ownerLockPath).catch(() => {});
+        }
       } catch (err) {
-        if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+        if ((err as NodeJS.ErrnoException | undefined)?.code !== "EEXIST") {
           throw err;
         }
+        await breakStaleLock();
+        await sleep(lockRetryMs);
       }
+    }
+  }
+
+  async function deleteOwnerFile() {
+    await fs.unlink(ownerFilePath).catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+        throw err;
+      }
+    });
+  }
+
+  return {
+    async claim(mode, port) {
+      return await withOwnerLock(async () => {
+        const previousOwner = await readOwner();
+        const owner: TailscaleExposureOwnerRecord = {
+          token: randomUUID(),
+          mode,
+          port,
+          pid: process.pid,
+          claimedAt: new Date().toISOString(),
+        };
+        await fs.writeFile(ownerFilePath, JSON.stringify(owner), "utf8");
+        return { owner, previousOwner };
+      });
+    },
+    async replaceIfCurrent(token, nextOwner) {
+      return await withOwnerLock(async () => {
+        const current = await readOwner();
+        if (current?.token !== token) {
+          return false;
+        }
+        if (nextOwner) {
+          await fs.writeFile(ownerFilePath, JSON.stringify(nextOwner), "utf8");
+        } else {
+          await deleteOwnerFile();
+        }
+        return true;
+      });
+    },
+    async runCleanupIfCurrentOwner(token, cleanup) {
+      return await withOwnerLock(async () => {
+        const current = await readOwner();
+        if (current?.token !== token) {
+          return false;
+        }
+        await cleanup();
+        await deleteOwnerFile();
+        return true;
+      });
     },
   };
 }
@@ -100,7 +184,7 @@ export async function startGatewayTailscaleExposure(params: {
   }
 
   const ownerStore = params.ownerStore ?? createTailscaleExposureOwnerStore();
-  const owner = await ownerStore.claim(params.tailscaleMode, params.port);
+  const { owner, previousOwner } = await ownerStore.claim(params.tailscaleMode, params.port);
 
   try {
     if (params.tailscaleMode === "serve") {
@@ -118,7 +202,7 @@ export async function startGatewayTailscaleExposure(params: {
       params.logTailscale.info(`${params.tailscaleMode} enabled`);
     }
   } catch (err) {
-    await ownerStore.clearIfCurrentOwner(owner.token).catch(() => {});
+    await ownerStore.replaceIfCurrent(owner.token, previousOwner).catch(() => {});
     params.logTailscale.warn(
       `${params.tailscaleMode} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -130,18 +214,16 @@ export async function startGatewayTailscaleExposure(params: {
 
   return async () => {
     try {
-      if (!(await ownerStore.isCurrentOwner(owner.token))) {
-        params.logTailscale.info(
-          `${params.tailscaleMode} cleanup skipped: newer gateway owns Tailscale exposure`,
-        );
-        return;
+      const cleanedUp = await ownerStore.runCleanupIfCurrentOwner(owner.token, async () => {
+        if (params.tailscaleMode === "serve") {
+          await disableTailscaleServe();
+        } else {
+          await disableTailscaleFunnel();
+        }
+      });
+      if (!cleanedUp) {
+        params.logTailscale.info(`${params.tailscaleMode} cleanup skipped: not the current owner`);
       }
-      if (params.tailscaleMode === "serve") {
-        await disableTailscaleServe();
-      } else {
-        await disableTailscaleFunnel();
-      }
-      await ownerStore.clearIfCurrentOwner(owner.token);
     } catch (err) {
       params.logTailscale.warn(
         `${params.tailscaleMode} cleanup failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -59,6 +59,7 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
   const lockRetryMs = 25;
   const lockStaleMs = 60_000;
   const cleanupClaimWaitMs = 20_000;
+  let ensureLockDirReady: Promise<void> | null = null;
 
   async function readOwner(): Promise<TailscaleExposureOwnerRecord | null> {
     try {
@@ -91,6 +92,18 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  function ensureLockDir() {
+    if (!ensureLockDirReady) {
+      ensureLockDirReady = fs
+        .mkdir(path.dirname(ownerLockPath), { recursive: true })
+        .catch((err: unknown) => {
+          ensureLockDirReady = null;
+          throw err;
+        });
+    }
+    return ensureLockDirReady;
+  }
+
   async function breakStaleLock() {
     try {
       const stat = await fs.stat(ownerLockPath);
@@ -113,7 +126,7 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
   }
 
   async function withOwnerLock<T>(fn: () => Promise<T>): Promise<T> {
-    await fs.mkdir(path.dirname(ownerLockPath), { recursive: true });
+    await ensureLockDir();
 
     while (true) {
       try {
@@ -245,6 +258,9 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
           return;
         }
         await deleteOwnerFile();
+      }).catch(() => {
+        // Tailscale cleanup already succeeded. If owner-file deletion fails, leave
+        // the stale cleaning record for best-effort recovery after this process exits.
       });
       return true;
     },

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveGatewayLockDir } from "../config/paths.js";
 import {
   disableTailscaleFunnel,
   disableTailscaleServe,
@@ -6,16 +10,97 @@ import {
   getTailnetHostname,
 } from "../infra/tailscale.js";
 
+type GatewayTailscaleMode = "off" | "serve" | "funnel";
+
+type TailscaleExposureOwnerRecord = {
+  token: string;
+  mode: Exclude<GatewayTailscaleMode, "off">;
+  port: number;
+  pid: number;
+  claimedAt: string;
+};
+
+type TailscaleExposureOwnerStore = {
+  claim(
+    mode: Exclude<GatewayTailscaleMode, "off">,
+    port: number,
+  ): Promise<TailscaleExposureOwnerRecord>;
+  isCurrentOwner(token: string): Promise<boolean>;
+  clearIfCurrentOwner(token: string): Promise<void>;
+};
+
+function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
+  const ownerFilePath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.json");
+
+  async function readOwner(): Promise<TailscaleExposureOwnerRecord | null> {
+    try {
+      const raw = await fs.readFile(ownerFilePath, "utf8");
+      const parsed = JSON.parse(raw);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof parsed.token === "string" &&
+        typeof parsed.mode === "string" &&
+        typeof parsed.port === "number" &&
+        typeof parsed.pid === "number" &&
+        typeof parsed.claimedAt === "string"
+      ) {
+        return parsed as TailscaleExposureOwnerRecord;
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+        // Ignore malformed or unreadable ownership state and continue.
+      }
+    }
+    return null;
+  }
+
+  return {
+    async claim(mode, port) {
+      const record: TailscaleExposureOwnerRecord = {
+        token: randomUUID(),
+        mode,
+        port,
+        pid: process.pid,
+        claimedAt: new Date().toISOString(),
+      };
+      await fs.mkdir(path.dirname(ownerFilePath), { recursive: true });
+      await fs.writeFile(ownerFilePath, JSON.stringify(record), "utf8");
+      return record;
+    },
+    async isCurrentOwner(token) {
+      const current = await readOwner();
+      return current?.token === token;
+    },
+    async clearIfCurrentOwner(token) {
+      if (!(await this.isCurrentOwner(token))) {
+        return;
+      }
+      try {
+        await fs.unlink(ownerFilePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+          throw err;
+        }
+      }
+    },
+  };
+}
+
 export async function startGatewayTailscaleExposure(params: {
-  tailscaleMode: "off" | "serve" | "funnel";
+  tailscaleMode: GatewayTailscaleMode;
   resetOnExit?: boolean;
   port: number;
   controlUiBasePath?: string;
   logTailscale: { info: (msg: string) => void; warn: (msg: string) => void };
+  ownerStore?: TailscaleExposureOwnerStore;
 }): Promise<(() => Promise<void>) | null> {
   if (params.tailscaleMode === "off") {
     return null;
   }
+
+  const ownerStore = params.ownerStore ?? createTailscaleExposureOwnerStore();
+  const owner = await ownerStore.claim(params.tailscaleMode, params.port);
 
   try {
     if (params.tailscaleMode === "serve") {
@@ -33,6 +118,7 @@ export async function startGatewayTailscaleExposure(params: {
       params.logTailscale.info(`${params.tailscaleMode} enabled`);
     }
   } catch (err) {
+    await ownerStore.clearIfCurrentOwner(owner.token).catch(() => {});
     params.logTailscale.warn(
       `${params.tailscaleMode} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -44,11 +130,18 @@ export async function startGatewayTailscaleExposure(params: {
 
   return async () => {
     try {
+      if (!(await ownerStore.isCurrentOwner(owner.token))) {
+        params.logTailscale.info(
+          `${params.tailscaleMode} cleanup skipped: newer gateway owns Tailscale exposure`,
+        );
+        return;
+      }
       if (params.tailscaleMode === "serve") {
         await disableTailscaleServe();
       } else {
         await disableTailscaleFunnel();
       }
+      await ownerStore.clearIfCurrentOwner(owner.token);
     } catch (err) {
       params.logTailscale.warn(
         `${params.tailscaleMode} cleanup failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -18,6 +18,8 @@ type TailscaleExposureOwnerRecord = {
   port: number;
   pid: number;
   claimedAt: string;
+  phase: "active" | "cleaning";
+  cleanupStartedAt?: string;
 };
 
 type TailscaleExposureOwnerStore = {
@@ -41,11 +43,22 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
+function createCleanupInProgressError(pid: number): Error {
+  const err = new Error(`previous cleanup still in progress (pid ${pid})`);
+  err.name = "TailscaleExposureCleanupInProgressError";
+  return err;
+}
+
+function isCleanupInProgressError(err: unknown): err is Error {
+  return err instanceof Error && err.name === "TailscaleExposureCleanupInProgressError";
+}
+
 function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
   const ownerFilePath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.json");
   const ownerLockPath = path.join(resolveGatewayLockDir(), "tailscale-exposure-owner.lock");
   const lockRetryMs = 25;
   const lockStaleMs = 60_000;
+  const cleanupClaimWaitMs = 20_000;
 
   async function readOwner(): Promise<TailscaleExposureOwnerRecord | null> {
     try {
@@ -60,7 +73,12 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
         typeof parsed.pid === "number" &&
         typeof parsed.claimedAt === "string"
       ) {
-        return parsed as TailscaleExposureOwnerRecord;
+        return {
+          ...(parsed as Omit<TailscaleExposureOwnerRecord, "phase">),
+          phase: parsed.phase === "cleaning" ? "cleaning" : "active",
+          cleanupStartedAt:
+            typeof parsed.cleanupStartedAt === "string" ? parsed.cleanupStartedAt : undefined,
+        };
       }
     } catch {
       // ENOENT means the file does not exist yet. Any other parse/read error is
@@ -89,10 +107,8 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
         // Unreadable lock state is treated as stale so a dead holder cannot block recovery.
       }
       await fs.unlink(ownerLockPath).catch(() => {});
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
-        // Ignore malformed or unreadable lock state and retry.
-      }
+    } catch {
+      // Ignore malformed or unreadable lock state and retry.
     }
   }
 
@@ -131,18 +147,42 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
 
   return {
     async claim(mode, port) {
-      return await withOwnerLock(async () => {
-        const previousOwner = await readOwner();
-        const owner: TailscaleExposureOwnerRecord = {
-          token: randomUUID(),
-          mode,
-          port,
-          pid: process.pid,
-          claimedAt: new Date().toISOString(),
-        };
-        await fs.writeFile(ownerFilePath, JSON.stringify(owner), "utf8");
-        return { owner, previousOwner };
-      });
+      while (true) {
+        const result = await withOwnerLock(async () => {
+          const previousOwner = await readOwner();
+          if (previousOwner?.phase === "cleaning" && isPidAlive(previousOwner.pid)) {
+            const cleanupStartedAtMs = Date.parse(
+              previousOwner.cleanupStartedAt ?? previousOwner.claimedAt,
+            );
+            const cleanupAgeMs = Number.isFinite(cleanupStartedAtMs)
+              ? Date.now() - cleanupStartedAtMs
+              : Number.POSITIVE_INFINITY;
+            if (cleanupAgeMs < cleanupClaimWaitMs) {
+              return { type: "wait" as const };
+            }
+            return { type: "blocked" as const, previousOwner };
+          }
+
+          const owner: TailscaleExposureOwnerRecord = {
+            token: randomUUID(),
+            mode,
+            port,
+            pid: process.pid,
+            claimedAt: new Date().toISOString(),
+            phase: "active",
+          };
+          await fs.writeFile(ownerFilePath, JSON.stringify(owner), "utf8");
+          return { type: "claimed" as const, owner, previousOwner };
+        });
+
+        if (result.type === "claimed") {
+          return result;
+        }
+        if (result.type === "blocked") {
+          throw createCleanupInProgressError(result.previousOwner.pid);
+        }
+        await sleep(lockRetryMs);
+      }
     },
     async replaceIfCurrent(token, nextOwner) {
       return await withOwnerLock(async () => {
@@ -159,18 +199,53 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
       });
     },
     async runCleanupIfCurrentOwner(token, cleanup) {
-      const shouldRunCleanup = await withOwnerLock(async () => {
+      const cleanupOwner = await withOwnerLock(async () => {
         const current = await readOwner();
         if (current?.token !== token) {
-          return false;
+          return null;
         }
-        await deleteOwnerFile();
-        return true;
+        // Mark cleanup in progress before releasing the lock so overlapping
+        // startups cannot claim exposure until this reset finishes or fails.
+        const nextOwner: TailscaleExposureOwnerRecord = {
+          ...current,
+          phase: "cleaning",
+          cleanupStartedAt: new Date().toISOString(),
+        };
+        await fs.writeFile(ownerFilePath, JSON.stringify(nextOwner), "utf8");
+        return nextOwner;
       });
-      if (!shouldRunCleanup) {
+      if (!cleanupOwner) {
         return false;
       }
-      await cleanup();
+
+      try {
+        await cleanup();
+      } catch (err) {
+        await withOwnerLock(async () => {
+          const current = await readOwner();
+          if (current?.token !== token || current.phase !== "cleaning") {
+            return;
+          }
+          await fs.writeFile(
+            ownerFilePath,
+            JSON.stringify({
+              ...cleanupOwner,
+              phase: "active",
+              cleanupStartedAt: undefined,
+            }),
+            "utf8",
+          );
+        }).catch(() => {});
+        throw err;
+      }
+
+      await withOwnerLock(async () => {
+        const current = await readOwner();
+        if (current?.token !== token || current.phase !== "cleaning") {
+          return;
+        }
+        await deleteOwnerFile();
+      });
       return true;
     },
   };
@@ -195,6 +270,12 @@ export async function startGatewayTailscaleExposure(params: {
   try {
     ({ owner, previousOwner } = await ownerStore.claim(params.tailscaleMode, params.port));
   } catch (err) {
+    if (isCleanupInProgressError(err)) {
+      params.logTailscale.warn(
+        `${params.tailscaleMode} ownership cleanup still in progress; skipping external exposure`,
+      );
+      return null;
+    }
     params.logTailscale.warn(
       `${params.tailscaleMode} ownership guard unavailable: ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -160,17 +160,12 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
 
   return {
     async claim(mode, port) {
+      const claimDeadline = Date.now() + cleanupClaimWaitMs;
       while (true) {
         const result = await withOwnerLock(async () => {
           const previousOwner = await readOwner();
           if (previousOwner?.phase === "cleaning" && isPidAlive(previousOwner.pid)) {
-            const cleanupStartedAtMs = Date.parse(
-              previousOwner.cleanupStartedAt ?? previousOwner.claimedAt,
-            );
-            const cleanupAgeMs = Number.isFinite(cleanupStartedAtMs)
-              ? Date.now() - cleanupStartedAtMs
-              : Number.POSITIVE_INFINITY;
-            if (cleanupAgeMs < cleanupClaimWaitMs) {
+            if (Date.now() < claimDeadline) {
               return { type: "wait" as const };
             }
             return { type: "blocked" as const, previousOwner };
@@ -214,9 +209,14 @@ function createTailscaleExposureOwnerStore(): TailscaleExposureOwnerStore {
     async runCleanupIfCurrentOwner(token, cleanup) {
       const cleanupOwner = await withOwnerLock(async () => {
         const current = await readOwner();
-        if (current?.token !== token) {
+        if (!current) {
           return null;
         }
+        if (current.token !== token && isPidAlive(current.pid)) {
+          return null;
+        }
+        // If a newer owner died without cleaning up, reclaim its stale exposure
+        // before this older process exits so resetOnExit still clears Tailscale.
         // Mark cleanup in progress before releasing the lock so overlapping
         // startups cannot claim exposure until this reset finishes or fails.
         const nextOwner: TailscaleExposureOwnerRecord = {
@@ -314,6 +314,9 @@ export async function startGatewayTailscaleExposure(params: {
     }
   } catch (err) {
     if (owner) {
+      // Restore the previous owner's original token so its own cleanup hook can
+      // still prove ownership later, or keep this failed owner if it needs to
+      // reset any partial/orphaned Tailscale state on exit.
       const nextOwner =
         previousOwner && isPidAlive(previousOwner.pid)
           ? previousOwner
@@ -331,15 +334,21 @@ export async function startGatewayTailscaleExposure(params: {
     return null;
   }
 
+  const disableExposure = async () => {
+    if (params.tailscaleMode === "serve") {
+      await disableTailscaleServe();
+    } else {
+      await disableTailscaleFunnel();
+    }
+  };
+
   return async () => {
     try {
       if (owner) {
+        // A failed enable can still leave behind partial or orphaned Tailscale
+        // config, so shutdown cleanup intentionally re-runs the global reset.
         const cleanedUp = await ownerStore.runCleanupIfCurrentOwner(owner.token, async () => {
-          if (params.tailscaleMode === "serve") {
-            await disableTailscaleServe();
-          } else {
-            await disableTailscaleFunnel();
-          }
+          await disableExposure();
         });
         if (!cleanedUp) {
           params.logTailscale.info(
@@ -349,15 +358,22 @@ export async function startGatewayTailscaleExposure(params: {
         return;
       }
 
-      if (params.tailscaleMode === "serve") {
-        await disableTailscaleServe();
-      } else {
-        await disableTailscaleFunnel();
-      }
+      await disableExposure();
     } catch (err) {
       params.logTailscale.warn(
         `${params.tailscaleMode} cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (!owner) {
+        return;
+      }
+      try {
+        await disableExposure();
+        params.logTailscale.warn(
+          `${params.tailscaleMode} cleanup guard failed; applied direct reset fallback`,
+        );
+      } catch {
+        // The direct reset failed too; keep the original warning above.
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary
- guard Tailscale Serve/Funnel cleanup so an older gateway process cannot clear exposure after a newer process has already taken ownership
- persist a small ownership record under the gateway lock dir and clear it only when the current owner exits
- add a regression test for overlapping gateway restarts and a startup-failure ownership cleanup test

## Why
On a host with `gateway.tailscale.mode=serve` and `gateway.tailscale.resetOnExit=true`, repeated gateway restarts can produce this sequence:
1. gateway A enables Tailscale Serve
2. gateway B starts and enables Serve again
3. gateway A exits and unconditionally runs `tailscale serve reset`
4. the still-running gateway B is left healthy on loopback, but no Tailscale Serve route remains

That matches the observed host behavior where the gateway kept logging `serve enabled` across multiple PIDs, but `tailscale serve status` later returned `No serve config`.

## Testing
- `pnpm test -- src/gateway/server-tailscale.test.ts src/infra/tailscale.test.ts`
