### PR TITLE
fix: move fs.constants.W_OK access inside function to fix browser bundle

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 
 export const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
-const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
 
 type ResolvePreferredOpenClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
@@ -49,6 +48,7 @@ export function resolvePreferredOpenClawTmpDir(
       }
     });
   const tmpdir = options.tmpdir ?? os.tmpdir;
+  const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
   const uid = getuid();
 
   const isSecureDirForUser = (st: { mode?: number; uid?: number }): boolean => {


### PR DESCRIPTION
## Summary

Move `fs.constants.W_OK` access from module scope into the function where it is actually used, so it is only executed in Node.js context and not during browser bundle loading, which fixes the Control UI blank screen issue.

## Changes

- Moved fs.constants.W_OK access inside resolvePreferredOpenClawTmpDir function in src/infra/tmp-openclaw-dir.ts
- No other changes to functionality

## Testing

Verified that the module imports without error (no immediate fs.constants access), and the function still works correctly when called in Node.js context.

Fixes openclaw/openclaw#48062