### PR TITLE
fix(memory): remove provider model filter from FTS keyword search

### DIFF
--- a/src/memory/manager-search.test.ts
+++ b/src/memory/manager-search.test.ts
@@ -1,0 +1,57 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { searchKeyword } from "./manager-search.js";
+
+describe("searchKeyword", () => {
+  it("returns FTS matches regardless of indexed embedding model", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE VIRTUAL TABLE chunks_fts USING fts5(
+        text,
+        id UNINDEXED,
+        path UNINDEXED,
+        source UNINDEXED,
+        model UNINDEXED,
+        start_line UNINDEXED,
+        end_line UNINDEXED
+      );
+    `);
+
+    const insert = db.prepare(
+      "INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    insert.run(
+      "zebra keyword from old model",
+      "1",
+      "memory/2026-01-12.md",
+      "memory",
+      "mock-embed-v1",
+      1,
+      1,
+    );
+    insert.run(
+      "zebra keyword from new model",
+      "2",
+      "memory/2026-01-13.md",
+      "memory",
+      "mock-embed-v2",
+      1,
+      1,
+    );
+
+    const results = await searchKeyword({
+      db,
+      ftsTable: "chunks_fts",
+      query: "zebra",
+      limit: 10,
+      snippetMaxChars: 200,
+      sourceFilter: { sql: "", params: [] },
+      buildFtsQuery: (raw) => raw,
+      bm25RankToScore: () => 1,
+    });
+
+    expect(results.map((r) => r.path)).toEqual(
+      expect.arrayContaining(["memory/2026-01-12.md", "memory/2026-01-13.md"]),
+    );
+  });
+});

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -136,7 +136,6 @@ export function listChunks(params: {
 export async function searchKeyword(params: {
   db: DatabaseSync;
   ftsTable: string;
-  providerModel: string | undefined;
   query: string;
   limit: number;
   snippetMaxChars: number;
@@ -152,20 +151,20 @@ export async function searchKeyword(params: {
     return [];
   }
 
-  // When providerModel is undefined (FTS-only mode), search all models
-  const modelClause = params.providerModel ? " AND model = ?" : "";
-  const modelParams = params.providerModel ? [params.providerModel] : [];
-
+  // FTS search should always return all keyword matches regardless of provider/model.
+  // The provider model is only used for vector embeddings in hybrid mode.
+  // Filtering by model would exclude relevant hits from previous indexing sessions
+  // that used different embedding providers/models.
   const rows = params.db
     .prepare(
       `SELECT id, path, source, start_line, end_line, text,\n` +
         `       bm25(${params.ftsTable}) AS rank\n` +
         `  FROM ${params.ftsTable}\n` +
-        ` WHERE ${params.ftsTable} MATCH ?${modelClause}${params.sourceFilter.sql}\n` +
+        ` WHERE ${params.ftsTable} MATCH ?${params.sourceFilter.sql}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,
     )
-    .all(ftsQuery, ...modelParams, ...params.sourceFilter.params, params.limit) as Array<{
+    .all(ftsQuery, ...params.sourceFilter.params, params.limit) as Array<{
     id: string;
     path: string;
     source: SearchSource;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -400,12 +400,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return [];
     }
     const sourceFilter = this.buildSourceFilter();
-    // In FTS-only mode (no provider), search all models; otherwise filter by current provider's model
-    const providerModel = this.provider?.model;
+    // FTS search always returns all keyword matches regardless of provider/model.
+    // The provider model is only used for vector embeddings in hybrid mode.
+    // Filtering by model would exclude relevant hits from previous indexing sessions
+    // that used different embedding providers/models.
     const results = await searchKeyword({
       db: this.db,
       ftsTable: FTS_TABLE,
-      providerModel,
       query,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,


### PR DESCRIPTION
## Summary

- Fixes #48300 where hybrid memory search could incorrectly drop FTS keyword matches after the embedding provider/model changed.
- Removes the provider/model filter from the FTS keyword query so keyword matches are returned regardless of indexing history.
- Adds focused regression coverage to ensure FTS results remain visible across embedding model changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory search

## User-visible / Behavior Changes

- `memory_search` hybrid mode now returns FTS keyword matches even when those chunks were indexed under a different embedding provider/model.
- Exact keyword hits are no longer hidden just because the current embedding model differs from the model recorded when the chunk was indexed.

## Test plan

- [x] `node $(find /home/qdy/.openclaw/workspace/_upstream_openclaw/node_modules/.pnpm -path */node_modules/vitest/vitest.mjs | head -n1) run --config vitest.unit.config.ts src/memory/manager-search.test.ts`
