### PR TITLE
fix: increase WebSocket handshake timeout for lower-powered hardware

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -21,13 +21,15 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
     maxChatHistoryMessagesBytes = value;
   }
 };
+const MAX_TIMER_MS = 2_147_483_647; // Node.js setTimeout max (32-bit signed int)
+
 export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
   // Test override takes highest priority when running under Vitest
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
     if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
+      return Math.min(parsed, MAX_TIMER_MS);
     }
   }
   // Production override via environment variable
@@ -35,7 +37,7 @@ export const getHandshakeTimeoutMs = () => {
   if (envVal) {
     const parsed = Number(envVal);
     if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
+      return Math.min(parsed, MAX_TIMER_MS);
     }
     console.warn(
       `[openclaw] Ignoring invalid OPENCLAW_HANDSHAKE_TIMEOUT_MS="${envVal}" (must be a positive number)`,

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -23,6 +23,13 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
 };
 export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
+  // Test override takes highest priority when running under Vitest
+  if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
+    const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
   // Production override via environment variable
   const envVal = process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;
   if (envVal) {
@@ -30,13 +37,9 @@ export const getHandshakeTimeoutMs = () => {
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }
-  }
-  // Test override (kept for backward compatibility)
-  if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
-    const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
+    console.warn(
+      `[openclaw] Ignoring invalid OPENCLAW_HANDSHAKE_TIMEOUT_MS="${envVal}" (must be a positive number)`,
+    );
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -21,8 +21,17 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
     maxChatHistoryMessagesBytes = value;
   }
 };
-export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 3_000;
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
+  // Production override via environment variable
+  const envVal = process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;
+  if (envVal) {
+    const parsed = Number(envVal);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  // Test override (kept for backward compatibility)
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
     if (Number.isFinite(parsed) && parsed > 0) {


### PR DESCRIPTION
## Problem

The gateway WebSocket handshake timeout (3s) is too short for lower-powered hardware where Node.js module loading is slow. On devices like Lenovo M700 mini PCs, module loading alone takes ~2.7s, leaving only ~300ms for the actual WS round-trip + crypto signing — causing intermittent CLI failures.

## Changes

- Increase `DEFAULT_HANDSHAKE_TIMEOUT_MS` from 3,000ms to 10,000ms
- Add `OPENCLAW_HANDSHAKE_TIMEOUT_MS` environment variable for production override (any platform, not just tests)
- Keep backward-compatible test override via `OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS`

## Rationale

10 seconds provides enough headroom for slow hardware while still failing fast on genuine connection issues. The timeout only applies to the initial handshake, not ongoing communication.

Closes #48168