### PR TITLE
feat(session): inject continuity hint after scheduled session reset

### DIFF
--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -40,5 +40,32 @@ export async function applySessionHints(params: {
     }
   }
 
+  // Inject a continuity hint when the session was reset by a scheduled policy (daily/idle)
+  // and the previous session ended with an assistant message — the agent may have been mid-task.
+  const resetHintMsg = params.sessionEntry?.lastAssistantMessageBeforeReset;
+  if (resetHintMsg) {
+    const resetHint = `Note: This session was automatically reset (daily/idle schedule). The last thing the assistant said before the reset was:\n"${resetHintMsg}"\nIf that suggests unfinished work, you may want to resume it.`;
+    prefixedBodyBase = `${resetHint}\n\n${prefixedBodyBase}`;
+    if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+      params.sessionEntry.lastAssistantMessageBeforeReset = undefined;
+      params.sessionEntry.updatedAt = Date.now();
+      params.sessionStore[params.sessionKey] = params.sessionEntry;
+      if (params.storePath) {
+        const sessionKey = params.sessionKey;
+        await updateSessionStore(params.storePath, (store) => {
+          const entry = store[sessionKey] ?? params.sessionEntry;
+          if (!entry) {
+            return;
+          }
+          store[sessionKey] = {
+            ...entry,
+            lastAssistantMessageBeforeReset: undefined,
+            updatedAt: Date.now(),
+          };
+        });
+      }
+    }
+  }
+
   return prefixedBodyBase;
 }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -29,7 +29,10 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
-import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
+import {
+  archiveSessionTranscripts,
+  readLastAssistantMessageFromTranscript,
+} from "../../gateway/session-utils.fs.js";
 import { resolveConversationIdFromTargets } from "../../infra/outbound/conversation-id.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -518,6 +521,23 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
+
+    // On a scheduled (daily/idle) reset — not an explicit /new or /reset — capture
+    // the last assistant message from the previous session's transcript.
+    // This lets the agent pick up where it left off if it was mid-task when the
+    // session rolled over. Explicit resets are intentional blanks; don't carry over.
+    if (!resetTriggered && previousSessionEntry) {
+      const MAX_HINT_CHARS = 500;
+      const lastMsg = readLastAssistantMessageFromTranscript(
+        previousSessionEntry.sessionId,
+        storePath,
+        previousSessionEntry.sessionFile,
+        agentId,
+      );
+      if (lastMsg) {
+        sessionEntry.lastAssistantMessageBeforeReset = lastMsg.slice(0, MAX_HINT_CHARS);
+      }
+    }
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -91,6 +91,12 @@ export type SessionEntry = {
   systemSent?: boolean;
   abortedLastRun?: boolean;
   /**
+   * Last assistant message text captured immediately before a scheduled (daily/idle) session reset.
+   * Not set for explicit /new or /reset triggers.
+   * Used to inject a continuity hint into the next session so the agent can resume mid-task work.
+   */
+  lastAssistantMessageBeforeReset?: string;
+  /**
    * Session-level stop cutoff captured when /stop is received.
    * Messages at/before this boundary are skipped to avoid replaying
    * queued pre-stop backlog.

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -476,6 +476,7 @@ const LAST_MSG_MAX_LINES = 20;
 function readLastMessagePreviewFromOpenTranscript(params: {
   fd: number;
   size: number;
+  role?: string;
 }): string | null {
   const readStart = Math.max(0, params.size - LAST_MSG_MAX_BYTES);
   const readLen = Math.min(params.size, LAST_MSG_MAX_BYTES);
@@ -486,12 +487,13 @@ function readLastMessagePreviewFromOpenTranscript(params: {
   const lines = chunk.split(/\r?\n/).filter((l) => l.trim());
   const tailLines = lines.slice(-LAST_MSG_MAX_LINES);
 
+  const acceptedRoles = params.role ? [params.role] : ["user", "assistant"];
   for (let i = tailLines.length - 1; i >= 0; i--) {
     const line = tailLines[i];
     try {
       const parsed = JSON.parse(line);
       const msg = parsed?.message as TranscriptMessage | undefined;
-      if (msg?.role !== "user" && msg?.role !== "assistant") {
+      if (!msg?.role || !acceptedRoles.includes(msg.role)) {
         continue;
       }
       const text = extractTextFromContent(msg.content);
@@ -523,6 +525,31 @@ export function readLastMessagePreviewFromTranscript(
       return null;
     }
     return readLastMessagePreviewFromOpenTranscript({ fd, size });
+  });
+}
+
+/**
+ * Reads the last assistant message text from a session transcript.
+ * Used to capture continuity context when a session is reset by a scheduled policy (daily/idle).
+ */
+export function readLastAssistantMessageFromTranscript(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+  agentId?: string,
+): string | null {
+  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile, agentId);
+  if (!filePath) {
+    return null;
+  }
+
+  return withOpenTranscriptFd(filePath, (fd) => {
+    const stat = fs.fstatSync(fd);
+    const size = stat.size;
+    if (size === 0) {
+      return null;
+    }
+    return readLastMessagePreviewFromOpenTranscript({ fd, size, role: "assistant" });
   });
 }
 


### PR DESCRIPTION
## Problem

When a session is reset by a **daily or idle policy**, the agent loses all context — including cases where it had just announced intent to perform work but hadn't executed it yet:

> "OK, starting to write the CNN page, I'll get right to it:"
> *(4 AM daily reset fires)*
> *(next morning: agent has no idea what it was doing)*

This is different from an explicit `/new` reset (intentional blank slate) — scheduled resets happen silently and can interrupt mid-task work.

## Solution

Capture the **last assistant message** from the outgoing session's transcript at reset time, and inject it as a one-shot hint into the first reply of the new session:

```
Note: This session was automatically reset (daily/idle schedule).
The last thing the assistant said before the reset was:
"OK, starting to write the CNN page, I'll get right to it:"
If that suggests unfinished work, you may want to resume it.
```

The hint is cleared after first use (same pattern as `abortedLastRun`).

## What's Not Changing

- Explicit `/new` and `/reset` carry nothing forward — intentional blanks stay blank
- No changes to reset timing or policies
- Hint only fires once per reset cycle

## Implementation

| File | Change |
|------|--------|
| `src/config/sessions/types.ts` | Add `lastAssistantMessageBeforeReset?: string` to `SessionEntry` |
| `src/gateway/session-utils.fs.ts` | Export `readLastAssistantMessageFromTranscript` (role-filtered tail reader) |
| `src/auto-reply/reply/session.ts` | On scheduled reset, read & store last assistant message (≤500 chars) |
| `src/auto-reply/reply/body.ts` | Prepend hint in `applySessionHints`, clear field after use |

The `readLastAssistantMessageFromTranscript` function reuses the existing `readLastMessagePreviewFromOpenTranscript` internal with a `role` filter — minimal surface area.