### PR TITLE
feat(bindings): add workspace override for project-specific context isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ ui/src/ui/__screenshots__
 ui/src/ui/views/__screenshots__
 ui/.vitest-attachments
 docs/superpowers
+.design-backup.md

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1190,6 +1190,7 @@ export async function processMessage(
     Timestamp: message.timestamp,
     OriginatingChannel: "bluebubbles",
     OriginatingTo: `bluebubbles:${outboundTarget}`,
+    WorkspaceOverride: route.workspaceOverride,
     WasMentioned: effectiveWasMentioned,
     CommandAuthorized: commandAuthorized,
   });

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -1108,6 +1108,7 @@ async function dispatchDiscordComponentEvent(params: {
     Timestamp: timestamp,
     OriginatingChannel: "discord" as const,
     OriginatingTo: `channel:${interactionCtx.channelId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await recordInboundSession({

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -390,6 +390,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     // Originating channel for reply routing.
     OriginatingChannel: "discord" as const,
     OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    WorkspaceOverride: route.workspaceOverride,
   });
   const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
 

--- a/extensions/discord/src/monitor/native-command-context.ts
+++ b/extensions/discord/src/monitor/native-command-context.ts
@@ -33,6 +33,7 @@ export type BuildDiscordNativeCommandContextParams = {
     tag?: string;
   };
   timestampMs?: number;
+  workspaceOverride?: string;
 };
 
 export function buildDiscordNativeCommandContext(params: BuildDiscordNativeCommandContextParams) {
@@ -89,5 +90,6 @@ export function buildDiscordNativeCommandContext(params: BuildDiscordNativeComma
       ? `user:${params.user.id}`
       : `channel:${params.channelId}`,
     ThreadParentId: params.isThreadChannel ? params.threadParentId : undefined,
+    WorkspaceOverride: params.workspaceOverride,
   });
 }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1686,6 +1686,7 @@ async function dispatchDiscordCommandInteraction(params: {
       globalName: user.globalName,
     },
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
+    workspaceOverride: effectiveRoute.workspaceOverride,
   });
 
   const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1591,6 +1591,7 @@ export async function handleFeishuMessage(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
+        WorkspaceOverride: route.workspaceOverride,
         GroupSystemPrompt: isGroup ? groupConfig?.systemPrompt?.trim() || undefined : undefined,
         ...mediaPayload,
       });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -259,6 +259,7 @@ async function processMessageWithPipeline(params: {
     GroupSystemPrompt: isGroup ? groupSystemPrompt : undefined,
     OriginatingChannel: "googlechat",
     OriginatingTo: `googlechat:${spaceId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   void core.channel.session

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -501,6 +501,7 @@ export function buildIMessageInboundContext(params: {
     CommandAuthorized: decision.commandAuthorized,
     OriginatingChannel: "imessage" as const,
     OriginatingTo: imessageTo,
+    WorkspaceOverride: decision.route.workspaceOverride,
   });
 
   return { ctxPayload, fromLabel, chatTarget, imessageTo, inboundHistory };

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -327,6 +327,7 @@ export async function handleIrcInbound(params: {
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: `irc:${peerId}`,
     CommandAuthorized: commandAuthorized,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await dispatchInboundReplyWithBase({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -617,6 +617,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         CommandSource: "text" as const,
         OriginatingChannel: "matrix" as const,
         OriginatingTo: `room:${roomId}`,
+        WorkspaceOverride: route.workspaceOverride,
         ThreadStarterBody: threadStarterBody,
         ThreadLabel: threadLabel,
         ParentSessionKey: parentSessionKey,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -687,6 +687,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           CommandAuthorized: false,
           OriginatingChannel: "mattermost" as const,
           OriginatingTo: to,
+          WorkspaceOverride: route.workspaceOverride,
         });
 
         const textLimit = core.channel.text.resolveTextChunkLimit(
@@ -976,6 +977,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       CommandSource: "native" as const,
       OriginatingChannel: "mattermost" as const,
       OriginatingTo: to,
+      WorkspaceOverride: params.route.workspaceOverride,
     });
 
     const tableMode = core.channel.text.resolveMarkdownTableMode({
@@ -1679,6 +1681,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "mattermost" as const,
       OriginatingTo: to,
+      WorkspaceOverride: route.workspaceOverride,
       ...mediaPayload,
     });
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -455,6 +455,7 @@ async function handleSlashCommandAsync(params: {
     CommandSource: "native" as const,
     OriginatingChannel: "mattermost" as const,
     OriginatingTo: to,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "mattermost", account.accountId, {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -526,6 +526,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "msteams" as const,
       OriginatingTo: teamsTo,
+      WorkspaceOverride: route.workspaceOverride,
       ...mediaPayload,
     });
 

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -281,6 +281,7 @@ export async function handleNextcloudTalkInbound(params: {
     Timestamp: message.timestamp,
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: `nextcloud-talk:${roomToken}`,
+    WorkspaceOverride: route.workspaceOverride,
     CommandAuthorized: commandAuthorized,
   });
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -218,6 +218,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
+      WorkspaceOverride: route.workspaceOverride,
     });
 
     await recordInboundSession({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -728,6 +728,7 @@ export async function prepareSlackMessage(params: {
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
+    WorkspaceOverride: route.workspaceOverride,
     NativeChannelId: message.channel,
   }) satisfies FinalizedMsgContext;
   const pinnedMainDmOwner = isDirectMessage

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -589,6 +589,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "slack" as const,
         OriginatingTo: `user:${command.user_id}`,
+        WorkspaceOverride: route.workspaceOverride,
       });
 
       await recordInboundSessionMetaSafe({

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -247,6 +247,7 @@ export async function buildTelegramInboundContextPayload(params: {
     IsForum: isForum,
     OriginatingChannel: "telegram" as const,
     OriginatingTo: `telegram:${chatId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const pinnedMainDmOwner = !isGroup

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -718,6 +718,7 @@ export const registerTelegramNativeCommands = ({
             // Originating context for sub-agent announce routing
             OriginatingChannel: "telegram" as const,
             OriginatingTo: `telegram:${chatId}`,
+            WorkspaceOverride: route.workspaceOverride,
           });
 
           await recordInboundSessionMetaSafe({

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -1057,6 +1057,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       ...(attachments.length > 0 && { Attachments: attachments }),
       OriginatingChannel: "tlon",
       OriginatingTo: `tlon:${isGroup ? groupChannel : botShipName}`,
+      WorkspaceOverride: route.workspaceOverride,
       // Include thread context for automatic reply routing
       ...(parentId && { ThreadId: String(parentId), ReplyToId: String(parentId) }),
     });

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -86,6 +86,7 @@ async function processTwitchMessage(params: {
     MessageSid: message.id,
     OriginatingChannel: "twitch",
     OriginatingTo: `twitch:channel:${message.channel}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -111,6 +111,7 @@ export function createWebOnMessageHandler(params: {
         Surface: "whatsapp",
         OriginatingChannel: "whatsapp",
         OriginatingTo: conversationId,
+        WorkspaceOverride: route.workspaceOverride,
       } satisfies MsgContext;
       updateLastRouteInBackground({
         cfg: params.cfg,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -331,6 +331,7 @@ export async function processMessage(params: {
     Surface: "whatsapp",
     OriginatingChannel: "whatsapp",
     OriginatingTo: params.msg.from,
+    WorkspaceOverride: params.route.workspaceOverride,
   });
 
   // Only update main session's lastRoute when DM actually IS the main session.

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -495,6 +495,7 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
     MediaUrl: mediaPath,
     OriginatingChannel: "zalo",
     OriginatingTo: `zalo:${chatId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await core.channel.session.recordInboundSession({

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -617,6 +617,7 @@ async function processMessage(
     }),
     OriginatingChannel: "zalouser",
     OriginatingTo: normalizedTo,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await core.channel.session.recordInboundSession({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -102,10 +102,14 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  const hasWorkspaceOverride = Boolean(ctx.WorkspaceOverride?.trim());
+  const workspaceDirRaw =
+    ctx.WorkspaceOverride?.trim() ||
+    (resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
-    ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
+    // Skip auto-creating bootstrap files in override workspaces — users manage those explicitly.
+    ensureBootstrapFiles: !hasWorkspaceOverride && !agentCfg?.skipBootstrap && !isFastTestEnv,
   });
   const workspaceDir = workspace.dir;
   const agentDir = resolveAgentDir(cfg, agentId);

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -47,6 +47,8 @@ export type MsgContext = {
   SessionKey?: string;
   /** Provider account id (multi-account). */
   AccountId?: string;
+  /** Binding-level workspace override for project-specific context isolation. */
+  WorkspaceOverride?: string;
   ParentSessionKey?: string;
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -303,6 +303,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "bindings[].match.peer": "Binding Peer Match",
   "bindings[].match.peer.kind": "Binding Peer Kind",
   "bindings[].match.peer.id": "Binding Peer ID",
+  "bindings[].workspace": "Binding Workspace Override",
   "bindings[].match.guildId": "Binding Guild ID",
   "bindings[].match.teamId": "Binding Team ID",
   "bindings[].match.roles": "Binding Roles",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -41,6 +41,8 @@ export type AgentRouteBinding = {
   agentId: string;
   comment?: string;
   match: AgentBindingMatch;
+  /** Override the agent workspace for this binding (project-specific context isolation). */
+  workspace?: string;
 };
 
 export type AgentAcpBinding = {

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -40,6 +40,7 @@ const RouteBindingSchema = z
     agentId: z.string(),
     comment: z.string().optional(),
     match: BindingMatchSchema,
+    workspace: z.string().trim().min(1).optional(),
   })
   .strict();
 

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -312,6 +312,7 @@ async function finalizeLineInboundContext(params: {
       ? resolveLineGroupSystemPrompt(params.account.config.groups, params.source)
       : undefined,
     InboundHistory: params.inboundHistory,
+    WorkspaceOverride: params.route.workspaceOverride,
   });
 
   const pinnedMainDmOwner = !params.source.isGroup

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -813,6 +813,135 @@ describe("role-based agent routing", () => {
   });
 });
 
+describe("binding-level workspace override", () => {
+  test("route carries workspaceOverride when binding has workspace field", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "/home/user/project-a/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-a" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-a" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("binding.peer");
+    expect(route.workspaceOverride).toBe("/home/user/project-a/");
+  });
+
+  test("route has no workspaceOverride when binding lacks workspace field", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-b" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-b" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("route has no workspaceOverride when no binding matches (default route)", () => {
+    const cfg: OpenClawConfig = {};
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "user-1" },
+    });
+    expect(route.matchedBy).toBe("default");
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("workspaceOverride is trimmed and empty strings are excluded", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "   ",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-empty" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-empty" },
+    });
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("different bindings can have different workspace overrides for same agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "/workspace/project-a/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-a" },
+          },
+        },
+        {
+          agentId: "main",
+          workspace: "/workspace/project-b/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-b" },
+          },
+        },
+      ],
+    };
+    const routeA = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-a" },
+    });
+    const routeB = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-b" },
+    });
+    expect(routeA.workspaceOverride).toBe("/workspace/project-a/");
+    expect(routeB.workspaceOverride).toBe("/workspace/project-b/");
+    expect(routeA.agentId).toBe(routeB.agentId);
+  });
+});
+
 describe("binding evaluation cache scalability", () => {
   test("does not rescan full bindings after channel/account cache rollover (#36915)", () => {
     const bindingCount = 2_205;

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -56,6 +56,8 @@ export type ResolvedAgentRoute = {
     | "binding.account"
     | "binding.channel"
     | "default";
+  /** Binding-level workspace override for project-specific context isolation. */
+  workspaceOverride?: string;
 };
 
 export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
@@ -658,7 +660,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
+  const choose = (
+    agentId: string,
+    matchedBy: ResolvedAgentRoute["matchedBy"],
+    workspaceOverride?: string,
+  ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
@@ -672,7 +678,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
     }).toLowerCase();
-    const route = {
+    const route: ResolvedAgentRoute = {
       agentId: resolvedAgentId,
       channel,
       accountId,
@@ -680,6 +686,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       mainSessionKey,
       lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
       matchedBy,
+      ...(workspaceOverride?.trim() ? { workspaceOverride: workspaceOverride.trim() } : {}),
     };
     if (routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);
@@ -796,7 +803,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      return choose(matched.binding.agentId, tier.matchedBy, matched.binding.workspace);
     }
   }
 


### PR DESCRIPTION
## Motivation

OpenClaw's workspace system provides excellent agent-level isolation — each agent gets its own `AGENTS.md`, `SOUL.md`, `MEMORY.md`, and `memory/` directory. But the fundamental unit of context isolation is wrong.

**The real isolation boundary isn't the agent. It's the conversation.**

Consider a common multi-project setup: one primary agent bound to three Matrix rooms — `#backend`, `#infrastructure`, `#research`. Today, all three rooms share one workspace. The agent's memory from a Kubernetes debugging session in `#infrastructure` bleeds into an unrelated API design discussion in `#backend`. There is no way to scope context to the conversation it belongs to.

The only workaround is creating duplicate agents (`main-backend`, `main-infra`, `main-research`) with separate workspaces. This works mechanically, but it's the wrong abstraction:

- **Identity fragmentation**: Three "copies" of the same agent with diverging memories. The agent in `#backend` doesn't know what happened in `#infrastructure` unless you manually cross-brief.
- **Config sprawl**: Every new project means a new agent entry, new bindings, new workspace setup. What should be a one-line config change becomes a multi-file operation.
- **Broken mental model**: Users think of agents as persistent identities. "My agent works on all my projects" is intuitive. "I have five copies of my agent, each knowing different things" is not.

OpenClaw already solved this at the agent level — `agents.list.*.workspace` gives each agent its own context. This PR extends the same pattern one level deeper: **bindings can override the workspace**, so the same agent loads different context depending on which conversation it's in.

## Token Efficiency

Beyond isolation, this directly reduces token waste in memory-heavy setups.

**Before:** A single workspace accumulates *all* project context in one `memory/` folder. When the agent recalls yesterday's work, `memory_search` scans everything — every project, every conversation, every tangent. Retrieved context is broader than needed, burning tokens on irrelevant memories.

**After:** Each project workspace has its own `memory/` folder. The agent only indexes memories relevant to the active conversation. Retrieval returns exactly the right project history — no noise.

This compounds over time. A workspace with months of mixed-project memories forces the agent to sift through hundreds of irrelevant entries on every recall. Scoped workspaces keep the index lean and retrieval precise.

Fewer indexed documents → fewer embedding comparisons → higher relevance in top-K results → fewer wasted context tokens → more room for actual work.

## The Fix

Add an optional `workspace` field to route bindings:

```json5
bindings: [
  {
    agentId: "main",
    workspace: "~/projects/backend/",
    match: { channel: "matrix", peer: { kind: "group", id: "!room1" } }
  },
  {
    agentId: "main",
    workspace: "~/projects/infra/",
    match: { channel: "matrix", peer: { kind: "group", id: "!room2" } }
  }
]
```

Same agent, same model, same personality — different memory per conversation. Bindings without `workspace` behave exactly as before.

## How It Works

The workspace override threads through three layers:

1. **Binding resolution** (`resolve-route.ts`): When a binding matches and has `workspace`, it's carried on `ResolvedAgentRoute.workspaceOverride`
2. **Context propagation**: Every channel handler passes `route.workspaceOverride` → `MsgContext.WorkspaceOverride`
3. **Workspace resolution** (`get-reply.ts`): `WorkspaceOverride` takes priority over the agent-level workspace for bootstrap files, memory search, and working directory

### What changes with an override active
- Bootstrap files (`AGENTS.md`, `SOUL.md`, `MEMORY.md`, `USER.md`) load from the override path
- `memory_search` indexes from the override workspace's `memory/` folder
- Tool working directory (`exec`, `read`, `write`) uses the override workspace
- Bootstrap file auto-creation is skipped — users manage override workspaces explicitly

### What stays the same
- Agent-level config (model, tools, identity, heartbeat) — resolved from agent config, not workspace
- `agentDir` — per-agent session state is unaffected
- Session keys — derived from agent ID + channel + peer as before
- Sub-agent spawning — inherits the active workspace through existing inheritance

## Impact on Token Usage

**None for existing users.** Bindings without `workspace` follow the exact same code path — the override check is a single falsy-or-default expression.

**For users with workspace overrides:** Each overridden workspace loads its own bootstrap files. If the override workspace has leaner files than the agent's main workspace, token usage decreases for that session. The user controls this. No system-injected tokens are added.

**No double-loading.** The override *replaces* the agent workspace, it doesn't layer on top.

## Scope

All channel handlers propagate `WorkspaceOverride`:

Telegram · Matrix · Discord · Slack · Signal · iMessage · Line · Feishu · Mattermost · MS Teams · WhatsApp · BlueBubbles · Google Chat · IRC · Tlon · Twitch · Zalo · Nextcloud Talk

34 files changed, +181/−5 lines. Zero new type errors, zero lint warnings.