### PR TITLE
fix(mattermost): thread resolved cfg through reply delivery send calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -549,6 +549,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/edit tool: accept common path/text alias spellings, show current file contents on exact-match failures, and avoid false edit failures after successful writes. (#52516) thanks @mbelinky.
 - Agents/compaction: reconcile `sessions.json.compactionCount` after a late embedded auto-compaction success so persisted session counts catch up once the handler reports completion. (#45493) Thanks @jackal092927.
+- Mattermost/replies: keep pairing replies, slash-command fallback replies, and model-picker messages on the resolved config path so `exec:` SecretRef bot tokens work across all outbound reply branches. (#48347) thanks @mathiasnagler.
 
 ## 2026.3.13
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1086,7 +1086,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   idLine: `Your Mattermost user id: ${senderId}`,
                   code,
                 }),
-                { accountId: account.accountId },
+                { cfg, accountId: account.accountId },
               );
               opts.statusSink?.({ lastOutboundAt: Date.now() });
             } catch (err) {

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -45,6 +45,7 @@ describe("deliverMattermostReplyPayload", () => {
         "channel:town-square",
         "caption",
         expect.objectContaining({
+          cfg,
           accountId: "default",
           mediaUrl,
           replyToId: "root-post",
@@ -63,6 +64,7 @@ describe("deliverMattermostReplyPayload", () => {
 
   it("forwards replyToId for text-only chunked replies", async () => {
     const sendMessage = vi.fn(async () => undefined);
+    const cfg = {} satisfies OpenClawConfig;
     const core = {
       channel: {
         text: {
@@ -75,7 +77,7 @@ describe("deliverMattermostReplyPayload", () => {
 
     await deliverMattermostReplyPayload({
       core,
-      cfg: {} satisfies OpenClawConfig,
+      cfg,
       payload: { text: "hello" },
       to: "channel:town-square",
       accountId: "default",
@@ -91,6 +93,7 @@ describe("deliverMattermostReplyPayload", () => {
       "channel:town-square",
       "hello",
       expect.objectContaining({
+        cfg,
         accountId: "default",
         replyToId: "root-post",
       }),

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -87,9 +87,13 @@ describe("deliverMattermostReplyPayload", () => {
     });
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith("channel:town-square", "hello", {
-      accountId: "default",
-      replyToId: "root-post",
-    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "channel:town-square",
+      "hello",
+      expect.objectContaining({
+        accountId: "default",
+        replyToId: "root-post",
+      }),
+    );
   });
 });

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -11,6 +11,7 @@ type SendMattermostMessage = (
   to: string,
   text: string,
   opts: {
+    cfg?: OpenClawConfig;
     accountId?: string;
     mediaUrl?: string;
     mediaLocalRoots?: readonly string[];
@@ -49,12 +50,14 @@ export async function deliverMattermostReplyPayload(params: {
       params.core.channel.text.chunkMarkdownTextWithMode(value, params.textLimit, chunkMode),
     sendText: async (chunk) => {
       await params.sendMessage(params.to, chunk, {
+        cfg: params.cfg,
         accountId: params.accountId,
         replyToId: params.replyToId,
       });
     },
     sendMedia: async ({ mediaUrl, caption }) => {
       await params.sendMessage(params.to, caption ?? "", {
+        cfg: params.cfg,
         accountId: params.accountId,
         mediaUrl,
         mediaLocalRoots,

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -1,0 +1,193 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk/mattermost";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedMattermostAccount } from "./accounts.js";
+
+const mockState = vi.hoisted(() => ({
+  readRequestBodyWithLimit: vi.fn(async () => "token=valid-token"),
+  parseSlashCommandPayload: vi.fn(() => ({
+    token: "valid-token",
+    command: "/oc_models",
+    text: "models",
+    channel_id: "chan-1",
+    user_id: "user-1",
+    user_name: "alice",
+    team_id: "team-1",
+  })),
+  resolveCommandText: vi.fn((_trigger: string, text: string) => text),
+  buildModelsProviderData: vi.fn(async () => ({ providers: [] })),
+  resolveMattermostModelPickerEntry: vi.fn(() => ({ kind: "summary" })),
+  authorizeMattermostCommandInvocation: vi.fn(() => ({
+    ok: true,
+    commandAuthorized: true,
+    channelInfo: { id: "chan-1", type: "O", name: "town-square", display_name: "Town Square" },
+    kind: "channel",
+    chatType: "channel",
+    channelName: "town-square",
+    channelDisplay: "Town Square",
+    roomLabel: "#town-square",
+  })),
+  createMattermostClient: vi.fn(() => ({})),
+  fetchMattermostChannel: vi.fn(async () => ({
+    id: "chan-1",
+    type: "O",
+    name: "town-square",
+    display_name: "Town Square",
+  })),
+  sendMessageMattermost: vi.fn(async () => ({ messageId: "post-1", channelId: "chan-1" })),
+  normalizeMattermostAllowList: vi.fn((value: unknown) => value),
+}));
+
+vi.mock("openclaw/plugin-sdk/mattermost", () => ({
+  buildModelsProviderData: mockState.buildModelsProviderData,
+  createReplyPrefixOptions: vi.fn(() => ({})),
+  createTypingCallbacks: vi.fn(() => ({ onReplyStart: vi.fn() })),
+  isRequestBodyLimitError: vi.fn(() => false),
+  logTypingFailure: vi.fn(),
+  readRequestBodyWithLimit: mockState.readRequestBodyWithLimit,
+}));
+
+vi.mock("../runtime.js", () => ({
+  getMattermostRuntime: () => ({
+    channel: {
+      commands: {
+        shouldHandleTextCommands: () => true,
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+      pairing: {
+        readAllowFromStore: vi.fn(async () => []),
+      },
+      routing: {
+        resolveAgentRoute: vi.fn(() => ({
+          agentId: "agent-1",
+          sessionKey: "mattermost:session:1",
+          accountId: "default",
+        })),
+      },
+    },
+  }),
+}));
+
+vi.mock("./client.js", () => ({
+  createMattermostClient: mockState.createMattermostClient,
+  fetchMattermostChannel: mockState.fetchMattermostChannel,
+  normalizeMattermostBaseUrl: vi.fn((value: string | undefined) => value?.trim() ?? ""),
+  sendMattermostTyping: vi.fn(),
+}));
+
+vi.mock("./model-picker.js", () => ({
+  renderMattermostModelSummaryView: vi.fn(),
+  renderMattermostModelsPickerView: vi.fn(),
+  renderMattermostProviderPickerView: vi.fn(),
+  resolveMattermostModelPickerCurrentModel: vi.fn(),
+  resolveMattermostModelPickerEntry: mockState.resolveMattermostModelPickerEntry,
+}));
+
+vi.mock("./monitor-auth.js", () => ({
+  authorizeMattermostCommandInvocation: mockState.authorizeMattermostCommandInvocation,
+  normalizeMattermostAllowList: mockState.normalizeMattermostAllowList,
+}));
+
+vi.mock("./reply-delivery.js", () => ({
+  deliverMattermostReplyPayload: vi.fn(),
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageMattermost: mockState.sendMessageMattermost,
+}));
+
+vi.mock("./slash-commands.js", () => ({
+  parseSlashCommandPayload: mockState.parseSlashCommandPayload,
+  resolveCommandText: mockState.resolveCommandText,
+}));
+
+import { createSlashCommandHttpHandler } from "./slash-http.js";
+
+function createRequest(body = "token=valid-token"): IncomingMessage {
+  const req = new PassThrough();
+  const incoming = req as unknown as IncomingMessage;
+  incoming.method = "POST";
+  incoming.headers = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  process.nextTick(() => {
+    req.end(body);
+  });
+  return incoming;
+}
+
+function createResponse(): {
+  res: ServerResponse;
+  getBody: () => string;
+} {
+  let body = "";
+  const res = {
+    statusCode: 200,
+    setHeader() {},
+    end(chunk?: string | Buffer) {
+      body = chunk ? String(chunk) : "";
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    getBody: () => body,
+  };
+}
+
+const accountFixture: ResolvedMattermostAccount = {
+  accountId: "default",
+  enabled: true,
+  botToken: "bot-token",
+  baseUrl: "https://chat.example.com",
+  botTokenSource: "config",
+  baseUrlSource: "config",
+  config: {},
+};
+
+describe("slash-http cfg threading", () => {
+  beforeEach(() => {
+    mockState.readRequestBodyWithLimit.mockClear();
+    mockState.parseSlashCommandPayload.mockClear();
+    mockState.resolveCommandText.mockClear();
+    mockState.buildModelsProviderData.mockClear();
+    mockState.resolveMattermostModelPickerEntry.mockClear();
+    mockState.authorizeMattermostCommandInvocation.mockClear();
+    mockState.createMattermostClient.mockClear();
+    mockState.fetchMattermostChannel.mockClear();
+    mockState.sendMessageMattermost.mockClear();
+    mockState.normalizeMattermostAllowList.mockClear();
+  });
+
+  it("passes cfg through the no-models slash reply send path", async () => {
+    const cfg = {
+      channels: {
+        mattermost: {
+          botToken: "exec:secret-ref",
+        },
+      },
+    } as OpenClawConfig;
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg,
+      runtime: {} as RuntimeEnv,
+      commandTokens: new Set(["valid-token"]),
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain("Processing");
+    expect(mockState.sendMessageMattermost).toHaveBeenCalledWith(
+      "channel:chan-1",
+      "No models available.",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+      }),
+    );
+  });
+});

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -316,6 +316,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       try {
         const to = `channel:${channelId}`;
         await sendMessageMattermost(to, "Sorry, something went wrong processing that command.", {
+          cfg,
           accountId: account.accountId,
         });
       } catch {
@@ -387,6 +388,7 @@ async function handleSlashCommandAsync(params: {
     const data = await buildModelsProviderData(cfg, route.agentId);
     if (data.providers.length === 0) {
       await sendMessageMattermost(to, "No models available.", {
+        cfg,
         accountId: account.accountId,
       });
       return;
@@ -418,6 +420,7 @@ async function handleSlashCommandAsync(params: {
             });
 
     await sendMessageMattermost(to, view.text, {
+      cfg,
       accountId: account.accountId,
       buttons: view.buttons,
     });


### PR DESCRIPTION
## Summary

- Commit `c965049dc` (Mar 12) extracted reply delivery into `reply-delivery.ts` but missed passing the resolved `cfg` through to `sendMessage()`, causing `sendMessageMattermost()` to fall back to `loadConfig()` which returns unresolved SecretRef objects instead of plain strings.
- This broke all Mattermost bot replies when using `exec:` SecretRefs for `botToken` (error: `unresolved SecretRef "exec:op-mm-deadman-bot:value"`).
- The fix threads `params.cfg` (which holds the resolved runtime config snapshot) through both the text and media send paths, matching the pattern established in `646817dd8` ("unify resolved cfg threading across send paths", #33987).

## Test plan

- [x] Verified Mattermost bot replies work with `exec:` SecretRef bot tokens after this fix
- [ ] Confirm no regression in outbound text replies
- [ ] Confirm no regression in outbound media replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)