### PR TITLE
fix(control-ui): shorten subagent UUID keys + refresh sessions on foreign chat events

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -315,8 +315,8 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
 
   // Foreign chat event: delivery targeted a different session than the one currently viewed.
-  // Instead of silently dropping, trigger a lightweight session-list refresh so the sidebar
-  // stays up to date and the user can see the new activity.
+  // Instead of silently dropping, trigger a lightweight session-list refresh and increment
+  // the per-session unread counter so the session switcher shows a dot.
   const isForeignSession =
     payload?.sessionKey != null &&
     (host as unknown as OpenClawApp).sessionKey !== payload.sessionKey;
@@ -324,6 +324,10 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     void loadSessions(host as unknown as OpenClawApp, {
       activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
     });
+    const app = host as unknown as OpenClawApp;
+    const key = payload.sessionKey;
+    const prev = app.sessionUnreadCounts.get(key) ?? 0;
+    app.sessionUnreadCounts = new Map(app.sessionUnreadCounts).set(key, prev + 1);
     return;
   }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -313,6 +313,20 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       payload.sessionKey,
     );
   }
+
+  // Foreign chat event: delivery targeted a different session than the one currently viewed.
+  // Instead of silently dropping, trigger a lightweight session-list refresh so the sidebar
+  // stays up to date and the user can see the new activity.
+  const isForeignSession =
+    payload?.sessionKey != null &&
+    (host as unknown as OpenClawApp).sessionKey !== payload.sessionKey;
+  if (isForeignSession && payload?.state === "final") {
+    void loadSessions(host as unknown as OpenClawApp, {
+      activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+    });
+    return;
+  }
+
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
   if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -489,6 +489,12 @@ export function renderChatMobileToggle(state: AppViewState) {
 
 function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
+  // Clear unread count for the session we're switching to
+  if (state.sessionUnreadCounts.has(nextSessionKey)) {
+    const next = new Map(state.sessionUnreadCounts);
+    next.delete(nextSessionKey);
+    state.sessionUnreadCounts = next;
+  }
   state.chatMessage = "";
   state.chatStream = null;
   // P1: Clear queued chat items from the previous session
@@ -827,7 +833,9 @@ export function resolveSessionOptionGroups(
         )
       : ensureGroup("other", "Other Sessions");
     const scopeLabel = parsed?.rest?.trim() || key;
-    const label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
+    const baseLabel = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
+    const unreadCount = state.sessionUnreadCounts?.get(key) ?? 0;
+    const label = unreadCount > 0 ? `● ${baseLabel}` : baseLabel;
     group.options.push({
       key,
       label,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -178,6 +178,8 @@ export type AppViewState = {
   agentSkillsError: string | null;
   agentSkillsReport: SkillStatusReport | null;
   agentSkillsAgentId: string | null;
+  /** Per-session unread counts. Incremented on foreign final chat events, cleared on session switch. */
+  sessionUnreadCounts: Map<string, number>;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
   sessionsError: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -146,6 +146,8 @@ export class OpenClawApp extends LitElement {
   @state() serverVersion: string | null = null;
 
   @state() sessionKey = this.settings.sessionKey;
+  /** Per-session unread counts: incremented when a foreign session receives a final chat event. Cleared on session switch. */
+  @state() sessionUnreadCounts: Map<string, number> = new Map();
   @state() chatLoading = false;
   @state() chatSending = false;
   @state() chatMessage = "";

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -126,6 +126,22 @@ function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string |
   return value;
 }
 
+/**
+ * Shorten subagent session keys for display.
+ * Converts `subagent:{uuid}` → `subagent:{short8}` when no label/displayName is set.
+ * The full key is preserved for routing — this is display-only.
+ */
+function shortenSessionKey(key: string, label?: string | null, displayName?: string | null): string {
+  if (label?.trim() || displayName?.trim()) {
+    return key;
+  }
+  const match = /^(subagent):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.exec(key);
+  if (!match) {
+    return key;
+  }
+  return `${match[1]}:${match[2].slice(0, 8)}`;
+}
+
 function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
   const q = query.trim().toLowerCase();
   if (!q) {
@@ -416,6 +432,7 @@ function renderRow(
   const chatUrl = canLink
     ? `${pathForTab("chat", basePath)}?session=${encodeURIComponent(row.key)}`
     : null;
+  const displayKey = shortenSessionKey(row.key, row.label, row.displayName);
   const isMenuOpen = actionsOpenKey === row.key;
   const badgeClass =
     row.kind === "direct"
@@ -430,7 +447,7 @@ function renderRow(
     <tr>
       <td>
         <div class="mono session-key-cell">
-          ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
+          ${canLink ? html`<a href=${chatUrl} class="session-link">${displayKey}</a>` : displayKey}
           ${
             showDisplayName
               ? html`<span class="muted session-key-display-name">${displayName}</span>`


### PR DESCRIPTION
## Summary

Three fixes for Control-UI session display issues.

---

### Fix 1: Shorten subagent session key display (`sessions.ts`)

Subagent sessions are created with keys like `subagent:{full-uuid}`. When no `label` or `displayName` is set, the full UUID is rendered in the sessions table.

**Change:** `shortenSessionKey()` converts `subagent:{uuid}` → `subagent:{short8}` for display when no label/displayName is present. Full key preserved for routing.

---

### Fix 2: Refresh session list on foreign chat delivery (`app-gateway.ts`)

Chat events targeting session B while viewing session A were silently dropped.

**Change:** Foreign `final` events trigger `loadSessions()` so the sidebar updates in real time.

---

### Fix 3: Per-session unread indicators in session switcher

No visual signal when a foreign session receives a message while you are viewing another.

**Change:** Track `sessionUnreadCounts: Map<string, number>` on app state. Incremented on foreign final events (alongside the loadSessions refresh). Session switcher `<option>` labels are prefixed with `●` when count > 0. Count is cleared on session switch.

**Files:** `app.ts`, `app-view-state.ts`, `app-gateway.ts`, `app-render.helpers.ts`

---

## Commits
1. `fix(control-ui): shorten subagent UUID keys + refresh sessions on foreign chat events`
2. `feat(control-ui): per-session unread indicators in session switcher`