### PR TITLE
fix(gateway): propagate meaningful restart reasons instead of none (fixes #48205)

### DIFF
--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -219,6 +219,7 @@ export function createGatewayReloadHandlers(params: {
 
       deferGatewayRestartUntilIdle({
         getPendingCount: () => getActiveCounts().totalActive,
+        reason: `config-reload: ${reasons}`,
         maxWaitMs: nextConfig.gateway?.reload?.deferralTimeoutMs,
         hooks: {
           onReady: () => {
@@ -243,7 +244,7 @@ export function createGatewayReloadHandlers(params: {
     } else {
       // No active operations or pending replies, restart immediately
       params.logReload.warn(`config change requires gateway restart (${reasons})`);
-      const emitted = emitGatewayRestart();
+      const emitted = emitGatewayRestart(`config-reload: ${reasons}`);
       if (!emitted) {
         params.logReload.info("gateway restart already scheduled; skipping duplicate signal");
       }

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -109,7 +109,7 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
  * Both scheduleGatewaySigusr1Restart and the config watcher should use this
  * to ensure only one restart fires.
  */
-export function emitGatewayRestart(): boolean {
+export function emitGatewayRestart(reason?: string): boolean {
   if (hasUnconsumedRestartSignal()) {
     clearPendingScheduledRestart();
     return false;
@@ -117,6 +117,19 @@ export function emitGatewayRestart(): boolean {
   clearPendingScheduledRestart();
   const cycleToken = ++restartCycleToken;
   emittedRestartToken = cycleToken;
+
+  // Log restart with reason and stack trace when reason is missing
+  if (!reason || reason.trim() === "") {
+    const stack = new Error().stack;
+    restartLog.warn(
+      `emitGatewayRestart called with missing reason; stack trace:
+${stack}`,
+    );
+    restartLog.info(`restart emitted (reason=none)`);
+  } else {
+    restartLog.info(`restart emitted (reason=${reason.trim().slice(0, 200)})`);
+  }
+
   authorizeGatewaySigusr1Restart();
   try {
     if (process.listenerCount("SIGUSR1") > 0) {
@@ -197,6 +210,7 @@ export type RestartDeferralHooks = {
  */
 export function deferGatewayRestartUntilIdle(opts: {
   getPendingCount: () => number;
+  reason?: string;
   hooks?: RestartDeferralHooks;
   pollMs?: number;
   maxWaitMs?: number;
@@ -211,12 +225,12 @@ export function deferGatewayRestartUntilIdle(opts: {
     pending = opts.getPendingCount();
   } catch (err) {
     opts.hooks?.onCheckError?.(err);
-    emitGatewayRestart();
+    emitGatewayRestart(opts.reason);
     return;
   }
   if (pending <= 0) {
     opts.hooks?.onReady?.();
-    emitGatewayRestart();
+    emitGatewayRestart(opts.reason);
     return;
   }
 
@@ -229,20 +243,20 @@ export function deferGatewayRestartUntilIdle(opts: {
     } catch (err) {
       clearInterval(poll);
       opts.hooks?.onCheckError?.(err);
-      emitGatewayRestart();
+      emitGatewayRestart(opts.reason);
       return;
     }
     if (current <= 0) {
       clearInterval(poll);
       opts.hooks?.onReady?.();
-      emitGatewayRestart();
+      emitGatewayRestart(opts.reason);
       return;
     }
     const elapsedMs = Date.now() - startedAt;
     if (elapsedMs >= maxWaitMs) {
       clearInterval(poll);
       opts.hooks?.onTimeout?.(current, elapsedMs);
-      emitGatewayRestart();
+      emitGatewayRestart(opts.reason);
     }
   }, pollMs);
 }
@@ -474,12 +488,13 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       pendingRestartReason = undefined;
       const pendingCheck = preRestartCheck;
       if (!pendingCheck) {
-        emitGatewayRestart();
+        emitGatewayRestart(reason);
         return;
       }
       const cfg = loadConfig();
       deferGatewayRestartUntilIdle({
         getPendingCount: pendingCheck,
+        reason,
         maxWaitMs: cfg.gateway?.reload?.deferralTimeoutMs,
       });
     },

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -118,16 +118,13 @@ export function emitGatewayRestart(reason?: string): boolean {
   const cycleToken = ++restartCycleToken;
   emittedRestartToken = cycleToken;
 
-  // Log restart with reason and stack trace when reason is missing
+  // Log restart reason diagnostics when reason is missing
   if (!reason || reason.trim() === "") {
     const stack = new Error().stack;
     restartLog.warn(
       `emitGatewayRestart called with missing reason; stack trace:
 ${stack}`,
     );
-    restartLog.info(`restart emitted (reason=none)`);
-  } else {
-    restartLog.info(`restart emitted (reason=${reason.trim().slice(0, 200)})`);
   }
 
   authorizeGatewaySigusr1Restart();
@@ -137,6 +134,8 @@ ${stack}`,
     } else {
       process.kill(process.pid, "SIGUSR1");
     }
+    const reasonStr = reason?.trim() ? reason.trim().slice(0, 200) : "none";
+    restartLog.info(`restart emitted (reason=${reasonStr})`);
   } catch {
     // Roll back the cycle marker so future restart requests can still proceed.
     emittedRestartToken = consumedRestartToken;


### PR DESCRIPTION
## Summary

Gateway restarts now log the actual reason instead of opaque `reason=none`.

## Problem

Users report the gateway restarting every ~50 minutes with `gateway tool: restart requested (delayMs=default, reason=none)`. No way to diagnose what triggers the restarts.

## Fix

- `emitGatewayRestart()` in `restart.ts` now accepts and logs an optional `reason` parameter
- Config-reload restarts include the changed config keys in the reason string
- Adds diagnostic logging at the restart entry point

This is an observability improvement — it does not change restart behavior, only makes the reason visible.

AI-assisted (Claude). Fixes #48205