### PR TITLE
fix(imessage): prevent infinite loop when running on personal account

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../../src/config/config.js";
 import { sanitizeTerminalText } from "../../../../src/terminal/safe-text.js";
+import { normalizeIMessageHandle } from "../targets.js";
 import {
   describeIMessageEchoDropLog,
   resolveIMessageInboundDecision,
@@ -315,5 +316,169 @@ describe("resolveIMessageInboundDecision command auth", () => {
       return;
     }
     expect(decision.commandAuthorized).toBe(true);
+  });
+});
+
+describe("resolveIMessageInboundDecision per-message account handle check", () => {
+  const cfg = {} as OpenClawConfig;
+  type InboundDecisionParams = Parameters<typeof resolveIMessageInboundDecision>[0];
+
+  function createInboundDecisionParams(
+    overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
+      message?: Partial<InboundDecisionParams["message"]>;
+    } = {},
+  ): InboundDecisionParams {
+    const { message: messageOverrides, ...restOverrides } = overrides;
+    const message = {
+      id: 42,
+      sender: "+15555550123",
+      text: "ok",
+      is_from_me: false,
+      is_group: false,
+      ...messageOverrides,
+    };
+    const messageText = restOverrides.messageText ?? message.text ?? "";
+    const bodyText = restOverrides.bodyText ?? messageText;
+    const baseParams: Omit<InboundDecisionParams, "message" | "messageText" | "bodyText"> = {
+      cfg,
+      accountId: "default",
+      opts: undefined,
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      selfChatCache: undefined,
+      logVerbose: undefined,
+    };
+    return {
+      ...baseParams,
+      ...restOverrides,
+      message,
+      messageText,
+      bodyText,
+    };
+  }
+
+  function resolveDecision(
+    overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
+      message?: Partial<InboundDecisionParams["message"]>;
+    } = {},
+  ) {
+    return resolveIMessageInboundDecision(createInboundDecisionParams(overrides));
+  }
+
+  it("drops messages when sender matches normalizedAccountHandle", () => {
+    const decision = resolveDecision({
+      message: { sender: "+15551234567", text: "hello" },
+      normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "account handle match" });
+  });
+
+  it("drops messages when sender phone format differs but normalizes to match", () => {
+    const decision = resolveDecision({
+      message: { sender: "+1 (555) 123-4567", text: "hello" },
+      normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "account handle match" });
+  });
+
+  it("drops messages when sender matches normalizedAccountHandle email (case-insensitive)", () => {
+    const decision = resolveDecision({
+      message: { sender: "Bot@Example.com", text: "hello" },
+      normalizedAccountHandle: normalizeIMessageHandle("bot@example.com"),
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "account handle match" });
+  });
+
+  it("does NOT drop messages from other senders when normalizedAccountHandle is set", () => {
+    const decision = resolveDecision({
+      message: { sender: "+15559876543", text: "hello" },
+      normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+    });
+
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("does NOT interfere when normalizedAccountHandle is undefined", () => {
+    const decision = resolveDecision({
+      message: { sender: "+15551234567", text: "hello" },
+      normalizedAccountHandle: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("seeds self-chat cache on account handle drop", () => {
+    const selfChatCache = createSelfChatCache();
+    const createdAt = "2026-03-02T20:58:10.649Z";
+
+    // First message: dropped by account handle match, should seed cache.
+    expect(
+      resolveDecision({
+        message: {
+          id: 9901,
+          sender: "+15551234567",
+          text: "seeded text",
+          created_at: createdAt,
+        },
+        messageText: "seeded text",
+        bodyText: "seeded text",
+        normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+        selfChatCache,
+      }),
+    ).toEqual({ kind: "drop", reason: "account handle match" });
+
+    // Second message: same text from the same sender (multi-device sync echo)
+    // should be caught by self-chat cache since the first drop seeded it.
+    expect(
+      resolveDecision({
+        message: {
+          id: 9902,
+          sender: "+15551234567",
+          text: "seeded text",
+          created_at: createdAt,
+        },
+        messageText: "seeded text",
+        bodyText: "seeded text",
+        selfChatCache,
+        // No normalizedAccountHandle — verifying the cache alone catches it.
+      }),
+    ).toEqual({ kind: "drop", reason: "self-chat echo" });
+  });
+
+  it("is_from_me takes precedence over account handle check", () => {
+    const decision = resolveDecision({
+      message: {
+        sender: "+15551234567",
+        text: "hello",
+        is_from_me: true,
+      },
+      normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "from me" });
+  });
+
+  it("works with dmPolicy open — message dropped BEFORE dmPolicy logic", () => {
+    const logVerbose = vi.fn();
+    const decision = resolveDecision({
+      message: { sender: "+15551234567", text: "hello" },
+      normalizedAccountHandle: normalizeIMessageHandle("+15551234567"),
+      dmPolicy: "open",
+      logVerbose,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "account handle match" });
+    expect(logVerbose).toHaveBeenCalledWith(
+      'imessage: dropping message from account handle: "+15551234567"',
+    );
   });
 });

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -108,6 +108,8 @@ export function resolveIMessageInboundDecision(params: {
   echoCache?: { has: (scope: string, lookup: { text?: string; messageId?: string }) => boolean };
   selfChatCache?: SelfChatCache;
   logVerbose?: (msg: string) => void;
+  /** Pre-normalized account handle for self-message detection. */
+  normalizedAccountHandle?: string;
 }): IMessageInboundDecision {
   const senderRaw = params.message.sender ?? "";
   const sender = senderRaw.trim();
@@ -153,6 +155,15 @@ export function resolveIMessageInboundDecision(params: {
     params.selfChatCache?.remember(selfChatLookup);
     return { kind: "drop", reason: "from me" };
   }
+
+  // Fallback: check sender against configured account handle.
+  // Catches self-messages when is_from_me is unreliable (multi-device sync).
+  if (params.normalizedAccountHandle && params.normalizedAccountHandle === senderNormalized) {
+    params.selfChatCache?.remember(selfChatLookup);
+    params.logVerbose?.(`imessage: dropping message from account handle: "${sender}"`);
+    return { kind: "drop", reason: "account handle match" };
+  }
+
   if (isGroup && !chatId) {
     return { kind: "drop", reason: "group without chat_id" };
   }

--- a/extensions/imessage/src/monitor/monitor-provider.account-handle.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.account-handle.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { validateAccountHandleNotInAllowFrom } from "./monitor-provider.js";
+
+describe("validateAccountHandleNotInAllowFrom", () => {
+  it("returns an error when accountHandle appears in config allowFrom", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "+15551234567",
+      configAllowFrom: ["+15551234567", "+15559876543"],
+      storeAllowFrom: [],
+    });
+    expect(result).toContain("infinite message loop");
+    expect(result).toContain("+15551234567");
+  });
+
+  it("returns an error when accountHandle appears in store allowFrom", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "+15551234567",
+      configAllowFrom: ["+15559876543"],
+      storeAllowFrom: ["+15551234567"],
+    });
+    expect(result).toContain("infinite message loop");
+  });
+
+  it("returns an error when accountHandle matches after normalization (email case)", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "Bot@Example.com",
+      configAllowFrom: ["bot@example.com"],
+      storeAllowFrom: [],
+    });
+    expect(result).toContain("infinite message loop");
+  });
+
+  it("returns an error when accountHandle matches with service prefix in allowFrom", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "+15551234567",
+      configAllowFrom: ["imessage:+15551234567"],
+      storeAllowFrom: [],
+    });
+    expect(result).toContain("infinite message loop");
+  });
+
+  it("returns undefined when accountHandle is not in allowFrom", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "+15551234567",
+      configAllowFrom: ["+15559876543", "+15550001111"],
+      storeAllowFrom: ["+15552223333"],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when accountHandle is omitted", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: undefined,
+      configAllowFrom: ["+15551234567"],
+      storeAllowFrom: ["+15559876543"],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when allowFrom lists are empty", () => {
+    const result = validateAccountHandleNotInAllowFrom({
+      accountHandle: "+15551234567",
+      configAllowFrom: [],
+      storeAllowFrom: [],
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -84,6 +84,33 @@ async function detectRemoteHostFromCliPath(cliPath: string): Promise<string | un
   }
 }
 
+/**
+ * Validates that `accountHandle` (this bot's own iMessage identity) does not
+ * appear in the combined allowFrom list.  If it does, every outbound reply
+ * would be picked up as an inbound message, creating an infinite loop.
+ *
+ * @returns An error message string if validation fails, or `undefined` if OK.
+ */
+export function validateAccountHandleNotInAllowFrom(params: {
+  accountHandle: string | undefined;
+  configAllowFrom: string[];
+  storeAllowFrom: string[];
+}): string | undefined {
+  const { accountHandle, configAllowFrom, storeAllowFrom } = params;
+  if (!accountHandle) {
+    return undefined;
+  }
+  const normalizedAccountHandle = normalizeIMessageHandle(accountHandle);
+  const combinedAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+  const found = combinedAllowFrom.some(
+    (entry) => normalizeIMessageHandle(entry) === normalizedAccountHandle,
+  );
+  if (found) {
+    return `iMessage: accountHandle "${accountHandle}" is also in allowFrom — this will cause an infinite message loop. Remove it from allowFrom, or use a separate iMessage account for openclaw.`;
+  }
+  return undefined;
+}
+
 export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): Promise<void> {
   const runtime = resolveRuntime(opts);
   const cfg = opts.config ?? loadConfig();
@@ -109,6 +136,27 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       imessageCfg.groupAllowFrom ??
       (imessageCfg.allowFrom && imessageCfg.allowFrom.length > 0 ? imessageCfg.allowFrom : []),
   );
+  // Pre-normalize the account handle once for use in per-message checks.
+  const normalizedAccountHandle = imessageCfg.accountHandle
+    ? normalizeIMessageHandle(imessageCfg.accountHandle)
+    : undefined;
+  // Startup validation: if accountHandle is configured, ensure it does not
+  // appear in the combined allowFrom list. If it does, the bot would process
+  // its own outbound messages as inbound, causing an infinite message loop.
+  const storeAllowFromStartup = await readChannelAllowFromStore(
+    "imessage",
+    process.env,
+    accountInfo.accountId,
+  ).catch(() => []);
+  const accountHandleError = validateAccountHandleNotInAllowFrom({
+    accountHandle: imessageCfg.accountHandle,
+    configAllowFrom: [...allowFrom, ...groupAllowFrom],
+    storeAllowFrom: storeAllowFromStartup,
+  });
+  if (accountHandleError) {
+    throw new Error(accountHandleError);
+  }
+
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({
     providerConfigPresent: cfg.channels?.imessage !== undefined,
@@ -256,6 +304,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       echoCache: sentMessageCache,
       selfChatCache,
       logVerbose,
+      normalizedAccountHandle,
     });
 
     // Build conversation key for rate limiting (used by both drop and dispatch paths).
@@ -272,7 +321,8 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         decision.reason === "echo" ||
         decision.reason === "self-chat echo" ||
         decision.reason === "reflected assistant content" ||
-        decision.reason === "from me";
+        decision.reason === "from me" ||
+        decision.reason === "account handle match";
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
       }

--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -14,6 +14,12 @@ import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./typ
 export type IMessageAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /**
+   * The phone number or iCloud email that this openclaw instance sends iMessages from.
+   * Used at startup to reject misconfiguration (accountHandle in allowFrom) and
+   * per-message to drop self-sent messages when is_from_me is unreliable.
+   */
+  accountHandle?: string;
   /** Optional provider capability tags used for agent/runtime guidance. */
   capabilities?: string[];
   /** Markdown formatting overrides (tables). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1238,6 +1238,7 @@ export const IrcConfigSchema = IrcAccountSchemaBase.extend({
 export const IMessageAccountSchemaBase = z
   .object({
     name: z.string().optional(),
+    accountHandle: z.string().optional(),
     capabilities: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Adds `accountHandle` config field — the phone/email this openclaw instance sends from
- At startup, validates `accountHandle` is not in `allowFrom` — throws with a clear error message if misconfigured
- Per-message, drops inbound messages where the sender matches `accountHandle` — catches self-echoes when `is_from_me` is unreliable (multi-device sync)
- Seeds the self-chat cache and feeds the loop rate limiter on account handle drops

## Problem
When openclaw is configured with the same iMessage account the user is actively using, outbound replies can echo back as inbound messages with `is_from_me: false`. The existing guards (echo cache with 5s TTL, self-chat cache, reflection guard) all miss this case under certain conditions, causing the bot to process its own replies in an infinite loop — generating hallucinated responses to itself, which is very dangerous.

This is especially dangerous with `dmPolicy: "open"`, where `allowFrom` is never consulted and any sender is processed unconditionally.

## Changes
- **`src/config/types.imessage.ts`** — Added `accountHandle?: string` to `IMessageAccountConfig`
- **`src/config/zod-schema.providers-core.ts`** — Added `accountHandle` to Zod schema
- **`extensions/imessage/src/monitor/monitor-provider.ts`** — Startup validation (`validateAccountHandleNotInAllowFrom`) + pre-normalized handle passed to per-message check + `"account handle match"` added to `isLoopDrop`
- **`extensions/imessage/src/monitor/inbound-processing.ts`** — Per-message sender check against `normalizedAccountHandle`, placed after `is_from_me` and before `dmPolicy` logic
- **`extensions/imessage/src/monitor/inbound-processing.test.ts`** — 8 tests for per-message filtering
- **`extensions/imessage/src/monitor/monitor-provider.account-handle.test.ts`** — 7 tests for startup validation

## Usage
```yaml
imessage:
  accountHandle: "+15551234567"  # or your iCloud email
```

## Test plan
- [x] 15 new tests covering startup validation + per-message filtering
- [x] Verified zero behavioral change when `accountHandle` is not configured
- [x] All 106 existing tests pass unchanged
- [x] Normalization verified: phone formats, email case, service prefixes