### PR TITLE
Agents: add transcript tail detector

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1009,6 +1009,12 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
+        guard: {
+          enabled: false,
+          maxCompactionsPerWindow: 3,
+          windowMinutes: 30,
+          escalation: "recommend-reset",
+        },
         postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
         model: "openrouter/anthropic/claude-sonnet-4-5", // optional compaction-only model override
         memoryFlush: {
@@ -1027,6 +1033,10 @@ Periodic heartbeat runs.
 - `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `900`.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
+- `guard`: reserved repeated-compaction guard scaffolding. Default: `{ enabled: false }`. This config currently does not change runtime behavior.
+- `guard.maxCompactionsPerWindow`: maximum compaction events allowed within the rolling guard window before future escalation. Integer range: `2-20`.
+- `guard.windowMinutes`: rolling guard window in minutes. Integer range: `1-1440`.
+- `guard.escalation`: reserved escalation policy for future guard trips. Currently only `recommend-reset` is accepted.
 - `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
 - `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.

--- a/src/agents/transcript-tail-detector.test.ts
+++ b/src/agents/transcript-tail-detector.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTranscriptTailSignals,
+  type TranscriptTailEntry,
+} from "./transcript-tail-detector.js";
+
+describe("detectTranscriptTailSignals", () => {
+  it("groups repeated tool failures with the same normalized signature", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("t1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("t2", "searchWeb", "request 987 timed out after 31 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([
+      {
+        signature: "searchweb: request <num> timed out after <num> seconds",
+        count: 2,
+        lastSeenEntryId: "t2",
+      },
+    ]);
+  });
+
+  it("separates different tool failures into distinct groups", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("a1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("a2", "searchWeb", "Permission denied for workspace alpha"),
+      toolFailure("a3", "fetchFile", "Request 999 timed out after 45 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([]);
+  });
+
+  it("detects duplicate assistant clusters from repeated normalized text", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Working on it now." },
+      { role: "assistant", text: "  working   on it now.  " },
+      { role: "assistant", text: "Different reply" },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).duplicateAssistantClusters).toBe(1);
+  });
+
+  it("detects stale directive-like system recurrences", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: do not retry the same failed tool call.",
+      },
+      { role: "assistant", text: "I will avoid that." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder:   do not retry the same failed tool call. ",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(1);
+  });
+
+  it("does not flag legitimate post-compaction reinjection prefixes as stale", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nKeep going.",
+      },
+      {
+        role: "system",
+        text: "Session was just compacted.\nPlease continue.",
+      },
+      {
+        role: "system",
+        text: "Injected sections from AGENTS.md\n- rule one",
+      },
+      {
+        role: "system",
+        text: "Current time: 2026-03-16T12:34:56Z\nTimezone: UTC",
+      },
+      {
+        role: "system",
+        text: "Critical rules from AGENTS.md:\n- do not reset",
+      },
+      {
+        role: "system",
+        text: "  Current time: 2026-03-16T12:35:56Z\nTimezone: UTC",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(0);
+  });
+
+  it("counts trailing user turns without a non-empty assistant reply", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Earlier grounded answer." },
+      { role: "user", text: "Can you keep going?" },
+      { role: "toolResult", toolName: "searchWeb", toolStatus: "error", errorText: "timeout" },
+      { role: "assistant", text: "   " },
+      { role: "user", text: "Still waiting." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).noGroundedReplyTurns).toBe(2);
+  });
+
+  it("reports multiple signal types together in a mixed tail", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nContext restored.",
+      },
+      {
+        id: "tool-1",
+        role: "toolResult",
+        toolName: "searchWeb",
+        toolStatus: "error",
+        errorText: "HTTP 500 for request 12345",
+      },
+      { role: "assistant", text: "I will check that now." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: always acknowledge repeated tool failures before retrying.",
+      },
+      {
+        id: "tool-2",
+        role: "toolResult",
+        toolName: "searchWeb",
+        isError: true,
+        errorText: "http 500 for request 99999",
+      },
+      { role: "assistant", text: "  i will check that now. " },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder: always acknowledge repeated tool failures before retrying. ",
+      },
+      { role: "user", text: "Any update?" },
+      { role: "user", text: "Please answer directly." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries)).toEqual({
+      repeatedToolFailures: [
+        {
+          signature: "searchweb: http <num> for request <num>",
+          count: 2,
+          lastSeenEntryId: "tool-2",
+        },
+      ],
+      duplicateAssistantClusters: 1,
+      staleSystemRecurrences: 1,
+      noGroundedReplyTurns: 2,
+    });
+  });
+});
+
+function toolFailure(id: string, toolName: string, errorText: string): TranscriptTailEntry {
+  return {
+    id,
+    role: "toolResult",
+    toolName,
+    toolStatus: "error",
+    errorText,
+  };
+}

--- a/src/agents/transcript-tail-detector.ts
+++ b/src/agents/transcript-tail-detector.ts
@@ -1,0 +1,237 @@
+export type TranscriptTailEntry = {
+  id?: string;
+  role?: string;
+  kind?: string;
+  text?: string;
+  toolName?: string;
+  toolStatus?: string;
+  errorText?: string;
+  isError?: boolean;
+};
+
+export type TranscriptTailSignal = {
+  repeatedToolFailures: Array<{
+    signature: string;
+    count: number;
+    lastSeenEntryId?: string;
+  }>;
+  duplicateAssistantClusters: number;
+  staleSystemRecurrences: number;
+  noGroundedReplyTurns: number;
+};
+
+const STALE_SYSTEM_EXEMPT_PREFIXES = [
+  "[Post-compaction context refresh]",
+  "Session was just compacted.",
+  "Critical rules from AGENTS.md:",
+  "Injected sections from AGENTS.md",
+] as const;
+
+const DIRECTIVE_TEXT_PATTERN =
+  /\b(always|avoid|critical|directive|do not|don't|follow|important|instruction|must|never|note|remember|reminder|required|rule|should)\b/;
+
+export function detectTranscriptTailSignals(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal {
+  return {
+    repeatedToolFailures: collectRepeatedToolFailures(entries),
+    duplicateAssistantClusters: countDuplicateAssistantClusters(entries),
+    staleSystemRecurrences: countStaleSystemRecurrences(entries),
+    noGroundedReplyTurns: countTrailingUserTurnsWithoutReply(entries),
+  };
+}
+
+function collectRepeatedToolFailures(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal["repeatedToolFailures"] {
+  const groupedFailures = new Map<
+    string,
+    { signature: string; count: number; lastSeenEntryId?: string }
+  >();
+
+  for (const entry of entries) {
+    const signature = getToolFailureSignature(entry);
+
+    if (!signature) {
+      continue;
+    }
+
+    const current = groupedFailures.get(signature);
+
+    if (current) {
+      current.count += 1;
+      current.lastSeenEntryId = entry.id ?? current.lastSeenEntryId;
+      continue;
+    }
+
+    groupedFailures.set(signature, {
+      signature,
+      count: 1,
+      lastSeenEntryId: entry.id,
+    });
+  }
+
+  return [...groupedFailures.values()].filter(({ count }) => count > 1);
+}
+
+function getToolFailureSignature(entry: TranscriptTailEntry): string | undefined {
+  if (!isToolFailureEntry(entry)) {
+    return undefined;
+  }
+
+  const toolName = normalizeComparableText(entry.toolName) || "unknown-tool";
+  const rawErrorText = entry.errorText ?? entry.text ?? "error";
+  const errorSignature = normalizeFailureSignature(rawErrorText) || "error";
+
+  return `${toolName}: ${errorSignature}`;
+}
+
+function isToolFailureEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+  const hasToolIdentity =
+    hasNonEmptyText(entry.toolName) ||
+    normalizedRole === "toolresult" ||
+    normalizedKind.includes("tool");
+
+  if (!hasToolIdentity) {
+    return false;
+  }
+
+  return (
+    entry.isError === true ||
+    normalizeToken(entry.toolStatus) === "error" ||
+    hasNonEmptyText(entry.errorText)
+  );
+}
+
+function countDuplicateAssistantClusters(entries: readonly TranscriptTailEntry[]): number {
+  const seenAssistantReplies = new Map<string, number>();
+  let duplicateClusters = 0;
+
+  for (const entry of entries) {
+    if (normalizeToken(entry.role) !== "assistant") {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(entry.text);
+
+    if (!normalizedText) {
+      continue;
+    }
+
+    const previousCount = seenAssistantReplies.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      duplicateClusters += 1;
+    }
+
+    seenAssistantReplies.set(normalizedText, previousCount + 1);
+  }
+
+  return duplicateClusters;
+}
+
+function countStaleSystemRecurrences(entries: readonly TranscriptTailEntry[]): number {
+  const seenSystemTexts = new Map<string, number>();
+  let staleRecurrences = 0;
+
+  for (const entry of entries) {
+    if (!isSystemLikeEntry(entry)) {
+      continue;
+    }
+
+    const text = entry.text?.trim();
+
+    if (!text || isLegitimateReinjectionText(text)) {
+      continue;
+    }
+
+    if (!isDirectiveLikeSystemText(text, entry.kind)) {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(text);
+    const previousCount = seenSystemTexts.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      staleRecurrences += 1;
+    }
+
+    seenSystemTexts.set(normalizedText, previousCount + 1);
+  }
+
+  return staleRecurrences;
+}
+
+function isSystemLikeEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+
+  return (
+    normalizedRole === "system" ||
+    normalizedKind.includes("system") ||
+    normalizedKind.includes("reminder")
+  );
+}
+
+function isLegitimateReinjectionText(text: string): boolean {
+  const trimmed = text.trimStart();
+
+  if (STALE_SYSTEM_EXEMPT_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+    return true;
+  }
+
+  return trimmed.split(/\r?\n/u).some((line) => line.trimStart().startsWith("Current time:"));
+}
+
+function isDirectiveLikeSystemText(text: string, kind?: string): boolean {
+  const normalizedKind = normalizeToken(kind);
+
+  if (normalizedKind.includes("reminder") || normalizedKind.includes("directive")) {
+    return true;
+  }
+
+  return DIRECTIVE_TEXT_PATTERN.test(text.toLowerCase());
+}
+
+function countTrailingUserTurnsWithoutReply(entries: readonly TranscriptTailEntry[]): number {
+  let trailingUserTurns = 0;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const normalizedRole = normalizeToken(entry.role);
+
+    if (normalizedRole === "assistant" && hasNonEmptyText(entry.text)) {
+      break;
+    }
+
+    if (normalizedRole === "user" && hasNonEmptyText(entry.text)) {
+      trailingUserTurns += 1;
+    }
+  }
+
+  return trailingUserTurns;
+}
+
+function normalizeFailureSignature(text: string): string {
+  return normalizeComparableText(
+    text
+      .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/giu, "<id>")
+      .replace(/\b0x[0-9a-f]+\b/giu, "<hex>")
+      .replace(/\b[a-f0-9]{12,}\b/giu, "<id>")
+      .replace(/\b\d{2,}\b/gu, "<num>"),
+  );
+}
+
+function normalizeComparableText(value?: string): string {
+  return normalizeToken(value).replace(/\s+/gu, " ").trim();
+}
+
+function normalizeToken(value?: string): string {
+  return value?.toLowerCase().trim() ?? "";
+}
+
+function hasNonEmptyText(value?: string): boolean {
+  return normalizeComparableText(value).length > 0;
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -109,6 +109,51 @@ describe("config compaction settings", () => {
     );
   });
 
+  it("preserves explicit compaction guard config values", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+              guard: {
+                enabled: true,
+                maxCompactionsPerWindow: 3,
+                windowMinutes: 30,
+                escalation: "recommend-reset",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard?.enabled).toBe(true);
+        expect(cfg.agents?.defaults?.compaction?.guard?.maxCompactionsPerWindow).toBe(3);
+        expect(cfg.agents?.defaults?.compaction?.guard?.windowMinutes).toBe(30);
+        expect(cfg.agents?.defaults?.compaction?.guard?.escalation).toBe("recommend-reset");
+      },
+    );
+  });
+
+  it("defaults compaction guard shape to disabled", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard).toEqual({ enabled: false });
+      },
+    );
+  });
+
   it("preserves oversized quality guard retry values for runtime clamping", async () => {
     await withTempHomeConfig(
       {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -224,4 +224,52 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it('rejects compaction.guard escalation values other than "recommend-reset"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              escalation: "reset-now",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.escalation"),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects compaction.guard numeric values outside conservative bounds", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              maxCompactionsPerWindow: 1,
+              windowMinutes: 1441,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) => issue.path === "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+        ),
+      ).toBe(true);
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.windowMinutes"),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -512,7 +512,9 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
     return cfg;
   }
   const compaction = defaults?.compaction;
-  if (compaction?.mode) {
+  const needsModeDefault = compaction?.mode === undefined;
+  const needsGuardDefault = compaction?.guard?.enabled === undefined;
+  if (!needsModeDefault && !needsGuardDefault) {
     return cfg;
   }
 
@@ -524,7 +526,11 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
         ...defaults,
         compaction: {
           ...compaction,
-          mode: "safeguard",
+          ...(needsModeDefault ? { mode: "safeguard" as const } : {}),
+          guard: {
+            ...compaction?.guard,
+            enabled: compaction?.guard?.enabled ?? false,
+          },
         },
       },
     },

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -381,6 +381,11 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.identifierPolicy",
   "agents.defaults.compaction.identifierInstructions",
   "agents.defaults.compaction.recentTurnsPreserve",
+  "agents.defaults.compaction.guard",
+  "agents.defaults.compaction.guard.enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+  "agents.defaults.compaction.guard.windowMinutes",
+  "agents.defaults.compaction.guard.escalation",
   "agents.defaults.compaction.qualityGuard",
   "agents.defaults.compaction.qualityGuard.enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries",
@@ -442,6 +447,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "cli.banner.taglineMode": ['"random"', '"default"', '"off"'],
   "update.channel": ['"stable"', '"beta"', '"dev"'],
   "agents.defaults.compaction.mode": ['"default"', '"safeguard"'],
+  "agents.defaults.compaction.guard.escalation": ['"recommend-reset"'],
   "agents.defaults.compaction.identifierPolicy": ['"strict"', '"off"', '"custom"'],
 };
 
@@ -803,7 +809,7 @@ describe("config help copy quality", () => {
     expect(/cooldown|backoff|retry/i.test(authCooldowns)).toBe(true);
   });
 
-  it("documents agent compaction safeguards and memory flush behavior", () => {
+  it("documents agent compaction safeguards, guard scaffolding, and memory flush behavior", () => {
     const mode = FIELD_HELP["agents.defaults.compaction.mode"];
     expect(mode.includes('"default"')).toBe(true);
     expect(mode.includes('"safeguard"')).toBe(true);
@@ -819,6 +825,14 @@ describe("config help copy quality", () => {
     const recentTurnsPreserve = FIELD_HELP["agents.defaults.compaction.recentTurnsPreserve"];
     expect(/recent.*turn|verbatim/i.test(recentTurnsPreserve)).toBe(true);
     expect(/default:\s*3/i.test(recentTurnsPreserve)).toBe(true);
+
+    const guard = FIELD_HELP["agents.defaults.compaction.guard"];
+    expect(/future|reserved|no runtime effect|does not change runtime behavior/i.test(guard)).toBe(
+      true,
+    );
+
+    const guardEscalation = FIELD_HELP["agents.defaults.compaction.guard.escalation"];
+    expect(guardEscalation.includes('"recommend-reset"')).toBe(true);
 
     const postCompactionSections = FIELD_HELP["agents.defaults.compaction.postCompactionSections"];
     expect(/Session Startup|Red Lines/i.test(postCompactionSections)).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1047,6 +1047,16 @@ export const FIELD_HELP: Record<string, string> = {
     'Custom identifier-preservation instruction text used when identifierPolicy="custom". Keep this explicit and safety-focused so compaction summaries do not rewrite opaque IDs, URLs, hosts, or ports.',
   "agents.defaults.compaction.recentTurnsPreserve":
     "Number of most recent user/assistant turns kept verbatim outside safeguard summarization (default: 3). Raise this to preserve exact recent dialogue context, or lower it to maximize compaction savings.",
+  "agents.defaults.compaction.guard":
+    "Reserved repeated-compaction guard scaffolding for future loop protection. Keep this block for pre-staging loop-protection settings, but use it as config-only for now because it does not change runtime behavior until compaction guard logic is implemented.",
+  "agents.defaults.compaction.guard.enabled":
+    "Enables reserved repeated-compaction guard scaffolding. Default: false, and setting this currently has no runtime effect until repeated-compaction guard behavior exists.",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Maximum compaction events allowed within the rolling guard window before the future guard would escalate (range 2-20). Keep this small if you are pre-staging repeated-compaction protection settings.",
+  "agents.defaults.compaction.guard.windowMinutes":
+    "Rolling time window in minutes used by the future compaction guard when counting repeated compactions (range 1-1440). Use shorter windows for burst detection or longer ones for broader session-level protection.",
+  "agents.defaults.compaction.guard.escalation":
+    'Reserved escalation mode for future compaction guard trips. Use "recommend-reset" to pre-stage a future session-reset recommendation once guard behavior is implemented; no other values are currently accepted.',
   "agents.defaults.compaction.qualityGuard":
     "Optional quality-audit retry settings for safeguard compaction summaries. Leave this disabled unless you explicitly want summary audits and one-shot regeneration on failed checks.",
   "agents.defaults.compaction.qualityGuard.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -472,6 +472,12 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
   "agents.defaults.compaction.recentTurnsPreserve": "Compaction Preserve Recent Turns",
+  "agents.defaults.compaction.guard": "Compaction Loop Guard",
+  "agents.defaults.compaction.guard.enabled": "Compaction Loop Guard Enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Compaction Loop Guard Max Compactions per Window",
+  "agents.defaults.compaction.guard.windowMinutes": "Compaction Loop Guard Window (Minutes)",
+  "agents.defaults.compaction.guard.escalation": "Compaction Loop Guard Escalation",
   "agents.defaults.compaction.qualityGuard": "Compaction Quality Guard",
   "agents.defaults.compaction.qualityGuard.enabled": "Compaction Quality Guard Enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -296,11 +296,22 @@ export type AgentDefaultsConfig = {
 export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionPostIndexSyncMode = "off" | "async" | "await";
 export type AgentCompactionIdentifierPolicy = "strict" | "off" | "custom";
+export type AgentCompactionGuardEscalation = "recommend-reset";
 export type AgentCompactionQualityGuardConfig = {
   /** Enable compaction summary quality audits and regeneration retries. Default: false. */
   enabled?: boolean;
   /** Maximum regeneration retries after a failed quality audit. Default: 1 when enabled. */
   maxRetries?: number;
+};
+export type AgentCompactionGuardConfig = {
+  /** Enable reserved repeated-compaction guard scaffolding. Default: false. */
+  enabled?: boolean;
+  /** Maximum compaction events allowed in the rolling guard window. */
+  maxCompactionsPerWindow?: number;
+  /** Rolling time window in minutes used by the reserved guard. */
+  windowMinutes?: number;
+  /** Escalation mode reserved for future guard trips. */
+  escalation?: AgentCompactionGuardEscalation;
 };
 
 export type AgentCompactionConfig = {
@@ -318,6 +329,8 @@ export type AgentCompactionConfig = {
   customInstructions?: string;
   /** Preserve this many most-recent user/assistant turns verbatim in compaction summary context. */
   recentTurnsPreserve?: number;
+  /** Reserved repeated-compaction guard scaffolding. */
+  guard?: AgentCompactionGuardConfig;
   /** Identifier-preservation instruction policy for compaction summaries. */
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,15 @@ export const AgentDefaultsSchema = z
           .optional(),
         identifierInstructions: z.string().optional(),
         recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+        guard: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxCompactionsPerWindow: z.number().int().min(2).max(20).optional(),
+            windowMinutes: z.number().int().min(1).max(1440).optional(),
+            escalation: z.enum(["recommend-reset"]).optional(),
+          })
+          .strict()
+          .optional(),
         qualityGuard: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Problem: the loop-aware compaction guard plan needed a pure transcript-tail detector before any runtime hook or compaction-path changes.
- Why it matters: PR3/PR4 need a small, deterministic signal source for repeated tool failures, duplicate assistant drift, stale reminder/system recurrence, and trailing ungrounded user asks.
- What changed: added a new pure detector module plus focused unit tests for the four signal families and mixed-tail behavior.
- What did NOT change (scope boundary): no runtime integration, no config/docs changes in this PR, no reset recommendation path, no user-visible warnings.
- Stacking note: this branch is stacked on top of #48278, so until that PR lands the compare view against `main` also includes the PR1 scaffolding commit.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48238
- Depends on #48278

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0 arm64
- Runtime/container: local host checkout
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Add a pure `TranscriptTailEntry -> TranscriptTailSignal` detector module.
2. Cover repeated tool failures, duplicate assistant replies, stale directive/system recurrence, exempt reinjection prefixes, and trailing ungrounded user turns with focused unit tests.
3. Run targeted detector tests.

### Expected

- Detector returns stable structured signals without touching runtime compaction.
- Legitimate post-compaction reinjection strings are exempt from stale-system counting.

### Actual

- Targeted detector tests passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: repeated tool failure grouping, distinct failure separation, duplicate assistant cluster detection, stale directive/system recurrence detection, post-compaction reinjection exemptions, trailing user-turn counting, mixed multi-signal fixture.
- Edge cases checked: lines starting with `Current time:` and known post-compaction refresh prefixes do not count as stale recurrence.
- What you did **not** verify: runtime consumption of the detector output (reserved for follow-up PRs).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `18b7401007e2be85ad6149426861cf29e2342e47`.
- Files/config to restore: `src/agents/transcript-tail-detector.ts`, `src/agents/transcript-tail-detector.test.ts`.
- Known bad symptoms reviewers should watch for: future runtime consumers misreading the detector contract or assuming it is already wired into compaction.

## Risks and Mitigations

- Risk: simple deterministic heuristics may undercount/overcount some real transcript patterns.
  - Mitigation: keep the module pure and narrow, document the false-positive guard for post-compaction reinjection, and defer policy/action decisions to PR3.
