### PR TITLE
fix: skills list should prefer cwd-matched workspace over default agent

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadConfigMock = vi.fn();
+const resolveAgentIdByWorkspacePathMock = vi.fn();
 const resolveAgentWorkspaceDirMock = vi.fn();
 const resolveDefaultAgentIdMock = vi.fn();
 const buildWorkspaceSkillStatusMock = vi.fn();
@@ -20,6 +21,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentIdByWorkspacePath: resolveAgentIdByWorkspacePathMock,
   resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock,
   resolveDefaultAgentId: resolveDefaultAgentIdMock,
 }));
@@ -60,6 +62,7 @@ describe("registerSkillsCli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     loadConfigMock.mockReturnValue({ gateway: {} });
+    resolveAgentIdByWorkspacePathMock.mockReturnValue(undefined);
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     buildWorkspaceSkillStatusMock.mockReturnValue(report);
@@ -71,6 +74,8 @@ describe("registerSkillsCli", () => {
   it("runs list command with resolved report and formatter options", async () => {
     await runCli(["skills", "list", "--eligible", "--verbose", "--json"]);
 
+    expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledWith({ gateway: {} }, process.cwd());
+    expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith({ gateway: {} }, "main");
     expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/workspace", {
       config: { gateway: {} },
     });
@@ -83,6 +88,19 @@ describe("registerSkillsCli", () => {
       }),
     );
     expect(runtime.log).toHaveBeenCalledWith("skills-list-output");
+  });
+
+  it("prefers the agent inferred from cwd over the default agent", async () => {
+    resolveAgentIdByWorkspacePathMock.mockReturnValue("ops");
+    resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/ops-workspace");
+
+    await runCli(["skills", "list"]);
+
+    expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith({ gateway: {} }, "ops");
+    expect(resolveDefaultAgentIdMock).not.toHaveBeenCalled();
+    expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/ops-workspace", {
+      config: { gateway: {} },
+    });
   });
 
   it("runs info command and forwards skill name", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentIdByWorkspacePath,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -19,7 +23,9 @@ type SkillStatusReport = Awaited<
 
 async function loadSkillsStatusReport(): Promise<SkillStatusReport> {
   const config = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const agentId =
+    resolveAgentIdByWorkspacePath(config, process.cwd()) ?? resolveDefaultAgentId(config);
+  const workspaceDir = resolveAgentWorkspaceDir(config, agentId);
   const { buildWorkspaceSkillStatus } = await import("../agents/skills-status.js");
   return buildWorkspaceSkillStatus(workspaceDir, { config });
 }


### PR DESCRIPTION
Fixes #48266

## Problem
Custom skills placed in `~/.openclaw/skills/` and `<workspace>/skills/` were not appearing in `openclaw skills list` because the CLI always used the default agent's workspace instead of inferring the agent from the current working directory.

## Solution
Modified `loadSkillsStatusReport()` in `src/cli/skills-cli.ts` to:
1. Call `resolveAgentIdByWorkspacePath(config, process.cwd())` to infer the agent from the current directory
2. Fall back to `resolveDefaultAgentId(config)` if no matching workspace is found

## Changes
- `src/cli/skills-cli.ts`: Added cwd-based agent inference
- `src/cli/skills-cli.commands.test.ts`: Added regression test

## Testing
- All existing tests pass (6/6)
- New test case verifies cwd-based agent inference

## Checklist
- [x] Tests pass
- [x] Follows project conventions (TypeScript, dynamic imports)
- [x] Minimal changes (only modified what was necessary)
- [ ] Waiting for CI (lint, type check, etc.)