### PR TITLE
fix(telegram): persist sticky IPv4 fallback across polling restarts (fixes #48177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: trigger overflow recovery from the tool-result guard once post-compaction context still exceeds the safe threshold, so long tool loops compact before the next model call hard-fails. (#29371) thanks @keshav55.
 - macOS/exec approvals: harden exec-host request HMAC verification to use a timing-safe compare and keep malformed or truncated signatures fail-closed in focused IPC auth coverage.
 - Gateway/exec approvals: surface requested env override keys in gateway-host approval prompts so operators can review surviving env context without inheriting noisy base host env.
+- Telegram/network: preserve sticky IPv4 fallback state across polling restarts so hosts with unstable IPv6 to `api.telegram.org` stop re-triggering repeated Telegram timeouts after each restart. (#48282) Thanks @yassinebkr.
 - Plugins/subagents: forward per-run provider and model overrides through gateway plugin subagent dispatch so plugin-launched agent delegations honor explicit model selection again. (#48277) Thanks @jalehman.
 
 ### Fixes

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -134,9 +134,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     : null;
   const telegramCfg = account.config;
 
-  const telegramTransport = opts.telegramTransport ?? resolveTelegramTransport(opts.proxyFetch, {
-    network: telegramCfg.network,
-  });
+  const telegramTransport =
+    opts.telegramTransport ??
+    resolveTelegramTransport(opts.proxyFetch, {
+      network: telegramCfg.network,
+    });
   const shouldProvideFetch = Boolean(telegramTransport.fetch);
   // grammY's ApiClientOptions types still track `node-fetch` types; Node 22+ global fetch
   // (undici) is structurally compatible at runtime but not assignable in TS.

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -38,7 +38,7 @@ import {
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
-import { resolveTelegramTransport } from "./fetch.js";
+import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
@@ -65,6 +65,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Pre-resolved Telegram transport to reuse across bot instances. If not provided, creates a new one. */
+  telegramTransport?: TelegramTransport;
 };
 
 export { getTelegramSequentialKey };
@@ -132,7 +134,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     : null;
   const telegramCfg = account.config;
 
-  const telegramTransport = resolveTelegramTransport(opts.proxyFetch, {
+  const telegramTransport = opts.telegramTransport ?? resolveTelegramTransport(opts.proxyFetch, {
     network: telegramCfg.network,
   });
   const shouldProvideFetch = Boolean(telegramTransport.fetch);

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -82,6 +82,12 @@ const { readTelegramUpdateOffsetSpy } = vi.hoisted(() => ({
 const { startTelegramWebhookSpy } = vi.hoisted(() => ({
   startTelegramWebhookSpy: vi.fn(async () => ({ server: { close: vi.fn() }, stop: vi.fn() })),
 }));
+const { resolveTelegramTransportSpy } = vi.hoisted(() => ({
+  resolveTelegramTransportSpy: vi.fn(() => ({
+    fetch: globalThis.fetch,
+    sourceFetch: globalThis.fetch,
+  })),
+}));
 
 type RunnerStub = {
   task: () => Promise<void>;
@@ -267,6 +273,10 @@ vi.mock("./webhook.js", () => ({
   startTelegramWebhook: startTelegramWebhookSpy,
 }));
 
+vi.mock("./fetch.js", () => ({
+  resolveTelegramTransport: resolveTelegramTransportSpy,
+}));
+
 vi.mock("./update-offset-store.js", () => ({
   readTelegramUpdateOffset: readTelegramUpdateOffsetSpy,
   writeTelegramUpdateOffset: vi.fn(async () => undefined),
@@ -298,6 +308,10 @@ describe("monitorTelegramProvider (grammY)", () => {
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
+    resolveTelegramTransportSpy.mockReset().mockImplementation(() => ({
+      fetch: globalThis.fetch,
+      sourceFetch: globalThis.fetch,
+    }));
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
@@ -497,6 +511,29 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(computeBackoff).toHaveBeenCalled();
     expect(sleepWithAbort).toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses the resolved transport across polling restarts", async () => {
+    const telegramTransport = {
+      fetch: globalThis.fetch,
+      sourceFetch: globalThis.fetch,
+    };
+    resolveTelegramTransportSpy.mockReturnValueOnce(telegramTransport);
+
+    const abort = new AbortController();
+    mockRunOnceWithStalledPollingRunner();
+    mockRunOnceAndAbort(abort);
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(createTelegramBotCalls.length).toBeGreaterThanOrEqual(1));
+
+    expect(emitUnhandledRejection(makeTaggedPollingFetchError())).toBe(true);
+    await monitor;
+
+    expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(1);
+    expect(createTelegramBotCalls).toHaveLength(2);
+    expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport);
+    expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport);
   });
 
   it("aborts the active Telegram fetch when unhandled network rejection forces restart", async () => {

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -514,26 +514,31 @@ describe("monitorTelegramProvider (grammY)", () => {
   });
 
   it("reuses the resolved transport across polling restarts", async () => {
-    const telegramTransport = {
-      fetch: globalThis.fetch,
-      sourceFetch: globalThis.fetch,
-    };
-    resolveTelegramTransportSpy.mockReturnValueOnce(telegramTransport);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const telegramTransport = {
+        fetch: globalThis.fetch,
+        sourceFetch: globalThis.fetch,
+      };
+      resolveTelegramTransportSpy.mockReturnValueOnce(telegramTransport);
 
-    const abort = new AbortController();
-    mockRunOnceWithStalledPollingRunner();
-    mockRunOnceAndAbort(abort);
+      const abort = new AbortController();
+      mockRunOnceWithStalledPollingRunner();
+      mockRunOnceAndAbort(abort);
 
-    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
-    await vi.waitFor(() => expect(createTelegramBotCalls.length).toBeGreaterThanOrEqual(1));
+      const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+      await vi.waitFor(() => expect(createTelegramBotCalls.length).toBeGreaterThanOrEqual(1));
 
-    expect(emitUnhandledRejection(makeTaggedPollingFetchError())).toBe(true);
-    await monitor;
+      vi.advanceTimersByTime(120_000);
+      await monitor;
 
-    expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(1);
-    expect(createTelegramBotCalls).toHaveLength(2);
-    expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport);
-    expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport);
+      expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(1);
+      expect(createTelegramBotCalls).toHaveLength(2);
+      expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport);
+      expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("aborts the active Telegram fetch when unhandled network rejection forces restart", async () => {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -9,6 +9,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
+import { resolveTelegramTransport } from "./fetch.js";
 import {
   isRecoverableTelegramNetworkError,
   isTelegramPollingNetworkError,
@@ -178,6 +179,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       return;
     }
 
+    // Create transport once to preserve sticky IPv4 fallback state across polling restarts
+    const telegramTransport = resolveTelegramTransport(proxyFetch, {
+      network: account.config.network,
+    });
+
     pollingSession = new TelegramPollingSession({
       token,
       config: cfg,
@@ -189,6 +195,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       getLastUpdateId: () => lastUpdateId,
       persistUpdateId,
       log,
+      telegramTransport,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -4,7 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { formatDurationPrecise } from "openclaw/plugin-sdk/infra-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
-import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
+import { type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { formatDurationPrecise } from "openclaw/plugin-sdk/infra-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {
@@ -47,6 +48,8 @@ type TelegramPollingSessionOpts = {
   getLastUpdateId: () => number | null;
   persistUpdateId: (updateId: number) => Promise<void>;
   log: (line: string) => void;
+  /** Pre-resolved Telegram transport to reuse across bot instances */
+  telegramTransport?: TelegramTransport;
 };
 
 export class TelegramPollingSession {
@@ -135,6 +138,7 @@ export class TelegramPollingSession {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,
         },
+        telegramTransport: this.opts.telegramTransport,
       });
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");


### PR DESCRIPTION
## Summary

Hoists `resolveTelegramTransport()` out of `createTelegramBot()` so the transport and its sticky IPv4 fallback state persists across polling restarts.

## Problem

When Node 22+ `autoSelectFamily=true` and the host has unstable IPv6 to `api.telegram.org`, the transport correctly enables sticky IPv4 fallback. But this state is **lost on every polling restart** because `createTelegramBot()` creates a fresh transport each time, resetting `stickyIpv4FallbackEnabled = false`.

This causes a repeating cycle of IPv6 timeouts — the reporter observed **47 polling stalls in 20 hours** with 30s-2min message loss per stall.

## Changes

- **`bot.ts`**: Accept optional `telegramTransport` in `TelegramBotOptions`, use it if provided
- **`monitor.ts`**: Resolve transport once before polling session creation
- **`polling-session.ts`**: Pass transport through to bot creation

## Testing

Minimal diff (+15 lines). All changes are additive — existing code paths without a pre-resolved transport still work identically.

AI-assisted (Claude Sonnet 4).

Fixes #48177