### PR TITLE
fix(feishu): feishu_doc create action now populates content when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Docx: allow `feishu_doc` create to populate initial markdown content, including explicit empty content, while keeping create responses free of misleading deleted-block counts. Fixes #48373; carries forward #48377. Thanks @wzx011011.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.

--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -43,7 +43,7 @@ Appends markdown to end of document.
 ### Create Document
 
 ```json
-{ "action": "create", "title": "New Document", "owner_open_id": "ou_xxx" }
+{ "action": "create", "title": "New Document" }
 ```
 
 With folder:
@@ -52,12 +52,23 @@ With folder:
 {
   "action": "create",
   "title": "New Document",
-  "folder_token": "fldcnXXX",
-  "owner_open_id": "ou_xxx"
+  "folder_token": "fldcnXXX"
 }
 ```
 
-**Important:** Always pass `owner_open_id` with the requesting user's `open_id` (from inbound metadata `sender_id`) so the user automatically gets `full_access` permission on the created document. Without this, only the bot app has access.
+With initial markdown content:
+
+```json
+{
+  "action": "create",
+  "title": "New Document",
+  "content": "# Title\n\nInitial content"
+}
+```
+
+`content` is optional. If provided as an empty string, the tool intentionally creates an empty document.
+
+By default, when called from a trusted Feishu message context, the tool grants the requester edit permission on the created document. Set `grant_to_requester: false` to skip that grant.
 
 ### List Blocks
 

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -42,6 +42,7 @@ export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
+    content: Type.Optional(Type.String({ description: "Markdown content to populate the document (optional)" })),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
     grant_to_requester: Type.Optional(
       Type.Boolean({

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -42,7 +42,9 @@ export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
-    content: Type.Optional(Type.String({ description: "Markdown content to populate the document (optional)" })),
+    content: Type.Optional(
+      Type.String({ description: "Markdown content to populate the document (optional)" }),
+    ),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
     grant_to_requester: Type.Optional(
       Type.Boolean({

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -43,7 +43,10 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     content: Type.Optional(
-      Type.String({ description: "Markdown content to populate the document (optional)" }),
+      Type.String({
+        description:
+          "Markdown content to populate the document (optional). Pass an empty string to create an empty document intentionally.",
+      }),
     ),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
     grant_to_requester: Type.Optional(

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -431,6 +431,69 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.requester_permission_added).toBeUndefined();
   });
 
+  it("create writes provided markdown content without reporting deleted blocks", async () => {
+    convertMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        blocks: [{ block_type: 2, block_id: "body_1" }],
+        first_level_block_ids: ["body_1"],
+      },
+    });
+    blockDescendantCreateMock.mockImplementationOnce(async ({ data }) => ({
+      code: 0,
+      data: {
+        children: (data.children_id as string[]).map((id) => ({ block_id: id })),
+      },
+    }));
+
+    const feishuDocTool = resolveFeishuDocTool();
+
+    const result = await executeFeishuDocTool(feishuDocTool, {
+      action: "create",
+      title: "Demo",
+      content: "# Hello",
+    });
+
+    expect(documentCreateMock).toHaveBeenCalledWith({
+      data: { title: "Demo", folder_token: undefined },
+    });
+    expect(convertMock).toHaveBeenCalledWith({
+      data: { content_type: "markdown", content: "# Hello" },
+    });
+    expect(blockDescendantCreateMock).toHaveBeenCalledTimes(1);
+    expect(result.details.document_id).toBe("doc_created");
+    expect(result.details.success).toBe(true);
+    expect(result.details.blocks_added).toBe(1);
+    expect(result.details.blocks_deleted).toBeUndefined();
+  });
+
+  it("create treats explicit empty content as an intentional empty write", async () => {
+    convertMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        blocks: [],
+        first_level_block_ids: [],
+      },
+    });
+
+    const feishuDocTool = resolveFeishuDocTool();
+
+    const result = await executeFeishuDocTool(feishuDocTool, {
+      action: "create",
+      title: "Demo",
+      content: "",
+    });
+
+    expect(convertMock).toHaveBeenCalledWith({
+      data: { content_type: "markdown", content: "" },
+    });
+    expect(blockDescendantCreateMock).not.toHaveBeenCalled();
+    expect(result.details.document_id).toBe("doc_created");
+    expect(result.details.success).toBe(true);
+    expect(result.details.blocks_added).toBe(0);
+    expect(result.details.blocks_deleted).toBeUndefined();
+  });
+
   it("returns an error when create response omits document_id", async () => {
     documentCreateMock.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -36,6 +36,10 @@ function json(data: unknown) {
   };
 }
 
+function hasOwnProperty(data: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(data, key);
+}
+
 function resolveDocToolLocalRoots(ctx: {
   workspaceDir?: string;
   fsPolicy?: { workspaceOnly: boolean };
@@ -1472,11 +1476,12 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     grantToRequester: p.grant_to_requester,
                     requesterOpenId: trustedRequesterOpenId,
                   });
-                  if (p.content) {
+                  if (hasOwnProperty(p, "content")) {
+                    const content = p.content ?? "";
                     const writeResult = await writeDoc(
                       client,
                       created.document_id,
-                      p.content,
+                      content,
                       getMediaMaxBytes(p, defaultAccountId),
                       api.logger,
                     );

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1467,13 +1467,24 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       api.logger,
                     ),
                   );
-                case "create":
-                  return json(
-                    await createDoc(client, p.title, p.folder_token, {
-                      grantToRequester: p.grant_to_requester,
-                      requesterOpenId: trustedRequesterOpenId,
-                    }),
-                  );
+                case "create": {
+                  const created = await createDoc(client, p.title, p.folder_token, {
+                    grantToRequester: p.grant_to_requester,
+                    requesterOpenId: trustedRequesterOpenId,
+                  });
+                  if (p.content) {
+                    const writeResult = await writeDoc(
+                      client,
+                      created.document_id,
+                      p.content,
+                      getMediaMaxBytes(p, defaultAccountId),
+                      api.logger,
+                    );
+                    const { blocks_deleted: _, ...writeRest } = writeResult;
+                    return json({ ...created, ...writeRest });
+                  }
+                  return json(created);
+                }
                 case "list_blocks":
                   return json(await listBlocks(client, p.doc_token));
                 case "get_block":

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1480,7 +1480,9 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       getMediaMaxBytes(p, defaultAccountId),
                       api.logger,
                     );
-                    const { blocks_deleted: _, ...writeRest } = writeResult;
+                    // Strip blocks_deleted from merged response (new doc has no deletions)
+                    const { blocks_deleted: omitted, ...writeRest } = writeResult;
+                    void omitted;
                     return json({ ...created, ...writeRest });
                   }
                   return json(created);


### PR DESCRIPTION
## Summary

Fixes #48373

The `feishu_doc` `create` action was silently ignoring the `content` parameter, creating an empty document with only the title. Agents had to make a separate `write` call to populate the document.

## Root Cause

In `extensions/feishu/src/docx.ts`, the `create` case only called `createDoc()`, which does not accept a `content` parameter. The `p.content` value was never referenced.

## Fix

The `create` case now:
1. Creates the document as before
2. If `content` is provided, calls `writeDoc()` to populate it
3. Returns merged results (document_id + URL + blocks_added + images_processed)

## Changes

```diff
- case "create":
-   return json(
-     await createDoc(client, p.title, p.folder_token, {
-       grantToRequester: p.grant_to_requester,
-       requesterOpenId: trustedRequesterOpenId,
-     }),
-   );
+ case "create": {
+   const created = await createDoc(client, p.title, p.folder_token, {
+     grantToRequester: p.grant_to_requester,
+     requesterOpenId: trustedRequesterOpenId,
+   });
+   if (p.content) {
+     const writeResult = await writeDoc(
+       client,
+       created.document_id,
+       p.content,
+       getMediaMaxBytes(p, defaultAccountId),
+       api.logger,
+     );
+     return json({ ...created, ...writeResult });
+   }
+   return json(created);
+ }
```

## Testing

- Verified locally that `createDoc()` signature and `writeDoc()` parameters match the existing codebase
- The fix reuses the existing `writeDoc()` function which handles markdown conversion, chunked insertion, and image processing
- No changes to the schema or public API — this is purely a behavior fix

🤖 Submitted by 小欧 🦊