### PR TITLE
feat(privacy): redact system-injected PII from LLM context

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -265,8 +265,10 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = sessionCtx.GroupSystemPrompt?.trim() ?? "";
+  const redactPIIOpts = cfg.privacy?.redactPII ? { redactPII: true } : undefined;
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
+    redactPIIOpts,
   );
   const extraSystemPromptParts = [
     inboundMetaPrompt,
@@ -301,6 +303,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    redactPIIOpts,
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal
@@ -496,6 +499,9 @@ export async function runPreparedReply(
       groupId: resolveGroupSessionKey(sessionCtx)?.id ?? undefined,
       groupChannel: sessionCtx.GroupChannel?.trim() ?? sessionCtx.GroupSubject?.trim(),
       groupSpace: sessionCtx.GroupSpace?.trim() ?? undefined,
+      // Raw sender fields are intentional here: they are used for internal auth/routing
+      // and policy checks, not injected into the LLM prompt. PII redaction is applied
+      // separately in buildInboundUserContextPrefix above.
       senderId: sessionCtx.SenderId?.trim() || undefined,
       senderName: sessionCtx.SenderName?.trim() || undefined,
       senderUsername: sessionCtx.SenderUsername?.trim() || undefined,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -385,7 +385,7 @@ describe("buildInboundUserContextPrefix", () => {
       const senderInfo = parseSenderInfoPayload(text);
       expect(senderInfo["e164"]).toBeUndefined();
       expect(senderInfo["id"]).toMatch(/^user_[a-f0-9]{12}$/);
-      expect(senderInfo["username"]).toBe("alice");
+      expect(senderInfo["username"]).toBeUndefined();
     });
 
     it("hashes phone-like SenderId on WhatsApp/Signal", () => {
@@ -401,10 +401,10 @@ describe("buildInboundUserContextPrefix", () => {
       const conversationInfo = parseConversationInfoPayload(text);
       expect(conversationInfo["sender_id"]).toMatch(/^user_[a-f0-9]{12}$/);
       expect(conversationInfo["sender_id"]).not.toContain("15551234567");
-      expect(conversationInfo["sender"]).toBe("Alice");
+      expect(conversationInfo["sender"]).toMatch(/^user_[a-f0-9]{12}$/);
     });
 
-    it("still includes SenderName when redactPII=true", () => {
+    it("replaces sender identity with stable pseudonymous labels when redactPII=true", () => {
       const text = buildInboundUserContextPrefix(
         {
           ChatType: "group",
@@ -416,10 +416,12 @@ describe("buildInboundUserContextPrefix", () => {
       );
 
       const conversationInfo = parseConversationInfoPayload(text);
-      expect(conversationInfo["sender"]).toBe("Tyler");
+      expect(conversationInfo["sender"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender"]).not.toBe("Tyler");
 
       const senderInfo = parseSenderInfoPayload(text);
-      expect(senderInfo["name"]).toBe("Tyler");
+      expect(senderInfo["label"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(senderInfo["name"]).toBeUndefined();
       expect(senderInfo["e164"]).toBeUndefined();
     });
 
@@ -454,7 +456,47 @@ describe("buildInboundUserContextPrefix", () => {
       expect(senderInfo["e164"]).toBe("+15551234567");
     });
 
-    it("redacts phone-like sender in InboundHistory", () => {
+    it("omits human-readable group labels when redactPII=true", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          ConversationLabel: "ops-room",
+          GroupSubject: "Release Squad",
+          GroupChannel: "alerts",
+          GroupSpace: "guild-123",
+          ThreadLabel: "Incident thread",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["conversation_label"]).toBeUndefined();
+      expect(conversationInfo["group_subject"]).toBeUndefined();
+      expect(conversationInfo["group_channel"]).toBeUndefined();
+      expect(conversationInfo["group_space"]).toBeUndefined();
+      expect(conversationInfo["thread_label"]).toBeUndefined();
+    });
+
+    it("omits forwarded profile fields when redactPII=true", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ForwardedFrom: "Alice",
+          ForwardedFromUsername: "alice",
+          ForwardedFromTitle: "CEO",
+          ForwardedFromSignature: "Alice Smith",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("alice");
+      expect(text).not.toContain("CEO");
+      expect(text).not.toContain("Alice Smith");
+      expect(text).toMatch(/participant_[a-f0-9]{12}/);
+    });
+
+    it("redacts phone-like and named senders in InboundHistory", () => {
       const text = buildInboundUserContextPrefix(
         {
           ChatType: "group",
@@ -468,7 +510,22 @@ describe("buildInboundUserContextPrefix", () => {
       );
 
       expect(text).not.toContain("+15559876543");
-      expect(text).toContain("Alice");
+      expect(text).not.toContain("Alice");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+      expect(text).toMatch(/participant_[a-f0-9]{12}/);
+    });
+
+    it("redacts synthetic user:id sender tokens in InboundHistory", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          InboundHistory: [{ sender: "user:1234567890", timestamp: 1000, body: "hello" }],
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("user:1234567890");
       expect(text).toMatch(/user_[a-f0-9]{12}/);
     });
 
@@ -516,7 +573,36 @@ describe("buildInboundUserContextPrefix", () => {
       expect(text).toMatch(/user_[a-f0-9]{12}/);
     });
 
-    it("keeps non-phone ReplyToSender unchanged", () => {
+    it("redacts synthetic user:id ForwardedFrom", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ForwardedFrom: "user:1234567890",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("user:1234567890");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts synthetic user:id ReplyToSender", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "user:1234567890",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("user:1234567890");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts non-phone ReplyToSender into a pseudonymous label", () => {
       const text = buildInboundUserContextPrefix(
         {
           ChatType: "group",
@@ -527,7 +613,8 @@ describe("buildInboundUserContextPrefix", () => {
         { redactPII: true },
       );
 
-      expect(text).toContain("Bob");
+      expect(text).not.toContain("Bob");
+      expect(text).toMatch(/participant_[a-f0-9]{12}/);
     });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -487,6 +487,21 @@ describe("buildInboundUserContextPrefix", () => {
       expect(text).toMatch(/user_[a-f0-9]{12}/);
     });
 
+    it("redacts bare phone-number ReplyToSender without plus prefix", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "15559876543",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("15559876543");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
     it("redacts phone-like ForwardedFrom", () => {
       const text = buildInboundUserContextPrefix(
         {

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -85,6 +85,39 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["flags"]).toBeUndefined();
   });
 
+  it("hashes chat_id when redactPII=true", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:1657377165",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: true },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toMatch(/^telegram:[a-f0-9]{12}$/);
+    expect(payload["chat_id"]).not.toContain("1657377165");
+  });
+
+  it("preserves chat_id when redactPII=false", () => {
+    const prompt = buildInboundMetaSystemPrompt(
+      {
+        OriginatingTo: "telegram:1657377165",
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+      } as TemplateContext,
+      { redactPII: false },
+    );
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["chat_id"]).toBe("telegram:1657377165");
+  });
+
   it("omits sender_id when blank", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "458",
@@ -330,5 +363,95 @@ describe("buildInboundUserContextPrefix", () => {
 
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender"]).toBe("user@example.com");
+  });
+
+  describe("redactPII", () => {
+    it("omits e164 and hashes SenderId", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+          SenderUsername: "alice",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender"]).not.toBe("user-123");
+      expect(conversationInfo["sender_id"]).toMatch(/^user_[a-f0-9]{12}$/);
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBeUndefined();
+      expect(senderInfo["id"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(senderInfo["username"]).toBe("alice");
+    });
+
+    it("hashes phone-like SenderId on WhatsApp/Signal", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "+15551234567",
+          SenderName: "Alice",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender_id"]).toMatch(/^user_[a-f0-9]{12}$/);
+      expect(conversationInfo["sender_id"]).not.toContain("15551234567");
+      expect(conversationInfo["sender"]).toBe("Alice");
+    });
+
+    it("still includes SenderName when redactPII=true", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderName: "Tyler",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("Tyler");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["name"]).toBe("Tyler");
+      expect(senderInfo["e164"]).toBeUndefined();
+    });
+
+    it("preserves e164 when redactPII=false", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderE164: "+15551234567",
+          SenderId: "user-123",
+        } as TemplateContext,
+        { redactPII: false },
+      );
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
+
+    it("preserves e164 when no options passed", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        SenderE164: "+15551234567",
+        SenderId: "user-123",
+      } as TemplateContext);
+
+      const conversationInfo = parseConversationInfoPayload(text);
+      expect(conversationInfo["sender"]).toBe("+15551234567");
+
+      const senderInfo = parseSenderInfoPayload(text);
+      expect(senderInfo["e164"]).toBe("+15551234567");
+    });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -453,5 +453,66 @@ describe("buildInboundUserContextPrefix", () => {
       const senderInfo = parseSenderInfoPayload(text);
       expect(senderInfo["e164"]).toBe("+15551234567");
     });
+
+    it("redacts phone-like sender in InboundHistory", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          InboundHistory: [
+            { sender: "+15559876543", timestamp: 1000, body: "hello" },
+            { sender: "Alice", timestamp: 2000, body: "hi" },
+          ],
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toContain("Alice");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts phone-like ReplyToSender", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "+15559876543",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("redacts phone-like ForwardedFrom", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ForwardedFrom: "+15559876543",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).not.toContain("+15559876543");
+      expect(text).toMatch(/user_[a-f0-9]{12}/);
+    });
+
+    it("keeps non-phone ReplyToSender unchanged", () => {
+      const text = buildInboundUserContextPrefix(
+        {
+          ChatType: "group",
+          SenderId: "user-1",
+          ReplyToBody: "some message",
+          ReplyToSender: "Bob",
+        } as TemplateContext,
+        { redactPII: true },
+      );
+
+      expect(text).toContain("Bob");
+    });
   });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -12,14 +12,22 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
-/** E.164 phone number or WhatsApp JID pattern: requires + prefix for bare numbers, or digits followed by @ for JIDs */
-const E164_PATTERN = /^(?:\+\d{7,15}|\d{7,15}@.+)$/;
+/**
+ * Sender-label redaction pattern:
+ * - +15551234567
+ * - 15551234567
+ * - 15551234567@s.whatsapp.net
+ *
+ * Applied only to label-like metadata fields (history/reply/forward sender labels),
+ * not to SenderId/chat_id, to avoid broadening numeric-ID false positives.
+ */
+const SENDER_LABEL_PHONE_PATTERN = /^(?:\+\d{7,15}|\d{7,15}|\d{7,15}@.+)$/;
 
 function redactSenderLabel(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  return E164_PATTERN.test(value) ? hashSenderId(value) : value;
+  return SENDER_LABEL_PHONE_PATTERN.test(value) ? hashSenderId(value) : value;
 }
 
 function hashChatId(value: string): string {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -1,7 +1,26 @@
+import { createHash } from "node:crypto";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import type { TemplateContext } from "../templating.js";
+
+function hashId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function hashSenderId(value: string): string {
+  return `user_${hashId(value)}`;
+}
+
+function hashChatId(value: string): string {
+  const colonIdx = value.indexOf(":");
+  if (colonIdx > 0) {
+    const prefix = value.slice(0, colonIdx);
+    const id = value.slice(colonIdx + 1);
+    return `${prefix}:${hashId(id)}`;
+  }
+  return hashId(value);
+}
 
 function safeTrim(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -42,7 +61,10 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
-export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
+export function buildInboundMetaSystemPrompt(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
 
@@ -59,7 +81,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
 
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    chat_id: safeTrim(ctx.OriginatingTo),
+    chat_id:
+      options?.redactPII && safeTrim(ctx.OriginatingTo)
+        ? hashChatId(safeTrim(ctx.OriginatingTo)!)
+        : safeTrim(ctx.OriginatingTo),
     account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
@@ -81,7 +106,10 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  options?: { redactPII?: boolean },
+): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -96,16 +124,17 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const resolvedMessageId = messageId ?? messageIdFull;
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
+  const senderE164 = options?.redactPII ? undefined : safeTrim(ctx.SenderE164);
+  const rawSenderId = safeTrim(ctx.SenderId);
+  const senderId = options?.redactPII && rawSenderId ? hashSenderId(rawSenderId) : rawSenderId;
+
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
-    sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
+    sender_id: shouldIncludeConversationInfo ? senderId : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ??
-        safeTrim(ctx.SenderE164) ??
-        safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername))
+      ? (safeTrim(ctx.SenderName) ?? senderE164 ?? senderId ?? safeTrim(ctx.SenderUsername))
       : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
@@ -140,14 +169,14 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
       name: safeTrim(ctx.SenderName),
       username: safeTrim(ctx.SenderUsername),
       tag: safeTrim(ctx.SenderTag),
-      e164: safeTrim(ctx.SenderE164),
-      id: safeTrim(ctx.SenderId),
+      e164: senderE164,
+      id: senderId,
     }),
-    id: safeTrim(ctx.SenderId),
+    id: senderId,
     name: safeTrim(ctx.SenderName),
     username: safeTrim(ctx.SenderUsername),
     tag: safeTrim(ctx.SenderTag),
-    e164: safeTrim(ctx.SenderE164),
+    e164: senderE164,
   };
   if (senderInfo?.label) {
     blocks.push(

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -12,8 +12,8 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
-/** E.164 phone number pattern: optional +, 7-15 digits, optionally followed by @... (WhatsApp JID) */
-const E164_PATTERN = /^\+?\d{7,15}(?:@.*)?$/;
+/** E.164 phone number or WhatsApp JID pattern: requires + prefix for bare numbers, or digits followed by @ for JIDs */
+const E164_PATTERN = /^(?:\+\d{7,15}|\d{7,15}@.+)$/;
 
 function redactSenderLabel(value: string | undefined): string | undefined {
   if (!value) {
@@ -88,13 +88,11 @@ export function buildInboundMetaSystemPrompt(
   // For webchat/Hub Chat sessions (when Surface is 'webchat' or undefined with no real channel),
   // omit the channel field entirely rather than falling back to an unrelated provider.
   const channelValue = resolveInboundChannel(ctx);
+  const chatId = safeTrim(ctx.OriginatingTo);
 
   const payload = {
     schema: "openclaw.inbound_meta.v1",
-    chat_id:
-      options?.redactPII && safeTrim(ctx.OriginatingTo)
-        ? hashChatId(safeTrim(ctx.OriginatingTo)!)
-        : safeTrim(ctx.OriginatingTo),
+    chat_id: options?.redactPII && chatId ? hashChatId(chatId) : chatId,
     account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -12,6 +12,16 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
+/** E.164 phone number pattern: optional +, 7-15 digits, optionally followed by @... (WhatsApp JID) */
+const E164_PATTERN = /^\+?\d{7,15}(?:@.*)?$/;
+
+function redactSenderLabel(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return E164_PATTERN.test(value) ? hashSenderId(value) : value;
+}
+
 function hashChatId(value: string): string {
   const colonIdx = value.indexOf(":");
   if (colonIdx > 0) {
@@ -204,7 +214,9 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           {
-            sender_label: safeTrim(ctx.ReplyToSender),
+            sender_label: options?.redactPII
+              ? redactSenderLabel(safeTrim(ctx.ReplyToSender))
+              : safeTrim(ctx.ReplyToSender),
             is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
             body: ctx.ReplyToBody,
           },
@@ -223,7 +235,9 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           {
-            from: safeTrim(ctx.ForwardedFrom),
+            from: options?.redactPII
+              ? redactSenderLabel(safeTrim(ctx.ForwardedFrom))
+              : safeTrim(ctx.ForwardedFrom),
             type: safeTrim(ctx.ForwardedFromType),
             username: safeTrim(ctx.ForwardedFromUsername),
             title: safeTrim(ctx.ForwardedFromTitle),
@@ -246,7 +260,7 @@ export function buildInboundUserContextPrefix(
         "```json",
         JSON.stringify(
           ctx.InboundHistory.map((entry) => ({
-            sender: entry.sender,
+            sender: options?.redactPII ? redactSenderLabel(entry.sender) : entry.sender,
             timestamp_ms: entry.timestamp,
             body: entry.body,
           })),

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -5,6 +5,7 @@ import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js
 import type { TemplateContext } from "../templating.js";
 
 function hashId(value: string): string {
+  // Keep 12-char truncation aligned with formatOwnerDisplayId.
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -13,6 +13,10 @@ function hashSenderId(value: string): string {
   return `user_${hashId(value)}`;
 }
 
+function hashParticipantLabel(value: string): string {
+  return `participant_${hashId(value)}`;
+}
+
 /**
  * Sender-label redaction pattern:
  * - +15551234567
@@ -23,12 +27,36 @@ function hashSenderId(value: string): string {
  * not to SenderId/chat_id, to avoid broadening numeric-ID false positives.
  */
 const SENDER_LABEL_PHONE_PATTERN = /^(?:\+\d{7,15}|\d{7,15}|\d{7,15}@.+)$/;
+const SENDER_LABEL_ID_PATTERN = /^user:(.+)$/;
 
 function redactSenderLabel(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  return SENDER_LABEL_PHONE_PATTERN.test(value) ? hashSenderId(value) : value;
+  const idMatch = value.match(SENDER_LABEL_ID_PATTERN);
+  if (idMatch) {
+    return hashSenderId(idMatch[1]);
+  }
+  if (SENDER_LABEL_PHONE_PATTERN.test(value)) {
+    return hashSenderId(value);
+  }
+  return hashParticipantLabel(value);
+}
+
+function resolveRedactedParticipantLabel(ctx: TemplateContext): string | undefined {
+  const rawSenderId = safeTrim(ctx.SenderId);
+  const senderE164 = safeTrim(ctx.SenderE164);
+  const senderName = safeTrim(ctx.SenderName);
+  const senderUsername = safeTrim(ctx.SenderUsername);
+  return rawSenderId
+    ? hashSenderId(rawSenderId)
+    : senderE164
+      ? hashSenderId(senderE164)
+      : senderName
+        ? hashParticipantLabel(senderName)
+        : senderUsername
+          ? hashParticipantLabel(senderUsername)
+          : undefined;
 }
 
 function hashChatId(value: string): string {
@@ -144,20 +172,26 @@ export function buildInboundUserContextPrefix(
   const senderE164 = options?.redactPII ? undefined : safeTrim(ctx.SenderE164);
   const rawSenderId = safeTrim(ctx.SenderId);
   const senderId = options?.redactPII && rawSenderId ? hashSenderId(rawSenderId) : rawSenderId;
+  const redactedParticipantLabel = options?.redactPII
+    ? resolveRedactedParticipantLabel(ctx)
+    : undefined;
 
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
     sender_id: shouldIncludeConversationInfo ? senderId : undefined,
-    conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
+    conversation_label:
+      options?.redactPII || isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
-      ? (safeTrim(ctx.SenderName) ?? senderE164 ?? senderId ?? safeTrim(ctx.SenderUsername))
+      ? options?.redactPII
+        ? redactedParticipantLabel
+        : (safeTrim(ctx.SenderName) ?? senderE164 ?? senderId ?? safeTrim(ctx.SenderUsername))
       : undefined,
     timestamp: timestampStr,
-    group_subject: safeTrim(ctx.GroupSubject),
-    group_channel: safeTrim(ctx.GroupChannel),
-    group_space: safeTrim(ctx.GroupSpace),
-    thread_label: safeTrim(ctx.ThreadLabel),
+    group_subject: options?.redactPII ? undefined : safeTrim(ctx.GroupSubject),
+    group_channel: options?.redactPII ? undefined : safeTrim(ctx.GroupChannel),
+    group_space: options?.redactPII ? undefined : safeTrim(ctx.GroupSpace),
+    thread_label: options?.redactPII ? undefined : safeTrim(ctx.ThreadLabel),
     topic_id: ctx.MessageThreadId != null ? String(ctx.MessageThreadId) : undefined,
     is_forum: ctx.IsForum === true ? true : undefined,
     is_group_chat: !isDirect ? true : undefined,
@@ -181,20 +215,25 @@ export function buildInboundUserContextPrefix(
     );
   }
 
-  const senderInfo = {
-    label: resolveSenderLabel({
-      name: safeTrim(ctx.SenderName),
-      username: safeTrim(ctx.SenderUsername),
-      tag: safeTrim(ctx.SenderTag),
-      e164: senderE164,
-      id: senderId,
-    }),
-    id: senderId,
-    name: safeTrim(ctx.SenderName),
-    username: safeTrim(ctx.SenderUsername),
-    tag: safeTrim(ctx.SenderTag),
-    e164: senderE164,
-  };
+  const senderInfo = options?.redactPII
+    ? {
+        label: redactedParticipantLabel,
+        id: senderId,
+      }
+    : {
+        label: resolveSenderLabel({
+          name: safeTrim(ctx.SenderName),
+          username: safeTrim(ctx.SenderUsername),
+          tag: safeTrim(ctx.SenderTag),
+          e164: senderE164,
+          id: senderId,
+        }),
+        id: senderId,
+        name: safeTrim(ctx.SenderName),
+        username: safeTrim(ctx.SenderUsername),
+        tag: safeTrim(ctx.SenderTag),
+        e164: senderE164,
+      };
   if (senderInfo?.label) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
@@ -246,9 +285,9 @@ export function buildInboundUserContextPrefix(
               ? redactSenderLabel(safeTrim(ctx.ForwardedFrom))
               : safeTrim(ctx.ForwardedFrom),
             type: safeTrim(ctx.ForwardedFromType),
-            username: safeTrim(ctx.ForwardedFromUsername),
-            title: safeTrim(ctx.ForwardedFromTitle),
-            signature: safeTrim(ctx.ForwardedFromSignature),
+            username: options?.redactPII ? undefined : safeTrim(ctx.ForwardedFromUsername),
+            title: options?.redactPII ? undefined : safeTrim(ctx.ForwardedFromTitle),
+            signature: options?.redactPII ? undefined : safeTrim(ctx.ForwardedFromSignature),
             chat_type: safeTrim(ctx.ForwardedFromChatType),
             date_ms: typeof ctx.ForwardedDate === "number" ? ctx.ForwardedDate : undefined,
           },

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -887,6 +887,12 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    privacy: z
+      .object({
+        redactPII: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     plugins: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
### Summary

Add a `privacy.redactPII` config option to reduce **system-injected** PII exposure in the prompt context sent to the LLM provider.

This PR is intentionally scoped to **metadata injected by OpenClaw itself**. It does **not** rewrite user-authored message body content.

### Scope

When `privacy.redactPII: true` is enabled, this PR redacts or pseudonymizes these **system-injected metadata paths**:

- `SenderE164`
- `SenderId`
- `chat_id`
- `InboundHistory.sender`
- `ReplyToSender`
- `ForwardedFrom`

Public user-chosen fields are intentionally preserved:

- `SenderName`
- `SenderUsername`
- `SenderTag`

### Why

OpenClaw currently injects raw phone numbers and platform/user identifiers into the LLM-facing prompt context.

Examples:
- `SenderE164` may contain a real phone number
- `SenderId` may contain a phone number or user ID depending on channel
- `chat_id` may contain a private-chat user ID
- history / reply / forward metadata may repeat the same identifiers

These values are not required by the model for auth or routing. Auth/routing happens at the gateway layer before the LLM call.

### Behavior

With `privacy.redactPII: true`:

| Field | Behavior |
|---|---|
| `SenderE164` | stripped |
| `SenderId` | deterministic pseudonym (`user_` + 12-char sha256) |
| `chat_id` | ID portion hashed, channel prefix preserved |
| `InboundHistory.sender` | phone-like values pseudonymized |
| `ReplyToSender` | phone-like values pseudonymized |
| `ForwardedFrom` | phone-like values pseudonymized |

### Non-goals

This PR intentionally does **not**:

- rewrite user-authored message bodies
- rewrite quoted/forwarded message body text
- redact public user-chosen fields (`SenderName`, `SenderUsername`, `SenderTag`)
- cover backup/export/log redaction paths
- attempt one-shot sanitization of every possible string that may contain an identifier

The goal is **incremental privacy improvement without functional regressions**, not full anonymization of all content.

### Design choices

#### 1. Deterministic pseudonyms
`SenderId` and redacted sender labels use deterministic 12-char SHA-256 truncation.

This preserves:
- speaker differentiation in group chats
- stable identity mapping across turns/sessions

#### 2. Strip vs hash
- `SenderE164` is stripped because it is explicit PII
- `SenderId` / `chat_id` are pseudonymized because the model still benefits from stable identifiers

#### 3. Public fields remain visible
`SenderName`, `SenderUsername`, and `SenderTag` are treated as user-chosen public identifiers and are left unchanged.

### Known trade-offs

- This provides **pseudonymization**, not strong anonymization.
- The hash is deterministic and unsalted by design to preserve stable speaker identity.
- Different metadata sources may still produce different pseudonyms if the upstream channel surfaces different raw identifiers.

These trade-offs are accepted in this PR to keep scope narrow and avoid functional regressions.

### Changes

- `src/config/zod-schema.ts`
  - add `privacy.redactPII`
- `src/auto-reply/reply/inbound-meta.ts`
  - redact/pseudonymize system-injected metadata fields
- `src/auto-reply/reply/get-reply-run.ts`
  - thread `redactPII` into builder calls
  - document raw internal fields used for auth/routing
- `src/auto-reply/reply/inbound-meta.test.ts`
  - add coverage for current sender, history, reply context, and forwarded context

### Validation

- focused unit tests added for all in-scope metadata paths
- default behavior unchanged when `privacy.redactPII` is disabled

Closes #47958