### PR TITLE
fix(ui): add missing CSS for code-block copy button states

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1341,6 +1341,12 @@
   display: inline;
 }
 
+.code-block-header + pre {
+  margin-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 :root[data-theme-mode="light"] .code-block,
 :root[data-theme-mode="light"] .list-item,
 :root[data-theme-mode="light"] .table-row,

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1295,6 +1295,52 @@
   max-width: 100%;
 }
 
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.code-block-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.code-block-copy:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+/* Hide "Copied!" by default, show "Copy" */
+.code-block-copy__done {
+  display: none;
+}
+
+/* When copied class is active: hide "Copy", show "Copied!" */
+.code-block-copy.copied .code-block-copy__idle {
+  display: none;
+}
+
+.code-block-copy.copied .code-block-copy__done {
+  display: inline;
+}
+
 :root[data-theme-mode="light"] .code-block,
 :root[data-theme-mode="light"] .list-item,
 :root[data-theme-mode="light"] .table-row,


### PR DESCRIPTION
## Summary

Fixes #48302.

The copy button on code blocks showed both 'Copy' and 'Copied!' simultaneously because the CSS to control visibility of the `__idle`/`__done` spans was entirely absent.

## Root cause

`markdown.ts` renders the copy button as:
```html
<button class="code-block-copy">
  <span class="code-block-copy__idle">Copy</span>
  <span class="code-block-copy__done">Copied!</span>
</button>
```

And `chat.ts` toggles a `copied` class on click. But `components.css` had no rules for `.code-block-copy`, `.code-block-copy__done`, or `.code-block-copy.copied` — so both spans rendered at the same time, always.

## Fix

Add the missing CSS:
- `.code-block-copy__done { display: none }` — hide 'Copied!' by default
- `.code-block-copy.copied .code-block-copy__idle { display: none }` — hide 'Copy' when copied
- `.code-block-copy.copied .code-block-copy__done { display: inline }` — show 'Copied!' when copied
- Basic styling for `.code-block-header` and the button itself

## Testing

The JS toggle logic already existed and was correct. This fix purely adds the missing CSS rules that the existing JS expected.

## AI disclosure

This PR was generated with Claude (Sonnet) via OpenClaw. The fix was reviewed and understood before submission.