### PR TITLE
Plugin SDK: expose session binding adapter registration

### DIFF
--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -96,6 +96,8 @@ describe("plugin-sdk exports", () => {
       "resolveChannelEntryMatchWithFallback",
       "normalizeChannelSlug",
       "buildChannelKeyCandidates",
+      "registerSessionBindingAdapter",
+      "unregisterSessionBindingAdapter",
     ];
 
     for (const key of requiredFunctions) {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -127,12 +127,18 @@ export type {
   UsageWindow,
 } from "../infra/provider-usage.types.js";
 export type {
+  BindingTargetKind,
   ConversationRef,
+  SessionBindingAdapter,
   SessionBindingBindInput,
   SessionBindingCapabilities,
   SessionBindingRecord,
   SessionBindingService,
   SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
+export {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
 } from "../infra/outbound/session-binding-service.js";
 export type {
   GatewayRequestHandler,


### PR DESCRIPTION
## Summary

- Problem: Channel extensions (discord, feishu, telegram) use `registerSessionBindingAdapter`, `unregisterSessionBindingAdapter`, and `BindingTargetKind` from internal source paths, but these are not available through the public `openclaw/plugin-sdk` entrypoint.
- Why it matters: Third-party plugins cannot register session binding adapters without reaching into internal modules, which is fragile and unsupported.
- What changed: Added 4 exports to `src/plugin-sdk/index.ts` — types `BindingTargetKind` and `SessionBindingAdapter`, functions `registerSessionBindingAdapter` and `unregisterSessionBindingAdapter`. Added regression test coverage. Intentionally omitted `SessionBindingAdapterCapabilities` (only used internally as a property type of `SessionBindingAdapter`, accessible via `SessionBindingAdapter["capabilities"]`).
- What did NOT change (scope boundary): No behavioral changes; existing internal imports in discord/feishu/telegram extensions are unaffected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

None — additive API surface only.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Evidence

- [x] Failing test/log before + passing after

`registerSessionBindingAdapter` and `unregisterSessionBindingAdapter` added to `"exports critical functions used by channel extensions"` test — passes with the new exports.

## Human Verification (required)

- Verified scenarios: `pnpm test -- src/plugin-sdk/index.test.ts` passes
- Edge cases checked: Confirmed `SessionBindingAdapterCapabilities` has zero external consumers — omitted from exports
- What you did **not** verify: Bundle build (`emits importable bundled subpath entries` test skipped locally due to timeout)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; no downstream code depends on the new exports yet.
- Files/config to restore: `src/plugin-sdk/index.ts`, `src/plugin-sdk/index.test.ts`
- Known bad symptoms reviewers should watch for: None expected — purely additive.

## Risks and Mitigations

None