### PR TITLE
feat(plugin-sdk): expose deliverOutboundPayloads on PluginRuntime

### DIFF
--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -258,6 +258,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       resolveApiKeyForProvider:
         vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
     },
+    outbound: {
+      deliverOutboundPayloads: vi.fn(async () => []),
+    },
     subagent: {
       run: vi.fn(),
       waitForRun: vi.fn(),

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -4,6 +4,7 @@ import {
   resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
 } from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { deliverOutboundPayloads } from "../../infra/outbound/deliver-runtime.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -54,6 +55,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     version: resolveVersion(),
     config: createRuntimeConfig(),
     subagent: _options.subagent ?? createUnavailableSubagentRuntime(),
+    outbound: { deliverOutboundPayloads },
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),
     tts: { textToSpeechTelephony },

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,7 +1,18 @@
+import type {
+  DeliverOutboundPayloadsParams,
+  OutboundDeliveryResult,
+} from "../../infra/outbound/deliver.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
 export type { RuntimeLogger };
+
+// ── Plugin-safe outbound delivery params (internal fields stripped) ──
+
+type PluginDeliverOutboundParams = Omit<
+  DeliverOutboundPayloadsParams,
+  "skipQueue" | "mirror" | "session" | "deps"
+>;
 
 // ── Subagent runtime types ──────────────────────────────────────────
 
@@ -61,7 +72,9 @@ export type PluginRuntime = PluginRuntimeCore & {
   };
   outbound: {
     /** Send payloads through the standard outbound delivery pipeline (chunking, hooks, queue). */
-    deliverOutboundPayloads: typeof import("../../infra/outbound/deliver.js").deliverOutboundPayloads;
+    deliverOutboundPayloads: (
+      params: PluginDeliverOutboundParams,
+    ) => Promise<OutboundDeliveryResult[]>;
   };
   channel: PluginRuntimeChannel;
 };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -59,5 +59,9 @@ export type PluginRuntime = PluginRuntimeCore & {
     getSession: (params: SubagentGetSessionParams) => Promise<SubagentGetSessionResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
   };
+  outbound: {
+    /** Send payloads through the standard outbound delivery pipeline (chunking, hooks, queue). */
+    deliverOutboundPayloads: typeof import("../../infra/outbound/deliver.js").deliverOutboundPayloads;
+  };
   channel: PluginRuntimeChannel;
 };


### PR DESCRIPTION
## Background

I'm building a plugin that receives GitHub PR webhooks, summarizes them with AI, and delivers notifications to Discord. This requires **push-based** outbound delivery — the plugin registers an HTTP route, receives external events asynchronously, and sends messages to a channel.

Today, the only built-in way to trigger cross-channel delivery through the standard pipeline is via **cron** (pull-based). But many real-world integrations are inherently event-driven: GitHub webhooks, CI/CD notifications, alerting systems, payment callbacks, etc. Forcing these into cron means polling external APIs on a schedule, which leads to:

- **Cron list explosion** — one cron job per repo/service/event type
- **Unnecessary polling** — frequent heartbeats burning API quota for "anything new?" checks
- **Delayed delivery** — events sit until the next cron tick instead of arriving instantly

Push-based plugins solve all of this, but they currently lack access to the standard outbound delivery pipeline. The only option is calling channel-specific send functions (`sendMessageDiscord`, `sendMessageTelegram`, etc.) directly, which bypasses:

- **Message chunking** — automatic splitting at channel limits (e.g., Discord's 2000-char limit)
- **Hook dispatch** — `message_sending` / `message_sent` plugin hooks are not fired
- **Write-ahead delivery queue** — crash recovery for in-flight messages
- **Thread/forum support** — automatic thread routing and forum channel handling
- **Identity injection** — agent name/avatar resolution

## Summary

- Add `runtime.outbound.deliverOutboundPayloads` to `PluginRuntime`, enabling plugins to send messages through the standard outbound delivery pipeline

## Prior art

- PR #5912 (`runtime.outbound.sendToSession`) — similar intent, closed by triage bot
- PR #5400 — parent PR, also closed by triage bot
- PR #32079 (`runtime.system.deliverToSession`) — closed, Greptile scored 5/5

All three were closed without maintainer review due to PR queue volume, not technical objections.

## Changes

| File | Change |
|------|--------|
| `src/plugins/runtime/types.ts` | Add `outbound.deliverOutboundPayloads` to `PluginRuntime` type |
| `src/plugins/runtime/index.ts` | Wire implementation via existing `deliver-runtime.js` re-export |
| `extensions/test-utils/plugin-runtime-mock.ts` | Add mock for `outbound` |

## Usage

```typescript
const cfg = runtime.config.loadConfig();
await runtime.outbound.deliverOutboundPayloads({
  cfg,
  channel: "discord",
  to: "channel:123456789",
  payloads: [{ text: "Hello from plugin!" }],
});
```

## Test plan

- [x] `pnpm tsgo` passes (no new type errors)
- [x] Existing test suite passes
- [x] Validated end-to-end with a GitHub webhook → AI summary → Discord notification plugin