### PR TITLE
fix: replace "Benevolent Dictator" with "Lead Maintainer" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Welcome to the lobster tank! 🦞
 
 ## Maintainers
 
-- **Peter Steinberger** - Benevolent Dictator
+- **Peter Steinberger** - Lead Maintainer
   - GitHub: [@steipete](https://github.com/steipete) · X: [@steipete](https://x.com/steipete)
 
 - **Shadow** - Discord subsystem, Discord admin, Clawhub, all community moderation


### PR DESCRIPTION
## Summary

Replace the term "Benevolent Dictator" with the more neutral and friendly "Lead Maintainer" in CONTRIBUTING.md to improve project tone.

## Changes

- Modified CONTRIBUTING.md: replaced 1 occurrence of the term
- No functional changes

Fixes openclaw/openclaw#48061