### PR TITLE
cron: add running-state fields without mutating last completed status

### DIFF
--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { MACOS_APP_SOURCES_DIR } from "../compat/legacy-names.js";
-import { CronDeliverySchema, CronJobStateSchema } from "../gateway/protocol/schema.js";
+import {
+  CronDeliverySchema,
+  CronJobPatchSchema,
+  CronJobStateSchema,
+} from "../gateway/protocol/schema.js";
 
 type SchemaLike = {
   anyOf?: Array<SchemaLike>;
@@ -112,5 +116,14 @@ describe("cron protocol conformance", () => {
       "model_not_found",
       "unknown",
     ]);
+  });
+
+  it("cron patch schema keeps derived read-model fields out of writable state", () => {
+    const properties = (CronJobPatchSchema as SchemaLike).properties ?? {};
+    const patchState = properties.state as SchemaLike | undefined;
+    const stateProperties = patchState?.properties ?? {};
+    expect(stateProperties.currentStatus).toBeUndefined();
+    expect(stateProperties.lastCompletedRunStatus).toBeUndefined();
+    expect(stateProperties.lastCompletedStatus).toBeUndefined();
   });
 });

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1545,8 +1545,24 @@ describe("Cron issue regressions", () => {
 
     const firstAck = await enqueueRun(state, first.id, "force");
     const secondAck = await enqueueRun(state, second.id, "force");
-    expect(firstAck).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
-    expect(secondAck).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+    expect(firstAck).toEqual(
+      expect.objectContaining({
+        ok: true,
+        enqueued: true,
+        runId: expect.any(String),
+        currentStatus: "running",
+        finalStatusAvailable: false,
+      }),
+    );
+    expect(secondAck).toEqual(
+      expect.objectContaining({
+        ok: true,
+        enqueued: true,
+        runId: expect.any(String),
+        currentStatus: "running",
+        finalStatusAvailable: false,
+      }),
+    );
 
     await vi.waitFor(() => expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1));
     expect(runIsolatedAgentJob.mock.calls[0]?.[0]).toMatchObject({ job: { id: first.id } });
@@ -1586,7 +1602,15 @@ describe("Cron issue regressions", () => {
     });
 
     const result = await enqueueRun(state, job.id, "force");
-    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        enqueued: true,
+        runId: expect.any(String),
+        currentStatus: "running",
+        finalStatusAvailable: false,
+      }),
+    );
 
     await vi.waitFor(() => expect(log.error).toHaveBeenCalledTimes(1));
     expect(log.error.mock.calls[0]?.[1]).toBe(

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -199,6 +199,10 @@ describe("CronService read ops while job is running", () => {
       await expect(
         withTimeout(cron.list({ includeDisabled: true }), 300, "cron.list during cron.run"),
       ).resolves.toBeTypeOf("object");
+      const running = await cron.list({ includeDisabled: true });
+      expect(running[0]?.state.currentStatus).toBe("running");
+      expect(running[0]?.state.lastRunStatus).toBeUndefined();
+      expect(running[0]?.state.lastStatus).toBeUndefined();
       await expect(withTimeout(cron.status(), 300, "cron.status during cron.run")).resolves.toEqual(
         expect.objectContaining({ enabled: true, storePath: store.storePath }),
       );
@@ -208,7 +212,67 @@ describe("CronService read ops while job is running", () => {
 
       const completed = await cron.list({ includeDisabled: true });
       expect(completed[0]?.state.lastStatus).toBe("ok");
+      expect(completed[0]?.state.currentStatus).toBeUndefined();
       expect(completed[0]?.state.runningAtMs).toBeUndefined();
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("preserves the last completed error while a manual run is in progress", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2025-12-13T00:00:00.000Z");
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        {
+          id: "manual-running-error",
+          name: "manual running error",
+          enabled: true,
+          createdAtMs: nowMs - 60_000,
+          updatedAtMs: nowMs - 60_000,
+          schedule: { kind: "at", at: new Date("2030-01-01T00:00:00.000Z").toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "manual run" },
+          delivery: { mode: "none" },
+          state: { lastRunStatus: "error", lastStatus: "error", lastRunAtMs: nowMs - 1_000 },
+        },
+      ],
+    });
+
+    const isolatedRun = createDeferredIsolatedRun();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: isolatedRun.runIsolatedAgentJob,
+    });
+
+    try {
+      await cron.start();
+      const runPromise = cron.run("manual-running-error", "force");
+      await isolatedRun.runStarted;
+
+      const running = await cron.list({ includeDisabled: true });
+      expect(running[0]?.state.currentStatus).toBe("running");
+      expect(running[0]?.state.lastRunStatus).toBe("error");
+      expect(running[0]?.state.lastStatus).toBe("error");
+      expect(running[0]?.state.lastCompletedRunStatus).toBe("error");
+      expect(running[0]?.state.lastCompletedStatus).toBe("error");
+
+      isolatedRun.completeRun({ status: "error", error: "still failing" });
+      await expect(runPromise).resolves.toEqual({ ok: true, ran: true });
+
+      const completed = await cron.list({ includeDisabled: true });
+      expect(completed[0]?.state.currentStatus).toBeUndefined();
+      expect(completed[0]?.state.lastRunStatus).toBe("error");
+      expect(completed[0]?.state.lastStatus).toBe("error");
     } finally {
       cron.stop();
       await store.cleanup();

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -1,6 +1,6 @@
 import * as ops from "./service/ops.js";
 import { type CronServiceDeps, createCronServiceState } from "./service/state.js";
-import type { CronJob, CronJobCreate, CronJobPatch } from "./types.js";
+import type { CronJob, CronJobCreate, CronJobPatch, CronReadJob } from "./types.js";
 
 export type { CronEvent, CronServiceDeps } from "./service/state.js";
 
@@ -22,11 +22,11 @@ export class CronService {
     return await ops.status(this.state);
   }
 
-  async list(opts?: { includeDisabled?: boolean }) {
+  async list(opts?: { includeDisabled?: boolean }): Promise<CronReadJob[]> {
     return await ops.list(this.state, opts);
   }
 
-  async listPage(opts?: ops.CronListPageOptions) {
+  async listPage(opts?: ops.CronListPageOptions): Promise<ops.CronListPageResult> {
     return await ops.listPage(this.state, opts);
   }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,6 +1,6 @@
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
-import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
+import type { CronJob, CronJobCreate, CronJobPatch, CronReadJob } from "../types.js";
 import { normalizeCronCreateDeliveryInput } from "./initial-delivery.js";
 import {
   applyJobPatch,
@@ -40,7 +40,7 @@ export type CronListPageOptions = {
 };
 
 export type CronListPageResult = {
-  jobs: ReturnType<typeof sortJobs>;
+  jobs: CronReadJob[];
   total: number;
   offset: number;
   limit: number;
@@ -151,8 +151,24 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
     await ensureLoadedForRead(state);
     const includeDisabled = opts?.includeDisabled === true;
     const jobs = (state.store?.jobs ?? []).filter((j) => includeDisabled || j.enabled);
-    return jobs.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    return jobs
+      .toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0))
+      .map(presentCronJobForRead);
   });
+}
+
+function presentCronJobForRead(job: CronJob): CronReadJob {
+  return typeof job.state.runningAtMs === "number"
+    ? {
+        ...job,
+        state: {
+          ...job.state,
+          currentStatus: "running",
+          lastCompletedRunStatus: job.state.lastRunStatus,
+          lastCompletedStatus: job.state.lastStatus,
+        },
+      }
+    : job;
 }
 
 function resolveEnabledFilter(opts?: CronListPageOptions): CronJobsEnabledFilter {
@@ -220,7 +236,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
     const defaultLimit = total === 0 ? 50 : total;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = sorted.slice(offset, offset + limit);
+    const jobs = sorted.slice(offset, offset + limit).map(presentCronJobForRead);
     const nextOffset = offset + jobs.length;
     return {
       jobs,
@@ -582,7 +598,14 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
       "cron: queued manual run background execution failed",
     );
   });
-  return { ok: true, enqueued: true, runId } as const;
+  return {
+    ok: true,
+    enqueued: true,
+    runId,
+    currentStatus: "running",
+    finalStatusAvailable: false,
+    statusText: "Triggered run still running; final status not yet available.",
+  } as const;
 }
 
 export function wakeNow(

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -42,6 +42,7 @@ export type CronDeliveryPatch = Partial<CronDelivery>;
 
 export type CronRunStatus = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
+export type CronCurrentStatus = "running";
 
 export type CronUsageSummary = {
   input_tokens?: number;
@@ -141,6 +142,16 @@ export type CronJob = CronJobBase<
   CronFailureAlert | false
 > & {
   state: CronJobState;
+};
+
+export type CronJobReadState = CronJobState & {
+  currentStatus?: CronCurrentStatus;
+  lastCompletedRunStatus?: CronRunStatus;
+  lastCompletedStatus?: CronRunStatus;
+};
+
+export type CronReadJob = Omit<CronJob, "state"> & {
+  state: CronJobReadState;
 };
 
 export type CronStoreFile = {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -229,9 +229,12 @@ export const CronJobStateSchema = Type.Object(
   {
     nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    currentStatus: Type.Optional(Type.Literal("running")),
     lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     lastRunStatus: Type.Optional(CronRunStatusSchema),
     lastStatus: Type.Optional(CronRunStatusSchema),
+    lastCompletedRunStatus: Type.Optional(CronRunStatusSchema),
+    lastCompletedStatus: Type.Optional(CronRunStatusSchema),
     lastError: Type.Optional(Type.String()),
     lastErrorReason: Type.Optional(CronFailoverReasonSchema),
     lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -225,24 +225,32 @@ export const CronDeliveryPatchSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const CronJobStateSchema = Type.Object(
+const CronJobStateProperties = {
+  nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastRunStatus: Type.Optional(CronRunStatusSchema),
+  lastStatus: Type.Optional(CronRunStatusSchema),
+  lastError: Type.Optional(Type.String()),
+  lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+  lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastDelivered: Type.Optional(Type.Boolean()),
+  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastDeliveryError: Type.Optional(Type.String()),
+  lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+};
+
+export const CronJobStateSchema = Type.Object(CronJobStateProperties, {
+  additionalProperties: false,
+});
+
+export const CronJobReadStateSchema = Type.Object(
   {
-    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    ...CronJobStateProperties,
     currentStatus: Type.Optional(Type.Literal("running")),
-    lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastRunStatus: Type.Optional(CronRunStatusSchema),
-    lastStatus: Type.Optional(CronRunStatusSchema),
     lastCompletedRunStatus: Type.Optional(CronRunStatusSchema),
     lastCompletedStatus: Type.Optional(CronRunStatusSchema),
-    lastError: Type.Optional(Type.String()),
-    lastErrorReason: Type.Optional(CronFailoverReasonSchema),
-    lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
-    consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
-    lastDelivered: Type.Optional(Type.Boolean()),
-    lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-    lastDeliveryError: Type.Optional(Type.String()),
-    lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );
@@ -264,7 +272,7 @@ export const CronJobSchema = Type.Object(
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
     failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
-    state: CronJobStateSchema,
+    state: CronJobReadStateSchema,
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -189,7 +189,15 @@ async function writeCronConfig(config: unknown) {
 async function runCronJobForce(ws: WebSocket, id: string) {
   const response = await rpcReq(ws, "cron.run", { id, mode: "force" }, 20_000);
   expect(response.ok).toBe(true);
-  expect(response.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+  expect(response.payload).toEqual(
+    expect.objectContaining({
+      ok: true,
+      enqueued: true,
+      runId: expect.any(String),
+      currentStatus: "running",
+      finalStatusAvailable: false,
+    }),
+  );
   return response;
 }
 
@@ -285,7 +293,15 @@ describe("gateway server cron", () => {
 
       const runRes = await rpcReq(ws, "cron.run", { id: routeJobId, mode: "force" }, 20_000);
       expect(runRes.ok).toBe(true);
-      expect(runRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(runRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       const events = await waitForSystemEvent();
       expect(events.some((event) => event.includes("cron route check"))).toBe(true);
 
@@ -492,7 +508,15 @@ describe("gateway server cron", () => {
       );
       const runRes = await rpcReq(ws, "cron.run", { id: jobId, mode: "force" }, 20_000);
       expect(runRes.ok).toBe(true);
-      expect(runRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(runRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       const finishedPayload = await finishedRun;
       expect(finishedPayload).toMatchObject({
         jobId,
@@ -601,7 +625,15 @@ describe("gateway server cron", () => {
       );
       const runRes = await rpcReq(ws, "cron.run", { id: jobId, mode: "force" }, 1_000);
       expect(runRes.ok).toBe(true);
-      expect(runRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(runRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       await startedRun;
       expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
 
@@ -659,7 +691,15 @@ describe("gateway server cron", () => {
       );
       const firstRunRes = await rpcReq(ws, "cron.run", { id: "busy-job", mode: "force" }, 1_000);
       expect(firstRunRes.ok).toBe(true);
-      expect(firstRunRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(firstRunRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       await startedRun;
       expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
 
@@ -786,7 +826,15 @@ describe("gateway server cron", () => {
         20_000,
       );
       expect(legacyRunRes.ok).toBe(true);
-      expect(legacyRunRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(legacyRunRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       await legacyFinished;
       const legacyCall = getWebhookCall(1);
       expect(legacyCall.url).toBe("https://legacy.example.invalid/cron-finished");
@@ -815,7 +863,15 @@ describe("gateway server cron", () => {
       );
       const silentRunRes = await rpcReq(ws, "cron.run", { id: silentJobId, mode: "force" }, 20_000);
       expect(silentRunRes.ok).toBe(true);
-      expect(silentRunRes.payload).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+      expect(silentRunRes.payload).toEqual(
+        expect.objectContaining({
+          ok: true,
+          enqueued: true,
+          runId: expect.any(String),
+          currentStatus: "running",
+          finalStatusAvailable: false,
+        }),
+      );
       await silentFinished;
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
## Concise Summary

Expose the current running state of cron jobs without redefining `lastRunStatus` or `lastStatus`, and return a clearer in-progress acknowledgment from `cron.run`.

## Problem

Manual `cron.run` calls only returned a generic enqueue acknowledgment, and `cron.list` exposed a running attempt alongside the previous completed status. Consumers could misreport a new in-progress run as a stale error.

## Fix

- Preserve `lastRunStatus` and `lastStatus` as the last completed run result.
- Add read-model fields when a job is running:
  - `currentStatus`
  - `lastCompletedRunStatus`
  - `lastCompletedStatus`
- Return explicit in-progress metadata from `cron.run` so clients can say the triggered run is still running.
- Update gateway/protocol typing and regression coverage accordingly.

## Tests

- `corepack pnpm exec vitest run src/cron/service.read-ops-nonblocking.test.ts src/cron/service.issue-regressions.test.ts src/gateway/server.cron.test.ts`
- Result:
  - `Test Files 3 passed (3)`
  - `Tests 49 passed (49)`

## Risks / Limitations

- Patch 3 should land after this one because the UI follow-up consumes `currentStatus`.
