### PR TITLE
feat: add per-model thinking control for MiniMax/Kimi

### DIFF
--- a/docs/model-thinking-control.md
+++ b/docs/model-thinking-control.md
@@ -1,0 +1,87 @@
+# Per-Model Thinking Control
+
+## Problem
+
+Some third-party models (MiniMax M2.5, Moonshot Kimi K2.5) leak their internal thinking/reasoning process into the `text` content of responses. This is visible to end users and not desirable for production use.
+
+## Solution
+
+OpenClaw now supports per-model thinking control via `compat` configuration in `openclaw.json`:
+
+### Option 1: `thinkingFormat: "disabled"`
+
+Disable thinking tag parsing entirely for models that don't use structured thinking:
+
+```json
+{
+  "models": {
+    "minimax/m2.5": {
+      "compat": {
+        "thinkingFormat": "disabled"
+      }
+    }
+  }
+}
+```
+
+### Option 2: `disableThinking: true` (API-level suppression)
+
+For models that support API-level thinking suppression (like Kimi):
+
+```json
+{
+  "models": {
+    "moonshot/kimi-k2.5": {
+      "compat": {
+        "disableThinking": true
+      }
+    }
+  }
+}
+```
+
+This sends `thinking: { type: "disabled" }` in the API request to suppress thinking at the source.
+
+## Full Example
+
+```json
+{
+  "models": {
+    "providers": {
+      "minimax": {
+        "baseUrl": "https://api.minimax.chat/v1",
+        "apiKey": "${MINIMAX_API_KEY}",
+        "models": [
+          {
+            "id": "minimax/m2.5",
+            "name": "MiniMax M2.5",
+            "reasoning": true,
+            "compat": {
+              "thinkingFormat": "disabled"
+            }
+          }
+        ]
+      },
+      "moonshot": {
+        "baseUrl": "https://api.moonshot.cn/v1",
+        "apiKey": "${MOONSHOT_API_KEY}",
+        "models": [
+          {
+            "id": "moonshot/kimi-k2.5",
+            "name": "Kimi K2.5",
+            "reasoning": true,
+            "compat": {
+              "disableThinking": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Implementation Details
+
+- `thinkingFormat: "disabled"` - Strips all thinking tags, no special parsing
+- `disableThinking: true` - Sends API parameter to prevent thinking generation at source (model-dependent)

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -21,7 +21,8 @@ export type ModelCompatConfig = {
   supportsTools?: boolean;
   supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
-  thinkingFormat?: "openai" | "zai" | "qwen";
+  thinkingFormat?: "openai" | "zai" | "qwen" | "disabled";
+  disableThinking?: boolean; // Send API param to suppress thinking at source (for MiniMax, Kimi, etc.)
   requiresToolResultName?: boolean;
   requiresAssistantAfterToolResult?: boolean;
   requiresThinkingAsText?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -191,7 +191,10 @@ export const ModelCompatSchema = z
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
-    thinkingFormat: z.union([z.literal("openai"), z.literal("zai"), z.literal("qwen")]).optional(),
+    thinkingFormat: z
+      .union([z.literal("openai"), z.literal("zai"), z.literal("qwen"), z.literal("disabled")])
+      .optional(),
+    disableThinking: z.boolean().optional(), // Suppress thinking at API level (MiniMax, Kimi, etc.)
     requiresToolResultName: z.boolean().optional(),
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),


### PR DESCRIPTION
Fixes #47913

## Problem
Third-party models (MiniMax M2.5, Moonshot Kimi K2.5) leak thinking content into text.

## Solution

**Option 1: `thinkingFormat: "disabled"`**
```json
{"models": {"minimax/m2.5": {"compat": {"thinkingFormat": "disabled"}}}}
```

**Option 2: `disableThinking: true`**
```json
{"models": {"moonshot/kimi-k2.5": {"compat": {"disableThinking": true}}}}
```

## Files Changed
- src/config/types.models.ts
- src/config/zod-schema.core.ts  
- docs/model-thinking-control.md