### PR TITLE
fix: correct Windows Chrome executable path extraction regex

### DIFF
--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -434,11 +434,11 @@ function expandWindowsEnvVars(value: string): string {
 }
 
 function extractWindowsExecutablePath(command: string): string | null {
-  const quoted = command.match(/"([^"]+\\.exe)"/i);
+  const quoted = command.match(/"([^"]+\.exe)"/i);
   if (quoted?.[1]) {
     return quoted[1];
   }
-  const unquoted = command.match(/([^\\s]+\\.exe)/i);
+  const unquoted = command.match(/(\S+\.exe)/i);
   if (unquoted?.[1]) {
     return unquoted[1];
   }


### PR DESCRIPTION
## Summary

Fix Chrome user profile attach functionality on Windows by correcting invalid regex patterns in `extractWindowsExecutablePath`:

- Removed extra backslash before `.exe` in quoted path regex that was preventing matches (the regex was incorrectly expecting `\.exe` instead of just `.exe` at the end of the path)
- Fixed unquoted path regex to properly handle Windows paths with backslashes (replaced invalid `[^\\s]+` pattern with `\S+` to match all non-whitespace characters including backslashes)
- Updated regex patterns to match all valid Windows executable paths ending with .exe

## Changes

- Only modified `src/browser/chrome.executables.ts`: updated the two regex patterns in the `extractWindowsExecutablePath` function
- No other functional changes

## Testing

Verified fix with test cases for both quoted and unquoted Windows paths, including paths with spaces, special characters, and different executable locations. All test cases now correctly extract the executable path.

Fixes openclaw/openclaw#48043