### PR TITLE
feat(feishu): expose directory peer email fields

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -444,7 +444,14 @@ describe("feishuPlugin actions", () => {
 
   it("lists directory-backed peers and groups", async () => {
     listFeishuDirectoryGroupsLiveMock.mockResolvedValueOnce([{ kind: "group", id: "oc_group_1" }]);
-    listFeishuDirectoryPeersLiveMock.mockResolvedValueOnce([{ kind: "user", id: "ou_1" }]);
+    listFeishuDirectoryPeersLiveMock.mockResolvedValueOnce([
+      {
+        kind: "user",
+        id: "ou_1",
+        email: "alice@example.com",
+        enterprise_email: "alice@corp.example.com",
+      },
+    ]);
 
     const result = await feishuPlugin.actions?.handleAction?.({
       action: "channel-list",
@@ -470,7 +477,13 @@ describe("feishuPlugin actions", () => {
     expect(result?.details).toMatchObject({
       ok: true,
       groups: [expect.objectContaining({ id: "oc_group_1" })],
-      peers: [expect.objectContaining({ id: "ou_1" })],
+      peers: [
+        expect.objectContaining({
+          id: "ou_1",
+          email: "alice@example.com",
+          enterprise_email: "alice@corp.example.com",
+        }),
+      ],
     });
   });
 

--- a/extensions/feishu/src/directory.static.ts
+++ b/extensions/feishu/src/directory.static.ts
@@ -10,6 +10,8 @@ export type FeishuDirectoryPeer = {
   kind: "user";
   id: string;
   name?: string;
+  email?: string;
+  enterprise_email?: string;
 };
 
 export type FeishuDirectoryGroup = {

--- a/extensions/feishu/src/directory.test.ts
+++ b/extensions/feishu/src/directory.test.ts
@@ -78,6 +78,47 @@ describe("feishu directory (config-backed)", () => {
     ]);
   });
 
+  it("returns email fields from live peer lookup and matches email queries", async () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      ...makeStaticAccount(),
+      configured: true,
+    });
+    createFeishuClientMock.mockReturnValueOnce({
+      contact: {
+        user: {
+          list: vi.fn(async () => ({
+            code: 0,
+            data: {
+              items: [
+                {
+                  open_id: "ou_1",
+                  name: "Alice",
+                  email: "alice@example.com",
+                  enterprise_email: "alice@corp.example.com",
+                },
+              ],
+            },
+          })),
+        },
+      },
+    });
+
+    const peers = await listFeishuDirectoryPeersLive({
+      cfg,
+      query: "corp.example.com",
+      fallbackToStatic: false,
+    });
+    expect(peers).toEqual([
+      {
+        kind: "user",
+        id: "ou_1",
+        name: "Alice",
+        email: "alice@example.com",
+        enterprise_email: "alice@corp.example.com",
+      },
+    ]);
+  });
+
   it("surfaces live peer lookup failures when fallback is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValueOnce({
       ...makeStaticAccount(),

--- a/extensions/feishu/src/directory.ts
+++ b/extensions/feishu/src/directory.ts
@@ -41,11 +41,21 @@ export async function listFeishuDirectoryPeersLive(params: {
       if (user.open_id) {
         const q = params.query?.trim().toLowerCase() || "";
         const name = user.name || "";
-        if (!q || user.open_id.toLowerCase().includes(q) || name.toLowerCase().includes(q)) {
+        const email = user.email || "";
+        const enterpriseEmail = user.enterprise_email || "";
+        if (
+          !q ||
+          user.open_id.toLowerCase().includes(q) ||
+          name.toLowerCase().includes(q) ||
+          email.toLowerCase().includes(q) ||
+          enterpriseEmail.toLowerCase().includes(q)
+        ) {
           peers.push({
             kind: "user",
             id: user.open_id,
             name: name || undefined,
+            email: email || undefined,
+            enterprise_email: enterpriseEmail || undefined,
           });
         }
       }


### PR DESCRIPTION
## Summary

- Problem: Feishu directory live peer lookup only returned `id` and `name`, even though Feishu user/member payloads already expose `email` and `enterprise_email`.
- Why it matters: some Feishu send/target flows already support `email`, but directory lookup could not surface email fields for discovery/query, which blocked email-based lookup workflows.
- What changed: extended `FeishuDirectoryPeer` with `email` and `enterprise_email`, populated those fields in live directory results, and included both fields in query matching.
- What did NOT change (scope boundary): static/config-backed directory entries were not enriched; no new tool/action was added; no send/auth/token flow was changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR


## User-visible / Behavior Changes

- Feishu `channel-list` / directory live peer results now include `email` and `enterprise_email` when the upstream Feishu API returns them.
- Peer lookup query matching now also matches against `email` and `enterprise_email`.
- No config changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: local OpenClaw repo checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): N/A for unit tests

### Steps

1. Mock Feishu `contact.user.list` to return a user with `open_id`, `name`, `email`, and `enterprise_email`.
2. Call `listFeishuDirectoryPeersLive()` with a query matching the email domain.
3. Invoke Feishu `channel-list` action and inspect returned peer payloads.

### Expected

- Live directory peers include `email` and `enterprise_email`.
- Query matching works on those fields.
- Existing directory/channel tests continue to pass.

### Actual

- Verified: both email fields are returned and matched; Feishu extension tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added/updated tests in `extensions/feishu/src/directory.test.ts` and `extensions/feishu/src/channel.test.ts`; verified `29` tests passing under `vitest.extensions.config.ts`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Live peer lookup returns `email` / `enterprise_email`
  - Query by email domain matches expected peer
  - `channel-list` action returns enriched peer payloads
- Edge cases checked:
  - Existing failure path for live lookup still throws/falls back as before
  - Group directory behavior unchanged
- What you did **not** verify:
  - Real Feishu tenant against live credentials
  - Static/config-backed directory entries with email enrichment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit or remove the added fields from `extensions/feishu/src/directory.ts` / `directory.static.ts`
- Files/config to restore:
  - `extensions/feishu/src/directory.ts`
  - `extensions/feishu/src/directory.static.ts`
  - related tests
- Known bad symptoms reviewers should watch for:
  - callers assuming peer objects only contain `id`/`name`
  - unexpected empty email fields when Feishu API omits them

## Risks and Mitigations

- Risk: some downstream code may implicitly assume a narrower peer object shape.
  - Mitigation: change is additive only; existing fields and behavior remain unchanged.
- Risk: users may expect static/config-backed directory entries to also include email fields.
  - Mitigation: PR scope is explicitly limited to live directory results only.
