### PR TITLE
Agents: add post-compaction validator

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1009,6 +1009,12 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
+        guard: {
+          enabled: false,
+          maxCompactionsPerWindow: 3,
+          windowMinutes: 30,
+          escalation: "recommend-reset",
+        },
         postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
         model: "openrouter/anthropic/claude-sonnet-4-5", // optional compaction-only model override
         memoryFlush: {
@@ -1027,6 +1033,10 @@ Periodic heartbeat runs.
 - `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `900`.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
+- `guard`: reserved repeated-compaction guard scaffolding. Default: `{ enabled: false }`. This config currently does not change runtime behavior.
+- `guard.maxCompactionsPerWindow`: maximum compaction events allowed within the rolling guard window before future escalation. Integer range: `2-20`.
+- `guard.windowMinutes`: rolling guard window in minutes. Integer range: `1-1440`.
+- `guard.escalation`: reserved escalation policy for future guard trips. Currently only `recommend-reset` is accepted.
 - `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
 - `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.

--- a/src/agents/compaction-guard.test.ts
+++ b/src/agents/compaction-guard.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultGuardThresholds, scoreCompactionGuard } from "./compaction-guard.js";
+import type { TranscriptTailSignal } from "./transcript-tail-detector.js";
+
+describe("resolveDefaultGuardThresholds", () => {
+  it("returns the documented defaults", () => {
+    expect(resolveDefaultGuardThresholds()).toEqual({
+      warnUsageRatio: 0.85,
+      riskUsageRatio: 0.9,
+      forceUsageRatio: 0.95,
+      repeatedToolFailureThreshold: 3,
+      duplicateAssistantThreshold: 2,
+      staleSystemRecurrenceThreshold: 2,
+      noGroundedReplyTurnsThreshold: 4,
+    });
+  });
+});
+
+describe("scoreCompactionGuard", () => {
+  it("returns none for a low-risk session", () => {
+    expect(
+      scoreCompactionGuard({
+        usageRatio: 0.84,
+        transcript: createTranscriptSignal(),
+      }),
+    ).toEqual({
+      usageRatio: 0.84,
+      repeatedToolFailures: [],
+      duplicateAssistantClusters: 0,
+      staleSystemRecurrences: 0,
+      noGroundedReplyTurns: 0,
+      score: 0,
+      action: "none",
+      reasons: [],
+    });
+  });
+
+  it("returns warn when usage pressure and duplicate assistant clusters cross thresholds", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.9,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+
+    expect(signal.score).toBe(4);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+
+  it("returns compact when combined loop signals reach the compaction band", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.85,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [createRepeatedToolFailure("shell: timeout", 3)],
+        noGroundedReplyTurns: 4,
+      }),
+    });
+
+    expect(signal.score).toBe(5);
+    expect(signal.action).toBe("compact");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "repeatedToolFailures>=threshold",
+      "noGroundedReplyTurns>=threshold",
+    ]);
+  });
+
+  it("returns reset-candidate for high score under force-level usage", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.96,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [createRepeatedToolFailure("shell: timeout", 3)],
+        staleSystemRecurrences: 2,
+        noGroundedReplyTurns: 4,
+      }),
+    });
+
+    expect(signal.score).toBe(11);
+    expect(signal.action).toBe("reset-candidate");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "usage>=force",
+      "repeatedToolFailures>=threshold",
+      "staleSystemRecurrences>=threshold",
+      "noGroundedReplyTurns>=threshold",
+    ]);
+  });
+
+  it("stays below and above the risk threshold deterministically", () => {
+    const justBelowRisk = scoreCompactionGuard({
+      usageRatio: 0.899,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+    const atRisk = scoreCompactionGuard({
+      usageRatio: 0.9,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 2,
+      }),
+    });
+
+    expect(justBelowRisk.score).toBe(2);
+    expect(justBelowRisk.action).toBe("none");
+    expect(justBelowRisk.reasons).toEqual(["usage>=warn", "duplicateAssistantClusters>=threshold"]);
+
+    expect(atRisk.score).toBe(4);
+    expect(atRisk.action).toBe("warn");
+    expect(atRisk.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+
+  it("counts repeated tool failures at most once even when multiple groups cross the threshold", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.85,
+      transcript: createTranscriptSignal({
+        repeatedToolFailures: [
+          createRepeatedToolFailure("shell: timeout", 3),
+          createRepeatedToolFailure("fetch: 500", 5),
+        ],
+      }),
+    });
+
+    expect(signal.score).toBe(3);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual(["usage>=warn", "repeatedToolFailures>=threshold"]);
+  });
+
+  it("applies custom thresholds on top of the defaults", () => {
+    const signal = scoreCompactionGuard({
+      usageRatio: 0.8,
+      transcript: createTranscriptSignal({
+        duplicateAssistantClusters: 1,
+      }),
+      thresholds: {
+        warnUsageRatio: 0.8,
+        riskUsageRatio: 0.8,
+        duplicateAssistantThreshold: 1,
+      },
+    });
+
+    expect(signal.score).toBe(4);
+    expect(signal.action).toBe("warn");
+    expect(signal.reasons).toEqual([
+      "usage>=warn",
+      "usage>=risk",
+      "duplicateAssistantClusters>=threshold",
+    ]);
+  });
+});
+
+function createTranscriptSignal(
+  overrides: Partial<TranscriptTailSignal> = {},
+): TranscriptTailSignal {
+  return {
+    repeatedToolFailures: [],
+    duplicateAssistantClusters: 0,
+    staleSystemRecurrences: 0,
+    noGroundedReplyTurns: 0,
+    ...overrides,
+  };
+}
+
+function createRepeatedToolFailure(
+  signature: string,
+  count: number,
+): TranscriptTailSignal["repeatedToolFailures"][number] {
+  return {
+    signature,
+    count,
+    lastSeenEntryId: `${signature}-${count}`,
+  };
+}

--- a/src/agents/compaction-guard.ts
+++ b/src/agents/compaction-guard.ts
@@ -1,0 +1,162 @@
+import type { TranscriptTailSignal } from "./transcript-tail-detector.js";
+
+export type GuardThresholds = {
+  warnUsageRatio: number;
+  riskUsageRatio: number;
+  forceUsageRatio: number;
+  repeatedToolFailureThreshold: number;
+  duplicateAssistantThreshold: number;
+  staleSystemRecurrenceThreshold: number;
+  noGroundedReplyTurnsThreshold: number;
+};
+
+export type GuardAction = "none" | "warn" | "compact" | "recommend-reset" | "reset-candidate";
+
+export type SessionGuardSignal = {
+  usageRatio: number;
+  repeatedToolFailures: TranscriptTailSignal["repeatedToolFailures"];
+  duplicateAssistantClusters: number;
+  staleSystemRecurrences: number;
+  noGroundedReplyTurns: number;
+  score: number;
+  action: GuardAction;
+  reasons: string[];
+};
+
+const DEFAULT_GUARD_THRESHOLDS: GuardThresholds = {
+  warnUsageRatio: 0.85,
+  riskUsageRatio: 0.9,
+  forceUsageRatio: 0.95,
+  repeatedToolFailureThreshold: 3,
+  duplicateAssistantThreshold: 2,
+  staleSystemRecurrenceThreshold: 2,
+  noGroundedReplyTurnsThreshold: 4,
+};
+
+const REASONS = {
+  usageWarn: "usage>=warn",
+  usageRisk: "usage>=risk",
+  usageForce: "usage>=force",
+  repeatedToolFailures: "repeatedToolFailures>=threshold",
+  duplicateAssistantClusters: "duplicateAssistantClusters>=threshold",
+  staleSystemRecurrences: "staleSystemRecurrences>=threshold",
+  noGroundedReplyTurns: "noGroundedReplyTurns>=threshold",
+} as const;
+
+export function resolveDefaultGuardThresholds(): GuardThresholds {
+  return { ...DEFAULT_GUARD_THRESHOLDS };
+}
+
+export function scoreCompactionGuard(params: {
+  usageRatio: number;
+  transcript: TranscriptTailSignal;
+  thresholds?: Partial<GuardThresholds>;
+}): SessionGuardSignal {
+  const thresholds = resolveGuardThresholds(params.thresholds);
+  const reasons: string[] = [];
+  let score = 0;
+
+  score += scoreUsagePressure(params.usageRatio, thresholds, reasons);
+  score += scoreLoopSignals(params.transcript, thresholds, reasons);
+
+  return {
+    usageRatio: params.usageRatio,
+    repeatedToolFailures: params.transcript.repeatedToolFailures.map((failure) => ({
+      ...failure,
+    })),
+    duplicateAssistantClusters: params.transcript.duplicateAssistantClusters,
+    staleSystemRecurrences: params.transcript.staleSystemRecurrences,
+    noGroundedReplyTurns: params.transcript.noGroundedReplyTurns,
+    score,
+    action: resolveGuardAction(score, params.usageRatio, thresholds),
+    reasons,
+  };
+}
+
+function resolveGuardThresholds(thresholds?: Partial<GuardThresholds>): GuardThresholds {
+  return {
+    ...DEFAULT_GUARD_THRESHOLDS,
+    ...thresholds,
+  };
+}
+
+function scoreUsagePressure(
+  usageRatio: number,
+  thresholds: GuardThresholds,
+  reasons: string[],
+): number {
+  let score = 0;
+
+  if (usageRatio >= thresholds.warnUsageRatio) {
+    score += 1;
+    reasons.push(REASONS.usageWarn);
+  }
+
+  if (usageRatio >= thresholds.riskUsageRatio) {
+    score += 2;
+    reasons.push(REASONS.usageRisk);
+  }
+
+  if (usageRatio >= thresholds.forceUsageRatio) {
+    score += 2;
+    reasons.push(REASONS.usageForce);
+  }
+
+  return score;
+}
+
+function scoreLoopSignals(
+  transcript: TranscriptTailSignal,
+  thresholds: GuardThresholds,
+  reasons: string[],
+): number {
+  let score = 0;
+
+  // Count repeated tool failures once so one noisy tool loop does not multiply
+  // into multiple risk buckets just because several signatures crossed the line.
+  if (
+    transcript.repeatedToolFailures.some(
+      ({ count }) => count >= thresholds.repeatedToolFailureThreshold,
+    )
+  ) {
+    score += 2;
+    reasons.push(REASONS.repeatedToolFailures);
+  }
+
+  if (transcript.duplicateAssistantClusters >= thresholds.duplicateAssistantThreshold) {
+    score += 1;
+    reasons.push(REASONS.duplicateAssistantClusters);
+  }
+
+  if (transcript.staleSystemRecurrences >= thresholds.staleSystemRecurrenceThreshold) {
+    score += 2;
+    reasons.push(REASONS.staleSystemRecurrences);
+  }
+
+  if (transcript.noGroundedReplyTurns >= thresholds.noGroundedReplyTurnsThreshold) {
+    score += 2;
+    reasons.push(REASONS.noGroundedReplyTurns);
+  }
+
+  return score;
+}
+
+function resolveGuardAction(
+  score: number,
+  usageRatio: number,
+  thresholds: GuardThresholds,
+): GuardAction {
+  if (score >= 8) {
+    return usageRatio >= thresholds.forceUsageRatio ? "reset-candidate" : "recommend-reset";
+  }
+
+  if (score >= 5) {
+    return "compact";
+  }
+
+  if (score >= 3) {
+    return "warn";
+  }
+
+  return "none";
+}

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -71,4 +71,36 @@ describe("buildEmbeddedExtensionFactories", () => {
       qualityGuardMaxRetries: 2,
     });
   });
+
+  it("wires compaction guard enablement into the safeguard runtime", () => {
+    const sessionManager = {} as SessionManager;
+    const model = {
+      id: "claude-sonnet-4-20250514",
+      contextWindow: 200_000,
+    } as Model<Api>;
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            mode: "safeguard",
+            guard: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    buildEmbeddedExtensionFactories({
+      cfg,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      model,
+    });
+
+    expect(getCompactionSafeguardRuntime(sessionManager)).toMatchObject({
+      guardEnabled: true,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -82,6 +82,7 @@ export function buildEmbeddedExtensionFactories(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      guardEnabled: compactionCfg?.guard?.enabled === true,
       identifierPolicy: compactionCfg?.identifierPolicy,
       identifierInstructions: compactionCfg?.identifierInstructions,
       customInstructions: compactionCfg?.customInstructions,

--- a/src/agents/pi-extensions/compaction-instructions.test.ts
+++ b/src/agents/pi-extensions/compaction-instructions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildGuardAugmentedCompactionInstructions,
   DEFAULT_COMPACTION_INSTRUCTIONS,
   resolveCompactionInstructions,
   composeSplitTurnInstructions,
@@ -233,5 +234,74 @@ describe("composeSplitTurnInstructions", () => {
     const result = composeSplitTurnInstructions(prefix, instructions);
     expect(result).toContain("Line 1\nLine 2");
     expect(result).toContain("Rule A\nRule B\nRule C");
+  });
+});
+
+describe("buildGuardAugmentedCompactionInstructions", () => {
+  const compactSignal = {
+    action: "compact" as const,
+    usageRatio: 0.93,
+    repeatedToolFailures: [
+      {
+        signature: "exec: permission denied",
+        count: 3,
+      },
+    ],
+    duplicateAssistantClusters: 2,
+    staleSystemRecurrences: 1,
+    noGroundedReplyTurns: 0,
+  };
+
+  it("leaves instructions unchanged when the guard is disabled or low-risk", () => {
+    expect(
+      buildGuardAugmentedCompactionInstructions({
+        baseInstructions: "Keep identifiers.",
+        guardEnabled: false,
+        guardSignal: compactSignal,
+      }),
+    ).toBe("Keep identifiers.");
+
+    expect(
+      buildGuardAugmentedCompactionInstructions({
+        baseInstructions: "Keep identifiers.",
+        guardEnabled: true,
+        guardSignal: {
+          ...compactSignal,
+          action: "warn",
+        },
+      }),
+    ).toBe("Keep identifiers.");
+  });
+
+  it("adds preservation and compression guidance for compact-level risk", () => {
+    const result = buildGuardAugmentedCompactionInstructions({
+      baseInstructions: "Keep identifiers.",
+      guardEnabled: true,
+      guardSignal: compactSignal,
+    });
+
+    expect(result).toContain("Loop-aware compaction guard:");
+    expect(result).toContain("The latest explicit user goal or request.");
+    expect(result).toContain("The latest meaningful assistant answer");
+    expect(result).toContain("Repeated tool failures with the same signature.");
+    expect(result).toContain("Do not represent stale reminder/system text as an active user goal.");
+    expect(result).toContain("Repeated tool failure pattern: exec: permission denied (count 3).");
+  });
+
+  it("preserves the existing instructions and appends the guard block on high-risk paths", () => {
+    const baseInstructions = "Keep identifiers.\nPreserve user preferences.";
+    const result = buildGuardAugmentedCompactionInstructions({
+      baseInstructions,
+      guardEnabled: true,
+      guardSignal: {
+        ...compactSignal,
+        action: "recommend-reset",
+        staleSystemRecurrences: 2,
+      },
+    });
+
+    expect(result.startsWith(baseInstructions)).toBe(true);
+    expect(result).toContain("\n\nLoop-aware compaction guard:");
+    expect(result).toContain("Repeated stale reminder/system entries in the recent tail: 2.");
   });
 });

--- a/src/agents/pi-extensions/compaction-instructions.ts
+++ b/src/agents/pi-extensions/compaction-instructions.ts
@@ -1,3 +1,5 @@
+import type { GuardAction, SessionGuardSignal } from "../compaction-guard.js";
+
 /**
  * Compaction instruction utilities.
  *
@@ -21,6 +23,12 @@ export const DEFAULT_COMPACTION_INSTRUCTIONS =
  * ~800 chars ≈ ~200 tokens — keeps summarization quality stable.
  */
 const MAX_INSTRUCTION_LENGTH = 800;
+const MAX_GUARD_FAILURE_PATTERNS = 3;
+const GUARDED_COMPACTION_ACTIONS = new Set<GuardAction>([
+  "compact",
+  "recommend-reset",
+  "reset-candidate",
+]);
 
 function truncateUnicodeSafe(s: string, maxCodePoints: number): string {
   const chars = Array.from(s);
@@ -65,4 +73,120 @@ export function composeSplitTurnInstructions(
   resolvedInstructions: string,
 ): string {
   return [turnPrefixInstructions, "Additional requirements:", resolvedInstructions].join("\n\n");
+}
+
+function formatGuardUsageRatio(usageRatio: number): string | null {
+  if (!Number.isFinite(usageRatio) || usageRatio <= 0) {
+    return null;
+  }
+  return `- Context pressure before compaction: ${(usageRatio * 100).toFixed(1)}% of the window.`;
+}
+
+function formatGuardRepeatedFailures(
+  repeatedToolFailures: SessionGuardSignal["repeatedToolFailures"],
+): string[] {
+  if (repeatedToolFailures.length === 0) {
+    return [];
+  }
+
+  const lines = repeatedToolFailures
+    .slice(0, MAX_GUARD_FAILURE_PATTERNS)
+    .map(
+      (failure) =>
+        `- Repeated tool failure pattern: ${failure.signature} (count ${failure.count}).`,
+    );
+
+  if (repeatedToolFailures.length > MAX_GUARD_FAILURE_PATTERNS) {
+    lines.push(
+      `- Additional repeated tool failure patterns: ${
+        repeatedToolFailures.length - MAX_GUARD_FAILURE_PATTERNS
+      } more.`,
+    );
+  }
+
+  return lines;
+}
+
+function buildGuardSignalLines(
+  guardSignal: Pick<
+    SessionGuardSignal,
+    | "usageRatio"
+    | "repeatedToolFailures"
+    | "duplicateAssistantClusters"
+    | "staleSystemRecurrences"
+    | "noGroundedReplyTurns"
+  >,
+): string[] {
+  const lines: string[] = [];
+  const usageRatioLine = formatGuardUsageRatio(guardSignal.usageRatio);
+
+  if (usageRatioLine) {
+    lines.push(usageRatioLine);
+  }
+
+  lines.push(...formatGuardRepeatedFailures(guardSignal.repeatedToolFailures));
+
+  if (guardSignal.duplicateAssistantClusters > 0) {
+    lines.push(
+      `- Duplicate assistant commentary clusters in the recent tail: ${guardSignal.duplicateAssistantClusters}.`,
+    );
+  }
+
+  if (guardSignal.staleSystemRecurrences > 0) {
+    lines.push(
+      `- Repeated stale reminder/system entries in the recent tail: ${guardSignal.staleSystemRecurrences}.`,
+    );
+  }
+
+  if (guardSignal.noGroundedReplyTurns > 0) {
+    lines.push(
+      `- Trailing user turns without a grounded assistant reply: ${guardSignal.noGroundedReplyTurns}.`,
+    );
+  }
+
+  return lines;
+}
+
+export function buildGuardAugmentedCompactionInstructions(params: {
+  baseInstructions: string;
+  guardEnabled?: boolean;
+  guardSignal?:
+    | Pick<
+        SessionGuardSignal,
+        | "action"
+        | "usageRatio"
+        | "repeatedToolFailures"
+        | "duplicateAssistantClusters"
+        | "staleSystemRecurrences"
+        | "noGroundedReplyTurns"
+      >
+    | undefined;
+}): string {
+  const { baseInstructions, guardEnabled, guardSignal } = params;
+
+  if (
+    guardEnabled !== true ||
+    !guardSignal ||
+    !GUARDED_COMPACTION_ACTIONS.has(guardSignal.action)
+  ) {
+    return baseInstructions;
+  }
+
+  const lines = [
+    "Loop-aware compaction guard:",
+    "Preserve, in priority order:",
+    "1. The latest explicit user goal or request.",
+    "2. Unresolved tasks, pending follow-through, and promises still owed to the user.",
+    "3. Recent decisions, constraints, and user preferences that still govern the work.",
+    "4. The latest meaningful assistant answer that directly addressed the user.",
+    "Compress aggressively:",
+    "- Repeated tool failures with the same signature.",
+    "- Duplicate assistant commentary or status updates that do not add new facts.",
+    "- Stale reminder/system text that was not reaffirmed by a recent user turn.",
+    "Do not represent stale reminder/system text as an active user goal.",
+    "If repeated failure patterns exist, summarize each pattern once with its count and latest reason.",
+    ...buildGuardSignalLines(guardSignal),
+  ];
+
+  return `${baseInstructions}\n\n${lines.join("\n")}`;
 }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -5,6 +5,7 @@ import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-r
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  guardEnabled?: boolean;
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   identifierInstructions?: string;
   customInstructions?: string;

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -113,6 +113,73 @@ const createCompactionEvent = (params: { messageText: string; tokensBefore: numb
   signal: new AbortController().signal,
 });
 
+const createHighRiskGuardEvent = (customInstructions = "Keep security caveats.") => ({
+  preparation: {
+    messagesToSummarize: [
+      {
+        role: "user",
+        content: "Keep the latest user goal grounded and avoid rewriting persistence.",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: "Retrying the failing command.",
+        timestamp: 2,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "exec",
+        isError: true,
+        details: { status: "error" },
+        content: [{ type: "text", text: "ENOENT: missing file" }],
+        timestamp: 3,
+      } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: "Retrying the failing command.",
+        timestamp: 4,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "call-2",
+        toolName: "exec",
+        isError: true,
+        details: { status: "error" },
+        content: [{ type: "text", text: "ENOENT: missing file" }],
+        timestamp: 5,
+      } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: "Retrying the failing command.",
+        timestamp: 6,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "call-3",
+        toolName: "exec",
+        isError: true,
+        details: { status: "error" },
+        content: [{ type: "text", text: "ENOENT: missing file" }],
+        timestamp: 7,
+      } as unknown as AgentMessage,
+    ],
+    turnPrefixMessages: [],
+    firstKeptEntryId: "entry-1",
+    tokensBefore: 180_000,
+    fileOps: {
+      read: [],
+      edited: [],
+      written: [],
+    },
+    settings: { reserveTokens: 4_000 },
+    previousSummary: undefined,
+    isSplitTurn: false,
+  },
+  customInstructions,
+  signal: new AbortController().signal,
+});
+
 const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
   getApiKeyMock: ReturnType<typeof vi.fn>;
@@ -1111,6 +1178,73 @@ describe("compaction-safeguard recent-turn preservation", () => {
     );
     expect(droppedCall?.customInstructions).toContain("## Decisions");
     expect(droppedCall?.customInstructions).toContain("Keep security caveats.");
+  });
+
+  it("augments summarization instructions when the guard is enabled and risk reaches compact", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("guarded summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      guardEnabled: true,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = createHighRiskGuardEvent();
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summaryCall = mockSummarizeInStages.mock.calls[0]?.[0];
+    expect(summaryCall?.customInstructions).toContain("Keep security caveats.");
+    expect(summaryCall?.customInstructions).toContain("Loop-aware compaction guard:");
+    expect(summaryCall?.customInstructions).toContain("The latest explicit user goal or request.");
+    expect(summaryCall?.customInstructions).toContain("Repeated tool failure pattern:");
+  });
+
+  it("keeps summarization instructions unchanged when the guard is disabled", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("unguarded summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      guardEnabled: false,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = createHighRiskGuardEvent();
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summaryCall = mockSummarizeInStages.mock.calls[0]?.[0];
+    expect(summaryCall?.customInstructions).toBe(
+      buildCompactionStructureInstructions("Keep security caveats."),
+    );
   });
 
   it("does not retry summaries unless quality guard is explicitly enabled", async () => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -6,6 +6,7 @@ import { extractSections } from "../../auto-reply/reply/post-compaction-context.
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { extractKeywords, isQueryStopWordToken } from "../../memory/query-expansion.js";
+import { scoreCompactionGuard } from "../compaction-guard.js";
 import {
   BASE_CHUNK_RATIO,
   type CompactionSummarizationInstructions,
@@ -24,6 +25,11 @@ import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
+  detectTranscriptTailSignals,
+  type TranscriptTailEntry,
+} from "../transcript-tail-detector.js";
+import {
+  buildGuardAugmentedCompactionInstructions,
   composeSplitTurnInstructions,
   resolveCompactionInstructions,
 } from "./compaction-instructions.js";
@@ -47,6 +53,7 @@ const MAX_EXTRACTED_IDENTIFIERS = 12;
 const MAX_UNTRUSTED_INSTRUCTION_CHARS = 4000;
 const MAX_ASK_OVERLAP_TOKENS = 12;
 const MIN_ASK_OVERLAP_TOKENS_FOR_DOUBLE_MATCH = 3;
+const MAX_GUARD_TAIL_MESSAGES = 24;
 const REQUIRED_SUMMARY_SECTIONS = [
   "## Decisions",
   "## Open TODOs",
@@ -83,6 +90,98 @@ function resolveQualityGuardMaxRetries(value: unknown): number {
     MAX_QUALITY_GUARD_MAX_RETRIES,
     clampNonNegativeInt(value, DEFAULT_QUALITY_GUARD_MAX_RETRIES),
   );
+}
+
+function resolveCompactionGuardUsageRatio(
+  tokensBefore: unknown,
+  contextWindowTokens: number,
+): number {
+  if (
+    typeof tokensBefore !== "number" ||
+    !Number.isFinite(tokensBefore) ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return 0;
+  }
+
+  return Math.max(0, tokensBefore / contextWindowTokens);
+}
+
+function normalizeGuardMessageRole(message: AgentMessage): string | undefined {
+  const role = (message as { role?: unknown }).role;
+  return typeof role === "string" && role.trim().length > 0 ? role : undefined;
+}
+
+function normalizeGuardMessageKind(message: AgentMessage): string | undefined {
+  const kind = (message as { kind?: unknown }).kind;
+  if (typeof kind === "string" && kind.trim().length > 0) {
+    return kind;
+  }
+
+  return normalizeGuardMessageRole(message) === "toolResult" ? "tool-result" : undefined;
+}
+
+function resolveGuardToolStatus(message: AgentMessage): string | undefined {
+  const details = (message as { details?: unknown }).details;
+  if (details && typeof details === "object") {
+    const status = (details as { status?: unknown }).status;
+    if (typeof status === "string" && status.trim().length > 0) {
+      return status;
+    }
+  }
+
+  return (message as { isError?: unknown }).isError === true ? "error" : undefined;
+}
+
+function buildCompactionGuardTailEntries(messages: readonly AgentMessage[]): TranscriptTailEntry[] {
+  const tailEntries = messages.slice(-MAX_GUARD_TAIL_MESSAGES);
+
+  return tailEntries.map((message, index) => {
+    const extractedText = extractMessageText(message);
+    const role = normalizeGuardMessageRole(message);
+    const isError = (message as { isError?: unknown }).isError === true;
+    const toolFailureMeta = isError
+      ? formatToolFailureMeta((message as { details?: unknown }).details)
+      : undefined;
+
+    return {
+      id: `guard-tail-${messages.length - tailEntries.length + index}`,
+      role,
+      kind: normalizeGuardMessageKind(message),
+      text: extractedText || undefined,
+      toolName:
+        typeof (message as { toolName?: unknown }).toolName === "string"
+          ? ((message as { toolName?: unknown }).toolName as string)
+          : undefined,
+      toolStatus: resolveGuardToolStatus(message),
+      errorText: isError ? extractedText || toolFailureMeta : undefined,
+      isError,
+    };
+  });
+}
+
+function logCompactionGuardDecision(params: {
+  usageRatio: number;
+  score: number;
+  action: string;
+  augmented: boolean;
+}): void {
+  const logger = log as {
+    info?: (message: string) => void;
+    debug?: (message: string) => void;
+  };
+  const message =
+    "Compaction safeguard guard: " +
+    `usageRatio=${params.usageRatio.toFixed(3)} ` +
+    `score=${params.score} action=${params.action} augmented=${params.augmented}`;
+
+  if (logger.info) {
+    logger.info(message);
+    return;
+  }
+
+  logger.debug?.(message);
 }
 
 function normalizeFailureText(text: string): string {
@@ -708,18 +807,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       );
       return { cancel: true };
     }
+    const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
     const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
     const toolFailures = collectToolFailures([
       ...preparation.messagesToSummarize,
-      ...preparation.turnPrefixMessages,
+      ...turnPrefixMessages,
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
 
     // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
     // Fall back to runtime.model which is explicitly passed when building extension paths.
     const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
-    const customInstructions = resolveCompactionInstructions(
+    const resolvedCustomInstructions = resolveCompactionInstructions(
       eventInstructions,
       runtime?.customInstructions,
     );
@@ -754,7 +854,35 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     try {
       const modelContextWindow = resolveContextWindowTokens(model);
       const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
-      const turnPrefixMessages = preparation.turnPrefixMessages ?? [];
+      const guardEnabled = runtime?.guardEnabled === true;
+      const guardSignal = guardEnabled
+        ? scoreCompactionGuard({
+            usageRatio: resolveCompactionGuardUsageRatio(
+              preparation.tokensBefore,
+              contextWindowTokens,
+            ),
+            transcript: detectTranscriptTailSignals(
+              buildCompactionGuardTailEntries([
+                ...preparation.messagesToSummarize,
+                ...turnPrefixMessages,
+              ]),
+            ),
+          })
+        : null;
+      const customInstructions = buildGuardAugmentedCompactionInstructions({
+        baseInstructions: resolvedCustomInstructions,
+        guardEnabled,
+        guardSignal: guardSignal ?? undefined,
+      });
+      const instructionsAugmented = customInstructions !== resolvedCustomInstructions;
+      if (guardEnabled && guardSignal) {
+        logCompactionGuardDecision({
+          usageRatio: guardSignal.usageRatio,
+          score: guardSignal.score,
+          action: guardSignal.action,
+          augmented: instructionsAugmented,
+        });
+      }
       let messagesToSummarize = preparation.messagesToSummarize;
       const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
       const qualityGuardEnabled = runtime?.qualityGuardEnabled ?? false;

--- a/src/agents/post-compaction-validator.test.ts
+++ b/src/agents/post-compaction-validator.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { SessionGuardSignal } from "./compaction-guard.js";
+import { validatePostCompaction } from "./post-compaction-validator.js";
+
+describe("validatePostCompaction", () => {
+  it("returns ok for a healthy validated compaction", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        usageRatio: 0.93,
+        repeatedToolFailures: buildRepeatedFailures(4),
+        staleSystemRecurrences: 1,
+      }),
+      compactionCountBefore: 2,
+      compactionCountAfter: 3,
+      projectedUsageRatioAfter: 0.61,
+      latestUserGoal: "Finish the post-compaction validator tests",
+      unresolvedItems: ["Add validator test coverage"],
+      summaryText:
+        "State: finish the post compaction validator tests. Remaining: add validator test coverage. Repeated tool failures were summarized into one note.",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      reasons: [],
+      shouldRecommendReset: false,
+    });
+  });
+
+  it("fails when the latest user goal is missing from the summary", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal(),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.5,
+      latestUserGoal: "Ship the validator module",
+      summaryText: "Pending notes were preserved for later follow-up.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("latest-user-goal-missing");
+  });
+
+  it("fails when unresolved items are missing from the summary", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal(),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.5,
+      unresolvedItems: ["stale directive case", "manual verification proof"],
+      summaryText: "Pending: stale directive case only.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("pending-items-missing");
+  });
+
+  it("fails when stale system directives appear to be promoted into active state", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        staleSystemRecurrences: 2,
+      }),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.5,
+      summaryText: "System reminder: always retry the same tool and do not change approach.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("stale-system-promoted");
+  });
+
+  it("fails when raw failure chatter is preserved instead of collapsed", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        repeatedToolFailures: buildRepeatedFailures(4),
+      }),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.5,
+      summaryText: [
+        "Tool error: network timeout",
+        "Tool error: network timeout",
+        "Tool error: network timeout",
+      ].join("\n"),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("failure-pattern-not-collapsed");
+  });
+
+  it("fails when there is no evidence that compaction helped", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        usageRatio: 0.91,
+      }),
+      compactionCountBefore: 3,
+      compactionCountAfter: 3,
+      projectedUsageRatioAfter: 0.91,
+      summaryText: "State preserved.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("compaction-count-not-incremented");
+    expect(result.reasons).toContain("usage-not-improved");
+  });
+
+  it("recommends reset only for severe pre-signals when validation fails", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        score: 8,
+        action: "recommend-reset",
+      }),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.4,
+      latestUserGoal: "Keep the latest goal",
+      summaryText: "Compaction retained unrelated context only.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.shouldRecommendReset).toBe(true);
+  });
+
+  it("does not recommend reset for compact-level validation failures", () => {
+    const result = validatePostCompaction({
+      signalBefore: buildSignal({
+        score: 5,
+        action: "compact",
+      }),
+      compactionCountBefore: 1,
+      compactionCountAfter: 2,
+      projectedUsageRatioAfter: 0.4,
+      latestUserGoal: "Keep the latest goal",
+      summaryText: "Compaction retained unrelated context only.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.shouldRecommendReset).toBe(false);
+  });
+});
+
+function buildSignal(overrides: Partial<SessionGuardSignal> = {}): SessionGuardSignal {
+  return {
+    usageRatio: 0.9,
+    repeatedToolFailures: [] as SessionGuardSignal["repeatedToolFailures"],
+    duplicateAssistantClusters: 0,
+    staleSystemRecurrences: 0,
+    noGroundedReplyTurns: 0,
+    score: 5,
+    action: "compact",
+    reasons: [],
+    ...overrides,
+  };
+}
+
+function buildRepeatedFailures(count: number): SessionGuardSignal["repeatedToolFailures"] {
+  return [{ count }] as SessionGuardSignal["repeatedToolFailures"];
+}

--- a/src/agents/post-compaction-validator.ts
+++ b/src/agents/post-compaction-validator.ts
@@ -1,0 +1,305 @@
+import type { SessionGuardSignal } from "./compaction-guard.js";
+
+export type PostCompactionValidation = {
+  ok: boolean;
+  reasons: string[];
+  shouldRecommendReset: boolean;
+};
+
+export type PostCompactionValidationInput = {
+  signalBefore: SessionGuardSignal;
+  compactionCountBefore?: number;
+  compactionCountAfter?: number;
+  summaryText?: string;
+  projectedUsageRatioAfter?: number;
+  latestUserGoal?: string;
+  unresolvedItems?: string[];
+};
+
+const REASONS = {
+  latestUserGoalMissing: "latest-user-goal-missing",
+  pendingItemsMissing: "pending-items-missing",
+  staleSystemPromoted: "stale-system-promoted",
+  failurePatternNotCollapsed: "failure-pattern-not-collapsed",
+  compactionCountNotIncremented: "compaction-count-not-incremented",
+  usageNotImproved: "usage-not-improved",
+} as const;
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "their",
+  "then",
+  "this",
+  "to",
+  "was",
+  "were",
+  "with",
+]);
+
+const ACTIVE_DIRECTIVE_MARKERS = [
+  "always",
+  "must",
+  "remember to",
+  "continue to",
+  "keep",
+  "do not",
+  "dont",
+  "never",
+  "ensure",
+];
+
+const STALE_CONTEXT_MARKERS = [
+  "system reminder",
+  "system directive",
+  "system instruction",
+  "prior instruction",
+  "previous instruction",
+  "earlier instruction",
+  "reminder",
+  "directive",
+  "instruction",
+];
+
+const COLLAPSE_CONTEXT_MARKERS = [
+  "collapsed",
+  "summarized",
+  "summary",
+  "ignored",
+  "discarded",
+  "duplicate reminder",
+  "repeated reminder",
+  "reminder loop",
+  "directive loop",
+];
+
+const FAILURE_COLLAPSE_MARKERS = [
+  "repeated tool failure",
+  "repeated tool failures",
+  "multiple tool failures",
+  "failure pattern",
+  "failure loop",
+  "summarized failure",
+  "summarized failures",
+  "collapsed failure",
+  "collapsed failures",
+];
+
+const FAILURE_LINE_MARKERS = [
+  "error",
+  "failed",
+  "failure",
+  "exception",
+  "timeout",
+  "stderr",
+  "exit code",
+  "traceback",
+  "enoent",
+  "rate limit",
+  "rpc",
+];
+
+export function validatePostCompaction(
+  input: PostCompactionValidationInput,
+): PostCompactionValidation {
+  const reasons: string[] = [];
+  const normalizedSummary = normalizeText(input.summaryText ?? "");
+
+  if (
+    hasMeaningfulText(input.latestUserGoal) &&
+    !isReflectedInSummary(input.latestUserGoal, normalizedSummary)
+  ) {
+    reasons.push(REASONS.latestUserGoalMissing);
+  }
+
+  if (
+    (input.unresolvedItems ?? [])
+      .filter(hasMeaningfulText)
+      .some((item) => !isReflectedInSummary(item, normalizedSummary))
+  ) {
+    reasons.push(REASONS.pendingItemsMissing);
+  }
+
+  if (
+    input.signalBefore.staleSystemRecurrences > 0 &&
+    looksLikeActiveStaleDirective(normalizedSummary)
+  ) {
+    reasons.push(REASONS.staleSystemPromoted);
+  }
+
+  if (
+    hadRepeatedFailuresBefore(input.signalBefore) &&
+    looksLikeRawFailureChatter(input.summaryText ?? "")
+  ) {
+    reasons.push(REASONS.failurePatternNotCollapsed);
+  }
+
+  const compactionIncremented = didCompactionCountIncrease(
+    input.compactionCountBefore,
+    input.compactionCountAfter,
+  );
+  const usageImproved = didUsageImprove(
+    input.projectedUsageRatioAfter,
+    input.signalBefore.usageRatio,
+  );
+
+  if (!compactionIncremented && !usageImproved) {
+    reasons.push(REASONS.compactionCountNotIncremented, REASONS.usageNotImproved);
+  }
+
+  const ok = reasons.length === 0;
+
+  return {
+    ok,
+    reasons,
+    shouldRecommendReset: !ok && shouldEscalateToReset(input.signalBefore),
+  };
+}
+
+function hasMeaningfulText(value?: string): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeText(text: string): string {
+  return ` ${text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()} `.replace(/\s+/g, " ");
+}
+
+function tokenizeMeaningfully(text: string): string[] {
+  return [...new Set(normalizeText(text).trim().split(" ").filter(isMeaningfulToken))];
+}
+
+function isMeaningfulToken(token: string): boolean {
+  return token.length >= 3 && !STOP_WORDS.has(token);
+}
+
+function isReflectedInSummary(sourceText: string, normalizedSummary: string): boolean {
+  const normalizedSource = normalizeText(sourceText);
+
+  if (!normalizedSource.trim()) {
+    return true;
+  }
+
+  if (normalizedSummary.includes(normalizedSource)) {
+    return true;
+  }
+
+  const sourceTokens = tokenizeMeaningfully(sourceText);
+
+  if (sourceTokens.length === 0) {
+    return false;
+  }
+
+  const summaryTokens = new Set(normalizedSummary.trim().split(" ").filter(Boolean));
+  const matchedTokens = sourceTokens.filter((token) => summaryTokens.has(token)).length;
+  const requiredMatches =
+    sourceTokens.length <= 2
+      ? sourceTokens.length
+      : Math.max(2, Math.ceil(sourceTokens.length * 0.6));
+
+  return matchedTokens >= requiredMatches;
+}
+
+function looksLikeActiveStaleDirective(normalizedSummary: string): boolean {
+  if (!normalizedSummary.trim()) {
+    return false;
+  }
+
+  return (
+    includesAnyPhrase(normalizedSummary, STALE_CONTEXT_MARKERS) &&
+    includesAnyPhrase(normalizedSummary, ACTIVE_DIRECTIVE_MARKERS) &&
+    !includesAnyPhrase(normalizedSummary, COLLAPSE_CONTEXT_MARKERS)
+  );
+}
+
+function includesAnyPhrase(text: string, phrases: readonly string[]): boolean {
+  return phrases.some((phrase) => text.includes(normalizeText(phrase)));
+}
+
+function hadRepeatedFailuresBefore(signal: SessionGuardSignal): boolean {
+  return signal.repeatedToolFailures.some((failure) => failure.count > 1);
+}
+
+function looksLikeRawFailureChatter(summaryText: string): boolean {
+  if (!hasMeaningfulText(summaryText)) {
+    return false;
+  }
+
+  const normalizedSummary = normalizeText(summaryText);
+
+  if (includesAnyPhrase(normalizedSummary, FAILURE_COLLAPSE_MARKERS)) {
+    return false;
+  }
+
+  const rawFailureLineCount = summaryText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter(looksLikeRawFailureLine).length;
+
+  if (rawFailureLineCount >= 2) {
+    return true;
+  }
+
+  const repeatedFailureMarkerCount = FAILURE_LINE_MARKERS.reduce(
+    (count, marker) => count + countOccurrences(normalizedSummary, normalizeText(marker).trim()),
+    0,
+  );
+
+  return repeatedFailureMarkerCount >= 3;
+}
+
+function looksLikeRawFailureLine(line: string): boolean {
+  const normalizedLine = normalizeText(line);
+
+  return (
+    includesAnyPhrase(normalizedLine, FAILURE_LINE_MARKERS) &&
+    (line.includes(":") ||
+      /exit code \d+/.test(normalizedLine) ||
+      normalizedLine.includes("stderr") ||
+      normalizedLine.includes("traceback"))
+  );
+}
+
+function countOccurrences(text: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+
+  return text.split(needle).length - 1;
+}
+
+function didCompactionCountIncrease(before?: number, after?: number): boolean {
+  return typeof after === "number" && after > (before ?? 0);
+}
+
+function didUsageImprove(projectedAfter?: number, before?: number): boolean {
+  return (
+    typeof projectedAfter === "number" && typeof before === "number" && projectedAfter < before
+  );
+}
+
+function shouldEscalateToReset(signal: SessionGuardSignal): boolean {
+  return (
+    signal.action === "recommend-reset" || signal.action === "reset-candidate" || signal.score >= 8
+  );
+}

--- a/src/agents/transcript-tail-detector.test.ts
+++ b/src/agents/transcript-tail-detector.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTranscriptTailSignals,
+  type TranscriptTailEntry,
+} from "./transcript-tail-detector.js";
+
+describe("detectTranscriptTailSignals", () => {
+  it("groups repeated tool failures with the same normalized signature", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("t1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("t2", "searchWeb", "request 987 timed out after 31 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([
+      {
+        signature: "searchweb: request <num> timed out after <num> seconds",
+        count: 2,
+        lastSeenEntryId: "t2",
+      },
+    ]);
+  });
+
+  it("separates different tool failures into distinct groups", () => {
+    const entries: TranscriptTailEntry[] = [
+      toolFailure("a1", "searchWeb", "Request 123 timed out after 45 seconds"),
+      toolFailure("a2", "searchWeb", "Permission denied for workspace alpha"),
+      toolFailure("a3", "fetchFile", "Request 999 timed out after 45 seconds"),
+    ];
+
+    expect(detectTranscriptTailSignals(entries).repeatedToolFailures).toEqual([]);
+  });
+
+  it("detects duplicate assistant clusters from repeated normalized text", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Working on it now." },
+      { role: "assistant", text: "  working   on it now.  " },
+      { role: "assistant", text: "Different reply" },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).duplicateAssistantClusters).toBe(1);
+  });
+
+  it("detects stale directive-like system recurrences", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: do not retry the same failed tool call.",
+      },
+      { role: "assistant", text: "I will avoid that." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder:   do not retry the same failed tool call. ",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(1);
+  });
+
+  it("does not flag legitimate post-compaction reinjection prefixes as stale", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nKeep going.",
+      },
+      {
+        role: "system",
+        text: "Session was just compacted.\nPlease continue.",
+      },
+      {
+        role: "system",
+        text: "Injected sections from AGENTS.md\n- rule one",
+      },
+      {
+        role: "system",
+        text: "Current time: 2026-03-16T12:34:56Z\nTimezone: UTC",
+      },
+      {
+        role: "system",
+        text: "Critical rules from AGENTS.md:\n- do not reset",
+      },
+      {
+        role: "system",
+        text: "  Current time: 2026-03-16T12:35:56Z\nTimezone: UTC",
+      },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).staleSystemRecurrences).toBe(0);
+  });
+
+  it("counts trailing user turns without a non-empty assistant reply", () => {
+    const entries: TranscriptTailEntry[] = [
+      { role: "assistant", text: "Earlier grounded answer." },
+      { role: "user", text: "Can you keep going?" },
+      { role: "toolResult", toolName: "searchWeb", toolStatus: "error", errorText: "timeout" },
+      { role: "assistant", text: "   " },
+      { role: "user", text: "Still waiting." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries).noGroundedReplyTurns).toBe(2);
+  });
+
+  it("reports multiple signal types together in a mixed tail", () => {
+    const entries: TranscriptTailEntry[] = [
+      {
+        role: "system",
+        text: "[Post-compaction context refresh]\nContext restored.",
+      },
+      {
+        id: "tool-1",
+        role: "toolResult",
+        toolName: "searchWeb",
+        toolStatus: "error",
+        errorText: "HTTP 500 for request 12345",
+      },
+      { role: "assistant", text: "I will check that now." },
+      {
+        role: "system",
+        kind: "reminder",
+        text: "Reminder: always acknowledge repeated tool failures before retrying.",
+      },
+      {
+        id: "tool-2",
+        role: "toolResult",
+        toolName: "searchWeb",
+        isError: true,
+        errorText: "http 500 for request 99999",
+      },
+      { role: "assistant", text: "  i will check that now. " },
+      {
+        role: "system",
+        kind: "reminder",
+        text: " reminder: always acknowledge repeated tool failures before retrying. ",
+      },
+      { role: "user", text: "Any update?" },
+      { role: "user", text: "Please answer directly." },
+    ];
+
+    expect(detectTranscriptTailSignals(entries)).toEqual({
+      repeatedToolFailures: [
+        {
+          signature: "searchweb: http <num> for request <num>",
+          count: 2,
+          lastSeenEntryId: "tool-2",
+        },
+      ],
+      duplicateAssistantClusters: 1,
+      staleSystemRecurrences: 1,
+      noGroundedReplyTurns: 2,
+    });
+  });
+});
+
+function toolFailure(id: string, toolName: string, errorText: string): TranscriptTailEntry {
+  return {
+    id,
+    role: "toolResult",
+    toolName,
+    toolStatus: "error",
+    errorText,
+  };
+}

--- a/src/agents/transcript-tail-detector.ts
+++ b/src/agents/transcript-tail-detector.ts
@@ -1,0 +1,237 @@
+export type TranscriptTailEntry = {
+  id?: string;
+  role?: string;
+  kind?: string;
+  text?: string;
+  toolName?: string;
+  toolStatus?: string;
+  errorText?: string;
+  isError?: boolean;
+};
+
+export type TranscriptTailSignal = {
+  repeatedToolFailures: Array<{
+    signature: string;
+    count: number;
+    lastSeenEntryId?: string;
+  }>;
+  duplicateAssistantClusters: number;
+  staleSystemRecurrences: number;
+  noGroundedReplyTurns: number;
+};
+
+const STALE_SYSTEM_EXEMPT_PREFIXES = [
+  "[Post-compaction context refresh]",
+  "Session was just compacted.",
+  "Critical rules from AGENTS.md:",
+  "Injected sections from AGENTS.md",
+] as const;
+
+const DIRECTIVE_TEXT_PATTERN =
+  /\b(always|avoid|critical|directive|do not|don't|follow|important|instruction|must|never|note|remember|reminder|required|rule|should)\b/;
+
+export function detectTranscriptTailSignals(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal {
+  return {
+    repeatedToolFailures: collectRepeatedToolFailures(entries),
+    duplicateAssistantClusters: countDuplicateAssistantClusters(entries),
+    staleSystemRecurrences: countStaleSystemRecurrences(entries),
+    noGroundedReplyTurns: countTrailingUserTurnsWithoutReply(entries),
+  };
+}
+
+function collectRepeatedToolFailures(
+  entries: readonly TranscriptTailEntry[],
+): TranscriptTailSignal["repeatedToolFailures"] {
+  const groupedFailures = new Map<
+    string,
+    { signature: string; count: number; lastSeenEntryId?: string }
+  >();
+
+  for (const entry of entries) {
+    const signature = getToolFailureSignature(entry);
+
+    if (!signature) {
+      continue;
+    }
+
+    const current = groupedFailures.get(signature);
+
+    if (current) {
+      current.count += 1;
+      current.lastSeenEntryId = entry.id ?? current.lastSeenEntryId;
+      continue;
+    }
+
+    groupedFailures.set(signature, {
+      signature,
+      count: 1,
+      lastSeenEntryId: entry.id,
+    });
+  }
+
+  return [...groupedFailures.values()].filter(({ count }) => count > 1);
+}
+
+function getToolFailureSignature(entry: TranscriptTailEntry): string | undefined {
+  if (!isToolFailureEntry(entry)) {
+    return undefined;
+  }
+
+  const toolName = normalizeComparableText(entry.toolName) || "unknown-tool";
+  const rawErrorText = entry.errorText ?? entry.text ?? "error";
+  const errorSignature = normalizeFailureSignature(rawErrorText) || "error";
+
+  return `${toolName}: ${errorSignature}`;
+}
+
+function isToolFailureEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+  const hasToolIdentity =
+    hasNonEmptyText(entry.toolName) ||
+    normalizedRole === "toolresult" ||
+    normalizedKind.includes("tool");
+
+  if (!hasToolIdentity) {
+    return false;
+  }
+
+  return (
+    entry.isError === true ||
+    normalizeToken(entry.toolStatus) === "error" ||
+    hasNonEmptyText(entry.errorText)
+  );
+}
+
+function countDuplicateAssistantClusters(entries: readonly TranscriptTailEntry[]): number {
+  const seenAssistantReplies = new Map<string, number>();
+  let duplicateClusters = 0;
+
+  for (const entry of entries) {
+    if (normalizeToken(entry.role) !== "assistant") {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(entry.text);
+
+    if (!normalizedText) {
+      continue;
+    }
+
+    const previousCount = seenAssistantReplies.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      duplicateClusters += 1;
+    }
+
+    seenAssistantReplies.set(normalizedText, previousCount + 1);
+  }
+
+  return duplicateClusters;
+}
+
+function countStaleSystemRecurrences(entries: readonly TranscriptTailEntry[]): number {
+  const seenSystemTexts = new Map<string, number>();
+  let staleRecurrences = 0;
+
+  for (const entry of entries) {
+    if (!isSystemLikeEntry(entry)) {
+      continue;
+    }
+
+    const text = entry.text?.trim();
+
+    if (!text || isLegitimateReinjectionText(text)) {
+      continue;
+    }
+
+    if (!isDirectiveLikeSystemText(text, entry.kind)) {
+      continue;
+    }
+
+    const normalizedText = normalizeComparableText(text);
+    const previousCount = seenSystemTexts.get(normalizedText) ?? 0;
+
+    if (previousCount >= 1) {
+      staleRecurrences += 1;
+    }
+
+    seenSystemTexts.set(normalizedText, previousCount + 1);
+  }
+
+  return staleRecurrences;
+}
+
+function isSystemLikeEntry(entry: TranscriptTailEntry): boolean {
+  const normalizedRole = normalizeToken(entry.role);
+  const normalizedKind = normalizeToken(entry.kind);
+
+  return (
+    normalizedRole === "system" ||
+    normalizedKind.includes("system") ||
+    normalizedKind.includes("reminder")
+  );
+}
+
+function isLegitimateReinjectionText(text: string): boolean {
+  const trimmed = text.trimStart();
+
+  if (STALE_SYSTEM_EXEMPT_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+    return true;
+  }
+
+  return trimmed.split(/\r?\n/u).some((line) => line.trimStart().startsWith("Current time:"));
+}
+
+function isDirectiveLikeSystemText(text: string, kind?: string): boolean {
+  const normalizedKind = normalizeToken(kind);
+
+  if (normalizedKind.includes("reminder") || normalizedKind.includes("directive")) {
+    return true;
+  }
+
+  return DIRECTIVE_TEXT_PATTERN.test(text.toLowerCase());
+}
+
+function countTrailingUserTurnsWithoutReply(entries: readonly TranscriptTailEntry[]): number {
+  let trailingUserTurns = 0;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const normalizedRole = normalizeToken(entry.role);
+
+    if (normalizedRole === "assistant" && hasNonEmptyText(entry.text)) {
+      break;
+    }
+
+    if (normalizedRole === "user" && hasNonEmptyText(entry.text)) {
+      trailingUserTurns += 1;
+    }
+  }
+
+  return trailingUserTurns;
+}
+
+function normalizeFailureSignature(text: string): string {
+  return normalizeComparableText(
+    text
+      .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/giu, "<id>")
+      .replace(/\b0x[0-9a-f]+\b/giu, "<hex>")
+      .replace(/\b[a-f0-9]{12,}\b/giu, "<id>")
+      .replace(/\b\d{2,}\b/gu, "<num>"),
+  );
+}
+
+function normalizeComparableText(value?: string): string {
+  return normalizeToken(value).replace(/\s+/gu, " ").trim();
+}
+
+function normalizeToken(value?: string): string {
+  return value?.toLowerCase().trim() ?? "";
+}
+
+function hasNonEmptyText(value?: string): boolean {
+  return normalizeComparableText(value).length > 0;
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -109,6 +109,51 @@ describe("config compaction settings", () => {
     );
   });
 
+  it("preserves explicit compaction guard config values", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+              guard: {
+                enabled: true,
+                maxCompactionsPerWindow: 3,
+                windowMinutes: 30,
+                escalation: "recommend-reset",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard?.enabled).toBe(true);
+        expect(cfg.agents?.defaults?.compaction?.guard?.maxCompactionsPerWindow).toBe(3);
+        expect(cfg.agents?.defaults?.compaction?.guard?.windowMinutes).toBe(30);
+        expect(cfg.agents?.defaults?.compaction?.guard?.escalation).toBe("recommend-reset");
+      },
+    );
+  });
+
+  it("defaults compaction guard shape to disabled", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.guard).toEqual({ enabled: false });
+      },
+    );
+  });
+
   it("preserves oversized quality guard retry values for runtime clamping", async () => {
     await withTempHomeConfig(
       {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -224,4 +224,52 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it('rejects compaction.guard escalation values other than "recommend-reset"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              escalation: "reset-now",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.escalation"),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects compaction.guard numeric values outside conservative bounds", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            guard: {
+              maxCompactionsPerWindow: 1,
+              windowMinutes: 1441,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) => issue.path === "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+        ),
+      ).toBe(true);
+      expect(
+        res.issues.some((issue) => issue.path === "agents.defaults.compaction.guard.windowMinutes"),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -512,7 +512,9 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
     return cfg;
   }
   const compaction = defaults?.compaction;
-  if (compaction?.mode) {
+  const needsModeDefault = compaction?.mode === undefined;
+  const needsGuardDefault = compaction?.guard?.enabled === undefined;
+  if (!needsModeDefault && !needsGuardDefault) {
     return cfg;
   }
 
@@ -524,7 +526,11 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
         ...defaults,
         compaction: {
           ...compaction,
-          mode: "safeguard",
+          ...(needsModeDefault ? { mode: "safeguard" as const } : {}),
+          guard: {
+            ...compaction?.guard,
+            enabled: compaction?.guard?.enabled ?? false,
+          },
         },
       },
     },

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -381,6 +381,11 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.identifierPolicy",
   "agents.defaults.compaction.identifierInstructions",
   "agents.defaults.compaction.recentTurnsPreserve",
+  "agents.defaults.compaction.guard",
+  "agents.defaults.compaction.guard.enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow",
+  "agents.defaults.compaction.guard.windowMinutes",
+  "agents.defaults.compaction.guard.escalation",
   "agents.defaults.compaction.qualityGuard",
   "agents.defaults.compaction.qualityGuard.enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries",
@@ -442,6 +447,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "cli.banner.taglineMode": ['"random"', '"default"', '"off"'],
   "update.channel": ['"stable"', '"beta"', '"dev"'],
   "agents.defaults.compaction.mode": ['"default"', '"safeguard"'],
+  "agents.defaults.compaction.guard.escalation": ['"recommend-reset"'],
   "agents.defaults.compaction.identifierPolicy": ['"strict"', '"off"', '"custom"'],
 };
 
@@ -803,7 +809,7 @@ describe("config help copy quality", () => {
     expect(/cooldown|backoff|retry/i.test(authCooldowns)).toBe(true);
   });
 
-  it("documents agent compaction safeguards and memory flush behavior", () => {
+  it("documents agent compaction safeguards, guard scaffolding, and memory flush behavior", () => {
     const mode = FIELD_HELP["agents.defaults.compaction.mode"];
     expect(mode.includes('"default"')).toBe(true);
     expect(mode.includes('"safeguard"')).toBe(true);
@@ -819,6 +825,14 @@ describe("config help copy quality", () => {
     const recentTurnsPreserve = FIELD_HELP["agents.defaults.compaction.recentTurnsPreserve"];
     expect(/recent.*turn|verbatim/i.test(recentTurnsPreserve)).toBe(true);
     expect(/default:\s*3/i.test(recentTurnsPreserve)).toBe(true);
+
+    const guard = FIELD_HELP["agents.defaults.compaction.guard"];
+    expect(/future|reserved|no runtime effect|does not change runtime behavior/i.test(guard)).toBe(
+      true,
+    );
+
+    const guardEscalation = FIELD_HELP["agents.defaults.compaction.guard.escalation"];
+    expect(guardEscalation.includes('"recommend-reset"')).toBe(true);
 
     const postCompactionSections = FIELD_HELP["agents.defaults.compaction.postCompactionSections"];
     expect(/Session Startup|Red Lines/i.test(postCompactionSections)).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1047,6 +1047,16 @@ export const FIELD_HELP: Record<string, string> = {
     'Custom identifier-preservation instruction text used when identifierPolicy="custom". Keep this explicit and safety-focused so compaction summaries do not rewrite opaque IDs, URLs, hosts, or ports.',
   "agents.defaults.compaction.recentTurnsPreserve":
     "Number of most recent user/assistant turns kept verbatim outside safeguard summarization (default: 3). Raise this to preserve exact recent dialogue context, or lower it to maximize compaction savings.",
+  "agents.defaults.compaction.guard":
+    "Reserved repeated-compaction guard scaffolding for future loop protection. Keep this block for pre-staging loop-protection settings, but use it as config-only for now because it does not change runtime behavior until compaction guard logic is implemented.",
+  "agents.defaults.compaction.guard.enabled":
+    "Enables reserved repeated-compaction guard scaffolding. Default: false, and setting this currently has no runtime effect until repeated-compaction guard behavior exists.",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Maximum compaction events allowed within the rolling guard window before the future guard would escalate (range 2-20). Keep this small if you are pre-staging repeated-compaction protection settings.",
+  "agents.defaults.compaction.guard.windowMinutes":
+    "Rolling time window in minutes used by the future compaction guard when counting repeated compactions (range 1-1440). Use shorter windows for burst detection or longer ones for broader session-level protection.",
+  "agents.defaults.compaction.guard.escalation":
+    'Reserved escalation mode for future compaction guard trips. Use "recommend-reset" to pre-stage a future session-reset recommendation once guard behavior is implemented; no other values are currently accepted.',
   "agents.defaults.compaction.qualityGuard":
     "Optional quality-audit retry settings for safeguard compaction summaries. Leave this disabled unless you explicitly want summary audits and one-shot regeneration on failed checks.",
   "agents.defaults.compaction.qualityGuard.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -472,6 +472,12 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
   "agents.defaults.compaction.recentTurnsPreserve": "Compaction Preserve Recent Turns",
+  "agents.defaults.compaction.guard": "Compaction Loop Guard",
+  "agents.defaults.compaction.guard.enabled": "Compaction Loop Guard Enabled",
+  "agents.defaults.compaction.guard.maxCompactionsPerWindow":
+    "Compaction Loop Guard Max Compactions per Window",
+  "agents.defaults.compaction.guard.windowMinutes": "Compaction Loop Guard Window (Minutes)",
+  "agents.defaults.compaction.guard.escalation": "Compaction Loop Guard Escalation",
   "agents.defaults.compaction.qualityGuard": "Compaction Quality Guard",
   "agents.defaults.compaction.qualityGuard.enabled": "Compaction Quality Guard Enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -296,11 +296,22 @@ export type AgentDefaultsConfig = {
 export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionPostIndexSyncMode = "off" | "async" | "await";
 export type AgentCompactionIdentifierPolicy = "strict" | "off" | "custom";
+export type AgentCompactionGuardEscalation = "recommend-reset";
 export type AgentCompactionQualityGuardConfig = {
   /** Enable compaction summary quality audits and regeneration retries. Default: false. */
   enabled?: boolean;
   /** Maximum regeneration retries after a failed quality audit. Default: 1 when enabled. */
   maxRetries?: number;
+};
+export type AgentCompactionGuardConfig = {
+  /** Enable reserved repeated-compaction guard scaffolding. Default: false. */
+  enabled?: boolean;
+  /** Maximum compaction events allowed in the rolling guard window. */
+  maxCompactionsPerWindow?: number;
+  /** Rolling time window in minutes used by the reserved guard. */
+  windowMinutes?: number;
+  /** Escalation mode reserved for future guard trips. */
+  escalation?: AgentCompactionGuardEscalation;
 };
 
 export type AgentCompactionConfig = {
@@ -318,6 +329,8 @@ export type AgentCompactionConfig = {
   customInstructions?: string;
   /** Preserve this many most-recent user/assistant turns verbatim in compaction summary context. */
   recentTurnsPreserve?: number;
+  /** Reserved repeated-compaction guard scaffolding. */
+  guard?: AgentCompactionGuardConfig;
   /** Identifier-preservation instruction policy for compaction summaries. */
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,15 @@ export const AgentDefaultsSchema = z
           .optional(),
         identifierInstructions: z.string().optional(),
         recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+        guard: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxCompactionsPerWindow: z.number().int().min(2).max(20).optional(),
+            windowMinutes: z.number().int().min(1).max(1440).optional(),
+            escalation: z.enum(["recommend-reset"]).optional(),
+          })
+          .strict()
+          .optional(),
         qualityGuard: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Problem: the loop-aware compaction guard flow still had no way to judge whether a guarded compaction actually preserved active state and reduced contamination.
- Why it matters: PR4 can strengthen compaction instructions for risky sessions, but the runtime should not assume that compaction succeeded just because compaction happened.
- What changed: added a pure post-compaction validator plus focused tests for goal retention, pending-item retention, stale-system promotion, failure collapse, compaction evidence, and conservative reset recommendation.
- What did NOT change (scope boundary): no runtime hook changes, no reset execution, no recommend-reset delivery, no session-store or transcript writes.
- Stacking note: this branch is stacked on top of #48335, which is stacked on #48312, #48293, and #48278, so compare views against `main` still include earlier PR commits until those land.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48238
- Depends on #48335
- Depends on #48312
- Depends on #48293
- Depends on #48278

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0 arm64
- Runtime/container: local host checkout
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Add a pure validator that accepts the PR3 `SessionGuardSignal`, post-compaction counters/usage hints, summary text, latest goal, and unresolved items.
2. Return deterministic `ok`, `reasons`, and conservative `shouldRecommendReset` values using heuristic checks only.
3. Cover healthy, missing-goal, missing-pending, stale-system, failure-collapse, no-evidence, severe-failed, and mild-failed cases with focused tests.
4. Run the targeted validator test wrapper.

### Expected

- Healthy compactions validate successfully.
- Missing preserved state or unchanged/unhelpful compactions fail with explainable reason codes.
- `shouldRecommendReset` remains conservative and only becomes `true` for severe failed validations.

### Actual

- Targeted validator tests passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: healthy validated compaction, missing latest goal, missing pending items, stale directive promotion, failure-pattern collapse failure, no evidence of compaction effect, severe failed validation causing `shouldRecommendReset=true`, and mild/compact failed validation keeping `shouldRecommendReset=false`.
- Edge cases checked: text retention uses normalized overlap instead of exact-match only; stale-system checks are gated on prior stale-system risk; reset recommendation stays conservative even when validation fails.
- What you did **not** verify: any runtime consumer of this validator or any recommend-reset delivery path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b013acd57dc648dab25303791d66f21985df95b4`.
- Files/config to restore: `src/agents/post-compaction-validator.ts`, `src/agents/post-compaction-validator.test.ts`.
- Known bad symptoms reviewers should watch for: false positives on retention/failure-collapse heuristics or future runtime callers treating `shouldRecommendReset` as an executable action instead of a recommendation signal.

## Risks and Mitigations

- Risk: simple deterministic text heuristics may undercount or overcount some real summaries.
  - Mitigation: keep the validator pure, emit explicit reason codes, and defer runtime delivery/policy choices to the next PR.
