### PR TITLE
fix: wire message_sending plugin hook into all channel reply dispatchers

### DIFF
--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -5,6 +5,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import { loadConfig } from "../../config/config.js";
 import type { MarkdownTableMode, ReplyToMode } from "../../config/types.base.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
+import { runOutboundMessageHook } from "../../plugins/outbound-hook.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
@@ -162,6 +163,17 @@ export async function deliverDiscordReply(params: {
   });
   const persona = resolveBindingPersona(binding);
   for (const payload of params.replies) {
+    // Apply outbound message hook before chunking/formatting.
+    const _discordHook = await runOutboundMessageHook({
+      to: params.target,
+      content: payload.text ?? "",
+      channel: "discord",
+      accountId: params.accountId,
+    });
+    if (_discordHook === null) {
+      continue;
+    }
+    payload.text = _discordHook.content;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const rawText = payload.text ?? "";
     const tableMode = params.tableMode ?? "code";

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -3,6 +3,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
+import { runOutboundMessageHook } from "../../plugins/outbound-hook.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
@@ -32,6 +33,17 @@ export async function deliverReplies(params: {
   });
   const chunkMode = resolveChunkMode(cfg, "imessage", accountId);
   for (const payload of replies) {
+    // Apply outbound message hook before chunking/formatting.
+    const _imsgHook = await runOutboundMessageHook({
+      to: target,
+      content: payload.text ?? "",
+      channel: "imessage",
+      accountId,
+    });
+    if (_imsgHook === null) {
+      continue;
+    }
+    payload.text = _imsgHook.content;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const rawText = payload.text ?? "";
     const text = convertMarkdownTables(rawText, tableMode);

--- a/src/line/auto-reply-delivery.ts
+++ b/src/line/auto-reply-delivery.ts
@@ -1,5 +1,6 @@
 import type { messagingApi } from "@line/bot-sdk";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { runOutboundMessageHook } from "../plugins/outbound-hook.js";
 import type { FlexContainer } from "./flex-templates.js";
 import type { ProcessedLineMessage } from "./markdown-to-line.js";
 import type { SendLineReplyChunksParams } from "./reply-chunks.js";
@@ -50,6 +51,18 @@ export async function deliverLineAutoReply(params: {
 }): Promise<{ replyTokenUsed: boolean }> {
   const { payload, lineData, replyToken, accountId, to, textLimit, deps } = params;
   let replyTokenUsed = params.replyTokenUsed;
+
+  // Apply outbound message hook before chunking/formatting.
+  const _lineHook = await runOutboundMessageHook({
+    to,
+    content: payload.text ?? "",
+    channel: "line",
+    accountId,
+  });
+  if (_lineHook === null) {
+    return { replyTokenUsed };
+  }
+  payload.text = _lineHook.content;
 
   const pushLineMessages = async (messages: messagingApi.Message[]): Promise<void> => {
     if (messages.length === 0) {

--- a/src/plugins/outbound-hook.ts
+++ b/src/plugins/outbound-hook.ts
@@ -1,0 +1,25 @@
+import { getGlobalHookRunner } from "./hook-runner-global.js";
+
+export async function runOutboundMessageHook(params: {
+  to: string;
+  content: string;
+  channel: string;
+  accountId?: string;
+}): Promise<{ content: string } | null> {
+  const runner = getGlobalHookRunner();
+  if (!runner || !runner.hasHooks("message_sending")) {
+    return { content: params.content };
+  }
+  try {
+    const result = await runner.runMessageSending(
+      { to: params.to, content: params.content },
+      { channelId: params.channel, accountId: params.accountId },
+    );
+    if (result?.cancel) {
+      return null;
+    }
+    return { content: result?.content ?? params.content };
+  } catch {
+    return { content: params.content };
+  }
+}

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -12,6 +12,7 @@ import type { SignalReactionNotificationMode } from "../config/types.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
+import { runOutboundMessageHook } from "../plugins/outbound-hook.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { normalizeE164 } from "../utils.js";
@@ -292,6 +293,17 @@ async function deliverReplies(params: {
   const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
     params;
   for (const payload of replies) {
+    // Apply outbound message hook before chunking/formatting.
+    const _signalHook = await runOutboundMessageHook({
+      to: target,
+      content: payload.text ?? "",
+      channel: "signal",
+      accountId,
+    });
+    if (_signalHook === null) {
+      continue;
+    }
+    payload.text = _signalHook.content;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
     if (!text && mediaList.length === 0) {

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -4,6 +4,7 @@ import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-refere
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import { runOutboundMessageHook } from "../../plugins/outbound-hook.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack } from "../send.js";
@@ -19,6 +20,17 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all";
 }) {
   for (const payload of params.replies) {
+    // Apply outbound message hook before chunking/formatting.
+    const _slackHook = await runOutboundMessageHook({
+      to: params.target,
+      content: payload.text ?? "",
+      channel: "slack",
+      accountId: params.accountId,
+    });
+    if (_slackHook === null) {
+      continue;
+    }
+    payload.text = _slackHook.content;
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
     // must not force threading.
     const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -10,6 +10,7 @@ import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import { runOutboundMessageHook } from "../../plugins/outbound-hook.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { loadWebMedia } from "../../web/media.js";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
@@ -100,6 +101,16 @@ export async function deliverReplies(params: {
     return chunks;
   };
   for (const reply of replies) {
+    // Apply outbound message hook before chunking/formatting.
+    const _tgHook = await runOutboundMessageHook({
+      to: chatId,
+      content: reply.text ?? "",
+      channel: "telegram",
+    });
+    if (_tgHook === null) {
+      continue;
+    }
+    reply.text = _tgHook.content;
     const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
     if (!reply?.text && !hasMedia) {
       if (reply?.audioAsVoice) {

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -4,6 +4,7 @@ import type { MarkdownTableMode } from "../../config/types.base.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import { markdownToWhatsApp } from "../../markdown/whatsapp.js";
+import { runOutboundMessageHook } from "../../plugins/outbound-hook.js";
 import { sleep } from "../../utils.js";
 import { loadWebMedia } from "../media.js";
 import { newConnectionId } from "../reconnect.js";
@@ -31,6 +32,16 @@ export async function deliverWebReply(params: {
   const replyStarted = Date.now();
   const tableMode = params.tableMode ?? "code";
   const chunkMode = params.chunkMode ?? "length";
+  // Apply outbound message hook before chunking/formatting.
+  const _webHook = await runOutboundMessageHook({
+    to: msg.from,
+    content: replyResult.text ?? "",
+    channel: "webchat",
+  });
+  if (_webHook === null) {
+    return;
+  }
+  replyResult.text = _webHook.content;
   const convertedText = markdownToWhatsApp(
     convertMarkdownTables(replyResult.text || "", tableMode),
   );


### PR DESCRIPTION
## Summary

The `message_sending` plugin hook is implemented in `deliverOutboundPayloads` but **never fires** because every channel has its own reply dispatcher that sends messages directly, bypassing the outbound hook pipeline.

Verified by instrumenting `deliverOutboundPayloadsCore` with `console.warn` — zero hook invocations across Telegram agent replies, webchat agent replies, and message tool sends.

## Changes

### New: `src/plugins/outbound-hook.ts`
Shared `runOutboundMessageHook()` utility wrapping `getGlobalHookRunner().runMessageSending()` with:
- Early exit when no hooks are registered (`hasHooks` check)
- Error swallowing so plugin bugs never break message delivery
- Consistent interface for all channel dispatchers

### Wired into all 7 channel reply dispatchers:
| Channel | File |
|---------|------|
| Telegram | `src/telegram/bot/delivery.ts` |
| WhatsApp | `src/web/auto-reply/deliver-reply.ts` |
| Discord | `src/discord/monitor/reply-delivery.ts` |
| Slack | `src/slack/monitor/replies.ts` |
| Signal | `src/signal/monitor.ts` |
| iMessage | `src/imessage/monitor/deliver.ts` |
| Line | `src/line/auto-reply-delivery.ts` |

Hook runs per-reply before chunking/formatting — plugins receive raw text and can modify content or cancel sends.

## Not covered
Webchat WebSocket streaming — requires buffering architectural changes, follow-up candidate.

## AI-Assisted PR 🤖
Written by Cass (AI agent on OpenClaw). Replaces #26921 which had irrecoverable rebase conflicts.

Fixes #26422
Refs #25715