### PR TITLE
fix(skills): trust user-configured env vars in skills.entries.<skill>.env

### DIFF
--- a/src/agents/skills/env-overrides.test.ts
+++ b/src/agents/skills/env-overrides.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applySkillEnvOverrides } from "./env-overrides.js";
+import type { SkillEntry } from "./types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+describe("skills/env-overrides", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear any env vars set by previous tests
+    for (const key of Object.keys(process.env)) {
+      if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    // Restore original env
+    for (const key of Object.keys(process.env)) {
+      if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  describe("user-configured env vars in skills.entries.<skill>.env", () => {
+    it("should allow API_KEY patterns when explicitly configured by user", () => {
+      const skillKey = "tavily";
+      const envKey = "TAVILY_API_KEY";
+      const envValue = "tvly-dev-test-key";
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {},
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              env: {
+                [envKey]: envValue,
+              },
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      expect(process.env[envKey]).toBe(envValue);
+
+      revert();
+
+      expect(process.env[envKey]).toBeUndefined();
+    });
+
+    it("should allow TOKEN patterns when explicitly configured by user", () => {
+      const skillKey = "test-service";
+      const envKey = "TEST_SERVICE_TOKEN";
+      const envValue = "test-token-value";
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {},
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              env: {
+                [envKey]: envValue,
+              },
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      expect(process.env[envKey]).toBe(envValue);
+
+      revert();
+
+      expect(process.env[envKey]).toBeUndefined();
+    });
+
+    it("should block dangerous host env vars even when configured by user", () => {
+      const skillKey = "test-skill";
+      const envKey = "OPENSSL_CONF";
+      const envValue = "/malicious/path";
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {},
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              env: {
+                [envKey]: envValue,
+              },
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      expect(process.env[envKey]).toBeUndefined();
+
+      revert();
+    });
+
+    it("should block env vars with null bytes", () => {
+      const skillKey = "test-skill";
+      const envKey = "TEST_API_KEY";
+      const envValue = "value\0with-null";
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {},
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              env: {
+                [envKey]: envValue,
+              },
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      expect(process.env[envKey]).toBeUndefined();
+
+      revert();
+    });
+
+    it("should respect primaryEnv metadata when injecting apiKey", () => {
+      const skillKey = "tavily";
+      const envKey = "TAVILY_API_KEY";
+      const apiKey = "tvly-dev-test-key";
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {
+          primaryEnv: envKey,
+        },
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              apiKey,
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      expect(process.env[envKey]).toBe(apiKey);
+
+      revert();
+
+      expect(process.env[envKey]).toBeUndefined();
+    });
+
+    it("should not override externally managed env vars", () => {
+      const skillKey = "tavily";
+      const envKey = "TAVILY_API_KEY";
+      const externalValue = "external-key";
+      const configValue = "config-key";
+
+      // Set external env var
+      process.env[envKey] = externalValue;
+
+      const skillEntry: SkillEntry = {
+        skill: {
+          name: skillKey,
+          version: "1.0.0",
+          description: "Test skill",
+        },
+        metadata: {},
+        location: "/test/skill",
+      };
+
+      const config: OpenClawConfig = {
+        skills: {
+          entries: {
+            [skillKey]: {
+              enabled: true,
+              env: {
+                [envKey]: configValue,
+              },
+            },
+          },
+        },
+      };
+
+      const revert = applySkillEnvOverrides({
+        skills: [skillEntry],
+        config,
+      });
+
+      // Should keep external value, not override with config
+      expect(process.env[envKey]).toBe(externalValue);
+
+      revert();
+
+      expect(process.env[envKey]).toBe(externalValue);
+    });
+  });
+});

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -163,6 +163,10 @@ function applySkillConfigEnvOverrides(params: {
         continue;
       }
       pendingOverrides[envKey] = envValue;
+      // Trust user-configured env vars from openclaw.json skills.entries.<skill>.env
+      // These are explicit user choices and should be allowed even if they match
+      // sensitive patterns (e.g., TAVILY_API_KEY).
+      allowedSensitiveKeys.add(envKey);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #48214

**Problem:**
Gateway's env injection system was blocking all environment variables matching \*_API_KEY\, \*_TOKEN\, etc. patterns, even when users explicitly configured them in \openclaw.json\ under \skills.entries.<skill>.env\.

This prevented skills from receiving their required API keys, despite users explicitly configuring them.

**Root Cause:**
The \sanitizeEnvVars\ function in \sanitize-env-vars.ts\ uses a blanket blocked pattern: \/_?(API_KEY|TOKEN|PASSWORD|PRIVATE_KEY|SECRET)\$/i\

This pattern matches all sensitive-looking env vars, but the \llowedSensitiveKeys\ mechanism only included vars declared in skill metadata (\primaryEnv\, \equiredEnv\), not user-configured vars.

**Solution:**
Add user-configured env vars from \skills.entries.<skill>.env\ to the \llowedSensitiveKeys\ set before sanitization. This trusts explicit user choices while still enforcing:

1. \isAlwaysBlockedSkillEnvKey\ check (blocks dangerous host vars like \OPENSSL_CONF\)
2. \alidateEnvVarValue\ check (blocks null bytes, validates length)
3. External env var precedence (won't override existing \process.env\)

## Changes

- Modified \pplySkillConfigEnvOverrides\ in \src/agents/skills/env-overrides.ts\ to add user-configured env vars to \llowedSensitiveKeys\
- Added comprehensive test suite in \src/agents/skills/env-overrides.test.ts\

## Testing

All tests pass:
- API_KEY patterns now allowed when user-configured
- TOKEN patterns now allowed when user-configured
- Dangerous host env vars still blocked
- Null bytes still blocked
- \primaryEnv\ metadata still works
- External env vars not overridden

Fixes #48214