### PR TITLE
Agents: add compaction guard scorer

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1009,6 +1009,12 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
+        guard: {
+          enabled: false,
+          maxCompactionsPerWindow: 3,
+          windowMinutes: 30,
+          escalation: "recommend-reset",
+        },
         postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
         model: "openrouter/anthropic/claude-sonnet-4-5", // optional compaction-only model override
         memoryFlush: {
@@ -1027,6 +1033,10 @@ Periodic heartbeat runs.
 - `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `900`.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
+- `guard`: reserved repeated-compaction guard scaffolding. Default: `{ enabled: false }`. This config currently does not change runtime behavior.
+- `guard.maxCompactionsPerWindow`: maximum compaction events allowed within the rolling guard window before future escalation. Integer range: `2-20`.
+- `guard.windowMinutes`: rolling guard window in minutes. Integer range: `1-1440`.
+- `guard.escalation`: reserved escalation policy for future guard trips. Currently only `recommend-reset` is accepted.
 - `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
 - `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.

--- a/src/agents/compaction-guard.test.ts
+++ b/src/agents/compaction-guard.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultGuardThresholds, scoreCompactionGuard } from "./compaction-guard.js";
+import type { TranscriptTailSignal } from "./transcript-tail-detector.js";
+
+describe("resolveDefaultGuardThresholds", () => {
+  it("returns the documented defaults", () => {
+    expect(resolveDefaultGuardThresholds()).toEqual({
+      warnUsageRatio: 0.85,
+      riskUsageRatio: 0.9,
+      forceUsageRatio: 0.95,
+      repeatedToolFailureThreshold: 3,
+      duplicateAssistantThreshold: 2,
+      staleSystemRecurrenceThreshold: 2,
+      noGroundedReplyTurnsThreshold: 4,
+    });
+  });
+});
+
+describe("scoreCompactionGuard", () => {
+  it("returns none for a low-risk session", () => {
+    expect(
+      scoreCompactionGuard({
+        usageRatio: 0.84,
+        transcript: createTranscriptSignal(),
+      }),
+    ).toEqual({
+      usageRatio: 0.84,
+      repeatedToolFailures: [],
+      duplicateAssistantClusters: 0,
+      staleSystemRecurrences: 0,
+      noGroundedReplyTurns: 0,
+      score: 0,
+      action: "none",
+      reasons: [],
+    });
+  });
+
+  it("returns warn when usage pressure and duplicate assistant clusters cross thresholds", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.9,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+
+    expect(signal.score).toBe(4);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+
+  it("returns compact when combined loop signals reach the compaction band", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.85,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [createRepeatedToolFailure("shell: timeout", 3)],
+        noGroundedReplyTurns: 4,
+      }),
+    });
+
+    expect(signal.score).toBe(5);
+    expect(signal.action).toBe("compact");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "repeatedToolFailures>=threshold",
+      "noGroundedReplyTurns>=threshold",
+    ]);
+  });
+
+  it("returns reset-candidate for high score under force-level usage", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.96,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [createRepeatedToolFailure("shell: timeout", 3)],
+        staleSystemRecurrences: 2,
+        noGroundedReplyTurns: 4,
+      }),
+    });
+
+    expect(signal.score).toBe(11);
+    expect(signal.action).toBe("reset-candidate");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "usage>=force",
+      "repeatedToolFailures>=threshold",
+      "staleSystemRecurrences>=threshold",
+      "noGroundedReplyTurns>=threshold",
+    ]);
+  });
+
+  it("stays below and above the risk threshold deterministically", () => {
+    const justBelowRisk = scoreCompactionGuard({
+      usageRatio: 0.899,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+    const atRisk = scoreCompactionGuard({
+      usageRatio: 0.9,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+
+    expect(justBelowRisk.score).toBe(2);
+    expect(justBelowRisk.action).toBe("none");
+    expect(justBelowRisk.reasons).toEqual(["usage>=warn", "duplicateAssistantClusters>=threshold"]);
+
+    expect(atRisk.score).toBe(4);
+    expect(atRisk.action).toBe("warn");
+    expect(atRisk.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+
+  it("counts repeated tool failures at most once even when multiple groups cross the threshold", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.85,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [
+          createRepeatedToolFailure("shell: timeout", 3),
+          createRepeatedToolFailure("fetch: 500", 5),
+        ],
+      }),
+    });
+
+    expect(signal.score).toBe(3);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual(["usage>=warn", "repeatedToolFailures>=threshold"]);
+  });
+
+  it("applies custom thresholds on top of the defaults", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.8,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 1,
+      }),
+      thresholds: {
+        warnUsageRatio: 0.8,
+        riskUsageRatio: 0.8,
+        duplicateAssistantThreshold: 1,
+      },
+    });
+
+    expect(signal.score).toBe(4);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+});
+
+function createTranscriptSignal(
+  overrides: Partial<TranscriptTailSignal> = {},
+): TranscriptTailSignal {
+  return {
+    repeatedToolFailures: [],
+    duplicateAssistantClusters: 0,
+    staleSystemRecurrences: 0,
+    noGroundedReplyTurns: 0,
+    ...overrides,
+  };
+}
+
+function createRepeatedToolFailure(
+  signature: string,
+  count: number,
+): TranscriptTailSignal["repeatedToolFailures"][number] {
+  return {
+    signature,
+    count,
+    lastSeenEntryId: `${signature}-${count}`,
+  };
+}

--- a/src/agents/compaction-guard.ts
+++ b/src/agents/compaction-guard.ts
@@ -1,0 +1,162 @@
+import type { TranscriptTailSignal } from "./transcript-tail-detector.js";
+
+export type GuardThresholds = {
+  warnUsageRatio: number;
+  riskUsageRatio: number;
+  forceUsageRatio: number;
+  repeatedToolFailureThreshold: number;
+  duplicateAssistantThreshold: number;
+  staleSystemRecurrenceThreshold: number;
+  noGroundedReplyTurnsThreshold: number;
+};
+
+export type GuardAction = "none" | "warn" | "compact" | "recommend-reset" | "reset-candidate";
+
+export type SessionGuardSignal = {
+  usageRatio: number;
+  repeatedToolFailures: TranscriptTailSignal["repeatedToolFailures"];
+  duplicateAssistantClusters: number;
+  staleSystemRecurrences: number;
+  noGroundedReplyTurns: number;
+  score: number;
+  action: GuardAction;
+  reasons: string[];
+};
+
+const DEFAULT_GUARD_THRESHOLDS: GuardThresholds = {
+  warnUsageRatio: 0.85,
+  riskUsageRatio: 0.9,
+  forceUsageRatio: 0.95,
+  repeatedToolFailureThreshold: 3,
+  duplicateAssistantThreshold: 2,
+  staleSystemRecurrenceThreshold: 2,
+  noGroundedReplyTurnsThreshold: 4,
+};
+
+const REASONS = {
+  usageWarn: "usage>=warn",
+  usageRisk: "usage>=risk",
+  usageForce: "usage>=force",
+  repeatedToolFailures: "repeatedToolFailures>=threshold",
+  duplicateAssistantClusters: "duplicateAssistantClusters>=threshold",
+  staleSystemRecurrences: "staleSystemRecurrences>=threshold",
+  noGroundedReplyTurns: "noGroundedReplyTurns>=threshold",
+} as const;
+
+export function resolveDefaultGuardThresholds(): GuardThresholds {
+  return { ...DEFAULT_GUARD_THRESHOLDS };
+}
+
+export function scoreCompactionGuard(params: {
+  usageRatio: number;
+  transcript: TranscriptTailSignal;
+  thresholds?: Partial<GuardThresholds>;
+}): SessionGuardSignal {
+  const thresholds = resolveGuardThresholds(params.thresholds);
+  const reasons: string[] = [];
+  let score = 0;
+
+  score += scoreUsagePressure(params.usageRatio, thresholds, reasons);
+  score += scoreLoopSignals(params.transcript, thresholds, reasons);
+
+  return {
+    usageRatio: params.usageRatio,
+    repeatedToolFailures: params.transcript.repeatedToolFailures.map((failure) => ({
+      ...failure,
+    })),
+    duplicateAssistantClusters: params.transcript.duplicateAssistantClusters,
+    staleSystemRecurrences: params.transcript.staleSystemRecurrences,
+    noGroundedReplyTurns: params.transcript.noGroundedReplyTurns,
+    score,
+    action: resolveGuardAction(score, params.usageRatio, thresholds),
+    reasons,
+  };
+}
+
+function resolveGuardThresholds(thresholds?: Partial<GuardThresholds>): GuardThresholds {
+  return {
+    ...DEFAULT_GUARD_THRESHOLDS,
+    ...thresholds,
+  };
+}
+
+function scoreUsagePressure(
+  usageRatio: number,
+  thresholds: GuardThresholds,
+  reasons: string[],
+): number {
+  let score = 0;
+
+  if (usageRatio >= thresholds.warnUsageRatio) {
+    score += 1;
+    reasons.push(REASONS.usageWarn);
+  }
+
+  if (usageRatio >= thresholds.riskUsageRatio) {
+    score += 2;
+    reasons.push(REASONS.usageRisk);
+  }
+
+  if (usageRatio >= thresholds.forceUsageRatio) {
+    score += 2;
+    reasons.push(REASONS.usageForce);
+  }
+
+  return score;
+}
+
+function scoreLoopSignals(
+  transcript: TranscriptTailSignal,
+  thresholds: GuardThresholds,
+  reasons: string[],
+): number {
+  let score = 0;
+
+  // Count repeated tool failures once so one noisy tool loop does not multiply
+  // into multiple risk buckets just because several signatures crossed the line.
+  if (
+    transcript.repeatedToolFailures.some(
+      ({ count }) => count >= thresholds.repeatedToolFailureThreshold,
+    )
+  ) {
+    score += 2;
+    reasons.push(REASONS.repeatedToolFailures);
+  }
+
+  if (transcript.duplicateAssistantClusters >= thresholds.duplicateAssistantThreshold) {
+    score += 1;
+    reasons.push(REASONS.duplicateAssistantClusters);
+  }
+
+  if (transcript.staleSystemRecurrences >= thresholds.staleSystemRecurrenceThreshold) {
+    score += 2;
+    reasons.push(REASONS.staleSystemRecurrences);
+  }
+
+  if (transcript.noGroundedReplyTurns >= thresholds.noGroundedReplyTurnsThreshold) {
+    score += 2;
+    reasons.push(REASONS.noGroundedReplyTurns);
+  }
+
+  return score;
+}
+
+function resolveGuardAction(
+  score: number,
+  usageRatio: number,
+  thresholds: GuardThresholds,
+): GuardAction {
+  if (score >= 8) {
+    return usageRatio >= thresholds.forceUsageRatio ? "reset-candidate" : "recommend-reset";
+  }
+
+  if (score >= 5) {
+    return "compact";
+  }
+
+  if (score >= 3) {
+    return "warn";
+  }
+
+  return "none";
+}

--- a/src/agents/transcript-tail-detector.test.ts
+++ b/src/agents/transcript-tail-detector.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTranscriptTailSignals,
+  type TranscriptTailEntry,
+} from "./transcript-tail-detector.js";
+
+describe("detectTranscriptTailSignals", () => {
+  it("groups repeated tool failures with the same normalized signature", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("t1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("t2", "searchWeb", "request 987 timed out after 31 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([
+      {
+        signature: "searchweb: request <num> timed out after <num> seconds",
+        count: 2,
+        lastSeenEntryId: "t2",
+      },
+    ]);
+  });
+
+  it("separates different tool failures into distinct groups", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("a1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("a2", "searchWeb", "Permission denied for workspace alpha"),
+      toolFailure("a3", "fetchFile", "Request 999 timed out after 45 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([]);
+  });
+
+  it("detects duplicate assistant clusters from repeated normalized text", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Working on it now." },
+      { role: "assistant", text: "  working   on it now.  " },
+      { role: "assistant", text: "Different reply" },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).duplicateAssistantClusters).toBe(1);
+  });
+
+  it("detects stale directive-like system recurrences", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: do not retry the same failed tool call.",
+      },
+      { role: "assistant", text: "I will avoid that." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder:   do not retry the same failed tool call. ",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(1);
+  });
+
+  it("does not flag legitimate post-compaction reinjection prefixes as stale", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nKeep going.",
+      },
+      {
+        role: "system",
+        text: "Session was just compacted.\nPlease continue.",
+      },
+      {
+        role: "system",
+        text: "Injected sections from AGENTS.md\n- rule one",
+      },
+      {
+        role: "system",
+        text: "Current time: 2026-03-16T12:34:56Z\nTimezone: UTC",
+      },
+      {
+        role: "system",
+        text: "Critical rules from AGENTS.md:\n- do not reset",
+      },
+      {
+        role: "system",
+        text: "  Current time: 2026-03-16T12:35:56Z\nTimezone: UTC",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(0);
+  });
+
+  it("counts trailing user turns without a non-empty assistant reply", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Earlier grounded answer." },
+      { role: "user", text: "Can you keep going?" },
+      { role: "toolResult", toolName: "searchWeb", toolStatus: "error", errorText: "timeout" },
+      { role: "assistant", text: "   " },
+      { role: "user", text: "Still waiting." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).noGroundedReplyTurns).toBe(2);
+  });
+
+  it("reports multiple signal types together in a mixed tail", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nContext restored.",
+      },
+      {
+        id: "tool-1",
+        role: "toolResult",
+        toolName: "searchWeb",
+        toolStatus: "error",
+        errorText: "HTTP 500 for request 12345",
+      },
+      { role: "assistant", text: "I will check that now." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: always acknowledge repeated tool failures before retrying.",
+      },
+      {
+        id: "tool-2",
+        role: "toolResult",
+        toolName: "searchWeb",
+        isError: true,
+        errorText: "http 500 for request 99999",
+      },
+      { role: "assistant", text: "  i will check that now. " },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder: always acknowledge repeated tool failures before retrying. ",
+      },
+      { role: "user", text: "Any update?" },
+      { role: "user", text: "Please answer directly." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries)).toEqual({
+      repeatedToolFailures: [
+        {
+          signature: "searchweb: http <num> for request <num>",
+          count: 2,
+          lastSeenEntryId: "tool-2",
+        },
+      ],
+      duplicateAssistantClusters: 1,
+      staleSystemRecurrences: 1,
+      noGroundedReplyTurns: 2,
+    });
+  });
+});
+
+function toolFailure(id: string, toolName: string, errorText: string): TranscriptTailEntry {
+  return {
+    id,
+    role: "toolResult",
+    toolName,
+    toolStatus: "error",
+    errorText,
+  };
+}

--- a/src/agents/transcript-tail-detector.ts
+++ b/src/agents/transcript-tail-detector.ts
@@ -1,0 +1,237 @@
+export type TranscriptTailEntry = {
+  id?: string;
+  role?: string;
+  kind?: string;
+  text?: string;
+  toolName?: string;
+  toolStatus?: string;
+  errorText?: string;
+  isError?: boolean;
+};
+
+export type TranscriptTailSignal = {
+  repeatedToolFailures: Array<{
+    signature: string;
+    count: number;
+    lastSeenEntryId?: string;
+  }>;
+  duplicateAssistantClusters: number;
+  staleSystemRecurrences: number;
+  noGroundedReplyTurns: number;
+};
+
+const STALE_SYSTEM_EXEMPT_PREFIXES = [
+  "[Post-compaction context refresh]",
+  "Session was just compacted.",
+  "Critical rules from AGENTS.md:",
+  "Injected sections from AGENTS.md",
+] as const;
+
+const DIRECTIVE_TEXT_PATTERN =
+  /\b(always|avoid|critical|directive|do not|don't|follow|important|instruction|must|never|note|remember|reminder|required|rule|should)\b/;
+
+export function detectTranscriptTailSignals(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal {
+  return {
+    repeatedToolFailures: collectRepeatedToolFailures(entries),
+    duplicateAssistantClusters: countDuplicateAssistantClusters(entries),
+    staleSystemRecurrences: countStaleSystemRecurrences(entries),
+    noGroundedReplyTurns: countTrailingUserTurnsWithoutReply(entries),
+  };
+}
+
+function collectRepeatedToolFailures(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal["repeatedToolFailures"] {
+  const groupedFailures = new Map<
+    string,
+    { signature: string; count: number; lastSeenEntryId?: string }
+  >();
+
+  for (const entry of entries) {
+    const signature = getToolFailureSignature(entry);
+
+    if (!signature) {
+      continue;
+    }
+
+    const current = groupedFailures.get(signature);
+
+    if (current) {
+      current.count += 1;
+      current.lastSeenEntryId = entry.id ?? current.lastSeenEntryId;
+      continue;
+    }
+
+    groupedFailures.set(signature, {
+      signature,
+      count: 1,
+      lastSeenEntryId: entry.id,
+    });
+  }
+
+  return [...groupedFailures.values()].filter(({ count }) => count > 1);
+}
+
+function getToolFailureSignature(entry: TranscriptTailEntry): string | undefined {
+  if (!isToolFailureEntry(entry)) {
+    return undefined;
+  }
+
+  const toolName = normalizeComparableText(entry.toolName) || "unknown-tool";
+  const rawErrorText = entry.errorText ?? entry.text ?? "error";
+  const errorSignature = normalizeFailureSignature(rawErrorText) || "error";
+
+  return `${toolName}: ${errorSignature}`;
+}
+
+function isToolFailureEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+  const hasToolIdentity =
+    hasNonEmptyText(entry.toolName) ||
+    normalizedRole === "toolresult" ||
+    normalizedKind.includes("tool");
+
+  if (!hasToolIdentity) {
+    return false;
+  }
+
+  return (
+    entry.isError === true ||
+    normalizeToken(entry.toolStatus) === "error" ||
+    hasNonEmptyText(entry.errorText)
+  );
+}
+
+function countDuplicateAssistantClusters(entries: readonly TranscriptTailEntry[]): number {
+  const seenAssistantReplies = new Map<string, number>();
+  let duplicateClusters = 0;
+
+  for (const entry of entries) {
+    if (normalizeToken(entry.role) !== "assistant") {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(entry.text);
+
+    if (!normalizedText) {
+      continue;
+    }
+
+    const previousCount = seenAssistantReplies.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      duplicateClusters += 1;
+    }
+
+    seenAssistantReplies.set(normalizedText, previousCount + 1);
+  }
+
+  return duplicateClusters;
+}
+
+function countStaleSystemRecurrences(entries: readonly TranscriptTailEntry[]): number {
+  const seenSystemTexts = new Map<string, number>();
+  let staleRecurrences = 0;
+
+  for (const entry of entries) {
+    if (!isSystemLikeEntry(entry)) {
+      continue;
+    }
+
+    const text = entry.text?.trim();
+
+    if (!text || isLegitimateReinjectionText(text)) {
+      continue;
+    }
+
+    if (!isDirectiveLikeSystemText(text, entry.kind)) {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(text);
+    const previousCount = seenSystemTexts.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      staleRecurrences += 1;
+    }
+
+    seenSystemTexts.set(normalizedText, previousCount + 1);
+  }
+
+  return staleRecurrences;
+}
+
+function isSystemLikeEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+
+  return (
+    normalizedRole === "system" ||
+    normalizedKind.includes("system") ||
+    normalizedKind.includes("reminder")
+  );
+}
+
+function isLegitimateReinjectionText(text: string): boolean {
+  const trimmed = text.trimStart();
+
+  if (STALE_SYSTEM_EXEMPT_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+    return true;
+  }
+
+  return trimmed.split(/\r?\n/u).some((line) => line.trimStart().startsWith("Current time:"));
+}
+
+function isDirectiveLikeSystemText(text: string, kind?: string): boolean {
+  const normalizedKind = normalizeToken(kind);
+
+  if (normalizedKind.includes("reminder") || normalizedKind.includes("directive")) {
+    return true;
+  }
+
+  return DIRECTIVE_TEXT_PATTERN.test(text.toLowerCase());
+}
+
+function countTrailingUserTurnsWithoutReply(entries: readonly TranscriptTailEntry[]): number {
+  let trailingUserTurns = 0;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const normalizedRole = normalizeToken(entry.role);
+
+    if (normalizedRole === "assistant" && hasNonEmptyText(entry.text)) {
+      break;
+    }
+
+    if (normalizedRole === "user" && hasNonEmptyText(entry.text)) {
+      trailingUserTurns += 1;
+    }
+  }
+
+  return trailingUserTurns;
+}
+
+function normalizeFailureSignature(text: string): string {
+  return normalizeComparableText(
+    text
+      .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/giu, "<id>")
+      .replace(/\b0x[0-9a-f]+\b/giu, "<hex>")
+      .replace(/\b[a-f0-9]{12,}\b/giu, "<id>")
+      .replace(/\b\d{2,}\b/gu, "<num>"),
+  );
+}
+
+function normalizeComparableText(value?: string): string {
+  return normalizeToken(value).replace(/\s+/gu, " ").trim();
+}
+
+function normalizeToken(value?: string): string {
+  return value?.toLowerCase().trim() ?? "";
+}
+
+function hasNonEmptyText(value?: string): boolean {
+  return normalizeComparableText(value).length > 0;
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -109,6 +109,51 @@ describe("config compaction settings", () => {
     );
   });
 
+  it("preserves explicit compaction guard config values", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+              guard: {
+                enabled: true,
+                maxCompactionsPerWindow: 3,
+                windowMinutes: 30,
+                escalation: "recommend-reset",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard?.enabled).toBe(true);
+        expect(cfg.agents?.defaults?.compaction?.guard?.maxCompactionsPerWindow).toBe(3);
+        expect(cfg.agents?.defaults?.compaction?.guard?.windowMinutes).toBe(30);
+        expect(cfg.agents?.defaults?.compaction?.guard?.escalation).toBe("recommend-reset");
+      },
+    );
+  });
+
+  it("defaults compaction guard shape to disabled", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard).toEqual({ enabled: false });
+      },
+    );
+  });
+
   it("preserves oversized quality guard retry values for runtime clamping", async () => {
     await withTempHomeConfig(
       {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -224,4 +224,52 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it('rejects compaction.guard escalation values other than "recommend-reset"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              escalation: "reset-now",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.escalation"),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects compaction.guard numeric values outside conservative bounds", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              maxCompactionsPerWindow: 1,
+              windowMinutes: 1441,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) => issue.path === "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+        ),
+      ).toBe(true);
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.windowMinutes"),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -512,7 +512,9 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
     return cfg;
   }
   const compaction = defaults?.compaction;
-  if (compaction?.mode) {
+  const needsModeDefault = compaction?.mode === undefined;
+  const needsGuardDefault = compaction?.guard?.enabled === undefined;
+  if (!needsModeDefault && !needsGuardDefault) {
     return cfg;
   }
 
@@ -524,7 +526,11 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
         ...defaults,
         compaction: {
           ...compaction,
-          mode: "safeguard",
+          ...(needsModeDefault ? { mode: "safeguard" as const } : {}),
+          guard: {
+            ...compaction?.guard,
+            enabled: compaction?.guard?.enabled ?? false,
+          },
         },
       },
     },

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -381,6 +381,11 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.identifierPolicy",
   "agents.defaults.compaction.identifierInstructions",
   "agents.defaults.compaction.recentTurnsPreserve",
+  "agents.defaults.compaction.guard",
+  "agents.defaults.compaction.guard.enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+  "agents.defaults.compaction.guard.windowMinutes",
+  "agents.defaults.compaction.guard.escalation",
   "agents.defaults.compaction.qualityGuard",
   "agents.defaults.compaction.qualityGuard.enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries",
@@ -442,6 +447,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "cli.banner.taglineMode": ['"random"', '"default"', '"off"'],
   "update.channel": ['"stable"', '"beta"', '"dev"'],
   "agents.defaults.compaction.mode": ['"default"', '"safeguard"'],
+  "agents.defaults.compaction.guard.escalation": ['"recommend-reset"'],
   "agents.defaults.compaction.identifierPolicy": ['"strict"', '"off"', '"custom"'],
 };
 
@@ -803,7 +809,7 @@ describe("config help copy quality", () => {
     expect(/cooldown|backoff|retry/i.test(authCooldowns)).toBe(true);
   });
 
-  it("documents agent compaction safeguards and memory flush behavior", () => {
+  it("documents agent compaction safeguards, guard scaffolding, and memory flush behavior", () => {
     const mode = FIELD_HELP["agents.defaults.compaction.mode"];
     expect(mode.includes('"default"')).toBe(true);
     expect(mode.includes('"safeguard"')).toBe(true);
@@ -819,6 +825,14 @@ describe("config help copy quality", () => {
     const recentTurnsPreserve = FIELD_HELP["agents.defaults.compaction.recentTurnsPreserve"];
     expect(/recent.*turn|verbatim/i.test(recentTurnsPreserve)).toBe(true);
     expect(/default:\s*3/i.test(recentTurnsPreserve)).toBe(true);
+
+    const guard = FIELD_HELP["agents.defaults.compaction.guard"];
+    expect(/future|reserved|no runtime effect|does not change runtime behavior/i.test(guard)).toBe(
+      true,
+    );
+
+    const guardEscalation = FIELD_HELP["agents.defaults.compaction.guard.escalation"];
+    expect(guardEscalation.includes('"recommend-reset"')).toBe(true);
 
     const postCompactionSections = FIELD_HELP["agents.defaults.compaction.postCompactionSections"];
     expect(/Session Startup|Red Lines/i.test(postCompactionSections)).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1047,6 +1047,16 @@ export const FIELD_HELP: Record<string, string> = {
     'Custom identifier-preservation instruction text used when identifierPolicy="custom". Keep this explicit and safety-focused so compaction summaries do not rewrite opaque IDs, URLs, hosts, or ports.',
   "agents.defaults.compaction.recentTurnsPreserve":
     "Number of most recent user/assistant turns kept verbatim outside safeguard summarization (default: 3). Raise this to preserve exact recent dialogue context, or lower it to maximize compaction savings.",
+  "agents.defaults.compaction.guard":
+    "Reserved repeated-compaction guard scaffolding for future loop protection. Keep this block for pre-staging loop-protection settings, but use it as config-only for now because it does not change runtime behavior until compaction guard logic is implemented.",
+  "agents.defaults.compaction.guard.enabled":
+    "Enables reserved repeated-compaction guard scaffolding. Default: false, and setting this currently has no runtime effect until repeated-compaction guard behavior exists.",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Maximum compaction events allowed within the rolling guard window before the future guard would escalate (range 2-20). Keep this small if you are pre-staging repeated-compaction protection settings.",
+  "agents.defaults.compaction.guard.windowMinutes":
+    "Rolling time window in minutes used by the future compaction guard when counting repeated compactions (range 1-1440). Use shorter windows for burst detection or longer ones for broader session-level protection.",
+  "agents.defaults.compaction.guard.escalation":
+    'Reserved escalation mode for future compaction guard trips. Use "recommend-reset" to pre-stage a future session-reset recommendation once guard behavior is implemented; no other values are currently accepted.',
   "agents.defaults.compaction.qualityGuard":
     "Optional quality-audit retry settings for safeguard compaction summaries. Leave this disabled unless you explicitly want summary audits and one-shot regeneration on failed checks.",
   "agents.defaults.compaction.qualityGuard.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -472,6 +472,12 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
   "agents.defaults.compaction.recentTurnsPreserve": "Compaction Preserve Recent Turns",
+  "agents.defaults.compaction.guard": "Compaction Loop Guard",
+  "agents.defaults.compaction.guard.enabled": "Compaction Loop Guard Enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Compaction Loop Guard Max Compactions per Window",
+  "agents.defaults.compaction.guard.windowMinutes": "Compaction Loop Guard Window (Minutes)",
+  "agents.defaults.compaction.guard.escalation": "Compaction Loop Guard Escalation",
   "agents.defaults.compaction.qualityGuard": "Compaction Quality Guard",
   "agents.defaults.compaction.qualityGuard.enabled": "Compaction Quality Guard Enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -296,11 +296,22 @@ export type AgentDefaultsConfig = {
 export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionPostIndexSyncMode = "off" | "async" | "await";
 export type AgentCompactionIdentifierPolicy = "strict" | "off" | "custom";
+export type AgentCompactionGuardEscalation = "recommend-reset";
 export type AgentCompactionQualityGuardConfig = {
   /** Enable compaction summary quality audits and regeneration retries. Default: false. */
   enabled?: boolean;
   /** Maximum regeneration retries after a failed quality audit. Default: 1 when enabled. */
   maxRetries?: number;
+};
+export type AgentCompactionGuardConfig = {
+  /** Enable reserved repeated-compaction guard scaffolding. Default: false. */
+  enabled?: boolean;
+  /** Maximum compaction events allowed in the rolling guard window. */
+  maxCompactionsPerWindow?: number;
+  /** Rolling time window in minutes used by the reserved guard. */
+  windowMinutes?: number;
+  /** Escalation mode reserved for future guard trips. */
+  escalation?: AgentCompactionGuardEscalation;
 };
 
 export type AgentCompactionConfig = {
@@ -318,6 +329,8 @@ export type AgentCompactionConfig = {
   customInstructions?: string;
   /** Preserve this many most-recent user/assistant turns verbatim in compaction summary context. */
   recentTurnsPreserve?: number;
+  /** Reserved repeated-compaction guard scaffolding. */
+  guard?: AgentCompactionGuardConfig;
   /** Identifier-preservation instruction policy for compaction summaries. */
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,15 @@ export const AgentDefaultsSchema = z
           .optional(),
         identifierInstructions: z.string().optional(),
         recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+        guard: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxCompactionsPerWindow: z.number().int().min(2).max(20).optional(),
+            windowMinutes: z.number().int().min(1).max(1440).optional(),
+            escalation: z.enum(["recommend-reset"]).optional(),
+          })
+          .strict()
+          .optional(),
         qualityGuard: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Problem: the loop-aware compaction guard plan needed a pure scorer layer between transcript-tail detection and future runtime compaction integration.
- Why it matters: runtime hooks in the next PR need a deterministic, explainable decision point that combines usage pressure with contamination/loop signals without introducing behavior changes yet.
- What changed: added a pure compaction guard scorer plus focused unit tests covering default thresholds, action mapping, reason tags, boundaries, and custom-threshold overrides.
- What did NOT change (scope boundary): no runtime integration, no compaction prompt augmentation, no post-compaction validation, no reset behavior, no session store writes.
- Stacking note: this branch is stacked on top of #48293, which is stacked on #48278, so until those land the compare view against `main` also includes PR1/PR2 commits.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48238
- Depends on #48293
- Depends on #48278

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0 arm64
- Runtime/container: local host checkout
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Add a pure scorer that combines `TranscriptTailSignal` with usage ratio and resolved thresholds.
2. Return deterministic `score`, `action`, and reason tags without side effects.
3. Cover low-risk, warn, compact, high-risk, boundary, reasons, and custom-threshold override cases with focused unit tests.
4. Run the targeted scorer test wrapper.

### Expected

- The scorer returns deterministic actions and reasons for the same input.
- High usage plus multiple contamination signals escalates conservatively toward `compact` / `recommend-reset` / `reset-candidate`.
- No runtime compaction path changes occur.

### Actual

- Targeted scorer tests passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: low-risk `none`, warn-tier, compact-tier, high-risk `recommend-reset`/`reset-candidate`, threshold boundaries, reasons, and custom-threshold overrides.
- Edge cases checked: repeated tool failures only contribute once total when any group crosses threshold; `reset-candidate` only appears for high scores with `usageRatio >= forceUsageRatio`.
- What you did **not** verify: runtime consumption of `score` / `action` / `reasons` (reserved for the next PR).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `3fa1ce5b617f2226dbd0e6d2fca30cb49e58db2b`.
- Files/config to restore: `src/agents/compaction-guard.ts`, `src/agents/compaction-guard.test.ts`.
- Known bad symptoms reviewers should watch for: future runtime consumers assuming the scorer is already wired into compaction or misinterpreting `reset-candidate` as an executable reset instruction.

## Risks and Mitigations

- Risk: initial weights/thresholds may undercount or overcount some real degraded-session patterns.
  - Mitigation: keep the scorer pure and explainable, centralize defaults, emit explicit reason tags, and defer runtime behavior/prompt effects to the next PR.
