### PR TITLE
Extensions: add plugin-insights extension

### DIFF
--- a/extensions/plugin-insights/LICENSE
+++ b/extensions/plugin-insights/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Taylor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/plugin-insights/README.md
+++ b/extensions/plugin-insights/README.md
@@ -35,8 +35,8 @@ openclaw plugins install plugin-insights
 
 You can also ask your agent directly:
 
-- *"How effective are my plugins?"* → triggers `insights_show`
-- *"Compare memory-core and memory-lancedb"* → triggers `insights_compare`
+- _"How effective are my plugins?"_ → triggers `insights_show`
+- _"Compare memory-core and memory-lancedb"_ → triggers `insights_compare`
 
 ### Report Example
 
@@ -92,17 +92,17 @@ Add to your OpenClaw config:
 }
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `true` | Enable/disable data collection |
-| `dbPath` | `~/.openclaw/plugin-insights.db` | Path to local SQLite database |
-| `retentionDays` | `90` | Days of data to retain before auto-cleanup |
-| `toolMappings` | `[]` | Explicit tool→plugin mappings for accurate attribution |
-| `llmJudge.enabled` | `false` | Enable LLM-as-Judge quality scoring |
-| `llmJudge.apiKey` | — | Your OpenAI-compatible API key |
-| `llmJudge.baseUrl` | `https://api.openai.com/v1` | API base URL |
-| `llmJudge.model` | `gpt-4o-mini` | Model to use for judging |
-| `llmJudge.maxEvalPerDay` | `20` | Max evaluations per day (cost control) |
+| Option                   | Default                          | Description                                            |
+| ------------------------ | -------------------------------- | ------------------------------------------------------ |
+| `enabled`                | `true`                           | Enable/disable data collection                         |
+| `dbPath`                 | `~/.openclaw/plugin-insights.db` | Path to local SQLite database                          |
+| `retentionDays`          | `90`                             | Days of data to retain before auto-cleanup             |
+| `toolMappings`           | `[]`                             | Explicit tool→plugin mappings for accurate attribution |
+| `llmJudge.enabled`       | `false`                          | Enable LLM-as-Judge quality scoring                    |
+| `llmJudge.apiKey`        | —                                | Your OpenAI-compatible API key                         |
+| `llmJudge.baseUrl`       | `https://api.openai.com/v1`      | API base URL                                           |
+| `llmJudge.model`         | `gpt-4o-mini`                    | Model to use for judging                               |
+| `llmJudge.maxEvalPerDay` | `20`                             | Max evaluations per day (cost control)                 |
 
 ## How It Works
 
@@ -120,13 +120,13 @@ Three layers work together to figure out which plugin caused what:
 
 ### Metrics
 
-| Metric | What it measures |
-|--------|------------------|
-| Trigger Frequency | How often a plugin activates |
-| Token Delta | Extra tokens consumed when plugin is active |
-| Conversation Turns | Whether sessions are shorter (more efficient) with the plugin |
-| Implicit Satisfaction | Retry/correction rates after plugin triggers |
-| LLM Judge | AI-scored quality comparison (optional, uses your API key) |
+| Metric                | What it measures                                              |
+| --------------------- | ------------------------------------------------------------- |
+| Trigger Frequency     | How often a plugin activates                                  |
+| Token Delta           | Extra tokens consumed when plugin is active                   |
+| Conversation Turns    | Whether sessions are shorter (more efficient) with the plugin |
+| Implicit Satisfaction | Retry/correction rates after plugin triggers                  |
+| LLM Judge             | AI-scored quality comparison (optional, uses your API key)    |
 
 ## For Plugin Developers
 
@@ -140,7 +140,11 @@ For best results, ask your users to add your tool names to the `toolMappings` co
     "entries": {
       "plugin-insights": {
         "toolMappings": [
-          { "toolName": "your_tool_name", "pluginId": "your-plugin-id", "pluginName": "Your Plugin" }
+          {
+            "toolName": "your_tool_name",
+            "pluginId": "your-plugin-id",
+            "pluginName": "Your Plugin"
+          }
         ]
       }
     }
@@ -157,10 +161,12 @@ import Database from "better-sqlite3";
 
 // Open the shared insights DB
 const db = new Database("~/.openclaw/plugin-insights.db");
-db.prepare(`
+db.prepare(
+  `
   INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, metadata_json)
   VALUES (?, ?, 'self_report', ?, ?)
-`).run(turnId, "my-plugin", "recall", JSON.stringify({ count: 5 }));
+`,
+).run(turnId, "my-plugin", "recall", JSON.stringify({ count: 5 }));
 ```
 
 > **Note:** A cleaner hook-based self-report API (`api.on("plugin_insights_report", ...)`) is planned for when the OpenClaw SDK supports custom hook names. The infrastructure is ready in the codebase.

--- a/extensions/plugin-insights/README.md
+++ b/extensions/plugin-insights/README.md
@@ -1,0 +1,186 @@
+# Plugin Insights
+
+> Automatically evaluate how much your installed OpenClaw plugins actually help.
+
+Plugin Insights is an OpenClaw plugin that tracks and analyzes the real-world effectiveness of your other plugins. It runs silently in the background, collecting data locally, and produces actionable reports so you know which plugins are worth keeping — and which ones are just wasting tokens.
+
+## Features
+
+- **Automatic data collection** via ContextEngine `afterTurn` hook and `after_tool_call` hook
+- **Three-layer attribution**: Tool Call matching (requires `toolMappings` config for accurate results), Context Injection detection (scans all message roles including system/context), Self-Report API
+- **Five evaluation metrics**: Trigger Frequency, Token Overhead, Conversation Turns, Implicit Satisfaction, LLM-as-Judge (optional, calls external API)
+- **Multiple report formats**: CLI slash-commands, HTML dashboard, JSON export
+- **Local-first data**: All collected data stays in a local SQLite database. No telemetry. LLM-as-Judge is opt-in and uses your own API key.
+
+## Install
+
+```bash
+openclaw plugins install plugin-insights
+```
+
+## Usage
+
+### Slash Commands (inside OpenClaw TUI/chat)
+
+```
+/insights-show
+/insights-show --plugin memory-tools
+/insights-compare memory-core memory-lancedb
+/insights-export --output ./data.json --format json
+/insights-dashboard --output ./dashboard.html
+/insights-reset --confirm
+```
+
+### Agent Tools
+
+You can also ask your agent directly:
+
+- *"How effective are my plugins?"* → triggers `insights_show`
+- *"Compare memory-core and memory-lancedb"* → triggers `insights_compare`
+
+### Report Example
+
+```
+╔════════════════════════════════════════════════════════╗
+║              Plugin Insights Report                    ║
+║              Period: 2026-02-14 → 2026-03-16           ║
+╠════════════════════════════════════════════════════════╣
+║                                                        ║
+║  Memory Tools          installed 30d                   ║
+║  ├─ Triggered: 247 times (8.2/day)                     ║
+║  ├─ Token overhead: +12% (~$0.80/mo)                   ║
+║  ├─ Avg turns/session: 4.2 → 3.1 (▼26%)               ║
+║  ├─ User acceptance rate: 84%                          ║
+║  └─ Verdict: ✅ KEEP — strong positive impact          ║
+║                                                        ║
+║  Auto-Translator       installed 7d                    ║
+║  ├─ Triggered: 89 times (12.7/day)                     ║
+║  ├─ Token overhead: +45% (~$3.20/mo)                   ║
+║  ├─ User acceptance rate: 42%                          ║
+║  ├─ Retry rate after trigger: 38%                      ║
+║  └─ Verdict: ❌ EXPENSIVE & LOW SATISFACTION           ║
+║                                                        ║
+╚════════════════════════════════════════════════════════╝
+```
+
+## Configuration
+
+Add to your OpenClaw config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "plugin-insights": {
+        "enabled": true,
+        "dbPath": "~/.openclaw/plugin-insights.db",
+        "retentionDays": 90,
+        "toolMappings": [
+          { "toolName": "memory_recall", "pluginId": "memory-core", "pluginName": "Memory Core" },
+          { "toolName": "web_search", "pluginId": "web-tools", "pluginName": "Web Tools" }
+        ],
+        "llmJudge": {
+          "enabled": false,
+          "apiKey": "sk-...",
+          "baseUrl": "https://api.openai.com/v1",
+          "model": "gpt-4o-mini",
+          "maxEvalPerDay": 20
+        }
+      }
+    }
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable/disable data collection |
+| `dbPath` | `~/.openclaw/plugin-insights.db` | Path to local SQLite database |
+| `retentionDays` | `90` | Days of data to retain before auto-cleanup |
+| `toolMappings` | `[]` | Explicit tool→plugin mappings for accurate attribution |
+| `llmJudge.enabled` | `false` | Enable LLM-as-Judge quality scoring |
+| `llmJudge.apiKey` | — | Your OpenAI-compatible API key |
+| `llmJudge.baseUrl` | `https://api.openai.com/v1` | API base URL |
+| `llmJudge.model` | `gpt-4o-mini` | Model to use for judging |
+| `llmJudge.maxEvalPerDay` | `20` | Max evaluations per day (cost control) |
+
+## How It Works
+
+### Data Collection
+
+Plugin Insights registers as a lightweight ContextEngine (`ownsCompaction: false`) so it can tap into the `afterTurn` lifecycle hook without affecting agent behavior. It also hooks into `after_tool_call` to observe tool calls at runtime.
+
+### Attribution
+
+Three layers work together to figure out which plugin caused what:
+
+1. **Tool Call Matching** — Hooks into `after_tool_call` to observe every tool invocation at runtime. Observed tool names are matched against user-configured `toolMappings` for plugin attribution. Tools without explicit mappings are logged for diagnostics but **not** attributed to any plugin (no false positives). Built-in agent tools (e.g., `web_search`, `write_file`) are automatically excluded.
+2. **Context Injection Detection** — Scans all messages — including system and context messages injected by other plugins — for known plugin markers (e.g., `[memory-core]`, `[semantic-memory]`).
+3. **Self-Report API** — Plugins can write directly to the plugin-insights SQLite database for the most precise attribution. (A hook-based API is planned for a future SDK version with custom hook support.)
+
+### Metrics
+
+| Metric | What it measures |
+|--------|------------------|
+| Trigger Frequency | How often a plugin activates |
+| Token Delta | Extra tokens consumed when plugin is active |
+| Conversation Turns | Whether sessions are shorter (more efficient) with the plugin |
+| Implicit Satisfaction | Retry/correction rates after plugin triggers |
+| LLM Judge | AI-scored quality comparison (optional, uses your API key) |
+
+## For Plugin Developers
+
+### Accurate Attribution via toolMappings
+
+For best results, ask your users to add your tool names to the `toolMappings` config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "plugin-insights": {
+        "toolMappings": [
+          { "toolName": "your_tool_name", "pluginId": "your-plugin-id", "pluginName": "Your Plugin" }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Direct Self-Reporting
+
+For the most precise attribution, your plugin can write directly to the plugin-insights DB:
+
+```typescript
+import Database from "better-sqlite3";
+
+// Open the shared insights DB
+const db = new Database("~/.openclaw/plugin-insights.db");
+db.prepare(`
+  INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, metadata_json)
+  VALUES (?, ?, 'self_report', ?, ?)
+`).run(turnId, "my-plugin", "recall", JSON.stringify({ count: 5 }));
+```
+
+> **Note:** A cleaner hook-based self-report API (`api.on("plugin_insights_report", ...)`) is planned for when the OpenClaw SDK supports custom hook names. The infrastructure is ready in the codebase.
+
+## Development
+
+```bash
+npm install
+npm test          # Run tests
+npm run build     # Build with tsup
+npm run lint      # Type check
+```
+
+## Tech Stack
+
+- TypeScript, Node.js
+- better-sqlite3 (local storage)
+- Vitest (testing)
+- tsup (bundling)
+
+## License
+
+MIT

--- a/extensions/plugin-insights/index.ts
+++ b/extensions/plugin-insights/index.ts
@@ -1,0 +1,100 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginDefinition,
+  PluginInsightsConfig,
+} from "./src/types.js";
+import { resolveConfig } from "./src/db/config.js";
+import { createDb } from "./src/db/connection.js";
+import {
+  createInsightsEngine,
+  cleanupOldData,
+  type ToolPluginMapping,
+} from "./src/engine.js";
+import { createInsightsShowTool } from "./src/tools/insights-show.js";
+import { createInsightsCompareTool } from "./src/tools/insights-compare.js";
+import { createCommands } from "./src/commands.js";
+
+/**
+ * Plugin Insights — OpenClaw plugin definition.
+ *
+ * Exported as OpenClawPluginDefinition per the real SDK contract.
+ * OpenClaw will call `register(api)` on plugin load.
+ */
+const pluginDefinition: OpenClawPluginDefinition = {
+  id: "plugin-insights",
+  name: "Plugin Insights",
+  description:
+    "Automatically evaluate how much your installed plugins actually help",
+  version: "0.1.0",
+
+  register(api: OpenClawPluginApi): void {
+    const userConfig = (api.pluginConfig ?? {}) as Partial<PluginInsightsConfig> & {
+      toolMappings?: { toolName: string; pluginId: string; pluginName?: string }[];
+    };
+    const config = resolveConfig(userConfig);
+
+    if (!config.enabled) return;
+
+    const db = createDb(config.dbPath);
+
+    // Layer 1: Seed tool→plugin mapping from user config
+    const toolPluginMappings: ToolPluginMapping[] =
+      userConfig.toolMappings?.map((m) => ({
+        toolName: m.toolName,
+        pluginId: m.pluginId,
+        pluginName: m.pluginName,
+      })) ?? [];
+
+    const { engine, toolDetector } = createInsightsEngine(
+      db,
+      config,
+      toolPluginMappings
+    );
+
+    // Register as ContextEngine (ownsCompaction: false — non-invasive)
+    api.registerContextEngine("plugin-insights", () => engine);
+
+    // Register agent tools (pass toolDetector for coverage diagnostics)
+    api.registerTool(createInsightsShowTool(db, config, toolDetector));
+    api.registerTool(createInsightsCompareTool(db, config, toolDetector));
+
+    // Register slash-commands (pass toolDetector for /insights-status)
+    for (const cmd of createCommands(db, config, toolDetector)) {
+      api.registerCommand(cmd);
+    }
+
+    // Layer 1: Observe tool calls at runtime via after_tool_call hook.
+    // Records non-builtin tool names for diagnostic purposes.
+    // Only tools with explicit toolMappings config appear in reports.
+    api.on("after_tool_call", (event, ctx) => {
+      const toolName = event?.toolName ?? ctx?.toolName;
+      if (!toolName) return;
+
+      // Skip our own tools
+      if (toolName === "insights_show" || toolName === "insights_compare") {
+        return;
+      }
+
+      try {
+        toolDetector.learnTool(toolName);
+      } catch {
+        // Best-effort
+      }
+    });
+
+    // Deferred cleanup of expired data (non-blocking)
+    setTimeout(() => {
+      try {
+        cleanupOldData(db, config.retentionDays);
+      } catch {
+        // Cleanup is best-effort
+      }
+    }, 5_000);
+  },
+};
+
+export default pluginDefinition;
+
+// Re-export types for consumers
+export type { InsightsAPIReport, PluginInsightsConfig } from "./src/types.js";
+export type { PluginInsightsPublicAPI } from "./src/collector/plugin-reporter.js";

--- a/extensions/plugin-insights/index.ts
+++ b/extensions/plugin-insights/index.ts
@@ -1,18 +1,14 @@
+import { createCommands } from "./src/commands.js";
+import { resolveConfig } from "./src/db/config.js";
+import { createDb } from "./src/db/connection.js";
+import { createInsightsEngine, cleanupOldData, type ToolPluginMapping } from "./src/engine.js";
+import { createInsightsCompareTool } from "./src/tools/insights-compare.js";
+import { createInsightsShowTool } from "./src/tools/insights-show.js";
 import type {
   OpenClawPluginApi,
   OpenClawPluginDefinition,
   PluginInsightsConfig,
 } from "./src/types.js";
-import { resolveConfig } from "./src/db/config.js";
-import { createDb } from "./src/db/connection.js";
-import {
-  createInsightsEngine,
-  cleanupOldData,
-  type ToolPluginMapping,
-} from "./src/engine.js";
-import { createInsightsShowTool } from "./src/tools/insights-show.js";
-import { createInsightsCompareTool } from "./src/tools/insights-compare.js";
-import { createCommands } from "./src/commands.js";
 
 /**
  * Plugin Insights — OpenClaw plugin definition.
@@ -23,8 +19,7 @@ import { createCommands } from "./src/commands.js";
 const pluginDefinition: OpenClawPluginDefinition = {
   id: "plugin-insights",
   name: "Plugin Insights",
-  description:
-    "Automatically evaluate how much your installed plugins actually help",
+  description: "Automatically evaluate how much your installed plugins actually help",
   version: "0.1.0",
 
   register(api: OpenClawPluginApi): void {
@@ -45,11 +40,7 @@ const pluginDefinition: OpenClawPluginDefinition = {
         pluginName: m.pluginName,
       })) ?? [];
 
-    const { engine, toolDetector } = createInsightsEngine(
-      db,
-      config,
-      toolPluginMappings
-    );
+    const { engine, toolDetector } = createInsightsEngine(db, config, toolPluginMappings);
 
     // Register as ContextEngine (ownsCompaction: false — non-invasive)
     api.registerContextEngine("plugin-insights", () => engine);

--- a/extensions/plugin-insights/openclaw.plugin.json
+++ b/extensions/plugin-insights/openclaw.plugin.json
@@ -1,0 +1,51 @@
+{
+  "id": "plugin-insights",
+  "name": "Plugin Insights",
+  "description": "Automatically evaluate how much your installed plugins actually help. Tracks trigger frequency, token overhead, conversation efficiency, and user satisfaction — all locally.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable or disable data collection"
+      },
+      "dbPath": {
+        "type": "string",
+        "default": "~/.openclaw/plugin-insights.db",
+        "description": "Path to the local SQLite database"
+      },
+      "retentionDays": {
+        "type": "integer",
+        "default": 90,
+        "description": "How many days of data to retain"
+      },
+      "toolMappings": {
+        "type": "array",
+        "description": "Map tool names to plugin IDs for attribution",
+        "items": {
+          "type": "object",
+          "properties": {
+            "toolName": { "type": "string" },
+            "pluginId": { "type": "string" },
+            "pluginName": { "type": "string" }
+          },
+          "required": ["toolName", "pluginId"]
+        }
+      },
+      "llmJudge": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean", "default": false },
+          "apiKey": { "type": "string" },
+          "baseUrl": { "type": "string", "default": "https://api.openai.com/v1" },
+          "model": { "type": "string", "default": "gpt-4o-mini" },
+          "maxEvalPerDay": { "type": "integer", "default": 20 }
+        },
+        "description": "Optional LLM-as-judge configuration. User must provide their own API key."
+      }
+    }
+  }
+}

--- a/extensions/plugin-insights/package.json
+++ b/extensions/plugin-insights/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/plugin-insights",
+  "version": "2026.3.16",
+  "private": true,
+  "description": "Automatically evaluate how much your installed plugins actually help",
+  "type": "module",
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.8"
+  },
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  },
+  "license": "MIT"
+}

--- a/extensions/plugin-insights/package.json
+++ b/extensions/plugin-insights/package.json
@@ -3,6 +3,7 @@
   "version": "2026.3.16",
   "private": true,
   "description": "Automatically evaluate how much your installed plugins actually help",
+  "license": "MIT",
   "type": "module",
   "dependencies": {
     "better-sqlite3": "^11.0.0"
@@ -11,7 +12,8 @@
     "@types/better-sqlite3": "^7.6.8"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
-  },
-  "license": "MIT"
+    "extensions": [
+      "./index.ts"
+    ]
+  }
 }

--- a/extensions/plugin-insights/src/collector/context-detector.ts
+++ b/extensions/plugin-insights/src/collector/context-detector.ts
@@ -1,0 +1,69 @@
+import type { AgentMessage } from "../types.js";
+import { extractAllText } from "../types.js";
+
+/**
+ * Layer 2: Context Injection Detection
+ * Heuristically detects plugin-injected content in messages
+ * by looking for known marker patterns.
+ */
+
+/** Known plugin marker patterns: regex → pluginId */
+const DEFAULT_MARKERS: [RegExp, string][] = [
+  [/\[memory-plugin\]/i, "memory-plugin"],
+  [/\[memory-core\]/i, "memory-core"],
+  [/\[memory-lancedb\]/i, "memory-lancedb"],
+  [/\[lcm\]/i, "lossless-claw"],
+  [/\[lossless-claw\]/i, "lossless-claw"],
+  [/\[semantic-memory\]/i, "semantic-memory"],
+  [/\[agent-brain\]/i, "agent-brain"],
+  [/\[mem0\]/i, "mem0"],
+  [/\[supermemory\]/i, "supermemory"],
+  [/\[memos\]/i, "memos-cloud"],
+  [/\[cognee\]/i, "cognee"],
+];
+
+export interface ContextDetection {
+  pluginId: string;
+  action: string;
+  marker: string;
+}
+
+export class ContextDetector {
+  private markers: [RegExp, string][];
+
+  constructor(extraMarkers?: [RegExp, string][]) {
+    this.markers = [...DEFAULT_MARKERS, ...(extraMarkers ?? [])];
+  }
+
+  /** Detect plugins that injected context into the messages */
+  detect(messages: AgentMessage[]): ContextDetection[] {
+    const results: ContextDetection[] = [];
+    const seen = new Set<string>();
+
+    for (const msg of messages) {
+      const content = extractAllText(msg);
+      if (!content) continue;
+
+      for (const [pattern, pluginId] of this.markers) {
+        if (seen.has(pluginId)) continue;
+
+        const match = content.match(pattern);
+        if (match) {
+          seen.add(pluginId);
+          results.push({
+            pluginId,
+            action: "context_injection",
+            marker: match[0],
+          });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /** Add custom markers at runtime */
+  addMarker(pattern: RegExp, pluginId: string): void {
+    this.markers.push([pattern, pluginId]);
+  }
+}

--- a/extensions/plugin-insights/src/collector/plugin-reporter.ts
+++ b/extensions/plugin-insights/src/collector/plugin-reporter.ts
@@ -1,0 +1,77 @@
+import type Database from "better-sqlite3";
+import type { InsightsAPIReport } from "../types.js";
+
+/**
+ * Layer 3: Insights API (Self-Report)
+ *
+ * Other plugins can report their own activity for precise attribution.
+ * Reports are session-scoped: only reports matching the current session
+ * are flushed to a turn, preventing cross-session contamination.
+ *
+ * Usage via after_tool_call or direct DB access:
+ *   reporter.report({ pluginId: "my-plugin", action: "recall", sessionId });
+ */
+export class PluginReporter {
+  private db: Database.Database;
+  private pendingReports: InsightsAPIReport[] = [];
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  /** Accept a report from an external plugin */
+  report(data: InsightsAPIReport): void {
+    this.pendingReports.push(data);
+  }
+
+  /** Flush pending reports that match the given session and associate them with a turn.
+   *  Reports without a sessionId are always flushed (backwards-compatible). */
+  flushToTurn(turnId: number, sessionId?: string): void {
+    if (this.pendingReports.length === 0) return;
+
+    // Partition: matching (flush now) vs non-matching (keep)
+    const toFlush: InsightsAPIReport[] = [];
+    const toKeep: InsightsAPIReport[] = [];
+
+    for (const report of this.pendingReports) {
+      if (!report.sessionId || !sessionId || report.sessionId === sessionId) {
+        toFlush.push(report);
+      } else {
+        toKeep.push(report);
+      }
+    }
+
+    if (toFlush.length === 0) {
+      return;
+    }
+
+    const insert = this.db.prepare(`
+      INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, metadata_json)
+      VALUES (?, ?, 'self_report', ?, ?)
+    `);
+
+    const tx = this.db.transaction(() => {
+      for (const report of toFlush) {
+        insert.run(
+          turnId,
+          report.pluginId,
+          report.action,
+          report.metadata ? JSON.stringify(report.metadata) : null
+        );
+      }
+    });
+    tx();
+
+    this.pendingReports = toKeep;
+  }
+
+  /** Get pending reports count (for testing) */
+  getPendingCount(): number {
+    return this.pendingReports.length;
+  }
+}
+
+/** The public API that other plugins can call */
+export interface PluginInsightsPublicAPI {
+  report(data: InsightsAPIReport): void;
+}

--- a/extensions/plugin-insights/src/collector/plugin-reporter.ts
+++ b/extensions/plugin-insights/src/collector/plugin-reporter.ts
@@ -65,6 +65,18 @@ export class PluginReporter {
     this.pendingReports = toKeep;
   }
 
+  /** Peek at plugin IDs from pending reports that would match the given session.
+   *  Used to include Layer 3 plugin IDs in plugins_triggered_json before insert. */
+  peekMatchingPluginIds(sessionId?: string): Set<string> {
+    const ids = new Set<string>();
+    for (const report of this.pendingReports) {
+      if (!report.sessionId || !sessionId || report.sessionId === sessionId) {
+        ids.add(report.pluginId);
+      }
+    }
+    return ids;
+  }
+
   /** Get pending reports count (for testing) */
   getPendingCount(): number {
     return this.pendingReports.length;

--- a/extensions/plugin-insights/src/collector/plugin-reporter.ts
+++ b/extensions/plugin-insights/src/collector/plugin-reporter.ts
@@ -56,7 +56,7 @@ export class PluginReporter {
           turnId,
           report.pluginId,
           report.action,
-          report.metadata ? JSON.stringify(report.metadata) : null
+          report.metadata ? JSON.stringify(report.metadata) : null,
         );
       }
     });

--- a/extensions/plugin-insights/src/collector/tool-detector.ts
+++ b/extensions/plugin-insights/src/collector/tool-detector.ts
@@ -37,7 +37,9 @@ export class ToolDetector {
     this.loadMappingCache();
   }
 
-  /** Rebuild the tool→plugin mapping from explicit entries */
+  /** Rebuild the tool→plugin mapping from explicit entries.
+   *  Purges stale mappings that are no longer in the config so removed
+   *  tool→plugin associations don't corrupt attribution diagnostics. */
   refreshMappingFromEntries(
     entries: { toolName: string; pluginId: string; pluginName?: string }[],
   ): void {
@@ -50,7 +52,19 @@ export class ToolDetector {
         updated_at = datetime('now')
     `);
 
+    const currentToolNames = new Set(entries.map((e) => e.toolName));
+
     const tx = this.db.transaction(() => {
+      // Purge mappings no longer present in config
+      const existing = this.db.prepare("SELECT tool_name FROM tool_plugin_mapping").all() as {
+        tool_name: string;
+      }[];
+      for (const row of existing) {
+        if (!currentToolNames.has(row.tool_name)) {
+          this.db.prepare("DELETE FROM tool_plugin_mapping WHERE tool_name = ?").run(row.tool_name);
+        }
+      }
+
       for (const entry of entries) {
         upsert.run(entry.toolName, entry.pluginId, entry.pluginName ?? null);
       }

--- a/extensions/plugin-insights/src/collector/tool-detector.ts
+++ b/extensions/plugin-insights/src/collector/tool-detector.ts
@@ -1,0 +1,159 @@
+import type Database from "better-sqlite3";
+import type { ToolCallContent, ToolPluginMappingRow } from "../types.js";
+
+/** Tools built into the OpenClaw agent runtime (not owned by any plugin) */
+const BUILTIN_TOOLS = new Set([
+  // Core agent tools
+  "web_search", "web_browse", "web_fetch",
+  "write_file", "read_file", "edit_file", "list_files",
+  "run_command", "run_shell",
+  "create_file", "delete_file",
+  "search_code", "search_files",
+  // Our own tools (should never be attributed)
+  "insights_show", "insights_compare",
+]);
+
+/**
+ * Layer 1: Tool Call Attribution
+ * Matches tool calls in a turn to known plugin-registered tools.
+ */
+export class ToolDetector {
+  private db: Database.Database;
+  private mappingCache: Map<string, string> = new Map();
+  /** In-memory set of tools already persisted this session — avoids repeated DB writes */
+  private knownUnmapped: Set<string> = new Set();
+
+  constructor(db: Database.Database) {
+    this.db = db;
+    this.loadMappingCache();
+  }
+
+  /** Rebuild the tool→plugin mapping from explicit entries */
+  refreshMappingFromEntries(
+    entries: { toolName: string; pluginId: string; pluginName?: string }[]
+  ): void {
+    const upsert = this.db.prepare(`
+      INSERT INTO tool_plugin_mapping (tool_name, plugin_id, plugin_name, updated_at)
+      VALUES (?, ?, ?, datetime('now'))
+      ON CONFLICT(tool_name) DO UPDATE SET
+        plugin_id = excluded.plugin_id,
+        plugin_name = excluded.plugin_name,
+        updated_at = datetime('now')
+    `);
+
+    const tx = this.db.transaction(() => {
+      for (const entry of entries) {
+        upsert.run(entry.toolName, entry.pluginId, entry.pluginName ?? null);
+      }
+    });
+    tx();
+
+    this.loadMappingCache();
+  }
+
+  /** Detect which plugins were triggered by tool calls in this turn */
+  detect(toolCalls: ToolCallContent[]): { pluginId: string; action: string }[] {
+    const results: { pluginId: string; action: string }[] = [];
+    const seen = new Set<string>();
+
+    for (const tc of toolCalls) {
+      const toolName = tc.name;
+      const pluginId = this.mappingCache.get(toolName);
+      if (pluginId) {
+        const key = `${pluginId}:${toolName}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          results.push({ pluginId, action: toolName });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /** Get the plugin ID for a given tool name */
+  getPluginForTool(toolName: string): string | undefined {
+    return this.mappingCache.get(toolName);
+  }
+
+  /** Record a tool name observed at runtime (after_tool_call hook).
+   *  Only records non-builtin, non-self tools that are NOT already
+   *  mapped to a plugin. Persists to SQLite so observations survive restarts.
+   *  Does NOT create fake plugin entries — unmapped tools are stored for
+   *  diagnostics only and won't appear in attribution reports until the
+   *  user adds a toolMapping. */
+  learnTool(toolName: string): void {
+    // Already mapped to a real plugin — nothing to learn
+    if (this.mappingCache.has(toolName)) return;
+
+    // Skip built-in agent tools
+    if (BUILTIN_TOOLS.has(toolName)) return;
+
+    if (this.knownUnmapped.has(toolName)) {
+      // Already seen this session — just bump the count
+      this.db.prepare(
+        `UPDATE observed_unmapped_tools
+         SET call_count = call_count + 1, last_seen_at = datetime('now')
+         WHERE tool_name = ?`
+      ).run(toolName);
+    } else {
+      // First time this session (may or may not exist in DB from prior sessions)
+      this.db.prepare(
+        `INSERT INTO observed_unmapped_tools (tool_name, call_count)
+         VALUES (?, 1)
+         ON CONFLICT(tool_name) DO UPDATE SET
+           call_count = call_count + 1,
+           last_seen_at = datetime('now')`
+      ).run(toolName);
+      this.knownUnmapped.add(toolName);
+    }
+  }
+
+  /** Get tool names observed at runtime that have no plugin mapping.
+   *  Reads from DB, excluding any tools that have since been mapped.
+   *  Useful for diagnostics: tell the user which tools need a toolMapping. */
+  getUnmappedTools(): string[] {
+    return this.getUnmappedToolsWithCounts().map((t) => t.toolName);
+  }
+
+  /** Get unmapped tools with their observation counts, sorted by count descending.
+   *  Reads from DB so observations survive across restarts.
+   *  Excludes tools that have since been added to tool_plugin_mapping. */
+  getUnmappedToolsWithCounts(): { toolName: string; count: number }[] {
+    const rows = this.db.prepare(
+      `SELECT tool_name, call_count FROM observed_unmapped_tools
+       WHERE tool_name NOT IN (SELECT tool_name FROM tool_plugin_mapping)
+       ORDER BY call_count DESC`
+    ).all() as { tool_name: string; call_count: number }[];
+
+    return rows.map((r) => ({ toolName: r.tool_name, count: r.call_count }));
+  }
+
+  /** Build a coverage disclaimer when unmapped tools are observed alongside mapped ones.
+   *  Returns null if there are no unmapped tools (report has full coverage).
+   *  Centralised here so all output paths (show/compare/export/dashboard) share one source. */
+  formatCoverageNote(): string | null {
+    const unmapped = this.getUnmappedToolsWithCounts();
+    if (unmapped.length === 0) return null;
+
+    const totalCalls = unmapped.reduce((sum, t) => sum + t.count, 0);
+    const toolList = unmapped.map((t) => t.toolName).join(", ");
+
+    return [
+      `\n⚠️  Partial coverage: ${unmapped.length} tool(s) observed but not mapped (${totalCalls} call${totalCalls === 1 ? "" : "s"} total): ${toolList}`,
+      `   The results above only reflect plugins with configured toolMappings.`,
+      `   Run /insights-status to see unmapped tools and configure tracking.`,
+    ].join("\n");
+  }
+
+  private loadMappingCache(): void {
+    this.mappingCache.clear();
+    const rows = this.db
+      .prepare("SELECT tool_name, plugin_id FROM tool_plugin_mapping")
+      .all() as ToolPluginMappingRow[];
+
+    for (const row of rows) {
+      this.mappingCache.set(row.tool_name, row.plugin_id);
+    }
+  }
+}

--- a/extensions/plugin-insights/src/collector/tool-detector.ts
+++ b/extensions/plugin-insights/src/collector/tool-detector.ts
@@ -112,28 +112,17 @@ export class ToolDetector {
     // Skip built-in agent tools
     if (BUILTIN_TOOLS.has(toolName)) return;
 
-    if (this.knownUnmapped.has(toolName)) {
-      // Already seen this session — just bump the count
-      this.db
-        .prepare(
-          `UPDATE observed_unmapped_tools
-         SET call_count = call_count + 1, last_seen_at = datetime('now')
-         WHERE tool_name = ?`,
-        )
-        .run(toolName);
-    } else {
-      // First time this session (may or may not exist in DB from prior sessions)
-      this.db
-        .prepare(
-          `INSERT INTO observed_unmapped_tools (tool_name, call_count)
+    // Use upsert unconditionally so rows deleted by /insights-reset are recreated
+    this.db
+      .prepare(
+        `INSERT INTO observed_unmapped_tools (tool_name, call_count)
          VALUES (?, 1)
          ON CONFLICT(tool_name) DO UPDATE SET
            call_count = call_count + 1,
            last_seen_at = datetime('now')`,
-        )
-        .run(toolName);
-      this.knownUnmapped.add(toolName);
-    }
+      )
+      .run(toolName);
+    this.knownUnmapped.add(toolName);
   }
 
   /** Get tool names observed at runtime that have no plugin mapping.

--- a/extensions/plugin-insights/src/collector/tool-detector.ts
+++ b/extensions/plugin-insights/src/collector/tool-detector.ts
@@ -4,13 +4,22 @@ import type { ToolCallContent, ToolPluginMappingRow } from "../types.js";
 /** Tools built into the OpenClaw agent runtime (not owned by any plugin) */
 const BUILTIN_TOOLS = new Set([
   // Core agent tools
-  "web_search", "web_browse", "web_fetch",
-  "write_file", "read_file", "edit_file", "list_files",
-  "run_command", "run_shell",
-  "create_file", "delete_file",
-  "search_code", "search_files",
+  "web_search",
+  "web_browse",
+  "web_fetch",
+  "write_file",
+  "read_file",
+  "edit_file",
+  "list_files",
+  "run_command",
+  "run_shell",
+  "create_file",
+  "delete_file",
+  "search_code",
+  "search_files",
   // Our own tools (should never be attributed)
-  "insights_show", "insights_compare",
+  "insights_show",
+  "insights_compare",
 ]);
 
 /**
@@ -30,7 +39,7 @@ export class ToolDetector {
 
   /** Rebuild the tool→plugin mapping from explicit entries */
   refreshMappingFromEntries(
-    entries: { toolName: string; pluginId: string; pluginName?: string }[]
+    entries: { toolName: string; pluginId: string; pluginName?: string }[],
   ): void {
     const upsert = this.db.prepare(`
       INSERT INTO tool_plugin_mapping (tool_name, plugin_id, plugin_name, updated_at)
@@ -91,20 +100,24 @@ export class ToolDetector {
 
     if (this.knownUnmapped.has(toolName)) {
       // Already seen this session — just bump the count
-      this.db.prepare(
-        `UPDATE observed_unmapped_tools
+      this.db
+        .prepare(
+          `UPDATE observed_unmapped_tools
          SET call_count = call_count + 1, last_seen_at = datetime('now')
-         WHERE tool_name = ?`
-      ).run(toolName);
+         WHERE tool_name = ?`,
+        )
+        .run(toolName);
     } else {
       // First time this session (may or may not exist in DB from prior sessions)
-      this.db.prepare(
-        `INSERT INTO observed_unmapped_tools (tool_name, call_count)
+      this.db
+        .prepare(
+          `INSERT INTO observed_unmapped_tools (tool_name, call_count)
          VALUES (?, 1)
          ON CONFLICT(tool_name) DO UPDATE SET
            call_count = call_count + 1,
-           last_seen_at = datetime('now')`
-      ).run(toolName);
+           last_seen_at = datetime('now')`,
+        )
+        .run(toolName);
       this.knownUnmapped.add(toolName);
     }
   }
@@ -120,11 +133,13 @@ export class ToolDetector {
    *  Reads from DB so observations survive across restarts.
    *  Excludes tools that have since been added to tool_plugin_mapping. */
   getUnmappedToolsWithCounts(): { toolName: string; count: number }[] {
-    const rows = this.db.prepare(
-      `SELECT tool_name, call_count FROM observed_unmapped_tools
+    const rows = this.db
+      .prepare(
+        `SELECT tool_name, call_count FROM observed_unmapped_tools
        WHERE tool_name NOT IN (SELECT tool_name FROM tool_plugin_mapping)
-       ORDER BY call_count DESC`
-    ).all() as { tool_name: string; call_count: number }[];
+       ORDER BY call_count DESC`,
+      )
+      .all() as { tool_name: string; call_count: number }[];
 
     return rows.map((r) => ({ toolName: r.tool_name, count: r.call_count }));
   }

--- a/extensions/plugin-insights/src/collector/tool-detector.ts
+++ b/extensions/plugin-insights/src/collector/tool-detector.ts
@@ -3,20 +3,52 @@ import type { ToolCallContent, ToolPluginMappingRow } from "../types.js";
 
 /** Tools built into the OpenClaw agent runtime (not owned by any plugin) */
 const BUILTIN_TOOLS = new Set([
-  // Core agent tools
+  // File system tools
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  // Legacy file tool aliases
+  "read_file",
+  "write_file",
+  "edit_file",
+  "create_file",
+  "delete_file",
+  "list_files",
+  "search_code",
+  "search_files",
+  // Execution tools
+  "exec",
+  "process",
+  "run_command",
+  "run_shell",
+  // Web tools
   "web_search",
   "web_browse",
   "web_fetch",
-  "write_file",
-  "read_file",
-  "edit_file",
-  "list_files",
-  "run_command",
-  "run_shell",
-  "create_file",
-  "delete_file",
-  "search_code",
-  "search_files",
+  "browser",
+  // Memory tools
+  "memory_search",
+  "memory_get",
+  // Session / agent tools
+  "sessions_list",
+  "sessions_history",
+  "sessions_send",
+  "sessions_spawn",
+  "sessions_yield",
+  "subagents",
+  "session_status",
+  "agents_list",
+  // Media / UI tools
+  "canvas",
+  "image",
+  "tts",
+  "pdf",
+  "message",
+  // Infrastructure tools
+  "cron",
+  "gateway",
+  "nodes",
   // Our own tools (should never be attributed)
   "insights_show",
   "insights_compare",

--- a/extensions/plugin-insights/src/collector/turn-collector.ts
+++ b/extensions/plugin-insights/src/collector/turn-collector.ts
@@ -1,0 +1,288 @@
+import type Database from "better-sqlite3";
+import type { AgentMessage, ToolCallContent, Usage } from "../types.js";
+import {
+  extractUserText,
+  extractAssistantText,
+  extractToolCalls,
+  extractUsage,
+} from "../types.js";
+import { ToolDetector } from "./tool-detector.js";
+import { ContextDetector } from "./context-detector.js";
+import { PluginReporter } from "./plugin-reporter.js";
+
+export class TurnCollector {
+  private db: Database.Database;
+  private toolDetector: ToolDetector;
+  private contextDetector: ContextDetector;
+  private pluginReporter: PluginReporter;
+
+  constructor(
+    db: Database.Database,
+    toolDetector: ToolDetector,
+    contextDetector: ContextDetector,
+    pluginReporter: PluginReporter
+  ) {
+    this.db = db;
+    this.toolDetector = toolDetector;
+    this.contextDetector = contextDetector;
+    this.pluginReporter = pluginReporter;
+  }
+
+  /** Process a completed turn and store all data */
+  collect(
+    sessionId: string,
+    turnIndex: number,
+    messages: AgentMessage[]
+  ): number {
+    const userPrompt = this.extractLastUserMessage(messages);
+    const assistantResponse = this.extractLastAssistantMessage(messages);
+
+    // Extract tool calls from assistant messages
+    const toolCalls = this.extractAllToolCalls(messages);
+
+    // Extract usage from the last assistant message
+    const usage = this.extractLastUsage(messages);
+
+    // Layer 1: Tool call attribution
+    const toolDetections = this.toolDetector.detect(toolCalls);
+
+    // Layer 2: Context injection detection
+    const contextDetections = this.contextDetector.detect(messages);
+
+    // Merge all detected plugin IDs
+    const allPluginIds = new Set<string>();
+    for (const d of toolDetections) allPluginIds.add(d.pluginId);
+    for (const d of contextDetections) allPluginIds.add(d.pluginId);
+
+    // Insert turn record
+    const turnId = this.insertTurn(
+      sessionId,
+      turnIndex,
+      userPrompt,
+      assistantResponse,
+      usage,
+      toolCalls,
+      allPluginIds
+    );
+
+    // Insert plugin events from Layer 1
+    this.insertPluginEvents(
+      turnId,
+      toolDetections.map((d) => ({
+        pluginId: d.pluginId,
+        method: "tool_call" as const,
+        action: d.action,
+      }))
+    );
+
+    // Insert plugin events from Layer 2
+    this.insertPluginEvents(
+      turnId,
+      contextDetections.map((d) => ({
+        pluginId: d.pluginId,
+        method: "context_injection" as const,
+        action: d.action,
+        metadata: { marker: d.marker },
+      }))
+    );
+
+    // Flush Layer 3 self-reports (session-scoped)
+    this.pluginReporter.flushToTurn(turnId, sessionId);
+
+    // Detect satisfaction signals (compare with previous turn)
+    this.detectSatisfactionSignals(turnId, sessionId, userPrompt);
+
+    return turnId;
+  }
+
+  private insertTurn(
+    sessionId: string,
+    turnIndex: number,
+    userPrompt: string | null,
+    assistantResponse: string | null,
+    usage: Usage | null,
+    toolCalls: ToolCallContent[],
+    pluginIds: Set<string>
+  ): number {
+    const stmt = this.db.prepare(`
+      INSERT INTO turns (
+        session_id, turn_index, timestamp,
+        user_prompt_preview, assistant_response_preview,
+        prompt_tokens, completion_tokens, total_tokens,
+        tool_calls_json, plugins_triggered_json
+      ) VALUES (?, ?, datetime('now'), ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      sessionId,
+      turnIndex,
+      userPrompt ? userPrompt.slice(0, 200) : null,
+      assistantResponse ? assistantResponse.slice(0, 200) : null,
+      usage?.input ?? null,
+      usage?.output ?? null,
+      usage?.total ?? null,
+      toolCalls.length > 0
+        ? JSON.stringify(toolCalls.map((tc) => tc.name))
+        : null,
+      pluginIds.size > 0 ? JSON.stringify([...pluginIds]) : null
+    );
+
+    return result.lastInsertRowid as number;
+  }
+
+  private insertPluginEvents(
+    turnId: number,
+    events: {
+      pluginId: string;
+      method: "tool_call" | "context_injection";
+      action: string;
+      metadata?: Record<string, unknown>;
+    }[]
+  ): void {
+    if (events.length === 0) return;
+
+    const stmt = this.db.prepare(`
+      INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, metadata_json)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    const tx = this.db.transaction(() => {
+      for (const event of events) {
+        stmt.run(
+          turnId,
+          event.pluginId,
+          event.method,
+          event.action,
+          event.metadata ? JSON.stringify(event.metadata) : null
+        );
+      }
+    });
+    tx();
+  }
+
+  private detectSatisfactionSignals(
+    currentTurnId: number,
+    sessionId: string,
+    currentPrompt: string | null
+  ): void {
+    if (!currentPrompt) return;
+
+    const prevTurn = this.db
+      .prepare(
+        `SELECT id, user_prompt_preview FROM turns
+         WHERE session_id = ? AND id < ?
+         ORDER BY id DESC LIMIT 1`
+      )
+      .get(sessionId, currentTurnId) as
+      | { id: number; user_prompt_preview: string | null }
+      | undefined;
+
+    if (!prevTurn || !prevTurn.user_prompt_preview) return;
+
+    const prevPrompt = prevTurn.user_prompt_preview;
+    const similarity = jaccardSimilarity(currentPrompt, prevPrompt);
+
+    const stmt = this.db.prepare(`
+      INSERT INTO satisfaction_signals (turn_id, signal_type, confidence, next_turn_id)
+      VALUES (?, ?, ?, ?)
+    `);
+
+    if (isCorrectionSignal(currentPrompt)) {
+      stmt.run(prevTurn.id, "corrected", 0.8, currentTurnId);
+      return;
+    }
+
+    if (similarity > 0.6) {
+      stmt.run(
+        prevTurn.id,
+        "retried",
+        Math.min(similarity, 1.0),
+        currentTurnId
+      );
+      return;
+    }
+
+    if (similarity < 0.3) {
+      stmt.run(prevTurn.id, "accepted", 1.0 - similarity, currentTurnId);
+    }
+  }
+
+  private extractLastUserMessage(messages: AgentMessage[]): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const text = extractUserText(messages[i]);
+      if (text !== null) return text;
+    }
+    return null;
+  }
+
+  private extractLastAssistantMessage(messages: AgentMessage[]): string | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const text = extractAssistantText(messages[i]);
+      if (text !== null) return text;
+    }
+    return null;
+  }
+
+  private extractAllToolCalls(messages: AgentMessage[]): ToolCallContent[] {
+    const all: ToolCallContent[] = [];
+    for (const msg of messages) {
+      all.push(...extractToolCalls(msg));
+    }
+    return all;
+  }
+
+  private extractLastUsage(messages: AgentMessage[]): Usage | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const usage = extractUsage(messages[i]);
+      if (usage) return usage;
+    }
+    return null;
+  }
+}
+
+// ---- Utility Functions ----
+
+/** Simple Jaccard similarity between two strings (word-level) */
+export function jaccardSimilarity(a: string, b: string): number {
+  const setA = new Set(tokenize(a));
+  const setB = new Set(tokenize(b));
+
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+
+  let intersection = 0;
+  for (const word of setA) {
+    if (setB.has(word)) intersection++;
+  }
+
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s\u4e00-\u9fff]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 0);
+}
+
+const CORRECTION_PATTERNS = [
+  /不对/,
+  /重新/,
+  /换个方式/,
+  /错了/,
+  /不是这样/,
+  /再试/,
+  /wrong/i,
+  /retry/i,
+  /redo/i,
+  /try again/i,
+  /not what i/i,
+  /that's not/i,
+  /incorrect/i,
+];
+
+function isCorrectionSignal(prompt: string): boolean {
+  return CORRECTION_PATTERNS.some((p) => p.test(prompt));
+}

--- a/extensions/plugin-insights/src/collector/turn-collector.ts
+++ b/extensions/plugin-insights/src/collector/turn-collector.ts
@@ -40,10 +40,12 @@ export class TurnCollector {
     // Layer 2: Context injection detection
     const contextDetections = this.contextDetector.detect(messages);
 
-    // Merge all detected plugin IDs
+    // Merge all detected plugin IDs (Layer 1 + Layer 2 + Layer 3 peek)
     const allPluginIds = new Set<string>();
     for (const d of toolDetections) allPluginIds.add(d.pluginId);
     for (const d of contextDetections) allPluginIds.add(d.pluginId);
+    // Include Layer 3 self-report plugin IDs so plugins_triggered_json is complete
+    for (const id of this.pluginReporter.peekMatchingPluginIds(sessionId)) allPluginIds.add(id);
 
     // Insert turn record
     const turnId = this.insertTurn(

--- a/extensions/plugin-insights/src/collector/turn-collector.ts
+++ b/extensions/plugin-insights/src/collector/turn-collector.ts
@@ -1,14 +1,9 @@
 import type Database from "better-sqlite3";
 import type { AgentMessage, ToolCallContent, Usage } from "../types.js";
-import {
-  extractUserText,
-  extractAssistantText,
-  extractToolCalls,
-  extractUsage,
-} from "../types.js";
-import { ToolDetector } from "./tool-detector.js";
+import { extractUserText, extractAssistantText, extractToolCalls, extractUsage } from "../types.js";
 import { ContextDetector } from "./context-detector.js";
 import { PluginReporter } from "./plugin-reporter.js";
+import { ToolDetector } from "./tool-detector.js";
 
 export class TurnCollector {
   private db: Database.Database;
@@ -20,7 +15,7 @@ export class TurnCollector {
     db: Database.Database,
     toolDetector: ToolDetector,
     contextDetector: ContextDetector,
-    pluginReporter: PluginReporter
+    pluginReporter: PluginReporter,
   ) {
     this.db = db;
     this.toolDetector = toolDetector;
@@ -29,11 +24,7 @@ export class TurnCollector {
   }
 
   /** Process a completed turn and store all data */
-  collect(
-    sessionId: string,
-    turnIndex: number,
-    messages: AgentMessage[]
-  ): number {
+  collect(sessionId: string, turnIndex: number, messages: AgentMessage[]): number {
     const userPrompt = this.extractLastUserMessage(messages);
     const assistantResponse = this.extractLastAssistantMessage(messages);
 
@@ -62,7 +53,7 @@ export class TurnCollector {
       assistantResponse,
       usage,
       toolCalls,
-      allPluginIds
+      allPluginIds,
     );
 
     // Insert plugin events from Layer 1
@@ -72,7 +63,7 @@ export class TurnCollector {
         pluginId: d.pluginId,
         method: "tool_call" as const,
         action: d.action,
-      }))
+      })),
     );
 
     // Insert plugin events from Layer 2
@@ -83,7 +74,7 @@ export class TurnCollector {
         method: "context_injection" as const,
         action: d.action,
         metadata: { marker: d.marker },
-      }))
+      })),
     );
 
     // Flush Layer 3 self-reports (session-scoped)
@@ -102,7 +93,7 @@ export class TurnCollector {
     assistantResponse: string | null,
     usage: Usage | null,
     toolCalls: ToolCallContent[],
-    pluginIds: Set<string>
+    pluginIds: Set<string>,
   ): number {
     const stmt = this.db.prepare(`
       INSERT INTO turns (
@@ -121,10 +112,8 @@ export class TurnCollector {
       usage?.input ?? null,
       usage?.output ?? null,
       usage?.total ?? null,
-      toolCalls.length > 0
-        ? JSON.stringify(toolCalls.map((tc) => tc.name))
-        : null,
-      pluginIds.size > 0 ? JSON.stringify([...pluginIds]) : null
+      toolCalls.length > 0 ? JSON.stringify(toolCalls.map((tc) => tc.name)) : null,
+      pluginIds.size > 0 ? JSON.stringify([...pluginIds]) : null,
     );
 
     return result.lastInsertRowid as number;
@@ -137,7 +126,7 @@ export class TurnCollector {
       method: "tool_call" | "context_injection";
       action: string;
       metadata?: Record<string, unknown>;
-    }[]
+    }[],
   ): void {
     if (events.length === 0) return;
 
@@ -153,7 +142,7 @@ export class TurnCollector {
           event.pluginId,
           event.method,
           event.action,
-          event.metadata ? JSON.stringify(event.metadata) : null
+          event.metadata ? JSON.stringify(event.metadata) : null,
         );
       }
     });
@@ -163,7 +152,7 @@ export class TurnCollector {
   private detectSatisfactionSignals(
     currentTurnId: number,
     sessionId: string,
-    currentPrompt: string | null
+    currentPrompt: string | null,
   ): void {
     if (!currentPrompt) return;
 
@@ -171,7 +160,7 @@ export class TurnCollector {
       .prepare(
         `SELECT id, user_prompt_preview FROM turns
          WHERE session_id = ? AND id < ?
-         ORDER BY id DESC LIMIT 1`
+         ORDER BY id DESC LIMIT 1`,
       )
       .get(sessionId, currentTurnId) as
       | { id: number; user_prompt_preview: string | null }
@@ -193,12 +182,7 @@ export class TurnCollector {
     }
 
     if (similarity > 0.6) {
-      stmt.run(
-        prevTurn.id,
-        "retried",
-        Math.min(similarity, 1.0),
-        currentTurnId
-      );
+      stmt.run(prevTurn.id, "retried", Math.min(similarity, 1.0), currentTurnId);
       return;
     }
 

--- a/extensions/plugin-insights/src/commands.ts
+++ b/extensions/plugin-insights/src/commands.ts
@@ -1,17 +1,17 @@
+import * as fs from "node:fs";
 import type Database from "better-sqlite3";
+import type { ToolDetector } from "./collector/tool-detector.js";
+import { buildReport } from "./engine.js";
+import { formatCLIReport, formatPluginSummary } from "./report/cli-report.js";
+import { generateHTMLReport } from "./report/html-report.js";
+import { exportJSON, exportRawData } from "./report/json-export.js";
+import { formatComparison } from "./tools/insights-compare.js";
 import type {
   OpenClawPluginCommandDefinition,
   PluginInsightsConfig,
   PluginCommandContext,
   ReplyPayload,
 } from "./types.js";
-import { buildReport } from "./engine.js";
-import { formatCLIReport, formatPluginSummary } from "./report/cli-report.js";
-import { generateHTMLReport } from "./report/html-report.js";
-import { exportJSON, exportRawData } from "./report/json-export.js";
-import { formatComparison } from "./tools/insights-compare.js";
-import type { ToolDetector } from "./collector/tool-detector.js";
-import * as fs from "node:fs";
 
 /** Parse --days flag with validation; returns days or an error message */
 function parseDays(flags: Record<string, string | boolean>): number | string {
@@ -25,7 +25,10 @@ function parseDays(flags: Record<string, string | boolean>): number | string {
 }
 
 /** Parse raw args string into positional args and flags */
-function parseArgs(raw?: string): { positional: string[]; flags: Record<string, string | boolean> } {
+function parseArgs(raw?: string): {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+} {
   const positional: string[] = [];
   const flags: Record<string, string | boolean> = {};
   if (!raw) return { positional, flags };
@@ -52,7 +55,7 @@ function parseArgs(raw?: string): { positional: string[]; flags: Record<string, 
 export function createCommands(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition[] {
   return [
     createShowCommand(db, config, toolDetector),
@@ -67,7 +70,7 @@ export function createCommands(
 function createShowCommand(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition {
   return {
     name: "insights-show",
@@ -82,13 +85,17 @@ function createShowCommand(
       const report = buildReport(db, config, days);
 
       if (report.plugins.length === 0) {
-        return { text: "No plugin activity data collected yet. Use /insights-status to see collection diagnostics." };
+        return {
+          text: "No plugin activity data collected yet. Use /insights-status to see collection diagnostics.",
+        };
       }
 
       if (pluginId) {
         const plugin = report.plugins.find((p) => p.pluginId === pluginId);
         if (!plugin) {
-          return { text: `No data found for plugin "${pluginId}". Available: ${report.plugins.map((p) => p.pluginId).join(", ")}` };
+          return {
+            text: `No data found for plugin "${pluginId}". Available: ${report.plugins.map((p) => p.pluginId).join(", ")}`,
+          };
         }
         return { text: formatPluginSummary(plugin) };
       }
@@ -106,7 +113,7 @@ function createShowCommand(
 function createCompareCommand(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition {
   return {
     name: "insights-compare",
@@ -147,7 +154,7 @@ function createCompareCommand(
 function createExportCommand(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition {
   return {
     name: "insights-export",
@@ -190,7 +197,7 @@ function createExportCommand(
 function createDashboardCommand(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition {
   return {
     name: "insights-dashboard",
@@ -198,8 +205,7 @@ function createDashboardCommand(
     acceptsArgs: true,
     handler(ctx: PluginCommandContext): ReplyPayload {
       const { flags } = parseArgs(ctx.args);
-      const output =
-        (flags.output as string) || "./plugin-insights-dashboard.html";
+      const output = (flags.output as string) || "./plugin-insights-dashboard.html";
       const days = parseDays(flags);
       if (typeof days === "string") return { text: days };
 
@@ -219,9 +225,7 @@ function createDashboardCommand(
   };
 }
 
-function createResetCommand(
-  db: Database.Database
-): OpenClawPluginCommandDefinition {
+function createResetCommand(db: Database.Database): OpenClawPluginCommandDefinition {
   return {
     name: "insights-reset",
     description: "Delete all collected insights data",
@@ -229,7 +233,9 @@ function createResetCommand(
     handler(ctx: PluginCommandContext): ReplyPayload {
       const { flags } = parseArgs(ctx.args);
       if (!flags.confirm) {
-        return { text: "This will permanently delete all collected data.\nRun with --confirm to proceed." };
+        return {
+          text: "This will permanently delete all collected data.\nRun with --confirm to proceed.",
+        };
       }
 
       db.transaction(() => {
@@ -248,7 +254,7 @@ function createResetCommand(
 
 function createStatusCommand(
   db: Database.Database,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): OpenClawPluginCommandDefinition {
   return {
     name: "insights-status",
@@ -257,23 +263,33 @@ function createStatusCommand(
       const lines: string[] = ["Plugin Insights — Collection Status", "═".repeat(40)];
 
       // Turn stats
-      const turnCount = (db.prepare("SELECT COUNT(*) as cnt FROM turns").get() as { cnt: number }).cnt;
-      const sessionCount = (db.prepare("SELECT COUNT(DISTINCT session_id) as cnt FROM turns").get() as { cnt: number }).cnt;
+      const turnCount = (db.prepare("SELECT COUNT(*) as cnt FROM turns").get() as { cnt: number })
+        .cnt;
+      const sessionCount = (
+        db.prepare("SELECT COUNT(DISTINCT session_id) as cnt FROM turns").get() as { cnt: number }
+      ).cnt;
       lines.push(`\nTurns collected: ${turnCount}`);
       lines.push(`Sessions tracked: ${sessionCount}`);
 
       // Plugin event stats
-      const eventCount = (db.prepare("SELECT COUNT(*) as cnt FROM plugin_events").get() as { cnt: number }).cnt;
+      const eventCount = (
+        db.prepare("SELECT COUNT(*) as cnt FROM plugin_events").get() as { cnt: number }
+      ).cnt;
       lines.push(`Plugin events recorded: ${eventCount}`);
 
       // Mapped plugins (from tool_plugin_mapping)
-      const mappedRows = db.prepare("SELECT DISTINCT plugin_id, plugin_name FROM tool_plugin_mapping").all() as { plugin_id: string; plugin_name: string | null }[];
+      const mappedRows = db
+        .prepare("SELECT DISTINCT plugin_id, plugin_name FROM tool_plugin_mapping")
+        .all() as { plugin_id: string; plugin_name: string | null }[];
       if (mappedRows.length > 0) {
         lines.push(`\nConfigured tool→plugin mappings (${mappedRows.length} plugin(s)):`);
         for (const row of mappedRows) {
           const name = row.plugin_name ? ` (${row.plugin_name})` : "";
-          const tools = (db.prepare("SELECT tool_name FROM tool_plugin_mapping WHERE plugin_id = ?").all(row.plugin_id) as { tool_name: string }[])
-            .map((r) => r.tool_name);
+          const tools = (
+            db
+              .prepare("SELECT tool_name FROM tool_plugin_mapping WHERE plugin_id = ?")
+              .all(row.plugin_id) as { tool_name: string }[]
+          ).map((r) => r.tool_name);
           lines.push(`  ${row.plugin_id}${name}: ${tools.join(", ")}`);
         }
       } else {
@@ -296,12 +312,18 @@ function createStatusCommand(
       } else if (turnCount > 0 && mappedRows.length === 0) {
         lines.push(
           "\nNo plugin tools observed yet.",
-          "Keep using plugins in conversations — tool names will appear here."
+          "Keep using plugins in conversations — tool names will appear here.",
         );
       }
 
       // Context detections
-      const contextCount = (db.prepare("SELECT COUNT(*) as cnt FROM plugin_events WHERE detection_method = 'context_injection'").get() as { cnt: number }).cnt;
+      const contextCount = (
+        db
+          .prepare(
+            "SELECT COUNT(*) as cnt FROM plugin_events WHERE detection_method = 'context_injection'",
+          )
+          .get() as { cnt: number }
+      ).cnt;
       if (contextCount > 0) {
         lines.push(`\nContext injection detections: ${contextCount}`);
       }

--- a/extensions/plugin-insights/src/commands.ts
+++ b/extensions/plugin-insights/src/commands.ts
@@ -13,6 +13,17 @@ import { formatComparison } from "./tools/insights-compare.js";
 import type { ToolDetector } from "./collector/tool-detector.js";
 import * as fs from "node:fs";
 
+/** Parse --days flag with validation; returns days or an error message */
+function parseDays(flags: Record<string, string | boolean>): number | string {
+  const raw = flags.days;
+  if (raw === undefined || raw === true) return 30;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    return `Invalid --days value "${raw}". Must be a positive number.`;
+  }
+  return Math.floor(n);
+}
+
 /** Parse raw args string into positional args and flags */
 function parseArgs(raw?: string): { positional: string[]; flags: Record<string, string | boolean> } {
   const positional: string[] = [];
@@ -64,7 +75,8 @@ function createShowCommand(
     acceptsArgs: true,
     handler(ctx: PluginCommandContext): ReplyPayload {
       const { positional, flags } = parseArgs(ctx.args);
-      const days = Number(flags.days ?? 30);
+      const days = parseDays(flags);
+      if (typeof days === "string") return { text: days };
       const pluginId = (flags.plugin as string) || positional[0];
 
       const report = buildReport(db, config, days);
@@ -108,7 +120,8 @@ function createCompareCommand(
       }
 
       const [pluginA, pluginB] = positional;
-      const days = Number(flags.days ?? 30);
+      const days = parseDays(flags);
+      if (typeof days === "string") return { text: days };
       const report = buildReport(db, config, days);
 
       const a = report.plugins.find((p) => p.pluginId === pluginA);
@@ -147,7 +160,8 @@ function createExportCommand(
         return { text: "Usage: /insights-export --output <path> [--format json|jsonl] [--raw]" };
       }
       const format = (flags.format as "json" | "jsonl") ?? "json";
-      const days = Number(flags.days ?? 30);
+      const days = parseDays(flags);
+      if (typeof days === "string") return { text: days };
       const raw = !!flags.raw;
 
       if (raw) {
@@ -186,7 +200,8 @@ function createDashboardCommand(
       const { flags } = parseArgs(ctx.args);
       const output =
         (flags.output as string) || "./plugin-insights-dashboard.html";
-      const days = Number(flags.days ?? 30);
+      const days = parseDays(flags);
+      if (typeof days === "string") return { text: days };
 
       const report = buildReport(db, config, days);
       const unmappedTools = toolDetector.getUnmappedToolsWithCounts();

--- a/extensions/plugin-insights/src/commands.ts
+++ b/extensions/plugin-insights/src/commands.ts
@@ -21,7 +21,8 @@ function parseDays(flags: Record<string, string | boolean>): number | string {
   if (!Number.isFinite(n) || n <= 0) {
     return `Invalid --days value "${raw}". Must be a positive number.`;
   }
-  return Math.floor(n);
+  // Clamp to at least 1 day so fractional values like 0.5 don't become a zero-day window
+  return Math.max(1, Math.floor(n));
 }
 
 /** Parse raw args string into positional args and flags */

--- a/extensions/plugin-insights/src/commands.ts
+++ b/extensions/plugin-insights/src/commands.ts
@@ -1,0 +1,297 @@
+import type Database from "better-sqlite3";
+import type {
+  OpenClawPluginCommandDefinition,
+  PluginInsightsConfig,
+  PluginCommandContext,
+  ReplyPayload,
+} from "./types.js";
+import { buildReport } from "./engine.js";
+import { formatCLIReport, formatPluginSummary } from "./report/cli-report.js";
+import { generateHTMLReport } from "./report/html-report.js";
+import { exportJSON, exportRawData } from "./report/json-export.js";
+import { formatComparison } from "./tools/insights-compare.js";
+import type { ToolDetector } from "./collector/tool-detector.js";
+import * as fs from "node:fs";
+
+/** Parse raw args string into positional args and flags */
+function parseArgs(raw?: string): { positional: string[]; flags: Record<string, string | boolean> } {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  if (!raw) return { positional, flags };
+
+  const parts = raw.trim().split(/\s+/);
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part.startsWith("--")) {
+      const key = part.slice(2);
+      const next = parts[i + 1];
+      if (next && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      positional.push(part);
+    }
+  }
+  return { positional, flags };
+}
+
+export function createCommands(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition[] {
+  return [
+    createShowCommand(db, config, toolDetector),
+    createCompareCommand(db, config, toolDetector),
+    createExportCommand(db, config, toolDetector),
+    createDashboardCommand(db, config, toolDetector),
+    createResetCommand(db),
+    createStatusCommand(db, toolDetector),
+  ];
+}
+
+function createShowCommand(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-show",
+    description: "Show effectiveness report for installed plugins",
+    acceptsArgs: true,
+    handler(ctx: PluginCommandContext): ReplyPayload {
+      const { positional, flags } = parseArgs(ctx.args);
+      const days = Number(flags.days ?? 30);
+      const pluginId = (flags.plugin as string) || positional[0];
+
+      const report = buildReport(db, config, days);
+
+      if (report.plugins.length === 0) {
+        return { text: "No plugin activity data collected yet. Use /insights-status to see collection diagnostics." };
+      }
+
+      if (pluginId) {
+        const plugin = report.plugins.find((p) => p.pluginId === pluginId);
+        if (!plugin) {
+          return { text: `No data found for plugin "${pluginId}". Available: ${report.plugins.map((p) => p.pluginId).join(", ")}` };
+        }
+        return { text: formatPluginSummary(plugin) };
+      }
+
+      let text = formatCLIReport(report);
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return { text };
+    },
+  };
+}
+
+function createCompareCommand(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-compare",
+    description: "Compare effectiveness of two plugins side by side",
+    acceptsArgs: true,
+    handler(ctx: PluginCommandContext): ReplyPayload {
+      const { positional, flags } = parseArgs(ctx.args);
+
+      if (positional.length < 2) {
+        return { text: "Usage: /insights-compare <pluginA> <pluginB> [--days 30]" };
+      }
+
+      const [pluginA, pluginB] = positional;
+      const days = Number(flags.days ?? 30);
+      const report = buildReport(db, config, days);
+
+      const a = report.plugins.find((p) => p.pluginId === pluginA);
+      const b = report.plugins.find((p) => p.pluginId === pluginB);
+
+      if (!a) {
+        return { text: `No data found for plugin "${pluginA}".` };
+      }
+      if (!b) {
+        return { text: `No data found for plugin "${pluginB}".` };
+      }
+
+      let text = formatComparison(a, b);
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return { text };
+    },
+  };
+}
+
+function createExportCommand(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-export",
+    description: "Export insights data as JSON",
+    acceptsArgs: true,
+    handler(ctx: PluginCommandContext): ReplyPayload {
+      const { flags } = parseArgs(ctx.args);
+      const output = flags.output as string;
+      if (!output || output === "true") {
+        return { text: "Usage: /insights-export --output <path> [--format json|jsonl] [--raw]" };
+      }
+      const format = (flags.format as "json" | "jsonl") ?? "json";
+      const days = Number(flags.days ?? 30);
+      const raw = !!flags.raw;
+
+      if (raw) {
+        exportRawData(db, { format, output, days });
+      } else {
+        const report = buildReport(db, config, days);
+        // Embed coverage metadata so the JSON file is self-describing
+        const unmapped = toolDetector.getUnmappedToolsWithCounts();
+        report.coverage = {
+          isComplete: unmapped.length === 0,
+          unmappedTools: unmapped.map((t) => ({ toolName: t.toolName, callCount: t.count })),
+        };
+        exportJSON(report, { format, output });
+      }
+
+      let text = `Data exported to ${output}`;
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return { text };
+    },
+  };
+}
+
+function createDashboardCommand(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-dashboard",
+    description: "Generate an HTML dashboard report",
+    acceptsArgs: true,
+    handler(ctx: PluginCommandContext): ReplyPayload {
+      const { flags } = parseArgs(ctx.args);
+      const output =
+        (flags.output as string) || "./plugin-insights-dashboard.html";
+      const days = Number(flags.days ?? 30);
+
+      const report = buildReport(db, config, days);
+      const unmappedTools = toolDetector.getUnmappedToolsWithCounts();
+      const html = generateHTMLReport(report, unmappedTools);
+
+      fs.writeFileSync(output, html, "utf-8");
+
+      let text = `Dashboard generated at ${output}`;
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return { text };
+    },
+  };
+}
+
+function createResetCommand(
+  db: Database.Database
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-reset",
+    description: "Delete all collected insights data",
+    acceptsArgs: true,
+    handler(ctx: PluginCommandContext): ReplyPayload {
+      const { flags } = parseArgs(ctx.args);
+      if (!flags.confirm) {
+        return { text: "This will permanently delete all collected data.\nRun with --confirm to proceed." };
+      }
+
+      db.transaction(() => {
+        db.exec("DELETE FROM satisfaction_signals");
+        db.exec("DELETE FROM llm_scores");
+        db.exec("DELETE FROM plugin_events");
+        db.exec("DELETE FROM turns");
+        db.exec("DELETE FROM plugin_installs");
+        db.exec("DELETE FROM observed_unmapped_tools");
+      })();
+
+      return { text: "All insights data has been reset." };
+    },
+  };
+}
+
+function createStatusCommand(
+  db: Database.Database,
+  toolDetector: ToolDetector
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "insights-status",
+    description: "Show data collection diagnostics and attribution status",
+    handler(): ReplyPayload {
+      const lines: string[] = ["Plugin Insights — Collection Status", "═".repeat(40)];
+
+      // Turn stats
+      const turnCount = (db.prepare("SELECT COUNT(*) as cnt FROM turns").get() as { cnt: number }).cnt;
+      const sessionCount = (db.prepare("SELECT COUNT(DISTINCT session_id) as cnt FROM turns").get() as { cnt: number }).cnt;
+      lines.push(`\nTurns collected: ${turnCount}`);
+      lines.push(`Sessions tracked: ${sessionCount}`);
+
+      // Plugin event stats
+      const eventCount = (db.prepare("SELECT COUNT(*) as cnt FROM plugin_events").get() as { cnt: number }).cnt;
+      lines.push(`Plugin events recorded: ${eventCount}`);
+
+      // Mapped plugins (from tool_plugin_mapping)
+      const mappedRows = db.prepare("SELECT DISTINCT plugin_id, plugin_name FROM tool_plugin_mapping").all() as { plugin_id: string; plugin_name: string | null }[];
+      if (mappedRows.length > 0) {
+        lines.push(`\nConfigured tool→plugin mappings (${mappedRows.length} plugin(s)):`);
+        for (const row of mappedRows) {
+          const name = row.plugin_name ? ` (${row.plugin_name})` : "";
+          const tools = (db.prepare("SELECT tool_name FROM tool_plugin_mapping WHERE plugin_id = ?").all(row.plugin_id) as { tool_name: string }[])
+            .map((r) => r.tool_name);
+          lines.push(`  ${row.plugin_id}${name}: ${tools.join(", ")}`);
+        }
+      } else {
+        lines.push("\nNo tool→plugin mappings configured.");
+      }
+
+      // Unmapped tools (with observation counts, from DB)
+      const unmappedWithCounts = toolDetector.getUnmappedToolsWithCounts();
+      if (unmappedWithCounts.length > 0) {
+        lines.push(`\nUnmapped tools observed at runtime (${unmappedWithCounts.length}):`);
+        for (const { toolName, count } of unmappedWithCounts) {
+          lines.push(`  - ${toolName} (seen ${count} time${count === 1 ? "" : "s"})`);
+        }
+        lines.push(`\nAdd these to your config to start tracking:`);
+        lines.push(`  "toolMappings": [`);
+        for (const { toolName } of unmappedWithCounts) {
+          lines.push(`    { "toolName": "${toolName}", "pluginId": "<plugin-id>" },`);
+        }
+        lines.push(`  ]`);
+      } else if (turnCount > 0 && mappedRows.length === 0) {
+        lines.push(
+          "\nNo plugin tools observed yet.",
+          "Keep using plugins in conversations — tool names will appear here."
+        );
+      }
+
+      // Context detections
+      const contextCount = (db.prepare("SELECT COUNT(*) as cnt FROM plugin_events WHERE detection_method = 'context_injection'").get() as { cnt: number }).cnt;
+      if (contextCount > 0) {
+        lines.push(`\nContext injection detections: ${contextCount}`);
+      }
+
+      return { text: lines.join("\n") };
+    },
+  };
+}

--- a/extensions/plugin-insights/src/db/config.ts
+++ b/extensions/plugin-insights/src/db/config.ts
@@ -4,7 +4,7 @@ import type { PluginInsightsConfig } from "../types.js";
 import { DEFAULT_CONFIG } from "../types.js";
 
 export function resolveConfig(
-  userConfig: Partial<PluginInsightsConfig> | undefined
+  userConfig: Partial<PluginInsightsConfig> | undefined,
 ): PluginInsightsConfig {
   const config = { ...DEFAULT_CONFIG, ...userConfig };
 

--- a/extensions/plugin-insights/src/db/config.ts
+++ b/extensions/plugin-insights/src/db/config.ts
@@ -1,0 +1,24 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import type { PluginInsightsConfig } from "../types.js";
+import { DEFAULT_CONFIG } from "../types.js";
+
+export function resolveConfig(
+  userConfig: Partial<PluginInsightsConfig> | undefined
+): PluginInsightsConfig {
+  const config = { ...DEFAULT_CONFIG, ...userConfig };
+
+  if (userConfig?.llmJudge) {
+    config.llmJudge = { ...DEFAULT_CONFIG.llmJudge, ...userConfig.llmJudge };
+  }
+
+  config.dbPath = resolveDbPath(config.dbPath);
+  return config;
+}
+
+export function resolveDbPath(dbPath: string): string {
+  if (dbPath.startsWith("~")) {
+    return path.join(os.homedir(), dbPath.slice(1));
+  }
+  return path.resolve(dbPath);
+}

--- a/extensions/plugin-insights/src/db/connection.ts
+++ b/extensions/plugin-insights/src/db/connection.ts
@@ -1,0 +1,31 @@
+import Database from "better-sqlite3";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { runMigrations } from "./migration.js";
+
+/**
+ * Create a new database connection instance.
+ * Each caller owns its own connection — no hidden singleton.
+ */
+export function createDb(dbPath: string): Database.Database {
+  const dir = path.dirname(dbPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  runMigrations(db);
+  return db;
+}
+
+/** Create an in-memory database for testing */
+export function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}

--- a/extensions/plugin-insights/src/db/connection.ts
+++ b/extensions/plugin-insights/src/db/connection.ts
@@ -1,6 +1,6 @@
-import Database from "better-sqlite3";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import Database from "better-sqlite3";
 import { runMigrations } from "./migration.js";
 
 /**

--- a/extensions/plugin-insights/src/db/migration.ts
+++ b/extensions/plugin-insights/src/db/migration.ts
@@ -95,7 +95,7 @@ export function runMigrations(db: Database.Database): void {
     db
       .prepare("SELECT version FROM _migrations")
       .all()
-      .map((row: any) => row.version as number)
+      .map((row: any) => row.version as number),
   );
 
   for (const migration of MIGRATIONS) {
@@ -103,9 +103,7 @@ export function runMigrations(db: Database.Database): void {
 
     db.transaction(() => {
       db.exec(migration.sql);
-      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(
-        migration.version
-      );
+      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(migration.version);
     })();
   }
 }

--- a/extensions/plugin-insights/src/db/migration.ts
+++ b/extensions/plugin-insights/src/db/migration.ts
@@ -1,0 +1,111 @@
+import type Database from "better-sqlite3";
+
+const MIGRATIONS: { version: number; sql: string }[] = [
+  {
+    version: 1,
+    sql: `
+      CREATE TABLE IF NOT EXISTS turns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        turn_index INTEGER NOT NULL,
+        timestamp TEXT NOT NULL,
+        user_prompt_preview TEXT,
+        assistant_response_preview TEXT,
+        prompt_tokens INTEGER,
+        completion_tokens INTEGER,
+        total_tokens INTEGER,
+        tool_calls_json TEXT,
+        plugins_triggered_json TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS plugin_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        turn_id INTEGER REFERENCES turns(id),
+        plugin_id TEXT NOT NULL,
+        detection_method TEXT NOT NULL,
+        action TEXT,
+        metadata_json TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS satisfaction_signals (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        turn_id INTEGER REFERENCES turns(id),
+        signal_type TEXT NOT NULL,
+        confidence REAL,
+        next_turn_id INTEGER REFERENCES turns(id),
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS llm_scores (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        turn_id INTEGER REFERENCES turns(id),
+        accuracy_score REAL,
+        completeness_score REAL,
+        relevance_score REAL,
+        overall_score REAL,
+        judge_model TEXT,
+        judge_response_json TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS tool_plugin_mapping (
+        tool_name TEXT PRIMARY KEY,
+        plugin_id TEXT NOT NULL,
+        plugin_name TEXT,
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS plugin_installs (
+        plugin_id TEXT PRIMARY KEY,
+        first_seen_at TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
+      CREATE INDEX IF NOT EXISTS idx_turns_timestamp ON turns(timestamp);
+      CREATE INDEX IF NOT EXISTS idx_plugin_events_plugin ON plugin_events(plugin_id);
+      CREATE INDEX IF NOT EXISTS idx_plugin_events_turn ON plugin_events(turn_id);
+      CREATE INDEX IF NOT EXISTS idx_satisfaction_turn ON satisfaction_signals(turn_id);
+    `,
+  },
+  {
+    version: 2,
+    sql: `
+      CREATE TABLE IF NOT EXISTS observed_unmapped_tools (
+        tool_name TEXT PRIMARY KEY,
+        call_count INTEGER NOT NULL DEFAULT 1,
+        first_seen_at TEXT DEFAULT (datetime('now')),
+        last_seen_at TEXT DEFAULT (datetime('now'))
+      );
+    `,
+  },
+];
+
+export function runMigrations(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+
+  const applied = new Set(
+    db
+      .prepare("SELECT version FROM _migrations")
+      .all()
+      .map((row: any) => row.version as number)
+  );
+
+  for (const migration of MIGRATIONS) {
+    if (applied.has(migration.version)) continue;
+
+    db.transaction(() => {
+      db.exec(migration.sql);
+      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(
+        migration.version
+      );
+    })();
+  }
+}

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -1,4 +1,13 @@
 import type Database from "better-sqlite3";
+import { ContextDetector } from "./collector/context-detector.js";
+import { PluginReporter } from "./collector/plugin-reporter.js";
+import { ToolDetector } from "./collector/tool-detector.js";
+import { TurnCollector } from "./collector/turn-collector.js";
+import { ConversationTurnsMetric } from "./metrics/conversation-turns.js";
+import { ImplicitSatisfactionMetric } from "./metrics/implicit-satisfaction.js";
+import { LLMJudgeMetric } from "./metrics/llm-judge.js";
+import { TokenDeltaMetric } from "./metrics/token-delta.js";
+import { TriggerFrequencyMetric } from "./metrics/trigger-frequency.js";
 import type {
   ContextEngine,
   AfterTurnParams,
@@ -14,15 +23,6 @@ import type {
   CompactResult,
   BootstrapResult,
 } from "./types.js";
-import { TurnCollector } from "./collector/turn-collector.js";
-import { ToolDetector } from "./collector/tool-detector.js";
-import { ContextDetector } from "./collector/context-detector.js";
-import { PluginReporter } from "./collector/plugin-reporter.js";
-import { TriggerFrequencyMetric } from "./metrics/trigger-frequency.js";
-import { TokenDeltaMetric } from "./metrics/token-delta.js";
-import { ConversationTurnsMetric } from "./metrics/conversation-turns.js";
-import { ImplicitSatisfactionMetric } from "./metrics/implicit-satisfaction.js";
-import { LLMJudgeMetric } from "./metrics/llm-judge.js";
 
 export interface ToolPluginMapping {
   toolName: string;
@@ -33,17 +33,12 @@ export interface ToolPluginMapping {
 export function createInsightsEngine(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolPluginMappings?: ToolPluginMapping[]
+  toolPluginMappings?: ToolPluginMapping[],
 ): { engine: ContextEngine; reporter: PluginReporter; toolDetector: ToolDetector } {
   const toolDetector = new ToolDetector(db);
   const contextDetector = new ContextDetector();
   const pluginReporter = new PluginReporter(db);
-  const turnCollector = new TurnCollector(
-    db,
-    toolDetector,
-    contextDetector,
-    pluginReporter
-  );
+  const turnCollector = new TurnCollector(db, toolDetector, contextDetector, pluginReporter);
 
   // Build tool→plugin mapping if provided
   if (toolPluginMappings && toolPluginMappings.length > 0) {
@@ -77,10 +72,7 @@ export function createInsightsEngine(
     },
 
     // Required: ingest each message (we just pass through)
-    async ingest(_params: {
-      sessionId: string;
-      message: AgentMessage;
-    }): Promise<IngestResult> {
+    async ingest(_params: { sessionId: string; message: AgentMessage }): Promise<IngestResult> {
       return { ingested: true };
     },
 
@@ -96,10 +88,7 @@ export function createInsightsEngine(
     },
 
     // Required: compact (we don't own compaction)
-    async compact(_params: {
-      sessionId: string;
-      sessionFile: string;
-    }): Promise<CompactResult> {
+    async compact(_params: { sessionId: string; sessionFile: string }): Promise<CompactResult> {
       return {
         ok: true,
         compacted: false,
@@ -108,10 +97,7 @@ export function createInsightsEngine(
     },
 
     // Optional: bootstrap
-    async bootstrap(_params: {
-      sessionId: string;
-      sessionFile: string;
-    }): Promise<BootstrapResult> {
+    async bootstrap(_params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {
       return { bootstrapped: true };
     },
 
@@ -150,15 +136,13 @@ export function createInsightsEngine(
 export function buildReport(
   db: Database.Database,
   config: PluginInsightsConfig,
-  days: number = 30
+  days: number = 30,
 ): InsightsReport {
   const triggerMetric = new TriggerFrequencyMetric(db);
   const tokenMetric = new TokenDeltaMetric(db);
   const turnsMetric = new ConversationTurnsMetric(db);
   const satisfactionMetric = new ImplicitSatisfactionMetric(db);
-  const judgeMetric = config.llmJudge.enabled
-    ? new LLMJudgeMetric(db, config.llmJudge)
-    : null;
+  const judgeMetric = config.llmJudge.enabled ? new LLMJudgeMetric(db, config.llmJudge) : null;
 
   const activePlugins = triggerMetric.getActivePlugins(days);
 
@@ -167,9 +151,7 @@ export function buildReport(
     const tokenDelta = tokenMetric.compute(pluginId, days);
     const conversationTurns = turnsMetric.compute(pluginId, days);
     const implicitSatisfaction = satisfactionMetric.compute(pluginId, days);
-    const llmJudge = judgeMetric
-      ? judgeMetric.computeResult(pluginId, days)
-      : undefined;
+    const llmJudge = judgeMetric ? judgeMetric.computeResult(pluginId, days) : undefined;
 
     const installedDays = getInstalledDays(db, pluginId);
     const pluginName = getPluginName(db, pluginId);
@@ -180,7 +162,7 @@ export function buildReport(
       tokenDelta.deltaPercent,
       implicitSatisfaction.acceptanceRate,
       implicitSatisfaction.retryRate,
-      implicitSatisfaction.totalSignals
+      implicitSatisfaction.totalSignals,
     );
 
     return {
@@ -224,7 +206,7 @@ function computeVerdict(
   tokenDeltaPercent: number,
   acceptanceRate: number,
   _retryRate: number,
-  totalSignals: number
+  totalSignals: number,
 ): PluginVerdict {
   // Low usage: only check absolute trigger count.
   // triggersPerDay is now window-scoped so the threshold would depend
@@ -268,10 +250,7 @@ function computeVerdict(
   };
 }
 
-function updatePluginInstalls(
-  db: Database.Database,
-  pluginIds: string[]
-): void {
+function updatePluginInstalls(db: Database.Database, pluginIds: string[]): void {
   const upsert = db.prepare(`
     INSERT INTO plugin_installs (plugin_id, first_seen_at, last_seen_at)
     VALUES (?, datetime('now'), datetime('now'))
@@ -295,18 +274,13 @@ function getInstalledDays(db: Database.Database, pluginId: string): number {
 
   const firstSeen = new Date(row.first_seen_at);
   const now = new Date();
-  return Math.floor(
-    (now.getTime() - firstSeen.getTime()) / (1000 * 60 * 60 * 24)
-  );
+  return Math.floor((now.getTime() - firstSeen.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-function getPluginName(
-  db: Database.Database,
-  pluginId: string
-): string | undefined {
+function getPluginName(db: Database.Database, pluginId: string): string | undefined {
   const row = db
     .prepare(
-      "SELECT DISTINCT plugin_name FROM tool_plugin_mapping WHERE plugin_id = ? AND plugin_name IS NOT NULL LIMIT 1"
+      "SELECT DISTINCT plugin_name FROM tool_plugin_mapping WHERE plugin_id = ? AND plugin_name IS NOT NULL LIMIT 1",
     )
     .get(pluginId) as { plugin_name: string } | undefined;
 
@@ -314,10 +288,7 @@ function getPluginName(
 }
 
 /** Clean up data older than retention period */
-export function cleanupOldData(
-  db: Database.Database,
-  retentionDays: number
-): void {
+export function cleanupOldData(db: Database.Database, retentionDays: number): void {
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - retentionDays);
   const cutoffStr = cutoff.toISOString().slice(0, 19).replace("T", " ");
@@ -327,16 +298,14 @@ export function cleanupOldData(
   // when many expired turns exist.
   db.transaction(() => {
     db.prepare(
-      `DELETE FROM satisfaction_signals WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+      `DELETE FROM satisfaction_signals WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`,
     ).run(cutoffStr);
     db.prepare(
-      `DELETE FROM llm_scores WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+      `DELETE FROM llm_scores WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`,
     ).run(cutoffStr);
     db.prepare(
-      `DELETE FROM plugin_events WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+      `DELETE FROM plugin_events WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`,
     ).run(cutoffStr);
-    db.prepare(
-      `DELETE FROM turns WHERE timestamp < ?`
-    ).run(cutoffStr);
+    db.prepare(`DELETE FROM turns WHERE timestamp < ?`).run(cutoffStr);
   })();
 }

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -40,8 +40,8 @@ export function createInsightsEngine(
   const pluginReporter = new PluginReporter(db);
   const turnCollector = new TurnCollector(db, toolDetector, contextDetector, pluginReporter);
 
-  // Build tool→plugin mapping if provided
-  if (toolPluginMappings && toolPluginMappings.length > 0) {
+  // Build tool→plugin mapping if provided (pass empty array to clear stale rows)
+  if (toolPluginMappings) {
     toolDetector.refreshMappingFromEntries(toolPluginMappings);
   }
 

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -58,6 +58,16 @@ export function createInsightsEngine(
 
   // Per-session turn counters — ensures turn_index is session-scoped
   const sessionTurnCounters = new Map<string, number>();
+  // Track how many messages we've already processed per session,
+  // so afterTurn only ingests newly added messages (not the full transcript).
+  const sessionMessageCounts = new Map<string, number>();
+
+  // Create LLM judge once (not per-turn) to avoid race conditions
+  // where concurrent evaluations both read budget as unfull.
+  const judge =
+    config.llmJudge.enabled && config.llmJudge.apiKey
+      ? new LLMJudgeMetric(db, config.llmJudge)
+      : null;
 
   const engine: ContextEngine = {
     info: {
@@ -112,11 +122,20 @@ export function createInsightsEngine(
       const sid = params.sessionId;
       const idx = sessionTurnCounters.get(sid) ?? 0;
       sessionTurnCounters.set(sid, idx + 1);
-      turnCollector.collect(sid, idx, params.messages);
 
-      // Async LLM judge evaluation (fire-and-forget)
-      if (config.llmJudge.enabled && config.llmJudge.apiKey) {
-        const judge = new LLMJudgeMetric(db, config.llmJudge);
+      // Only process newly added messages since last afterTurn call.
+      // The SDK passes the full transcript each time; re-processing
+      // old messages would inflate plugin events and metrics.
+      const prevCount = sessionMessageCounts.get(sid) ?? 0;
+      const newMessages = params.messages.slice(prevCount);
+      sessionMessageCounts.set(sid, params.messages.length);
+
+      if (newMessages.length > 0) {
+        turnCollector.collect(sid, idx, newMessages);
+      }
+
+      // Async LLM judge evaluation (fire-and-forget, single instance)
+      if (judge) {
         judge.evaluate().catch(() => {
           // Silently ignore judge errors
         });
@@ -303,27 +322,21 @@ export function cleanupOldData(
   cutoff.setDate(cutoff.getDate() - retentionDays);
   const cutoffStr = cutoff.toISOString().slice(0, 19).replace("T", " ");
 
+  // Use subqueries instead of spreading turn IDs as bind parameters.
+  // This avoids hitting SQLite's SQLITE_MAX_VARIABLE_NUMBER limit
+  // when many expired turns exist.
   db.transaction(() => {
-    const turnIds = db
-      .prepare("SELECT id FROM turns WHERE timestamp < ?")
-      .all(cutoffStr) as { id: number }[];
-
-    if (turnIds.length === 0) return;
-
-    const ids = turnIds.map((r) => r.id);
-    const placeholders = ids.map(() => "?").join(",");
-
     db.prepare(
-      `DELETE FROM satisfaction_signals WHERE turn_id IN (${placeholders})`
-    ).run(...ids);
+      `DELETE FROM satisfaction_signals WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+    ).run(cutoffStr);
     db.prepare(
-      `DELETE FROM llm_scores WHERE turn_id IN (${placeholders})`
-    ).run(...ids);
+      `DELETE FROM llm_scores WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+    ).run(cutoffStr);
     db.prepare(
-      `DELETE FROM plugin_events WHERE turn_id IN (${placeholders})`
-    ).run(...ids);
+      `DELETE FROM plugin_events WHERE turn_id IN (SELECT id FROM turns WHERE timestamp < ?)`
+    ).run(cutoffStr);
     db.prepare(
-      `DELETE FROM turns WHERE id IN (${placeholders})`
-    ).run(...ids);
+      `DELETE FROM turns WHERE timestamp < ?`
+    ).run(cutoffStr);
   })();
 }

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -1,0 +1,329 @@
+import type Database from "better-sqlite3";
+import type {
+  ContextEngine,
+  AfterTurnParams,
+  AgentMessage,
+  PluginInsightsConfig,
+  InsightsReport,
+  PluginReport,
+  PluginVerdict,
+  VerdictLevel,
+  PluginInstallRow,
+  IngestResult,
+  AssembleResult,
+  CompactResult,
+  BootstrapResult,
+} from "./types.js";
+import { TurnCollector } from "./collector/turn-collector.js";
+import { ToolDetector } from "./collector/tool-detector.js";
+import { ContextDetector } from "./collector/context-detector.js";
+import { PluginReporter } from "./collector/plugin-reporter.js";
+import { TriggerFrequencyMetric } from "./metrics/trigger-frequency.js";
+import { TokenDeltaMetric } from "./metrics/token-delta.js";
+import { ConversationTurnsMetric } from "./metrics/conversation-turns.js";
+import { ImplicitSatisfactionMetric } from "./metrics/implicit-satisfaction.js";
+import { LLMJudgeMetric } from "./metrics/llm-judge.js";
+
+export interface ToolPluginMapping {
+  toolName: string;
+  pluginId: string;
+  pluginName?: string;
+}
+
+export function createInsightsEngine(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolPluginMappings?: ToolPluginMapping[]
+): { engine: ContextEngine; reporter: PluginReporter; toolDetector: ToolDetector } {
+  const toolDetector = new ToolDetector(db);
+  const contextDetector = new ContextDetector();
+  const pluginReporter = new PluginReporter(db);
+  const turnCollector = new TurnCollector(
+    db,
+    toolDetector,
+    contextDetector,
+    pluginReporter
+  );
+
+  // Build tool→plugin mapping if provided
+  if (toolPluginMappings && toolPluginMappings.length > 0) {
+    toolDetector.refreshMappingFromEntries(toolPluginMappings);
+  }
+
+  // Track known plugins from mapping
+  if (toolPluginMappings) {
+    const pluginIds = new Set(toolPluginMappings.map((m) => m.pluginId));
+    updatePluginInstalls(db, [...pluginIds]);
+  }
+
+  // Per-session turn counters — ensures turn_index is session-scoped
+  const sessionTurnCounters = new Map<string, number>();
+
+  const engine: ContextEngine = {
+    info: {
+      id: "plugin-insights",
+      name: "Plugin Insights",
+      ownsCompaction: false,
+    },
+
+    // Required: ingest each message (we just pass through)
+    async ingest(_params: {
+      sessionId: string;
+      message: AgentMessage;
+    }): Promise<IngestResult> {
+      return { ingested: true };
+    },
+
+    // Required: assemble messages for context (pass through unchanged)
+    async assemble(params: {
+      sessionId: string;
+      messages: AgentMessage[];
+    }): Promise<AssembleResult> {
+      return {
+        messages: params.messages,
+        estimatedTokens: 0,
+      };
+    },
+
+    // Required: compact (we don't own compaction)
+    async compact(_params: {
+      sessionId: string;
+      sessionFile: string;
+    }): Promise<CompactResult> {
+      return {
+        ok: true,
+        compacted: false,
+        reason: "plugin-insights does not manage compaction",
+      };
+    },
+
+    // Optional: bootstrap
+    async bootstrap(_params: {
+      sessionId: string;
+      sessionFile: string;
+    }): Promise<BootstrapResult> {
+      return { bootstrapped: true };
+    },
+
+    // Optional: afterTurn — our main data collection point
+    async afterTurn(params: AfterTurnParams): Promise<void> {
+      if (!config.enabled) return;
+
+      const sid = params.sessionId;
+      const idx = sessionTurnCounters.get(sid) ?? 0;
+      sessionTurnCounters.set(sid, idx + 1);
+      turnCollector.collect(sid, idx, params.messages);
+
+      // Async LLM judge evaluation (fire-and-forget)
+      if (config.llmJudge.enabled && config.llmJudge.apiKey) {
+        const judge = new LLMJudgeMetric(db, config.llmJudge);
+        judge.evaluate().catch(() => {
+          // Silently ignore judge errors
+        });
+      }
+    },
+  };
+
+  return { engine, reporter: pluginReporter, toolDetector };
+}
+
+/** Build a complete insights report for all active plugins */
+export function buildReport(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  days: number = 30
+): InsightsReport {
+  const triggerMetric = new TriggerFrequencyMetric(db);
+  const tokenMetric = new TokenDeltaMetric(db);
+  const turnsMetric = new ConversationTurnsMetric(db);
+  const satisfactionMetric = new ImplicitSatisfactionMetric(db);
+  const judgeMetric = config.llmJudge.enabled
+    ? new LLMJudgeMetric(db, config.llmJudge)
+    : null;
+
+  const activePlugins = triggerMetric.getActivePlugins(days);
+
+  const plugins: PluginReport[] = activePlugins.map((pluginId) => {
+    const triggerFrequency = triggerMetric.compute(pluginId, days);
+    const tokenDelta = tokenMetric.compute(pluginId, days);
+    const conversationTurns = turnsMetric.compute(pluginId, days);
+    const implicitSatisfaction = satisfactionMetric.compute(pluginId, days);
+    const llmJudge = judgeMetric
+      ? judgeMetric.computeResult(pluginId, days)
+      : undefined;
+
+    const installedDays = getInstalledDays(db, pluginId);
+    const pluginName = getPluginName(db, pluginId);
+
+    const verdict = computeVerdict(
+      triggerFrequency.totalTriggers,
+      triggerFrequency.triggersPerDay,
+      tokenDelta.deltaPercent,
+      implicitSatisfaction.acceptanceRate,
+      implicitSatisfaction.retryRate,
+      implicitSatisfaction.totalSignals
+    );
+
+    return {
+      pluginId,
+      pluginName,
+      installedDays,
+      triggerFrequency,
+      tokenDelta,
+      conversationTurns,
+      implicitSatisfaction,
+      llmJudge,
+      verdict,
+    };
+  });
+
+  // Sort: keep > low_usage > expensive/low_satisfaction > remove
+  const order: Record<VerdictLevel, number> = {
+    keep: 0,
+    low_usage: 1,
+    expensive: 2,
+    low_satisfaction: 3,
+    remove: 4,
+  };
+  plugins.sort((a, b) => order[a.verdict.level] - order[b.verdict.level]);
+
+  const now = new Date();
+  const periodStart = new Date(now);
+  periodStart.setDate(periodStart.getDate() - days);
+
+  return {
+    periodStart: periodStart.toISOString().slice(0, 10),
+    periodEnd: now.toISOString().slice(0, 10),
+    plugins,
+    generatedAt: now.toISOString(),
+  };
+}
+
+function computeVerdict(
+  totalTriggers: number,
+  _triggersPerDay: number,
+  tokenDeltaPercent: number,
+  acceptanceRate: number,
+  _retryRate: number,
+  totalSignals: number
+): PluginVerdict {
+  // Low usage: only check absolute trigger count.
+  // triggersPerDay is now window-scoped so the threshold would depend
+  // on how many days the user asks for; total triggers is more stable.
+  if (totalTriggers < 5) {
+    return {
+      level: "low_usage",
+      label: "LOW USAGE — consider removing",
+      reason: "Plugin is rarely triggered",
+    };
+  }
+
+  if (tokenDeltaPercent > 30 && totalSignals > 5 && acceptanceRate < 50) {
+    return {
+      level: "remove",
+      label: "EXPENSIVE & LOW SATISFACTION — recommend removing",
+      reason: "High token overhead with low user acceptance",
+    };
+  }
+
+  if (tokenDeltaPercent > 40) {
+    return {
+      level: "expensive",
+      label: "EXPENSIVE — high token overhead",
+      reason: `${tokenDeltaPercent}% extra tokens per trigger`,
+    };
+  }
+
+  if (totalSignals > 5 && acceptanceRate < 50) {
+    return {
+      level: "low_satisfaction",
+      label: "LOW SATISFACTION — users often retry",
+      reason: `Only ${acceptanceRate}% acceptance rate`,
+    };
+  }
+
+  return {
+    level: "keep",
+    label: "KEEP — strong positive impact",
+    reason: "Good trigger frequency with acceptable overhead",
+  };
+}
+
+function updatePluginInstalls(
+  db: Database.Database,
+  pluginIds: string[]
+): void {
+  const upsert = db.prepare(`
+    INSERT INTO plugin_installs (plugin_id, first_seen_at, last_seen_at)
+    VALUES (?, datetime('now'), datetime('now'))
+    ON CONFLICT(plugin_id) DO UPDATE SET last_seen_at = datetime('now')
+  `);
+
+  const tx = db.transaction(() => {
+    for (const id of pluginIds) {
+      upsert.run(id);
+    }
+  });
+  tx();
+}
+
+function getInstalledDays(db: Database.Database, pluginId: string): number {
+  const row = db
+    .prepare("SELECT first_seen_at FROM plugin_installs WHERE plugin_id = ?")
+    .get(pluginId) as PluginInstallRow | undefined;
+
+  if (!row) return 0;
+
+  const firstSeen = new Date(row.first_seen_at);
+  const now = new Date();
+  return Math.floor(
+    (now.getTime() - firstSeen.getTime()) / (1000 * 60 * 60 * 24)
+  );
+}
+
+function getPluginName(
+  db: Database.Database,
+  pluginId: string
+): string | undefined {
+  const row = db
+    .prepare(
+      "SELECT DISTINCT plugin_name FROM tool_plugin_mapping WHERE plugin_id = ? AND plugin_name IS NOT NULL LIMIT 1"
+    )
+    .get(pluginId) as { plugin_name: string } | undefined;
+
+  return row?.plugin_name;
+}
+
+/** Clean up data older than retention period */
+export function cleanupOldData(
+  db: Database.Database,
+  retentionDays: number
+): void {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - retentionDays);
+  const cutoffStr = cutoff.toISOString().slice(0, 19).replace("T", " ");
+
+  db.transaction(() => {
+    const turnIds = db
+      .prepare("SELECT id FROM turns WHERE timestamp < ?")
+      .all(cutoffStr) as { id: number }[];
+
+    if (turnIds.length === 0) return;
+
+    const ids = turnIds.map((r) => r.id);
+    const placeholders = ids.map(() => "?").join(",");
+
+    db.prepare(
+      `DELETE FROM satisfaction_signals WHERE turn_id IN (${placeholders})`
+    ).run(...ids);
+    db.prepare(
+      `DELETE FROM llm_scores WHERE turn_id IN (${placeholders})`
+    ).run(...ids);
+    db.prepare(
+      `DELETE FROM plugin_events WHERE turn_id IN (${placeholders})`
+    ).run(...ids);
+    db.prepare(
+      `DELETE FROM turns WHERE id IN (${placeholders})`
+    ).run(...ids);
+  })();
+}

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -63,6 +63,8 @@ export function createInsightsEngine(
     config.llmJudge.enabled && config.llmJudge.apiKey
       ? new LLMJudgeMetric(db, config.llmJudge)
       : null;
+  // Guard against concurrent judge evaluations from rapid afterTurn calls
+  let judgeInFlight = false;
 
   const engine: ContextEngine = {
     info: {
@@ -120,11 +122,19 @@ export function createInsightsEngine(
         turnCollector.collect(sid, idx, newMessages);
       }
 
-      // Async LLM judge evaluation (fire-and-forget, single instance)
-      if (judge) {
-        judge.evaluate().catch(() => {
-          // Silently ignore judge errors
-        });
+      // Async LLM judge evaluation (fire-and-forget, single instance).
+      // Skip if a previous evaluation is still running to avoid
+      // concurrent budget reads that could exceed the daily limit.
+      if (judge && !judgeInFlight) {
+        judgeInFlight = true;
+        judge
+          .evaluate()
+          .catch(() => {
+            // Silently ignore judge errors
+          })
+          .finally(() => {
+            judgeInFlight = false;
+          });
       }
     },
   };

--- a/extensions/plugin-insights/src/engine.ts
+++ b/extensions/plugin-insights/src/engine.ts
@@ -299,6 +299,10 @@ function getPluginName(db: Database.Database, pluginId: string): string | undefi
 
 /** Clean up data older than retention period */
 export function cleanupOldData(db: Database.Database, retentionDays: number): void {
+  // Guard against zero/negative values that would wipe all data
+  if (!Number.isFinite(retentionDays) || retentionDays < 1) {
+    retentionDays = 90;
+  }
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - retentionDays);
   const cutoffStr = cutoff.toISOString().slice(0, 19).replace("T", " ");

--- a/extensions/plugin-insights/src/metrics/conversation-turns.ts
+++ b/extensions/plugin-insights/src/metrics/conversation-turns.ts
@@ -26,7 +26,7 @@ export class ConversationTurnsMetric {
            HAVING COUNT(*) >= 2
          )
          AND t.timestamp >= ?
-         GROUP BY t.session_id`
+         GROUP BY t.session_id`,
       )
       .all(pluginId, since, since) as { session_id: string; turn_count: number }[];
 
@@ -44,7 +44,7 @@ export class ConversationTurnsMetric {
            GROUP BY t2.session_id
            HAVING COUNT(*) >= 2
          )
-         GROUP BY t.session_id`
+         GROUP BY t.session_id`,
       )
       .all(since, pluginId, since) as { session_id: string; turn_count: number }[];
 
@@ -67,4 +67,3 @@ function average(nums: number[]): number {
   if (nums.length === 0) return 0;
   return nums.reduce((a, b) => a + b, 0) / nums.length;
 }
-

--- a/extensions/plugin-insights/src/metrics/conversation-turns.ts
+++ b/extensions/plugin-insights/src/metrics/conversation-turns.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { ConversationTurnsResult } from "../types.js";
+import { daysAgo, round } from "../utils.js";
 
 export class ConversationTurnsMetric {
   private db: Database.Database;
@@ -67,13 +68,3 @@ function average(nums: number[]): number {
   return nums.reduce((a, b) => a + b, 0) / nums.length;
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}
-
-function round(n: number, decimals: number = 1): number {
-  const f = 10 ** decimals;
-  return Math.round(n * f) / f;
-}

--- a/extensions/plugin-insights/src/metrics/conversation-turns.ts
+++ b/extensions/plugin-insights/src/metrics/conversation-turns.ts
@@ -1,0 +1,79 @@
+import type Database from "better-sqlite3";
+import type { ConversationTurnsResult } from "../types.js";
+
+export class ConversationTurnsMetric {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  compute(pluginId: string, days: number = 30): ConversationTurnsResult {
+    const since = daysAgo(days);
+
+    // Sessions where this plugin was frequently triggered (>= 2 times)
+    const sessionsWithPlugin = this.db
+      .prepare(
+        `SELECT t.session_id, COUNT(DISTINCT t.id) as turn_count
+         FROM turns t
+         WHERE t.session_id IN (
+           SELECT DISTINCT t2.session_id
+           FROM plugin_events pe
+           JOIN turns t2 ON pe.turn_id = t2.id
+           WHERE pe.plugin_id = ? AND pe.created_at >= ?
+           GROUP BY t2.session_id
+           HAVING COUNT(*) >= 2
+         )
+         AND t.timestamp >= ?
+         GROUP BY t.session_id`
+      )
+      .all(pluginId, since, since) as { session_id: string; turn_count: number }[];
+
+    // Sessions where this plugin was rarely or never triggered (0-1 times)
+    const sessionsWithoutPlugin = this.db
+      .prepare(
+        `SELECT t.session_id, COUNT(*) as turn_count
+         FROM turns t
+         WHERE t.timestamp >= ?
+         AND t.session_id NOT IN (
+           SELECT DISTINCT t2.session_id
+           FROM plugin_events pe
+           JOIN turns t2 ON pe.turn_id = t2.id
+           WHERE pe.plugin_id = ? AND pe.created_at >= ?
+           GROUP BY t2.session_id
+           HAVING COUNT(*) >= 2
+         )
+         GROUP BY t.session_id`
+      )
+      .all(since, pluginId, since) as { session_id: string; turn_count: number }[];
+
+    const avgWith = average(sessionsWithPlugin.map((s) => s.turn_count));
+    const avgWithout = average(sessionsWithoutPlugin.map((s) => s.turn_count));
+    const delta = avgWith - avgWithout;
+    const deltaPercent = avgWithout > 0 ? (delta / avgWithout) * 100 : 0;
+
+    return {
+      pluginId,
+      avgTurnsWithPlugin: round(avgWith),
+      avgTurnsWithoutPlugin: round(avgWithout),
+      deltaTurns: round(delta),
+      deltaPercent: round(deltaPercent),
+    };
+  }
+}
+
+function average(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/src/metrics/conversation-turns.ts
+++ b/extensions/plugin-insights/src/metrics/conversation-turns.ts
@@ -12,7 +12,9 @@ export class ConversationTurnsMetric {
   compute(pluginId: string, days: number = 30): ConversationTurnsResult {
     const since = daysAgo(days);
 
-    // Sessions where this plugin was frequently triggered (>= 2 times)
+    // Sessions where this plugin was frequently triggered (>= 2 distinct turns)
+    // Use COUNT(DISTINCT pe.turn_id) to avoid inflating counts when a single
+    // turn generates multiple plugin_events rows (e.g. tool_call + context_injection).
     const sessionsWithPlugin = this.db
       .prepare(
         `SELECT t.session_id, COUNT(DISTINCT t.id) as turn_count
@@ -23,14 +25,14 @@ export class ConversationTurnsMetric {
            JOIN turns t2 ON pe.turn_id = t2.id
            WHERE pe.plugin_id = ? AND pe.created_at >= ?
            GROUP BY t2.session_id
-           HAVING COUNT(*) >= 2
+           HAVING COUNT(DISTINCT pe.turn_id) >= 2
          )
          AND t.timestamp >= ?
          GROUP BY t.session_id`,
       )
       .all(pluginId, since, since) as { session_id: string; turn_count: number }[];
 
-    // Sessions where this plugin was rarely or never triggered (0-1 times)
+    // Sessions where this plugin was rarely or never triggered (0-1 distinct turns)
     const sessionsWithoutPlugin = this.db
       .prepare(
         `SELECT t.session_id, COUNT(*) as turn_count
@@ -42,7 +44,7 @@ export class ConversationTurnsMetric {
            JOIN turns t2 ON pe.turn_id = t2.id
            WHERE pe.plugin_id = ? AND pe.created_at >= ?
            GROUP BY t2.session_id
-           HAVING COUNT(*) >= 2
+           HAVING COUNT(DISTINCT pe.turn_id) >= 2
          )
          GROUP BY t.session_id`,
       )

--- a/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
+++ b/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
@@ -1,0 +1,64 @@
+import type Database from "better-sqlite3";
+import type { ImplicitSatisfactionResult } from "../types.js";
+
+export class ImplicitSatisfactionMetric {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  compute(pluginId: string, days: number = 30): ImplicitSatisfactionResult {
+    const since = daysAgo(days);
+
+    // Get satisfaction signals for turns where this plugin was triggered
+    const signals = this.db
+      .prepare(
+        `SELECT ss.signal_type, COUNT(*) as cnt
+         FROM satisfaction_signals ss
+         JOIN plugin_events pe ON pe.turn_id = ss.turn_id
+         WHERE pe.plugin_id = ? AND ss.created_at >= ?
+         GROUP BY ss.signal_type`
+      )
+      .all(pluginId, since) as { signal_type: string; cnt: number }[];
+
+    let accepted = 0;
+    let retried = 0;
+    let corrected = 0;
+
+    for (const s of signals) {
+      switch (s.signal_type) {
+        case "accepted":
+          accepted = s.cnt;
+          break;
+        case "retried":
+          retried = s.cnt;
+          break;
+        case "corrected":
+          corrected = s.cnt;
+          break;
+      }
+    }
+
+    const total = accepted + retried + corrected;
+
+    return {
+      pluginId,
+      acceptanceRate: total > 0 ? round((accepted / total) * 100) : 0,
+      retryRate: total > 0 ? round((retried / total) * 100) : 0,
+      correctionRate: total > 0 ? round((corrected / total) * 100) : 0,
+      totalSignals: total,
+    };
+  }
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
+++ b/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
@@ -19,7 +19,7 @@ export class ImplicitSatisfactionMetric {
          FROM satisfaction_signals ss
          JOIN plugin_events pe ON pe.turn_id = ss.turn_id
          WHERE pe.plugin_id = ? AND ss.created_at >= ?
-         GROUP BY ss.signal_type`
+         GROUP BY ss.signal_type`,
       )
       .all(pluginId, since) as { signal_type: string; cnt: number }[];
 
@@ -52,4 +52,3 @@ export class ImplicitSatisfactionMetric {
     };
   }
 }
-

--- a/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
+++ b/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { ImplicitSatisfactionResult } from "../types.js";
+import { daysAgo, round } from "../utils.js";
 
 export class ImplicitSatisfactionMetric {
   private db: Database.Database;
@@ -52,13 +53,3 @@ export class ImplicitSatisfactionMetric {
   }
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}
-
-function round(n: number, decimals: number = 1): number {
-  const f = 10 ** decimals;
-  return Math.round(n * f) / f;
-}

--- a/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
+++ b/extensions/plugin-insights/src/metrics/implicit-satisfaction.ts
@@ -12,16 +12,21 @@ export class ImplicitSatisfactionMetric {
   compute(pluginId: string, days: number = 30): ImplicitSatisfactionResult {
     const since = daysAgo(days);
 
-    // Get satisfaction signals for turns where this plugin was triggered
+    // Get satisfaction signals for turns where this plugin was triggered.
+    // Use a subquery to deduplicate: a turn with multiple plugin_events
+    // for the same plugin should only count its satisfaction signal once.
     const signals = this.db
       .prepare(
         `SELECT ss.signal_type, COUNT(*) as cnt
          FROM satisfaction_signals ss
-         JOIN plugin_events pe ON pe.turn_id = ss.turn_id
-         WHERE pe.plugin_id = ? AND ss.created_at >= ?
+         WHERE ss.turn_id IN (
+           SELECT DISTINCT pe.turn_id FROM plugin_events pe
+           WHERE pe.plugin_id = ? AND pe.created_at >= ?
+         )
+           AND ss.created_at >= ?
          GROUP BY ss.signal_type`,
       )
-      .all(pluginId, since) as { signal_type: string; cnt: number }[];
+      .all(pluginId, since, since) as { signal_type: string; cnt: number }[];
 
     let accepted = 0;
     let retried = 0;

--- a/extensions/plugin-insights/src/metrics/llm-judge.ts
+++ b/extensions/plugin-insights/src/metrics/llm-judge.ts
@@ -63,7 +63,7 @@ export class LLMJudgeMetric {
            AND t.assistant_response_preview IS NOT NULL
            AND t.timestamp >= datetime('now', ?)
          ORDER BY RANDOM()
-         LIMIT ?`
+         LIMIT ?`,
       )
       .all(`-${days} days`, remaining) as {
       id: number;
@@ -75,7 +75,7 @@ export class LLMJudgeMetric {
       try {
         const score = await this.callJudge(
           turn.user_prompt_preview,
-          turn.assistant_response_preview
+          turn.assistant_response_preview,
         );
         if (score) {
           this.insertScore(turn.id, score);
@@ -96,7 +96,7 @@ export class LLMJudgeMetric {
         `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
          FROM llm_scores ls
          JOIN plugin_events pe ON pe.turn_id = ls.turn_id
-         WHERE pe.plugin_id = ? AND ls.created_at >= ?`
+         WHERE pe.plugin_id = ? AND ls.created_at >= ?`,
       )
       .get(pluginId, since) as { avg_score: number | null; cnt: number };
 
@@ -107,7 +107,7 @@ export class LLMJudgeMetric {
          FROM llm_scores ls
          JOIN turns t ON t.id = ls.turn_id
          WHERE (t.plugins_triggered_json IS NULL OR t.plugins_triggered_json = '[]')
-           AND ls.created_at >= ?`
+           AND ls.created_at >= ?`,
       )
       .get(since) as { avg_score: number | null; cnt: number };
 
@@ -125,11 +125,12 @@ export class LLMJudgeMetric {
 
   private async callJudge(
     userPrompt: string,
-    assistantResponse: string
+    assistantResponse: string,
   ): Promise<JudgeResponse | null> {
-    const prompt = JUDGE_PROMPT_TEMPLATE
-      .replace("{user_prompt}", userPrompt)
-      .replace("{assistant_response}", assistantResponse);
+    const prompt = JUDGE_PROMPT_TEMPLATE.replace("{user_prompt}", userPrompt).replace(
+      "{assistant_response}",
+      assistantResponse,
+    );
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30_000);
@@ -189,7 +190,7 @@ export class LLMJudgeMetric {
         `INSERT INTO llm_scores (
           turn_id, accuracy_score, completeness_score,
           relevance_score, overall_score, judge_model, judge_response_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         turnId,
@@ -198,7 +199,7 @@ export class LLMJudgeMetric {
         score.relevance,
         score.overall,
         this.config.model,
-        JSON.stringify(score)
+        JSON.stringify(score),
       );
   }
 
@@ -206,7 +207,7 @@ export class LLMJudgeMetric {
     const row = this.db
       .prepare(
         `SELECT COUNT(*) as cnt FROM llm_scores
-         WHERE created_at >= date('now')`
+         WHERE created_at >= date('now')`,
       )
       .get() as { cnt: number };
     return row.cnt;
@@ -216,4 +217,3 @@ export class LLMJudgeMetric {
 function isValidScore(n: unknown): n is number {
   return typeof n === "number" && n >= 1 && n <= 5;
 }
-

--- a/extensions/plugin-insights/src/metrics/llm-judge.ts
+++ b/extensions/plugin-insights/src/metrics/llm-judge.ts
@@ -90,15 +90,20 @@ export class LLMJudgeMetric {
   computeResult(pluginId: string, days: number = 30): LLMJudgeResult {
     const since = daysAgo(days);
 
-    // Scores for turns where plugin was triggered
+    // Scores for turns where plugin was triggered.
+    // Use a subquery to deduplicate: a turn with multiple plugin_events
+    // for the same plugin should only count its LLM score once.
     const withPlugin = this.db
       .prepare(
         `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
          FROM llm_scores ls
-         JOIN plugin_events pe ON pe.turn_id = ls.turn_id
-         WHERE pe.plugin_id = ? AND ls.created_at >= ?`,
+         WHERE ls.turn_id IN (
+           SELECT DISTINCT pe.turn_id FROM plugin_events pe
+           WHERE pe.plugin_id = ? AND pe.created_at >= ?
+         )
+           AND ls.created_at >= ?`,
       )
-      .get(pluginId, since) as { avg_score: number | null; cnt: number };
+      .get(pluginId, since, since) as { avg_score: number | null; cnt: number };
 
     // Baseline scores (turns without any plugin)
     const withoutPlugin = this.db

--- a/extensions/plugin-insights/src/metrics/llm-judge.ts
+++ b/extensions/plugin-insights/src/metrics/llm-judge.ts
@@ -1,0 +1,228 @@
+import type Database from "better-sqlite3";
+import type { LLMJudgeConfig, LLMJudgeResult } from "../types.js";
+
+const JUDGE_PROMPT_TEMPLATE = `You are an expert evaluator assessing the quality of an AI assistant's response.
+
+User prompt:
+{user_prompt}
+
+Assistant response:
+{assistant_response}
+
+Please rate the response on the following dimensions (1-5 scale):
+1. Accuracy: Is the information correct and factual?
+2. Completeness: Does the response fully address the user's request?
+3. Relevance: Is the response focused on what the user asked?
+4. Overall: What is your overall assessment of the response quality?
+
+Respond in JSON format:
+{
+  "accuracy": <1-5>,
+  "completeness": <1-5>,
+  "relevance": <1-5>,
+  "overall": <1-5>,
+  "reasoning": "<brief explanation>"
+}`;
+
+interface JudgeResponse {
+  accuracy: number;
+  completeness: number;
+  relevance: number;
+  overall: number;
+  reasoning?: string;
+}
+
+export class LLMJudgeMetric {
+  private db: Database.Database;
+  private config: LLMJudgeConfig;
+
+  constructor(db: Database.Database, config: LLMJudgeConfig) {
+    this.db = db;
+    this.config = config;
+  }
+
+  /** Run LLM evaluation on sampled turns */
+  async evaluate(days: number = 7): Promise<void> {
+    if (!this.config.enabled || !this.config.apiKey) return;
+
+    // Check daily evaluation budget
+    const todayCount = this.getTodayEvalCount();
+    if (todayCount >= this.config.maxEvalPerDay) return;
+
+    const remaining = this.config.maxEvalPerDay - todayCount;
+
+    // Sample unevaluated turns
+    const turns = this.db
+      .prepare(
+        `SELECT t.id, t.user_prompt_preview, t.assistant_response_preview
+         FROM turns t
+         LEFT JOIN llm_scores ls ON ls.turn_id = t.id
+         WHERE ls.id IS NULL
+           AND t.user_prompt_preview IS NOT NULL
+           AND t.assistant_response_preview IS NOT NULL
+           AND t.timestamp >= datetime('now', ?)
+         ORDER BY RANDOM()
+         LIMIT ?`
+      )
+      .all(`-${days} days`, remaining) as {
+      id: number;
+      user_prompt_preview: string;
+      assistant_response_preview: string;
+    }[];
+
+    for (const turn of turns) {
+      try {
+        const score = await this.callJudge(
+          turn.user_prompt_preview,
+          turn.assistant_response_preview
+        );
+        if (score) {
+          this.insertScore(turn.id, score);
+        }
+      } catch {
+        // Silently skip failed evaluations
+      }
+    }
+  }
+
+  /** Compute aggregate LLM judge scores for a plugin */
+  computeResult(pluginId: string, days: number = 30): LLMJudgeResult {
+    const since = daysAgo(days);
+
+    // Scores for turns where plugin was triggered
+    const withPlugin = this.db
+      .prepare(
+        `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
+         FROM llm_scores ls
+         JOIN plugin_events pe ON pe.turn_id = ls.turn_id
+         WHERE pe.plugin_id = ? AND ls.created_at >= ?`
+      )
+      .get(pluginId, since) as { avg_score: number | null; cnt: number };
+
+    // Baseline scores (turns without any plugin)
+    const withoutPlugin = this.db
+      .prepare(
+        `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
+         FROM llm_scores ls
+         JOIN turns t ON t.id = ls.turn_id
+         WHERE (t.plugins_triggered_json IS NULL OR t.plugins_triggered_json = '[]')
+           AND ls.created_at >= ?`
+      )
+      .get(since) as { avg_score: number | null; cnt: number };
+
+    const avgWith = withPlugin.avg_score ?? 0;
+    const avgWithout = withoutPlugin.avg_score ?? 0;
+
+    return {
+      pluginId,
+      avgScoreWithPlugin: round(avgWith),
+      avgScoreWithoutPlugin: round(avgWithout),
+      deltaScore: round(avgWith - avgWithout),
+      sampleCount: withPlugin.cnt,
+    };
+  }
+
+  private async callJudge(
+    userPrompt: string,
+    assistantResponse: string
+  ): Promise<JudgeResponse | null> {
+    const prompt = JUDGE_PROMPT_TEMPLATE
+      .replace("{user_prompt}", userPrompt)
+      .replace("{assistant_response}", assistantResponse);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.config.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.config.model,
+          messages: [{ role: "user", content: prompt }],
+          temperature: 0,
+          response_format: { type: "json_object" },
+        }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      choices: { message: { content: string } }[];
+    };
+
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) return null;
+
+    let parsed: JudgeResponse;
+    try {
+      parsed = JSON.parse(content) as JudgeResponse;
+    } catch {
+      return null;
+    }
+
+    // Validate score ranges
+    if (
+      !isValidScore(parsed.accuracy) ||
+      !isValidScore(parsed.completeness) ||
+      !isValidScore(parsed.relevance) ||
+      !isValidScore(parsed.overall)
+    ) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  private insertScore(turnId: number, score: JudgeResponse): void {
+    this.db
+      .prepare(
+        `INSERT INTO llm_scores (
+          turn_id, accuracy_score, completeness_score,
+          relevance_score, overall_score, judge_model, judge_response_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        turnId,
+        score.accuracy,
+        score.completeness,
+        score.relevance,
+        score.overall,
+        this.config.model,
+        JSON.stringify(score)
+      );
+  }
+
+  private getTodayEvalCount(): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM llm_scores
+         WHERE created_at >= date('now')`
+      )
+      .get() as { cnt: number };
+    return row.cnt;
+  }
+}
+
+function isValidScore(n: unknown): n is number {
+  return typeof n === "number" && n >= 1 && n <= 5;
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/src/metrics/llm-judge.ts
+++ b/extensions/plugin-insights/src/metrics/llm-judge.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { LLMJudgeConfig, LLMJudgeResult } from "../types.js";
+import { daysAgo, round } from "../utils.js";
 
 const JUDGE_PROMPT_TEMPLATE = `You are an expert evaluator assessing the quality of an AI assistant's response.
 
@@ -216,13 +217,3 @@ function isValidScore(n: unknown): n is number {
   return typeof n === "number" && n >= 1 && n <= 5;
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}
-
-function round(n: number, decimals: number = 1): number {
-  const f = 10 ** decimals;
-  return Math.round(n * f) / f;
-}

--- a/extensions/plugin-insights/src/metrics/llm-judge.ts
+++ b/extensions/plugin-insights/src/metrics/llm-judge.ts
@@ -79,9 +79,14 @@ export class LLMJudgeMetric {
         );
         if (score) {
           this.insertScore(turn.id, score);
+        } else {
+          // Mark as attempted so this turn is not retried and counts against
+          // the daily budget even when the API returns unparseable output.
+          this.insertFailedAttempt(turn.id);
         }
       } catch {
-        // Silently skip failed evaluations
+        // API error — still count against budget to prevent runaway retries
+        this.insertFailedAttempt(turn.id);
       }
     }
   }
@@ -93,25 +98,29 @@ export class LLMJudgeMetric {
     // Scores for turns where plugin was triggered.
     // Use a subquery to deduplicate: a turn with multiple plugin_events
     // for the same plugin should only count its LLM score once.
+    // Exclude failed attempts (overall_score = -1).
     const withPlugin = this.db
       .prepare(
         `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
          FROM llm_scores ls
-         WHERE ls.turn_id IN (
-           SELECT DISTINCT pe.turn_id FROM plugin_events pe
-           WHERE pe.plugin_id = ? AND pe.created_at >= ?
-         )
+         WHERE ls.overall_score > 0
+           AND ls.turn_id IN (
+             SELECT DISTINCT pe.turn_id FROM plugin_events pe
+             WHERE pe.plugin_id = ? AND pe.created_at >= ?
+           )
            AND ls.created_at >= ?`,
       )
       .get(pluginId, since, since) as { avg_score: number | null; cnt: number };
 
     // Baseline scores (turns without any plugin)
+    // Exclude failed attempts (overall_score = -1).
     const withoutPlugin = this.db
       .prepare(
         `SELECT AVG(ls.overall_score) as avg_score, COUNT(*) as cnt
          FROM llm_scores ls
          JOIN turns t ON t.id = ls.turn_id
-         WHERE (t.plugins_triggered_json IS NULL OR t.plugins_triggered_json = '[]')
+         WHERE ls.overall_score > 0
+           AND (t.plugins_triggered_json IS NULL OR t.plugins_triggered_json = '[]')
            AND ls.created_at >= ?`,
       )
       .get(since) as { avg_score: number | null; cnt: number };
@@ -206,6 +215,18 @@ export class LLMJudgeMetric {
         this.config.model,
         JSON.stringify(score),
       );
+  }
+
+  /** Record a failed API attempt so the turn is not retried and counts against budget */
+  private insertFailedAttempt(turnId: number): void {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO llm_scores (
+          turn_id, accuracy_score, completeness_score,
+          relevance_score, overall_score, judge_model, judge_response_json
+        ) VALUES (?, -1, -1, -1, -1, ?, '{"error":"failed"}')`,
+      )
+      .run(turnId, this.config.model);
   }
 
   private getTodayEvalCount(): number {

--- a/extensions/plugin-insights/src/metrics/token-delta.ts
+++ b/extensions/plugin-insights/src/metrics/token-delta.ts
@@ -33,7 +33,7 @@ export class TokenDeltaMetric {
            WHERE pe.plugin_id = ? AND pe.created_at >= ?
          )
            AND t.timestamp >= ?
-           AND t.total_tokens IS NOT NULL`
+           AND t.total_tokens IS NOT NULL`,
       )
       .get(pluginId, since, since) as {
       avg_total: number | null;
@@ -53,7 +53,7 @@ export class TokenDeltaMetric {
          FROM turns
          WHERE timestamp >= ?
            AND total_tokens IS NOT NULL
-           AND (plugins_triggered_json IS NULL OR plugins_triggered_json = '[]')`
+           AND (plugins_triggered_json IS NULL OR plugins_triggered_json = '[]')`,
       )
       .get(since) as {
       avg_total: number | null;
@@ -68,12 +68,9 @@ export class TokenDeltaMetric {
     const deltaPercent = avgWithout > 0 ? (delta / avgWithout) * 100 : 0;
 
     // Estimate monthly cost: assume 30 triggers/day * 30 days
-    const triggersPerMonth = withPlugin.cnt > 0
-      ? (withPlugin.cnt / days) * 30
-      : 0;
+    const triggersPerMonth = withPlugin.cnt > 0 ? (withPlugin.cnt / days) * 30 : 0;
     const extraTokensPerMonth = delta > 0 ? delta * triggersPerMonth : 0;
-    const estimatedCost =
-      (extraTokensPerMonth / 1_000_000) * DEFAULT_COST_PER_1M_BLENDED;
+    const estimatedCost = (extraTokensPerMonth / 1_000_000) * DEFAULT_COST_PER_1M_BLENDED;
 
     return {
       pluginId,
@@ -85,4 +82,3 @@ export class TokenDeltaMetric {
     };
   }
 }
-

--- a/extensions/plugin-insights/src/metrics/token-delta.ts
+++ b/extensions/plugin-insights/src/metrics/token-delta.ts
@@ -1,0 +1,93 @@
+import type Database from "better-sqlite3";
+import type { TokenDeltaResult } from "../types.js";
+
+// Approximate pricing per 1M tokens (GPT-4o class)
+const DEFAULT_COST_PER_1M_INPUT = 2.5;
+const DEFAULT_COST_PER_1M_OUTPUT = 10.0;
+const DEFAULT_COST_PER_1M_BLENDED = 5.0;
+
+export class TokenDeltaMetric {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  compute(pluginId: string, days: number = 30): TokenDeltaResult {
+    const since = daysAgo(days);
+
+    // Average tokens for turns where this plugin was triggered
+    const withPlugin = this.db
+      .prepare(
+        `SELECT
+           AVG(t.total_tokens) as avg_total,
+           AVG(t.prompt_tokens) as avg_prompt,
+           AVG(t.completion_tokens) as avg_completion,
+           COUNT(*) as cnt
+         FROM turns t
+         JOIN plugin_events pe ON pe.turn_id = t.id
+         WHERE pe.plugin_id = ?
+           AND t.timestamp >= ?
+           AND t.total_tokens IS NOT NULL`
+      )
+      .get(pluginId, since) as {
+      avg_total: number | null;
+      avg_prompt: number | null;
+      avg_completion: number | null;
+      cnt: number;
+    };
+
+    // Average tokens for turns where NO plugin was triggered
+    const withoutPlugin = this.db
+      .prepare(
+        `SELECT
+           AVG(total_tokens) as avg_total,
+           AVG(prompt_tokens) as avg_prompt,
+           AVG(completion_tokens) as avg_completion,
+           COUNT(*) as cnt
+         FROM turns
+         WHERE timestamp >= ?
+           AND total_tokens IS NOT NULL
+           AND (plugins_triggered_json IS NULL OR plugins_triggered_json = '[]')`
+      )
+      .get(since) as {
+      avg_total: number | null;
+      avg_prompt: number | null;
+      avg_completion: number | null;
+      cnt: number;
+    };
+
+    const avgWith = withPlugin.avg_total ?? 0;
+    const avgWithout = withoutPlugin.avg_total ?? 0;
+    const delta = avgWith - avgWithout;
+    const deltaPercent = avgWithout > 0 ? (delta / avgWithout) * 100 : 0;
+
+    // Estimate monthly cost: assume 30 triggers/day * 30 days
+    const triggersPerMonth = withPlugin.cnt > 0
+      ? (withPlugin.cnt / days) * 30
+      : 0;
+    const extraTokensPerMonth = delta > 0 ? delta * triggersPerMonth : 0;
+    const estimatedCost =
+      (extraTokensPerMonth / 1_000_000) * DEFAULT_COST_PER_1M_BLENDED;
+
+    return {
+      pluginId,
+      avgTokensWithPlugin: round(avgWith),
+      avgTokensWithoutPlugin: round(avgWithout),
+      deltaTokens: round(delta),
+      deltaPercent: round(deltaPercent),
+      estimatedMonthlyCostUSD: round(estimatedCost, 2),
+    };
+  }
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/src/metrics/token-delta.ts
+++ b/extensions/plugin-insights/src/metrics/token-delta.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { TokenDeltaResult } from "../types.js";
+import { daysAgo, round } from "../utils.js";
 
 // Approximate pricing per 1M tokens (GPT-4o class)
 const DEFAULT_COST_PER_1M_INPUT = 2.5;
@@ -16,7 +17,9 @@ export class TokenDeltaMetric {
   compute(pluginId: string, days: number = 30): TokenDeltaResult {
     const since = daysAgo(days);
 
-    // Average tokens for turns where this plugin was triggered
+    // Average tokens for turns where this plugin was triggered.
+    // Use a subquery to deduplicate: a turn with multiple plugin_events
+    // for the same plugin should only be counted once.
     const withPlugin = this.db
       .prepare(
         `SELECT
@@ -25,12 +28,14 @@ export class TokenDeltaMetric {
            AVG(t.completion_tokens) as avg_completion,
            COUNT(*) as cnt
          FROM turns t
-         JOIN plugin_events pe ON pe.turn_id = t.id
-         WHERE pe.plugin_id = ?
+         WHERE t.id IN (
+           SELECT DISTINCT pe.turn_id FROM plugin_events pe
+           WHERE pe.plugin_id = ? AND pe.created_at >= ?
+         )
            AND t.timestamp >= ?
            AND t.total_tokens IS NOT NULL`
       )
-      .get(pluginId, since) as {
+      .get(pluginId, since, since) as {
       avg_total: number | null;
       avg_prompt: number | null;
       avg_completion: number | null;
@@ -81,13 +86,3 @@ export class TokenDeltaMetric {
   }
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}
-
-function round(n: number, decimals: number = 1): number {
-  const f = 10 ** decimals;
-  return Math.round(n * f) / f;
-}

--- a/extensions/plugin-insights/src/metrics/trigger-frequency.ts
+++ b/extensions/plugin-insights/src/metrics/trigger-frequency.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { TriggerFrequencyResult } from "../types.js";
+import { daysAgo, round } from "../utils.js";
 
 export class TriggerFrequencyMetric {
   private db: Database.Database;
@@ -68,13 +69,3 @@ export class TriggerFrequencyMetric {
   }
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}
-
-function round(n: number, decimals: number = 1): number {
-  const f = 10 ** decimals;
-  return Math.round(n * f) / f;
-}

--- a/extensions/plugin-insights/src/metrics/trigger-frequency.ts
+++ b/extensions/plugin-insights/src/metrics/trigger-frequency.ts
@@ -16,7 +16,7 @@ export class TriggerFrequencyMetric {
     const totalRow = this.db
       .prepare(
         `SELECT COUNT(*) as cnt FROM plugin_events
-         WHERE plugin_id = ? AND created_at >= ?`
+         WHERE plugin_id = ? AND created_at >= ?`,
       )
       .get(pluginId, since) as { cnt: number };
 
@@ -27,7 +27,7 @@ export class TriggerFrequencyMetric {
          FROM plugin_events
          WHERE plugin_id = ? AND created_at >= ?
          GROUP BY date(created_at)
-         ORDER BY date(created_at)`
+         ORDER BY date(created_at)`,
       )
       .all(pluginId, since) as { date: string; cnt: number }[];
 
@@ -37,7 +37,7 @@ export class TriggerFrequencyMetric {
         `SELECT COUNT(DISTINCT t.session_id) as cnt
          FROM plugin_events pe
          JOIN turns t ON pe.turn_id = t.id
-         WHERE pe.plugin_id = ? AND pe.created_at >= ?`
+         WHERE pe.plugin_id = ? AND pe.created_at >= ?`,
       )
       .get(pluginId, since) as { cnt: number };
 
@@ -61,11 +61,8 @@ export class TriggerFrequencyMetric {
   getActivePlugins(days: number = 30): string[] {
     const since = daysAgo(days);
     const rows = this.db
-      .prepare(
-        `SELECT DISTINCT plugin_id FROM plugin_events WHERE created_at >= ?`
-      )
+      .prepare(`SELECT DISTINCT plugin_id FROM plugin_events WHERE created_at >= ?`)
       .all(since) as { plugin_id: string }[];
     return rows.map((r) => r.plugin_id);
   }
 }
-

--- a/extensions/plugin-insights/src/metrics/trigger-frequency.ts
+++ b/extensions/plugin-insights/src/metrics/trigger-frequency.ts
@@ -1,0 +1,80 @@
+import type Database from "better-sqlite3";
+import type { TriggerFrequencyResult } from "../types.js";
+
+export class TriggerFrequencyMetric {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  compute(pluginId: string, days: number = 30): TriggerFrequencyResult {
+    const since = daysAgo(days);
+
+    // Total trigger count
+    const totalRow = this.db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM plugin_events
+         WHERE plugin_id = ? AND created_at >= ?`
+      )
+      .get(pluginId, since) as { cnt: number };
+
+    // Daily breakdown
+    const dailyRows = this.db
+      .prepare(
+        `SELECT date(created_at) as date, COUNT(*) as cnt
+         FROM plugin_events
+         WHERE plugin_id = ? AND created_at >= ?
+         GROUP BY date(created_at)
+         ORDER BY date(created_at)`
+      )
+      .all(pluginId, since) as { date: string; cnt: number }[];
+
+    // Unique sessions where plugin was triggered
+    const sessionRow = this.db
+      .prepare(
+        `SELECT COUNT(DISTINCT t.session_id) as cnt
+         FROM plugin_events pe
+         JOIN turns t ON pe.turn_id = t.id
+         WHERE pe.plugin_id = ? AND pe.created_at >= ?`
+      )
+      .get(pluginId, since) as { cnt: number };
+
+    const totalTriggers = totalRow.cnt;
+    // Use the report window (days) as denominator, not just days-with-triggers.
+    // This avoids inflating triggersPerDay when the plugin is only active on
+    // a few days within the window.
+    const windowDays = Math.max(days, 1);
+    const sessions = Math.max(sessionRow.cnt, 1);
+
+    return {
+      pluginId,
+      totalTriggers,
+      triggersPerDay: round(totalTriggers / windowDays),
+      triggersPerSession: round(totalTriggers / sessions),
+      dailyTrend: dailyRows.map((r) => ({ date: r.date, count: r.cnt })),
+    };
+  }
+
+  /** Get all plugin IDs that have events */
+  getActivePlugins(days: number = 30): string[] {
+    const since = daysAgo(days);
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT plugin_id FROM plugin_events WHERE created_at >= ?`
+      )
+      .all(since) as { plugin_id: string }[];
+    return rows.map((r) => r.plugin_id);
+  }
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/src/report/cli-report.ts
+++ b/extensions/plugin-insights/src/report/cli-report.ts
@@ -14,11 +14,7 @@ export function formatCLIReport(report: InsightsReport): string {
 
   lines.push("╔" + "═".repeat(W) + "╗");
   lines.push("║" + center("Plugin Insights Report", W) + "║");
-  lines.push(
-    "║" +
-      center(`Period: ${report.periodStart} → ${report.periodEnd}`, W) +
-      "║"
-  );
+  lines.push("║" + center(`Period: ${report.periodStart} → ${report.periodEnd}`, W) + "║");
   lines.push("╠" + "═".repeat(W) + "╣");
   lines.push("║" + " ".repeat(W) + "║");
 
@@ -41,9 +37,7 @@ function formatPluginSection(plugin: PluginReport, W: number): string[] {
 
   const tf = plugin.triggerFrequency;
   lines.push(
-    "║" +
-      pad(`  ├─ Triggered: ${tf.totalTriggers} times (${tf.triggersPerDay}/day)`, W) +
-      "║"
+    "║" + pad(`  ├─ Triggered: ${tf.totalTriggers} times (${tf.triggersPerDay}/day)`, W) + "║",
   );
 
   const td = plugin.tokenDelta;
@@ -52,9 +46,9 @@ function formatPluginSection(plugin: PluginReport, W: number): string[] {
     "║" +
       pad(
         `  ├─ Token overhead: ${sign}${td.deltaPercent}% (~$${td.estimatedMonthlyCostUSD}/mo)`,
-        W
+        W,
       ) +
-      "║"
+      "║",
   );
 
   const ct = plugin.conversationTurns;
@@ -64,25 +58,17 @@ function formatPluginSection(plugin: PluginReport, W: number): string[] {
       "║" +
         pad(
           `  ├─ Avg turns/session: ${ct.avgTurnsWithoutPlugin} → ${ct.avgTurnsWithPlugin} (${arrow}${Math.abs(ct.deltaPercent)}%)`,
-          W
+          W,
         ) +
-        "║"
+        "║",
     );
   }
 
   const is = plugin.implicitSatisfaction;
   if (is.totalSignals > 0) {
-    lines.push(
-      "║" +
-        pad(`  ├─ User acceptance rate: ${is.acceptanceRate}%`, W) +
-        "║"
-    );
+    lines.push("║" + pad(`  ├─ User acceptance rate: ${is.acceptanceRate}%`, W) + "║");
     if (is.retryRate > 0) {
-      lines.push(
-        "║" +
-          pad(`  ├─ Retry rate after trigger: ${is.retryRate}%`, W) +
-          "║"
-      );
+      lines.push("║" + pad(`  ├─ Retry rate after trigger: ${is.retryRate}%`, W) + "║");
     }
   }
 
@@ -92,18 +78,14 @@ function formatPluginSection(plugin: PluginReport, W: number): string[] {
       "║" +
         pad(
           `  ├─ LLM Judge score: ${lj.avgScoreWithPlugin}/5 (vs ${lj.avgScoreWithoutPlugin} baseline)`,
-          W
+          W,
         ) +
-        "║"
+        "║",
     );
   }
 
   const icon = VERDICT_ICONS[plugin.verdict.level];
-  lines.push(
-    "║" +
-      pad(`  └─ Verdict: ${icon} ${plugin.verdict.label}`, W) +
-      "║"
-  );
+  lines.push("║" + pad(`  └─ Verdict: ${icon} ${plugin.verdict.label}`, W) + "║");
 
   return lines;
 }

--- a/extensions/plugin-insights/src/report/cli-report.ts
+++ b/extensions/plugin-insights/src/report/cli-report.ts
@@ -1,0 +1,157 @@
+import type { InsightsReport, PluginReport, VerdictLevel } from "../types.js";
+
+const VERDICT_ICONS: Record<VerdictLevel, string> = {
+  keep: "✅",
+  low_usage: "⚠️ ",
+  expensive: "❌",
+  low_satisfaction: "❌",
+  remove: "❌",
+};
+
+export function formatCLIReport(report: InsightsReport): string {
+  const lines: string[] = [];
+  const W = 56;
+
+  lines.push("╔" + "═".repeat(W) + "╗");
+  lines.push("║" + center("Plugin Insights Report", W) + "║");
+  lines.push(
+    "║" +
+      center(`Period: ${report.periodStart} → ${report.periodEnd}`, W) +
+      "║"
+  );
+  lines.push("╠" + "═".repeat(W) + "╣");
+  lines.push("║" + " ".repeat(W) + "║");
+
+  for (const plugin of report.plugins) {
+    lines.push(...formatPluginSection(plugin, W));
+    lines.push("║" + " ".repeat(W) + "║");
+  }
+
+  lines.push("╚" + "═".repeat(W) + "╝");
+
+  return lines.join("\n");
+}
+
+function formatPluginSection(plugin: PluginReport, W: number): string[] {
+  const lines: string[] = [];
+  const name = plugin.pluginName ?? plugin.pluginId;
+  const header = `  ${name}${" ".repeat(Math.max(1, 30 - name.length))}installed ${plugin.installedDays}d`;
+
+  lines.push("║" + pad(header, W) + "║");
+
+  const tf = plugin.triggerFrequency;
+  lines.push(
+    "║" +
+      pad(`  ├─ Triggered: ${tf.totalTriggers} times (${tf.triggersPerDay}/day)`, W) +
+      "║"
+  );
+
+  const td = plugin.tokenDelta;
+  const sign = td.deltaPercent >= 0 ? "+" : "";
+  lines.push(
+    "║" +
+      pad(
+        `  ├─ Token overhead: ${sign}${td.deltaPercent}% (~$${td.estimatedMonthlyCostUSD}/mo)`,
+        W
+      ) +
+      "║"
+  );
+
+  const ct = plugin.conversationTurns;
+  if (ct.avgTurnsWithPlugin > 0 || ct.avgTurnsWithoutPlugin > 0) {
+    const arrow = ct.deltaPercent < 0 ? "▼" : ct.deltaPercent > 0 ? "▲" : "─";
+    lines.push(
+      "║" +
+        pad(
+          `  ├─ Avg turns/session: ${ct.avgTurnsWithoutPlugin} → ${ct.avgTurnsWithPlugin} (${arrow}${Math.abs(ct.deltaPercent)}%)`,
+          W
+        ) +
+        "║"
+    );
+  }
+
+  const is = plugin.implicitSatisfaction;
+  if (is.totalSignals > 0) {
+    lines.push(
+      "║" +
+        pad(`  ├─ User acceptance rate: ${is.acceptanceRate}%`, W) +
+        "║"
+    );
+    if (is.retryRate > 0) {
+      lines.push(
+        "║" +
+          pad(`  ├─ Retry rate after trigger: ${is.retryRate}%`, W) +
+          "║"
+      );
+    }
+  }
+
+  if (plugin.llmJudge && plugin.llmJudge.sampleCount > 0) {
+    const lj = plugin.llmJudge;
+    lines.push(
+      "║" +
+        pad(
+          `  ├─ LLM Judge score: ${lj.avgScoreWithPlugin}/5 (vs ${lj.avgScoreWithoutPlugin} baseline)`,
+          W
+        ) +
+        "║"
+    );
+  }
+
+  const icon = VERDICT_ICONS[plugin.verdict.level];
+  lines.push(
+    "║" +
+      pad(`  └─ Verdict: ${icon} ${plugin.verdict.label}`, W) +
+      "║"
+  );
+
+  return lines;
+}
+
+function center(text: string, width: number): string {
+  const len = visualLength(text);
+  if (len >= width) return text.slice(0, width);
+  const left = Math.floor((width - len) / 2);
+  const right = width - len - left;
+  return " ".repeat(left) + text + " ".repeat(right);
+}
+
+function pad(text: string, width: number): string {
+  const len = visualLength(text);
+  if (len >= width) return text.slice(0, width);
+  return text + " ".repeat(width - len);
+}
+
+/** Account for emoji/wide chars in visual width (simplified) */
+function visualLength(text: string): number {
+  // Simple approximation: count emoji as 2 chars
+  let len = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0)!;
+    if (code > 0xffff || (code >= 0x2600 && code <= 0x27bf)) {
+      len += 2;
+    } else {
+      len += 1;
+    }
+  }
+  return len;
+}
+
+/** Format a single plugin report for compact inline display */
+export function formatPluginSummary(plugin: PluginReport): string {
+  const name = plugin.pluginName ?? plugin.pluginId;
+  const tf = plugin.triggerFrequency;
+  const td = plugin.tokenDelta;
+  const is = plugin.implicitSatisfaction;
+  const icon = VERDICT_ICONS[plugin.verdict.level];
+
+  return [
+    `${icon} ${name} (installed ${plugin.installedDays}d)`,
+    `  Triggers: ${tf.totalTriggers} (${tf.triggersPerDay}/day)`,
+    `  Token overhead: ${td.deltaPercent >= 0 ? "+" : ""}${td.deltaPercent}% (~$${td.estimatedMonthlyCostUSD}/mo)`,
+    is.totalSignals > 0 ? `  Acceptance: ${is.acceptanceRate}%` : null,
+    `  Verdict: ${plugin.verdict.label}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/extensions/plugin-insights/src/report/html-report.ts
+++ b/extensions/plugin-insights/src/report/html-report.ts
@@ -1,0 +1,193 @@
+import type { InsightsReport, PluginReport, VerdictLevel } from "../types.js";
+
+const VERDICT_COLORS: Record<VerdictLevel, string> = {
+  keep: "#22c55e",
+  low_usage: "#f59e0b",
+  expensive: "#ef4444",
+  low_satisfaction: "#ef4444",
+  remove: "#ef4444",
+};
+
+export function generateHTMLReport(
+  report: InsightsReport,
+  unmappedTools?: { toolName: string; count: number }[]
+): string {
+  const pluginCards = report.plugins.map(generatePluginCard).join("\n");
+  const coverageBanner = generateCoverageBanner(unmappedTools);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Plugin Insights Dashboard</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a; color: #e2e8f0; padding: 2rem;
+    }
+    .header {
+      text-align: center; margin-bottom: 2rem; padding: 2rem;
+      background: linear-gradient(135deg, #1e293b, #334155);
+      border-radius: 12px; border: 1px solid #475569;
+    }
+    .header h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    .header .period { color: #94a3b8; font-size: 0.9rem; }
+    .coverage-warning {
+      margin-bottom: 1.5rem; padding: 1rem 1.5rem;
+      background: #422006; border: 1px solid #92400e; border-radius: 8px;
+      color: #fbbf24; font-size: 0.9rem;
+    }
+    .coverage-warning strong { color: #fde68a; }
+    .coverage-warning .tool-list { color: #d4d4d8; margin-top: 0.5rem; font-size: 0.85rem; }
+    .grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+      gap: 1.5rem;
+    }
+    .card {
+      background: #1e293b; border-radius: 12px; padding: 1.5rem;
+      border: 1px solid #334155; transition: transform 0.2s;
+    }
+    .card:hover { transform: translateY(-2px); border-color: #475569; }
+    .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+    .card-header h2 { font-size: 1.2rem; }
+    .badge {
+      padding: 0.25rem 0.75rem; border-radius: 99px; font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .metric { display: flex; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px solid #334155; }
+    .metric:last-child { border-bottom: none; }
+    .metric-label { color: #94a3b8; }
+    .metric-value { font-weight: 600; }
+    .verdict { margin-top: 1rem; padding: 0.75rem; border-radius: 8px; font-weight: 600; text-align: center; }
+    .trend-bar { display: flex; gap: 2px; height: 24px; align-items: flex-end; margin-top: 0.5rem; }
+    .trend-bar .bar {
+      flex: 1; background: #3b82f6; border-radius: 2px 2px 0 0;
+      min-width: 4px; transition: height 0.3s;
+    }
+    .footer { text-align: center; color: #64748b; margin-top: 2rem; font-size: 0.8rem; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Plugin Insights Dashboard</h1>
+    <div class="period">Period: ${report.periodStart} &rarr; ${report.periodEnd}</div>
+    <div class="period">Generated: ${report.generatedAt}</div>
+  </div>
+  ${coverageBanner}
+  <div class="grid">
+    ${pluginCards}
+  </div>
+  <div class="footer">
+    Plugin Insights &mdash; Data stored locally. No telemetry.
+  </div>
+</body>
+</html>`;
+}
+
+function generatePluginCard(plugin: PluginReport): string {
+  const name = plugin.pluginName ?? plugin.pluginId;
+  const verdictColor = VERDICT_COLORS[plugin.verdict.level];
+  const tf = plugin.triggerFrequency;
+  const td = plugin.tokenDelta;
+  const ct = plugin.conversationTurns;
+  const is = plugin.implicitSatisfaction;
+
+  // Generate sparkline for daily trend
+  const trendBars = generateTrendBars(tf.dailyTrend);
+
+  let metricsHTML = `
+    <div class="metric">
+      <span class="metric-label">Triggers</span>
+      <span class="metric-value">${tf.totalTriggers} (${tf.triggersPerDay}/day)</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">Token overhead</span>
+      <span class="metric-value">${td.deltaPercent >= 0 ? "+" : ""}${td.deltaPercent}% (~$${td.estimatedMonthlyCostUSD}/mo)</span>
+    </div>`;
+
+  if (ct.avgTurnsWithPlugin > 0 || ct.avgTurnsWithoutPlugin > 0) {
+    const arrow = ct.deltaPercent < 0 ? "&#9660;" : ct.deltaPercent > 0 ? "&#9650;" : "&mdash;";
+    metricsHTML += `
+    <div class="metric">
+      <span class="metric-label">Avg turns/session</span>
+      <span class="metric-value">${ct.avgTurnsWithoutPlugin} &rarr; ${ct.avgTurnsWithPlugin} (${arrow}${Math.abs(ct.deltaPercent)}%)</span>
+    </div>`;
+  }
+
+  if (is.totalSignals > 0) {
+    metricsHTML += `
+    <div class="metric">
+      <span class="metric-label">Acceptance rate</span>
+      <span class="metric-value">${is.acceptanceRate}%</span>
+    </div>`;
+  }
+
+  if (plugin.llmJudge && plugin.llmJudge.sampleCount > 0) {
+    const lj = plugin.llmJudge;
+    metricsHTML += `
+    <div class="metric">
+      <span class="metric-label">LLM Judge score</span>
+      <span class="metric-value">${lj.avgScoreWithPlugin}/5 (baseline: ${lj.avgScoreWithoutPlugin})</span>
+    </div>`;
+  }
+
+  return `
+    <div class="card">
+      <div class="card-header">
+        <h2>${escapeHTML(name)}</h2>
+        <span class="badge" style="background:${verdictColor}20;color:${verdictColor}">
+          ${plugin.installedDays}d installed
+        </span>
+      </div>
+      ${metricsHTML}
+      ${trendBars}
+      <div class="verdict" style="background:${verdictColor}15;color:${verdictColor};border:1px solid ${verdictColor}40">
+        ${escapeHTML(plugin.verdict.label)}
+      </div>
+    </div>`;
+}
+
+function generateTrendBars(
+  trend: { date: string; count: number }[]
+): string {
+  if (trend.length === 0) return "";
+
+  const max = Math.max(...trend.map((t) => t.count), 1);
+  const bars = trend
+    .slice(-14) // Show last 14 days
+    .map(
+      (t) =>
+        `<div class="bar" style="height:${Math.max((t.count / max) * 24, 2)}px" title="${t.date}: ${t.count}"></div>`
+    )
+    .join("");
+
+  return `<div class="trend-bar">${bars}</div>`;
+}
+
+function generateCoverageBanner(
+  unmappedTools?: { toolName: string; count: number }[]
+): string {
+  if (!unmappedTools || unmappedTools.length === 0) return "";
+
+  const totalCalls = unmappedTools.reduce((sum, t) => sum + t.count, 0);
+  const toolItems = unmappedTools
+    .map((t) => `<code>${escapeHTML(t.toolName)}</code> (${t.count}x)`)
+    .join(", ");
+
+  return `
+  <div class="coverage-warning">
+    <strong>&#9888; Partial coverage:</strong> ${unmappedTools.length} tool(s) observed but not mapped to any plugin (${totalCalls} total calls).
+    This dashboard only reflects plugins with configured <code>toolMappings</code>.
+    <div class="tool-list">Unmapped: ${toolItems}</div>
+  </div>`;
+}
+
+function escapeHTML(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/extensions/plugin-insights/src/report/html-report.ts
+++ b/extensions/plugin-insights/src/report/html-report.ts
@@ -10,7 +10,7 @@ const VERDICT_COLORS: Record<VerdictLevel, string> = {
 
 export function generateHTMLReport(
   report: InsightsReport,
-  unmappedTools?: { toolName: string; count: number }[]
+  unmappedTools?: { toolName: string; count: number }[],
 ): string {
   const pluginCards = report.plugins.map(generatePluginCard).join("\n");
   const coverageBanner = generateCoverageBanner(unmappedTools);
@@ -149,9 +149,7 @@ function generatePluginCard(plugin: PluginReport): string {
     </div>`;
 }
 
-function generateTrendBars(
-  trend: { date: string; count: number }[]
-): string {
+function generateTrendBars(trend: { date: string; count: number }[]): string {
   if (trend.length === 0) return "";
 
   const max = Math.max(...trend.map((t) => t.count), 1);
@@ -159,16 +157,14 @@ function generateTrendBars(
     .slice(-14) // Show last 14 days
     .map(
       (t) =>
-        `<div class="bar" style="height:${Math.max((t.count / max) * 24, 2)}px" title="${t.date}: ${t.count}"></div>`
+        `<div class="bar" style="height:${Math.max((t.count / max) * 24, 2)}px" title="${t.date}: ${t.count}"></div>`,
     )
     .join("");
 
   return `<div class="trend-bar">${bars}</div>`;
 }
 
-function generateCoverageBanner(
-  unmappedTools?: { toolName: string; count: number }[]
-): string {
+function generateCoverageBanner(unmappedTools?: { toolName: string; count: number }[]): string {
   if (!unmappedTools || unmappedTools.length === 0) return "";
 
   const totalCalls = unmappedTools.reduce((sum, t) => sum + t.count, 0);

--- a/extensions/plugin-insights/src/report/json-export.ts
+++ b/extensions/plugin-insights/src/report/json-export.ts
@@ -1,0 +1,105 @@
+import type Database from "better-sqlite3";
+import type { InsightsReport } from "../types.js";
+import * as fs from "node:fs";
+
+export interface ExportOptions {
+  format: "json" | "jsonl";
+  output?: string;
+  pretty?: boolean;
+}
+
+/** Export full insights report as JSON */
+export function exportJSON(
+  report: InsightsReport,
+  options: ExportOptions
+): string {
+  const content =
+    options.format === "jsonl"
+      ? report.plugins.map((p) => JSON.stringify(p)).join("\n")
+      : JSON.stringify(report, null, options.pretty !== false ? 2 : undefined);
+
+  if (options.output) {
+    fs.writeFileSync(options.output, content, "utf-8");
+  }
+
+  return content;
+}
+
+/** Export raw data from tables for advanced analysis */
+export function exportRawData(
+  db: Database.Database,
+  options: ExportOptions & { days?: number }
+): string {
+  const days = options.days ?? 30;
+  const since = daysAgo(days);
+
+  const turns = db
+    .prepare("SELECT * FROM turns WHERE timestamp >= ? ORDER BY timestamp")
+    .all(since);
+
+  const events = db
+    .prepare(
+      `SELECT pe.* FROM plugin_events pe
+       JOIN turns t ON pe.turn_id = t.id
+       WHERE t.timestamp >= ?
+       ORDER BY pe.created_at`
+    )
+    .all(since);
+
+  const signals = db
+    .prepare(
+      `SELECT ss.* FROM satisfaction_signals ss
+       JOIN turns t ON ss.turn_id = t.id
+       WHERE t.timestamp >= ?
+       ORDER BY ss.created_at`
+    )
+    .all(since);
+
+  const scores = db
+    .prepare(
+      `SELECT ls.* FROM llm_scores ls
+       JOIN turns t ON ls.turn_id = t.id
+       WHERE t.timestamp >= ?
+       ORDER BY ls.created_at`
+    )
+    .all(since);
+
+  // Include unmapped tools for coverage context
+  const unmappedTools = db
+    .prepare(
+      `SELECT tool_name, call_count FROM observed_unmapped_tools
+       WHERE tool_name NOT IN (SELECT tool_name FROM tool_plugin_mapping)
+       ORDER BY call_count DESC`
+    )
+    .all() as { tool_name: string; call_count: number }[];
+
+  const data = {
+    exportedAt: new Date().toISOString(),
+    periodDays: days,
+    coverage: {
+      isComplete: unmappedTools.length === 0,
+      unmappedTools: unmappedTools.map((r) => ({
+        toolName: r.tool_name,
+        callCount: r.call_count,
+      })),
+    },
+    turns,
+    pluginEvents: events,
+    satisfactionSignals: signals,
+    llmScores: scores,
+  };
+
+  const content = JSON.stringify(data, null, options.pretty !== false ? 2 : undefined);
+
+  if (options.output) {
+    fs.writeFileSync(options.output, content, "utf-8");
+  }
+
+  return content;
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}

--- a/extensions/plugin-insights/src/report/json-export.ts
+++ b/extensions/plugin-insights/src/report/json-export.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { InsightsReport } from "../types.js";
+import { daysAgo } from "../utils.js";
 import * as fs from "node:fs";
 
 export interface ExportOptions {
@@ -98,8 +99,3 @@ export function exportRawData(
   return content;
 }
 
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 19).replace("T", " ");
-}

--- a/extensions/plugin-insights/src/report/json-export.ts
+++ b/extensions/plugin-insights/src/report/json-export.ts
@@ -1,7 +1,7 @@
+import * as fs from "node:fs";
 import type Database from "better-sqlite3";
 import type { InsightsReport } from "../types.js";
 import { daysAgo } from "../utils.js";
-import * as fs from "node:fs";
 
 export interface ExportOptions {
   format: "json" | "jsonl";
@@ -10,10 +10,7 @@ export interface ExportOptions {
 }
 
 /** Export full insights report as JSON */
-export function exportJSON(
-  report: InsightsReport,
-  options: ExportOptions
-): string {
+export function exportJSON(report: InsightsReport, options: ExportOptions): string {
   const content =
     options.format === "jsonl"
       ? report.plugins.map((p) => JSON.stringify(p)).join("\n")
@@ -29,7 +26,7 @@ export function exportJSON(
 /** Export raw data from tables for advanced analysis */
 export function exportRawData(
   db: Database.Database,
-  options: ExportOptions & { days?: number }
+  options: ExportOptions & { days?: number },
 ): string {
   const days = options.days ?? 30;
   const since = daysAgo(days);
@@ -43,7 +40,7 @@ export function exportRawData(
       `SELECT pe.* FROM plugin_events pe
        JOIN turns t ON pe.turn_id = t.id
        WHERE t.timestamp >= ?
-       ORDER BY pe.created_at`
+       ORDER BY pe.created_at`,
     )
     .all(since);
 
@@ -52,7 +49,7 @@ export function exportRawData(
       `SELECT ss.* FROM satisfaction_signals ss
        JOIN turns t ON ss.turn_id = t.id
        WHERE t.timestamp >= ?
-       ORDER BY ss.created_at`
+       ORDER BY ss.created_at`,
     )
     .all(since);
 
@@ -61,7 +58,7 @@ export function exportRawData(
       `SELECT ls.* FROM llm_scores ls
        JOIN turns t ON ls.turn_id = t.id
        WHERE t.timestamp >= ?
-       ORDER BY ls.created_at`
+       ORDER BY ls.created_at`,
     )
     .all(since);
 
@@ -70,7 +67,7 @@ export function exportRawData(
     .prepare(
       `SELECT tool_name, call_count FROM observed_unmapped_tools
        WHERE tool_name NOT IN (SELECT tool_name FROM tool_plugin_mapping)
-       ORDER BY call_count DESC`
+       ORDER BY call_count DESC`,
     )
     .all() as { tool_name: string; call_count: number }[];
 
@@ -98,4 +95,3 @@ export function exportRawData(
 
   return content;
 }
-

--- a/extensions/plugin-insights/src/tools/insights-compare.ts
+++ b/extensions/plugin-insights/src/tools/insights-compare.ts
@@ -1,13 +1,13 @@
 import type Database from "better-sqlite3";
+import type { ToolDetector } from "../collector/tool-detector.js";
+import { buildReport } from "../engine.js";
 import type { PluginInsightsConfig, PluginReport, AgentTool } from "../types.js";
 import { textToolResult } from "../types.js";
-import { buildReport } from "../engine.js";
-import type { ToolDetector } from "../collector/tool-detector.js";
 
 export function createInsightsCompareTool(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): AgentTool {
   return {
     name: "insights_compare",
@@ -97,18 +97,11 @@ export function formatComparison(a: PluginReport, b: PluginReport): string {
       `${a.implicitSatisfaction.acceptanceRate}%`,
       `${b.implicitSatisfaction.acceptanceRate}%`,
     ],
-    [
-      "Retry rate",
-      `${a.implicitSatisfaction.retryRate}%`,
-      `${b.implicitSatisfaction.retryRate}%`,
-    ],
+    ["Retry rate", `${a.implicitSatisfaction.retryRate}%`, `${b.implicitSatisfaction.retryRate}%`],
     ["Verdict", a.verdict.label, b.verdict.label],
   ];
 
-  if (
-    (a.llmJudge && a.llmJudge.sampleCount > 0) ||
-    (b.llmJudge && b.llmJudge.sampleCount > 0)
-  ) {
+  if ((a.llmJudge && a.llmJudge.sampleCount > 0) || (b.llmJudge && b.llmJudge.sampleCount > 0)) {
     rows.splice(-1, 0, [
       "LLM Judge",
       a.llmJudge ? `${a.llmJudge.avgScoreWithPlugin}/5` : "N/A",
@@ -121,9 +114,6 @@ export function formatComparison(a: PluginReport, b: PluginReport): string {
   const col2 = Math.max(...rows.map((r) => r[2].length));
 
   return rows
-    .map(
-      ([c0, c1, c2]) =>
-        `${c0.padEnd(col0)}  ${c1.padEnd(col1)}  ${c2.padEnd(col2)}`
-    )
+    .map(([c0, c1, c2]) => `${c0.padEnd(col0)}  ${c1.padEnd(col1)}  ${c2.padEnd(col2)}`)
     .join("\n");
 }

--- a/extensions/plugin-insights/src/tools/insights-compare.ts
+++ b/extensions/plugin-insights/src/tools/insights-compare.ts
@@ -1,0 +1,129 @@
+import type Database from "better-sqlite3";
+import type { PluginInsightsConfig, PluginReport, AgentTool } from "../types.js";
+import { textToolResult } from "../types.js";
+import { buildReport } from "../engine.js";
+import type { ToolDetector } from "../collector/tool-detector.js";
+
+export function createInsightsCompareTool(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): AgentTool {
+  return {
+    name: "insights_compare",
+    label: "Compare Plugin Insights",
+    description:
+      "Compare the effectiveness of two plugins side by side. " +
+      "Shows trigger frequency, token overhead, user satisfaction, " +
+      "and overall verdict for each plugin.",
+    parameters: {
+      type: "object",
+      properties: {
+        pluginA: {
+          type: "string",
+          description: "First plugin ID to compare",
+        },
+        pluginB: {
+          type: "string",
+          description: "Second plugin ID to compare",
+        },
+        days: {
+          type: "number",
+          description: "Number of days to analyze (default: 30)",
+        },
+      },
+      required: ["pluginA", "pluginB"],
+    },
+    async execute(_toolCallId, params) {
+      const pluginA = params.pluginA as string;
+      const pluginB = params.pluginB as string;
+      const days = (params.days as number) ?? 30;
+
+      const report = buildReport(db, config, days);
+
+      const a = report.plugins.find((p) => p.pluginId === pluginA);
+      const b = report.plugins.find((p) => p.pluginId === pluginB);
+
+      if (!a && !b) {
+        return textToolResult(`No data found for either "${pluginA}" or "${pluginB}".`);
+      }
+      if (!a) {
+        return textToolResult(`No data found for plugin "${pluginA}".`);
+      }
+      if (!b) {
+        return textToolResult(`No data found for plugin "${pluginB}".`);
+      }
+
+      let text = formatComparison(a, b);
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return textToolResult(text);
+    },
+  };
+}
+
+export function formatComparison(a: PluginReport, b: PluginReport): string {
+  const nameA = a.pluginName ?? a.pluginId;
+  const nameB = b.pluginName ?? b.pluginId;
+
+  const rows: [string, string, string][] = [
+    ["Metric", nameA, nameB],
+    ["─".repeat(20), "─".repeat(15), "─".repeat(15)],
+    ["Installed", `${a.installedDays}d`, `${b.installedDays}d`],
+    [
+      "Total triggers",
+      `${a.triggerFrequency.totalTriggers}`,
+      `${b.triggerFrequency.totalTriggers}`,
+    ],
+    [
+      "Triggers/day",
+      `${a.triggerFrequency.triggersPerDay}`,
+      `${b.triggerFrequency.triggersPerDay}`,
+    ],
+    [
+      "Token overhead",
+      `${a.tokenDelta.deltaPercent >= 0 ? "+" : ""}${a.tokenDelta.deltaPercent}%`,
+      `${b.tokenDelta.deltaPercent >= 0 ? "+" : ""}${b.tokenDelta.deltaPercent}%`,
+    ],
+    [
+      "Est. cost/mo",
+      `$${a.tokenDelta.estimatedMonthlyCostUSD}`,
+      `$${b.tokenDelta.estimatedMonthlyCostUSD}`,
+    ],
+    [
+      "Acceptance rate",
+      `${a.implicitSatisfaction.acceptanceRate}%`,
+      `${b.implicitSatisfaction.acceptanceRate}%`,
+    ],
+    [
+      "Retry rate",
+      `${a.implicitSatisfaction.retryRate}%`,
+      `${b.implicitSatisfaction.retryRate}%`,
+    ],
+    ["Verdict", a.verdict.label, b.verdict.label],
+  ];
+
+  if (
+    (a.llmJudge && a.llmJudge.sampleCount > 0) ||
+    (b.llmJudge && b.llmJudge.sampleCount > 0)
+  ) {
+    rows.splice(-1, 0, [
+      "LLM Judge",
+      a.llmJudge ? `${a.llmJudge.avgScoreWithPlugin}/5` : "N/A",
+      b.llmJudge ? `${b.llmJudge.avgScoreWithPlugin}/5` : "N/A",
+    ]);
+  }
+
+  const col0 = Math.max(...rows.map((r) => r[0].length));
+  const col1 = Math.max(...rows.map((r) => r[1].length));
+  const col2 = Math.max(...rows.map((r) => r[2].length));
+
+  return rows
+    .map(
+      ([c0, c1, c2]) =>
+        `${c0.padEnd(col0)}  ${c1.padEnd(col1)}  ${c2.padEnd(col2)}`
+    )
+    .join("\n");
+}

--- a/extensions/plugin-insights/src/tools/insights-show.ts
+++ b/extensions/plugin-insights/src/tools/insights-show.ts
@@ -1,14 +1,14 @@
 import type Database from "better-sqlite3";
-import type { PluginInsightsConfig, AgentTool } from "../types.js";
-import { textToolResult } from "../types.js";
+import type { ToolDetector } from "../collector/tool-detector.js";
 import { buildReport } from "../engine.js";
 import { formatCLIReport, formatPluginSummary } from "../report/cli-report.js";
-import type { ToolDetector } from "../collector/tool-detector.js";
+import type { PluginInsightsConfig, AgentTool } from "../types.js";
+import { textToolResult } from "../types.js";
 
 export function createInsightsShowTool(
   db: Database.Database,
   config: PluginInsightsConfig,
-  toolDetector: ToolDetector
+  toolDetector: ToolDetector,
 ): AgentTool {
   return {
     name: "insights_show",
@@ -23,8 +23,7 @@ export function createInsightsShowTool(
       properties: {
         plugin: {
           type: "string",
-          description:
-            "Optional plugin ID to show detailed report for a specific plugin",
+          description: "Optional plugin ID to show detailed report for a specific plugin",
         },
         days: {
           type: "number",
@@ -45,7 +44,9 @@ export function createInsightsShowTool(
       if (pluginId) {
         const plugin = report.plugins.find((p) => p.pluginId === pluginId);
         if (!plugin) {
-          return textToolResult(`No data found for plugin "${pluginId}". Available plugins: ${report.plugins.map((p) => p.pluginId).join(", ")}`);
+          return textToolResult(
+            `No data found for plugin "${pluginId}". Available plugins: ${report.plugins.map((p) => p.pluginId).join(", ")}`,
+          );
         }
         return textToolResult(formatPluginSummary(plugin));
       }
@@ -74,7 +75,7 @@ function buildEmptyReportMessage(db: Database.Database, toolDetector: ToolDetect
   const unmappedWithCounts = toolDetector.getUnmappedToolsWithCounts();
   if (unmappedWithCounts.length > 0) {
     lines.push(
-      `\n${unmappedWithCounts.length} plugin tool(s) observed but not mapped to a plugin:`
+      `\n${unmappedWithCounts.length} plugin tool(s) observed but not mapped to a plugin:`,
     );
     for (const { toolName, count } of unmappedWithCounts) {
       lines.push(`  - ${toolName} (seen ${count} time${count === 1 ? "" : "s"})`);
@@ -83,9 +84,10 @@ function buildEmptyReportMessage(db: Database.Database, toolDetector: ToolDetect
       `\nTo start tracking, add toolMappings to your plugin-insights config:`,
       `  "toolMappings": [`,
       ...unmappedWithCounts.map(
-        ({ toolName }) => `    { "toolName": "${toolName}", "pluginId": "<plugin-id>", "pluginName": "<Plugin Name>" },`
+        ({ toolName }) =>
+          `    { "toolName": "${toolName}", "pluginId": "<plugin-id>", "pluginName": "<Plugin Name>" },`,
       ),
-      `  ]`
+      `  ]`,
     );
   } else if (turnCount === 0) {
     lines.push("\nKeep using OpenClaw and check back later.");
@@ -93,7 +95,7 @@ function buildEmptyReportMessage(db: Database.Database, toolDetector: ToolDetect
     lines.push(
       "\nTurns were recorded but no plugin tools were observed.",
       "If you have plugins installed, make sure they are being used in conversations.",
-      "Context injection markers (e.g., [memory-core]) are also detected automatically."
+      "Context injection markers (e.g., [memory-core]) are also detected automatically.",
     );
   }
 

--- a/extensions/plugin-insights/src/tools/insights-show.ts
+++ b/extensions/plugin-insights/src/tools/insights-show.ts
@@ -1,0 +1,101 @@
+import type Database from "better-sqlite3";
+import type { PluginInsightsConfig, AgentTool } from "../types.js";
+import { textToolResult } from "../types.js";
+import { buildReport } from "../engine.js";
+import { formatCLIReport, formatPluginSummary } from "../report/cli-report.js";
+import type { ToolDetector } from "../collector/tool-detector.js";
+
+export function createInsightsShowTool(
+  db: Database.Database,
+  config: PluginInsightsConfig,
+  toolDetector: ToolDetector
+): AgentTool {
+  return {
+    name: "insights_show",
+    label: "Plugin Insights Report",
+    description:
+      "Show the effectiveness report of installed plugins. " +
+      "Displays trigger frequency, token overhead, user satisfaction, " +
+      "and overall verdict for each plugin. " +
+      "Use plugin parameter to see a specific plugin's detailed report.",
+    parameters: {
+      type: "object",
+      properties: {
+        plugin: {
+          type: "string",
+          description:
+            "Optional plugin ID to show detailed report for a specific plugin",
+        },
+        days: {
+          type: "number",
+          description: "Number of days to analyze (default: 30)",
+        },
+      },
+    },
+    async execute(_toolCallId, params) {
+      const days = (params.days as number) ?? 30;
+      const pluginId = params.plugin as string | undefined;
+
+      const report = buildReport(db, config, days);
+
+      if (report.plugins.length === 0) {
+        return textToolResult(buildEmptyReportMessage(db, toolDetector));
+      }
+
+      if (pluginId) {
+        const plugin = report.plugins.find((p) => p.pluginId === pluginId);
+        if (!plugin) {
+          return textToolResult(`No data found for plugin "${pluginId}". Available plugins: ${report.plugins.map((p) => p.pluginId).join(", ")}`);
+        }
+        return textToolResult(formatPluginSummary(plugin));
+      }
+
+      let text = formatCLIReport(report);
+      const coverageNote = toolDetector.formatCoverageNote();
+      if (coverageNote) {
+        text += "\n" + coverageNote;
+      }
+      return textToolResult(text);
+    },
+  };
+}
+
+/** Build an informative message when no plugin attribution data exists */
+function buildEmptyReportMessage(db: Database.Database, toolDetector: ToolDetector): string {
+  const lines: string[] = ["No plugin attribution data yet."];
+
+  // How many turns were collected?
+  const turnCount = (db.prepare("SELECT COUNT(*) as cnt FROM turns").get() as { cnt: number }).cnt;
+  if (turnCount > 0) {
+    lines.push(`\n${turnCount} conversation turn(s) have been recorded.`);
+  }
+
+  // Are there unmapped tools observed at runtime? Show with counts for prioritization.
+  const unmappedWithCounts = toolDetector.getUnmappedToolsWithCounts();
+  if (unmappedWithCounts.length > 0) {
+    lines.push(
+      `\n${unmappedWithCounts.length} plugin tool(s) observed but not mapped to a plugin:`
+    );
+    for (const { toolName, count } of unmappedWithCounts) {
+      lines.push(`  - ${toolName} (seen ${count} time${count === 1 ? "" : "s"})`);
+    }
+    lines.push(
+      `\nTo start tracking, add toolMappings to your plugin-insights config:`,
+      `  "toolMappings": [`,
+      ...unmappedWithCounts.map(
+        ({ toolName }) => `    { "toolName": "${toolName}", "pluginId": "<plugin-id>", "pluginName": "<Plugin Name>" },`
+      ),
+      `  ]`
+    );
+  } else if (turnCount === 0) {
+    lines.push("\nKeep using OpenClaw and check back later.");
+  } else {
+    lines.push(
+      "\nTurns were recorded but no plugin tools were observed.",
+      "If you have plugins installed, make sure they are being used in conversations.",
+      "Context injection markers (e.g., [memory-core]) are also detected automatically."
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/extensions/plugin-insights/src/types.ts
+++ b/extensions/plugin-insights/src/types.ts
@@ -2,10 +2,9 @@
 // OpenClaw SDK-compatible types for plugin-insights
 //
 // These types mirror the real OpenClaw plugin-sdk interfaces.
-// When integrating with the real SDK, replace these with:
-//   import type { OpenClawPluginApi, ContextEngine, ... } from "openclaw/plugin-sdk";
-//   import type { Message, ToolCall, Usage } from "@mariozechner/pi-ai";
-//   import type { AgentMessage } from "@mariozechner/pi-agent-core";
+// When integrating with the real SDK, replace these with imports
+// from openclaw/plugin-sdk/core (or /compat for broader internals),
+// @mariozechner/pi-ai, and @mariozechner/pi-agent-core.
 // ============================================================
 
 // --- pi-ai compatible message types ---

--- a/extensions/plugin-insights/src/types.ts
+++ b/extensions/plugin-insights/src/types.ts
@@ -1,0 +1,549 @@
+// ============================================================
+// OpenClaw SDK-compatible types for plugin-insights
+//
+// These types mirror the real OpenClaw plugin-sdk interfaces.
+// When integrating with the real SDK, replace these with:
+//   import type { OpenClawPluginApi, ContextEngine, ... } from "openclaw/plugin-sdk";
+//   import type { Message, ToolCall, Usage } from "@mariozechner/pi-ai";
+//   import type { AgentMessage } from "@mariozechner/pi-agent-core";
+// ============================================================
+
+// --- pi-ai compatible message types ---
+
+export interface TextContent {
+  type: "text";
+  text: string;
+}
+
+export interface ImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export interface ThinkingContent {
+  type: "thinking";
+  thinking: string;
+}
+
+export interface ToolCallContent {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface Usage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+}
+
+export interface UserMessage {
+  role: "user";
+  content: string | (TextContent | ImageContent)[];
+  timestamp: number;
+}
+
+export interface AssistantMessage {
+  role: "assistant";
+  content: (TextContent | ThinkingContent | ToolCallContent)[];
+  usage: Usage;
+  model: string;
+  api: string;
+  provider: string;
+  stopReason: string;
+  timestamp: number;
+}
+
+export interface ToolResultMessage {
+  role: "toolResult";
+  toolCallId: string;
+  content: (TextContent | ImageContent)[];
+  isError: boolean;
+  timestamp: number;
+}
+
+export type PiMessage = UserMessage | AssistantMessage | ToolResultMessage;
+
+// AgentMessage in the real SDK: Message | CustomAgentMessages[keyof CustomAgentMessages]
+// We use a broad type to accept any message shape from the runtime
+export type AgentMessage = PiMessage | Record<string, unknown>;
+
+// --- ContextEngine types (from openclaw/plugin-sdk → context-engine/types) ---
+
+export interface ContextEngineInfo {
+  id: string;
+  name: string;
+  version?: string;
+  ownsCompaction?: boolean;
+}
+
+export interface AssembleResult {
+  messages: AgentMessage[];
+  estimatedTokens: number;
+  systemPromptAddition?: string;
+}
+
+export interface CompactResult {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+}
+
+export interface IngestResult {
+  ingested: boolean;
+}
+
+export interface BootstrapResult {
+  bootstrapped: boolean;
+  importedMessages?: number;
+  reason?: string;
+}
+
+export type SubagentEndReason = "deleted" | "completed" | "swept" | "released";
+
+export interface SubagentSpawnPreparation {
+  rollback: () => void | Promise<void>;
+}
+
+export interface ContextEngine {
+  readonly info: ContextEngineInfo;
+
+  // Required methods
+  ingest(params: {
+    sessionId: string;
+    message: AgentMessage;
+    isHeartbeat?: boolean;
+  }): Promise<IngestResult>;
+
+  assemble(params: {
+    sessionId: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+  }): Promise<AssembleResult>;
+
+  compact(params: {
+    sessionId: string;
+    sessionFile: string;
+    tokenBudget?: number;
+    force?: boolean;
+  }): Promise<CompactResult>;
+
+  // Optional hooks
+  bootstrap?(params: {
+    sessionId: string;
+    sessionFile: string;
+  }): Promise<BootstrapResult>;
+
+  afterTurn?(params: AfterTurnParams): Promise<void>;
+
+  prepareSubagentSpawn?(params: {
+    parentSessionKey: string;
+    childSessionKey: string;
+    ttlMs?: number;
+  }): Promise<SubagentSpawnPreparation | undefined>;
+
+  onSubagentEnded?(params: {
+    childSessionKey: string;
+    reason: SubagentEndReason;
+  }): Promise<void>;
+
+  dispose?(): Promise<void>;
+}
+
+export type ContextEngineFactory = () => ContextEngine | Promise<ContextEngine>;
+
+/** Parameters passed to afterTurn by the OpenClaw runtime */
+export interface AfterTurnParams {
+  sessionId: string;
+  sessionFile: string;
+  messages: AgentMessage[];
+  prePromptMessageCount: number;
+  autoCompactionSummary?: string;
+  isHeartbeat?: boolean;
+  tokenBudget?: number;
+}
+
+// --- OpenClaw Plugin API types ---
+
+export interface PluginLogger {
+  debug?(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+/** Reply payload returned by command handlers */
+export interface ReplyPayload {
+  text?: string;
+  isError?: boolean;
+}
+
+export interface PluginCommandContext {
+  /** The sender's identifier */
+  senderId?: string;
+  /** The channel/surface (e.g., "telegram", "discord") */
+  channel: string;
+  /** Whether the sender is on the allowlist */
+  isAuthorizedSender: boolean;
+  /** Raw command arguments after the command name (single string) */
+  args?: string;
+  /** The full normalized command body */
+  commandBody: string;
+  /** Current OpenClaw configuration */
+  config: Record<string, unknown>;
+}
+
+export interface OpenClawPluginCommandDefinition {
+  name: string;
+  description: string;
+  nativeNames?: Partial<Record<string, string>> & { default?: string };
+  acceptsArgs?: boolean;
+  requireAuth?: boolean;
+  handler(ctx: PluginCommandContext): ReplyPayload | Promise<ReplyPayload>;
+}
+
+/** Tool result type from pi-agent-core */
+export interface AgentToolResult {
+  content: (TextContent | ImageContent)[];
+  details: unknown;
+}
+
+/** Agent tool type compatible with real OpenClaw AnyAgentTool (pi-agent-core) */
+export interface AgentTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute(
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<AgentToolResult>;
+  ownerOnly?: boolean;
+}
+
+/** Helper to create a text-only AgentToolResult */
+export function textToolResult(text: string): AgentToolResult {
+  return { content: [{ type: "text", text }], details: undefined };
+}
+
+export interface OpenClawPluginApi {
+  id: string;
+  name: string;
+  version?: string;
+  description?: string;
+  source: string;
+  pluginConfig?: Record<string, unknown>;
+  logger: PluginLogger;
+
+  registerTool(tool: AgentTool): void;
+  registerCommand(command: OpenClawPluginCommandDefinition): void;
+  registerContextEngine(
+    id: string,
+    factory: ContextEngineFactory
+  ): void;
+  registerCli?(
+    registrar: (ctx: unknown) => void | Promise<void>,
+    opts?: { commands?: string[] }
+  ): void;
+  resolvePath?(input: string): string;
+
+  // Hook registration — supports typed SDK hooks (after_tool_call, etc.)
+  on(
+    hookName: string,
+    handler: (...args: any[]) => void | Promise<void>,
+    opts?: { priority?: number }
+  ): void;
+}
+
+/** Plugin definition shape expected by OpenClaw */
+export interface OpenClawPluginDefinition {
+  id?: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  configSchema?: Record<string, unknown>;
+  register?(api: OpenClawPluginApi): void | Promise<void>;
+  activate?(api: OpenClawPluginApi): void | Promise<void>;
+}
+
+// ============================================================
+// Plugin Insights internal types
+// ============================================================
+
+export interface PluginInsightsConfig {
+  enabled: boolean;
+  dbPath: string;
+  retentionDays: number;
+  llmJudge: LLMJudgeConfig;
+}
+
+export interface LLMJudgeConfig {
+  enabled: boolean;
+  apiKey?: string;
+  baseUrl: string;
+  model: string;
+  maxEvalPerDay: number;
+}
+
+export const DEFAULT_CONFIG: PluginInsightsConfig = {
+  enabled: true,
+  dbPath: "~/.openclaw/plugin-insights.db",
+  retentionDays: 90,
+  llmJudge: {
+    enabled: false,
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-4o-mini",
+    maxEvalPerDay: 20,
+  },
+};
+
+// DB row types
+
+export interface TurnRow {
+  id: number;
+  session_id: string;
+  turn_index: number;
+  timestamp: string;
+  user_prompt_preview: string | null;
+  assistant_response_preview: string | null;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+  tool_calls_json: string | null;
+  plugins_triggered_json: string | null;
+  created_at: string;
+}
+
+export interface PluginEventRow {
+  id: number;
+  turn_id: number;
+  plugin_id: string;
+  detection_method: "tool_call" | "context_injection" | "self_report";
+  action: string | null;
+  metadata_json: string | null;
+  created_at: string;
+}
+
+export interface SatisfactionSignalRow {
+  id: number;
+  turn_id: number;
+  signal_type: "accepted" | "retried" | "corrected";
+  confidence: number | null;
+  next_turn_id: number | null;
+  created_at: string;
+}
+
+export interface LLMScoreRow {
+  id: number;
+  turn_id: number;
+  accuracy_score: number;
+  completeness_score: number;
+  relevance_score: number;
+  overall_score: number;
+  judge_model: string;
+  judge_response_json: string | null;
+  created_at: string;
+}
+
+export interface ToolPluginMappingRow {
+  tool_name: string;
+  plugin_id: string;
+  plugin_name: string | null;
+  updated_at: string;
+}
+
+export interface PluginInstallRow {
+  plugin_id: string;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+// Metrics result types
+
+export interface TriggerFrequencyResult {
+  pluginId: string;
+  totalTriggers: number;
+  triggersPerDay: number;
+  triggersPerSession: number;
+  dailyTrend: { date: string; count: number }[];
+}
+
+export interface TokenDeltaResult {
+  pluginId: string;
+  avgTokensWithPlugin: number;
+  avgTokensWithoutPlugin: number;
+  deltaTokens: number;
+  deltaPercent: number;
+  estimatedMonthlyCostUSD: number;
+}
+
+export interface ConversationTurnsResult {
+  pluginId: string;
+  avgTurnsWithPlugin: number;
+  avgTurnsWithoutPlugin: number;
+  deltaTurns: number;
+  deltaPercent: number;
+}
+
+export interface ImplicitSatisfactionResult {
+  pluginId: string;
+  acceptanceRate: number;
+  retryRate: number;
+  correctionRate: number;
+  totalSignals: number;
+}
+
+export interface LLMJudgeResult {
+  pluginId: string;
+  avgScoreWithPlugin: number;
+  avgScoreWithoutPlugin: number;
+  deltaScore: number;
+  sampleCount: number;
+}
+
+export interface PluginReport {
+  pluginId: string;
+  pluginName?: string;
+  installedDays: number;
+  triggerFrequency: TriggerFrequencyResult;
+  tokenDelta: TokenDeltaResult;
+  conversationTurns: ConversationTurnsResult;
+  implicitSatisfaction: ImplicitSatisfactionResult;
+  llmJudge?: LLMJudgeResult;
+  verdict: PluginVerdict;
+}
+
+export type VerdictLevel =
+  | "keep"
+  | "low_usage"
+  | "expensive"
+  | "low_satisfaction"
+  | "remove";
+
+export interface PluginVerdict {
+  level: VerdictLevel;
+  label: string;
+  reason: string;
+}
+
+export interface CoverageInfo {
+  /** Whether all observed tools have plugin mappings */
+  isComplete: boolean;
+  /** Tools observed at runtime but not mapped to any plugin */
+  unmappedTools: { toolName: string; callCount: number }[];
+}
+
+export interface InsightsReport {
+  periodStart: string;
+  periodEnd: string;
+  plugins: PluginReport[];
+  generatedAt: string;
+  /** Attribution coverage metadata — present when unmapped tools exist */
+  coverage?: CoverageInfo;
+}
+
+// Insights API (Layer 3) types
+
+export interface InsightsAPIReport {
+  pluginId: string;
+  action: string;
+  sessionId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// --- Message utility helpers ---
+
+/** Extract text content from a UserMessage */
+export function extractUserText(msg: AgentMessage): string | null {
+  if (!msg || typeof msg !== "object" || !("role" in msg)) return null;
+  if (msg.role !== "user") return null;
+
+  const userMsg = msg as UserMessage;
+  if (typeof userMsg.content === "string") return userMsg.content;
+  if (Array.isArray(userMsg.content)) {
+    return (
+      userMsg.content
+        .filter((c): c is TextContent => c.type === "text")
+        .map((c) => c.text)
+        .join("\n") || null
+    );
+  }
+  return null;
+}
+
+/** Extract text content from an AssistantMessage */
+export function extractAssistantText(msg: AgentMessage): string | null {
+  if (!msg || typeof msg !== "object" || !("role" in msg)) return null;
+  if (msg.role !== "assistant") return null;
+
+  const assistantMsg = msg as AssistantMessage;
+  if (!Array.isArray(assistantMsg.content)) return null;
+  return (
+    assistantMsg.content
+      .filter((c): c is TextContent => c.type === "text")
+      .map((c) => c.text)
+      .join("\n") || null
+  );
+}
+
+/** Extract ToolCall entries from an AssistantMessage */
+export function extractToolCalls(msg: AgentMessage): ToolCallContent[] {
+  if (!msg || typeof msg !== "object" || !("role" in msg)) return [];
+  if (msg.role !== "assistant") return [];
+
+  const assistantMsg = msg as AssistantMessage;
+  if (!Array.isArray(assistantMsg.content)) return [];
+  return assistantMsg.content.filter(
+    (c): c is ToolCallContent => c.type === "toolCall"
+  );
+}
+
+/** Extract Usage from an AssistantMessage */
+export function extractUsage(msg: AgentMessage): Usage | null {
+  if (!msg || typeof msg !== "object" || !("role" in msg)) return null;
+  if (msg.role !== "assistant") return null;
+
+  const assistantMsg = msg as AssistantMessage;
+  return assistantMsg.usage ?? null;
+}
+
+/** Extract all text from any message for context scanning.
+ *  Handles user, assistant, AND unknown roles (system, context, etc.)
+ *  since OpenClaw plugins inject context into system/context messages. */
+export function extractAllText(msg: AgentMessage): string | null {
+  // Try known roles first
+  const known = extractUserText(msg) ?? extractAssistantText(msg);
+  if (known) return known;
+
+  // Handle unknown roles (system, context, toolResult, etc.)
+  if (!msg || typeof msg !== "object") return null;
+
+  const rec = msg as Record<string, unknown>;
+
+  // String content
+  if (typeof rec.content === "string") return rec.content;
+
+  // Array content — extract text parts
+  if (Array.isArray(rec.content)) {
+    const texts = rec.content
+      .filter(
+        (c: unknown): c is { type: string; text: string } =>
+          typeof c === "object" &&
+          c !== null &&
+          "text" in c &&
+          typeof (c as Record<string, unknown>).text === "string"
+      )
+      .map((c) => c.text);
+    return texts.length > 0 ? texts.join("\n") : null;
+  }
+
+  // systemPrompt field (present in some hook events)
+  if (typeof rec.systemPrompt === "string") return rec.systemPrompt;
+
+  return null;
+}

--- a/extensions/plugin-insights/src/types.ts
+++ b/extensions/plugin-insights/src/types.ts
@@ -133,10 +133,7 @@ export interface ContextEngine {
   }): Promise<CompactResult>;
 
   // Optional hooks
-  bootstrap?(params: {
-    sessionId: string;
-    sessionFile: string;
-  }): Promise<BootstrapResult>;
+  bootstrap?(params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult>;
 
   afterTurn?(params: AfterTurnParams): Promise<void>;
 
@@ -146,10 +143,7 @@ export interface ContextEngine {
     ttlMs?: number;
   }): Promise<SubagentSpawnPreparation | undefined>;
 
-  onSubagentEnded?(params: {
-    childSessionKey: string;
-    reason: SubagentEndReason;
-  }): Promise<void>;
+  onSubagentEnded?(params: { childSessionKey: string; reason: SubagentEndReason }): Promise<void>;
 
   dispose?(): Promise<void>;
 }
@@ -221,7 +215,7 @@ export interface AgentTool {
   execute(
     toolCallId: string,
     params: Record<string, unknown>,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<AgentToolResult>;
   ownerOnly?: boolean;
 }
@@ -242,13 +236,10 @@ export interface OpenClawPluginApi {
 
   registerTool(tool: AgentTool): void;
   registerCommand(command: OpenClawPluginCommandDefinition): void;
-  registerContextEngine(
-    id: string,
-    factory: ContextEngineFactory
-  ): void;
+  registerContextEngine(id: string, factory: ContextEngineFactory): void;
   registerCli?(
     registrar: (ctx: unknown) => void | Promise<void>,
-    opts?: { commands?: string[] }
+    opts?: { commands?: string[] },
   ): void;
   resolvePath?(input: string): string;
 
@@ -256,7 +247,7 @@ export interface OpenClawPluginApi {
   on(
     hookName: string,
     handler: (...args: any[]) => void | Promise<void>,
-    opts?: { priority?: number }
+    opts?: { priority?: number },
   ): void;
 }
 
@@ -418,12 +409,7 @@ export interface PluginReport {
   verdict: PluginVerdict;
 }
 
-export type VerdictLevel =
-  | "keep"
-  | "low_usage"
-  | "expensive"
-  | "low_satisfaction"
-  | "remove";
+export type VerdictLevel = "keep" | "low_usage" | "expensive" | "low_satisfaction" | "remove";
 
 export interface PluginVerdict {
   level: VerdictLevel;
@@ -498,9 +484,7 @@ export function extractToolCalls(msg: AgentMessage): ToolCallContent[] {
 
   const assistantMsg = msg as AssistantMessage;
   if (!Array.isArray(assistantMsg.content)) return [];
-  return assistantMsg.content.filter(
-    (c): c is ToolCallContent => c.type === "toolCall"
-  );
+  return assistantMsg.content.filter((c): c is ToolCallContent => c.type === "toolCall");
 }
 
 /** Extract Usage from an AssistantMessage */
@@ -536,7 +520,7 @@ export function extractAllText(msg: AgentMessage): string | null {
           typeof c === "object" &&
           c !== null &&
           "text" in c &&
-          typeof (c as Record<string, unknown>).text === "string"
+          typeof (c as Record<string, unknown>).text === "string",
       )
       .map((c) => c.text);
     return texts.length > 0 ? texts.join("\n") : null;

--- a/extensions/plugin-insights/src/utils.ts
+++ b/extensions/plugin-insights/src/utils.ts
@@ -1,0 +1,12 @@
+/** Compute a SQLite-compatible datetime string for N days ago */
+export function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/** Round a number to the given decimal places (default 1) */
+export function round(n: number, decimals: number = 1): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/extensions/plugin-insights/test/activate.test.ts
+++ b/extensions/plugin-insights/test/activate.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import pluginDefinition from "../index.js";
 import type {
@@ -9,9 +12,6 @@ import type {
   UserMessage,
   AssistantMessage,
 } from "../src/types.js";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
 
 function createMockAPI(configOverrides?: Record<string, unknown>): {
   api: OpenClawPluginApi;
@@ -78,9 +78,14 @@ function mkUserMessage(content: string): UserMessage {
 function mkAssistantMessage(
   text: string,
   opts?: {
-    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    toolCalls?: {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }[];
     usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
-  }
+  },
 ): AssistantMessage {
   const content: AssistantMessage["content"] = [{ type: "text", text }];
   if (opts?.toolCalls) {
@@ -191,9 +196,7 @@ describe("pluginDefinition.register()", () => {
     const messages: AgentMessage[] = [
       mkUserMessage("test"),
       mkAssistantMessage("response", {
-        toolCalls: [
-          { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
-        ],
+        toolCalls: [{ type: "toolCall", id: "tc1", name: "memory_search", arguments: {} }],
         usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
       }),
     ];
@@ -233,13 +236,13 @@ describe("pluginDefinition.register() → after_tool_call hook auto-learning", (
     // Simulate after_tool_call event for an external tool
     hook(
       { toolName: "memory_recall", params: {}, durationMs: 100 },
-      { toolName: "memory_recall", sessionId: "test-sess" }
+      { toolName: "memory_recall", sessionId: "test-sess" },
     );
 
     // Should NOT learn our own tools
     hook(
       { toolName: "insights_show", params: {} },
-      { toolName: "insights_show", sessionId: "test-sess" }
+      { toolName: "insights_show", sessionId: "test-sess" },
     );
 
     // The tool should be recorded in the DB for future attribution

--- a/extensions/plugin-insights/test/activate.test.ts
+++ b/extensions/plugin-insights/test/activate.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import pluginDefinition from "../index.js";
+import type {
+  OpenClawPluginApi,
+  ContextEngine,
+  AgentTool,
+  OpenClawPluginCommandDefinition,
+  AgentMessage,
+  UserMessage,
+  AssistantMessage,
+} from "../src/types.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+function createMockAPI(configOverrides?: Record<string, unknown>): {
+  api: OpenClawPluginApi;
+  registered: {
+    contextEngines: { id: string; factory: () => ContextEngine }[];
+    tools: AgentTool[];
+    commands: OpenClawPluginCommandDefinition[];
+    hooks: { hookName: string; handler: Function }[];
+  };
+} {
+  const registered = {
+    contextEngines: [] as { id: string; factory: () => ContextEngine }[],
+    tools: [] as AgentTool[],
+    commands: [] as OpenClawPluginCommandDefinition[],
+    hooks: [] as { hookName: string; handler: Function }[],
+  };
+
+  const api: OpenClawPluginApi = {
+    id: "plugin-insights",
+    name: "Plugin Insights",
+    source: "test",
+    pluginConfig: {
+      enabled: true,
+      dbPath: path.join(os.tmpdir(), `plugin-insights-test-${Date.now()}.db`),
+      retentionDays: 90,
+      llmJudge: { enabled: false },
+      ...configOverrides,
+    },
+    logger: {
+      info: console.log,
+      warn: console.warn,
+      error: console.error,
+    },
+    registerContextEngine(id, factory) {
+      registered.contextEngines.push({ id, factory });
+    },
+    registerTool(tool) {
+      registered.tools.push(tool);
+    },
+    registerCommand(cmd) {
+      registered.commands.push(cmd);
+    },
+    on(hookName, handler) {
+      registered.hooks.push({ hookName, handler });
+    },
+  };
+
+  return { api, registered };
+}
+
+function cleanupDb(api: OpenClawPluginApi) {
+  const config = api.pluginConfig as any;
+  try {
+    fs.unlinkSync(config.dbPath);
+  } catch {
+    // ignore
+  }
+}
+
+function mkUserMessage(content: string): UserMessage {
+  return { role: "user", content, timestamp: Date.now() };
+}
+
+function mkAssistantMessage(
+  text: string,
+  opts?: {
+    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+  }
+): AssistantMessage {
+  const content: AssistantMessage["content"] = [{ type: "text", text }];
+  if (opts?.toolCalls) {
+    content.push(...opts.toolCalls);
+  }
+  return {
+    role: "assistant",
+    content,
+    usage: opts?.usage ?? { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+    model: "test",
+    api: "test",
+    provider: "test",
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+describe("pluginDefinition.register()", () => {
+  const apis: OpenClawPluginApi[] = [];
+
+  afterEach(() => {
+    for (const api of apis) {
+      cleanupDb(api);
+    }
+    apis.length = 0;
+  });
+
+  it("should register exactly 1 ContextEngine named 'plugin-insights'", () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    expect(registered.contextEngines).toHaveLength(1);
+    expect(registered.contextEngines[0].id).toBe("plugin-insights");
+  });
+
+  it("should register 2 agent tools: insights_show and insights_compare", () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    expect(registered.tools).toHaveLength(2);
+    const names = registered.tools.map((t) => t.name);
+    expect(names).toContain("insights_show");
+    expect(names).toContain("insights_compare");
+  });
+
+  it("should register 6 CLI commands", () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    expect(registered.commands).toHaveLength(6);
+    const names = registered.commands.map((c) => c.name);
+    expect(names).toContain("insights-show");
+    expect(names).toContain("insights-compare");
+    expect(names).toContain("insights-export");
+    expect(names).toContain("insights-dashboard");
+    expect(names).toContain("insights-reset");
+    expect(names).toContain("insights-status");
+  });
+
+  it("should register after_tool_call hook for runtime tool learning", () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    expect(registered.hooks).toHaveLength(1);
+    expect(registered.hooks[0].hookName).toBe("after_tool_call");
+    expect(typeof registered.hooks[0].handler).toBe("function");
+  });
+
+  it("should produce a working ContextEngine with info.ownsCompaction=false", async () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    const engine = registered.contextEngines[0].factory();
+    expect(engine.info.ownsCompaction).toBe(false);
+    expect(typeof engine.afterTurn).toBe("function");
+  });
+
+  it("should NOT register anything when enabled=false", () => {
+    const { api, registered } = createMockAPI({ enabled: false });
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    expect(registered.contextEngines).toHaveLength(0);
+    expect(registered.tools).toHaveLength(0);
+    expect(registered.commands).toHaveLength(0);
+    expect(registered.hooks).toHaveLength(0);
+  });
+
+  it("should handle afterTurn with tool calls in assistant content", async () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    const engine = registered.contextEngines[0].factory();
+
+    const messages: AgentMessage[] = [
+      mkUserMessage("test"),
+      mkAssistantMessage("response", {
+        toolCalls: [
+          { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
+        ],
+        usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+      }),
+    ];
+
+    // Simulate a turn with memory_search tool call
+    await engine.afterTurn!({
+      sessionId: "test-sess",
+      sessionFile: "/tmp/test-session.json",
+      messages,
+      prePromptMessageCount: 0,
+    });
+
+    // The afterTurn should not throw, meaning data was collected
+    // (We can't directly query the DB here since it's encapsulated,
+    // but no error means the pipeline worked end-to-end)
+  });
+});
+
+describe("pluginDefinition.register() → after_tool_call hook auto-learning", () => {
+  const apis: OpenClawPluginApi[] = [];
+
+  afterEach(() => {
+    for (const api of apis) {
+      cleanupDb(api);
+    }
+    apis.length = 0;
+  });
+
+  it("should auto-learn tool names from after_tool_call events", async () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    const hook = registered.hooks[0].handler;
+
+    // Simulate after_tool_call event for an external tool
+    hook(
+      { toolName: "memory_recall", params: {}, durationMs: 100 },
+      { toolName: "memory_recall", sessionId: "test-sess" }
+    );
+
+    // Should NOT learn our own tools
+    hook(
+      { toolName: "insights_show", params: {} },
+      { toolName: "insights_show", sessionId: "test-sess" }
+    );
+
+    // The tool should be recorded in the DB for future attribution
+    // (No error means the hook processed successfully)
+  });
+
+  it("should skip tools without a name", () => {
+    const { api, registered } = createMockAPI();
+    apis.push(api);
+
+    pluginDefinition.register!(api);
+
+    const hook = registered.hooks[0].handler;
+
+    // Should not throw when event has no toolName
+    hook({}, {});
+  });
+});

--- a/extensions/plugin-insights/test/activate.test.ts
+++ b/extensions/plugin-insights/test/activate.test.ts
@@ -16,14 +16,14 @@ import type {
 function createMockAPI(configOverrides?: Record<string, unknown>): {
   api: OpenClawPluginApi;
   registered: {
-    contextEngines: { id: string; factory: () => ContextEngine }[];
+    contextEngines: { id: string; factory: () => ContextEngine | Promise<ContextEngine> }[];
     tools: AgentTool[];
     commands: OpenClawPluginCommandDefinition[];
     hooks: { hookName: string; handler: Function }[];
   };
 } {
   const registered = {
-    contextEngines: [] as { id: string; factory: () => ContextEngine }[],
+    contextEngines: [] as { id: string; factory: () => ContextEngine | Promise<ContextEngine> }[],
     tools: [] as AgentTool[],
     commands: [] as OpenClawPluginCommandDefinition[],
     hooks: [] as { hookName: string; handler: Function }[],
@@ -168,7 +168,7 @@ describe("pluginDefinition.register()", () => {
 
     pluginDefinition.register!(api);
 
-    const engine = registered.contextEngines[0].factory();
+    const engine = await registered.contextEngines[0].factory();
     expect(engine.info.ownsCompaction).toBe(false);
     expect(typeof engine.afterTurn).toBe("function");
   });
@@ -191,7 +191,7 @@ describe("pluginDefinition.register()", () => {
 
     pluginDefinition.register!(api);
 
-    const engine = registered.contextEngines[0].factory();
+    const engine = await registered.contextEngines[0].factory();
 
     const messages: AgentMessage[] = [
       mkUserMessage("test"),

--- a/extensions/plugin-insights/test/collector/context-detector.test.ts
+++ b/extensions/plugin-insights/test/collector/context-detector.test.ts
@@ -66,9 +66,7 @@ describe("ContextDetector", () => {
     const detector = new ContextDetector();
 
     // The new ContextDetector uses extractAllText which reads both user and assistant text
-    const messages: AgentMessage[] = [
-      mkAssistantMessage("[memory-core] I found some data"),
-    ];
+    const messages: AgentMessage[] = [mkAssistantMessage("[memory-core] I found some data")];
 
     const results = detector.detect(messages);
     expect(results).toHaveLength(1);
@@ -78,9 +76,7 @@ describe("ContextDetector", () => {
   it("should support custom markers", () => {
     const detector = new ContextDetector([[/\[my-plugin\]/i, "my-plugin"]]);
 
-    const messages: AgentMessage[] = [
-      mkUserMessage("[my-plugin] custom data"),
-    ];
+    const messages: AgentMessage[] = [mkUserMessage("[my-plugin] custom data")];
 
     const results = detector.detect(messages);
     expect(results).toHaveLength(1);

--- a/extensions/plugin-insights/test/collector/context-detector.test.ts
+++ b/extensions/plugin-insights/test/collector/context-detector.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { ContextDetector } from "../../src/collector/context-detector.js";
+import type { AgentMessage, UserMessage, AssistantMessage } from "../../src/types.js";
+
+function mkUserMessage(content: string): UserMessage {
+  return { role: "user", content, timestamp: Date.now() };
+}
+
+function mkAssistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    usage: { input: 50, output: 30, cacheRead: 0, cacheWrite: 0, total: 80 },
+    model: "test",
+    api: "test",
+    provider: "test",
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+describe("ContextDetector", () => {
+  it("should detect known plugin markers in user messages", () => {
+    const detector = new ContextDetector();
+
+    const messages: AgentMessage[] = [
+      mkUserMessage("[memory-plugin] Here is your relevant memory..."),
+      mkUserMessage("What did I work on yesterday?"),
+    ];
+
+    const results = detector.detect(messages);
+    expect(results).toHaveLength(1);
+    expect(results[0].pluginId).toBe("memory-plugin");
+    expect(results[0].action).toBe("context_injection");
+  });
+
+  it("should detect multiple plugins in different messages", () => {
+    const detector = new ContextDetector();
+
+    const messages: AgentMessage[] = [
+      mkUserMessage("[memory-core] Recalled facts..."),
+      mkUserMessage("[lcm] Lossless context data..."),
+      mkUserMessage("Hello"),
+    ];
+
+    const results = detector.detect(messages);
+    expect(results).toHaveLength(2);
+    const ids = results.map((r) => r.pluginId);
+    expect(ids).toContain("memory-core");
+    expect(ids).toContain("lossless-claw");
+  });
+
+  it("should not duplicate same plugin from multiple messages", () => {
+    const detector = new ContextDetector();
+
+    const messages: AgentMessage[] = [
+      mkUserMessage("[memory-core] data 1"),
+      mkUserMessage("[memory-core] data 2"),
+    ];
+
+    const results = detector.detect(messages);
+    expect(results).toHaveLength(1);
+  });
+
+  it("should also detect markers in assistant messages via extractAllText", () => {
+    const detector = new ContextDetector();
+
+    // The new ContextDetector uses extractAllText which reads both user and assistant text
+    const messages: AgentMessage[] = [
+      mkAssistantMessage("[memory-core] I found some data"),
+    ];
+
+    const results = detector.detect(messages);
+    expect(results).toHaveLength(1);
+    expect(results[0].pluginId).toBe("memory-core");
+  });
+
+  it("should support custom markers", () => {
+    const detector = new ContextDetector([[/\[my-plugin\]/i, "my-plugin"]]);
+
+    const messages: AgentMessage[] = [
+      mkUserMessage("[my-plugin] custom data"),
+    ];
+
+    const results = detector.detect(messages);
+    expect(results).toHaveLength(1);
+    expect(results[0].pluginId).toBe("my-plugin");
+  });
+});

--- a/extensions/plugin-insights/test/collector/plugin-reporter.test.ts
+++ b/extensions/plugin-insights/test/collector/plugin-reporter.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { runMigrations } from "../../src/db/migration.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { PluginReporter } from "../../src/collector/plugin-reporter.js";
+import { runMigrations } from "../../src/db/migration.js";
 
 describe("PluginReporter", () => {
   let db: Database.Database;
@@ -14,7 +14,7 @@ describe("PluginReporter", () => {
 
     // Insert a turn to reference
     db.prepare(
-      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`,
     ).run();
   });
 
@@ -32,9 +32,7 @@ describe("PluginReporter", () => {
 
     expect(reporter.getPendingCount()).toBe(0);
 
-    const events = db
-      .prepare("SELECT * FROM plugin_events WHERE turn_id = 1")
-      .all() as any[];
+    const events = db.prepare("SELECT * FROM plugin_events WHERE turn_id = 1").all() as any[];
     expect(events).toHaveLength(2);
     expect(events[0].detection_method).toBe("self_report");
     expect(events[0].plugin_id).toBe("my-plugin");
@@ -43,9 +41,7 @@ describe("PluginReporter", () => {
 
   it("should handle empty flush gracefully", () => {
     reporter.flushToTurn(1);
-    const events = db
-      .prepare("SELECT * FROM plugin_events WHERE turn_id = 1")
-      .all();
+    const events = db.prepare("SELECT * FROM plugin_events WHERE turn_id = 1").all();
     expect(events).toHaveLength(0);
   });
 });

--- a/extensions/plugin-insights/test/collector/plugin-reporter.test.ts
+++ b/extensions/plugin-insights/test/collector/plugin-reporter.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { PluginReporter } from "../../src/collector/plugin-reporter.js";
+
+describe("PluginReporter", () => {
+  let db: Database.Database;
+  let reporter: PluginReporter;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    reporter = new PluginReporter(db);
+
+    // Insert a turn to reference
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should accumulate reports and flush to turn", () => {
+    reporter.report({ pluginId: "my-plugin", action: "recall", metadata: { count: 5 } });
+    reporter.report({ pluginId: "my-plugin", action: "store" });
+
+    expect(reporter.getPendingCount()).toBe(2);
+
+    reporter.flushToTurn(1);
+
+    expect(reporter.getPendingCount()).toBe(0);
+
+    const events = db
+      .prepare("SELECT * FROM plugin_events WHERE turn_id = 1")
+      .all() as any[];
+    expect(events).toHaveLength(2);
+    expect(events[0].detection_method).toBe("self_report");
+    expect(events[0].plugin_id).toBe("my-plugin");
+    expect(events[0].action).toBe("recall");
+  });
+
+  it("should handle empty flush gracefully", () => {
+    reporter.flushToTurn(1);
+    const events = db
+      .prepare("SELECT * FROM plugin_events WHERE turn_id = 1")
+      .all();
+    expect(events).toHaveLength(0);
+  });
+});

--- a/extensions/plugin-insights/test/collector/tool-detector.test.ts
+++ b/extensions/plugin-insights/test/collector/tool-detector.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { ToolDetector } from "../../src/collector/tool-detector.js";
+import type { ToolCallContent } from "../../src/types.js";
+
+describe("ToolDetector", () => {
+  let db: Database.Database;
+  let detector: ToolDetector;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    detector = new ToolDetector(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should detect tool calls from registered plugins", () => {
+    const entries = [
+      { toolName: "memory_search", pluginId: "memory-core", pluginName: "Memory Core" },
+      { toolName: "memory_store", pluginId: "memory-core", pluginName: "Memory Core" },
+      { toolName: "format_code", pluginId: "code-fmt", pluginName: "Code Formatter" },
+    ];
+
+    detector.refreshMappingFromEntries(entries);
+
+    const toolCalls: ToolCallContent[] = [
+      { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
+      { type: "toolCall", id: "tc2", name: "unknown_tool", arguments: {} },
+    ];
+
+    const results = detector.detect(toolCalls);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ pluginId: "memory-core", action: "memory_search" });
+  });
+
+  it("should not duplicate detections for the same plugin+tool", () => {
+    detector.refreshMappingFromEntries([
+      { toolName: "mem_recall", pluginId: "mem", pluginName: "Mem" },
+    ]);
+
+    const toolCalls: ToolCallContent[] = [
+      { type: "toolCall", id: "tc1", name: "mem_recall", arguments: {} },
+      { type: "toolCall", id: "tc2", name: "mem_recall", arguments: {} },
+    ];
+
+    const results = detector.detect(toolCalls);
+    expect(results).toHaveLength(1);
+  });
+
+  it("should return empty for unrecognized tools", () => {
+    const toolCalls: ToolCallContent[] = [
+      { type: "toolCall", id: "tc1", name: "unknown_tool", arguments: {} },
+    ];
+
+    const results = detector.detect(toolCalls);
+    expect(results).toHaveLength(0);
+  });
+
+  it("should handle entries without pluginName", () => {
+    detector.refreshMappingFromEntries([
+      { toolName: "some_tool", pluginId: "no-name" },
+    ]);
+
+    expect(detector.getPluginForTool("some_tool")).toBe("no-name");
+    expect(detector.getPluginForTool("anything")).toBeUndefined();
+  });
+});

--- a/extensions/plugin-insights/test/collector/tool-detector.test.ts
+++ b/extensions/plugin-insights/test/collector/tool-detector.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { runMigrations } from "../../src/db/migration.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ToolDetector } from "../../src/collector/tool-detector.js";
+import { runMigrations } from "../../src/db/migration.js";
 import type { ToolCallContent } from "../../src/types.js";
 
 describe("ToolDetector", () => {
@@ -61,9 +61,7 @@ describe("ToolDetector", () => {
   });
 
   it("should handle entries without pluginName", () => {
-    detector.refreshMappingFromEntries([
-      { toolName: "some_tool", pluginId: "no-name" },
-    ]);
+    detector.refreshMappingFromEntries([{ toolName: "some_tool", pluginId: "no-name" }]);
 
     expect(detector.getPluginForTool("some_tool")).toBe("no-name");
     expect(detector.getPluginForTool("anything")).toBeUndefined();

--- a/extensions/plugin-insights/test/collector/turn-collector.test.ts
+++ b/extensions/plugin-insights/test/collector/turn-collector.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { TurnCollector, jaccardSimilarity } from "../../src/collector/turn-collector.js";
+import { ToolDetector } from "../../src/collector/tool-detector.js";
+import { ContextDetector } from "../../src/collector/context-detector.js";
+import { PluginReporter } from "../../src/collector/plugin-reporter.js";
+import type { AgentMessage, UserMessage, AssistantMessage } from "../../src/types.js";
+
+function mkUserMessage(content: string): UserMessage {
+  return { role: "user", content, timestamp: Date.now() };
+}
+
+function mkAssistantMessage(
+  text: string,
+  opts?: {
+    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+  }
+): AssistantMessage {
+  const contentArr: AssistantMessage["content"] = [{ type: "text", text }];
+  if (opts?.toolCalls) {
+    contentArr.push(...opts.toolCalls);
+  }
+  return {
+    role: "assistant",
+    content: contentArr,
+    usage: opts?.usage ?? { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+    model: "test",
+    api: "test",
+    provider: "test",
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+describe("TurnCollector", () => {
+  let db: Database.Database;
+  let collector: TurnCollector;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+
+    const toolDetector = new ToolDetector(db);
+    toolDetector.refreshMappingFromEntries([
+      { toolName: "memory_search", pluginId: "mem", pluginName: "Memory" },
+    ]);
+
+    const contextDetector = new ContextDetector();
+    const pluginReporter = new PluginReporter(db);
+
+    collector = new TurnCollector(db, toolDetector, contextDetector, pluginReporter);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should insert a turn record", () => {
+    const messages: AgentMessage[] = [
+      mkUserMessage("What did I do yesterday?"),
+      mkAssistantMessage("Based on your history..."),
+    ];
+
+    const turnId = collector.collect("sess-1", 0, messages);
+    expect(turnId).toBeGreaterThan(0);
+
+    const row = db.prepare("SELECT * FROM turns WHERE id = ?").get(turnId) as any;
+    expect(row.session_id).toBe("sess-1");
+    expect(row.turn_index).toBe(0);
+    expect(row.total_tokens).toBe(150);
+    expect(row.user_prompt_preview).toBe("What did I do yesterday?");
+  });
+
+  it("should detect and record tool-call plugin events", () => {
+    const messages: AgentMessage[] = [
+      mkUserMessage("Recall something"),
+      mkAssistantMessage("Here you go", {
+        toolCalls: [
+          { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
+        ],
+      }),
+    ];
+
+    const turnId = collector.collect("sess-1", 0, messages);
+
+    const events = db
+      .prepare("SELECT * FROM plugin_events WHERE turn_id = ?")
+      .all(turnId) as any[];
+    expect(events).toHaveLength(1);
+    expect(events[0].plugin_id).toBe("mem");
+    expect(events[0].detection_method).toBe("tool_call");
+  });
+
+  it("should detect satisfaction signals between turns", () => {
+    // First turn
+    const messages1: AgentMessage[] = [
+      mkUserMessage("How do I configure webpack?"),
+      mkAssistantMessage("You can use webpack.config.js..."),
+    ];
+    collector.collect("sess-1", 0, messages1);
+
+    // Second turn with completely different topic → accepted
+    const messages2: AgentMessage[] = [
+      mkUserMessage("How do I configure webpack?"),
+      mkAssistantMessage("You can use webpack.config.js..."),
+      mkUserMessage("Now let me work on the database schema"),
+      mkAssistantMessage("Sure, here is a schema..."),
+    ];
+    collector.collect("sess-1", 1, messages2);
+
+    const signals = db.prepare("SELECT * FROM satisfaction_signals").all() as any[];
+    expect(signals.length).toBeGreaterThanOrEqual(1);
+    expect(signals[0].signal_type).toBe("accepted");
+  });
+
+  it("should truncate previews to 200 chars", () => {
+    const longText = "a".repeat(500);
+    const messages: AgentMessage[] = [
+      mkUserMessage(longText),
+      mkAssistantMessage(longText),
+    ];
+
+    const turnId = collector.collect("sess-1", 0, messages);
+    const row = db.prepare("SELECT * FROM turns WHERE id = ?").get(turnId) as any;
+    expect(row.user_prompt_preview.length).toBe(200);
+    expect(row.assistant_response_preview.length).toBe(200);
+  });
+});
+
+describe("jaccardSimilarity", () => {
+  it("should return 1 for identical strings", () => {
+    expect(jaccardSimilarity("hello world", "hello world")).toBe(1);
+  });
+
+  it("should return 0 for completely different strings", () => {
+    expect(jaccardSimilarity("hello world", "foo bar baz")).toBe(0);
+  });
+
+  it("should return a value between 0 and 1 for partially similar strings", () => {
+    const sim = jaccardSimilarity("configure webpack", "configure babel");
+    expect(sim).toBeGreaterThan(0);
+    expect(sim).toBeLessThan(1);
+  });
+
+  it("should handle empty strings", () => {
+    expect(jaccardSimilarity("", "")).toBe(1);
+    expect(jaccardSimilarity("hello", "")).toBe(0);
+  });
+});

--- a/extensions/plugin-insights/test/collector/turn-collector.test.ts
+++ b/extensions/plugin-insights/test/collector/turn-collector.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { runMigrations } from "../../src/db/migration.js";
-import { TurnCollector, jaccardSimilarity } from "../../src/collector/turn-collector.js";
-import { ToolDetector } from "../../src/collector/tool-detector.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ContextDetector } from "../../src/collector/context-detector.js";
 import { PluginReporter } from "../../src/collector/plugin-reporter.js";
+import { ToolDetector } from "../../src/collector/tool-detector.js";
+import { TurnCollector, jaccardSimilarity } from "../../src/collector/turn-collector.js";
+import { runMigrations } from "../../src/db/migration.js";
 import type { AgentMessage, UserMessage, AssistantMessage } from "../../src/types.js";
 
 function mkUserMessage(content: string): UserMessage {
@@ -14,9 +14,14 @@ function mkUserMessage(content: string): UserMessage {
 function mkAssistantMessage(
   text: string,
   opts?: {
-    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    toolCalls?: {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }[];
     usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
-  }
+  },
 ): AssistantMessage {
   const contentArr: AssistantMessage["content"] = [{ type: "text", text }];
   if (opts?.toolCalls) {
@@ -77,17 +82,13 @@ describe("TurnCollector", () => {
     const messages: AgentMessage[] = [
       mkUserMessage("Recall something"),
       mkAssistantMessage("Here you go", {
-        toolCalls: [
-          { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
-        ],
+        toolCalls: [{ type: "toolCall", id: "tc1", name: "memory_search", arguments: {} }],
       }),
     ];
 
     const turnId = collector.collect("sess-1", 0, messages);
 
-    const events = db
-      .prepare("SELECT * FROM plugin_events WHERE turn_id = ?")
-      .all(turnId) as any[];
+    const events = db.prepare("SELECT * FROM plugin_events WHERE turn_id = ?").all(turnId) as any[];
     expect(events).toHaveLength(1);
     expect(events[0].plugin_id).toBe("mem");
     expect(events[0].detection_method).toBe("tool_call");
@@ -117,10 +118,7 @@ describe("TurnCollector", () => {
 
   it("should truncate previews to 200 chars", () => {
     const longText = "a".repeat(500);
-    const messages: AgentMessage[] = [
-      mkUserMessage(longText),
-      mkAssistantMessage(longText),
-    ];
+    const messages: AgentMessage[] = [mkUserMessage(longText), mkAssistantMessage(longText)];
 
     const turnId = collector.collect("sess-1", 0, messages);
     const row = db.prepare("SELECT * FROM turns WHERE id = ?").get(turnId) as any;

--- a/extensions/plugin-insights/test/commands.test.ts
+++ b/extensions/plugin-insights/test/commands.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { runMigrations } from "../src/db/migration.js";
-import { createCommands } from "../src/commands.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ToolDetector } from "../src/collector/tool-detector.js";
+import { createCommands } from "../src/commands.js";
+import { runMigrations } from "../src/db/migration.js";
 import type { PluginInsightsConfig, PluginCommandContext } from "../src/types.js";
 import { DEFAULT_CONFIG } from "../src/types.js";
 
@@ -64,16 +64,18 @@ describe("CLI Commands", () => {
   it("insights-reset with --confirm should delete all data", () => {
     // Seed data
     db.prepare(
-      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`,
     ).run();
     db.prepare(
-      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action) VALUES (1, 'mem', 'tool_call', 'x')`
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action) VALUES (1, 'mem', 'tool_call', 'x')`,
     ).run();
 
     const commands = createCommands(db, config, toolDetector);
     const resetCmd = commands.find((c) => c.name === "insights-reset")!;
 
-    const result = resetCmd.handler(mkCommandContext({ args: "--confirm", commandBody: "insights-reset --confirm" }));
+    const result = resetCmd.handler(
+      mkCommandContext({ args: "--confirm", commandBody: "insights-reset --confirm" }),
+    );
 
     const turns = db.prepare("SELECT * FROM turns").all();
     expect(turns).toHaveLength(0);

--- a/extensions/plugin-insights/test/commands.test.ts
+++ b/extensions/plugin-insights/test/commands.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../src/db/migration.js";
+import { createCommands } from "../src/commands.js";
+import { ToolDetector } from "../src/collector/tool-detector.js";
+import type { PluginInsightsConfig, PluginCommandContext } from "../src/types.js";
+import { DEFAULT_CONFIG } from "../src/types.js";
+
+function mkCommandContext(overrides?: Partial<PluginCommandContext>): PluginCommandContext {
+  return {
+    channel: "test",
+    isAuthorizedSender: true,
+    commandBody: "",
+    config: {},
+    ...overrides,
+  };
+}
+
+describe("CLI Commands", () => {
+  let db: Database.Database;
+  let toolDetector: ToolDetector;
+  const config: PluginInsightsConfig = { ...DEFAULT_CONFIG };
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    toolDetector = new ToolDetector(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should create all 6 commands", () => {
+    const commands = createCommands(db, config, toolDetector);
+    expect(commands).toHaveLength(6);
+
+    const names = commands.map((c) => c.name);
+    expect(names).toContain("insights-show");
+    expect(names).toContain("insights-compare");
+    expect(names).toContain("insights-export");
+    expect(names).toContain("insights-dashboard");
+    expect(names).toContain("insights-reset");
+    expect(names).toContain("insights-status");
+  });
+
+  it("insights-show should handle empty data", () => {
+    const commands = createCommands(db, config, toolDetector);
+    const showCmd = commands.find((c) => c.name === "insights-show")!;
+
+    const result = showCmd.handler(mkCommandContext());
+    expect(result).toBeDefined();
+    expect((result as { text?: string }).text).toContain("No plugin activity");
+  });
+
+  it("insights-reset without --confirm should show warning", () => {
+    const commands = createCommands(db, config, toolDetector);
+    const resetCmd = commands.find((c) => c.name === "insights-reset")!;
+
+    const result = resetCmd.handler(mkCommandContext());
+    expect((result as { text?: string }).text).toContain("permanently delete");
+  });
+
+  it("insights-reset with --confirm should delete all data", () => {
+    // Seed data
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action) VALUES (1, 'mem', 'tool_call', 'x')`
+    ).run();
+
+    const commands = createCommands(db, config, toolDetector);
+    const resetCmd = commands.find((c) => c.name === "insights-reset")!;
+
+    const result = resetCmd.handler(mkCommandContext({ args: "--confirm", commandBody: "insights-reset --confirm" }));
+
+    const turns = db.prepare("SELECT * FROM turns").all();
+    expect(turns).toHaveLength(0);
+    const events = db.prepare("SELECT * FROM plugin_events").all();
+    expect(events).toHaveLength(0);
+
+    expect((result as { text?: string }).text).toContain("reset");
+  });
+});

--- a/extensions/plugin-insights/test/engine.test.ts
+++ b/extensions/plugin-insights/test/engine.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../src/db/migration.js";
+import { buildReport, cleanupOldData } from "../src/engine.js";
+import type { PluginInsightsConfig } from "../src/types.js";
+import { DEFAULT_CONFIG } from "../src/types.js";
+
+function makeConfig(overrides?: Partial<PluginInsightsConfig>): PluginInsightsConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+describe("buildReport", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should return empty report when no data", () => {
+    const report = buildReport(db, makeConfig(), 30);
+    expect(report.plugins).toHaveLength(0);
+    expect(report.periodStart).toBeTruthy();
+    expect(report.periodEnd).toBeTruthy();
+  });
+
+  it("should compute report for active plugins", () => {
+    // Seed data
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+       VALUES ('s1', 0, datetime('now'), 1000, '["mem"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'search')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_installs (plugin_id, first_seen_at, last_seen_at)
+       VALUES ('mem', datetime('now', '-10 days'), datetime('now'))`
+    ).run();
+
+    const report = buildReport(db, makeConfig(), 30);
+    expect(report.plugins).toHaveLength(1);
+    expect(report.plugins[0].pluginId).toBe("mem");
+    expect(report.plugins[0].installedDays).toBeGreaterThanOrEqual(9);
+    expect(report.plugins[0].verdict).toBeDefined();
+    expect(report.plugins[0].triggerFrequency.totalTriggers).toBe(1);
+  });
+
+  it("should sort plugins by verdict severity", () => {
+    // Plugin A: frequently used → keep
+    for (let i = 0; i < 10; i++) {
+      db.prepare(
+        `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["plugA"]')`
+      ).run();
+      db.prepare(
+        `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+         VALUES (${i + 1}, 'plugA', 'tool_call', 'action')`
+      ).run();
+    }
+
+    // Plugin B: rarely used → low_usage
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+       VALUES ('sB', 0, datetime('now'), 500, '["plugB"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (11, 'plugB', 'tool_call', 'action')`
+    ).run();
+
+    const report = buildReport(db, makeConfig(), 30);
+    expect(report.plugins.length).toBe(2);
+    // "keep" should come before "low_usage"
+    expect(report.plugins[0].verdict.level).toBe("keep");
+    expect(report.plugins[1].verdict.level).toBe("low_usage");
+  });
+});
+
+describe("computeVerdict (via buildReport)", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should give 'low_usage' for rarely triggered plugins", () => {
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, plugins_triggered_json)
+       VALUES ('s1', 0, datetime('now'), '["rare"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'rare', 'tool_call', 'x')`
+    ).run();
+
+    const report = buildReport(db, makeConfig(), 30);
+    expect(report.plugins[0].verdict.level).toBe("low_usage");
+  });
+
+  it("should give 'keep' for frequently triggered plugins with OK metrics", () => {
+    for (let i = 0; i < 20; i++) {
+      db.prepare(
+        `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["good"]')`
+      ).run();
+      db.prepare(
+        `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+         VALUES (${i + 1}, 'good', 'tool_call', 'action')`
+      ).run();
+    }
+
+    // Also add some baseline turns
+    for (let i = 0; i < 5; i++) {
+      db.prepare(
+        `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens)
+         VALUES ('baseline${i}', 0, datetime('now'), 500)`
+      ).run();
+    }
+
+    const report = buildReport(db, makeConfig(), 30);
+    expect(report.plugins[0].verdict.level).toBe("keep");
+  });
+});
+
+describe("cleanupOldData", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should delete turns older than retention period", () => {
+    // Old turn (100 days ago)
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('old', 0, datetime('now', '-100 days'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'search')`
+    ).run();
+    db.prepare(
+      `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence)
+       VALUES (1, 'accepted', 0.9)`
+    ).run();
+
+    // Recent turn (1 day ago)
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('new', 0, datetime('now', '-1 day'))`
+    ).run();
+
+    cleanupOldData(db, 90);
+
+    const turns = db.prepare("SELECT * FROM turns").all();
+    expect(turns).toHaveLength(1);
+    expect((turns[0] as any).session_id).toBe("new");
+
+    const events = db.prepare("SELECT * FROM plugin_events").all();
+    expect(events).toHaveLength(0);
+
+    const signals = db.prepare("SELECT * FROM satisfaction_signals").all();
+    expect(signals).toHaveLength(0);
+  });
+
+  it("should keep all data if nothing is expired", () => {
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('recent', 0, datetime('now'))`
+    ).run();
+
+    cleanupOldData(db, 90);
+
+    const turns = db.prepare("SELECT * FROM turns").all();
+    expect(turns).toHaveLength(1);
+  });
+});

--- a/extensions/plugin-insights/test/engine.test.ts
+++ b/extensions/plugin-insights/test/engine.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../src/db/migration.js";
 import { buildReport, cleanupOldData } from "../src/engine.js";
 import type { PluginInsightsConfig } from "../src/types.js";
@@ -32,15 +32,15 @@ describe("buildReport", () => {
     // Seed data
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-       VALUES ('s1', 0, datetime('now'), 1000, '["mem"]')`
+       VALUES ('s1', 0, datetime('now'), 1000, '["mem"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'search')`
+       VALUES (1, 'mem', 'tool_call', 'search')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_installs (plugin_id, first_seen_at, last_seen_at)
-       VALUES ('mem', datetime('now', '-10 days'), datetime('now'))`
+       VALUES ('mem', datetime('now', '-10 days'), datetime('now'))`,
     ).run();
 
     const report = buildReport(db, makeConfig(), 30);
@@ -56,22 +56,22 @@ describe("buildReport", () => {
     for (let i = 0; i < 10; i++) {
       db.prepare(
         `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["plugA"]')`
+         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["plugA"]')`,
       ).run();
       db.prepare(
         `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-         VALUES (${i + 1}, 'plugA', 'tool_call', 'action')`
+         VALUES (${i + 1}, 'plugA', 'tool_call', 'action')`,
       ).run();
     }
 
     // Plugin B: rarely used → low_usage
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-       VALUES ('sB', 0, datetime('now'), 500, '["plugB"]')`
+       VALUES ('sB', 0, datetime('now'), 500, '["plugB"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (11, 'plugB', 'tool_call', 'action')`
+       VALUES (11, 'plugB', 'tool_call', 'action')`,
     ).run();
 
     const report = buildReport(db, makeConfig(), 30);
@@ -97,11 +97,11 @@ describe("computeVerdict (via buildReport)", () => {
   it("should give 'low_usage' for rarely triggered plugins", () => {
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, plugins_triggered_json)
-       VALUES ('s1', 0, datetime('now'), '["rare"]')`
+       VALUES ('s1', 0, datetime('now'), '["rare"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'rare', 'tool_call', 'x')`
+       VALUES (1, 'rare', 'tool_call', 'x')`,
     ).run();
 
     const report = buildReport(db, makeConfig(), 30);
@@ -112,11 +112,11 @@ describe("computeVerdict (via buildReport)", () => {
     for (let i = 0; i < 20; i++) {
       db.prepare(
         `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["good"]')`
+         VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["good"]')`,
       ).run();
       db.prepare(
         `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-         VALUES (${i + 1}, 'good', 'tool_call', 'action')`
+         VALUES (${i + 1}, 'good', 'tool_call', 'action')`,
       ).run();
     }
 
@@ -124,7 +124,7 @@ describe("computeVerdict (via buildReport)", () => {
     for (let i = 0; i < 5; i++) {
       db.prepare(
         `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens)
-         VALUES ('baseline${i}', 0, datetime('now'), 500)`
+         VALUES ('baseline${i}', 0, datetime('now'), 500)`,
       ).run();
     }
 
@@ -149,21 +149,21 @@ describe("cleanupOldData", () => {
     // Old turn (100 days ago)
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('old', 0, datetime('now', '-100 days'))`
+       VALUES ('old', 0, datetime('now', '-100 days'))`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'search')`
+       VALUES (1, 'mem', 'tool_call', 'search')`,
     ).run();
     db.prepare(
       `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence)
-       VALUES (1, 'accepted', 0.9)`
+       VALUES (1, 'accepted', 0.9)`,
     ).run();
 
     // Recent turn (1 day ago)
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('new', 0, datetime('now', '-1 day'))`
+       VALUES ('new', 0, datetime('now', '-1 day'))`,
     ).run();
 
     cleanupOldData(db, 90);
@@ -182,7 +182,7 @@ describe("cleanupOldData", () => {
   it("should keep all data if nothing is expired", () => {
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('recent', 0, datetime('now'))`
+       VALUES ('recent', 0, datetime('now'))`,
     ).run();
 
     cleanupOldData(db, 90);

--- a/extensions/plugin-insights/test/integration.test.ts
+++ b/extensions/plugin-insights/test/integration.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../src/db/migration.js";
 import { createInsightsEngine, buildReport, type ToolPluginMapping } from "../src/engine.js";
-import type { AgentMessage, UserMessage, AssistantMessage, PluginInsightsConfig } from "../src/types.js";
+import type {
+  AgentMessage,
+  UserMessage,
+  AssistantMessage,
+  PluginInsightsConfig,
+} from "../src/types.js";
 import { DEFAULT_CONFIG } from "../src/types.js";
 
 function mkUserMessage(content: string): UserMessage {
@@ -12,9 +17,14 @@ function mkUserMessage(content: string): UserMessage {
 function mkAssistantMessage(
   text: string,
   opts?: {
-    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    toolCalls?: {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }[];
     usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
-  }
+  },
 ): AssistantMessage {
   const contentArr: AssistantMessage["content"] = [{ type: "text", text }];
   if (opts?.toolCalls) {
@@ -106,9 +116,7 @@ describe("Integration: full lifecycle", () => {
         }),
         mkUserMessage("Format this code for me"),
         mkAssistantMessage("Here is the formatted code...", {
-          toolCalls: [
-            { type: "toolCall", id: "tc2", name: "format_code", arguments: {} },
-          ],
+          toolCalls: [{ type: "toolCall", id: "tc2", name: "format_code", arguments: {} }],
           usage: { input: 300, output: 100, cacheRead: 0, cacheWrite: 0, total: 400 },
         }),
       ],
@@ -122,9 +130,7 @@ describe("Integration: full lifecycle", () => {
       messages: [
         mkUserMessage("Recall my notes on database design"),
         mkAssistantMessage("Here are your notes...", {
-          toolCalls: [
-            { type: "toolCall", id: "tc3", name: "memory_search", arguments: {} },
-          ],
+          toolCalls: [{ type: "toolCall", id: "tc3", name: "memory_search", arguments: {} }],
           usage: { input: 400, output: 150, cacheRead: 0, cacheWrite: 0, total: 550 },
         }),
       ],
@@ -154,7 +160,11 @@ describe("Integration: full lifecycle", () => {
     const { engine, reporter } = createInsightsEngine(db, config, toolPluginMappings);
 
     // Simulate another plugin reporting its activity
-    reporter.report({ pluginId: "custom-plugin", action: "custom_action", metadata: { foo: "bar" } });
+    reporter.report({
+      pluginId: "custom-plugin",
+      action: "custom_action",
+      metadata: { foo: "bar" },
+    });
 
     // The report gets flushed during the next afterTurn
     await engine.afterTurn!({
@@ -169,7 +179,9 @@ describe("Integration: full lifecycle", () => {
       prePromptMessageCount: 0,
     });
 
-    const events = db.prepare("SELECT * FROM plugin_events WHERE plugin_id = 'custom-plugin'").all() as any[];
+    const events = db
+      .prepare("SELECT * FROM plugin_events WHERE plugin_id = 'custom-plugin'")
+      .all() as any[];
     expect(events).toHaveLength(1);
     expect(events[0].detection_method).toBe("self_report");
     expect(events[0].action).toBe("custom_action");
@@ -185,9 +197,7 @@ describe("Integration: full lifecycle", () => {
       messages: [
         mkUserMessage("How do I optimize database queries for large tables?"),
         mkAssistantMessage("You can use indexing and query optimization...", {
-          toolCalls: [
-            { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
-          ],
+          toolCalls: [{ type: "toolCall", id: "tc1", name: "memory_search", arguments: {} }],
           usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
         }),
       ],

--- a/extensions/plugin-insights/test/integration.test.ts
+++ b/extensions/plugin-insights/test/integration.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../src/db/migration.js";
+import { createInsightsEngine, buildReport, type ToolPluginMapping } from "../src/engine.js";
+import type { AgentMessage, UserMessage, AssistantMessage, PluginInsightsConfig } from "../src/types.js";
+import { DEFAULT_CONFIG } from "../src/types.js";
+
+function mkUserMessage(content: string): UserMessage {
+  return { role: "user", content, timestamp: Date.now() };
+}
+
+function mkAssistantMessage(
+  text: string,
+  opts?: {
+    toolCalls?: { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }[];
+    usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+  }
+): AssistantMessage {
+  const contentArr: AssistantMessage["content"] = [{ type: "text", text }];
+  if (opts?.toolCalls) {
+    contentArr.push(...opts.toolCalls);
+  }
+  return {
+    role: "assistant",
+    content: contentArr,
+    usage: opts?.usage ?? { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+    model: "test",
+    api: "test",
+    provider: "test",
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Integration test: simulates the full lifecycle of
+ * register → afterTurn (multiple) → buildReport
+ */
+describe("Integration: full lifecycle", () => {
+  let db: Database.Database;
+  const config: PluginInsightsConfig = { ...DEFAULT_CONFIG };
+
+  const toolPluginMappings: ToolPluginMapping[] = [
+    { toolName: "memory_search", pluginId: "memory-tools", pluginName: "Memory Tools" },
+    { toolName: "memory_store", pluginId: "memory-tools", pluginName: "Memory Tools" },
+    { toolName: "format_code", pluginId: "code-fmt", pluginName: "Code Formatter" },
+  ];
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should collect data across multiple turns and produce a report", async () => {
+    const { engine, reporter } = createInsightsEngine(db, config, toolPluginMappings);
+
+    // Turn 1: memory_search triggered
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("What was the bug I fixed yesterday?"),
+        mkAssistantMessage("Based on your memory, you fixed the auth timeout bug.", {
+          toolCalls: [
+            { type: "toolCall", id: "tc1", name: "memory_search", arguments: { query: "bug fix" } },
+          ],
+          usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // Turn 2: no plugin triggered
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("What was the bug I fixed yesterday?"),
+        mkAssistantMessage("Based on your memory, you fixed the auth timeout bug.", {
+          usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
+        }),
+        mkUserMessage("Thanks, now help me write a React component."),
+        mkAssistantMessage("Sure, here is a component...", {
+          usage: { input: 600, output: 300, cacheRead: 0, cacheWrite: 0, total: 900 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // Turn 3: format_code triggered
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("Format this code for me"),
+        mkAssistantMessage("Here is the formatted code...", {
+          toolCalls: [
+            { type: "toolCall", id: "tc2", name: "format_code", arguments: {} },
+          ],
+          usage: { input: 300, output: 100, cacheRead: 0, cacheWrite: 0, total: 400 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // Turn 4: memory_search again in new session
+    await engine.afterTurn!({
+      sessionId: "sess-2",
+      sessionFile: "/tmp/sess-2.json",
+      messages: [
+        mkUserMessage("Recall my notes on database design"),
+        mkAssistantMessage("Here are your notes...", {
+          toolCalls: [
+            { type: "toolCall", id: "tc3", name: "memory_search", arguments: {} },
+          ],
+          usage: { input: 400, output: 150, cacheRead: 0, cacheWrite: 0, total: 550 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // Verify raw data
+    const turns = db.prepare("SELECT * FROM turns").all();
+    expect(turns).toHaveLength(4);
+
+    const events = db.prepare("SELECT * FROM plugin_events").all() as any[];
+    expect(events.length).toBeGreaterThanOrEqual(2); // at least memory-tools + code-fmt
+
+    const memEvents = events.filter((e: any) => e.plugin_id === "memory-tools");
+    expect(memEvents).toHaveLength(2);
+
+    // Build report
+    const report = buildReport(db, config, 30);
+    expect(report.plugins.length).toBeGreaterThanOrEqual(1);
+
+    const memPlugin = report.plugins.find((p) => p.pluginId === "memory-tools");
+    expect(memPlugin).toBeDefined();
+    expect(memPlugin!.triggerFrequency.totalTriggers).toBe(2);
+  });
+
+  it("should handle Layer 3 self-reports", async () => {
+    const { engine, reporter } = createInsightsEngine(db, config, toolPluginMappings);
+
+    // Simulate another plugin reporting its activity
+    reporter.report({ pluginId: "custom-plugin", action: "custom_action", metadata: { foo: "bar" } });
+
+    // The report gets flushed during the next afterTurn
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("Hello"),
+        mkAssistantMessage("Hi there!", {
+          usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    const events = db.prepare("SELECT * FROM plugin_events WHERE plugin_id = 'custom-plugin'").all() as any[];
+    expect(events).toHaveLength(1);
+    expect(events[0].detection_method).toBe("self_report");
+    expect(events[0].action).toBe("custom_action");
+  });
+
+  it("should detect satisfaction signals across turns", async () => {
+    const { engine } = createInsightsEngine(db, config, toolPluginMappings);
+
+    // Turn 1: user asks a question
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("How do I optimize database queries for large tables?"),
+        mkAssistantMessage("You can use indexing and query optimization...", {
+          toolCalls: [
+            { type: "toolCall", id: "tc1", name: "memory_search", arguments: {} },
+          ],
+          usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // Turn 2: user retries (similar prompt → dissatisfied)
+    await engine.afterTurn!({
+      sessionId: "sess-1",
+      sessionFile: "/tmp/sess-1.json",
+      messages: [
+        mkUserMessage("How do I optimize database queries for large tables?"),
+        mkAssistantMessage("You can use indexing and query optimization...", {
+          usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
+        }),
+        mkUserMessage("不对，重新回答一下优化数据库查询的方法"),
+        mkAssistantMessage("Let me provide a more detailed answer...", {
+          usage: { input: 600, output: 300, cacheRead: 0, cacheWrite: 0, total: 900 },
+        }),
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    const signals = db.prepare("SELECT * FROM satisfaction_signals").all() as any[];
+    expect(signals.length).toBeGreaterThanOrEqual(1);
+    // Should detect correction signal ("不对", "重新")
+    expect(signals[0].signal_type).toBe("corrected");
+  });
+});

--- a/extensions/plugin-insights/test/integration.test.ts
+++ b/extensions/plugin-insights/test/integration.test.ts
@@ -91,11 +91,19 @@ describe("Integration: full lifecycle", () => {
       prePromptMessageCount: 0,
     });
 
-    // Turn 3: format_code triggered
+    // Turn 3: format_code triggered (cumulative transcript for sess-1)
     await engine.afterTurn!({
       sessionId: "sess-1",
       sessionFile: "/tmp/sess-1.json",
       messages: [
+        mkUserMessage("What was the bug I fixed yesterday?"),
+        mkAssistantMessage("Based on your memory, you fixed the auth timeout bug.", {
+          usage: { input: 500, output: 200, cacheRead: 0, cacheWrite: 0, total: 700 },
+        }),
+        mkUserMessage("Thanks, now help me write a React component."),
+        mkAssistantMessage("Sure, here is a component...", {
+          usage: { input: 600, output: 300, cacheRead: 0, cacheWrite: 0, total: 900 },
+        }),
         mkUserMessage("Format this code for me"),
         mkAssistantMessage("Here is the formatted code...", {
           toolCalls: [

--- a/extensions/plugin-insights/test/manifest.test.ts
+++ b/extensions/plugin-insights/test/manifest.test.ts
@@ -13,13 +13,13 @@ describe("Plugin Manifest (openclaw.plugin.json)", () => {
   it("should have required fields", () => {
     expect(manifest.id).toBe("plugin-insights");
     expect(manifest.name).toBeTruthy();
-    expect(manifest.version).toBeTruthy();
     expect(manifest.description).toBeTruthy();
-    expect(manifest.main).toBe("dist/index.js");
   });
 
-  it("should have version matching package.json", () => {
-    expect(manifest.version).toBe(pkg.version);
+  it("should have id matching package name suffix", () => {
+    // In the monorepo, package name is @openclaw/plugin-insights
+    const suffix = pkg.name.replace(/^@openclaw\//, "");
+    expect(manifest.id).toBe(suffix);
   });
 
   it("should have a valid configSchema", () => {

--- a/extensions/plugin-insights/test/manifest.test.ts
+++ b/extensions/plugin-insights/test/manifest.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { describe, it, expect } from "vitest";
 import { DEFAULT_CONFIG } from "../src/types.js";
 
 const MANIFEST_PATH = path.resolve(__dirname, "../openclaw.plugin.json");

--- a/extensions/plugin-insights/test/manifest.test.ts
+++ b/extensions/plugin-insights/test/manifest.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DEFAULT_CONFIG } from "../src/types.js";
+
+const MANIFEST_PATH = path.resolve(__dirname, "../openclaw.plugin.json");
+const PACKAGE_PATH = path.resolve(__dirname, "../package.json");
+
+describe("Plugin Manifest (openclaw.plugin.json)", () => {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf-8"));
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_PATH, "utf-8"));
+
+  it("should have required fields", () => {
+    expect(manifest.id).toBe("plugin-insights");
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.version).toBeTruthy();
+    expect(manifest.description).toBeTruthy();
+    expect(manifest.main).toBe("dist/index.js");
+  });
+
+  it("should have version matching package.json", () => {
+    expect(manifest.version).toBe(pkg.version);
+  });
+
+  it("should have a valid configSchema", () => {
+    expect(manifest.configSchema).toBeDefined();
+    expect(manifest.configSchema.type).toBe("object");
+    expect(manifest.configSchema.properties).toBeDefined();
+  });
+
+  it("configSchema defaults should match DEFAULT_CONFIG", () => {
+    const schema = manifest.configSchema.properties;
+
+    expect(schema.enabled.default).toBe(DEFAULT_CONFIG.enabled);
+    expect(schema.dbPath.default).toBe(DEFAULT_CONFIG.dbPath);
+    expect(schema.retentionDays.default).toBe(DEFAULT_CONFIG.retentionDays);
+
+    const judgeSchema = schema.llmJudge.properties;
+    expect(judgeSchema.enabled.default).toBe(DEFAULT_CONFIG.llmJudge.enabled);
+    expect(judgeSchema.baseUrl.default).toBe(DEFAULT_CONFIG.llmJudge.baseUrl);
+    expect(judgeSchema.model.default).toBe(DEFAULT_CONFIG.llmJudge.model);
+    expect(judgeSchema.maxEvalPerDay.default).toBe(DEFAULT_CONFIG.llmJudge.maxEvalPerDay);
+  });
+
+  it("configSchema should not allow additional properties", () => {
+    expect(manifest.configSchema.additionalProperties).toBe(false);
+  });
+});

--- a/extensions/plugin-insights/test/metrics/implicit-satisfaction.test.ts
+++ b/extensions/plugin-insights/test/metrics/implicit-satisfaction.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { ImplicitSatisfactionMetric } from "../../src/metrics/implicit-satisfaction.js";
+
+describe("ImplicitSatisfactionMetric", () => {
+  let db: Database.Database;
+  let metric: ImplicitSatisfactionMetric;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    metric = new ImplicitSatisfactionMetric(db);
+
+    // Create turns
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 1, datetime('now'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 2, datetime('now'))`
+    ).run();
+
+    // Plugin events for turn 1 and 2
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'search')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (2, 'mem', 'tool_call', 'search')`
+    ).run();
+
+    // Satisfaction signals
+    db.prepare(
+      `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence, next_turn_id)
+       VALUES (1, 'accepted', 0.9, 2)`
+    ).run();
+    db.prepare(
+      `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence, next_turn_id)
+       VALUES (2, 'retried', 0.7, 3)`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should compute acceptance rate", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.acceptanceRate).toBe(50);
+    expect(result.retryRate).toBe(50);
+    expect(result.totalSignals).toBe(2);
+  });
+
+  it("should return zeros for unknown plugin", () => {
+    const result = metric.compute("unknown", 30);
+    expect(result.acceptanceRate).toBe(0);
+    expect(result.retryRate).toBe(0);
+    expect(result.totalSignals).toBe(0);
+  });
+});

--- a/extensions/plugin-insights/test/metrics/implicit-satisfaction.test.ts
+++ b/extensions/plugin-insights/test/metrics/implicit-satisfaction.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../../src/db/migration.js";
 import { ImplicitSatisfactionMetric } from "../../src/metrics/implicit-satisfaction.js";
 
@@ -14,33 +14,33 @@ describe("ImplicitSatisfactionMetric", () => {
 
     // Create turns
     db.prepare(
-      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 0, datetime('now'))`,
     ).run();
     db.prepare(
-      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 1, datetime('now'))`
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 1, datetime('now'))`,
     ).run();
     db.prepare(
-      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 2, datetime('now'))`
+      `INSERT INTO turns (session_id, turn_index, timestamp) VALUES ('s1', 2, datetime('now'))`,
     ).run();
 
     // Plugin events for turn 1 and 2
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'search')`
+       VALUES (1, 'mem', 'tool_call', 'search')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (2, 'mem', 'tool_call', 'search')`
+       VALUES (2, 'mem', 'tool_call', 'search')`,
     ).run();
 
     // Satisfaction signals
     db.prepare(
       `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence, next_turn_id)
-       VALUES (1, 'accepted', 0.9, 2)`
+       VALUES (1, 'accepted', 0.9, 2)`,
     ).run();
     db.prepare(
       `INSERT INTO satisfaction_signals (turn_id, signal_type, confidence, next_turn_id)
-       VALUES (2, 'retried', 0.7, 3)`
+       VALUES (2, 'retried', 0.7, 3)`,
     ).run();
   });
 

--- a/extensions/plugin-insights/test/metrics/token-delta.test.ts
+++ b/extensions/plugin-insights/test/metrics/token-delta.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../../src/db/migration.js";
 import { TokenDeltaMetric } from "../../src/metrics/token-delta.js";
 
@@ -15,31 +15,31 @@ describe("TokenDeltaMetric", () => {
     // Turns WITH plugin (higher tokens)
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens, plugins_triggered_json)
-       VALUES ('s1', 0, datetime('now'), 800, 200, 1000, '["mem"]')`
+       VALUES ('s1', 0, datetime('now'), 800, 200, 1000, '["mem"]')`,
     ).run();
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens, plugins_triggered_json)
-       VALUES ('s1', 1, datetime('now'), 900, 300, 1200, '["mem"]')`
+       VALUES ('s1', 1, datetime('now'), 900, 300, 1200, '["mem"]')`,
     ).run();
 
     // Link plugin events
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'search')`
+       VALUES (1, 'mem', 'tool_call', 'search')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (2, 'mem', 'tool_call', 'search')`
+       VALUES (2, 'mem', 'tool_call', 'search')`,
     ).run();
 
     // Turns WITHOUT plugin (lower tokens)
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens)
-       VALUES ('s2', 0, datetime('now'), 400, 100, 500)`
+       VALUES ('s2', 0, datetime('now'), 400, 100, 500)`,
     ).run();
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens)
-       VALUES ('s2', 1, datetime('now'), 500, 100, 600)`
+       VALUES ('s2', 1, datetime('now'), 500, 100, 600)`,
     ).run();
   });
 

--- a/extensions/plugin-insights/test/metrics/token-delta.test.ts
+++ b/extensions/plugin-insights/test/metrics/token-delta.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { TokenDeltaMetric } from "../../src/metrics/token-delta.js";
+
+describe("TokenDeltaMetric", () => {
+  let db: Database.Database;
+  let metric: TokenDeltaMetric;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    metric = new TokenDeltaMetric(db);
+
+    // Turns WITH plugin (higher tokens)
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens, plugins_triggered_json)
+       VALUES ('s1', 0, datetime('now'), 800, 200, 1000, '["mem"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens, plugins_triggered_json)
+       VALUES ('s1', 1, datetime('now'), 900, 300, 1200, '["mem"]')`
+    ).run();
+
+    // Link plugin events
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'search')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (2, 'mem', 'tool_call', 'search')`
+    ).run();
+
+    // Turns WITHOUT plugin (lower tokens)
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens)
+       VALUES ('s2', 0, datetime('now'), 400, 100, 500)`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, prompt_tokens, completion_tokens, total_tokens)
+       VALUES ('s2', 1, datetime('now'), 500, 100, 600)`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should compute token delta between with/without plugin", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.avgTokensWithPlugin).toBe(1100);
+    expect(result.avgTokensWithoutPlugin).toBe(550);
+    expect(result.deltaTokens).toBe(550);
+    expect(result.deltaPercent).toBe(100);
+  });
+
+  it("should estimate monthly cost", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.estimatedMonthlyCostUSD).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should return zero for avgTokensWithPlugin for unknown plugin", () => {
+    const result = metric.compute("unknown", 30);
+    expect(result.avgTokensWithPlugin).toBe(0);
+    // deltaTokens will be negative since baseline exists but plugin has no triggers
+    expect(result.deltaTokens).toBeLessThanOrEqual(0);
+  });
+});

--- a/extensions/plugin-insights/test/metrics/trigger-frequency.test.ts
+++ b/extensions/plugin-insights/test/metrics/trigger-frequency.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../../src/db/migration.js";
 import { TriggerFrequencyMetric } from "../../src/metrics/trigger-frequency.js";
 
@@ -15,29 +15,29 @@ describe("TriggerFrequencyMetric", () => {
     // Seed test data: 3 turns across 2 sessions
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('s1', 0, datetime('now', '-1 day'))`
+       VALUES ('s1', 0, datetime('now', '-1 day'))`,
     ).run();
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('s1', 1, datetime('now', '-1 day'))`
+       VALUES ('s1', 1, datetime('now', '-1 day'))`,
     ).run();
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp)
-       VALUES ('s2', 0, datetime('now'))`
+       VALUES ('s2', 0, datetime('now'))`,
     ).run();
 
     // Plugin events
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'memory_search')`
+       VALUES (1, 'mem', 'tool_call', 'memory_search')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (2, 'mem', 'tool_call', 'memory_store')`
+       VALUES (2, 'mem', 'tool_call', 'memory_store')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (3, 'mem', 'tool_call', 'memory_search')`
+       VALUES (3, 'mem', 'tool_call', 'memory_search')`,
     ).run();
   });
 

--- a/extensions/plugin-insights/test/metrics/trigger-frequency.test.ts
+++ b/extensions/plugin-insights/test/metrics/trigger-frequency.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { TriggerFrequencyMetric } from "../../src/metrics/trigger-frequency.js";
+
+describe("TriggerFrequencyMetric", () => {
+  let db: Database.Database;
+  let metric: TriggerFrequencyMetric;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    metric = new TriggerFrequencyMetric(db);
+
+    // Seed test data: 3 turns across 2 sessions
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('s1', 0, datetime('now', '-1 day'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('s1', 1, datetime('now', '-1 day'))`
+    ).run();
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp)
+       VALUES ('s2', 0, datetime('now'))`
+    ).run();
+
+    // Plugin events
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'memory_search')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (2, 'mem', 'tool_call', 'memory_store')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (3, 'mem', 'tool_call', 'memory_search')`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should compute total trigger count", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.totalTriggers).toBe(3);
+  });
+
+  it("should compute triggers per day", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.triggersPerDay).toBeGreaterThan(0);
+  });
+
+  it("should compute triggers per session", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.triggersPerSession).toBe(1.5);
+  });
+
+  it("should return daily trend data", () => {
+    const result = metric.compute("mem", 30);
+    expect(result.dailyTrend.length).toBeGreaterThan(0);
+  });
+
+  it("should list active plugins", () => {
+    const plugins = metric.getActivePlugins(30);
+    expect(plugins).toContain("mem");
+  });
+
+  it("should return zero for unknown plugin", () => {
+    const result = metric.compute("unknown", 30);
+    expect(result.totalTriggers).toBe(0);
+  });
+});

--- a/extensions/plugin-insights/test/openclaw-compat.test.ts
+++ b/extensions/plugin-insights/test/openclaw-compat.test.ts
@@ -176,24 +176,12 @@ describe("OpenClaw integration readiness checklist", () => {
    * serve as a checklist for real integration testing.
    */
 
-  it.todo(
-    "afterTurn receives correct AfterTurnParams shape from OpenClaw runtime"
-  );
-  it.todo(
-    "registerContextEngine factory is called exactly once per session"
-  );
+  it.todo("afterTurn receives correct AfterTurnParams shape from OpenClaw runtime");
+  it.todo("registerContextEngine factory is called exactly once per session");
   it.todo("registerTool makes tools available to the agent via tool_use");
-  it.todo(
-    "registerCommand makes commands available via `openclaw <cmd>`"
-  );
-  it.todo(
-    "api.on('plugin_insights_report') hook receives cross-plugin reports"
-  );
-  it.todo(
-    "plugin activates correctly after `openclaw plugins install plugin-insights`"
-  );
-  it.todo(
-    "SQLite DB is created at the configured path on first activation"
-  );
+  it.todo("registerCommand makes commands available via `openclaw <cmd>`");
+  it.todo("api.on('plugin_insights_report') hook receives cross-plugin reports");
+  it.todo("plugin activates correctly after `openclaw plugins install plugin-insights`");
+  it.todo("SQLite DB is created at the configured path on first activation");
   it.todo("data survives across multiple openclaw sessions");
 });

--- a/extensions/plugin-insights/test/openclaw-compat.test.ts
+++ b/extensions/plugin-insights/test/openclaw-compat.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import type {
+  ContextEngine,
+  OpenClawPluginApi,
+  AgentTool,
+  OpenClawPluginCommandDefinition,
+  AgentToolResult,
+  ReplyPayload,
+  ContextEngineInfo,
+  IngestResult,
+  AssembleResult,
+  CompactResult,
+} from "../src/types.js";
+import { textToolResult } from "../src/types.js";
+
+/**
+ * OpenClaw Compatibility Contract Tests
+ *
+ * These tests validate that our type interfaces match the expected
+ * OpenClaw plugin-sdk contracts (openclaw@2026.3.7+).
+ * When integrating with the real SDK, replace these with:
+ *   import type { OpenClawPluginApi, ContextEngine, ... } from "openclaw/plugin-sdk";
+ *
+ * If any of these tests break after importing real OpenClaw types,
+ * it means our interface assumptions were wrong and need fixing.
+ */
+describe("OpenClaw API contract", () => {
+  it("OpenClawPluginApi should have all required properties and methods", () => {
+    const keys: (keyof OpenClawPluginApi)[] = [
+      "id",
+      "name",
+      "source",
+      "pluginConfig",
+      "logger",
+      "registerContextEngine",
+      "registerTool",
+      "registerCommand",
+    ];
+
+    for (const key of keys) {
+      expect(typeof key).toBe("string");
+    }
+  });
+
+  it("ContextEngine should have info with ownsCompaction, and required methods", () => {
+    // Structural contract: minimum ContextEngine matching real SDK
+    const minimalEngine: ContextEngine = {
+      info: { id: "test", name: "Test", ownsCompaction: false },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble(params) {
+        return { messages: params.messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+    };
+
+    expect(minimalEngine.info.ownsCompaction).toBe(false);
+    expect(typeof minimalEngine.ingest).toBe("function");
+    expect(typeof minimalEngine.assemble).toBe("function");
+    expect(typeof minimalEngine.compact).toBe("function");
+  });
+
+  it("ContextEngine should allow optional hooks", () => {
+    const engine: ContextEngine = {
+      info: { id: "test", name: "Test", ownsCompaction: false },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble(params) {
+        return { messages: params.messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+    };
+
+    // Optional hooks should be undefined
+    expect(engine.bootstrap).toBeUndefined();
+    expect(engine.afterTurn).toBeUndefined();
+    expect(engine.prepareSubagentSpawn).toBeUndefined();
+    expect(engine.onSubagentEnded).toBeUndefined();
+    expect(engine.dispose).toBeUndefined();
+  });
+
+  it("AgentTool should have name, label, description, parameters, execute", () => {
+    const tool: AgentTool = {
+      name: "test_tool",
+      label: "Test Tool",
+      description: "A test tool",
+      parameters: { type: "object", properties: {} },
+      async execute(_toolCallId, _params) {
+        return textToolResult("result");
+      },
+    };
+
+    expect(tool.name).toBeTruthy();
+    expect(tool.label).toBeTruthy();
+    expect(tool.description).toBeTruthy();
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  });
+
+  it("AgentTool.execute should return AgentToolResult", async () => {
+    const tool: AgentTool = {
+      name: "test_tool",
+      label: "Test Tool",
+      description: "A test tool",
+      parameters: { type: "object", properties: {} },
+      async execute(toolCallId, params) {
+        return textToolResult("hello");
+      },
+    };
+
+    const result = await tool.execute("call-1", {});
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({ type: "text", text: "hello" });
+    expect(result.details).toBeUndefined();
+  });
+
+  it("OpenClawPluginCommandDefinition should have name, description, handler returning ReplyPayload", () => {
+    const cmd: OpenClawPluginCommandDefinition = {
+      name: "test cmd",
+      description: "A test command",
+      handler(_ctx) {
+        return { text: "done" };
+      },
+    };
+
+    expect(cmd.name).toBeTruthy();
+    expect(cmd.description).toBeTruthy();
+    expect(typeof cmd.handler).toBe("function");
+
+    const result = cmd.handler({
+      channel: "test",
+      isAuthorizedSender: true,
+      commandBody: "test cmd",
+      config: {},
+    }) as ReplyPayload;
+    expect(result.text).toBe("done");
+  });
+
+  it("ContextEngine factory should return engine with info.ownsCompaction=false", () => {
+    // This mirrors how OpenClaw calls our factory:
+    //   api.registerContextEngine("plugin-insights", () => engine)
+    const factory = (): ContextEngine => ({
+      info: {
+        id: "plugin-insights",
+        name: "Plugin Insights",
+        ownsCompaction: false,
+      },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble(params) {
+        return { messages: params.messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async afterTurn() {},
+    });
+
+    const engine = factory();
+    expect(engine.info.ownsCompaction).toBe(false);
+    expect(engine.info.id).toBe("plugin-insights");
+  });
+});
+
+describe("OpenClaw integration readiness checklist", () => {
+  /**
+   * NOTE: These tests document what needs to be verified against
+   * the real OpenClaw runtime. They all pass trivially now but
+   * serve as a checklist for real integration testing.
+   */
+
+  it.todo(
+    "afterTurn receives correct AfterTurnParams shape from OpenClaw runtime"
+  );
+  it.todo(
+    "registerContextEngine factory is called exactly once per session"
+  );
+  it.todo("registerTool makes tools available to the agent via tool_use");
+  it.todo(
+    "registerCommand makes commands available via `openclaw <cmd>`"
+  );
+  it.todo(
+    "api.on('plugin_insights_report') hook receives cross-plugin reports"
+  );
+  it.todo(
+    "plugin activates correctly after `openclaw plugins install plugin-insights`"
+  );
+  it.todo(
+    "SQLite DB is created at the configured path on first activation"
+  );
+  it.todo("data survives across multiple openclaw sessions");
+});

--- a/extensions/plugin-insights/test/report/cli-report.test.ts
+++ b/extensions/plugin-insights/test/report/cli-report.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { formatCLIReport, formatPluginSummary } from "../../src/report/cli-report.js";
+import type { InsightsReport, PluginReport } from "../../src/types.js";
+
+function makePlugin(overrides: Partial<PluginReport> = {}): PluginReport {
+  return {
+    pluginId: "test-plugin",
+    pluginName: "Test Plugin",
+    installedDays: 30,
+    triggerFrequency: {
+      pluginId: "test-plugin",
+      totalTriggers: 100,
+      triggersPerDay: 3.3,
+      triggersPerSession: 2.5,
+      dailyTrend: [],
+    },
+    tokenDelta: {
+      pluginId: "test-plugin",
+      avgTokensWithPlugin: 1100,
+      avgTokensWithoutPlugin: 900,
+      deltaTokens: 200,
+      deltaPercent: 22.2,
+      estimatedMonthlyCostUSD: 0.5,
+    },
+    conversationTurns: {
+      pluginId: "test-plugin",
+      avgTurnsWithPlugin: 3.5,
+      avgTurnsWithoutPlugin: 5.0,
+      deltaTurns: -1.5,
+      deltaPercent: -30,
+    },
+    implicitSatisfaction: {
+      pluginId: "test-plugin",
+      acceptanceRate: 82,
+      retryRate: 12,
+      correctionRate: 6,
+      totalSignals: 50,
+    },
+    verdict: {
+      level: "keep",
+      label: "KEEP — strong positive impact",
+      reason: "Good metrics",
+    },
+    ...overrides,
+  };
+}
+
+describe("CLI Report", () => {
+  it("should format a full report", () => {
+    const report: InsightsReport = {
+      periodStart: "2026-02-14",
+      periodEnd: "2026-03-16",
+      plugins: [makePlugin()],
+      generatedAt: new Date().toISOString(),
+    };
+
+    const output = formatCLIReport(report);
+    expect(output).toContain("Plugin Insights Report");
+    expect(output).toContain("Test Plugin");
+    expect(output).toContain("100 times");
+    expect(output).toContain("+22.2%");
+    expect(output).toContain("82%");
+    expect(output).toContain("KEEP");
+  });
+
+  it("should format plugin summary", () => {
+    const plugin = makePlugin();
+    const output = formatPluginSummary(plugin);
+    expect(output).toContain("Test Plugin");
+    expect(output).toContain("3.3/day");
+  });
+
+  it("should handle multiple plugins", () => {
+    const report: InsightsReport = {
+      periodStart: "2026-02-14",
+      periodEnd: "2026-03-16",
+      plugins: [
+        makePlugin({ pluginId: "plugin-a", pluginName: "Plugin A" }),
+        makePlugin({
+          pluginId: "plugin-b",
+          pluginName: "Plugin B",
+          verdict: { level: "low_usage", label: "LOW USAGE", reason: "Rarely used" },
+        }),
+      ],
+      generatedAt: new Date().toISOString(),
+    };
+
+    const output = formatCLIReport(report);
+    expect(output).toContain("Plugin A");
+    expect(output).toContain("Plugin B");
+    expect(output).toContain("LOW USAGE");
+  });
+});

--- a/extensions/plugin-insights/test/report/html-report.test.ts
+++ b/extensions/plugin-insights/test/report/html-report.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { generateHTMLReport } from "../../src/report/html-report.js";
+import type { InsightsReport, PluginReport } from "../../src/types.js";
+
+function makePlugin(): PluginReport {
+  return {
+    pluginId: "test-plugin",
+    pluginName: "Test Plugin",
+    installedDays: 30,
+    triggerFrequency: {
+      pluginId: "test-plugin",
+      totalTriggers: 100,
+      triggersPerDay: 3.3,
+      triggersPerSession: 2.5,
+      dailyTrend: [
+        { date: "2026-03-15", count: 5 },
+        { date: "2026-03-16", count: 3 },
+      ],
+    },
+    tokenDelta: {
+      pluginId: "test-plugin",
+      avgTokensWithPlugin: 1100,
+      avgTokensWithoutPlugin: 900,
+      deltaTokens: 200,
+      deltaPercent: 22.2,
+      estimatedMonthlyCostUSD: 0.5,
+    },
+    conversationTurns: {
+      pluginId: "test-plugin",
+      avgTurnsWithPlugin: 3.5,
+      avgTurnsWithoutPlugin: 5.0,
+      deltaTurns: -1.5,
+      deltaPercent: -30,
+    },
+    implicitSatisfaction: {
+      pluginId: "test-plugin",
+      acceptanceRate: 82,
+      retryRate: 12,
+      correctionRate: 6,
+      totalSignals: 50,
+    },
+    verdict: {
+      level: "keep",
+      label: "KEEP — strong positive impact",
+      reason: "Good metrics",
+    },
+  };
+}
+
+describe("HTML Report", () => {
+  it("should generate valid HTML", () => {
+    const report: InsightsReport = {
+      periodStart: "2026-02-14",
+      periodEnd: "2026-03-16",
+      plugins: [makePlugin()],
+      generatedAt: new Date().toISOString(),
+    };
+
+    const html = generateHTMLReport(report);
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("Plugin Insights Dashboard");
+    expect(html).toContain("Test Plugin");
+    expect(html).toContain("100 (3.3/day)");
+  });
+
+  it("should include trend bars", () => {
+    const report: InsightsReport = {
+      periodStart: "2026-02-14",
+      periodEnd: "2026-03-16",
+      plugins: [makePlugin()],
+      generatedAt: new Date().toISOString(),
+    };
+
+    const html = generateHTMLReport(report);
+    expect(html).toContain("trend-bar");
+    expect(html).toContain("class=\"bar\"");
+  });
+
+  it("should escape HTML in plugin names", () => {
+    const plugin = makePlugin();
+    plugin.pluginName = '<script>alert("xss")</script>';
+
+    const report: InsightsReport = {
+      periodStart: "2026-02-14",
+      periodEnd: "2026-03-16",
+      plugins: [plugin],
+      generatedAt: new Date().toISOString(),
+    };
+
+    const html = generateHTMLReport(report);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/extensions/plugin-insights/test/report/html-report.test.ts
+++ b/extensions/plugin-insights/test/report/html-report.test.ts
@@ -73,7 +73,7 @@ describe("HTML Report", () => {
 
     const html = generateHTMLReport(report);
     expect(html).toContain("trend-bar");
-    expect(html).toContain("class=\"bar\"");
+    expect(html).toContain('class="bar"');
   });
 
   it("should escape HTML in plugin names", () => {

--- a/extensions/plugin-insights/test/report/json-export.test.ts
+++ b/extensions/plugin-insights/test/report/json-export.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runMigrations } from "../../src/db/migration.js";
 import { exportJSON, exportRawData } from "../../src/report/json-export.js";
 import type { InsightsReport, PluginReport } from "../../src/types.js";
@@ -84,11 +84,11 @@ describe("exportRawData", () => {
 
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens)
-       VALUES ('s1', 0, datetime('now'), 500)`
+       VALUES ('s1', 0, datetime('now'), 500)`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (1, 'mem', 'tool_call', 'search')`
+       VALUES (1, 'mem', 'tool_call', 'search')`,
     ).run();
   });
 

--- a/extensions/plugin-insights/test/report/json-export.test.ts
+++ b/extensions/plugin-insights/test/report/json-export.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { exportJSON, exportRawData } from "../../src/report/json-export.js";
+import type { InsightsReport, PluginReport } from "../../src/types.js";
+
+function makeReport(): InsightsReport {
+  return {
+    periodStart: "2026-02-14",
+    periodEnd: "2026-03-16",
+    generatedAt: new Date().toISOString(),
+    plugins: [
+      {
+        pluginId: "test",
+        pluginName: "Test",
+        installedDays: 30,
+        triggerFrequency: {
+          pluginId: "test",
+          totalTriggers: 10,
+          triggersPerDay: 1,
+          triggersPerSession: 1,
+          dailyTrend: [],
+        },
+        tokenDelta: {
+          pluginId: "test",
+          avgTokensWithPlugin: 1000,
+          avgTokensWithoutPlugin: 800,
+          deltaTokens: 200,
+          deltaPercent: 25,
+          estimatedMonthlyCostUSD: 0.3,
+        },
+        conversationTurns: {
+          pluginId: "test",
+          avgTurnsWithPlugin: 4,
+          avgTurnsWithoutPlugin: 5,
+          deltaTurns: -1,
+          deltaPercent: -20,
+        },
+        implicitSatisfaction: {
+          pluginId: "test",
+          acceptanceRate: 80,
+          retryRate: 15,
+          correctionRate: 5,
+          totalSignals: 20,
+        },
+        verdict: { level: "keep", label: "KEEP", reason: "Good" },
+      } as PluginReport,
+    ],
+  };
+}
+
+describe("exportJSON", () => {
+  it("should export as formatted JSON", () => {
+    const report = makeReport();
+    const content = exportJSON(report, { format: "json" });
+    const parsed = JSON.parse(content);
+    expect(parsed.plugins).toHaveLength(1);
+    expect(parsed.periodStart).toBe("2026-02-14");
+  });
+
+  it("should export as JSONL", () => {
+    const report = makeReport();
+    const content = exportJSON(report, { format: "jsonl" });
+    const lines = content.split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.pluginId).toBe("test");
+  });
+
+  it("should export compact JSON when pretty=false", () => {
+    const report = makeReport();
+    const pretty = exportJSON(report, { format: "json", pretty: true });
+    const compact = exportJSON(report, { format: "json", pretty: false });
+    expect(compact.length).toBeLessThan(pretty.length);
+  });
+});
+
+describe("exportRawData", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens)
+       VALUES ('s1', 0, datetime('now'), 500)`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (1, 'mem', 'tool_call', 'search')`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should export raw data with all tables and coverage", () => {
+    const content = exportRawData(db, { format: "json" });
+    const parsed = JSON.parse(content);
+    expect(parsed.turns).toHaveLength(1);
+    expect(parsed.pluginEvents).toHaveLength(1);
+    expect(parsed.satisfactionSignals).toHaveLength(0);
+    expect(parsed.llmScores).toHaveLength(0);
+    expect(parsed.exportedAt).toBeTruthy();
+    expect(parsed.coverage).toBeDefined();
+    expect(parsed.coverage.isComplete).toBe(true);
+    expect(parsed.coverage.unmappedTools).toHaveLength(0);
+  });
+});

--- a/extensions/plugin-insights/test/tools/tool-handlers.test.ts
+++ b/extensions/plugin-insights/test/tools/tool-handlers.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migration.js";
+import { createInsightsShowTool } from "../../src/tools/insights-show.js";
+import { createInsightsCompareTool } from "../../src/tools/insights-compare.js";
+import { ToolDetector } from "../../src/collector/tool-detector.js";
+import type { PluginInsightsConfig, AgentToolResult } from "../../src/types.js";
+import { DEFAULT_CONFIG } from "../../src/types.js";
+
+/** Extract text from an AgentToolResult */
+function resultText(result: AgentToolResult): string {
+  return (result.content[0] as { type: "text"; text: string }).text;
+}
+
+describe("insights_show tool handler", () => {
+  let db: Database.Database;
+  let toolDetector: ToolDetector;
+  const config: PluginInsightsConfig = { ...DEFAULT_CONFIG };
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    toolDetector = new ToolDetector(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should return 'no data' message when database is empty", async () => {
+    const tool = createInsightsShowTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", {});
+    expect(resultText(result)).toContain("No plugin attribution data");
+  });
+
+  it("should return a full report when data exists", async () => {
+    seedTestData(db);
+
+    const tool = createInsightsShowTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", {});
+
+    expect(resultText(result)).toContain("Plugin Insights Report");
+    expect(resultText(result)).toContain("mem");
+  });
+
+  it("should filter by plugin ID", async () => {
+    seedTestData(db);
+
+    const tool = createInsightsShowTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", { plugin: "mem" });
+
+    expect(resultText(result)).toContain("mem");
+    expect(resultText(result)).toContain("Triggers:");
+  });
+
+  it("should return error for unknown plugin ID", async () => {
+    seedTestData(db);
+
+    const tool = createInsightsShowTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", { plugin: "nonexistent" });
+
+    expect(resultText(result)).toContain("No data found");
+    expect(resultText(result)).toContain("Available plugins");
+  });
+
+  it("should respect days parameter", async () => {
+    // Insert old data (40 days ago) — both timestamp and created_at must be old
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, plugins_triggered_json)
+       VALUES ('s1', 0, datetime('now', '-40 days'), '["old-plug"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, created_at)
+       VALUES (1, 'old-plug', 'tool_call', 'x', datetime('now', '-40 days'))`
+    ).run();
+
+    const tool = createInsightsShowTool(db, config, toolDetector);
+
+    // 30 days should NOT include the old data
+    const result30 = await tool.execute("test-call-id", { days: 30 });
+    expect(resultText(result30)).toContain("No plugin attribution data");
+
+    // 60 days SHOULD include it
+    const result60 = await tool.execute("test-call-id", { days: 60 });
+    expect(resultText(result60)).toContain("old-plug");
+  });
+});
+
+describe("insights_compare tool handler", () => {
+  let db: Database.Database;
+  let toolDetector: ToolDetector;
+  const config: PluginInsightsConfig = { ...DEFAULT_CONFIG };
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+    toolDetector = new ToolDetector(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should compare two plugins", async () => {
+    seedTwoPlugins(db);
+
+    const tool = createInsightsCompareTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", { pluginA: "mem", pluginB: "fmt" });
+
+    expect(resultText(result)).toContain("mem");
+    expect(resultText(result)).toContain("fmt");
+    expect(resultText(result)).toContain("Total triggers");
+    expect(resultText(result)).toContain("Verdict");
+  });
+
+  it("should handle missing pluginA", async () => {
+    seedTwoPlugins(db);
+
+    const tool = createInsightsCompareTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", { pluginA: "nonexistent", pluginB: "fmt" });
+
+    expect(resultText(result)).toContain("No data found");
+    expect(resultText(result)).toContain("nonexistent");
+  });
+
+  it("should handle both plugins missing", async () => {
+    const tool = createInsightsCompareTool(db, config, toolDetector);
+    const result = await tool.execute("test-call-id", { pluginA: "a", pluginB: "b" });
+
+    expect(resultText(result)).toContain("No data found");
+  });
+});
+
+// --- Seed helpers ---
+
+function seedTestData(db: Database.Database) {
+  for (let i = 0; i < 10; i++) {
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (${i + 1}, 'mem', 'tool_call', 'memory_search')`
+    ).run();
+  }
+}
+
+function seedTwoPlugins(db: Database.Database) {
+  for (let i = 0; i < 10; i++) {
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (${i + 1}, 'mem', 'tool_call', 'search')`
+    ).run();
+  }
+  for (let i = 0; i < 6; i++) {
+    db.prepare(
+      `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
+       VALUES ('sf${i}', 0, datetime('now', '-${i} hours'), 300, '["fmt"]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
+       VALUES (${10 + i + 1}, 'fmt', 'tool_call', 'format')`
+    ).run();
+  }
+}

--- a/extensions/plugin-insights/test/tools/tool-handlers.test.ts
+++ b/extensions/plugin-insights/test/tools/tool-handlers.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { runMigrations } from "../../src/db/migration.js";
-import { createInsightsShowTool } from "../../src/tools/insights-show.js";
-import { createInsightsCompareTool } from "../../src/tools/insights-compare.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ToolDetector } from "../../src/collector/tool-detector.js";
+import { runMigrations } from "../../src/db/migration.js";
+import { createInsightsCompareTool } from "../../src/tools/insights-compare.js";
+import { createInsightsShowTool } from "../../src/tools/insights-show.js";
 import type { PluginInsightsConfig, AgentToolResult } from "../../src/types.js";
 import { DEFAULT_CONFIG } from "../../src/types.js";
 
@@ -67,11 +67,11 @@ describe("insights_show tool handler", () => {
     // Insert old data (40 days ago) — both timestamp and created_at must be old
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, plugins_triggered_json)
-       VALUES ('s1', 0, datetime('now', '-40 days'), '["old-plug"]')`
+       VALUES ('s1', 0, datetime('now', '-40 days'), '["old-plug"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action, created_at)
-       VALUES (1, 'old-plug', 'tool_call', 'x', datetime('now', '-40 days'))`
+       VALUES (1, 'old-plug', 'tool_call', 'x', datetime('now', '-40 days'))`,
     ).run();
 
     const tool = createInsightsShowTool(db, config, toolDetector);
@@ -137,11 +137,11 @@ function seedTestData(db: Database.Database) {
   for (let i = 0; i < 10; i++) {
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`
+       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (${i + 1}, 'mem', 'tool_call', 'memory_search')`
+       VALUES (${i + 1}, 'mem', 'tool_call', 'memory_search')`,
     ).run();
   }
 }
@@ -150,21 +150,21 @@ function seedTwoPlugins(db: Database.Database) {
   for (let i = 0; i < 10; i++) {
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`
+       VALUES ('s${i}', 0, datetime('now', '-${i} hours'), 500, '["mem"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (${i + 1}, 'mem', 'tool_call', 'search')`
+       VALUES (${i + 1}, 'mem', 'tool_call', 'search')`,
     ).run();
   }
   for (let i = 0; i < 6; i++) {
     db.prepare(
       `INSERT INTO turns (session_id, turn_index, timestamp, total_tokens, plugins_triggered_json)
-       VALUES ('sf${i}', 0, datetime('now', '-${i} hours'), 300, '["fmt"]')`
+       VALUES ('sf${i}', 0, datetime('now', '-${i} hours'), 300, '["fmt"]')`,
     ).run();
     db.prepare(
       `INSERT INTO plugin_events (turn_id, plugin_id, detection_method, action)
-       VALUES (${10 + i + 1}, 'fmt', 'tool_call', 'format')`
+       VALUES (${10 + i + 1}, 'fmt', 'tool_call', 'format')`,
     ).run();
   }
 }

--- a/package.json
+++ b/package.json
@@ -489,6 +489,7 @@
       "@tloncorp/api",
       "@whiskeysockets/baileys",
       "authenticate-pam",
+      "better-sqlite3",
       "esbuild",
       "koffi",
       "node-llama-cpp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,16 @@ importers:
 
   extensions/perplexity: {}
 
+  extensions/plugin-insights:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.8
+        version: 7.6.13
+
   extensions/qianfan: {}
 
   extensions/sglang: {}
@@ -3379,6 +3389,9 @@ packages:
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -3907,6 +3920,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3917,8 +3933,14 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   blamer@1.0.7:
     resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
@@ -3963,6 +3985,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -4026,6 +4051,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -4228,6 +4256,10 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -4449,6 +4481,10 @@ packages:
     resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
     engines: {node: '>=10'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4522,6 +4558,9 @@ packages:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   filename-reserved-regex@3.0.0:
     resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4585,6 +4624,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.3:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
@@ -4652,6 +4694,9 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   gitignore-to-glob@0.3.0:
     resolution: {integrity: sha512-mk74BdnK7lIwDHnotHddx1wsjMOFIThpLY3cPNniJ/2fA/tlLzHnFxIdR+4sLOu5KGgQJdij4kjJ2RoUNnCNMA==}
@@ -5365,6 +5410,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -5382,6 +5431,9 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -5425,6 +5477,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -5436,6 +5491,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-addon-api@8.6.0:
     resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
@@ -5806,6 +5865,12 @@ packages:
   postgres@3.4.8:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
     engines: {node: '>=12'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
@@ -6200,6 +6265,12 @@ packages:
     peerDependencies:
       signal-polyfill: ^0.2.0
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-git@3.32.3:
     resolution: {integrity: sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==}
 
@@ -6398,6 +6469,13 @@ packages:
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
@@ -10418,6 +10496,10 @@ snapshots:
 
   '@types/aws-lambda@8.10.161': {}
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -11023,6 +11105,11 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -11031,7 +11118,17 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@4.0.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   blamer@1.0.7:
     dependencies:
@@ -11092,6 +11189,11 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -11155,6 +11257,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -11346,6 +11450,10 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
 
   deep-extend@0.6.0: {}
 
@@ -11553,6 +11661,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -11687,6 +11797,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  file-uri-to-path@1.0.0: {}
+
   filename-reserved-regex@3.0.0: {}
 
   filenamify@6.0.0:
@@ -11753,6 +11865,8 @@ snapshots:
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.3:
     dependencies:
@@ -11848,6 +11962,8 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   gitignore-to-glob@0.3.0: {}
 
@@ -12613,6 +12729,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
@@ -12626,6 +12744,8 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
+
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@3.0.1: {}
 
@@ -12677,11 +12797,17 @@ snapshots:
 
   nanoid@5.1.6: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   node-addon-api@8.6.0: {}
 
@@ -13191,6 +13317,21 @@ snapshots:
 
   postgres@3.4.8: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-bytes@6.1.1: {}
 
   pretty-ms@8.0.0:
@@ -13421,7 +13562,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@5.0.0: {}
 
@@ -13721,6 +13861,14 @@ snapshots:
     dependencies:
       signal-polyfill: 0.2.2
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-git@3.32.3:
     dependencies:
       '@kwsites/file-exists': 1.1.1
@@ -13896,7 +14044,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -13933,6 +14080,21 @@ snapshots:
     dependencies:
       array-back: 6.2.2
       wordwrapjs: 5.1.1
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar-stream@3.1.8:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ onlyBuiltDependencies:
   - "@tloncorp/api"
   - "@whiskeysockets/baileys"
   - authenticate-pam
+  - better-sqlite3
   - esbuild
   - node-llama-cpp
   - protobufjs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ onlyBuiltDependencies:
   - "@tloncorp/api"
   - "@whiskeysockets/baileys"
   - authenticate-pam
-  - better-sqlite3
   - esbuild
   - node-llama-cpp
   - protobufjs


### PR DESCRIPTION
## Summary

- Add a new `plugin-insights` extension that automatically evaluates how much installed plugins actually help
- Tracks five metrics: trigger frequency, token delta, conversation turns, implicit satisfaction, and optional LLM-as-judge scoring
- All data stored locally in SQLite — no external services required
- Includes coverage diagnostics that persist unmapped tool observations across restarts, with disclaimers on all output paths (CLI, HTML dashboard, JSON export)

## Features

- **Non-invasive ContextEngine** — hooks into `after_tool_call` to collect data without affecting plugin behavior
- **Tool→plugin attribution** — configurable `toolMappings` in plugin config, with runtime discovery of unmapped tools
- **Six slash commands**: `/insights-show`, `/insights-compare`, `/insights-export`, `/insights-dashboard`, `/insights-reset`, `/insights-status`
- **Two agent tools**: `insights_show` and `insights_compare` for in-conversation use
- **Multiple output formats**: CLI text report, interactive HTML dashboard, JSON/JSONL export (all include coverage metadata)
- **83 tests** covering collectors, metrics, reports, commands, tools, and integration scenarios

## Test plan

- [ ] Run `pnpm test` for the extension tests (vitest, all 83 tests passing locally)
- [ ] Verify extension loads correctly via `openclaw.plugin.json` manifest
- [ ] Test with sample `toolMappings` config to confirm tool→plugin attribution works
- [ ] Verify unmapped tool diagnostics appear in `/insights-status` output
- [ ] Check that coverage disclaimers appear on all output paths when unmapped tools exist
