### PR TITLE
feat(bindings): add workspace override for project-specific context isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/superpowers
 
 # Deprecated changelog fragment workflow
 changelog/fragments/
+.design-backup.md

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -7767,6 +7767,19 @@
       "hasChildren": false
     },
     {
+      "path": "bindings.*.workspace",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Binding Workspace Override",
+      "hasChildren": false
+    },
+    {
       "path": "broadcast",
       "kind": "core",
       "type": "object",
@@ -8347,8 +8360,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/bluebubbles",
-      "help": "BlueBubbles channel provider configuration used for Apple messaging bridge integrations. Keep DM policy aligned with your trusted sender model in shared deployments.",
+      "label": "BlueBubbles",
+      "help": "iMessage via the BlueBubbles mac app + REST API.",
       "hasChildren": true
     },
     {
@@ -9317,8 +9330,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/discord",
-      "help": "Discord channel provider configuration for bot auth, retry policy, streaming, thread bindings, and optional voice capabilities. Keep privileged intents and advanced features disabled unless needed.",
+      "label": "Discord",
+      "help": "very well supported right now.",
       "hasChildren": true
     },
     {
@@ -15229,7 +15242,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/feishu",
+      "label": "Feishu",
+      "help": "飞书/Lark enterprise messaging with doc/wiki/drive tools.",
       "hasChildren": true
     },
     {
@@ -17230,7 +17244,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/googlechat",
+      "label": "Google Chat",
+      "help": "Google Workspace Chat app via HTTP webhooks.",
       "hasChildren": true
     },
     {
@@ -18616,8 +18631,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/imessage",
-      "help": "iMessage channel provider configuration for CLI integration and DM access policy handling. Use explicit CLI paths when runtime environments have non-standard binary locations.",
+      "label": "iMessage",
+      "help": "this is still a work in progress.",
       "hasChildren": true
     },
     {
@@ -19974,8 +19989,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/irc",
-      "help": "IRC channel provider configuration and compatibility settings for classic IRC transport workflows. Use this section when bridging legacy chat infrastructure into OpenClaw.",
+      "label": "IRC",
+      "help": "classic IRC networks with DM/channel routing and pairing controls.",
       "hasChildren": true
     },
     {
@@ -21497,7 +21512,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/line",
+      "label": "LINE",
+      "help": "LINE Messaging API bot for Japan/Taiwan/Thailand markets.",
       "hasChildren": true
     },
     {
@@ -22065,7 +22081,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/matrix",
+      "label": "Matrix",
+      "help": "open protocol; install the plugin to enable.",
       "hasChildren": true
     },
     {
@@ -23122,8 +23139,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/mattermost",
-      "help": "Mattermost channel provider configuration for bot credentials, base URL, and message trigger modes. Keep mention/trigger rules strict in high-volume team channels.",
+      "label": "Mattermost",
+      "help": "self-hosted Slack-style chat; install the plugin to enable.",
       "hasChildren": true
     },
     {
@@ -24253,8 +24270,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/msteams",
-      "help": "Microsoft Teams channel provider configuration and provider-specific policy toggles. Use this section to isolate Teams behavior from other enterprise chat providers.",
+      "label": "Microsoft Teams",
+      "help": "Bot Framework; enterprise support.",
       "hasChildren": true
     },
     {
@@ -25185,7 +25202,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/nextcloud-talk",
+      "label": "Nextcloud Talk",
+      "help": "Self-hosted chat via Nextcloud Talk webhook bots.",
       "hasChildren": true
     },
     {
@@ -26405,7 +26423,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/nostr",
+      "label": "Nostr",
+      "help": "Decentralized protocol; encrypted DMs via NIP-04.",
       "hasChildren": true
     },
     {
@@ -26633,8 +26652,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/signal",
-      "help": "Signal channel provider configuration including account identity and DM policy behavior. Keep account mapping explicit so routing remains stable across multi-device setups.",
+      "label": "Signal",
+      "help": "signal-cli linked device; more setup (David Reagans: \"Hop on Discord.\").",
       "hasChildren": true
     },
     {
@@ -28180,8 +28199,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/slack",
-      "help": "Slack channel provider configuration for bot/app tokens, streaming behavior, and DM policy controls. Keep token handling and thread behavior explicit to avoid noisy workspace interactions.",
+      "label": "Slack",
+      "help": "supported (Socket Mode).",
       "hasChildren": true
     },
     {
@@ -31012,7 +31031,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/synology-chat",
+      "label": "Synology Chat",
+      "help": "Connect your Synology NAS Chat to OpenClaw with full agent capabilities.",
       "hasChildren": true
     },
     {
@@ -31035,8 +31055,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/telegram",
-      "help": "Telegram channel provider configuration including auth tokens, retry behavior, and message rendering controls. Use this section to tune bot behavior for Telegram-specific API semantics.",
+      "label": "Telegram",
+      "help": "simplest way to get started — register a bot with @BotFather and get going.",
       "hasChildren": true
     },
     {
@@ -31176,6 +31196,16 @@
         "number",
         "string"
       ],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.telegram.accounts.*.apiRoot",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -33083,6 +33113,21 @@
       "deprecated": false,
       "sensitive": false,
       "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.telegram.apiRoot",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "channels",
+        "network"
+      ],
+      "label": "Telegram API Root URL",
+      "help": "Custom Telegram Bot API root URL. Use for self-hosted Bot API servers (https://github.com/tdlib/telegram-bot-api) or reverse proxies in regions where api.telegram.org is blocked.",
       "hasChildren": false
     },
     {
@@ -35027,7 +35072,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/tlon",
+      "label": "Tlon",
+      "help": "decentralized messaging on Urbit; install the plugin to enable.",
       "hasChildren": true
     },
     {
@@ -35465,7 +35511,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/twitch",
+      "label": "Twitch",
+      "help": "Twitch chat integration",
       "hasChildren": true
     },
     {
@@ -35854,8 +35901,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/whatsapp",
-      "help": "WhatsApp channel provider configuration for access policy and message batching behavior. Use this section to tune responsiveness and direct-message routing safety for WhatsApp chats.",
+      "label": "WhatsApp",
+      "help": "works with your own number; recommend a separate phone + eSIM.",
       "hasChildren": true
     },
     {
@@ -37222,7 +37269,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/zalo",
+      "label": "Zalo",
+      "help": "Vietnam-focused messaging platform with Bot API.",
       "hasChildren": true
     },
     {
@@ -37802,7 +37850,8 @@
         "channels",
         "network"
       ],
-      "label": "@openclaw/zalouser",
+      "label": "Zalo Personal",
+      "help": "Zalo personal account via QR code login.",
       "hasChildren": true
     },
     {

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5549}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5552}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -688,6 +688,7 @@
 {"recordType":"path","path":"bindings.*.match.roles.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"bindings.*.match.teamId","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Binding Team ID","help":"Optional team/workspace ID constraint used by providers that scope chats under teams. Add this when you need bindings isolated to one workspace context.","hasChildren":false}
 {"recordType":"path","path":"bindings.*.type","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Binding Type","help":"Binding kind. Use \"route\" (or omit for legacy route entries) for normal routing, and \"acp\" for persistent ACP conversation bindings.","hasChildren":false}
+{"recordType":"path","path":"bindings.*.workspace","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Binding Workspace Override","hasChildren":false}
 {"recordType":"path","path":"broadcast","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Broadcast","help":"Broadcast routing map for sending the same outbound message to multiple peer IDs per source conversation. Keep this minimal and audited because one source can fan out to many destinations.","hasChildren":true}
 {"recordType":"path","path":"broadcast.*","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Broadcast Destination List","help":"Per-source broadcast destination list where each key is a source peer ID and the value is an array of destination peer IDs. Keep lists intentional to avoid accidental message amplification.","hasChildren":true}
 {"recordType":"path","path":"broadcast.*.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -730,7 +731,7 @@
 {"recordType":"path","path":"canvasHost.port","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Canvas Host Port","help":"TCP port used by the canvas host HTTP server when canvas hosting is enabled. Choose a non-conflicting port and align firewall/proxy policy accordingly.","hasChildren":false}
 {"recordType":"path","path":"canvasHost.root","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Canvas Host Root Directory","help":"Filesystem root directory served by canvas host for canvas content and static assets. Use a dedicated directory and avoid broad repo roots for least-privilege file exposure.","hasChildren":false}
 {"recordType":"path","path":"channels","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Channels","help":"Channel provider configurations plus shared defaults that control access policies, heartbeat visibility, and per-surface behavior. Keep defaults centralized and override per provider only where required.","hasChildren":true}
-{"recordType":"path","path":"channels.bluebubbles","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/bluebubbles","help":"BlueBubbles channel provider configuration used for Apple messaging bridge integrations. Keep DM policy aligned with your trusted sender model in shared deployments.","hasChildren":true}
+{"recordType":"path","path":"channels.bluebubbles","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"BlueBubbles","help":"iMessage via the BlueBubbles mac app + REST API.","hasChildren":true}
 {"recordType":"path","path":"channels.bluebubbles.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.bluebubbles.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -818,7 +819,7 @@
 {"recordType":"path","path":"channels.bluebubbles.serverUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.bluebubbles.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.discord","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/discord","help":"Discord channel provider configuration for bot auth, retry policy, streaming, thread bindings, and optional voice capabilities. Keep privileged intents and advanced features disabled unless needed.","hasChildren":true}
+{"recordType":"path","path":"channels.discord","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Discord","help":"very well supported right now.","hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.ackReaction","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1352,7 +1353,7 @@
 {"recordType":"path","path":"channels.discord.voice.tts.provider","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.voice.tts.summaryModel","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.voice.tts.timeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/feishu","hasChildren":true}
+{"recordType":"path","path":"channels.feishu","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Feishu","help":"飞书/Lark enterprise messaging with doc/wiki/drive tools.","hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1532,7 +1533,7 @@
 {"recordType":"path","path":"channels.feishu.webhookHost","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookPath","kind":"channel","type":"string","required":true,"defaultValue":"/feishu/events","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookPort","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.googlechat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/googlechat","hasChildren":true}
+{"recordType":"path","path":"channels.googlechat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Google Chat","help":"Google Workspace Chat app via HTTP webhooks.","hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1660,7 +1661,7 @@
 {"recordType":"path","path":"channels.googlechat.typingIndicator","kind":"channel","type":"string","required":false,"enumValues":["none","message","reaction"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.webhookUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.imessage","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/imessage","help":"iMessage channel provider configuration for CLI integration and DM access policy handling. Use explicit CLI paths when runtime environments have non-standard binary locations.","hasChildren":true}
+{"recordType":"path","path":"channels.imessage","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"iMessage","help":"this is still a work in progress.","hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1788,7 +1789,7 @@
 {"recordType":"path","path":"channels.imessage.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.service","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.irc","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/irc","help":"IRC channel provider configuration and compatibility settings for classic IRC transport workflows. Use this section when bridging legacy chat infrastructure into OpenClaw.","hasChildren":true}
+{"recordType":"path","path":"channels.irc","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"IRC","help":"classic IRC networks with DM/channel routing and pairing controls.","hasChildren":true}
 {"recordType":"path","path":"channels.irc.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.irc.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1928,7 +1929,7 @@
 {"recordType":"path","path":"channels.irc.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.tls","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.irc.username","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.line","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/line","hasChildren":true}
+{"recordType":"path","path":"channels.line","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"LINE","help":"LINE Messaging API bot for Japan/Taiwan/Thailand markets.","hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.line.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1980,7 +1981,7 @@
 {"recordType":"path","path":"channels.line.secretFile","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.line.tokenFile","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.line.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.matrix","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/matrix","hasChildren":true}
+{"recordType":"path","path":"channels.matrix","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Matrix","help":"open protocol; install the plugin to enable.","hasChildren":true}
 {"recordType":"path","path":"channels.matrix.accessToken","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.accounts.*","kind":"channel","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2077,7 +2078,7 @@
 {"recordType":"path","path":"channels.matrix.threadBindings.spawnSubagentSessions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.threadReplies","kind":"channel","type":"string","required":false,"enumValues":["off","inbound","always"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.userId","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.mattermost","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/mattermost","help":"Mattermost channel provider configuration for bot credentials, base URL, and message trigger modes. Keep mention/trigger rules strict in high-volume team channels.","hasChildren":true}
+{"recordType":"path","path":"channels.mattermost","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Mattermost","help":"self-hosted Slack-style chat; install the plugin to enable.","hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.accounts.*.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -2177,7 +2178,7 @@
 {"recordType":"path","path":"channels.mattermost.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Mattermost Require Mention","help":"Require @mention in channels before responding (default: true).","hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.msteams","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/msteams","help":"Microsoft Teams channel provider configuration and provider-specific policy toggles. Use this section to isolate Teams behavior from other enterprise chat providers.","hasChildren":true}
+{"recordType":"path","path":"channels.msteams","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Microsoft Teams","help":"Bot Framework; enterprise support.","hasChildren":true}
 {"recordType":"path","path":"channels.msteams.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.appId","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2265,7 +2266,7 @@
 {"recordType":"path","path":"channels.msteams.webhook","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.webhook.path","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.webhook.port","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.nextcloud-talk","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/nextcloud-talk","hasChildren":true}
+{"recordType":"path","path":"channels.nextcloud-talk","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Nextcloud Talk","help":"Self-hosted chat via Nextcloud Talk webhook bots.","hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -2381,7 +2382,7 @@
 {"recordType":"path","path":"channels.nextcloud-talk.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.webhookPort","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.webhookPublicUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.nostr","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/nostr","hasChildren":true}
+{"recordType":"path","path":"channels.nostr","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Nostr","help":"Decentralized protocol; encrypted DMs via NIP-04.","hasChildren":true}
 {"recordType":"path","path":"channels.nostr.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nostr.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nostr.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2402,7 +2403,7 @@
 {"recordType":"path","path":"channels.nostr.profile.website","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nostr.relays","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nostr.relays.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.signal","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/signal","help":"Signal channel provider configuration including account identity and DM policy behavior. Keep account mapping explicit so routing remains stable across multi-device setups.","hasChildren":true}
+{"recordType":"path","path":"channels.signal","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Signal","help":"signal-cli linked device; more setup (David Reagans: \"Hop on Discord.\").","hasChildren":true}
 {"recordType":"path","path":"channels.signal.account","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Signal Account","help":"Signal account identifier (phone/number handle) used to bind this channel config to a specific Signal identity. Keep this aligned with your linked device/session state.","hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -2546,7 +2547,7 @@
 {"recordType":"path","path":"channels.signal.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.startupTimeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.slack","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/slack","help":"Slack channel provider configuration for bot/app tokens, streaming behavior, and DM policy controls. Keep token handling and thread behavior explicit to avoid noisy workspace interactions.","hasChildren":true}
+{"recordType":"path","path":"channels.slack","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Slack","help":"supported (Socket Mode).","hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.ackReaction","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2798,9 +2799,9 @@
 {"recordType":"path","path":"channels.slack.userToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.userTokenReadOnly","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":["auth","channels","network","security"],"label":"Slack User Token Read Only","help":"When true, treat configured Slack user token usage as read-only helper behavior where possible. Keep enabled if you only need supplemental reads without user-context writes.","hasChildren":false}
 {"recordType":"path","path":"channels.slack.webhookPath","kind":"channel","type":"string","required":true,"defaultValue":"/slack/events","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.synology-chat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/synology-chat","hasChildren":true}
+{"recordType":"path","path":"channels.synology-chat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Synology Chat","help":"Connect your Synology NAS Chat to OpenClaw with full agent capabilities.","hasChildren":true}
 {"recordType":"path","path":"channels.synology-chat.*","kind":"channel","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.telegram","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/telegram","help":"Telegram channel provider configuration including auth tokens, retry behavior, and message rendering controls. Use this section to tune bot behavior for Telegram-specific API semantics.","hasChildren":true}
+{"recordType":"path","path":"channels.telegram","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Telegram","help":"simplest way to get started — register a bot with @BotFather and get going.","hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.ackReaction","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2815,6 +2816,7 @@
 {"recordType":"path","path":"channels.telegram.accounts.*.actions.sticker","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.accounts.*.apiRoot","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.blockStreamingCoalesce.idleMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2992,6 +2994,7 @@
 {"recordType":"path","path":"channels.telegram.actions.sticker","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.apiRoot","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Telegram API Root URL","help":"Custom Telegram Bot API root URL. Use for self-hosted Bot API servers (https://github.com/tdlib/telegram-bot-api) or reverse proxies in regions where api.telegram.org is blocked.","hasChildren":false}
 {"recordType":"path","path":"channels.telegram.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.blockStreamingCoalesce.idleMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3158,7 +3161,7 @@
 {"recordType":"path","path":"channels.telegram.webhookSecret.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.webhookSecret.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.webhookUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.tlon","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/tlon","hasChildren":true}
+{"recordType":"path","path":"channels.tlon","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Tlon","help":"decentralized messaging on Urbit; install the plugin to enable.","hasChildren":true}
 {"recordType":"path","path":"channels.tlon.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.tlon.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.tlon.accounts.*.allowPrivateNetwork","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3201,7 +3204,7 @@
 {"recordType":"path","path":"channels.tlon.ship","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.tlon.showModelSignature","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.tlon.url","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.twitch","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/twitch","hasChildren":true}
+{"recordType":"path","path":"channels.twitch","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Twitch","help":"Twitch chat integration","hasChildren":true}
 {"recordType":"path","path":"channels.twitch.accessToken","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.twitch.accounts","kind":"channel","type":"object","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.twitch.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -3237,7 +3240,7 @@
 {"recordType":"path","path":"channels.twitch.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.twitch.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.twitch.username","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.whatsapp","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/whatsapp","help":"WhatsApp channel provider configuration for access policy and message batching behavior. Use this section to tune responsiveness and direct-message routing safety for WhatsApp chats.","hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"WhatsApp","help":"works with your own number; recommend a separate phone + eSIM.","hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.ackReaction","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -3365,7 +3368,7 @@
 {"recordType":"path","path":"channels.whatsapp.selfChatMode","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"WhatsApp Self-Phone Mode","help":"Same-phone setup (bot uses your personal WhatsApp number).","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalo","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/zalo","hasChildren":true}
+{"recordType":"path","path":"channels.zalo","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Zalo","help":"Vietnam-focused messaging platform with Bot API.","hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -3417,7 +3420,7 @@
 {"recordType":"path","path":"channels.zalo.webhookSecret.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.webhookSecret.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo.webhookUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.zalouser","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"@openclaw/zalouser","hasChildren":true}
+{"recordType":"path","path":"channels.zalouser","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Zalo Personal","help":"Zalo personal account via QR code login.","hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.zalouser.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1192,6 +1192,7 @@ export async function processMessage(
     Timestamp: message.timestamp,
     OriginatingChannel: "bluebubbles",
     OriginatingTo: `bluebubbles:${outboundTarget}`,
+    WorkspaceOverride: route.workspaceOverride,
     WasMentioned: effectiveWasMentioned,
     CommandAuthorized: commandAuthorized,
   });

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -168,6 +168,7 @@ export type DiscordComponentEntry = {
   sessionKey?: string;
   agentId?: string;
   accountId?: string;
+  workspaceOverride?: string;
   reusable?: boolean;
   allowedUsers?: string[];
   messageId?: string;
@@ -199,6 +200,7 @@ export type DiscordModalEntry = {
   sessionKey?: string;
   agentId?: string;
   accountId?: string;
+  workspaceOverride?: string;
   reusable?: boolean;
   messageId?: string;
   createdAt?: number;
@@ -951,6 +953,7 @@ export function buildDiscordComponentMessage(params: {
   sessionKey?: string;
   agentId?: string;
   accountId?: string;
+  workspaceOverride?: string;
 }): DiscordComponentBuildResult {
   const entries: DiscordComponentEntry[] = [];
   const modals: DiscordModalEntry[] = [];
@@ -978,6 +981,7 @@ export function buildDiscordComponentMessage(params: {
       sessionKey: params.sessionKey,
       agentId: params.agentId,
       accountId: params.accountId,
+      workspaceOverride: params.workspaceOverride,
       reusable: entry.reusable ?? params.spec.reusable,
     });
   };
@@ -1077,6 +1081,7 @@ export function buildDiscordComponentMessage(params: {
       sessionKey: params.sessionKey,
       agentId: params.agentId,
       accountId: params.accountId,
+      workspaceOverride: params.workspaceOverride,
       reusable: params.spec.reusable,
       allowedUsers: params.spec.modal.allowedUsers,
     });

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -245,7 +245,12 @@ async function dispatchDiscordComponentEvent(params: {
   guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
   eventText: string;
   replyToId?: string;
-  routeOverrides?: { sessionKey?: string; agentId?: string; accountId?: string };
+  routeOverrides?: {
+    sessionKey?: string;
+    agentId?: string;
+    accountId?: string;
+    workspaceOverride?: string;
+  };
 }): Promise<void> {
   const { ctx, interaction, interactionCtx, channelCtx, guildInfo, eventText } = params;
   const runtime = ctx.runtime ?? createNonExitingRuntime();
@@ -366,6 +371,7 @@ async function dispatchDiscordComponentEvent(params: {
     Timestamp: timestamp,
     OriginatingChannel: "discord" as const,
     OriginatingTo: `channel:${interactionCtx.channelId}`,
+    WorkspaceOverride: params.routeOverrides?.workspaceOverride ?? route.workspaceOverride,
   });
 
   await recordInboundSession({
@@ -638,6 +644,7 @@ async function handleDiscordComponentEvent(params: {
       sessionKey: consumed.sessionKey,
       agentId: consumed.agentId,
       accountId: consumed.accountId,
+      workspaceOverride: consumed.workspaceOverride,
     },
   });
 }
@@ -1268,6 +1275,7 @@ class DiscordComponentModal extends Modal {
         sessionKey: consumed.sessionKey,
         agentId: consumed.agentId,
         accountId: consumed.accountId,
+        workspaceOverride: consumed.workspaceOverride,
       },
     });
   }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -391,6 +391,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     // Originating channel for reply routing.
     OriginatingChannel: "discord" as const,
     OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    WorkspaceOverride: route.workspaceOverride,
   });
   const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
 

--- a/extensions/discord/src/monitor/native-command-context.ts
+++ b/extensions/discord/src/monitor/native-command-context.ts
@@ -33,6 +33,7 @@ export type BuildDiscordNativeCommandContextParams = {
     tag?: string;
   };
   timestampMs?: number;
+  workspaceOverride?: string;
 };
 
 export function buildDiscordNativeCommandContext(params: BuildDiscordNativeCommandContextParams) {
@@ -89,5 +90,6 @@ export function buildDiscordNativeCommandContext(params: BuildDiscordNativeComma
       ? `user:${params.user.id}`
       : `channel:${params.channelId}`,
     ThreadParentId: params.isThreadChannel ? params.threadParentId : undefined,
+    WorkspaceOverride: params.workspaceOverride,
   });
 }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -768,6 +768,7 @@ async function dispatchDiscordCommandInteraction(params: {
       globalName: user.globalName,
     },
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
+    workspaceOverride: effectiveRoute.workspaceOverride,
   });
 
   const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -49,6 +49,7 @@ type DiscordComponentSendOpts = {
   replyTo?: string;
   sessionKey?: string;
   agentId?: string;
+  workspaceOverride?: string;
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   filename?: string;
@@ -76,6 +77,7 @@ export async function sendDiscordComponentMessage(
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
     accountId: accountInfo.accountId,
+    workspaceOverride: opts.workspaceOverride,
   });
   const flags = buildDiscordComponentMessageFlags(buildResult.components);
   const finalFlags = opts.silent

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -922,6 +922,7 @@ export async function handleFeishuMessage(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
+        WorkspaceOverride: route.workspaceOverride,
         GroupSystemPrompt: isGroup ? groupConfig?.systemPrompt?.trim() || undefined : undefined,
         ...mediaPayload,
       });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -263,6 +263,7 @@ async function processMessageWithPipeline(params: {
     GroupSystemPrompt: isGroup ? groupSystemPrompt : undefined,
     OriginatingChannel: "googlechat",
     OriginatingTo: `googlechat:${spaceId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   void core.channel.session

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -499,6 +499,7 @@ export function buildIMessageInboundContext(params: {
     CommandAuthorized: decision.commandAuthorized,
     OriginatingChannel: "imessage" as const,
     OriginatingTo: imessageTo,
+    WorkspaceOverride: decision.route.workspaceOverride,
   });
 
   return { ctxPayload, fromLabel, chatTarget, imessageTo, inboundHistory };

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -323,6 +323,7 @@ export async function handleIrcInbound(params: {
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: `irc:${peerId}`,
     CommandAuthorized: commandAuthorized,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await dispatchInboundReplyWithBase({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -765,6 +765,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         CommandSource: "text" as const,
         OriginatingChannel: "matrix" as const,
         OriginatingTo: `room:${roomId}`,
+        WorkspaceOverride: route.workspaceOverride,
       });
 
       await core.channel.session.recordInboundSession({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -448,6 +448,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           CommandAuthorized: false,
           OriginatingChannel: "mattermost" as const,
           OriginatingTo: to,
+          WorkspaceOverride: route.workspaceOverride,
         });
 
         const textLimit = core.channel.text.resolveTextChunkLimit(
@@ -637,6 +638,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       CommandSource: "native" as const,
       OriginatingChannel: "mattermost" as const,
       OriginatingTo: to,
+      WorkspaceOverride: params.route.workspaceOverride,
     });
 
     const tableMode = core.channel.text.resolveMarkdownTableMode({
@@ -1340,6 +1342,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "mattermost" as const,
       OriginatingTo: to,
+      WorkspaceOverride: route.workspaceOverride,
       ...mediaPayload,
     });
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -454,6 +454,7 @@ async function handleSlashCommandAsync(params: {
     CommandSource: "native" as const,
     OriginatingChannel: "mattermost" as const,
     OriginatingTo: to,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "mattermost", account.accountId, {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -533,6 +533,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "msteams" as const,
       OriginatingTo: teamsTo,
+      WorkspaceOverride: route.workspaceOverride,
       ...mediaPayload,
     });
 

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -277,6 +277,7 @@ export async function handleNextcloudTalkInbound(params: {
     Timestamp: message.timestamp,
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: `nextcloud-talk:${roomToken}`,
+    WorkspaceOverride: route.workspaceOverride,
     CommandAuthorized: commandAuthorized,
   });
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -216,6 +216,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
+      WorkspaceOverride: route.workspaceOverride,
     });
 
     await recordInboundSession({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -728,6 +728,7 @@ export async function prepareSlackMessage(params: {
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
+    WorkspaceOverride: route.workspaceOverride,
     NativeChannelId: message.channel,
   }) satisfies FinalizedMsgContext;
   const pinnedMainDmOwner = isDirectMessage

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -588,6 +588,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "slack" as const,
         OriginatingTo: `user:${command.user_id}`,
+        WorkspaceOverride: route.workspaceOverride,
       });
 
       await recordInboundSessionMetaSafe({

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -248,6 +248,7 @@ export async function buildTelegramInboundContextPayload(params: {
     IsForum: isForum,
     OriginatingChannel: "telegram" as const,
     OriginatingTo: `telegram:${chatId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const pinnedMainDmOwner = !isGroup

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -760,6 +760,7 @@ export const registerTelegramNativeCommands = ({
             // Originating context for sub-agent announce routing
             OriginatingChannel: "telegram" as const,
             OriginatingTo: `telegram:${chatId}`,
+            WorkspaceOverride: route.workspaceOverride,
           });
 
           await recordInboundSessionMetaSafe({

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -533,6 +533,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       ...(attachments.length > 0 && { Attachments: attachments }),
       OriginatingChannel: "tlon",
       OriginatingTo: `tlon:${isGroup ? groupChannel : botShipName}`,
+      WorkspaceOverride: route.workspaceOverride,
       // Include thread context for automatic reply routing
       ...(parentId && { ThreadId: String(parentId), ReplyToId: String(parentId) }),
     });

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -86,6 +86,7 @@ async function processTwitchMessage(params: {
     MessageSid: message.id,
     OriginatingChannel: "twitch",
     OriginatingTo: `twitch:channel:${message.channel}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -111,6 +111,7 @@ export function createWebOnMessageHandler(params: {
         Surface: "whatsapp",
         OriginatingChannel: "whatsapp",
         OriginatingTo: conversationId,
+        WorkspaceOverride: route.workspaceOverride,
       } satisfies MsgContext;
       updateLastRouteInBackground({
         cfg: params.cfg,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -334,6 +334,7 @@ export async function processMessage(params: {
     Surface: "whatsapp",
     OriginatingChannel: "whatsapp",
     OriginatingTo: params.msg.from,
+    WorkspaceOverride: params.route.workspaceOverride,
   });
 
   // Only update main session's lastRoute when DM actually IS the main session.

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -487,6 +487,7 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
     MediaUrl: mediaPath,
     OriginatingChannel: "zalo",
     OriginatingTo: `zalo:${chatId}`,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await core.channel.session.recordInboundSession({

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -615,6 +615,7 @@ async function processMessage(
     }),
     OriginatingChannel: "zalouser",
     OriginatingTo: normalizedTo,
+    WorkspaceOverride: route.workspaceOverride,
   });
 
   await core.channel.session.recordInboundSession({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -10,6 +10,7 @@ import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
+import { logDebug } from "../../logger.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -102,12 +103,20 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  const workspaceOverrideTrimmed = ctx.WorkspaceOverride?.trim();
+  const hasWorkspaceOverride = Boolean(workspaceOverrideTrimmed);
+  const workspaceDirRaw =
+    workspaceOverrideTrimmed ||
+    (resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
-    ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
+    // Skip auto-creating bootstrap files in override workspaces — users manage those explicitly.
+    ensureBootstrapFiles: !hasWorkspaceOverride && !agentCfg?.skipBootstrap && !isFastTestEnv,
   });
   const workspaceDir = workspace.dir;
+  logDebug(
+    `[workspace] agent=${agentId} binding-override=${workspaceOverrideTrimmed || "none"} agent-config=${resolveAgentWorkspaceDir(cfg, agentId) || "default"} resolved=${workspaceDirRaw}`,
+  );
   const agentDir = resolveAgentDir(cfg, agentId);
   const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
   const configuredTypingSeconds =

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -47,6 +47,8 @@ export type MsgContext = {
   SessionKey?: string;
   /** Provider account id (multi-account). */
   AccountId?: string;
+  /** Binding-level workspace override for project-specific context isolation. */
+  WorkspaceOverride?: string;
   ParentSessionKey?: string;
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -290,6 +290,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "bindings[].match.peer": "Binding Peer Match",
   "bindings[].match.peer.kind": "Binding Peer Kind",
   "bindings[].match.peer.id": "Binding Peer ID",
+  "bindings[].workspace": "Binding Workspace Override",
   "bindings[].match.guildId": "Binding Guild ID",
   "bindings[].match.teamId": "Binding Team ID",
   "bindings[].match.roles": "Binding Roles",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -41,6 +41,8 @@ export type AgentRouteBinding = {
   agentId: string;
   comment?: string;
   match: AgentBindingMatch;
+  /** Override the agent workspace for this binding (project-specific context isolation). */
+  workspace?: string;
 };
 
 export type AgentAcpBinding = {

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -40,6 +40,7 @@ const RouteBindingSchema = z
     agentId: z.string(),
     comment: z.string().optional(),
     match: BindingMatchSchema,
+    workspace: z.string().trim().min(1).optional(),
   })
   .strict();
 

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -312,6 +312,7 @@ async function finalizeLineInboundContext(params: {
       ? resolveLineGroupSystemPrompt(params.account.config.groups, params.source)
       : undefined,
     InboundHistory: params.inboundHistory,
+    WorkspaceOverride: params.route.workspaceOverride,
   });
 
   const pinnedMainDmOwner = !params.source.isGroup

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -813,6 +813,167 @@ describe("role-based agent routing", () => {
   });
 });
 
+describe("binding-level workspace override", () => {
+  test("route carries workspaceOverride when binding has workspace field", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "/home/user/project-a/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-a" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-a" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("binding.peer");
+    expect(route.workspaceOverride).toBe("/home/user/project-a/");
+  });
+
+  test("route has no workspaceOverride when binding lacks workspace field", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-b" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-b" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("route has no workspaceOverride when no binding matches (default route)", () => {
+    const cfg: OpenClawConfig = {};
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: null,
+      peer: { kind: "direct", id: "user-1" },
+    });
+    expect(route.matchedBy).toBe("default");
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("workspaceOverride is trimmed and empty strings are excluded", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "   ",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-empty" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-empty" },
+    });
+    expect(route.workspaceOverride).toBeUndefined();
+  });
+
+  test("binding workspace override takes precedence over agent-level workspace config", () => {
+    // Both sources coexist: agent has its own workspace config, and the binding also
+    // has a workspace override. The route carries the binding value; get-reply then
+    // uses it instead of the agent-level config.
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "dev", workspace: "/agent/config/workspace" }],
+      },
+      bindings: [
+        {
+          agentId: "dev",
+          workspace: "/binding/project-workspace/",
+          match: {
+            channel: "slack",
+            accountId: "default",
+            peer: { kind: "channel", id: "C123" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: "default",
+      peer: { kind: "channel", id: "C123" },
+    });
+    expect(route.agentId).toBe("dev");
+    expect(route.matchedBy).toBe("binding.peer");
+    // Binding workspace override wins; agent-level "/agent/config/workspace" is not surfaced here.
+    expect(route.workspaceOverride).toBe("/binding/project-workspace/");
+  });
+
+  test("different bindings can have different workspace overrides for same agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+      bindings: [
+        {
+          agentId: "main",
+          workspace: "/workspace/project-a/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-a" },
+          },
+        },
+        {
+          agentId: "main",
+          workspace: "/workspace/project-b/",
+          match: {
+            channel: "matrix",
+            accountId: "bot",
+            peer: { kind: "group", id: "!room-b" },
+          },
+        },
+      ],
+    };
+    const routeA = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-a" },
+    });
+    const routeB = resolveAgentRoute({
+      cfg,
+      channel: "matrix",
+      accountId: "bot",
+      peer: { kind: "group", id: "!room-b" },
+    });
+    expect(routeA.workspaceOverride).toBe("/workspace/project-a/");
+    expect(routeB.workspaceOverride).toBe("/workspace/project-b/");
+    expect(routeA.agentId).toBe(routeB.agentId);
+  });
+});
+
 describe("binding evaluation cache scalability", () => {
   test("does not rescan full bindings after channel/account cache rollover (#36915)", () => {
     const bindingCount = 2_205;

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -56,6 +56,8 @@ export type ResolvedAgentRoute = {
     | "binding.account"
     | "binding.channel"
     | "default";
+  /** Binding-level workspace override for project-specific context isolation. */
+  workspaceOverride?: string;
 };
 
 export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
@@ -658,7 +660,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
+  const choose = (
+    agentId: string,
+    matchedBy: ResolvedAgentRoute["matchedBy"],
+    workspaceOverride?: string,
+  ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
@@ -672,7 +678,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
     }).toLowerCase();
-    const route = {
+    const route: ResolvedAgentRoute = {
       agentId: resolvedAgentId,
       channel,
       accountId,
@@ -680,6 +686,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       mainSessionKey,
       lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
       matchedBy,
+      ...(workspaceOverride?.trim() ? { workspaceOverride: workspaceOverride.trim() } : {}),
     };
     if (routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);
@@ -796,7 +803,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      return choose(matched.binding.agentId, tier.matchedBy, matched.binding.workspace);
     }
   }
 


### PR DESCRIPTION
## Motivation

OpenClaw's workspace system provides excellent agent-level isolation — each agent gets its own `AGENTS.md`, `SOUL.md`, `MEMORY.md`, and `memory/` directory. But the fundamental unit of context isolation is wrong.

**The real isolation boundary isn't the agent. It's the conversation.**

Consider a common multi-project setup: one primary agent bound to three Matrix rooms — `#backend`, `#infrastructure`, `#research`. Today, all three rooms share one workspace. The agent's memory from a Kubernetes debugging session in `#infrastructure` bleeds into an unrelated API design discussion in `#backend`. There is no way to scope context to the conversation it belongs to.

The only workaround is creating duplicate agents (`main-backend`, `main-infra`, `main-research`) with separate workspaces. This works mechanically, but it's the wrong abstraction:

- **Identity fragmentation**: Three "copies" of the same agent with diverging memories. The agent in `#backend` doesn't know what happened in `#infrastructure` unless you manually cross-brief.
- **Config sprawl**: Every new project means a new agent entry, new bindings, new workspace setup. What should be a one-line config change becomes a multi-file operation.
- **Broken mental model**: Users think of agents as persistent identities. "My agent works on all my projects" is intuitive. "I have five copies of my agent, each knowing different things" is not.

OpenClaw already solved this at the agent level — `agents.list.*.workspace` gives each agent its own context. This PR extends the same pattern one level deeper: **bindings can override the workspace**, so the same agent loads different context depending on which conversation it's in.

## Token Efficiency

Beyond isolation, this directly reduces token waste in memory-heavy setups.

**Before:** A single workspace accumulates *all* project context in one `memory/` folder. When the agent recalls yesterday's work, `memory_search` scans everything — every project, every conversation, every tangent. Retrieved context is broader than needed, burning tokens on irrelevant memories.

**After:** Each project workspace has its own `memory/` folder. The agent only indexes memories relevant to the active conversation. Retrieval returns exactly the right project history — no noise.

Fewer indexed documents → fewer embedding comparisons → higher relevance in top-K results → fewer wasted context tokens → more room for actual work.

## The Fix

Add an optional `workspace` field to route bindings:

```json5
bindings: [
  {
    agentId: "main",
    workspace: "~/projects/backend/",
    match: { channel: "matrix", peer: { kind: "group", id: "!room1" } }
  },
  {
    agentId: "main",
    workspace: "~/projects/infra/",
    match: { channel: "matrix", peer: { kind: "group", id: "!room2" } }
  }
]
```

Same agent, same model, same personality — different memory per conversation. Bindings without `workspace` behave exactly as before.

## How It Works

The workspace override threads through three layers:

1. **Binding resolution** (`resolve-route.ts`): When a binding matches and has `workspace`, it's carried on `ResolvedAgentRoute.workspaceOverride`
2. **Context propagation**: Every channel handler passes `route.workspaceOverride` → `MsgContext.WorkspaceOverride`
3. **Workspace resolution** (`get-reply.ts`): `WorkspaceOverride` takes priority over the agent-level workspace for bootstrap files, memory search, and working directory

### What changes with an override active
- Bootstrap files (`AGENTS.md`, `SOUL.md`, `MEMORY.md`, `USER.md`) load from the override path
- `memory_search` indexes from the override workspace's `memory/` folder
- Tool working directory (`exec`, `read`, `write`) uses the override workspace
- Bootstrap file auto-creation is skipped — users manage override workspaces explicitly

### What stays the same
- Agent-level config (model, tools, identity, heartbeat) — resolved from agent config, not workspace
- `agentDir` — per-agent session state is unaffected
- Session keys — derived from agent ID + channel + peer as before
- Sub-agent spawning — inherits the active workspace through existing inheritance

### Discord component interactions
When Discord buttons/selects/modals are created, the active `workspaceOverride` is stored on the component entry. When the interaction fires later, the stored workspace is threaded back through `routeOverrides`, ensuring the reply runs in the correct project workspace even if routing has changed since the component was rendered.

## Scope

All channel handlers propagate `WorkspaceOverride`:

Telegram · Matrix · Discord · Slack · Signal · iMessage · Line · Feishu · Mattermost · MS Teams · WhatsApp · BlueBubbles · Google Chat · IRC · Tlon · Twitch · Zalo · Nextcloud Talk

35 files changed, +192/−6 lines. Zero new type errors, zero lint warnings.
