### PR TITLE
fix(cron): enforce timeoutSeconds for script payloads

### DIFF
--- a/src/cron/service/timeout-policy.test.ts
+++ b/src/cron/service/timeout-policy.test.ts
@@ -46,4 +46,16 @@ describe("timeout-policy", () => {
     );
     expect(timeout).toBe(1_900);
   });
+
+  it("applies explicit timeoutSeconds for script payloads (#47608)", () => {
+    const timeout = resolveCronJobTimeoutMs(
+      makeJob({ kind: "script", script: "echo hi", timeoutSeconds: 30 }),
+    );
+    expect(timeout).toBe(30_000);
+  });
+
+  it("uses DEFAULT_JOB_TIMEOUT_MS for script payloads without explicit timeout", () => {
+    const timeout = resolveCronJobTimeoutMs(makeJob({ kind: "script", script: "echo hi" }));
+    expect(timeout).toBe(DEFAULT_JOB_TIMEOUT_MS);
+  });
 });

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -15,7 +15,8 @@ export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
   const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+    (job.payload.kind === "agentTurn" || job.payload.kind === "script") &&
+    typeof job.payload.timeoutSeconds === "number"
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {


### PR DESCRIPTION
## Summary

Fixes #47608.

`CronScriptPayload.timeoutSeconds` was defined in the type but silently ignored — script jobs always ran with `DEFAULT_JOB_TIMEOUT_MS` (10 minutes) regardless of the configured value.

## Root cause

`resolveCronJobTimeoutMs` in `src/cron/service/timeout-policy.ts` only read `timeoutSeconds` for `agentTurn` payloads. Script payloads fell through unconditionally.

## Fix

One-line extension of the existing condition to also cover `script` payloads.

## Scope

Intentionally minimal — two files only: `timeout-policy.ts` and its test. No type changes, no schema changes.

## Testing

- New tests: script jobs respect `timeoutSeconds`, and fall back to `DEFAULT_JOB_TIMEOUT_MS` when unset
- All existing timeout-policy tests pass

## AI disclosure

This PR was generated with Claude (Sonnet) via OpenClaw. The fix was reviewed and understood before submission.