### PR TITLE
fix: profile gateway cron sessions persist correct context window from model registry

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -30,6 +30,7 @@ type ResolvedAgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentEntry["model"];
+  contextTokens?: AgentEntry["contextTokens"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
@@ -131,6 +132,10 @@ export function resolveAgentConfig(
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model
+        : undefined,
+    contextTokens:
+      typeof entry.contextTokens === "number" && entry.contextTokens > 0
+        ? entry.contextTokens
         : undefined,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -163,6 +163,10 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
 
   const cfg = primeConfiguredContextWindows();
   if (!cfg) {
+    // If config is not yet available (cold start or backoff after failure),
+    // return immediately without setting loadPromise so the next caller can
+    // retry once the backoff window has elapsed.  resolveContextTokensForModelAsync
+    // will fall back to DEFAULT_CONTEXT_TOKENS for this call.
     return Promise.resolve();
   }
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -210,6 +210,17 @@ export function lookupContextTokens(modelId?: string): number | undefined {
   return MODEL_CACHE.get(modelId);
 }
 
+export async function resolveContextTokensForModelAsync(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
+  contextTokensOverride?: number;
+  fallbackContextTokens?: number;
+}): Promise<number | undefined> {
+  await ensureContextWindowCacheLoaded();
+  return resolveContextTokensForModel(params);
+}
+
 if (!shouldSkipEagerContextWindowWarmup()) {
   // Keep prior behavior where model limits begin loading during startup.
   // This avoids a cold-start miss on the first context token lookup.

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -1,2 +1,3 @@
 export { resolveContextTokensForModel } from "../agents/context.js";
+export { resolveContextTokensForModelAsync } from "../agents/context.js";
 export { classifySessionKey, resolveSessionModelRef } from "../gateway/session-utils.js";

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -6,6 +6,7 @@ vi.mock("../channels/config-presence.js", () => ({
 
 vi.mock("../agents/context.js", () => ({
   resolveContextTokensForModel: vi.fn(() => 200_000),
+  resolveContextTokensForModelAsync: vi.fn(async () => 200_000),
 }));
 
 vi.mock("../agents/defaults.js", () => ({
@@ -105,5 +106,46 @@ describe("getStatusSummary", () => {
     expect(summary.linkChannel).toBeUndefined();
     expect(buildChannelSummary).not.toHaveBeenCalled();
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
+  });
+
+  it("repairs stale stored fallback context tokens when the model registry resolves a larger window", async () => {
+    const { resolveContextTokensForModelAsync } = await import("../agents/context.js");
+    const { loadSessionStore } = await import("../config/sessions.js");
+    const { resolveSessionModelRef } = await import("../gateway/session-utils.js");
+    const { getStatusSummary } = await import("./status.summary.js");
+
+    vi.mocked(resolveContextTokensForModelAsync).mockImplementation(async (params) => {
+      if (params.model === "claude-opus-4-6") {
+        return 1_000_000;
+      }
+      return 200_000;
+    });
+    vi.mocked(resolveSessionModelRef).mockReturnValue({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:cron:test": {
+        sessionId: "sess-cron",
+        updatedAt: Date.now(),
+        model: "claude-opus-4-6",
+        modelProvider: "anthropic",
+        contextTokens: 200_000,
+      },
+    });
+
+    const summary = await getStatusSummary({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+            },
+          },
+        },
+      },
+    });
+
+    expect(summary.sessions.recent[0]?.contextTokens).toBe(1_000_000);
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
@@ -36,6 +37,42 @@ function loadLinkChannelModule() {
 function loadStatusSummaryRuntimeModule() {
   statusSummaryRuntimeModulePromise ??= import("./status.summary.runtime.js");
   return statusSummaryRuntimeModulePromise;
+}
+
+function hasExplicitContextTokensCap(cfg: OpenClawConfig, agentId?: string): boolean {
+  if (
+    typeof cfg.agents?.defaults?.contextTokens === "number" &&
+    cfg.agents.defaults.contextTokens > 0
+  ) {
+    return true;
+  }
+  if (!agentId) {
+    return false;
+  }
+  const agentContextTokens = resolveAgentConfig(cfg, agentId)?.contextTokens;
+  return typeof agentContextTokens === "number" && agentContextTokens > 0;
+}
+
+function shouldRepairStoredContextTokens(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  entry?: SessionEntry;
+  resolvedContextTokens?: number | null;
+}): boolean {
+  const storedContextTokens = params.entry?.contextTokens;
+  if (storedContextTokens !== DEFAULT_CONTEXT_TOKENS) {
+    return false;
+  }
+  if (
+    typeof params.resolvedContextTokens !== "number" ||
+    params.resolvedContextTokens <= DEFAULT_CONTEXT_TOKENS
+  ) {
+    return false;
+  }
+  // Older cron/profile sessions could persist the hard fallback before the
+  // async model registry finished loading. If there is no explicit cap in the
+  // current config, prefer the resolved model window for status display.
+  return !hasExplicitContextTokensCap(params.cfg, params.agentId);
 }
 
 const buildFlags = (entry?: SessionEntry): string[] => {
@@ -103,7 +140,7 @@ export async function getStatusSummary(
   } = {},
 ): Promise<StatusSummary> {
   const { includeSensitive = true } = options;
-  const { classifySessionKey, resolveContextTokensForModel, resolveSessionModelRef } =
+  const { classifySessionKey, resolveContextTokensForModelAsync, resolveSessionModelRef } =
     await loadStatusSummaryRuntimeModule();
   const cfg = options.config ?? loadConfig();
   const needsChannelPlugins = hasPotentialConfiguredChannels(cfg);
@@ -141,13 +178,13 @@ export async function getStatusSummary(
   });
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const configContextTokens =
-    resolveContextTokensForModel({
+    (await resolveContextTokensForModelAsync({
       cfg,
       provider: resolved.provider ?? DEFAULT_PROVIDER,
       model: configModel,
       contextTokensOverride: cfg.agents?.defaults?.contextTokens,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-    }) ?? DEFAULT_CONTEXT_TOKENS;
+    })) ?? DEFAULT_CONTEXT_TOKENS;
 
   const now = Date.now();
   const storeCache = new Map<string, Record<string, SessionEntry | undefined>>();
@@ -160,82 +197,102 @@ export async function getStatusSummary(
     storeCache.set(storePath, store);
     return store;
   };
-  const buildSessionRows = (
+  const buildSessionRows = async (
     store: Record<string, SessionEntry | undefined>,
     opts: { agentIdOverride?: string } = {},
-  ) =>
-    Object.entries(store)
-      .filter(([key]) => key !== "global" && key !== "unknown")
-      .map(([key, entry]) => {
-        const updatedAt = entry?.updatedAt ?? null;
-        const age = updatedAt ? now - updatedAt : null;
-        const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
-        const model = resolvedModel.model ?? configModel ?? null;
-        const contextTokens =
-          resolveContextTokensForModel({
+  ) => {
+    const rows = await Promise.all(
+      Object.entries(store)
+        .filter(([key]) => key !== "global" && key !== "unknown")
+        .map(async ([key, entry]) => {
+          const updatedAt = entry?.updatedAt ?? null;
+          const age = updatedAt ? now - updatedAt : null;
+          const parsedAgentId = parseAgentSessionKey(key)?.agentId;
+          const agentId = opts.agentIdOverride ?? parsedAgentId;
+          const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
+          const model = resolvedModel.model ?? configModel ?? null;
+          const storedContextTokens =
+            typeof entry?.contextTokens === "number" ? entry.contextTokens : undefined;
+          const resolvedContextTokens =
+            (await resolveContextTokensForModelAsync({
+              cfg,
+              provider: resolvedModel.provider,
+              model,
+              fallbackContextTokens: configContextTokens ?? undefined,
+            })) ?? null;
+          const contextTokens = shouldRepairStoredContextTokens({
             cfg,
-            provider: resolvedModel.provider,
-            model,
-            contextTokensOverride: entry?.contextTokens,
-            fallbackContextTokens: configContextTokens ?? undefined,
-          }) ?? null;
-        const total = resolveFreshSessionTotalTokens(entry);
-        const totalTokensFresh =
-          typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
-        const remaining =
-          contextTokens != null && total !== undefined ? Math.max(0, contextTokens - total) : null;
-        const pct =
-          contextTokens && contextTokens > 0 && total !== undefined
-            ? Math.min(999, Math.round((total / contextTokens) * 100))
-            : null;
-        const parsedAgentId = parseAgentSessionKey(key)?.agentId;
-        const agentId = opts.agentIdOverride ?? parsedAgentId;
+            agentId,
+            entry,
+            resolvedContextTokens,
+          })
+            ? resolvedContextTokens
+            : (storedContextTokens ?? resolvedContextTokens);
+          const total = resolveFreshSessionTotalTokens(entry);
+          const totalTokensFresh =
+            typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
+          const remaining =
+            contextTokens != null && total !== undefined
+              ? Math.max(0, contextTokens - total)
+              : null;
+          const pct =
+            contextTokens && contextTokens > 0 && total !== undefined
+              ? Math.min(999, Math.round((total / contextTokens) * 100))
+              : null;
 
-        return {
-          agentId,
-          key,
-          kind: classifySessionKey(key, entry),
-          sessionId: entry?.sessionId,
-          updatedAt,
-          age,
-          thinkingLevel: entry?.thinkingLevel,
-          fastMode: entry?.fastMode,
-          verboseLevel: entry?.verboseLevel,
-          reasoningLevel: entry?.reasoningLevel,
-          elevatedLevel: entry?.elevatedLevel,
-          systemSent: entry?.systemSent,
-          abortedLastRun: entry?.abortedLastRun,
-          inputTokens: entry?.inputTokens,
-          outputTokens: entry?.outputTokens,
-          cacheRead: entry?.cacheRead,
-          cacheWrite: entry?.cacheWrite,
-          totalTokens: total ?? null,
-          totalTokensFresh,
-          remainingTokens: remaining,
-          percentUsed: pct,
-          model,
-          contextTokens,
-          flags: buildFlags(entry),
-        } satisfies SessionStatus;
-      })
-      .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+          return {
+            agentId,
+            key,
+            kind: classifySessionKey(key, entry),
+            sessionId: entry?.sessionId,
+            updatedAt,
+            age,
+            thinkingLevel: entry?.thinkingLevel,
+            fastMode: entry?.fastMode,
+            verboseLevel: entry?.verboseLevel,
+            reasoningLevel: entry?.reasoningLevel,
+            elevatedLevel: entry?.elevatedLevel,
+            systemSent: entry?.systemSent,
+            abortedLastRun: entry?.abortedLastRun,
+            inputTokens: entry?.inputTokens,
+            outputTokens: entry?.outputTokens,
+            cacheRead: entry?.cacheRead,
+            cacheWrite: entry?.cacheWrite,
+            totalTokens: total ?? null,
+            totalTokensFresh,
+            remainingTokens: remaining,
+            percentUsed: pct,
+            model,
+            contextTokens,
+            flags: buildFlags(entry),
+          } satisfies SessionStatus;
+        }),
+    );
+    return rows.toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+  };
 
   const paths = new Set<string>();
-  const byAgent = agentList.agents.map((agent) => {
-    const storePath = resolveStorePath(cfg.session?.store, { agentId: agent.id });
-    paths.add(storePath);
-    const store = loadStore(storePath);
-    const sessions = buildSessionRows(store, { agentIdOverride: agent.id });
-    return {
-      agentId: agent.id,
-      path: storePath,
-      count: sessions.length,
-      recent: sessions.slice(0, 10),
-    };
-  });
+  const byAgent = await Promise.all(
+    agentList.agents.map(async (agent) => {
+      const storePath = resolveStorePath(cfg.session?.store, { agentId: agent.id });
+      paths.add(storePath);
+      const store = loadStore(storePath);
+      const sessions = await buildSessionRows(store, { agentIdOverride: agent.id });
+      return {
+        agentId: agent.id,
+        path: storePath,
+        count: sessions.length,
+        recent: sessions.slice(0, 10),
+      };
+    }),
+  );
 
-  const allSessions = Array.from(paths)
-    .flatMap((storePath) => buildSessionRows(loadStore(storePath)))
+  const allSessions = (
+    await Promise.all(
+      Array.from(paths).map(async (storePath) => await buildSessionRows(loadStore(storePath))),
+    )
+  )
+    .flat()
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
   const recent = allSessions.slice(0, 10);
   const totalSessions = allSessions.length;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -65,6 +65,8 @@ export type AgentConfig = {
   workspace?: string;
   agentDir?: string;
   model?: AgentModelConfig;
+  /** Optional per-agent context window cap for runtime estimates + status %. */
+  contextTokens?: number;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -10,6 +10,7 @@ import {
   resolveConfiguredModelRefMock,
   resolveCronSessionMock,
   resetRunCronIsolatedAgentTurnHarness,
+  resolveContextTokensForModelAsyncMock,
   restoreFastTestEnv,
   runWithModelFallbackMock,
   updateSessionStoreMock,
@@ -164,6 +165,15 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(preRunSnapshot.model).toBe("claude-sonnet-4-6");
     expect(preRunSnapshot.modelProvider).toBe("anthropic");
     expect(preRunSnapshot.systemSent).toBe(true);
+  });
+
+  it("persists the resolved model context window instead of the hard fallback", async () => {
+    resolveContextTokensForModelAsyncMock.mockResolvedValueOnce(1_000_000);
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(cronSession.sessionEntry.contextTokens).toBe(1_000_000);
   });
 
   it("returns error without persisting model when payload model is disallowed", async () => {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -40,6 +40,7 @@ export const getCliSessionIdMock = createMock();
 export const updateSessionStoreMock = createMock();
 export const resolveCronSessionMock = createMock();
 export const logWarnMock = createMock();
+export const resolveContextTokensForModelAsyncMock = createMock();
 export const countActiveDescendantRunsMock = createMock();
 export const listDescendantRunsForRequesterMock = createMock();
 export const pickLastNonEmptyTextFromPayloadsMock = createMock();
@@ -126,6 +127,8 @@ vi.mock("../../agents/context.js", async (importOriginal) => {
   return {
     ...actual,
     lookupContextTokens: vi.fn().mockReturnValue(128000),
+    resolveContextTokensForModelAsync: (...args: unknown[]) =>
+      resolveContextTokensForModelAsyncMock(...args),
   };
 });
 
@@ -374,6 +377,8 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
 
   runCliAgentMock.mockReset();
   getCliSessionIdMock.mockReturnValue(undefined);
+  resolveContextTokensForModelAsyncMock.mockReset();
+  resolveContextTokensForModelAsyncMock.mockResolvedValue(128000);
 
   updateSessionStoreMock.mockReset();
   updateSessionStoreMock.mockResolvedValue(undefined);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,7 +9,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModelAsync } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
@@ -739,7 +739,13 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = finalRunResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = finalRunResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      (await resolveContextTokensForModelAsync({
+        cfg: cfgWithAgentDefaults,
+        provider: providerUsed,
+        model: modelUsed,
+        contextTokensOverride: agentCfg?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      })) ?? DEFAULT_CONTEXT_TOKENS;
 
     setSessionRuntimeModel(cronSession.sessionEntry, {
       provider: providerUsed,


### PR DESCRIPTION
## Problem

Profile gateways (e.g. `--profile vesper`) show `200k ctx` in `openclaw status` despite `openclaw models list` correctly reporting 977k for the same model (`anthropic/claude-opus-4-6`). The default/main gateway correctly shows 1000k.

## Root Cause

Cron isolated-agent runs in `src/cron/isolated-agent/run.ts` used a non-blocking `lookupContextTokens()` that fell through to `DEFAULT_CONTEXT_TOKENS` (200000) on cold cache — especially in profile gateways where the model registry may not be warmed yet. This stale value was then persisted into the session entry.

Interactive sessions used the provider-aware `resolveContextTokensForModel()` and got the correct value, creating a split where the same model showed different context windows depending on how the session was created.

## Fix

- Added `resolveContextTokensForModelAsync()` as a shared blocking resolver that waits for the model registry cache to load
- Updated cron isolated-agent path to use the async resolver instead of the non-blocking fallback
- `status` display now repairs stale 200k fallback values when the registry resolves a larger window (read-side only, no session JSON rewrite)
- Added type support for per-agent `contextTokens` in AgentConfig for TypeScript correctness

## Testing

- Regression tests for cron persistence (verifies 1M stored instead of 200k fallback)
- Regression test for status display repair
- `pnpm build` passes
- Verified against live `--profile vesper` gateway: status now reports 1000000 for previously affected sessions

## Files Changed

- `src/agents/context.ts` — new async resolver
- `src/cron/isolated-agent/run.ts` — use async resolver
- `src/commands/status.summary.ts` / `status.summary.runtime.ts` — display repair
- `src/config/types.agents.ts` / `src/agents/agent-scope.ts` — type support
- 3 test files added