### PR TITLE
fix(gateway): add Cache-Control: no-store to default security headers

### DIFF
--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -24,6 +24,12 @@ describe("setDefaultSecurityHeaders", () => {
     );
   });
 
+  it("sets Cache-Control to no-store", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+  });
+
   it("sets Strict-Transport-Security when provided", () => {
     const { res, setHeader } = makeMockHttpResponse();
     setDefaultSecurityHeaders(res, {

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -7,6 +7,11 @@ import { readJsonBody } from "./hooks.js";
  * HTML pages, static assets, SSE streams). Headers that restrict framing or set a
  * Content-Security-Policy are intentionally omitted here because some handlers
  * (canvas host, A2UI) serve content that may be loaded inside frames.
+ *
+ * `Cache-Control: no-store` prevents intermediate proxies and browsers from
+ * caching potentially sensitive API responses (model outputs, auth failures,
+ * session data). Individual handlers may override this with a more permissive
+ * value when the response is safe to cache (e.g. static assets).
  */
 export function setDefaultSecurityHeaders(
   res: ServerResponse,
@@ -15,6 +20,7 @@ export function setDefaultSecurityHeaders(
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  res.setHeader("Cache-Control", "no-store");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Problem

The gateway's `setDefaultSecurityHeaders` function sets `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on all HTTP responses, but does not include a `Cache-Control` header. This means API endpoints (OpenAI-compat, OpenResponses, hooks, tools-invoke) serve responses without cache directives.

Intermediate proxies, CDN edges, or shared browser caches could inadvertently store and replay responses containing model outputs, session data, or authentication error details.

## Fix

Add `Cache-Control: no-store` to `setDefaultSecurityHeaders` so all HTTP responses default to non-cacheable. Handlers that serve intentionally cacheable content (static assets, etc.) can still override the header on a per-response basis.

The health/readiness endpoint already set `no-store` explicitly — that still works fine since the later `setHeader` call just confirms the same value.

## Changes

- `src/gateway/http-common.ts`: Add `Cache-Control: no-store` to the default security headers
- `src/gateway/http-common.test.ts`: Add test coverage for the new header

## Testing

- Existing tests pass
- New test verifies the Cache-Control header is set