### PR TITLE
fix(agent): discard aborted assistant messages to prevent stale content (fixes #48241)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -334,6 +334,71 @@ function stripSessionsYieldArtifacts(activeSession: {
   }
 }
 
+// Remove aborted assistant messages from session when run is aborted (not just yield-aborted)
+function stripAbortedAssistantMessages(activeSession: {
+  messages: AgentMessage[];
+  agent: { replaceMessages: (messages: AgentMessage[]) => void };
+  sessionManager?: unknown;
+}) {
+  const strippedMessages = activeSession.messages.slice();
+  while (strippedMessages.length > 0) {
+    const last = strippedMessages.at(-1) as
+      | AgentMessage
+      | { role?: string; stopReason?: string };
+    if (last?.role === "assistant" && "stopReason" in last && last.stopReason === "aborted") {
+      strippedMessages.pop();
+      continue;
+    }
+    break;
+  }
+  if (strippedMessages.length !== activeSession.messages.length) {
+    activeSession.agent.replaceMessages(strippedMessages);
+  }
+
+  const sessionManager = activeSession.sessionManager as
+    | {
+        fileEntries?: Array<{
+          type?: string;
+          id?: string;
+          parentId?: string | null;
+          message?: { role?: string; stopReason?: string };
+        }>;
+        byId?: Map<string, { id: string }>;
+        leafId?: string | null;
+        _rewriteFile?: () => void;
+      }
+    | undefined;
+  const fileEntries = sessionManager?.fileEntries;
+  const byId = sessionManager?.byId;
+  if (!fileEntries || !byId) {
+    return;
+  }
+
+  let changed = false;
+  while (fileEntries.length > 1) {
+    const last = fileEntries.at(-1);
+    if (!last || last.type === "session") {
+      break;
+    }
+    const isAbortedAssistant =
+      last.type === "message" &&
+      last.message?.role === "assistant" &&
+      last.message?.stopReason === "aborted";
+    if (!isAbortedAssistant) {
+      break;
+    }
+    fileEntries.pop();
+    if (last.id) {
+      byId.delete(last.id);
+    }
+    sessionManager.leafId = last.parentId ?? null;
+    changed = true;
+  }
+  if (changed) {
+    sessionManager._rewriteFile?.();
+  }
+}
+
 export function isOllamaCompatProvider(model: {
   provider?: string;
   baseUrl?: string;
@@ -2547,6 +2612,11 @@ export async function runEmbeddedAttempt(
           } else {
             promptError = err;
             promptErrorSource = "prompt";
+            // Clean up any aborted assistant messages from the session to prevent
+            // stale buffer content from being written as the response (fixes #48241)
+            if (isRunnerAbortError(err)) {
+              stripAbortedAssistantMessages(activeSession);
+            }
           }
         } finally {
           log.debug(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -342,9 +342,7 @@ function stripAbortedAssistantMessages(activeSession: {
 }) {
   const strippedMessages = activeSession.messages.slice();
   while (strippedMessages.length > 0) {
-    const last = strippedMessages.at(-1) as
-      | AgentMessage
-      | { role?: string; stopReason?: string };
+    const last = strippedMessages.at(-1) as AgentMessage | { role?: string; stopReason?: string };
     if (last?.role === "assistant" && "stopReason" in last && last.stopReason === "aborted") {
       strippedMessages.pop();
       continue;


### PR DESCRIPTION
## Summary

When a run is aborted with in-flight streaming, stale buffer content was being written as an assistant message — causing users to receive fabricated/garbage responses (VSCode tutorials, FAQ templates, etc.) completely unrelated to the conversation.

## Problem

The reporter observed:
- Assistant responses with **unrelated content** after abort
- Upstream API logs confirm **zero requests** during the garbage response window
- `output: 2` tokens for a response hundreds of tokens long — count mismatch
- `customType: "openclaw:prompt-error"` with `"error": "aborted"` at exact timestamp

## Root Cause

When multiple user messages arrive quickly, the gateway aborts in-progress runs. The streaming buffer may contain stale data from a previous response that was not cleared. The abort handler wrote this stale content as an assistant message.

## Fix

Add `stripAbortedAssistantMessages()` that runs on the abort error path:
1. Removes assistant messages with `stopReason: "aborted"` from the in-memory message list
2. Cleans up corresponding file entries in the session manager
3. Rewrites the session file to ensure consistency

This is defensive — even if the buffer is clean, aborted messages should not persist.

## Testing

AI-assisted (Claude Sonnet 4). The fix adds a focused guard in the existing abort error handler.

Fixes #48241