### PR TITLE
feat(gateway): add general per-IP request rate limiter

### DIFF
--- a/src/gateway/request-rate-limit.test.ts
+++ b/src/gateway/request-rate-limit.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRequestRateLimiter, type RequestRateLimiter } from "./request-rate-limit.js";
+
+describe("request rate limiter", () => {
+  let limiter: RequestRateLimiter;
+
+  afterEach(() => {
+    limiter?.dispose();
+  });
+
+  // ---------- basic counting ----------
+
+  it("allows requests when under the limit", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 5, windowMs: 60_000 });
+    const result = limiter.check("192.168.1.1");
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(4); // 5 max - 1 counted
+    expect(result.retryAfterMs).toBe(0);
+  });
+
+  it("decrements remaining count on each request", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 3, windowMs: 60_000 });
+    expect(limiter.check("10.0.0.1").remaining).toBe(2);
+    expect(limiter.check("10.0.0.1").remaining).toBe(1);
+    expect(limiter.check("10.0.0.1").remaining).toBe(0);
+  });
+
+  it("blocks after maxRequests is exceeded", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 2, windowMs: 60_000 });
+    expect(limiter.check("10.0.0.2").allowed).toBe(true);
+    expect(limiter.check("10.0.0.2").allowed).toBe(true);
+
+    const result = limiter.check("10.0.0.2");
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(60_000);
+  });
+
+  // ---------- window expiry ----------
+
+  it("resets counter after the window expires", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createRequestRateLimiter({ maxRequests: 2, windowMs: 10_000 });
+      limiter.check("10.0.0.3");
+      limiter.check("10.0.0.3");
+      expect(limiter.check("10.0.0.3").allowed).toBe(false);
+
+      vi.advanceTimersByTime(10_001);
+      const result = limiter.check("10.0.0.3");
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(1); // fresh window, first request counted
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ---------- per-IP isolation ----------
+
+  it("tracks IPs independently", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    limiter.check("10.0.0.10");
+    expect(limiter.check("10.0.0.10").allowed).toBe(false);
+
+    // A different IP should be unaffected.
+    expect(limiter.check("10.0.0.11").allowed).toBe(true);
+  });
+
+  it("treats ipv4 and ipv4-mapped ipv6 as the same client", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    limiter.check("1.2.3.4");
+    expect(limiter.check("::ffff:1.2.3.4").allowed).toBe(false);
+  });
+
+  // ---------- loopback exemption ----------
+
+  it.each(["127.0.0.1", "::1"])("exempts loopback address %s by default", (ip) => {
+    limiter = createRequestRateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    limiter.check(ip);
+    // Should still be allowed even after exceeding maxRequests.
+    expect(limiter.check(ip).allowed).toBe(true);
+    expect(limiter.check(ip).remaining).toBe(1);
+  });
+
+  it("rate-limits loopback when exemptLoopback is false", () => {
+    limiter = createRequestRateLimiter({
+      maxRequests: 1,
+      windowMs: 60_000,
+      exemptLoopback: false,
+    });
+    limiter.check("127.0.0.1");
+    expect(limiter.check("127.0.0.1").allowed).toBe(false);
+  });
+
+  // ---------- undefined / empty IP ----------
+
+  it("normalizes undefined IP to 'unknown'", () => {
+    limiter = createRequestRateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    limiter.check(undefined);
+    expect(limiter.check(undefined).allowed).toBe(false);
+    expect(limiter.size()).toBe(1);
+  });
+
+  // ---------- prune ----------
+
+  it("prune removes expired window entries", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createRequestRateLimiter({ maxRequests: 100, windowMs: 5_000 });
+      limiter.check("10.0.0.30");
+      expect(limiter.size()).toBe(1);
+
+      vi.advanceTimersByTime(6_000);
+      limiter.prune();
+      expect(limiter.size()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prune keeps active window entries", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createRequestRateLimiter({ maxRequests: 100, windowMs: 10_000 });
+      limiter.check("10.0.0.31");
+
+      vi.advanceTimersByTime(5_000); // Still within window.
+      limiter.prune();
+      expect(limiter.size()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ---------- dispose ----------
+
+  it("dispose clears all entries", () => {
+    limiter = createRequestRateLimiter();
+    limiter.check("10.0.0.40");
+    expect(limiter.size()).toBe(1);
+    limiter.dispose();
+    expect(limiter.size()).toBe(0);
+  });
+});

--- a/src/gateway/request-rate-limit.ts
+++ b/src/gateway/request-rate-limit.ts
@@ -1,0 +1,139 @@
+/**
+ * General-purpose per-IP request rate limiter for the gateway.
+ *
+ * Unlike the auth rate limiter (which tracks failed authentication attempts),
+ * this module counts ALL incoming HTTP requests per client IP using a fixed
+ * time window. It protects the gateway from request flooding when exposed
+ * via Tailscale Funnel, a public reverse proxy, or any non-loopback binding.
+ *
+ * Design decisions:
+ * - Fixed-window counter per IP – simple, low overhead, no per-request
+ *   array allocations (unlike sliding window).
+ * - Loopback addresses (127.0.0.1 / ::1) are exempt by default so that
+ *   local CLI sessions are never throttled.
+ * - Side-effect-free module: callers create an instance via
+ *   {@link createRequestRateLimiter} and pass it where needed.
+ */
+
+import { isLoopbackAddress, resolveClientIp } from "./net.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RequestRateLimitConfig {
+  /** Maximum requests per window.  @default 120 */
+  maxRequests?: number;
+  /** Window duration in milliseconds.  @default 60_000 (1 min) */
+  windowMs?: number;
+  /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
+  exemptLoopback?: boolean;
+  /** Background prune interval in milliseconds; set <= 0 to disable.  @default 60_000 */
+  pruneIntervalMs?: number;
+}
+
+export interface RequestRateLimitResult {
+  /** Whether the request is allowed to proceed. */
+  allowed: boolean;
+  /** Number of remaining requests in the current window. */
+  remaining: number;
+  /** Milliseconds until the current window resets (0 when allowed). */
+  retryAfterMs: number;
+}
+
+export interface RequestRateLimiter {
+  /** Check and count a request from the given IP. */
+  check(ip: string | undefined): RequestRateLimitResult;
+  /** Current number of tracked IPs. */
+  size(): number;
+  /** Remove expired window entries. */
+  prune(): void;
+  /** Dispose the limiter and cancel periodic cleanup timers. */
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_REQUESTS = 120;
+const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+const PRUNE_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+}
+
+export function createRequestRateLimiter(config?: RequestRateLimitConfig): RequestRateLimiter {
+  const maxRequests = config?.maxRequests ?? DEFAULT_MAX_REQUESTS;
+  const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
+  const exemptLoopback = config?.exemptLoopback ?? true;
+  const pruneIntervalMs = config?.pruneIntervalMs ?? PRUNE_INTERVAL_MS;
+
+  const entries = new Map<string, WindowEntry>();
+
+  const pruneTimer = pruneIntervalMs > 0 ? setInterval(() => prune(), pruneIntervalMs) : null;
+  if (pruneTimer?.unref) {
+    pruneTimer.unref();
+  }
+
+  function normalizeIp(ip: string | undefined): string {
+    return resolveClientIp({ remoteAddr: ip }) ?? "unknown";
+  }
+
+  function isExempt(ip: string): boolean {
+    return exemptLoopback && isLoopbackAddress(ip);
+  }
+
+  function check(rawIp: string | undefined): RequestRateLimitResult {
+    const ip = normalizeIp(rawIp);
+    if (isExempt(ip)) {
+      return { allowed: true, remaining: maxRequests, retryAfterMs: 0 };
+    }
+
+    const now = Date.now();
+    let entry = entries.get(ip);
+
+    // New IP or window expired — start a fresh window.
+    if (!entry || now - entry.windowStart >= windowMs) {
+      entry = { count: 0, windowStart: now };
+      entries.set(ip, entry);
+    }
+
+    entry.count += 1;
+
+    if (entry.count > maxRequests) {
+      const retryAfterMs = windowMs - (now - entry.windowStart);
+      return { allowed: false, remaining: 0, retryAfterMs: Math.max(retryAfterMs, 0) };
+    }
+
+    return { allowed: true, remaining: maxRequests - entry.count, retryAfterMs: 0 };
+  }
+
+  function prune(): void {
+    const now = Date.now();
+    for (const [key, entry] of entries) {
+      if (now - entry.windowStart >= windowMs) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  function size(): number {
+    return entries.size;
+  }
+
+  function dispose(): void {
+    if (pruneTimer) {
+      clearInterval(pruneTimer);
+    }
+    entries.clear();
+  }
+
+  return { check, size, prune, dispose };
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -52,7 +52,8 @@ import {
   resolveHookChannel,
   resolveHookDeliver,
 } from "./hooks.js";
-import { sendGatewayAuthFailure, setDefaultSecurityHeaders } from "./http-common.js";
+import { sendGatewayAuthFailure, sendText, setDefaultSecurityHeaders } from "./http-common.js";
+import type { RequestRateLimiter } from "./request-rate-limit.js";
 import { getBearerToken } from "./http-utils.js";
 import { resolveRequestClientIp } from "./net.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
@@ -729,6 +730,8 @@ export function createGatewayHttpServer(opts: {
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
+  /** Optional per-IP request rate limiter for general flood protection. */
+  requestRateLimiter?: RequestRateLimiter;
   getReadiness?: ReadinessChecker;
   tlsOptions?: TlsOptions;
 }): HttpServer {
@@ -748,6 +751,7 @@ export function createGatewayHttpServer(opts: {
     shouldEnforcePluginGatewayAuth,
     resolvedAuth,
     rateLimiter,
+    requestRateLimiter,
     getReadiness,
   } = opts;
   const httpServer: HttpServer = opts.tlsOptions
@@ -762,6 +766,17 @@ export function createGatewayHttpServer(opts: {
     setDefaultSecurityHeaders(res, {
       strictTransportSecurity: strictTransportSecurityHeader,
     });
+
+    // General per-IP request rate limiting (flood protection).
+    if (requestRateLimiter) {
+      const result = requestRateLimiter.check(req.socket?.remoteAddress);
+      if (!result.allowed) {
+        const retryAfter = result.retryAfterMs > 0 ? Math.ceil(result.retryAfterMs / 1000) : 1;
+        res.setHeader("Retry-After", String(retryAfter));
+        sendText(res, 429, "Too Many Requests");
+        return;
+      }
+    }
 
     // Don't interfere with WebSocket upgrades; ws handles the 'upgrade' event.
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -12,6 +12,7 @@ import {
 } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { RequestRateLimiter } from "./request-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ControlUiRootState } from "./control-ui.js";
@@ -60,6 +61,8 @@ export async function createGatewayRuntimeState(params: {
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
+  /** Optional per-IP request rate limiter for general flood protection. */
+  requestRateLimiter?: RequestRateLimiter;
   gatewayTls?: GatewayTlsRuntime;
   hooksConfig: () => HooksConfigResolved | null;
   getHookClientIpConfig: () => HookClientIpConfig;
@@ -175,6 +178,7 @@ export async function createGatewayRuntimeState(params: {
         shouldEnforcePluginGatewayAuth,
         resolvedAuth: params.resolvedAuth,
         rateLimiter: params.rateLimiter,
+        requestRateLimiter: params.requestRateLimiter,
         getReadiness: params.getReadiness,
         tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
       });


### PR DESCRIPTION
## Summary
- Adds a general-purpose per-IP request rate limiter to protect the gateway from request flooding when exposed publicly (Tailscale Funnel, reverse proxy, LAN binding)
- Unlike the existing auth rate limiter (which only tracks failed auth attempts), this counts **all** incoming HTTP requests per client IP
- Default: 120 requests/minute per IP, loopback exempt, configurable via `RequestRateLimitConfig`
- Returns `429 Too Many Requests` with `Retry-After` header when limit exceeded
- Wired into the HTTP request pipeline as an optional `requestRateLimiter` parameter — checked early, before all request stages

## Files
| File | Change |
|------|--------|
| `src/gateway/request-rate-limit.ts` | New module: `createRequestRateLimiter()` with fixed-window counter |
| `src/gateway/request-rate-limit.test.ts` | 13 unit tests |
| `src/gateway/server-http.ts` | Accept + check `requestRateLimiter` in `handleRequest()` |
| `src/gateway/server-runtime-state.ts` | Thread `requestRateLimiter` through to HTTP server creation |

## Design
- **Fixed window** (not sliding) — simpler, lower overhead than per-request array allocations
- **Follows existing patterns** — mirrors `auth-rate-limit.ts` API shape (check/size/prune/dispose)
- **Opt-in** — callers create a limiter instance and pass it; no behavior change if omitted
- **Loopback exempt by default** — local CLI sessions are never throttled

## Test plan
- [x] `pnpm vitest run src/gateway/request-rate-limit.test.ts` — 13/13 passing
- [x] `pnpm vitest run src/gateway/auth-rate-limit.test.ts` — 21/21 passing (no regression)
- [x] TypeScript compilation clean (no errors in changed files)
- [x] Tests cover: basic counting, window expiry, per-IP isolation, IPv4/IPv6 normalization, loopback exemption, prune, dispose

Closes #20373

🤖 Generated with [Claude Code](https://claude.com/claude-code)