### PR TITLE
Fix Control UI stale session dropdown entries

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -289,7 +289,11 @@ describe("refreshChat", () => {
       },
       applySettings,
       loadAssistantIdentity,
-    }) as ChatHost & { sessionsLoading: boolean; sessionsResult: unknown };
+    }) as ChatHost & {
+      sessionsLoading: boolean;
+      sessionsResult: unknown;
+      chatSessionsResult?: unknown;
+    };
     host.sessionsLoading = true;
     host.sessionsResult = {
       ts: 0,
@@ -319,6 +323,7 @@ describe("refreshChat", () => {
         { key: "main", kind: "direct", updatedAt: null },
       ],
     });
+    expect(host.chatSessionsResult).toEqual(host.sessionsResult);
     expect(applySettings).not.toHaveBeenCalled();
     expect(loadAssistantIdentity).not.toHaveBeenCalled();
     expect(request).toHaveBeenCalledWith("sessions.list", {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { handleSendChat, refreshChatAvatar, type ChatHost } from "./app-chat.ts";
+import { handleSendChat, refreshChat, refreshChatAvatar, type ChatHost } from "./app-chat.ts";
 
 function makeHost(overrides?: Partial<ChatHost>): ChatHost {
   return {
@@ -126,6 +126,104 @@ describe("handleSendChat", () => {
     expect(host.chatModelOverrides.main).toEqual({
       kind: "qualified",
       value: "openai/gpt-5-mini",
+    });
+  });
+});
+
+describe("refreshChat", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("switches away from a missing direct session and reloads chat state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }) as unknown as typeof fetch,
+    );
+    const applySettings = vi.fn();
+    const loadAssistantIdentity = vi.fn(async () => {});
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              text: `history:${String(params?.sessionKey)}`,
+            },
+          ],
+          thinkingLevel: null,
+        };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+        };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:main:discord:channel:123",
+      chatMessage: "draft",
+      chatQueue: [{ id: "q1", text: "queued", createdAt: 1 }],
+      chatRunId: "run-1",
+      chatStream: "stale",
+      settings: {
+        gatewayUrl: "",
+        token: "",
+        sessionKey: "agent:main:discord:channel:123",
+        lastActiveSessionKey: "agent:main:discord:channel:123",
+        theme: "claw",
+        themeMode: "dark",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        chatShowToolCalls: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navWidth: 280,
+        navGroupsCollapsed: {},
+      },
+      applySettings,
+      loadAssistantIdentity,
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+
+    expect(host.sessionKey).toBe("main");
+    expect(host.chatMessage).toBe("");
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        text: "history:main",
+      },
+    ]);
+    expect(applySettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        lastActiveSessionKey: "main",
+      }),
+    );
+    expect(loadAssistantIdentity).toHaveBeenCalled();
+    expect(request).toHaveBeenNthCalledWith(1, "chat.history", {
+      sessionKey: "agent:main:discord:channel:123",
+      limit: 200,
+    });
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 200,
     });
   });
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -309,6 +309,16 @@ describe("refreshChat", () => {
         text: "history:agent:main:discord:channel:123",
       },
     ]);
+    expect(host.sessionsResult).toEqual({
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        { key: "agent:main:discord:channel:123", kind: "direct", updatedAt: null },
+        { key: "main", kind: "direct", updatedAt: null },
+      ],
+    });
     expect(applySettings).not.toHaveBeenCalled();
     expect(loadAssistantIdentity).not.toHaveBeenCalled();
     expect(request).toHaveBeenCalledWith("sessions.list", {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -175,6 +175,7 @@ describe("refreshChat", () => {
       client: { request } as unknown as ChatHost["client"],
       sessionKey: "agent:main:discord:channel:123",
       chatMessage: "draft",
+      chatAttachments: [{ id: "a1", dataUrl: "data:image/png;base64,abc", mimeType: "image/png" }],
       chatQueue: [{ id: "q1", text: "queued", createdAt: 1 }],
       chatRunId: "run-1",
       chatStream: "stale",
@@ -201,6 +202,7 @@ describe("refreshChat", () => {
 
     expect(host.sessionKey).toBe("main");
     expect(host.chatMessage).toBe("");
+    expect(host.chatAttachments).toEqual([]);
     expect(host.chatQueue).toEqual([]);
     expect(host.chatRunId).toBeNull();
     expect(host.chatStream).toBeNull();
@@ -224,6 +226,94 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 200,
+    });
+  });
+
+  it("uses a fresh sessions snapshot before falling back when sessions are already loading", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }) as unknown as typeof fetch,
+    );
+    const applySettings = vi.fn();
+    const loadAssistantIdentity = vi.fn(async () => {});
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              text: `history:${String(params?.sessionKey)}`,
+            },
+          ],
+          thinkingLevel: null,
+        };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [
+            { key: "agent:main:discord:channel:123", kind: "direct", updatedAt: null },
+            { key: "main", kind: "direct", updatedAt: null },
+          ],
+        };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:main:discord:channel:123",
+      chatMessage: "draft",
+      settings: {
+        gatewayUrl: "",
+        token: "",
+        sessionKey: "agent:main:discord:channel:123",
+        lastActiveSessionKey: "agent:main:discord:channel:123",
+        theme: "claw",
+        themeMode: "dark",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        chatShowToolCalls: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navWidth: 280,
+        navGroupsCollapsed: {},
+      },
+      applySettings,
+      loadAssistantIdentity,
+    }) as ChatHost & { sessionsLoading: boolean; sessionsResult: unknown };
+    host.sessionsLoading = true;
+    host.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+    };
+
+    await refreshChat(host, { scheduleScroll: false });
+
+    expect(host.sessionKey).toBe("agent:main:discord:channel:123");
+    expect(host.chatMessage).toBe("draft");
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        text: "history:agent:main:discord:channel:123",
+      },
+    ]);
+    expect(applySettings).not.toHaveBeenCalled();
+    expect(loadAssistantIdentity).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
     });
   });
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -3,17 +3,35 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleSendChat, refreshChat, refreshChatAvatar, type ChatHost } from "./app-chat.ts";
 
-function makeHost(overrides?: Partial<ChatHost>): ChatHost {
+type TestChatHost = ChatHost & {
+  chatHasAutoScrolled: boolean;
+  chatNewMessagesBelow: boolean;
+  chatUserNearBottom: boolean;
+  chatStreamStartedAt: number | null;
+  chatStreamSegments: Array<{ text: string; ts: number }>;
+  chatToolMessages: Record<string, unknown>[];
+  toolStreamById: Map<string, Record<string, unknown>>;
+  toolStreamOrder: string[];
+  toolStreamSyncTimer: number | null;
+};
+
+function makeHost(overrides?: Partial<TestChatHost>): TestChatHost {
   return {
     client: null,
     chatMessages: [],
     chatStream: null,
+    chatStreamStartedAt: null,
+    chatStreamSegments: [],
+    chatToolMessages: [],
     connected: true,
     chatMessage: "",
     chatAttachments: [],
+    chatHasAutoScrolled: false,
+    chatNewMessagesBelow: false,
     chatQueue: [],
     chatRunId: null,
     chatSending: false,
+    chatUserNearBottom: true,
     lastError: null,
     sessionKey: "agent:main",
     basePath: "",
@@ -22,6 +40,9 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatModelOverrides: {},
     chatModelsLoading: false,
     chatModelCatalog: [],
+    toolStreamById: new Map(),
+    toolStreamOrder: [],
+    toolStreamSyncTimer: null,
     refreshSessionsAfterChat: new Set<string>(),
     updateComplete: Promise.resolve(),
     ...overrides,
@@ -229,6 +250,74 @@ describe("refreshChat", () => {
     });
   });
 
+  it("resets tool stream and scroll state when missing-session fallback history reload fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }) as unknown as typeof fetch,
+    );
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.history") {
+        throw new Error(`history failed:${String(params?.sessionKey)}`);
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+        };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:main:discord:channel:123",
+      settings: {
+        gatewayUrl: "",
+        token: "",
+        sessionKey: "agent:main:discord:channel:123",
+        lastActiveSessionKey: "agent:main:discord:channel:123",
+        theme: "claw",
+        themeMode: "dark",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        chatShowToolCalls: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navWidth: 280,
+        navGroupsCollapsed: {},
+      },
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatNewMessagesBelow = true;
+    host.chatUserNearBottom = false;
+    host.chatStreamStartedAt = 123;
+    host.chatStreamSegments = [{ text: "delta", ts: 1 }];
+    host.chatToolMessages = [{ role: "assistant", text: "tool" }];
+    host.toolStreamById = new Map([["call-1", { id: "call-1" }]]);
+    host.toolStreamOrder = ["call-1"];
+    host.toolStreamSyncTimer = null;
+
+    await refreshChat(host, { scheduleScroll: false });
+
+    expect(host.sessionKey).toBe("main");
+    expect(host.toolStreamById.size).toBe(0);
+    expect(host.toolStreamOrder).toEqual([]);
+    expect(host.chatToolMessages).toEqual([]);
+    expect(host.chatStreamSegments).toEqual([]);
+    expect(host.chatHasAutoScrolled).toBe(false);
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(false);
+    expect(host.lastError).toContain("history failed:main");
+  });
+
   it("uses a fresh sessions snapshot before falling back when sessions are already loading", async () => {
     vi.stubGlobal(
       "fetch",
@@ -289,7 +378,7 @@ describe("refreshChat", () => {
       },
       applySettings,
       loadAssistantIdentity,
-    }) as ChatHost & {
+    }) as unknown as TestChatHost & {
       sessionsLoading: boolean;
       sessionsResult: unknown;
       chatSessionsResult?: unknown;

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -92,9 +92,36 @@ function normalizeMissingChatSessionSelection(
   return !nextSessionKey || nextSessionKey === currentSessionKey ? null : nextSessionKey;
 }
 
+async function loadRefreshChatSessionsResult(host: ChatHost): Promise<SessionsListResult | null> {
+  if (!host.client || !host.connected) {
+    return null;
+  }
+  const appHost = host as unknown as OpenClawApp;
+  if (appHost.sessionsLoading) {
+    try {
+      return (
+        (await host.client.request<SessionsListResult | undefined>("sessions.list", {
+          includeGlobal: true,
+          includeUnknown: true,
+        })) ?? null
+      );
+    } catch {
+      return null;
+    }
+  }
+  await loadSessions(appHost, {
+    activeMinutes: 0,
+    limit: 0,
+    includeGlobal: true,
+    includeUnknown: true,
+  });
+  return appHost.sessionsError ? null : (appHost.sessionsResult ?? null);
+}
+
 async function switchMissingChatSession(host: ChatHost, nextSessionKey: string) {
   host.sessionKey = nextSessionKey;
   host.chatMessage = "";
+  host.chatAttachments = [];
   host.chatStream = null;
   host.chatRunId = null;
   host.chatQueue = [];
@@ -434,21 +461,13 @@ function injectCommandResult(host: ChatHost, content: string) {
 }
 
 export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: boolean }) {
-  await Promise.all([
+  const [, sessionsResult] = await Promise.all([
     loadChatHistory(host as unknown as OpenClawApp),
-    loadSessions(host as unknown as OpenClawApp, {
-      activeMinutes: 0,
-      limit: 0,
-      includeGlobal: true,
-      includeUnknown: true,
-    }),
+    loadRefreshChatSessionsResult(host),
     refreshChatAvatar(host),
     refreshChatModels(host),
   ]);
-  const nextSessionKey = normalizeMissingChatSessionSelection(
-    host,
-    (host as unknown as OpenClawApp).sessionsResult ?? null,
-  );
+  const nextSessionKey = normalizeMissingChatSessionSelection(host, sessionsResult);
   if (nextSessionKey) {
     await switchMissingChatSession(host, nextSessionKey);
   }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,6 @@
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
-import { setLastActiveSessionKey } from "./app-settings.ts";
+import { setLastActiveSessionKey, syncUrlWithSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
@@ -10,6 +10,8 @@ import { loadModels } from "./controllers/models.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
+import type { UiSettings } from "./storage.ts";
+import type { SessionsListResult } from "./types.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
@@ -34,11 +36,90 @@ export type ChatHost = {
   chatModelCatalog: ModelCatalogEntry[];
   updateComplete?: Promise<unknown>;
   refreshSessionsAfterChat: Set<string>;
+  settings?: UiSettings;
+  applySettings?: (next: UiSettings) => void;
+  loadAssistantIdentity?: () => Promise<void>;
   /** Callback for slash-command side effects that need app-level access. */
   onSlashAction?: (action: string) => void;
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
+
+function isCronSessionKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.startsWith("cron:")) {
+    return true;
+  }
+  if (!normalized.startsWith("agent:")) {
+    return false;
+  }
+  const parts = normalized.split(":").filter(Boolean);
+  if (parts.length < 3) {
+    return false;
+  }
+  const rest = parts.slice(2).join(":");
+  return rest.startsWith("cron:");
+}
+
+function shouldPreserveMissingChatSessionKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return normalized.includes(":subagent:") || isCronSessionKey(normalized);
+}
+
+function normalizeMissingChatSessionSelection(
+  host: ChatHost,
+  sessions: SessionsListResult | null,
+): string | null {
+  const currentSessionKey = host.sessionKey?.trim();
+  if (!currentSessionKey || !sessions || shouldPreserveMissingChatSessionKey(currentSessionKey)) {
+    return null;
+  }
+  if (sessions.sessions.some((row) => row.key === currentSessionKey)) {
+    return null;
+  }
+  const preferredLastActive = host.settings?.lastActiveSessionKey?.trim();
+  const nextSessionKey =
+    (preferredLastActive &&
+    preferredLastActive !== currentSessionKey &&
+    sessions.sessions.some((row) => row.key === preferredLastActive)
+      ? preferredLastActive
+      : null) ??
+    sessions.sessions.find((row) => row.key === "main")?.key ??
+    sessions.sessions[0]?.key;
+  return !nextSessionKey || nextSessionKey === currentSessionKey ? null : nextSessionKey;
+}
+
+async function switchMissingChatSession(host: ChatHost, nextSessionKey: string) {
+  host.sessionKey = nextSessionKey;
+  host.chatMessage = "";
+  host.chatStream = null;
+  host.chatRunId = null;
+  host.chatQueue = [];
+  const hostWithStream = host as ChatHost & { chatStreamStartedAt?: number | null };
+  hostWithStream.chatStreamStartedAt = null;
+  if (host.settings) {
+    const nextSettings: UiSettings = {
+      ...host.settings,
+      sessionKey: nextSessionKey,
+      lastActiveSessionKey: nextSessionKey,
+    };
+    if (typeof host.applySettings === "function") {
+      host.applySettings(nextSettings);
+    } else {
+      host.settings = nextSettings;
+    }
+  }
+  syncUrlWithSessionKey(
+    host as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
+    nextSessionKey,
+    true,
+  );
+  await host.loadAssistantIdentity?.();
+  await Promise.all([loadChatHistory(host as unknown as OpenClawApp), refreshChatAvatar(host)]);
+}
 
 export function isChatBusy(host: ChatHost) {
   return host.chatSending || Boolean(host.chatRunId);
@@ -364,6 +445,13 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
     refreshChatAvatar(host),
     refreshChatModels(host),
   ]);
+  const nextSessionKey = normalizeMissingChatSessionSelection(
+    host,
+    (host as unknown as OpenClawApp).sessionsResult ?? null,
+  );
+  if (nextSessionKey) {
+    await switchMissingChatSession(host, nextSessionKey);
+  }
   if (opts?.scheduleScroll !== false) {
     scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
   }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -99,12 +99,15 @@ async function loadRefreshChatSessionsResult(host: ChatHost): Promise<SessionsLi
   const appHost = host as unknown as OpenClawApp;
   if (appHost.sessionsLoading) {
     try {
-      return (
+      const res =
         (await host.client.request<SessionsListResult | undefined>("sessions.list", {
           includeGlobal: true,
           includeUnknown: true,
-        })) ?? null
-      );
+        })) ?? null;
+      if (res) {
+        appHost.sessionsResult = res;
+      }
+      return res;
     } catch {
       return null;
     }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -131,6 +131,8 @@ async function switchMissingChatSession(host: ChatHost, nextSessionKey: string) 
   host.chatQueue = [];
   const hostWithStream = host as ChatHost & { chatStreamStartedAt?: number | null };
   hostWithStream.chatStreamStartedAt = null;
+  resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
+  resetChatScroll(host as unknown as Parameters<typeof resetChatScroll>[0]);
   if (host.settings) {
     const nextSettings: UiSettings = {
       ...host.settings,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -106,6 +106,7 @@ async function loadRefreshChatSessionsResult(host: ChatHost): Promise<SessionsLi
         })) ?? null;
       if (res) {
         appHost.sessionsResult = res;
+        appHost.chatSessionsResult = res;
       }
       return res;
     } catch {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -557,6 +557,8 @@ describe("connectGateway", () => {
       host,
       expect.objectContaining({
         activeMinutes: 120,
+        includeGlobal: true,
+        includeUnknown: true,
         syncChatSnapshot: true,
       }),
     );

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -5,6 +5,7 @@ import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts"
 import type { GatewayHelloOk } from "./gateway.ts";
 
 const loadChatHistoryMock = vi.hoisted(() => vi.fn(async () => undefined));
+const loadSessionsMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;
@@ -92,6 +93,14 @@ vi.mock("./controllers/chat.ts", async (importOriginal) => {
   };
 });
 
+vi.mock("./controllers/sessions.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./controllers/sessions.ts")>();
+  return {
+    ...actual,
+    loadSessions: loadSessionsMock,
+  };
+});
+
 function createHost() {
   return {
     settings: {
@@ -148,6 +157,7 @@ describe("connectGateway", () => {
   beforeEach(() => {
     gatewayClientInstances.length = 0;
     loadChatHistoryMock.mockClear();
+    loadSessionsMock.mockClear();
   });
 
   it("ignores stale client onGap callbacks after reconnect", () => {
@@ -520,6 +530,36 @@ describe("connectGateway", () => {
     });
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("syncs the chat snapshot when a tracked chat run finishes", () => {
+    const host = createHost();
+    host.refreshSessionsAfterChat.add("engine-run-1");
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-1",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+        },
+      },
+    });
+
+    expect(loadSessionsMock).toHaveBeenCalledWith(
+      host,
+      expect.objectContaining({
+        activeMinutes: 120,
+        syncChatSnapshot: true,
+      }),
+    );
   });
 });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -294,6 +294,7 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as OpenClawApp, {
         activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+        syncChatSnapshot: true,
       });
     }
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -294,6 +294,8 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as OpenClawApp, {
         activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+        includeGlobal: true,
+        includeUnknown: true,
         syncChatSnapshot: true,
       });
     }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -134,7 +134,11 @@ function renderCronFilterIcon(hiddenCount: number) {
 }
 
 export function renderChatSessionSelect(state: AppViewState) {
-  const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
+  const sessionGroups = resolveSessionOptionGroups(
+    state,
+    state.sessionKey,
+    resolveChatSessionsSnapshot(state),
+  );
   const modelSelect = renderChatModelSelect(state);
   return html`
     <div class="chat-controls__session-row">
@@ -175,7 +179,7 @@ export function renderChatSessionSelect(state: AppViewState) {
 export function renderChatControls(state: AppViewState) {
   const hideCron = state.sessionsHideCron ?? true;
   const hiddenCronCount = hideCron
-    ? countHiddenCronSessions(state.sessionKey, state.sessionsResult)
+    ? countHiddenCronSessions(state.sessionKey, resolveChatSessionsSnapshot(state))
     : 0;
   const disableThinkingToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
@@ -336,7 +340,11 @@ export function renderChatControls(state: AppViewState) {
  * Hidden on desktop via CSS.
  */
 export function renderChatMobileToggle(state: AppViewState) {
-  const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
+  const sessionGroups = resolveSessionOptionGroups(
+    state,
+    state.sessionKey,
+    resolveChatSessionsSnapshot(state),
+  );
   const disableThinkingToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
@@ -522,7 +530,7 @@ async function refreshSessionOptions(state: AppViewState) {
 }
 
 function resolveActiveSessionRow(state: AppViewState) {
-  return state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
+  return resolveChatSessionsSnapshot(state)?.sessions?.find((row) => row.key === state.sessionKey);
 }
 
 function resolveModelOverrideValue(state: AppViewState): string {
@@ -545,7 +553,7 @@ function resolveModelOverrideValue(state: AppViewState): string {
 }
 
 function resolveDefaultModelValue(state: AppViewState): string {
-  const defaults = state.sessionsResult?.defaults;
+  const defaults = resolveChatSessionsSnapshot(state)?.defaults;
   return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
 }
 
@@ -774,6 +782,10 @@ export function isCronSessionKey(key: string): boolean {
 
 function shouldPreserveMissingSessionOption(key: string): boolean {
   return key.includes(":subagent:") || isCronSessionKey(key);
+}
+
+function resolveChatSessionsSnapshot(state: AppViewState): SessionsListResult | null {
+  return state.chatSessionsResult ?? state.sessionsResult;
 }
 
 type SessionOptionEntry = {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -772,6 +772,10 @@ export function isCronSessionKey(key: string): boolean {
   return rest.startsWith("cron:");
 }
 
+function shouldPreserveMissingSessionOption(key: string): boolean {
+  return key.includes(":subagent:") || isCronSessionKey(key);
+}
+
 type SessionOptionEntry = {
   key: string;
   label: string;
@@ -845,7 +849,9 @@ export function resolveSessionOptionGroups(
     }
     addOption(row.key);
   }
-  addOption(sessionKey);
+  if (byKey.has(sessionKey) || shouldPreserveMissingSessionOption(sessionKey)) {
+    addOption(sessionKey);
+  }
 
   for (const group of groups.values()) {
     const counts = new Map<string, number>();

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -180,6 +180,7 @@ export type AppViewState = {
   agentSkillsAgentId: string | null;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
+  chatSessionsResult?: SessionsListResult | null;
   sessionsError: string | null;
   sessionsFilterActive: string;
   sessionsFilterLimit: string;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -278,6 +278,7 @@ export class OpenClawApp extends LitElement {
 
   @state() sessionsLoading = false;
   @state() sessionsResult: SessionsListResult | null = null;
+  @state() chatSessionsResult: SessionsListResult | null = null;
   @state() sessionsError: string | null = null;
   @state() sessionsFilterActive = "";
   @state() sessionsFilterLimit = "120";

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -143,10 +143,12 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(state.sessionKey).toBe("main");
-    expect(applySettings).toHaveBeenCalledWith({
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
-    });
+    expect(applySettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        lastActiveSessionKey: "main",
+      }),
+    );
   });
 
   it("preserves missing grouped sessions so ephemeral subagent selections stay visible", async () => {
@@ -175,6 +177,35 @@ describe("loadSessions", () => {
     await loadSessions(state);
 
     expect(state.sessionKey).toBe("agent:main:subagent:child");
+    expect(applySettings).not.toHaveBeenCalled();
+  });
+
+  it("preserves missing top-level cron sessions so active cron views stay stable", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const applySettings = vi.fn();
+    const state = createState(request, {
+      sessionKey: "cron:hourly-check",
+      settings: createSettings({
+        sessionKey: "cron:hourly-check",
+        lastActiveSessionKey: "cron:hourly-check",
+      }),
+      applySettings,
+    });
+
+    await loadSessions(state);
+
+    expect(state.sessionKey).toBe("cron:hourly-check");
     expect(applySettings).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionsListResult } from "../types.ts";
 import {
   deleteSession,
   deleteSessionAndRefresh,
@@ -119,14 +120,14 @@ describe("loadSessions", () => {
   });
 
   it("does not overwrite the chat snapshot for filtered refreshes by default", async () => {
-    const filtered = {
+    const filtered: SessionsListResult = {
       ts: 0,
       path: "",
       count: 1,
       defaults: { modelProvider: null, model: null, contextTokens: null },
       sessions: [{ key: "main", kind: "direct", updatedAt: null }],
     };
-    const existingChatSnapshot = {
+    const existingChatSnapshot: SessionsListResult = {
       ts: 1,
       path: "",
       count: 2,
@@ -153,7 +154,7 @@ describe("loadSessions", () => {
   });
 
   it("updates the chat snapshot when a chat-driven refresh asks for it", async () => {
-    const filtered = {
+    const filtered: SessionsListResult = {
       ts: 0,
       path: "",
       count: 1,

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -117,6 +117,73 @@ describe("loadSessions", () => {
 
     expect(state.sessionKey).toBe("agent:main:discord:channel:123");
   });
+
+  it("does not overwrite the chat snapshot for filtered refreshes by default", async () => {
+    const filtered = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+    };
+    const existingChatSnapshot = {
+      ts: 1,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [
+        { key: "main", kind: "direct", updatedAt: null },
+        { key: "agent:main:discord:channel:123", kind: "direct", updatedAt: null },
+      ],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return filtered;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request, {
+      chatSessionsResult: existingChatSnapshot,
+    });
+
+    await loadSessions(state, { activeMinutes: 120 });
+
+    expect(state.sessionsResult).toEqual(filtered);
+    expect(state.chatSessionsResult).toEqual(existingChatSnapshot);
+  });
+
+  it("updates the chat snapshot when a chat-driven refresh asks for it", async () => {
+    const filtered = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return filtered;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request, {
+      chatSessionsResult: {
+        ts: 1,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          { key: "main", kind: "direct", updatedAt: null },
+          { key: "agent:main:discord:channel:123", kind: "direct", updatedAt: null },
+        ],
+      },
+    });
+
+    await loadSessions(state, { activeMinutes: 120, syncChatSnapshot: true });
+
+    expect(state.sessionsResult).toEqual(filtered);
+    expect(state.chatSessionsResult).toEqual(filtered);
+  });
 });
 
 describe("deleteSession", () => {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { UiSettings } from "../storage.ts";
 import {
   deleteSession,
   deleteSessionAndRefresh,
@@ -20,25 +19,6 @@ function createState(request: RequestFn, overrides: Partial<SessionsState> = {})
     sessionsFilterLimit: "0",
     sessionsIncludeGlobal: true,
     sessionsIncludeUnknown: true,
-    ...overrides,
-  };
-}
-
-function createSettings(overrides: Partial<UiSettings> = {}): UiSettings {
-  return {
-    gatewayUrl: "",
-    token: "",
-    sessionKey: "main",
-    lastActiveSessionKey: "main",
-    theme: "claw",
-    themeMode: "dark",
-    chatFocusMode: false,
-    chatShowThinking: true,
-    chatShowToolCalls: true,
-    splitRatio: 0.6,
-    navCollapsed: false,
-    navWidth: 280,
-    navGroupsCollapsed: {},
     ...overrides,
   };
 }
@@ -117,7 +97,7 @@ describe("deleteSessionAndRefresh", () => {
 });
 
 describe("loadSessions", () => {
-  it("switches away from a missing direct session after refresh", async () => {
+  it("refreshes sessions without rewriting the active selection", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.list") {
         return {
@@ -130,83 +110,12 @@ describe("loadSessions", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const applySettings = vi.fn();
-    const state = createState(request, {
-      sessionKey: "agent:main:discord:channel:123",
-      settings: createSettings({
-        sessionKey: "agent:main:discord:channel:123",
-        lastActiveSessionKey: "agent:main:discord:channel:123",
-      }),
-      applySettings,
-    });
+    const state = createState(request) as SessionsState & { sessionKey?: string };
+    state.sessionKey = "agent:main:discord:channel:123";
 
     await loadSessions(state);
 
-    expect(state.sessionKey).toBe("main");
-    expect(applySettings).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey: "main",
-        lastActiveSessionKey: "main",
-      }),
-    );
-  });
-
-  it("preserves missing grouped sessions so ephemeral subagent selections stay visible", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method === "sessions.list") {
-        return {
-          ts: 0,
-          path: "",
-          count: 1,
-          defaults: { modelProvider: null, model: null, contextTokens: null },
-          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
-        };
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const applySettings = vi.fn();
-    const state = createState(request, {
-      sessionKey: "agent:main:subagent:child",
-      settings: createSettings({
-        sessionKey: "agent:main:subagent:child",
-        lastActiveSessionKey: "agent:main:subagent:child",
-      }),
-      applySettings,
-    });
-
-    await loadSessions(state);
-
-    expect(state.sessionKey).toBe("agent:main:subagent:child");
-    expect(applySettings).not.toHaveBeenCalled();
-  });
-
-  it("preserves missing top-level cron sessions so active cron views stay stable", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method === "sessions.list") {
-        return {
-          ts: 0,
-          path: "",
-          count: 1,
-          defaults: { modelProvider: null, model: null, contextTokens: null },
-          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
-        };
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const applySettings = vi.fn();
-    const state = createState(request, {
-      sessionKey: "cron:hourly-check",
-      settings: createSettings({
-        sessionKey: "cron:hourly-check",
-        lastActiveSessionKey: "cron:hourly-check",
-      }),
-      applySettings,
-    });
-
-    await loadSessions(state);
-
-    expect(state.sessionKey).toBe("cron:hourly-check");
-    expect(applySettings).not.toHaveBeenCalled();
+    expect(state.sessionKey).toBe("agent:main:discord:channel:123");
   });
 });
 

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteSession, deleteSessionAndRefresh, type SessionsState } from "./sessions.ts";
+import type { UiSettings } from "../storage.ts";
+import {
+  deleteSession,
+  deleteSessionAndRefresh,
+  loadSessions,
+  type SessionsState,
+} from "./sessions.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -14,6 +20,25 @@ function createState(request: RequestFn, overrides: Partial<SessionsState> = {})
     sessionsFilterLimit: "0",
     sessionsIncludeGlobal: true,
     sessionsIncludeUnknown: true,
+    ...overrides,
+  };
+}
+
+function createSettings(overrides: Partial<UiSettings> = {}): UiSettings {
+  return {
+    gatewayUrl: "",
+    token: "",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "claw",
+    themeMode: "dark",
+    chatFocusMode: false,
+    chatShowThinking: true,
+    chatShowToolCalls: true,
+    splitRatio: 0.6,
+    navCollapsed: false,
+    navWidth: 280,
+    navGroupsCollapsed: {},
     ...overrides,
   };
 }
@@ -88,6 +113,69 @@ describe("deleteSessionAndRefresh", () => {
     });
     expect(state.sessionsError).toContain("delete boom");
     expect(state.sessionsLoading).toBe(false);
+  });
+});
+
+describe("loadSessions", () => {
+  it("switches away from a missing direct session after refresh", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const applySettings = vi.fn();
+    const state = createState(request, {
+      sessionKey: "agent:main:discord:channel:123",
+      settings: createSettings({
+        sessionKey: "agent:main:discord:channel:123",
+        lastActiveSessionKey: "agent:main:discord:channel:123",
+      }),
+      applySettings,
+    });
+
+    await loadSessions(state);
+
+    expect(state.sessionKey).toBe("main");
+    expect(applySettings).toHaveBeenCalledWith({
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+    });
+  });
+
+  it("preserves missing grouped sessions so ephemeral subagent selections stay visible", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const applySettings = vi.fn();
+    const state = createState(request, {
+      sessionKey: "agent:main:subagent:child",
+      settings: createSettings({
+        sessionKey: "agent:main:subagent:child",
+        lastActiveSessionKey: "agent:main:subagent:child",
+      }),
+      applySettings,
+    });
+
+    await loadSessions(state);
+
+    expect(state.sessionKey).toBe("agent:main:subagent:child");
+    expect(applySettings).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -19,7 +19,12 @@ export type SessionsState = {
 };
 
 function shouldPreserveMissingSessionKey(key: string): boolean {
-  return key.includes(":subagent:") || key.includes(":cron:");
+  const normalized = key.trim().toLowerCase();
+  return (
+    normalized.includes(":subagent:") ||
+    normalized.startsWith("cron:") ||
+    normalized.includes(":cron:")
+  );
 }
 
 function normalizeMissingSessionSelection(state: SessionsState, res: SessionsListResult) {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,6 +1,5 @@
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { UiSettings } from "../storage.ts";
 import type { SessionsListResult } from "../types.ts";
 
 export type SessionsState = {
@@ -13,54 +12,7 @@ export type SessionsState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
-  sessionKey?: string;
-  settings?: UiSettings;
-  applySettings?: (next: UiSettings) => void;
 };
-
-function shouldPreserveMissingSessionKey(key: string): boolean {
-  const normalized = key.trim().toLowerCase();
-  return (
-    normalized.includes(":subagent:") ||
-    normalized.startsWith("cron:") ||
-    normalized.includes(":cron:")
-  );
-}
-
-function normalizeMissingSessionSelection(state: SessionsState, res: SessionsListResult) {
-  const currentSessionKey = state.sessionKey?.trim();
-  if (!currentSessionKey || shouldPreserveMissingSessionKey(currentSessionKey)) {
-    return;
-  }
-  if (res.sessions.some((row) => row.key === currentSessionKey)) {
-    return;
-  }
-  const preferredLastActive = state.settings?.lastActiveSessionKey?.trim();
-  const nextSessionKey =
-    (preferredLastActive &&
-    preferredLastActive !== currentSessionKey &&
-    res.sessions.some((row) => row.key === preferredLastActive)
-      ? preferredLastActive
-      : null) ??
-    res.sessions.find((row) => row.key === "main")?.key ??
-    res.sessions[0]?.key;
-  if (!nextSessionKey || nextSessionKey === currentSessionKey) {
-    return;
-  }
-  state.sessionKey = nextSessionKey;
-  if (state.settings) {
-    const nextSettings: UiSettings = {
-      ...state.settings,
-      sessionKey: nextSessionKey,
-      lastActiveSessionKey: nextSessionKey,
-    };
-    if (typeof state.applySettings === "function") {
-      state.applySettings(nextSettings);
-    } else {
-      state.settings = nextSettings;
-    }
-  }
-}
 
 export async function loadSessions(
   state: SessionsState,
@@ -97,7 +49,6 @@ export async function loadSessions(
     const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
       state.sessionsResult = res;
-      normalizeMissingSessionSelection(state, res);
     }
   } catch (err) {
     state.sessionsError = String(err);

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -22,6 +22,7 @@ export async function loadSessions(
     limit?: number;
     includeGlobal?: boolean;
     includeUnknown?: boolean;
+    syncChatSnapshot?: boolean;
   },
 ) {
   if (!state.client || !state.connected) {
@@ -37,6 +38,9 @@ export async function loadSessions(
     const includeUnknown = overrides?.includeUnknown ?? state.sessionsIncludeUnknown;
     const activeMinutes = overrides?.activeMinutes ?? toNumber(state.sessionsFilterActive, 0);
     const limit = overrides?.limit ?? toNumber(state.sessionsFilterLimit, 0);
+    const syncChatSnapshot =
+      overrides?.syncChatSnapshot ??
+      (includeGlobal && includeUnknown && activeMinutes <= 0 && limit <= 0);
     const params: Record<string, unknown> = {
       includeGlobal,
       includeUnknown,
@@ -50,7 +54,7 @@ export async function loadSessions(
     const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
       state.sessionsResult = res;
-      if (includeGlobal && includeUnknown && activeMinutes <= 0 && limit <= 0) {
+      if (syncChatSnapshot) {
         state.chatSessionsResult = res;
       }
     }

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -7,6 +7,7 @@ export type SessionsState = {
   connected: boolean;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
+  chatSessionsResult?: SessionsListResult | null;
   sessionsError: string | null;
   sessionsFilterActive: string;
   sessionsFilterLimit: string;
@@ -49,6 +50,9 @@ export async function loadSessions(
     const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
       state.sessionsResult = res;
+      if (includeGlobal && includeUnknown && activeMinutes <= 0 && limit <= 0) {
+        state.chatSessionsResult = res;
+      }
     }
   } catch (err) {
     state.sessionsError = String(err);

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,5 +1,6 @@
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import type { UiSettings } from "../storage.ts";
 import type { SessionsListResult } from "../types.ts";
 
 export type SessionsState = {
@@ -12,7 +13,49 @@ export type SessionsState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionKey?: string;
+  settings?: UiSettings;
+  applySettings?: (next: UiSettings) => void;
 };
+
+function shouldPreserveMissingSessionKey(key: string): boolean {
+  return key.includes(":subagent:") || key.includes(":cron:");
+}
+
+function normalizeMissingSessionSelection(state: SessionsState, res: SessionsListResult) {
+  const currentSessionKey = state.sessionKey?.trim();
+  if (!currentSessionKey || shouldPreserveMissingSessionKey(currentSessionKey)) {
+    return;
+  }
+  if (res.sessions.some((row) => row.key === currentSessionKey)) {
+    return;
+  }
+  const preferredLastActive = state.settings?.lastActiveSessionKey?.trim();
+  const nextSessionKey =
+    (preferredLastActive &&
+    preferredLastActive !== currentSessionKey &&
+    res.sessions.some((row) => row.key === preferredLastActive)
+      ? preferredLastActive
+      : null) ??
+    res.sessions.find((row) => row.key === "main")?.key ??
+    res.sessions[0]?.key;
+  if (!nextSessionKey || nextSessionKey === currentSessionKey) {
+    return;
+  }
+  state.sessionKey = nextSessionKey;
+  if (state.settings) {
+    const nextSettings: UiSettings = {
+      ...state.settings,
+      sessionKey: nextSessionKey,
+      lastActiveSessionKey: nextSessionKey,
+    };
+    if (typeof state.applySettings === "function") {
+      state.applySettings(nextSettings);
+    } else {
+      state.settings = nextSettings;
+    }
+  }
+}
 
 export async function loadSessions(
   state: SessionsState,
@@ -49,6 +92,7 @@ export async function loadSessions(
     const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
       state.sessionsResult = res;
+      normalizeMissingSessionSelection(state, res);
     }
   } catch (err) {
     state.sessionsError = String(err);

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -845,6 +845,35 @@ describe("chat view", () => {
     expect(labels).not.toContain("Subagent:");
   });
 
+  it("does not keep a missing direct session in the grouped chat session selector", () => {
+    const { state } = createChatHeaderState();
+    state.sessionKey = "agent:main:discord:channel:123";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).not.toContain("discord:channel:123");
+    expect(labels).toContain("main");
+  });
+
   it("keeps a unique scoped fallback when a grouped session row has no label or displayName", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -874,6 +874,53 @@ describe("chat view", () => {
     expect(labels).toContain("main");
   });
 
+  it("keeps the active direct session visible when chat has a fresher snapshot than the filtered sessions list", () => {
+    const { state } = createChatHeaderState();
+    state.sessionKey = "agent:main:discord:channel:123";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+    };
+    state.chatSessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "agent:main:discord:channel:123",
+          kind: "direct",
+          updatedAt: null,
+        },
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain("discord:channel:123");
+    expect(labels).toContain("main");
+  });
+
   it("keeps a unique scoped fallback when a grouped session row has no label or displayName", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";


### PR DESCRIPTION
## Problem
Fixes #48108.

When the active direct session disappears from sessions.list after a delete or reset flow, the Control UI keeps the stale session key alive in the chat session dropdown. That makes deleted sessions continue to appear even though they no longer exist in the backend store.

## Fix
- stop re-inserting missing normal direct sessions into the grouped chat session dropdown
- keep the existing fallback behavior for ephemeral missing keys that should remain visible (subagent / cron)
- normalize the active selection away from a missing direct session when a fresh sessions.list response arrives
- add controller and chat-selector regression tests

## Testing
- Passed: npm exec --yes pnpm@10.23.0 -- vitest run ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts
- Passed: npm exec --yes pnpm@10.23.0 -- exec oxfmt --check ui/src/ui/controllers/sessions.ts ui/src/ui/app-render.helpers.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts
- Passed: npm exec --yes pnpm@10.23.0 -- exec oxlint ui/src/ui/controllers/sessions.ts ui/src/ui/app-render.helpers.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts
- Ran: /Users/jamesavery/.openclaw/openclaw-pr-check.sh
- build passed
- check currently fails on unrelated upstream baseline TypeScript errors in src/cron/..., src/infra/gaxios-fetch-compat..., src/media-understanding/apply.test.ts, and src/plugins/provider-runtime.test.ts
- the full test step did not run because check failed first