### PR TITLE
fix(ui): avoid tmp dir fs.constants access at import time

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 
 export const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
-const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
+
+function getTmpDirAccessMode(): number {
+  return fs.constants.W_OK | fs.constants.X_OK;
+}
 
 type ResolvePreferredOpenClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
@@ -86,7 +89,7 @@ export function resolvePreferredOpenClawTmpDir(
       if (!isTrustedTmpDir(candidate)) {
         return "invalid";
       }
-      accessSync(candidatePath, TMP_DIR_ACCESS_MODE);
+      accessSync(candidatePath, getTmpDirAccessMode());
       return "available";
     } catch (err) {
       if (isNodeErrorWithCode(err, "ENOENT")) {
@@ -152,7 +155,7 @@ export function resolvePreferredOpenClawTmpDir(
   }
 
   try {
-    accessSync("/tmp", TMP_DIR_ACCESS_MODE);
+    accessSync("/tmp", getTmpDirAccessMode());
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
     chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);


### PR DESCRIPTION
## Summary
- make temp-dir access mode resolution lazy in `tmp-openclaw-dir`
- avoid reading `fs.constants` at module scope

## Why
Issue #48062 reports that the Control UI can render a blank screen because:

- `src/infra/tmp-openclaw-dir.ts` reads `fs.constants.W_OK` / `X_OK` at module scope
- that module is pulled into the browser bundle through a transitive import chain
- in the browser build, `node:fs` is externalized, so evaluating `fs.constants` at import time crashes before the UI mounts

## Changes
- `src/infra/tmp-openclaw-dir.ts`
  - replace the top-level `TMP_DIR_ACCESS_MODE` constant with a lazy `getTmpDirAccessMode()` helper
  - use the helper at the two `accessSync(...)` call sites

This keeps Node runtime behavior the same while preventing browser-side import-time evaluation from crashing the bundle.

## Validation
- `pnpm exec vitest run src/infra/tmp-openclaw-dir.test.ts`
- `pnpm exec oxfmt --check src/infra/tmp-openclaw-dir.ts`

Closes #48062
