### PR TITLE
Fix Control UI blank screen from server-only thinking import

### DIFF
--- a/src/auto-reply/thinking-shared.ts
+++ b/src/auto-reply/thinking-shared.ts
@@ -1,0 +1,253 @@
+export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+export type VerboseLevel = "off" | "on" | "full";
+export type NoticeLevel = "off" | "on" | "full";
+export type ElevatedLevel = "off" | "on" | "ask" | "full";
+export type ElevatedMode = "off" | "ask" | "full";
+export type ReasoningLevel = "off" | "on" | "stream";
+export type UsageDisplayLevel = "off" | "tokens" | "full";
+export type ThinkingCatalogEntry = {
+    provider: string;
+    id: string;
+    reasoning?: boolean;
+};
+
+const CLAUDE_46_MODEL_RE = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
+
+export function normalizeProviderId(provider?: string | null): string {
+    if (!provider) {
+        return "";
+    }
+    const normalized = provider.trim().toLowerCase();
+    if (normalized === "z.ai" || normalized === "z-ai") {
+        return "zai";
+    }
+    if (normalized === "bedrock" || normalized === "aws-bedrock") {
+        return "amazon-bedrock";
+    }
+    return normalized;
+}
+
+export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined {
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.trim().toLowerCase();
+    const collapsed = key.replace(/[\s_-]+/g, "");
+    if (collapsed === "adaptive" || collapsed === "auto") {
+        return "adaptive";
+    }
+    if (collapsed === "xhigh" || collapsed === "extrahigh") {
+        return "xhigh";
+    }
+    if (["off"].includes(key)) {
+        return "off";
+    }
+    if (["on", "enable", "enabled"].includes(key)) {
+        return "low";
+    }
+    if (["min", "minimal"].includes(key)) {
+        return "minimal";
+    }
+    if (["low", "thinkhard", "think-hard", "think_hard"].includes(key)) {
+        return "low";
+    }
+    if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
+        return "medium";
+    }
+    if (
+        ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(
+            key,
+        )
+    ) {
+        return "high";
+    }
+    if (["think"].includes(key)) {
+        return "minimal";
+    }
+    return undefined;
+}
+
+export function listThinkingLevels(params?: { supportsXHigh?: boolean }): ThinkLevel[] {
+    const levels: ThinkLevel[] = ["off", "minimal", "low", "medium", "high"];
+    if (params?.supportsXHigh) {
+        levels.push("xhigh");
+    }
+    levels.push("adaptive");
+    return levels;
+}
+
+export function listThinkingLevelLabels(params?: {
+    isBinary?: boolean;
+    supportsXHigh?: boolean;
+}): string[] {
+    if (params?.isBinary) {
+        return ["off", "on"];
+    }
+    return listThinkingLevels({ supportsXHigh: params?.supportsXHigh });
+}
+
+export function formatThinkingLevelLabels(params?: {
+    isBinary?: boolean;
+    supportsXHigh?: boolean;
+    separator?: string;
+}): string {
+    return listThinkingLevelLabels({
+        isBinary: params?.isBinary,
+        supportsXHigh: params?.supportsXHigh,
+    }).join(params?.separator ?? ", ");
+}
+
+export function formatThinkingLevels(
+    _provider?: string | null,
+    _model?: string | null,
+    separator = ", ",
+): string {
+    return formatThinkingLevelLabels({ separator });
+}
+
+export function resolveThinkingDefaultForModelFallback(params: {
+    provider: string;
+    model: string;
+    catalog?: ThinkingCatalogEntry[];
+}): ThinkLevel {
+    const normalizedProvider = normalizeProviderId(params.provider);
+    const modelLower = params.model.trim().toLowerCase();
+    const candidate = params.catalog?.find(
+        (entry) => entry.provider === params.provider && entry.id === params.model,
+    );
+
+    if (normalizedProvider === "amazon-bedrock" && CLAUDE_46_MODEL_RE.test(modelLower)) {
+        return "adaptive";
+    }
+    if (candidate?.reasoning) {
+        return "low";
+    }
+    return "off";
+}
+
+export function resolveThinkingDefaultForModel(params: {
+    provider: string;
+    model: string;
+    catalog?: ThinkingCatalogEntry[];
+}): ThinkLevel {
+    return resolveThinkingDefaultForModelFallback(params);
+}
+
+type OnOffFullLevel = "off" | "on" | "full";
+
+function normalizeOnOffFullLevel(raw?: string | null): OnOffFullLevel | undefined {
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.toLowerCase();
+    if (["off", "false", "no", "0"].includes(key)) {
+        return "off";
+    }
+    if (["full", "all", "everything"].includes(key)) {
+        return "full";
+    }
+    if (["on", "minimal", "true", "yes", "1"].includes(key)) {
+        return "on";
+    }
+    return undefined;
+}
+
+export function normalizeVerboseLevel(raw?: string | null): VerboseLevel | undefined {
+    return normalizeOnOffFullLevel(raw);
+}
+
+export function normalizeNoticeLevel(raw?: string | null): NoticeLevel | undefined {
+    return normalizeOnOffFullLevel(raw);
+}
+
+export function normalizeUsageDisplay(raw?: string | null): UsageDisplayLevel | undefined {
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.toLowerCase();
+    if (["off", "false", "no", "0", "disable", "disabled"].includes(key)) {
+        return "off";
+    }
+    if (["on", "true", "yes", "1", "enable", "enabled"].includes(key)) {
+        return "tokens";
+    }
+    if (["tokens", "token", "tok", "minimal", "min"].includes(key)) {
+        return "tokens";
+    }
+    if (["full", "session"].includes(key)) {
+        return "full";
+    }
+    return undefined;
+}
+
+export function resolveResponseUsageMode(raw?: string | null): UsageDisplayLevel {
+    return normalizeUsageDisplay(raw) ?? "off";
+}
+
+export function normalizeFastMode(raw?: string | boolean | null): boolean | undefined {
+    if (typeof raw === "boolean") {
+        return raw;
+    }
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.toLowerCase();
+    if (["off", "false", "no", "0", "disable", "disabled", "normal"].includes(key)) {
+        return false;
+    }
+    if (["on", "true", "yes", "1", "enable", "enabled", "fast"].includes(key)) {
+        return true;
+    }
+    return undefined;
+}
+
+export function normalizeElevatedLevel(raw?: string | null): ElevatedLevel | undefined {
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.toLowerCase();
+    if (["off", "false", "no", "0"].includes(key)) {
+        return "off";
+    }
+    if (["full", "auto", "auto-approve", "autoapprove"].includes(key)) {
+        return "full";
+    }
+    if (["ask", "prompt", "approval", "approve"].includes(key)) {
+        return "ask";
+    }
+    if (["on", "true", "yes", "1"].includes(key)) {
+        return "on";
+    }
+    return undefined;
+}
+
+export function resolveElevatedMode(level?: ElevatedLevel | null): ElevatedMode {
+    if (!level || level === "off") {
+        return "off";
+    }
+    if (level === "full") {
+        return "full";
+    }
+    return "ask";
+}
+
+export function normalizeReasoningLevel(raw?: string | null): ReasoningLevel | undefined {
+    if (!raw) {
+        return undefined;
+    }
+    const key = raw.toLowerCase();
+    if (["off", "false", "no", "0", "hide", "hidden", "disable", "disabled"].includes(key)) {
+        return "off";
+    }
+    if (["on", "true", "yes", "1", "show", "visible", "enable", "enabled"].includes(key)) {
+        return "on";
+    }
+    if (["stream", "streaming", "draft", "live"].includes(key)) {
+        return "stream";
+    }
+    return undefined;
+}
+
+export function formatXHighModelHint(): string {
+    return "provider models that advertise xhigh reasoning";
+}

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -3,35 +3,37 @@ import {
   resolveProviderDefaultThinkingLevel,
   resolveProviderXHighThinking,
 } from "../plugins/provider-runtime.js";
+import {
+  formatThinkingLevelLabels,
+  listThinkingLevels as listSharedThinkingLevels,
+  normalizeProviderId,
+  resolveThinkingDefaultForModelFallback,
+  type ThinkLevel,
+  type ThinkingCatalogEntry,
+} from "./thinking-shared.js";
 
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
-export type VerboseLevel = "off" | "on" | "full";
-export type NoticeLevel = "off" | "on" | "full";
-export type ElevatedLevel = "off" | "on" | "ask" | "full";
-export type ElevatedMode = "off" | "ask" | "full";
-export type ReasoningLevel = "off" | "on" | "stream";
-export type UsageDisplayLevel = "off" | "tokens" | "full";
-export type ThinkingCatalogEntry = {
-  provider: string;
-  id: string;
-  reasoning?: boolean;
-};
-
-const CLAUDE_46_MODEL_RE = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
-
-function normalizeProviderId(provider?: string | null): string {
-  if (!provider) {
-    return "";
-  }
-  const normalized = provider.trim().toLowerCase();
-  if (normalized === "z.ai" || normalized === "z-ai") {
-    return "zai";
-  }
-  if (normalized === "bedrock" || normalized === "aws-bedrock") {
-    return "amazon-bedrock";
-  }
-  return normalized;
-}
+export type {
+  ElevatedLevel,
+  ElevatedMode,
+  NoticeLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  ThinkingCatalogEntry,
+  UsageDisplayLevel,
+  VerboseLevel,
+} from "./thinking-shared.js";
+export {
+  formatXHighModelHint,
+  normalizeElevatedLevel,
+  normalizeFastMode,
+  normalizeNoticeLevel,
+  normalizeReasoningLevel,
+  normalizeThinkLevel,
+  normalizeUsageDisplay,
+  normalizeVerboseLevel,
+  resolveElevatedMode,
+  resolveResponseUsageMode,
+} from "./thinking-shared.js";
 
 export function isBinaryThinkingProvider(provider?: string | null, model?: string | null): boolean {
   const normalizedProvider = normalizeProviderId(provider);
@@ -50,45 +52,6 @@ export function isBinaryThinkingProvider(provider?: string | null, model?: strin
     return pluginDecision;
   }
   return false;
-}
-
-// Normalize user-provided thinking level strings to the canonical enum.
-export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.trim().toLowerCase();
-  const collapsed = key.replace(/[\s_-]+/g, "");
-  if (collapsed === "adaptive" || collapsed === "auto") {
-    return "adaptive";
-  }
-  if (collapsed === "xhigh" || collapsed === "extrahigh") {
-    return "xhigh";
-  }
-  if (["off"].includes(key)) {
-    return "off";
-  }
-  if (["on", "enable", "enabled"].includes(key)) {
-    return "low";
-  }
-  if (["min", "minimal"].includes(key)) {
-    return "minimal";
-  }
-  if (["low", "thinkhard", "think-hard", "think_hard"].includes(key)) {
-    return "low";
-  }
-  if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
-    return "medium";
-  }
-  if (
-    ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
-  ) {
-    return "high";
-  }
-  if (["think"].includes(key)) {
-    return "minimal";
-  }
-  return undefined;
 }
 
 export function supportsXHighThinking(provider?: string | null, model?: string | null): boolean {
@@ -113,12 +76,7 @@ export function supportsXHighThinking(provider?: string | null, model?: string |
 }
 
 export function listThinkingLevels(provider?: string | null, model?: string | null): ThinkLevel[] {
-  const levels: ThinkLevel[] = ["off", "minimal", "low", "medium", "high"];
-  if (supportsXHighThinking(provider, model)) {
-    levels.push("xhigh");
-  }
-  levels.push("adaptive");
-  return levels;
+  return listSharedThinkingLevels({ supportsXHigh: supportsXHighThinking(provider, model) });
 }
 
 export function listThinkingLevelLabels(provider?: string | null, model?: string | null): string[] {
@@ -133,11 +91,11 @@ export function formatThinkingLevels(
   model?: string | null,
   separator = ", ",
 ): string {
-  return listThinkingLevelLabels(provider, model).join(separator);
-}
-
-export function formatXHighModelHint(): string {
-  return "provider models that advertise xhigh reasoning";
+  return formatThinkingLevelLabels({
+    isBinary: isBinaryThinkingProvider(provider, model),
+    supportsXHigh: supportsXHighThinking(provider, model),
+    separator,
+  });
 }
 
 export function resolveThinkingDefaultForModel(params: {
@@ -146,148 +104,18 @@ export function resolveThinkingDefaultForModel(params: {
   catalog?: ThinkingCatalogEntry[];
 }): ThinkLevel {
   const normalizedProvider = normalizeProviderId(params.provider);
-  const modelLower = params.model.trim().toLowerCase();
-  const candidate = params.catalog?.find(
-    (entry) => entry.provider === params.provider && entry.id === params.model,
-  );
   const pluginDecision = resolveProviderDefaultThinkingLevel({
     provider: normalizedProvider,
     context: {
       provider: normalizedProvider,
       modelId: params.model,
-      reasoning: candidate?.reasoning,
+      reasoning: params.catalog?.find(
+        (entry) => entry.provider === params.provider && entry.id === params.model,
+      )?.reasoning,
     },
   });
   if (pluginDecision) {
     return pluginDecision;
   }
-
-  if (normalizedProvider === "amazon-bedrock" && CLAUDE_46_MODEL_RE.test(modelLower)) {
-    return "adaptive";
-  }
-  if (candidate?.reasoning) {
-    return "low";
-  }
-  return "off";
-}
-
-type OnOffFullLevel = "off" | "on" | "full";
-
-function normalizeOnOffFullLevel(raw?: string | null): OnOffFullLevel | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.toLowerCase();
-  if (["off", "false", "no", "0"].includes(key)) {
-    return "off";
-  }
-  if (["full", "all", "everything"].includes(key)) {
-    return "full";
-  }
-  if (["on", "minimal", "true", "yes", "1"].includes(key)) {
-    return "on";
-  }
-  return undefined;
-}
-
-// Normalize verbose flags used to toggle agent verbosity.
-export function normalizeVerboseLevel(raw?: string | null): VerboseLevel | undefined {
-  return normalizeOnOffFullLevel(raw);
-}
-
-// Normalize system notice flags used to toggle system notifications.
-export function normalizeNoticeLevel(raw?: string | null): NoticeLevel | undefined {
-  return normalizeOnOffFullLevel(raw);
-}
-
-// Normalize response-usage display modes used to toggle per-response usage footers.
-export function normalizeUsageDisplay(raw?: string | null): UsageDisplayLevel | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.toLowerCase();
-  if (["off", "false", "no", "0", "disable", "disabled"].includes(key)) {
-    return "off";
-  }
-  if (["on", "true", "yes", "1", "enable", "enabled"].includes(key)) {
-    return "tokens";
-  }
-  if (["tokens", "token", "tok", "minimal", "min"].includes(key)) {
-    return "tokens";
-  }
-  if (["full", "session"].includes(key)) {
-    return "full";
-  }
-  return undefined;
-}
-
-export function resolveResponseUsageMode(raw?: string | null): UsageDisplayLevel {
-  return normalizeUsageDisplay(raw) ?? "off";
-}
-
-// Normalize fast-mode flags used to toggle low-latency model behavior.
-export function normalizeFastMode(raw?: string | boolean | null): boolean | undefined {
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.toLowerCase();
-  if (["off", "false", "no", "0", "disable", "disabled", "normal"].includes(key)) {
-    return false;
-  }
-  if (["on", "true", "yes", "1", "enable", "enabled", "fast"].includes(key)) {
-    return true;
-  }
-  return undefined;
-}
-
-// Normalize elevated flags used to toggle elevated bash permissions.
-export function normalizeElevatedLevel(raw?: string | null): ElevatedLevel | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.toLowerCase();
-  if (["off", "false", "no", "0"].includes(key)) {
-    return "off";
-  }
-  if (["full", "auto", "auto-approve", "autoapprove"].includes(key)) {
-    return "full";
-  }
-  if (["ask", "prompt", "approval", "approve"].includes(key)) {
-    return "ask";
-  }
-  if (["on", "true", "yes", "1"].includes(key)) {
-    return "on";
-  }
-  return undefined;
-}
-
-export function resolveElevatedMode(level?: ElevatedLevel | null): ElevatedMode {
-  if (!level || level === "off") {
-    return "off";
-  }
-  if (level === "full") {
-    return "full";
-  }
-  return "ask";
-}
-
-// Normalize reasoning visibility flags used to toggle reasoning exposure.
-export function normalizeReasoningLevel(raw?: string | null): ReasoningLevel | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const key = raw.toLowerCase();
-  if (["off", "false", "no", "0", "hide", "hidden", "disable", "disabled"].includes(key)) {
-    return "off";
-  }
-  if (["on", "true", "yes", "1", "show", "visible", "enable", "enabled"].includes(key)) {
-    return "on";
-  }
-  if (["stream", "streaming", "draft", "live"].includes(key)) {
-    return "stream";
-  }
-  return undefined;
+  return resolveThinkingDefaultForModelFallback(params);
 }

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -9,7 +9,7 @@ import {
   normalizeThinkLevel,
   normalizeVerboseLevel,
   resolveThinkingDefaultForModel,
-} from "../../../../src/auto-reply/thinking.js";
+} from "../../../../src/auto-reply/thinking-shared.js";
 import {
   DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
@@ -32,14 +32,14 @@ export type SlashCommandResult = {
   content: string;
   /** Side-effect action the caller should perform after displaying the result. */
   action?:
-    | "refresh"
-    | "export"
-    | "new-session"
-    | "reset"
-    | "stop"
-    | "clear"
-    | "toggle-focus"
-    | "navigate-usage";
+  | "refresh"
+  | "export"
+  | "new-session"
+  | "reset"
+  | "stop"
+  | "clear"
+  | "toggle-focus"
+  | "navigate-usage";
   /** Optional session-level directive changes that the caller should mirror locally. */
   sessionPatch?: {
     modelOverride?: ChatModelOverride | null;


### PR DESCRIPTION
## Summary
- extract browser-safe thinking helpers into a shared module
- stop the Control UI slash command executor from importing the server/plugin-aware thinking module
- keep provider-runtime logic on the server side so browser builds do not pull Node/plugin code into the UI bundle

Fixes #48062.
Related to #47998 and #45194.

## Problem
The Control UI could load a blank page because `ui/src/ui/chat/slash-command-executor.ts` imported `src/auto-reply/thinking.ts`, which transitively imports `src/plugins/provider-runtime.ts`.

That server-side path drags plugin runtime and Node-oriented code into the browser bundle, producing a much larger client asset and browser-side failures.

## Fix
This change moves the browser-safe types and normalization helpers into `src/auto-reply/thinking-shared.ts`, re-exports them from `thinking.ts`, and updates the Control UI to import the shared module directly.

## Validation
- rebuilt the Control UI successfully after the change
- verified the deployed Control UI no longer bundled provider-runtime, Jiti, or Node-only strings
- verified the live page rendered normally instead of a blank screen