### PR TITLE
feat(ui): add reseller nav section with placeholder view

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -17,6 +17,7 @@ export const en: TranslationMap = {
     chat: "Chat",
     control: "Control",
     agent: "Agent",
+    reseller: "Reseller",
     settings: "Settings",
     expand: "Expand sidebar",
     collapse: "Collapse sidebar",
@@ -35,6 +36,7 @@ export const en: TranslationMap = {
     config: "Config",
     debug: "Debug",
     logs: "Logs",
+    reseller: "Reseller",
   },
   subtitles: {
     agents: "Manage agent workspaces, tools, and identities.",
@@ -50,6 +52,7 @@ export const en: TranslationMap = {
     config: "Edit ~/.openclaw/openclaw.json safely.",
     debug: "Gateway snapshots, events, and manual RPC calls.",
     logs: "Live tail of the gateway file logs.",
+    reseller: "Reseller portal and partner management.",
   },
   overview: {
     access: {
@@ -106,6 +109,9 @@ export const en: TranslationMap = {
     thinkingToggle: "Toggle assistant thinking/working output",
     focusToggle: "Toggle focus mode (hide sidebar + page header)",
     onboardingDisabled: "Disabled during onboarding",
+  },
+  reseller: {
+    placeholder: "Reseller portal coming soon.",
   },
   languages: {
     en: "English",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -17,6 +17,7 @@ export const pt_BR: TranslationMap = {
     chat: "Chat",
     control: "Controle",
     agent: "Agente",
+    reseller: "Revendedor",
     settings: "Configurações",
     expand: "Expandir barra lateral",
     collapse: "Recolher barra lateral",
@@ -35,6 +36,7 @@ export const pt_BR: TranslationMap = {
     config: "Config",
     debug: "Debug",
     logs: "Logs",
+    reseller: "Revendedor",
   },
   subtitles: {
     agents: "Gerenciar espaços de trabalho, ferramentas e identidades de agentes.",
@@ -50,6 +52,7 @@ export const pt_BR: TranslationMap = {
     config: "Editar ~/.openclaw/openclaw.json com segurança.",
     debug: "Snapshots do gateway, eventos e chamadas RPC manuais.",
     logs: "Acompanhamento ao vivo dos logs de arquivo do gateway.",
+    reseller: "Portal de revendedor e gerenciamento de parceiros.",
   },
   overview: {
     access: {
@@ -108,6 +111,9 @@ export const pt_BR: TranslationMap = {
     thinkingToggle: "Alternar saída de pensamento/trabalho do assistente",
     focusToggle: "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",
     onboardingDisabled: "Desativado durante a integração",
+  },
+  reseller: {
+    placeholder: "Portal de revendedor em breve.",
   },
   languages: {
     en: "English",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -17,6 +17,7 @@ export const zh_CN: TranslationMap = {
     chat: "聊天",
     control: "控制",
     agent: "代理",
+    reseller: "代理商",
     settings: "设置",
     expand: "展开侧边栏",
     collapse: "折叠侧边栏",
@@ -35,6 +36,7 @@ export const zh_CN: TranslationMap = {
     config: "配置",
     debug: "调试",
     logs: "日志",
+    reseller: "代理商",
   },
   subtitles: {
     agents: "管理代理工作区、工具和身份。",
@@ -50,6 +52,7 @@ export const zh_CN: TranslationMap = {
     config: "安全地编辑 ~/.openclaw/openclaw.json。",
     debug: "网关快照、事件和手动 RPC 调用。",
     logs: "网关文件日志的实时追踪。",
+    reseller: "代理商门户与合作伙伴管理。",
   },
   overview: {
     access: {
@@ -105,6 +108,9 @@ export const zh_CN: TranslationMap = {
     thinkingToggle: "切换助手思考/工作输出",
     focusToggle: "切换专注模式 (隐藏侧边栏 + 页面页眉)",
     onboardingDisabled: "引导期间禁用",
+  },
+  reseller: {
+    placeholder: "代理商门户即将上线。",
   },
   languages: {
     en: "English",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -17,6 +17,7 @@ export const zh_TW: TranslationMap = {
     chat: "聊天",
     control: "控制",
     agent: "代理",
+    reseller: "代理商",
     settings: "設置",
     expand: "展開側邊欄",
     collapse: "折疊側邊欄",
@@ -35,6 +36,7 @@ export const zh_TW: TranslationMap = {
     config: "配置",
     debug: "調試",
     logs: "日誌",
+    reseller: "代理商",
   },
   subtitles: {
     agents: "管理代理工作區、工具和身份。",
@@ -50,6 +52,7 @@ export const zh_TW: TranslationMap = {
     config: "安全地編輯 ~/.openclaw/openclaw.json。",
     debug: "網關快照、事件和手動 RPC 調用。",
     logs: "網關文件日志的實時追蹤。",
+    reseller: "代理商門戶與合作夥伴管理。",
   },
   overview: {
     access: {
@@ -105,6 +108,9 @@ export const zh_TW: TranslationMap = {
     thinkingToggle: "切換助手思考/工作輸出",
     focusToggle: "切換專注模式 (隱藏側邊欄 + 頁面頁眉)",
     onboardingDisabled: "引導期間禁用",
+  },
+  reseller: {
+    placeholder: "代理商門戶即將上線。",
   },
   languages: {
     en: "English",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,6 +66,7 @@ import { renderInstances } from "./views/instances.ts";
 import { renderLogs } from "./views/logs.ts";
 import { renderNodes } from "./views/nodes.ts";
 import { renderOverview } from "./views/overview.ts";
+import { renderReseller } from "./views/reseller.ts";
 import { renderSessions } from "./views/sessions.ts";
 import { renderSkills } from "./views/skills.ts";
 
@@ -945,6 +946,7 @@ export function renderApp(state: AppViewState) {
               })
             : nothing
         }
+        ${state.tab === "reseller" ? renderReseller() : nothing}
       </main>
       ${renderExecApprovalPrompt(state)}
       ${renderGatewayUrlConfirmation(state)}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -8,6 +8,7 @@ export const TAB_GROUPS = [
     tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
   },
   { label: "agent", tabs: ["agents", "skills", "nodes"] },
+  { label: "reseller", tabs: ["reseller"] },
   { label: "settings", tabs: ["config", "debug", "logs"] },
 ] as const;
 
@@ -24,7 +25,8 @@ export type Tab =
   | "chat"
   | "config"
   | "debug"
-  | "logs";
+  | "logs"
+  | "reseller";
 
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
@@ -40,6 +42,7 @@ const TAB_PATHS: Record<Tab, string> = {
   config: "/config",
   debug: "/debug",
   logs: "/logs",
+  reseller: "/reseller",
 };
 
 const PATH_TO_TAB = new Map(Object.entries(TAB_PATHS).map(([tab, path]) => [path, tab as Tab]));
@@ -151,6 +154,8 @@ export function iconForTab(tab: Tab): IconName {
       return "bug";
     case "logs":
       return "scrollText";
+    case "reseller":
+      return "globe";
     default:
       return "folder";
   }

--- a/ui/src/ui/views/reseller.ts
+++ b/ui/src/ui/views/reseller.ts
@@ -1,0 +1,12 @@
+import { html } from "lit";
+import { t } from "../../i18n/index.ts";
+
+export function renderReseller() {
+  return html`
+    <div class="reseller-view">
+      <div class="reseller-placeholder">
+        <p class="reseller-placeholder__text">${t("reseller.placeholder")}</p>
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
## 变更内容

新增代理商（Reseller）导航区域，为后续代理商门户功能打下基础。

### 改动

- `navigation.ts` — 新增 `reseller` tab 类型、分组（位于 agent 与 settings 之间）、`/reseller` 路径、`globe` 图标
- `views/reseller.ts` — 新建占位视图
- `app-render.ts` — 接入 `renderReseller()`
- 4 个 i18n locale 文件（en / zh-CN / zh-TW / pt-BR）— 补充 nav/tabs/subtitles/reseller keys

### 验证

- `vite build` ✓
- 已有失败测试（`navigation.test.ts` 大小写不匹配）为上游既有 bug，与本 PR 无关