### PR TITLE
feat(plugin-runtime): expose deliverOutboundPayloads on PluginRuntime

### DIFF
--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -259,7 +259,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
     },
     outbound: {
-      deliverOutboundPayloads: vi.fn(async () => []),
+      deliverOutboundPayloads: vi.fn(
+        async () => [],
+      ) as unknown as PluginRuntime["outbound"]["deliverOutboundPayloads"],
     },
     subagent: {
       run: vi.fn(),

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -258,6 +258,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       resolveApiKeyForProvider:
         vi.fn() as unknown as PluginRuntime["modelAuth"]["resolveApiKeyForProvider"],
     },
+    outbound: {
+      deliverOutboundPayloads: vi.fn(async () => []),
+    },
     subagent: {
       run: vi.fn(),
       waitForRun: vi.fn(),

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -63,12 +63,14 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
           mirror: _mi,
           session: _se,
           deps: _de,
+          abortSignal: _as,
           ...publicParams
         } = params as typeof params & {
           skipQueue?: unknown;
           mirror?: unknown;
           session?: unknown;
           deps?: unknown;
+          abortSignal?: unknown;
         };
         return deliverOutboundPayloads(publicParams);
       },

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -64,10 +64,13 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
           session: _se,
           deps: _de,
           ...publicParams
-        } = params as Record<string, unknown>;
-        return deliverOutboundPayloads(
-          publicParams as Parameters<typeof deliverOutboundPayloads>[0],
-        );
+        } = params as typeof params & {
+          skipQueue?: unknown;
+          mirror?: unknown;
+          session?: unknown;
+          deps?: unknown;
+        };
+        return deliverOutboundPayloads(publicParams);
       },
     },
     system: createRuntimeSystem(),

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -4,6 +4,7 @@ import {
   resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
 } from "../../agents/model-auth.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { deliverOutboundPayloads } from "../../infra/outbound/deliver-runtime.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -54,6 +55,21 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     version: resolveVersion(),
     config: createRuntimeConfig(),
     subagent: _options.subagent ?? createUnavailableSubagentRuntime(),
+    outbound: {
+      deliverOutboundPayloads: (params) => {
+        // Strip internal-only fields at runtime so JS/CJS plugins cannot bypass safeguards.
+        const {
+          skipQueue: _sq,
+          mirror: _mi,
+          session: _se,
+          deps: _de,
+          ...publicParams
+        } = params as Record<string, unknown>;
+        return deliverOutboundPayloads(
+          publicParams as Parameters<typeof deliverOutboundPayloads>[0],
+        );
+      },
+    },
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),
     tts: { textToSpeechTelephony },

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,4 +1,7 @@
-import type { OutboundDeliveryResult, deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
+import type {
+  OutboundDeliveryResult,
+  deliverOutboundPayloads,
+} from "../../infra/outbound/deliver.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,5 +1,4 @@
-import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
-import type { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
+import type { OutboundDeliveryResult, deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -12,6 +12,7 @@ import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 export type {
   NormalizedOutboundPayload,
   OutboundChannel,
+  OutboundDeliveryResult,
   OutboundIdentity,
   ReplyPayload,
   RuntimeLogger,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -75,7 +75,13 @@ export type PluginRuntime = PluginRuntimeCore & {
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
   };
   outbound: {
-    /** Send payloads through the standard outbound delivery pipeline (chunking, hooks, queue). */
+    /**
+     * Send payloads through the standard outbound delivery pipeline (chunking, hooks, queue).
+     *
+     * Note: when `bestEffort` is true and no `onError` callback is provided,
+     * per-payload delivery failures are silently swallowed and the returned
+     * results array may be shorter than the input payloads array.
+     */
     deliverOutboundPayloads: (
       params: PluginDeliverOutboundParams,
     ) => Promise<OutboundDeliveryResult[]>;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,12 +1,21 @@
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { deliverOutboundPayloads } from "../../infra/outbound/deliver-runtime.js";
 import type {
   NormalizedOutboundPayload,
   OutboundDeliveryResult,
-  deliverOutboundPayloads,
 } from "../../infra/outbound/deliver.js";
+import type { OutboundIdentity } from "../../infra/outbound/identity.js";
+import type { OutboundChannel } from "../../infra/outbound/targets.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
-export type { NormalizedOutboundPayload, RuntimeLogger };
+export type {
+  NormalizedOutboundPayload,
+  OutboundChannel,
+  OutboundIdentity,
+  ReplyPayload,
+  RuntimeLogger,
+};
 
 // ── Outbound delivery types (plugin-facing) ─────────────────────────
 

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -22,11 +22,11 @@ export type {
 
 /**
  * Plugin-facing params for `deliverOutboundPayloads`.
- * Internal fields (`skipQueue`, `mirror`, `session`, `deps`) are excluded.
+ * Internal fields (`skipQueue`, `mirror`, `session`, `deps`, `abortSignal`) are excluded.
  */
 export type PluginDeliverOutboundParams = Omit<
   Parameters<typeof deliverOutboundPayloads>[0],
-  "skipQueue" | "mirror" | "session" | "deps"
+  "skipQueue" | "mirror" | "session" | "deps" | "abortSignal"
 >;
 
 // ── Subagent runtime types ──────────────────────────────────────────

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,7 +1,20 @@
+import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
+import type { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
 export type { RuntimeLogger };
+
+// ── Outbound delivery types (plugin-facing) ─────────────────────────
+
+/**
+ * Plugin-facing params for `deliverOutboundPayloads`.
+ * Internal fields (`skipQueue`, `mirror`, `session`, `deps`) are excluded.
+ */
+export type PluginDeliverOutboundParams = Omit<
+  Parameters<typeof deliverOutboundPayloads>[0],
+  "skipQueue" | "mirror" | "session" | "deps"
+>;
 
 // ── Subagent runtime types ──────────────────────────────────────────
 
@@ -58,6 +71,12 @@ export type PluginRuntime = PluginRuntimeCore & {
     /** @deprecated Use getSessionMessages. */
     getSession: (params: SubagentGetSessionParams) => Promise<SubagentGetSessionResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
+  };
+  outbound: {
+    /** Send payloads through the standard outbound delivery pipeline (chunking, hooks, queue). */
+    deliverOutboundPayloads: (
+      params: PluginDeliverOutboundParams,
+    ) => Promise<OutboundDeliveryResult[]>;
   };
   channel: PluginRuntimeChannel;
 };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,11 +1,12 @@
 import type {
+  NormalizedOutboundPayload,
   OutboundDeliveryResult,
   deliverOutboundPayloads,
 } from "../../infra/outbound/deliver.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
-export type { RuntimeLogger };
+export type { NormalizedOutboundPayload, RuntimeLogger };
 
 // ── Outbound delivery types (plugin-facing) ─────────────────────────
 


### PR DESCRIPTION
## Background

I'm building a plugin that receives webhooks, such as GITHUB webhooks, summarizes them with AI, and delivers notifications to an app like Discord. This requires **push-based** outbound delivery — the plugin registers an HTTP route, receives external events asynchronously, and sends messages to a channel.

Today, the only built-in way to trigger cross-channel delivery through the standard pipeline is via **cron** (pull-based). But many real-world integrations are inherently event-driven: GitHub webhooks, CI/CD notifications, alerting systems, payment callbacks, etc. Forcing these into cron means polling external APIs on a schedule, which leads to:

- **Cron list explosion** — one cron job per repo/service/event type
- **Unnecessary polling** — frequent heartbeats burning API quota for "anything new?" checks
- **Delayed delivery** — events sit until the next cron tick instead of arriving instantly

Push-based plugins solve all of this, but they currently lack access to the standard outbound delivery pipeline. The only option is calling channel-specific send functions (`sendMessageDiscord`, `sendMessageTelegram`, etc.) directly, which bypasses:

- **Message chunking** — automatic splitting at channel limits (e.g., Discord's 2000-char limit)
- **Hook dispatch** — `message_sending` / `message_sent` plugin hooks are not fired
- **Write-ahead delivery queue** — crash recovery for in-flight messages
- **Thread/forum support** — automatic thread routing and forum channel handling
- **Identity injection** — agent name/avatar resolution

## Summary

- Add `runtime.outbound.deliverOutboundPayloads` to `PluginRuntime`, enabling plugins to send messages through the standard outbound delivery pipeline
- Sanitize params at both type level and runtime level to prevent plugins from accessing internal-only options

## Prior art

- PR #5912 (`runtime.outbound.sendToSession`) — similar intent, closed by triage bot
- PR #5400 — parent PR, also closed by triage bot
- PR #32079 (`runtime.system.deliverToSession`) — closed, Greptile scored 5/5

All three were closed without maintainer review due to PR queue volume, not technical objections.

## Changes

| File | Change |
|------|--------|
| `src/plugins/runtime/types.ts` | Define `PluginDeliverOutboundParams` via `Omit<>` to exclude `@internal` fields (`skipQueue`, `mirror`, `session`, `deps`); add `outbound.deliverOutboundPayloads` to `PluginRuntime` type |
| `src/plugins/runtime/index.ts` | Wire implementation via `deliver-runtime.js` with a runtime wrapper that strips internal fields, preventing JS/CJS plugins from bypassing write-ahead persistence |
| `extensions/test-utils/plugin-runtime-mock.ts` | Add `outbound` mock |

## Usage

```typescript
const cfg = runtime.config.loadConfig();
await runtime.outbound.deliverOutboundPayloads({
  cfg,
  channel: "discord",
  to: "channel:123456789",
  payloads: [{ text: "Hello from plugin!" }],
});
```

## Test plan

- [x] `pnpm tsgo` passes (no new type errors)
- [x] Existing test suite passes
- [x] Validated end-to-end with a GitHub webhook → AI summary → Discord notification plugin
- [x] Passing `skipQueue`/`mirror`/`session`/`deps` from JS plugin has no effect (stripped at runtime)