### PR TITLE
fix: add compact mode to cron list tool

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -35,6 +35,7 @@ const CronToolSchema = Type.Object(
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
     includeDisabled: Type.Optional(Type.Boolean()),
+    compact: Type.Optional(Type.Boolean()),
     job: Type.Optional(Type.Object({}, { additionalProperties: true })),
     jobId: Type.Optional(Type.String()),
     id: Type.Optional(Type.String()),
@@ -217,7 +218,7 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
 
 ACTIONS:
 - status: Check cron scheduler status
-- list: List jobs (use includeDisabled:true to include disabled)
+- list: List jobs (use includeDisabled:true to include disabled; use compact:true for minimal summaries — id/name/enabled/nextRunAtMs/scheduleKind/lastRunStatus — avoids token bloat with large job lists)
 - add: Create job (requires job object, see schema below)
 - update: Modify job (requires jobId + patch object)
 - remove: Delete job (requires jobId)
@@ -299,6 +300,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           return jsonResult(
             await callGateway("cron.list", gatewayOpts, {
               includeDisabled: Boolean(params.includeDisabled),
+              ...(params.compact !== undefined ? { compact: Boolean(params.compact) } : {}),
             }),
           );
         case "add": {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -37,10 +37,21 @@ export type CronListPageOptions = {
   enabled?: CronJobsEnabledFilter;
   sortBy?: CronJobsSortBy;
   sortDir?: CronSortDir;
+  /** When true, return minimal job summaries (id/name/enabled/nextRunAtMs/scheduleKind/lastRunStatus) instead of full objects. */
+  compact?: boolean;
+};
+
+export type CronJobCompact = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  nextRunAtMs: number | null;
+  scheduleKind: string;
+  lastRunStatus: string | null;
 };
 
 export type CronListPageResult = {
-  jobs: ReturnType<typeof sortJobs>;
+  jobs: ReturnType<typeof sortJobs> | CronJobCompact[];
   total: number;
   offset: number;
   limit: number;
@@ -220,8 +231,18 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
     const defaultLimit = total === 0 ? 50 : total;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = sorted.slice(offset, offset + limit);
-    const nextOffset = offset + jobs.length;
+    const pageJobs = sorted.slice(offset, offset + limit);
+    const nextOffset = offset + pageJobs.length;
+    const jobs = opts?.compact
+      ? pageJobs.map((job) => ({
+          id: job.id,
+          name: job.name,
+          enabled: job.enabled,
+          nextRunAtMs: job.state.nextRunAtMs ?? null,
+          scheduleKind: job.schedule.kind,
+          lastRunStatus: job.state.lastRunStatus ?? job.state.lastStatus ?? null,
+        }))
+      : pageJobs;
     return {
       jobs,
       total,

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -275,6 +275,7 @@ export const CronListParamsSchema = Type.Object(
     enabled: Type.Optional(CronJobsEnabledFilterSchema),
     sortBy: Type.Optional(CronJobsSortBySchema),
     sortDir: Type.Optional(CronSortDirSchema),
+    compact: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -61,6 +61,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled?: "all" | "enabled" | "disabled";
       sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
       sortDir?: "asc" | "desc";
+      compact?: boolean;
     };
     const page = await context.cron.listPage({
       includeDisabled: p.includeDisabled,
@@ -70,6 +71,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled: p.enabled,
       sortBy: p.sortBy,
       sortDir: p.sortDir,
+      compact: p.compact,
     });
     respond(true, page, undefined);
   },


### PR DESCRIPTION
Fixes #48333.

The `cron` tool's `list` action returns full `CronJob` objects including payload text, delivery config, session targets, and full schedule details. With 10+ jobs this causes LLMs to truncate responses, hallucinate missing entries, and burn unnecessary tokens on fields that aren't needed for most operations.

**What this adds:** a `compact: true` parameter to `cron(action="list")`. When set, each job in the response is reduced to 6 fields: `id`, `name`, `enabled`, `nextRunAtMs`, `scheduleKind`, `lastRunStatus`. Default behavior is unchanged — existing callers get full objects as before.

**Changes:**
- `src/gateway/protocol/schema/cron.ts` — add `compact` to `CronListParamsSchema`
- `src/gateway/server-methods/cron.ts` — thread `compact` through to `listPage()`
- `src/cron/service/ops.ts` — apply field projection in `listPage()` when `compact: true`; export `CronJobCompact` type; widen `CronListPageResult.jobs`
- `src/agents/tools/cron-tool.ts` — add `compact` param to tool schema; update description to document it

Backward-compatible. No existing callers affected.