### PR TITLE
fix(ui): show current context tokens instead of cumulative in Control UI

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -323,7 +323,38 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(result.content).toBe(
-      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **30%** of 4k\nModel: `gpt-4.1-mini`",
+      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **38%** of 4k\nModel: `gpt-4.1-mini`",
+    );
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("shows n/a for total usage when the current context snapshot is unavailable", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:main", {
+              model: "gpt-4.1-mini",
+              inputTokens: 1200,
+              outputTokens: 300,
+              contextTokens: 4000,
+              totalTokensFresh: false,
+            }),
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "usage",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **n/a** tokens\nModel: `gpt-4.1-mini`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
   });

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -302,15 +302,19 @@ async function executeUsage(
     }
     const input = session.inputTokens ?? 0;
     const output = session.outputTokens ?? 0;
-    const total = session.totalTokens ?? input + output;
+    const total =
+      session.totalTokensFresh === false || !Number.isFinite(session.totalTokens)
+        ? null
+        : (session.totalTokens ?? null);
     const ctx = session.contextTokens ?? 0;
-    const pct = ctx > 0 ? Math.round((input / ctx) * 100) : null;
+    const pct = total !== null && ctx > 0 ? Math.round((total / ctx) * 100) : null;
+    const totalDisplay = total === null ? "n/a" : fmtTokens(total);
 
     const lines = [
       "**Session Usage**",
       `Input: **${fmtTokens(input)}** tokens`,
       `Output: **${fmtTokens(output)}** tokens`,
-      `Total: **${fmtTokens(total)}** tokens`,
+      `Total: **${totalDisplay}** tokens`,
     ];
     if (pct !== null) {
       lines.push(`Context: **${pct}%** of ${fmtTokens(ctx)}`);


### PR DESCRIPTION
## Summary

- Problem: Control UI `/usage` displayed cumulative token totals when the current context snapshot was missing or stale.
- Why it matters: it disagrees with the TUI and misleads users about live context pressure.
- What changed: `/usage` now renders only fresh `totalTokens` snapshots, calculates context percentage from that value, and shows `n/a` when no current snapshot is available.
- What did NOT change (scope boundary): no gateway-side session accounting logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47885

## User-visible / Behavior Changes

- Control UI `/usage` now shows current-context totals only.
- When there is no fresh current-context total, it shows `Total: n/a` instead of synthesizing a cumulative number.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: n/a
- Integration/channel (if any): Control UI `/usage`
- Relevant config (redacted): n/a

### Steps

1. Open Control UI and run `/usage` for a session with `inputTokens`, `outputTokens`, `contextTokens`, and a fresh `totalTokens` snapshot.
2. Repeat for a session where `totalTokensFresh === false`.
3. Compare the displayed total/context values.

### Expected

- Fresh snapshots use current-context totals.
- Stale or missing snapshots render `n/a` instead of a synthesized cumulative total.

### Actual

- Before this change, Control UI fell back to cumulative `input + output` and computed the percentage from `inputTokens`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification command:

```bash
PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run --config vitest.node.config.ts src/ui/chat/slash-command-executor.node.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: fresh totals now report 38% of 4k for the fixture; stale totals show `n/a` and omit the context percentage.
- Edge cases checked: input/output token rendering remains unchanged.
- What you did **not** verify: a live browser session against the full Control UI shell.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `ui/src/ui/chat/slash-command-executor.ts`
- Known bad symptoms reviewers should watch for: missing totals when a fresh snapshot is actually present.

## Risks and Mitigations

- Risk: sessions without fresh totals now show less detail.
  - Mitigation: this is intentional and avoids presenting incorrect cumulative data as current context usage.
