### PR TITLE
feat(feishu): add document ownership transfer support to feishu_doc tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
+- Feishu/docs: add `feishu_doc` document ownership transfer support and default omitted `old_owner_perm` to `full_access`, carrying forward #48138. Thanks @Swt242.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.
 - Security/networking: add opt-in operator-managed outbound proxy routing (proxy.enabled + proxy.proxyUrl/OPENCLAW_PROXY_URL) with strict http:// forward-proxy validation, loopback-only Gateway bypass, and cleanup of proxy env/dispatcher state on exit. (#70044) Thanks @jesse-merhi and @joshavant.
 

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -177,6 +177,29 @@ export const FeishuDocSchema = Type.Union([
         'Text with color markup. Tags: [red], [green], [blue], [orange], [yellow], [purple], [grey], [bold], [bg:yellow]. Example: "Revenue [green]+15%[/green] YoY"',
     }),
   }),
+  // Transfer ownership
+  Type.Object({
+    action: Type.Literal("transfer"),
+    doc_token: Type.String({ description: "Document token" }),
+    member_type: Type.Union([Type.Literal("email"), Type.Literal("openid"), Type.Literal("userid")], {
+      description: "New owner's member type",
+    }),
+    member_id: Type.String({ description: "New owner's ID (email, openid, or userid)" }),
+    type: Type.Optional(
+      Type.Union([Type.Literal("doc"), Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")], {
+        description: "File type (default: docx)",
+        default: "docx",
+      }),
+    ),
+    options: Type.Optional(
+      Type.Object({
+        need_notification: Type.Optional(Type.Boolean({ description: "Notify new owner", default: true })),
+        remove_old_owner: Type.Optional(Type.Boolean({ description: "Remove old owner's permissions", default: false })),
+        stay_put: Type.Optional(Type.Boolean({ description: "Keep file in current location", default: false })),
+        old_owner_perm: Type.Optional(Type.String({ description: "Old owner's new permission level", default: "full_access" })),
+      }),
+    ),
+  }),
 ]);
 
 export type FeishuDocParams = Static<typeof FeishuDocSchema>;

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -181,22 +181,36 @@ export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("transfer"),
     doc_token: Type.String({ description: "Document token" }),
-    member_type: Type.Union([Type.Literal("email"), Type.Literal("openid"), Type.Literal("userid")], {
-      description: "New owner's member type",
-    }),
+    member_type: Type.Union(
+      [Type.Literal("email"), Type.Literal("openid"), Type.Literal("userid")],
+      {
+        description: "New owner's member type",
+      },
+    ),
     member_id: Type.String({ description: "New owner's ID (email, openid, or userid)" }),
     type: Type.Optional(
-      Type.Union([Type.Literal("doc"), Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")], {
-        description: "File type (default: docx)",
-        default: "docx",
-      }),
+      Type.Union(
+        [Type.Literal("doc"), Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")],
+        {
+          description: "File type (default: docx)",
+          default: "docx",
+        },
+      ),
     ),
     options: Type.Optional(
       Type.Object({
-        need_notification: Type.Optional(Type.Boolean({ description: "Notify new owner", default: true })),
-        remove_old_owner: Type.Optional(Type.Boolean({ description: "Remove old owner's permissions", default: false })),
-        stay_put: Type.Optional(Type.Boolean({ description: "Keep file in current location", default: false })),
-        old_owner_perm: Type.Optional(Type.String({ description: "Old owner's new permission level", default: "full_access" })),
+        need_notification: Type.Optional(
+          Type.Boolean({ description: "Notify new owner", default: true }),
+        ),
+        remove_old_owner: Type.Optional(
+          Type.Boolean({ description: "Remove old owner's permissions", default: false }),
+        ),
+        stay_put: Type.Optional(
+          Type.Boolean({ description: "Keep file in current location", default: false }),
+        ),
+        old_owner_perm: Type.Optional(
+          Type.String({ description: "Old owner's new permission level", default: "full_access" }),
+        ),
       }),
     ),
   }),

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -1,5 +1,7 @@
 import { Type, type Static } from "typebox";
 
+export const FEISHU_DOC_TRANSFER_DEFAULT_OLD_OWNER_PERM = "full_access";
+
 const tableCreationProperties = {
   doc_token: Type.String({ description: "Document token" }),
   parent_block_id: Type.Optional(
@@ -209,7 +211,10 @@ export const FeishuDocSchema = Type.Union([
           Type.Boolean({ description: "Keep file in current location", default: false }),
         ),
         old_owner_perm: Type.Optional(
-          Type.String({ description: "Old owner's new permission level", default: "full_access" }),
+          Type.String({
+            description: "Old owner's new permission level",
+            default: FEISHU_DOC_TRANSFER_DEFAULT_OLD_OWNER_PERM,
+          }),
         ),
       }),
     ),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -16,6 +16,7 @@ const blockChildrenBatchDeleteMock = vi.hoisted(() => vi.fn());
 const blockDescendantCreateMock = vi.hoisted(() => vi.fn());
 const driveUploadAllMock = vi.hoisted(() => vi.fn());
 const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
+const permissionMemberTransferOwnerMock = vi.hoisted(() => vi.fn());
 const blockPatchMock = vi.hoisted(() => vi.fn());
 const scopeListMock = vi.hoisted(() => vi.fn());
 const toolAccountModule = await import("./tool-account.js");
@@ -90,6 +91,7 @@ describe("feishu_doc image fetch hardening", () => {
         },
         permissionMember: {
           create: permissionMemberCreateMock,
+          transferOwner: permissionMemberTransferOwnerMock,
         },
       },
       application: {
@@ -140,6 +142,7 @@ describe("feishu_doc image fetch hardening", () => {
       data: { document: { document_id: "doc_created", title: "Created Doc" } },
     });
     permissionMemberCreateMock.mockResolvedValue({ code: 0 });
+    permissionMemberTransferOwnerMock.mockResolvedValue({ code: 0 });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
   });
@@ -429,6 +432,33 @@ describe("feishu_doc image fetch hardening", () => {
 
     expect(permissionMemberCreateMock).not.toHaveBeenCalled();
     expect(result.details.requester_permission_added).toBeUndefined();
+  });
+
+  it("defaults omitted transfer old_owner_perm to full_access", async () => {
+    const feishuDocTool = resolveFeishuDocTool();
+
+    const result = await executeFeishuDocTool(feishuDocTool, {
+      action: "transfer",
+      doc_token: "doc_1",
+      member_type: "email",
+      member_id: "new-owner@example.com",
+    });
+
+    expect(result.details.success).toBe(true);
+    expect(permissionMemberTransferOwnerMock).toHaveBeenCalledWith({
+      path: { token: "doc_1" },
+      params: {
+        type: "docx",
+        need_notification: true,
+        remove_old_owner: false,
+        stay_put: false,
+        old_owner_perm: "full_access",
+      },
+      data: {
+        member_type: "email",
+        member_id: "new-owner@example.com",
+      },
+    });
   });
 
   it("returns an error when create response omits document_id", async () => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -140,7 +140,7 @@ async function transferOwnership(
       need_notification: options?.need_notification ?? true,
       remove_old_owner: options?.remove_old_owner ?? false,
       stay_put: options?.stay_put ?? false,
-      old_owner_perm: options?.old_owner_perm,
+      old_owner_perm: options?.old_owner_perm ?? "full_access",
     },
     data: {
       member_type: memberType as "email" | "openid" | "userid",

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -147,7 +147,7 @@ async function transferOwnership(
       member_id: memberId,
     },
   });
-  
+
   if (res.code !== 0) {
     throw new Error(res.msg);
   }

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -119,6 +119,47 @@ function cleanBlocksForInsert(blocks: FeishuDocxBlock[]): {
 
 // ============ Core Functions ============
 
+/** Transfer document ownership to another user */
+async function transferOwnership(
+  client: Lark.Client,
+  docToken: string,
+  memberType: string,
+  memberId: string,
+  fileType: string,
+  options?: {
+    need_notification?: boolean;
+    remove_old_owner?: boolean;
+    stay_put?: boolean;
+    old_owner_perm?: string;
+  },
+) {
+  const res = await client.drive.permissionMember.transferOwner({
+    path: { token: docToken },
+    params: {
+      type: fileType as "doc" | "docx" | "sheet" | "bitable" | "file" | "wiki" | "mindnote",
+      need_notification: options?.need_notification ?? true,
+      remove_old_owner: options?.remove_old_owner ?? false,
+      stay_put: options?.stay_put ?? false,
+      old_owner_perm: options?.old_owner_perm,
+    },
+    data: {
+      member_type: memberType as "email" | "openid" | "userid",
+      member_id: memberId,
+    },
+  });
+  
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    success: true,
+    message: "Document ownership transferred successfully",
+    new_owner: memberId,
+    file_token: docToken,
+  };
+}
+
 /** Max blocks per documentBlockChildren.create request */
 const MAX_BLOCKS_PER_INSERT = 50;
 const MAX_CONVERT_RETRY_DEPTH = 8;
@@ -1577,6 +1618,17 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       p.row_end,
                       p.column_start,
                       p.column_end,
+                    ),
+                  );
+                case "transfer":
+                  return json(
+                    await transferOwnership(
+                      client,
+                      p.doc_token,
+                      p.member_type,
+                      p.member_id,
+                      p.type ?? "docx",
+                      p.options,
                     ),
                   );
                 default:

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -8,7 +8,11 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
+import {
+  FEISHU_DOC_TRANSFER_DEFAULT_OLD_OWNER_PERM,
+  FeishuDocSchema,
+  type FeishuDocParams,
+} from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
 import { updateColorText } from "./docx-color-text.js";
 import {
@@ -133,6 +137,7 @@ async function transferOwnership(
     old_owner_perm?: string;
   },
 ) {
+  const oldOwnerPerm = options?.old_owner_perm ?? FEISHU_DOC_TRANSFER_DEFAULT_OLD_OWNER_PERM;
   const res = await client.drive.permissionMember.transferOwner({
     path: { token: docToken },
     params: {
@@ -140,7 +145,7 @@ async function transferOwnership(
       need_notification: options?.need_notification ?? true,
       remove_old_owner: options?.remove_old_owner ?? false,
       stay_put: options?.stay_put ?? false,
-      old_owner_perm: options?.old_owner_perm ?? "full_access",
+      old_owner_perm: oldOwnerPerm,
     },
     data: {
       member_type: memberType as "email" | "openid" | "userid",


### PR DESCRIPTION
# PR: 为 feishu_doc 工具添加文档所有权转移功能

## 📋 问题描述

当前 `feishu_doc` 工具不支持转移飞书文档所有权，用户创建文档后无法通过 API 将文档所有权转移给自己。这导致：

1. 用户只有编辑权限，无法分享或管理文档
2. 需要手动在飞书界面操作转移所有权
3. 无法实现自动化的文档管理流程

## ✨ 解决方案

在 `feishu_doc` 工具中新增 `transfer` action，支持通过 API 转移飞书文档所有权。

### 新增功能

```typescript
{
  action: "transfer",
  doc_token: "文档 token",
  member_type: "openid" | "email" | "userid",
  member_id: "用户 ID",
  type: "docx" | "doc" | "sheet" | "bitable", // 可选，默认 docx
  options: {
    need_notification: true,      // 是否通知新所有者
    remove_old_owner: false,      // 是否移除旧所有者权限
    stay_put: false,              // 是否保持文件位置
    old_owner_perm: "full_access" // 旧所有者的新权限级别
  }
}
```

### 使用示例

```typescript
// 转移文档所有权
{
  action: "transfer",
  doc_token: "Jk0wdd1SpoqiWNxk1KfcIIrEnWe",
  member_type: "openid",
  member_id: "ou_253f74e872b10b9499768b782aab5e9b",
  type: "docx",
  options: {
    need_notification: true,
    remove_old_owner: false
  }
}
```

### 返回结果

```json
{
  "success": true,
  "message": "Document ownership transferred successfully",
  "new_owner": "ou_253f74e872b10b9499768b782aab5e9b",
  "file_token": "Jk0wdd1SpoqiWNxk1KfcIIrEnWe"
}
```

## 📝 修改文件

### 1. `/extensions/feishu/src/doc-schema.ts`

添加 `transfer` action 的 schema 定义：

```typescript
// Transfer ownership
Type.Object({
  action: Type.Literal("transfer"),
  doc_token: Type.String({ description: "Document token" }),
  member_type: Type.Union([Type.Literal("email"), Type.Literal("openid"), Type.Literal("userid")], {
    description: "New owner's member type",
  }),
  member_id: Type.String({ description: "New owner's ID (email, openid, or userid)" }),
  type: Type.Optional(
    Type.Union([Type.Literal("doc"), Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")], {
      description: "File type (default: docx)",
      default: "docx",
    }),
  ),
  options: Type.Optional(
    Type.Object({
      need_notification: Type.Optional(Type.Boolean({ description: "Notify new owner", default: true })),
      remove_old_owner: Type.Optional(Type.Boolean({ description: "Remove old owner's permissions", default: false })),
      stay_put: Type.Optional(Type.Boolean({ description: "Keep file in current location", default: false })),
      old_owner_perm: Type.Optional(Type.String({ description: "Old owner's new permission level", default: "full_access" })),
    }),
  ),
}),
```

### 2. `/extensions/feishu/src/docx.ts`

添加 `transferOwnership` 函数实现：

```typescript
/** Transfer document ownership to another user */
async function transferOwnership(
  client: Lark.Client,
  docToken: string,
  memberType: string,
  memberId: string,
  fileType: string,
  options?: {
    need_notification?: boolean;
    remove_old_owner?: boolean;
    stay_put?: boolean;
    old_owner_perm?: string;
  },
) {
  const res = await client.drive.permissionMember.transferOwner({
    path: { token: docToken },
    params: {
      type: fileType as "doc" | "docx" | "sheet" | "bitable" | "file" | "wiki" | "mindnote",
      need_notification: options?.need_notification ?? true,
      remove_old_owner: options?.remove_old_owner ?? false,
      stay_put: options?.stay_put ?? false,
      old_owner_perm: options?.old_owner_perm,
    },
    data: {
      member_type: memberType as "email" | "openid" | "userid",
      member_id: memberId,
    },
  });
  
  if (res.code !== 0) {
    throw new Error(res.msg);
  }

  return {
    success: true,
    message: "Document ownership transferred successfully",
    new_owner: memberId,
    file_token: docToken,
  };
}
```

在工具执行的 switch 语句中添加 `transfer` case：

```typescript
case "transfer":
  return json(
    await transferOwnership(
      client,
      p.doc_token,
      p.member_type,
      p.member_id,
      p.type ?? "docx",
      p.options,
    ),
  );
```

## 🔧 技术细节

### API 调用

使用飞书开放平台 API：
- **端点**: `POST /open-apis/drive/v1/permissions/:token/members/transfer_owner`
- **SDK 方法**: `client.drive.permissionMember.transferOwner()`
- **所需权限**: `docs:permission.member:transfer`

### 参数说明

| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| `doc_token` | string | 是 | 文档 token |
| `member_type` | string | 是 | 新所有者类型 (email/openid/userid) |
| `member_id` | string | 是 | 新所有者 ID |
| `type` | string | 否 | 文件类型，默认 docx |
| `options.need_notification` | boolean | 否 | 是否通知新所有者，默认 true |
| `options.remove_old_owner` | boolean | 否 | 是否移除旧所有者权限，默认 false |
| `options.stay_put` | boolean | 否 | 是否保持文件位置，默认 false |
| `options.old_owner_perm` | string | 否 | 旧所有者的新权限级别，默认 full_access |

## ✅ 测试验证

已在实际环境中测试通过：

```typescript
// 测试用例 1: 基本转移
{
  action: "transfer",
  doc_token: "YdX1deuoKoncFWx1jhqcxCEHnuh",
  member_type: "openid",
  member_id: "ou_253f74e872b10b9499768b782aab5e9b",
  type: "docx"
}
// ✅ 成功转移

// 测试用例 2: 带选项转移
{
  action: "transfer",
  doc_token: "Jk0wdd1SpoqiWNxk1KfcIIrEnWe",
  member_type: "openid",
  member_id: "ou_253f74e872b10b9499768b782aab5e9b",
  options: {
    need_notification: true,
    remove_old_owner: false
  }
}
// ✅ 成功转移
```

## 📚 相关文档

- [飞书开放平台 - 转移云文档所有者](https://open.feishu.cn/document/server-docs/docs/permission/permission-member/transfer_owner)
- [OpenClaw Feishu 文档工具](https://docs.openclaw.ai/tools/feishu-doc)

## 🎯 使用场景

1. **自动化文档创建**: 创建文档后自动转移所有权给用户
2. **批量文档管理**: 批量转移多个文档的所有权
3. **团队协作**: 在项目交接时转移文档所有权
4. **权限管理**: 确保用户始终拥有自己文档的完整控制权

## 📌 注意事项

1. 调用者必须是文档的当前所有者
2. 需要 `docs:permission.member:transfer` 权限
3. 转移后原所有者权限由 `remove_old_owner` 和 `old_owner_perm` 控制
4. 个人文件夹中的文档转移后默认移动到新所有者的空间（可通过 `stay_put` 控制）

## 🔄 后续优化建议

1. 添加批量转移功能
2. 支持转移 Bitable、Sheet 等其他文件类型
3. 添加转移历史记录查询
4. 支持转移前权限检查

---

**Related Issues**: N/A
**Breaking Changes**: No
**Test Coverage**: Manual testing completed
