### PR TITLE
feat(ui): add parallel thread creation in chat

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -549,6 +549,78 @@
   scrollbar-width: thin;
 }
 
+.chat-thread-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.chat-thread-modal {
+  width: min(560px, 100%);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-strong);
+  background: var(--card);
+  box-shadow: var(--shadow-lg);
+  padding: 18px;
+}
+
+.chat-thread-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.chat-thread-modal__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.chat-thread-modal__sub {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.chat-thread-modal__close {
+  flex-shrink: 0;
+}
+
+.chat-thread-modal__form {
+  margin-top: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.chat-thread-modal__form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.chat-thread-modal__error {
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--danger) 22%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
+  padding: 10px 12px;
+  font-size: 0.84rem;
+}
+
+.chat-thread-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 .slash-menu-group + .slash-menu-group {
   margin-top: 4px;
   padding-top: 4px;

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,6 @@
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { scheduleChatScroll } from "./app-scroll.ts";
-import { applySettings, setLastActiveSessionKey } from "./app-settings.ts";
+import { applySettings, setLastActiveSessionKey, syncUrlWithSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
@@ -172,6 +172,7 @@ export async function handleCreateThread(
     sessionKey: nextSessionKey,
     lastActiveSessionKey: nextSessionKey,
   });
+  syncUrlWithSessionKey(host, nextSessionKey, false);
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);
   void host.loadAssistantIdentity();
   void refreshChatAvatar(host);
@@ -200,6 +201,7 @@ export async function handleCreateThread(
       sessionKey: previousSessionKey,
       lastActiveSessionKey: previousLastActiveSessionKey,
     });
+    syncUrlWithSessionKey(host, previousSessionKey, true);
     host.lastError = `Failed to create thread: ${String(err)}`;
     await loadChatHistory(host);
     void host.loadAssistantIdentity();

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,6 @@
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { scheduleChatScroll } from "./app-scroll.ts";
-import { setLastActiveSessionKey } from "./app-settings.ts";
+import { applySettings, setLastActiveSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
@@ -72,6 +72,162 @@ function isChatResetCommand(text: string) {
     return true;
   }
   return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
+}
+
+export type CreateThreadInput = {
+  agentId: string;
+  label?: string | null;
+  firstMessage: string;
+};
+
+function normalizeThreadLabel(raw?: string | null): string | null {
+  const trimmed = raw?.trim() ?? "";
+  return trimmed ? trimmed : null;
+}
+
+function buildThreadSessionKey(agentId: string, now = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(
+    now.getHours(),
+  )}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const suffix = Math.random().toString(36).slice(2, 6);
+  return `agent:${agentId}:thread-${stamp}-${suffix}`;
+}
+
+function buildOptimisticUserMessage(text: string, timestamp: number) {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp,
+  };
+}
+
+async function waitForSessionToAppear(
+  client: GatewayBrowserClient,
+  key: string,
+  attempts = 5,
+): Promise<boolean> {
+  for (let index = 0; index < attempts; index++) {
+    try {
+      const res = await client.request<{ sessions?: Array<{ key?: string | null }> }>(
+        "sessions.list",
+        {
+          includeGlobal: true,
+          includeUnknown: true,
+        },
+      );
+      if (Array.isArray(res.sessions) && res.sessions.some((session) => session?.key === key)) {
+        return true;
+      }
+    } catch {
+      // Ignore transient session-list failures; thread creation already succeeded.
+    }
+    if (index < attempts - 1) {
+      await new Promise((resolve) => window.setTimeout(resolve, 250));
+    }
+  }
+  return false;
+}
+
+export async function handleCreateThread(
+  host: OpenClawApp,
+  input: CreateThreadInput,
+): Promise<string | null> {
+  if (!host.client || !host.connected || isChatBusy(host)) {
+    return null;
+  }
+
+  const agentId = input.agentId.trim() || "main";
+  const label = normalizeThreadLabel(input.label);
+  const firstMessage = input.firstMessage.trim();
+  if (!firstMessage) {
+    host.lastError = "First message is required to create a new thread.";
+    return null;
+  }
+
+  const previousSessionKey = host.sessionKey;
+  const previousLastActiveSessionKey = host.settings.lastActiveSessionKey;
+  const previousDraft = host.chatMessage;
+  const previousAttachments = host.chatAttachments.map((attachment) => ({ ...attachment }));
+  const nextSessionKey = buildThreadSessionKey(agentId);
+  const now = Date.now();
+  const runId = generateUUID();
+
+  resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
+  host.sessionKey = nextSessionKey;
+  host.chatMessage = "";
+  host.chatAttachments = [];
+  host.chatMessages = [buildOptimisticUserMessage(firstMessage, now)];
+  host.chatToolMessages = [];
+  host.chatStreamSegments = [];
+  host.chatStream = "";
+  host.chatStreamStartedAt = now;
+  host.chatRunId = runId;
+  host.chatSending = true;
+  host.chatLoading = false;
+  host.lastError = null;
+  host.chatQueue = [];
+  applySettings(host, {
+    ...host.settings,
+    sessionKey: nextSessionKey,
+    lastActiveSessionKey: nextSessionKey,
+  });
+  scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);
+  void host.loadAssistantIdentity();
+  void refreshChatAvatar(host);
+
+  try {
+    await host.client.request("chat.send", {
+      sessionKey: nextSessionKey,
+      message: firstMessage,
+      deliver: false,
+      idempotencyKey: runId,
+    });
+    host.chatSending = false;
+  } catch (err) {
+    host.sessionKey = previousSessionKey;
+    host.chatMessage = previousDraft;
+    host.chatAttachments = previousAttachments;
+    host.chatMessages = [];
+    host.chatToolMessages = [];
+    host.chatStreamSegments = [];
+    host.chatStream = null;
+    host.chatStreamStartedAt = null;
+    host.chatRunId = null;
+    host.chatSending = false;
+    applySettings(host, {
+      ...host.settings,
+      sessionKey: previousSessionKey,
+      lastActiveSessionKey: previousLastActiveSessionKey,
+    });
+    host.lastError = `Failed to create thread: ${String(err)}`;
+    await loadChatHistory(host);
+    void host.loadAssistantIdentity();
+    void refreshChatAvatar(host);
+    return null;
+  }
+
+  host.refreshSessionsAfterChat.add(runId);
+
+  if (label) {
+    try {
+      const appeared = await waitForSessionToAppear(host.client, nextSessionKey);
+      if (!appeared) {
+        host.lastError = "Thread created, but the session row did not appear in time to apply its label.";
+      } else {
+        await host.client.request("sessions.patch", { key: nextSessionKey, label });
+      }
+    } catch (err) {
+      host.lastError = `Thread created, but failed to set label: ${String(err)}`;
+    }
+  }
+
+  void loadSessions(host, {
+    activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+    includeGlobal: true,
+    includeUnknown: true,
+  });
+  return nextSessionKey;
 }
 
 export async function handleAbortChat(host: ChatHost) {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -215,7 +215,8 @@ export async function handleCreateThread(
     try {
       const appeared = await waitForSessionToAppear(host.client, nextSessionKey);
       if (!appeared) {
-        host.lastError = "Thread created, but the session row did not appear in time to apply its label.";
+        host.lastError =
+          "Thread created, but the session row did not appear in time to apply its label.";
       } else {
         await host.client.request("sessions.patch", { key: nextSessionKey, label });
       }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1395,6 +1395,13 @@ export function renderApp(state: AppViewState) {
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onCreateThread: async (input) => {
+                  const created = await state.handleCreateThread(input);
+                  if (!created) {
+                    throw new Error(state.lastError ?? "Failed to create thread.");
+                  }
+                  return created;
+                },
                 onClearHistory: async () => {
                   if (!state.client || !state.connected) {
                     return;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -33,6 +33,7 @@ import type {
   StatusSummary,
   ToolsCatalogResult,
 } from "./types.ts";
+import type { CreateThreadInput } from "./app-chat.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 import type { SessionLogEntry } from "./views/usage.ts";
@@ -359,6 +360,7 @@ export type AppViewState = {
     setSessionKey: (next: string) => void;
     setChatMessage: (next: string) => void;
     handleSendChat: (messageOverride?: string, opts?: { restoreDraft?: boolean }) => Promise<void>;
+    handleCreateThread: (input: CreateThreadInput) => Promise<string | null>;
     handleAbortChat: () => Promise<void>;
     removeQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -16,8 +16,10 @@ import {
 } from "./app-channels.ts";
 import {
   handleAbortChat as handleAbortChatInternal,
+  handleCreateThread as handleCreateThreadInternal,
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
+  type CreateThreadInput,
 } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults.ts";
 import type { EventLogEntry } from "./app-events.ts";
@@ -596,6 +598,10 @@ export class OpenClawApp extends LitElement {
       messageOverride,
       opts,
     );
+  }
+
+  async handleCreateThread(input: CreateThreadInput) {
+    return await handleCreateThreadInternal(this, input);
   }
 
   async handleWhatsAppStart(force: boolean) {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -821,9 +821,9 @@ const NEW_THREAD_DIALOG_LABEL_INPUT_ID = "chat-thread-label-input";
 
 function focusNewThreadDialogPrimaryField() {
   requestAnimationFrame(() => {
-    const input = document.getElementById(NEW_THREAD_DIALOG_LABEL_INPUT_ID) as
-      | HTMLInputElement
-      | null;
+    const input = document.getElementById(
+      NEW_THREAD_DIALOG_LABEL_INPUT_ID,
+    ) as HTMLInputElement | null;
     input?.focus();
     input?.select();
   });
@@ -943,13 +943,15 @@ function renderNewThreadDialog(
                 requestUpdate();
               }}
             >
-              ${agents.length > 0
-                ? agents.map(
-                    (agent) => html`
+              ${
+                agents.length > 0
+                  ? agents.map(
+                      (agent) => html`
                       <option value=${agent.id}>${agent.identity?.name || agent.name || agent.id}</option>
                     `,
-                  )
-                : html`<option value=${props.currentAgentId}>${props.currentAgentId}</option>`}
+                    )
+                  : html`<option value=${props.currentAgentId}>${props.currentAgentId}</option>`
+              }
             </select>
           </label>
 
@@ -979,9 +981,11 @@ function renderNewThreadDialog(
             ></textarea>
           </label>
 
-          ${vs.newThreadError
-            ? html`<div class="chat-thread-modal__error">${vs.newThreadError}</div>`
-            : nothing}
+          ${
+            vs.newThreadError
+              ? html`<div class="chat-thread-modal__error">${vs.newThreadError}</div>`
+              : nothing
+          }
 
           <div class="chat-thread-modal__actions">
             <button class="btn" type="button" @click=${() => closeNewThreadDialog(requestUpdate)}>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -816,6 +816,28 @@ function renderSlashMenu(
   `;
 }
 
+const NEW_THREAD_DIALOG_TITLE_ID = "chat-thread-modal-title";
+const NEW_THREAD_DIALOG_LABEL_INPUT_ID = "chat-thread-label-input";
+
+function focusNewThreadDialogPrimaryField() {
+  requestAnimationFrame(() => {
+    const input = document.getElementById(NEW_THREAD_DIALOG_LABEL_INPUT_ID) as
+      | HTMLInputElement
+      | null;
+    input?.focus();
+    input?.select();
+  });
+}
+
+function handleNewThreadDialogKeydown(event: KeyboardEvent, requestUpdate: () => void) {
+  if (event.key !== "Escape") {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  closeNewThreadDialog(requestUpdate);
+}
+
 function openNewThreadDialog(props: ChatProps, requestUpdate: () => void) {
   vs.newThreadOpen = true;
   vs.newThreadCreating = false;
@@ -824,6 +846,7 @@ function openNewThreadDialog(props: ChatProps, requestUpdate: () => void) {
   vs.newThreadLabel = "";
   vs.newThreadMessage = (props.getDraft?.() ?? "").trim();
   requestUpdate();
+  focusNewThreadDialogPrimaryField();
 }
 
 function closeNewThreadDialog(requestUpdate: () => void) {
@@ -873,11 +896,22 @@ function renderNewThreadDialog(
   }
   const agents = props.agentsList?.agents ?? [];
   return html`
-    <div class="chat-thread-modal-overlay" @click=${() => closeNewThreadDialog(requestUpdate)}>
-      <div class="chat-thread-modal" @click=${(event: Event) => event.stopPropagation()}>
+    <div
+      class="chat-thread-modal-overlay"
+      @click=${() => closeNewThreadDialog(requestUpdate)}
+      @keydown=${(event: KeyboardEvent) => handleNewThreadDialogKeydown(event, requestUpdate)}
+    >
+      <div
+        class="chat-thread-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby=${NEW_THREAD_DIALOG_TITLE_ID}
+        tabindex="-1"
+        @click=${(event: Event) => event.stopPropagation()}
+      >
         <div class="chat-thread-modal__header">
           <div>
-            <div class="chat-thread-modal__title">Create new thread</div>
+            <div class="chat-thread-modal__title" id=${NEW_THREAD_DIALOG_TITLE_ID}>Create new thread</div>
             <div class="chat-thread-modal__sub">
               Start a parallel conversation without resetting the current session.
             </div>
@@ -922,6 +956,7 @@ function renderNewThreadDialog(
           <label class="field">
             <span>Thread label (optional)</span>
             <input
+              id=${NEW_THREAD_DIALOG_LABEL_INPUT_ID}
               .value=${vs.newThreadLabel}
               @input=${(event: Event) => {
                 vs.newThreadLabel = (event.target as HTMLInputElement).value;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -95,6 +95,11 @@ export type ChatProps = {
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onNewSession: () => void;
+  onCreateThread?: (input: {
+    agentId: string;
+    label?: string | null;
+    firstMessage: string;
+  }) => Promise<string | null> | string | null;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -151,6 +156,12 @@ interface ChatEphemeralState {
   searchOpen: boolean;
   searchQuery: string;
   pinnedExpanded: boolean;
+  newThreadOpen: boolean;
+  newThreadAgentId: string;
+  newThreadLabel: string;
+  newThreadMessage: string;
+  newThreadCreating: boolean;
+  newThreadError: string;
 }
 
 function createChatEphemeralState(): ChatEphemeralState {
@@ -166,6 +177,12 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchOpen: false,
     searchQuery: "",
     pinnedExpanded: false,
+    newThreadOpen: false,
+    newThreadAgentId: "main",
+    newThreadLabel: "",
+    newThreadMessage: "",
+    newThreadCreating: false,
+    newThreadError: "",
   };
 }
 
@@ -799,6 +816,156 @@ function renderSlashMenu(
   `;
 }
 
+function openNewThreadDialog(props: ChatProps, requestUpdate: () => void) {
+  vs.newThreadOpen = true;
+  vs.newThreadCreating = false;
+  vs.newThreadError = "";
+  vs.newThreadAgentId = props.currentAgentId || props.agentsList?.defaultId || "main";
+  vs.newThreadLabel = "";
+  vs.newThreadMessage = (props.getDraft?.() ?? "").trim();
+  requestUpdate();
+}
+
+function closeNewThreadDialog(requestUpdate: () => void) {
+  vs.newThreadOpen = false;
+  vs.newThreadCreating = false;
+  vs.newThreadError = "";
+  requestUpdate();
+}
+
+async function submitNewThread(props: ChatProps, requestUpdate: () => void) {
+  if (!props.onCreateThread || vs.newThreadCreating) {
+    return;
+  }
+  const firstMessage = vs.newThreadMessage.trim();
+  if (!firstMessage) {
+    vs.newThreadError = "First message is required.";
+    requestUpdate();
+    return;
+  }
+
+  vs.newThreadCreating = true;
+  vs.newThreadError = "";
+  requestUpdate();
+  try {
+    const created = await props.onCreateThread({
+      agentId: vs.newThreadAgentId.trim() || props.currentAgentId || "main",
+      label: vs.newThreadLabel.trim() || null,
+      firstMessage,
+    });
+    if (!created) {
+      throw new Error("Failed to create thread.");
+    }
+    closeNewThreadDialog(requestUpdate);
+  } catch (err) {
+    vs.newThreadCreating = false;
+    vs.newThreadError = err instanceof Error ? err.message : String(err);
+    requestUpdate();
+  }
+}
+
+function renderNewThreadDialog(
+  props: ChatProps,
+  requestUpdate: () => void,
+): TemplateResult | typeof nothing {
+  if (!vs.newThreadOpen) {
+    return nothing;
+  }
+  const agents = props.agentsList?.agents ?? [];
+  return html`
+    <div class="chat-thread-modal-overlay" @click=${() => closeNewThreadDialog(requestUpdate)}>
+      <div class="chat-thread-modal" @click=${(event: Event) => event.stopPropagation()}>
+        <div class="chat-thread-modal__header">
+          <div>
+            <div class="chat-thread-modal__title">Create new thread</div>
+            <div class="chat-thread-modal__sub">
+              Start a parallel conversation without resetting the current session.
+            </div>
+          </div>
+          <button
+            class="btn-ghost chat-thread-modal__close"
+            type="button"
+            @click=${() => closeNewThreadDialog(requestUpdate)}
+            aria-label="Close"
+            title="Close"
+          >
+            ${icons.x}
+          </button>
+        </div>
+
+        <form
+          class="chat-thread-modal__form"
+          @submit=${(event: Event) => {
+            event.preventDefault();
+            void submitNewThread(props, requestUpdate);
+          }}
+        >
+          <label class="field">
+            <span>Agent</span>
+            <select
+              .value=${vs.newThreadAgentId}
+              @change=${(event: Event) => {
+                vs.newThreadAgentId = (event.target as HTMLSelectElement).value;
+                requestUpdate();
+              }}
+            >
+              ${agents.length > 0
+                ? agents.map(
+                    (agent) => html`
+                      <option value=${agent.id}>${agent.identity?.name || agent.name || agent.id}</option>
+                    `,
+                  )
+                : html`<option value=${props.currentAgentId}>${props.currentAgentId}</option>`}
+            </select>
+          </label>
+
+          <label class="field">
+            <span>Thread label (optional)</span>
+            <input
+              .value=${vs.newThreadLabel}
+              @input=${(event: Event) => {
+                vs.newThreadLabel = (event.target as HTMLInputElement).value;
+                requestUpdate();
+              }}
+              placeholder="Design review / bug hunt / follow-up"
+            />
+          </label>
+
+          <label class="field">
+            <span>First message</span>
+            <textarea
+              .value=${vs.newThreadMessage}
+              @input=${(event: Event) => {
+                vs.newThreadMessage = (event.target as HTMLTextAreaElement).value;
+                requestUpdate();
+              }}
+              placeholder="What should this new thread work on?"
+              rows="4"
+            ></textarea>
+          </label>
+
+          ${vs.newThreadError
+            ? html`<div class="chat-thread-modal__error">${vs.newThreadError}</div>`
+            : nothing}
+
+          <div class="chat-thread-modal__actions">
+            <button class="btn" type="button" @click=${() => closeNewThreadDialog(requestUpdate)}>
+              Cancel
+            </button>
+            <button
+              class="btn primary"
+              type="submit"
+              ?disabled=${vs.newThreadCreating || !vs.newThreadMessage.trim()}
+            >
+              ${vs.newThreadCreating ? "Creating…" : "Create thread"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
+}
+
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
@@ -1280,6 +1447,15 @@ export function renderChat(props: ChatProps) {
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
+            <button
+              class="btn-ghost"
+              @click=${() => openNewThreadDialog(props, requestUpdate)}
+              title="New thread"
+              aria-label="New thread"
+              ?disabled=${!props.connected || isBusy || !props.onCreateThread}
+            >
+              ${icons.messageSquare}
+            </button>
             ${
               canAbort
                 ? nothing
@@ -1324,6 +1500,7 @@ export function renderChat(props: ChatProps) {
           </div>
         </div>
       </div>
+      ${renderNewThreadDialog(props, requestUpdate)}
     </section>
   `;
 }


### PR DESCRIPTION
## What

Add a first-pass `New thread` flow to chat so users can branch into a parallel thread without resetting the current session.

## Includes

- toolbar entry + create-thread modal
- new thread creation/switch/send flow
- sessions refresh after creation
- label timing fix
- `chatSending` finalization fix
- URL session sync after thread creation
- dialog accessibility improvements (`role="dialog"`, `aria-modal`, `aria-labelledby`, `Escape` close, initial focus)

## Testing

- real browser retest on `:4174`