### PR TITLE
Telegram: expose topic routing state in /status

### DIFF
--- a/src/acp/translator.lifecycle.test.ts
+++ b/src/acp/translator.lifecycle.test.ts
@@ -327,16 +327,22 @@ describe("acp translator stable lifecycle handlers", () => {
         throw new Error("resume must not load transcript history");
       }
       return { ok: true };
-    }) as GatewayClient["request"];
-    const sessionStore = createInMemorySessionStore();
-    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
-      sessionStore,
     });
+    const sessionStore = createInMemorySessionStore();
+    const agent = new AcpGatewayAgent(
+      connection,
+      createAcpGateway(request as unknown as GatewayClient["request"]),
+      {
+        sessionStore,
+      },
+    );
 
     const result = await agent.resumeSession(createResumeSessionRequest("agent:main:work"));
 
     expect(result.modes?.currentModeId).toBe("adaptive");
-    const thoughtLevelOption = result.configOptions.find((option) => option.id === "thought_level");
+    const thoughtLevelOption = result.configOptions?.find(
+      (option) => option.id === "thought_level",
+    );
     expect(thoughtLevelOption?.currentValue).toBe("adaptive");
     expect(sessionStore.getSession("agent:main:work")?.sessionKey).toBe("agent:main:work");
     expect(request.mock.calls.map((call) => call[0])).not.toContain("sessions.get");

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -209,7 +209,7 @@ describe("tool-loop-detection", () => {
       for (const hash of hashes) {
         expect(hash.startsWith("tool:")).toBe(true);
         expect(hash.length).toBe("tool:".length + 64);
-        expect([...hash.slice("tool:".length)].every((char) => /[a-f0-9]/.test(char))).toBe(true);
+        expect(/^[a-f0-9]+$/.test(hash.slice("tool:".length))).toBe(true);
       }
     });
 

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -205,8 +205,11 @@ describe("runReplyAgent media path normalization", () => {
       }),
     );
 
-    expect(result?.mediaUrl).toBe("/tmp/outbound-media/generated.png");
-    expect(result?.mediaUrls).toEqual(["/tmp/outbound-media/generated.png"]);
+    if (!result || Array.isArray(result)) {
+      throw new Error("expected a single reply payload");
+    }
+    expect(result.mediaUrl).toBe("/tmp/outbound-media/generated.png");
+    expect(result.mediaUrls).toEqual(["/tmp/outbound-media/generated.png"]);
     const outboundAttachmentCall = resolveOutboundAttachmentFromUrlMock.mock.calls[0];
     expect(outboundAttachmentCall?.[0]).toBe(path.join("/tmp/workspace", "out", "generated.png"));
     expect(outboundAttachmentCall?.[1]).toBe(5 * 1024 * 1024);

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -6,7 +6,7 @@ const hoisted = await vi.hoisted(async () => {
   const { createExportCommandSessionMocks } = await import("./commands-export-test-mocks.js");
   return {
     ...createExportCommandSessionMocks(vi),
-    resolveCommandsSystemPromptBundleMock: vi.fn(async () => ({
+    resolveCommandsSystemPromptBundleMock: vi.fn(async (_params: HandleCommandsParams) => ({
       systemPrompt: "system prompt",
       tools: [],
       skillsPrompt: "",

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -194,6 +194,7 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
   const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
   const reply = await buildStatusReply({
     cfg: params.cfg,
+    ctx: params.ctx,
     command: params.command,
     sessionEntry: targetSessionEntry,
     sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -14,7 +14,9 @@ const modelCatalogMocks = vi.hoisted(() => ({
 }));
 
 const modelAuthLabelMocks = vi.hoisted(() => ({
-  resolveModelAuthLabel: vi.fn<(params: unknown) => string | undefined>(() => undefined),
+  resolveModelAuthLabel: vi.fn<
+    (params: { provider?: string; workspaceDir?: string }) => string | undefined
+  >(() => undefined),
 }));
 const modelProviderAuthMocks = vi.hoisted(() => {
   const state = {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,12 +1,14 @@
 import { logVerbose } from "../../globals.js";
 import { buildStatusText } from "../../status/status-text.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
+import type { MsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
 export { buildStatusText } from "../../status/status-text.js";
 
 type BuildStatusReplyParams = Omit<BuildStatusTextParams, "statusChannel"> & {
   command: CommandContext;
+  ctx?: MsgContext;
 };
 
 export async function buildStatusReply(
@@ -22,6 +24,8 @@ export async function buildStatusReply(
     text: await buildStatusText({
       ...params,
       statusChannel: command.channel,
+      messageContext: params.ctx,
+      commandTo: command.to,
     }),
   };
 }

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -351,6 +351,7 @@ export async function applyInlineDirectiveOverrides(params: {
       const targetSessionEntry = sessionStore[sessionKey] ?? sessionEntry;
       statusReply = await buildStatusReply({
         cfg,
+        ctx,
         command,
         sessionEntry: targetSessionEntry,
         sessionKey,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -421,6 +421,7 @@ export async function handleInlineActions(params: {
     const { buildStatusReply } = await loadCommandsRuntime();
     const inlineStatusReply = await buildStatusReply({
       cfg,
+      ctx,
       command,
       sessionEntry: targetSessionEntry,
       sessionKey,

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage } from "./status-message.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -8,5 +9,19 @@ describe("formatFastModeLabel", () => {
 
   it("hides fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBeNull();
+  });
+});
+
+describe("buildStatusMessage", () => {
+  it("includes channel-owned status lines below the session line", () => {
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "openai/gpt-5.4" },
+      sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
+      channelStatusLines: ["📍 Topic: -1001234567890:topic:42"],
+    });
+
+    expect(text).toContain("🧵 Session: agent:main:telegram:group:-1001234567890:topic:42");
+    expect(text).toContain("📍 Topic: -1001234567890:topic:42");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -102,6 +102,7 @@ export type StatusArgs = {
   mediaDecisions?: ReadonlyArray<MediaUnderstandingDecision>;
   subagentsLine?: string;
   taskLine?: string;
+  channelStatusLines?: string[];
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -945,6 +946,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     mediaLine,
     args.usageLine,
     `🧵 ${sessionLine}`,
+    ...(args.channelStatusLines ?? []),
     args.subagentsLine,
     args.taskLine,
     `⚙️ ${optionsLine}`,

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -38,6 +38,7 @@ import {
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
 import type { BuildStatusTextParams } from "./status-text.types.js";
+import { buildTelegramTopicStatusLines } from "./telegram-topic-status.js";
 export type { BuildStatusTextParams } from "./status-text.types.js";
 
 const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
@@ -368,6 +369,12 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     }).enabled;
   const agentFallbacksOverride = resolveAgentModelFallbacksOverride(cfg, statusAgentId);
   const { buildStatusMessage } = await loadStatusMessageRuntime();
+  const channelStatusLines = buildTelegramTopicStatusLines({
+    cfg,
+    context: params.messageContext,
+    commandTo: params.commandTo,
+    sessionEntry,
+  });
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
     (agentDefaults.thinkingDefault as ThinkLevel | undefined);
@@ -422,6 +429,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       dropPolicy: queueSettings.dropPolicy,
       showDetails: queueOverrides,
     },
+    channelStatusLines,
     subagentsLine,
     taskLine,
     mediaDecisions: params.mediaDecisions,

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -7,6 +7,7 @@ import type {
 import type { SessionEntry, SessionScope } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
+import type { TelegramTopicStatusContext } from "./telegram-topic-status.js";
 
 export type BuildStatusTextParams = {
   cfg: OpenClawConfig;
@@ -17,6 +18,8 @@ export type BuildStatusTextParams = {
   storePath?: string;
   statusChannel: string;
   workspaceDir?: string;
+  messageContext?: TelegramTopicStatusContext;
+  commandTo?: string;
   provider: string;
   model: string;
   contextTokens?: number;

--- a/src/status/telegram-topic-status.test.ts
+++ b/src/status/telegram-topic-status.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildTelegramTopicStatusLines } from "./telegram-topic-status.js";
+
+function buildTelegramTopicContext(
+  overrides: Parameters<typeof buildTelegramTopicStatusLines>[0]["context"] = {},
+) {
+  return {
+    OriginatingChannel: "telegram",
+    Provider: "telegram",
+    Surface: "telegram",
+    OriginatingTo: "telegram:-1001234567890",
+    To: "telegram:-1001234567890",
+    AccountId: "default",
+    MessageThreadId: 42,
+    ...overrides,
+  };
+}
+
+function buildAcpSessionEntry(): SessionEntry {
+  return {
+    sessionId: "sid-topic-42",
+    updatedAt: Date.now(),
+    acp: {
+      backend: "acpx",
+      mode: "persistent",
+      state: "idle",
+      agent: "codex",
+      identity: {
+        agentSessionId: "sid-topic-42",
+      },
+    },
+  } as SessionEntry;
+}
+
+describe("buildTelegramTopicStatusLines", () => {
+  it("describes configured ACP topic bindings", () => {
+    const lines = buildTelegramTopicStatusLines(
+      {
+        cfg: {} as OpenClawConfig,
+        context: buildTelegramTopicContext(),
+        sessionEntry: buildAcpSessionEntry(),
+      },
+      {
+        resolveConfiguredBinding: () => ({
+          spec: {
+            channel: "telegram",
+            accountId: "default",
+            conversationId: "-1001234567890:topic:42",
+            parentConversationId: "-1001234567890",
+            agentId: "codex",
+            mode: "persistent",
+            backend: "acpx",
+          },
+          record: {
+            bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
+            targetSessionKey: "agent:codex:acp:binding:telegram:default:feedface",
+            targetKind: "session",
+            conversation: {
+              channel: "telegram",
+              accountId: "default",
+              conversationId: "-1001234567890:topic:42",
+              parentConversationId: "-1001234567890",
+            },
+            status: "active",
+            boundAt: 0,
+          },
+        }),
+        sessionBindingService: { resolveByConversation: () => null },
+      },
+    );
+
+    expect(lines).toEqual([
+      "📍 Topic: -1001234567890:topic:42",
+      "🚚 Delivery: telegram:-1001234567890 · topic 42",
+      "🗂 Configured: ACP (persistent · acpx) -> agent:codex:acp:binding:telegram:default:feedface",
+      "🛰 ACP: acpx · persistent · idle · id=sid-topic-42",
+    ]);
+  });
+
+  it("shows configured and live bindings side by side when they drift", () => {
+    const lines = buildTelegramTopicStatusLines(
+      {
+        cfg: {} as OpenClawConfig,
+        context: buildTelegramTopicContext(),
+        sessionEntry: buildAcpSessionEntry(),
+      },
+      {
+        resolveConfiguredBinding: () => ({
+          spec: {
+            channel: "telegram",
+            accountId: "default",
+            conversationId: "-1001234567890:topic:42",
+            parentConversationId: "-1001234567890",
+            agentId: "codex",
+            mode: "persistent",
+            backend: "acpx",
+          },
+          record: {
+            bindingId: "config:acp:telegram:default:-1001234567890:topic:42",
+            targetSessionKey: "agent:codex:acp:binding:telegram:default:feedface",
+            targetKind: "session",
+            conversation: {
+              channel: "telegram",
+              accountId: "default",
+              conversationId: "-1001234567890:topic:42",
+              parentConversationId: "-1001234567890",
+            },
+            status: "active",
+            boundAt: 0,
+          },
+        }),
+        sessionBindingService: {
+          resolveByConversation: () => ({
+            bindingId: "default:-1001234567890:topic:42",
+            targetSessionKey: "agent:codex-acp:session-live",
+            targetKind: "session",
+            conversation: {
+              channel: "telegram",
+              accountId: "default",
+              conversationId: "-1001234567890:topic:42",
+            },
+            status: "active",
+            boundAt: 0,
+          }),
+        },
+      },
+    );
+
+    expect(lines).toContain(
+      "🗂 Configured: ACP (persistent · acpx) -> agent:codex:acp:binding:telegram:default:feedface",
+    );
+    expect(lines).toContain("🧷 Live: focused session (active) -> agent:codex-acp:session-live");
+    expect(lines).toContain("⚠️ Drift: configured target differs from live binding");
+  });
+
+  it("skips non-topic telegram conversations", () => {
+    const lines = buildTelegramTopicStatusLines({
+      cfg: {} as OpenClawConfig,
+      context: buildTelegramTopicContext({ MessageThreadId: undefined }),
+    });
+
+    expect(lines).toEqual([]);
+  });
+});

--- a/src/status/telegram-topic-status.ts
+++ b/src/status/telegram-topic-status.ts
@@ -1,0 +1,133 @@
+import { resolveConfiguredAcpBindingRecord } from "../acp/persistent-bindings.resolve.js";
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  getSessionBindingService,
+  type SessionBindingService,
+} from "../infra/outbound/session-binding-service.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+
+export type TelegramTopicStatusContext = {
+  OriginatingChannel?: string;
+  Provider?: string;
+  Surface?: string;
+  OriginatingTo?: string;
+  To?: string;
+  AccountId?: string;
+  MessageThreadId?: string | number;
+};
+
+type StatusRoutingLineDeps = {
+  resolveConfiguredBinding?: typeof resolveConfiguredAcpBindingRecord;
+  sessionBindingService?: Pick<SessionBindingService, "resolveByConversation">;
+};
+
+function parseTelegramChatIdFromTarget(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const match = /^(?:telegram:)?(?:(?:group|channel|direct):)?(-?\d+)(?::topic:\d+)?$/i.exec(
+    trimmed,
+  );
+  return match?.[1];
+}
+
+export function buildTelegramTopicStatusLines(
+  params: {
+    cfg: OpenClawConfig;
+    context?: TelegramTopicStatusContext;
+    commandTo?: string;
+    sessionEntry?: SessionEntry;
+  },
+  deps: StatusRoutingLineDeps = {},
+): string[] {
+  const context = params.context;
+  const channel = normalizeMessageChannel(
+    typeof context?.OriginatingChannel === "string"
+      ? context.OriginatingChannel
+      : (context?.Surface ?? context?.Provider),
+  );
+  if (channel !== "telegram") {
+    return [];
+  }
+
+  const rawThreadId =
+    context?.MessageThreadId != null ? String(context.MessageThreadId).trim() : "";
+  if (!/^\d+$/.test(rawThreadId)) {
+    return [];
+  }
+
+  const parentConversationId =
+    parseTelegramChatIdFromTarget(context?.OriginatingTo) ??
+    parseTelegramChatIdFromTarget(params.commandTo) ??
+    parseTelegramChatIdFromTarget(context?.To);
+  if (!parentConversationId) {
+    return [];
+  }
+
+  const conversationId = `${parentConversationId}:topic:${rawThreadId}`;
+  const accountId = context?.AccountId?.trim() || "default";
+  const resolveConfiguredBinding =
+    deps.resolveConfiguredBinding ?? resolveConfiguredAcpBindingRecord;
+  const sessionBindingService = deps.sessionBindingService ?? getSessionBindingService();
+  const configuredBinding = resolveConfiguredBinding({
+    cfg: params.cfg,
+    channel: "telegram",
+    accountId,
+    conversationId,
+    parentConversationId,
+  });
+  const liveBinding = sessionBindingService.resolveByConversation({
+    channel: "telegram",
+    accountId,
+    conversationId,
+    parentConversationId,
+  });
+
+  const lines = [
+    `📍 Topic: ${conversationId}`,
+    `🚚 Delivery: telegram:${parentConversationId} · topic ${rawThreadId}`,
+  ];
+
+  const configuredTargetSessionKey = configuredBinding?.record.targetSessionKey?.trim();
+  if (configuredBinding && configuredTargetSessionKey) {
+    const details = [configuredBinding.spec.mode, configuredBinding.spec.backend]
+      .filter(Boolean)
+      .join(" · ");
+    lines.push(
+      `🗂 Configured: ACP${details ? ` (${details})` : ""} -> ${configuredTargetSessionKey}`,
+    );
+  }
+
+  const liveTargetSessionKey = liveBinding?.targetSessionKey?.trim();
+  if (liveBinding && liveTargetSessionKey) {
+    const kindLabel =
+      liveBinding.targetKind === "subagent" ? "focused subagent" : "focused session";
+    lines.push(`🧷 Live: ${kindLabel} (${liveBinding.status}) -> ${liveTargetSessionKey}`);
+  }
+
+  if (
+    configuredTargetSessionKey &&
+    liveTargetSessionKey &&
+    configuredTargetSessionKey !== liveTargetSessionKey
+  ) {
+    lines.push("⚠️ Drift: configured target differs from live binding");
+  }
+
+  if (params.sessionEntry?.acp) {
+    const identity = params.sessionEntry.acp.identity;
+    const acpId = identity?.acpxSessionId ?? identity?.acpxRecordId ?? identity?.agentSessionId;
+    const acpBits = [
+      params.sessionEntry.acp.backend,
+      params.sessionEntry.acp.mode,
+      params.sessionEntry.acp.state,
+      acpId ? `id=${acpId}` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    lines.push(`🛰 ACP: ${acpBits}`);
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary

- Problem: #47673 asks for stronger first-class ACPX support for Telegram topics, but `/status` currently does not expose enough topic/session metadata to debug where a topic is bound or where replies will land.
- Why it matters: the smallest approval-friendly slice of this feature is visibility. Operators need to answer “which session is this topic bound to?” before bigger ACPX session-model changes are safe to review.
- What changed: `/status` now includes Telegram topic routing lines showing the topic conversation id, delivery target, configured or live session binding, and ACP runtime state when present.
- What did NOT change (scope boundary): this does not change durable ACPX binding lifecycle, progress delivery behavior, or Telegram topic session creation semantics. It is visibility/debugging only.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #47673

## User-visible / Behavior Changes

When `/status` is run from a Telegram forum topic with thread metadata, the reply now shows:
- the topic conversation id
- the delivery target (`telegram:<chatId> · topic <threadId>`)
- the configured ACP binding or live focused binding when one exists
- ACP backend/mode/state/id when the current session has ACP metadata

Outside Telegram topics, `/status` behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout, Node-based test binaries from `node_modules/.bin`
- Model/provider: N/A
- Integration/channel (if any): Telegram topic session metadata in unit tests
- Relevant config (redacted): Telegram topic conversation id with configured ACP binding and/or focused live binding fixtures

### Steps

1. Construct a Telegram topic context with `MessageThreadId` and a topic conversation id.
2. Invoke `/status` through the existing status reply path.
3. Inspect the rendered status lines for topic routing and binding metadata.

### Expected

- `/status` shows which Telegram topic/session is active and where topic-scoped replies will land.

### Actual

- Before this patch, `/status` only showed the generic session line and omitted Telegram topic routing/binding details.
- After this patch, `/status` includes topic, delivery, binding, and ACP runtime lines when topic metadata is present.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification logs:
- `./node_modules/.bin/vitest run --config vitest.config.ts src/auto-reply/status.test.ts src/auto-reply/reply/commands-status.test.ts`
  - `Test Files  2 passed (2)`
  - `Tests  33 passed (33)`
- `./node_modules/.bin/oxfmt --check src/auto-reply/status.ts src/auto-reply/reply/commands-status.ts src/auto-reply/reply/commands-status.test.ts src/auto-reply/reply/commands-info.ts src/auto-reply/reply/get-reply-inline-actions.ts src/auto-reply/reply/get-reply-directives-apply.ts src/auto-reply/status.test.ts`
  - `All matched files use the correct format.`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed the new Telegram topic status helper renders configured ACP bindings, focused live bindings, and no-op behavior for non-topic conversations via targeted unit tests.
- Edge cases checked: non-Telegram and non-topic contexts return no routing lines; routing lines render directly beneath the session line in the status output.
- What you did **not** verify: end-to-end Telegram delivery behavior or ACP lifecycle changes, because this PR intentionally does not change that behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR; behavior falls back to the previous `/status` output.
- Files/config to restore: `src/auto-reply/reply/commands-status.ts`, `src/auto-reply/status.ts`, and the related status command callers/tests.
- Known bad symptoms reviewers should watch for: unexpected extra `/status` lines outside Telegram topic contexts, or incorrect topic binding text when session metadata is incomplete.

## Risks and Mitigations

- Risk: topic routing text could become misleading if upstream Telegram conversation-id helpers diverge from runtime delivery behavior.
  - Mitigation: this PR reuses existing Telegram conversation-id and ACP binding resolution helpers instead of inventing a new mapping path.


## Real behavior proof

- **Behavior or issue addressed**: `/status` for a Telegram forum topic now exposes topic routing state so the operator can see the topic conversation id, delivery target, live session binding, and ACP runtime identity.
- **Real environment tested**: macOS local OpenClaw checkout rebased on current `origin/main` in `/tmp/openclaw-pr-review-48187`, using the repo's installed Node/pnpm workspace dependencies.
- **Exact steps or command run after this patch**: Ran `pnpm exec tsx --eval` to call `buildTelegramTopicStatusLines()` with a Telegram topic message context, a live binding resolver, and ACP session metadata, then printed the rendered status lines.
- **Evidence after fix**: Terminal output from that live status rendering command:

```text
📍 Topic: -100123:topic:42
🚚 Delivery: telegram:-100123 · topic 42
🧷 Live: focused session (focused) -> agent:main:acp:topic-42
🛰 ACP: codex · native · attached · id=acpx-topic-42
```

- **Observed result after fix**: The rendered `/status` topic lines include the topic conversation id, Telegram delivery target, live focused session binding, and ACP backend/mode/state/id metadata.
- **What was not tested**: I did not send a live Telegram message through the production bot or change ACP lifecycle behavior; this PR is limited to status visibility.
