### PR TITLE
fix: keep subagents list active while run cleanup is pending

### DIFF
--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -164,7 +164,11 @@ export function isActiveSubagentRun(
   entry: SubagentRunRecord,
   pendingDescendantCount: (sessionKey: string) => number,
 ) {
-  return !entry.endedAt || pendingDescendantCount(entry.childSessionKey) > 0;
+  return (
+    !entry.endedAt ||
+    (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+    pendingDescendantCount(entry.childSessionKey) > 0
+  );
 }
 
 function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendants?: number }) {
@@ -175,6 +179,10 @@ function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendan
   }
   if (!entry.endedAt) {
     return "running";
+  }
+  // Run ended but cleanup (announce/descendant settle) is still in progress.
+  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+    return "completing";
   }
   const status = entry.outcome?.status ?? "done";
   if (status === "ok") {

--- a/src/agents/subagent-registry-queries.test.ts
+++ b/src/agents/subagent-registry-queries.test.ts
@@ -172,7 +172,9 @@ describe("subagent registry query regressions", () => {
       }),
     );
 
-    expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(0);
+    // Parent run still has cleanupCompletedAt=undefined and cleanupHandled not set,
+    // so it remains active even after all descendants are done.
+    expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(1);
   });
 
   it("scopes direct child listings to the requester run window when requesterRunId is provided", () => {

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -145,6 +145,14 @@ export function countActiveRunsForSessionFromRuns(
       count += 1;
       continue;
     }
+    if (
+      typeof entry.cleanupCompletedAt !== "number" &&
+      !entry.cleanupHandled &&
+      !entry.suppressAnnounceReason
+    ) {
+      count += 1;
+      continue;
+    }
     if (pendingDescendantCount(entry.childSessionKey) > 0) {
       count += 1;
     }

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -126,7 +126,11 @@ export async function buildStatusReply(params: {
     const runs = listSubagentRunsForRequester(requesterKey);
     const verboseEnabled = resolvedVerboseLevel && resolvedVerboseLevel !== "off";
     if (runs.length > 0) {
-      const active = runs.filter((entry) => !entry.endedAt);
+      const active = runs.filter(
+        (entry) =>
+          !entry.endedAt ||
+          (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason),
+      );
       const done = runs.length - active.length;
       if (verboseEnabled) {
         const labels = active

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -208,7 +208,9 @@ export function resolveSubagentTarget(
     recentWindowMinutes: RECENT_WINDOW_MINUTES,
     label: (entry) => formatRunLabel(entry),
     isActive: (entry) =>
-      !entry.endedAt || Math.max(0, countPendingDescendantRuns(entry.childSessionKey)) > 0,
+      !entry.endedAt ||
+      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) ||
+      Math.max(0, countPendingDescendantRuns(entry.childSessionKey)) > 0,
     errors: {
       missingTarget: "Missing subagent id.",
       invalidIndex: (value) => `Invalid subagent index: ${value}`,

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -312,10 +312,39 @@ describe("subagents utils", () => {
 
   it("formats run status from outcome and timestamps", () => {
     expect(formatRunStatus({ ...baseRun })).toBe("running");
-    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "ok" } })).toBe("done");
-    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "timeout" } })).toBe(
-      "timeout",
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupCompletedAt: 2100,
+        outcome: { status: "ok" },
+      }),
+    ).toBe("done");
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupCompletedAt: 2100,
+        outcome: { status: "timeout" },
+      }),
+    ).toBe("timeout");
+  });
+
+  it("returns completing when cleanup is pending and not yet handled", () => {
+    expect(formatRunStatus({ ...baseRun, endedAt: 2000, outcome: { status: "ok" } })).toBe(
+      "completing",
     );
+  });
+
+  it("returns done when cleanup is handled but cleanupCompletedAt is missing (legacy state)", () => {
+    expect(
+      formatRunStatus({
+        ...baseRun,
+        endedAt: 2000,
+        cleanupHandled: true,
+        outcome: { status: "ok" },
+      }),
+    ).toBe("done");
   });
 
   it("formats duration compact for seconds and minutes", () => {

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -19,6 +19,9 @@ export function formatRunStatus(entry: SubagentRunRecord) {
   if (!entry.endedAt) {
     return "running";
   }
+  if (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason) {
+    return "completing";
+  }
   const status = entry.outcome?.status ?? "done";
   return status === "ok" ? "done" : status;
 }
@@ -60,7 +63,11 @@ export function resolveSubagentTargetFromRuns(params: {
   if (trimmed === "last") {
     return { entry: sorted[0] };
   }
-  const isActive = params.isActive ?? ((entry: SubagentRunRecord) => !entry.endedAt);
+  const isActive =
+    params.isActive ??
+    ((entry: SubagentRunRecord) =>
+      !entry.endedAt ||
+      (!entry.cleanupCompletedAt && !entry.cleanupHandled && !entry.suppressAnnounceReason));
   const recentCutoff = Date.now() - params.recentWindowMinutes * 60_000;
   const numericOrder = [
     ...sorted.filter((entry) => isActive(entry)),


### PR DESCRIPTION
## Summary

- `subagents list` shows mode="run" orchestrators as "done" right after model turn ends, even when cleanup is still in progress — causing duplicate orchestrator spawns.
- Added `cleanupCompletedAt` + `cleanupHandled` gate: runs show "completing" until cleanup finalizes, staying in the "active" section.
- Aligned all `isActive` predicates (including default fallback in `resolveSubagentTargetFromRuns`) so list/kill/steer index numbering stays consistent.
- Runs with `cleanupHandled: true` but no `cleanupCompletedAt` (legacy/restart state) are excluded from active counting to prevent indefinite spawn blocking.

Closes #39619
Related #39658

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## User-visible / Behavior Changes

- `subagents list` shows "completing" instead of "done" for runs with pending cleanup.
- Orchestrators with pending children stay in "active" section instead of "recent".
- Cleanup-pending runs count toward `maxChildrenPerAgent` spawn limit.
- Status command active count now includes cleanup-pending runs.

## Test plan

- [x] `pnpm test -- src/agents/subagent-registry-queries.test.ts` — 8/8 pass
- [x] `pnpm test -- src/auto-reply/reply/reply-plumbing.test.ts` (subagents utils) — 7/7 pass