### PR TITLE
feat: add pagination support to sessions_history tool

### DIFF
--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -20,6 +20,7 @@ import {
 const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: Type.Optional(Type.Number({ minimum: 1 })),
+  offset: Type.Optional(Type.Number({ minimum: 0 })),
   includeTools: Type.Optional(Type.Boolean()),
 });
 
@@ -237,10 +238,14 @@ export function createSessionsHistoryTool(opts?: {
         typeof params.limit === "number" && Number.isFinite(params.limit)
           ? Math.max(1, Math.floor(params.limit))
           : undefined;
+      const offset =
+        typeof params.offset === "number" && Number.isFinite(params.offset)
+          ? Math.max(0, Math.floor(params.offset))
+          : undefined;
       const includeTools = Boolean(params.includeTools);
-      const result = await callGateway<{ messages: Array<unknown> }>({
+      const result = await callGateway<{ messages: Array<unknown>; total?: number }>({
         method: "chat.history",
-        params: { sessionKey: resolvedKey, limit },
+        params: { sessionKey: resolvedKey, limit, offset },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
@@ -260,6 +265,7 @@ export function createSessionsHistoryTool(opts?: {
       return jsonResult({
         sessionKey: displayKey,
         messages: hardened.items,
+        total: result?.total,
         truncated: droppedMessages || contentTruncated || hardened.hardCapped,
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    offset: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -970,19 +970,26 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    const { sessionKey, limit, offset } = params as {
       sessionKey: string;
       limit?: number;
+      offset?: number;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
     const rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+    const total = rawMessages.length;
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+    const requestedOffset = typeof offset === "number" ? Math.max(0, offset) : 0;
+    // Pagination: slice from the end (most recent messages)
+    // offset=0 means the most recent messages
+    const startIndex = Math.max(0, rawMessages.length - requestedOffset - max);
+    const endIndex = rawMessages.length - requestedOffset;
+    const sliced = rawMessages.slice(startIndex, endIndex);
     const sanitized = stripEnvelopeFromMessages(sliced);
     const normalized = sanitizeChatHistoryMessages(sanitized);
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
@@ -1017,6 +1024,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey,
       sessionId,
       messages: bounded.messages,
+      total,
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,


### PR DESCRIPTION
- Add offset parameter to ChatHistoryParamsSchema
- Update sessions-history-tool to pass offset and return total
- Update chat.history handler to support offset-based pagination
- Return total message count in response for pagination UI