### PR TITLE
fix: wire restart sentinel for /restart slash command

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -618,38 +618,8 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
-  const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
-  if (hasSigusr1Listener) {
-    // Write restart sentinel for post-restart notification
-    const { deliveryContext, threadId } = extractDeliveryInfo(params.sessionKey);
-    const payload: RestartSentinelPayload = {
-      kind: "restart",
-      status: "ok",
-      ts: Date.now(),
-      sessionKey: params.sessionKey,
-      deliveryContext,
-      threadId,
-      message: "/restart slash command",
-      doctorHint: formatDoctorNonInteractiveHint(),
-      stats: {
-        mode: "gateway.restart",
-        reason: "/restart",
-      },
-    };
-    await writeRestartSentinel(payload).catch(() => {
-      // ignore: sentinel is best-effort
-    });
-    scheduleGatewaySigusr1Restart({ reason: "/restart" });
-    return {
-      shouldContinue: false,
-      reply: {
-        text: "⚙️ Restarting OpenClaw in-process (SIGUSR1); back in a few seconds.",
-      },
-    };
-  }
-  // Write restart sentinel for post-restart notification
   const { deliveryContext, threadId } = extractDeliveryInfo(params.sessionKey);
-  const payload: RestartSentinelPayload = {
+  const sentinelPayload: RestartSentinelPayload = {
     kind: "restart",
     status: "ok",
     ts: Date.now(),
@@ -663,9 +633,21 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       reason: "/restart",
     },
   };
-  await writeRestartSentinel(payload).catch(() => {
-    // ignore: sentinel is best-effort
-  });
+  const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
+  if (hasSigusr1Listener) {
+    // SIGUSR1 is reliable — write sentinel before triggering restart
+    await writeRestartSentinel(sentinelPayload).catch(() => {
+      // ignore: sentinel is best-effort
+    });
+    scheduleGatewaySigusr1Restart({ reason: "/restart" });
+    return {
+      shouldContinue: false,
+      reply: {
+        text: "⚙️ Restarting OpenClaw in-process (SIGUSR1); back in a few seconds.",
+      },
+    };
+  }
+  // Fallback path: only write sentinel after confirming restart will proceed
   const restartMethod = triggerOpenClawRestart();
   if (!restartMethod.ok) {
     const detail = restartMethod.detail ? ` Details: ${restartMethod.detail}` : "";
@@ -676,6 +658,10 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
+  // Restart confirmed — write sentinel now
+  await writeRestartSentinel(sentinelPayload).catch(() => {
+    // ignore: sentinel is best-effort
+  });
   return {
     shouldContinue: false,
     reply: {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -9,9 +9,11 @@ import type { SessionBindingRecord } from "../../infra/outbound/session-binding-
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
 import {
   formatDoctorNonInteractiveHint,
+  resolveRestartSentinelPath,
   writeRestartSentinel,
   type RestartSentinelPayload,
 } from "../../infra/restart-sentinel.js";
+import fs from "node:fs/promises";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
@@ -647,9 +649,16 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
-  // Fallback path: only write sentinel after confirming restart will proceed
+  // Fallback path: write sentinel before triggering restart (process may be terminated immediately).
+  // On failure, clean up the orphaned sentinel file.
+  await writeRestartSentinel(sentinelPayload).catch(() => {
+    // ignore: sentinel is best-effort
+  });
   const restartMethod = triggerOpenClawRestart();
   if (!restartMethod.ok) {
+    // Clean up orphaned sentinel so it doesn't fire on next startup
+    const sentinelPath = resolveRestartSentinelPath();
+    await fs.unlink(sentinelPath).catch(() => {});
     const detail = restartMethod.detail ? ` Details: ${restartMethod.detail}` : "";
     return {
       shouldContinue: false,
@@ -658,10 +667,6 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
-  // Restart confirmed — write sentinel now
-  await writeRestartSentinel(sentinelPayload).catch(() => {
-    // ignore: sentinel is best-effort
-  });
   return {
     shouldContinue: false,
     reply: {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -1,11 +1,17 @@
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { formatThreadBindingDurationLabel } from "../../channels/thread-bindings-messages.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
+import { extractDeliveryInfo } from "../../config/sessions/delivery-info.js";
 import { isRestartEnabled } from "../../config/commands.js";
 import { logVerbose } from "../../globals.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
+import {
+  formatDoctorNonInteractiveHint,
+  writeRestartSentinel,
+  type RestartSentinelPayload,
+} from "../../infra/restart-sentinel.js";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
@@ -614,6 +620,25 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
   }
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
   if (hasSigusr1Listener) {
+    // Write restart sentinel for post-restart notification
+    const { deliveryContext, threadId } = extractDeliveryInfo(params.sessionKey);
+    const payload: RestartSentinelPayload = {
+      kind: "restart",
+      status: "ok",
+      ts: Date.now(),
+      sessionKey: params.sessionKey,
+      deliveryContext,
+      threadId,
+      message: "/restart slash command",
+      doctorHint: formatDoctorNonInteractiveHint(),
+      stats: {
+        mode: "gateway.restart",
+        reason: "/restart",
+      },
+    };
+    await writeRestartSentinel(payload).catch(() => {
+      // ignore: sentinel is best-effort
+    });
     scheduleGatewaySigusr1Restart({ reason: "/restart" });
     return {
       shouldContinue: false,
@@ -622,6 +647,25 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
       },
     };
   }
+  // Write restart sentinel for post-restart notification
+  const { deliveryContext, threadId } = extractDeliveryInfo(params.sessionKey);
+  const payload: RestartSentinelPayload = {
+    kind: "restart",
+    status: "ok",
+    ts: Date.now(),
+    sessionKey: params.sessionKey,
+    deliveryContext,
+    threadId,
+    message: "/restart slash command",
+    doctorHint: formatDoctorNonInteractiveHint(),
+    stats: {
+      mode: "gateway.restart",
+      reason: "/restart",
+    },
+  };
+  await writeRestartSentinel(payload).catch(() => {
+    // ignore: sentinel is best-effort
+  });
   const restartMethod = triggerOpenClawRestart();
   if (!restartMethod.ok) {
     const detail = restartMethod.detail ? ` Details: ${restartMethod.detail}` : "";


### PR DESCRIPTION
## Problem

When a user sends `/restart` on any channel (Telegram, Discord, etc.), they get an immediate "Restarting..." message but **no confirmation that the bot actually came back online**. The user has to send a test message to verify.

## Solution

Wire `handleRestartCommand` to call `writeRestartSentinel()` before triggering the restart, using the session's delivery context for routing. The existing `scheduleRestartSentinelWake` on startup handles the post-restart notification.

## Changes

- Import `writeRestartSentinel`, `extractDeliveryInfo`, and related types
- Write restart sentinel before both SIGUSR1 and fallback restart paths
- Captures sessionKey, deliveryContext, and threadId for proper routing after restart

## Testing

The sentinel mechanism is already tested and used by:
- `gateway.restart` tool
- Config apply/patch operations
- Update operations

This change brings `/restart` slash command in line with existing behavior.

Closes #48102