### PR TITLE
fix(install): retry npm install with --strict-ssl=false on TLS verification failure (Windows) (#48117)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -207,8 +207,15 @@ function Install-OpenClawNpm {
     Write-Host "Installing OpenClaw ($installSpec)..." -Level info
     
     # First attempt: standard install with SSL verification enabled (default/safe)
-    $output = npm install -g $installSpec --no-fund --no-audit 2>&1
-    $exitCode = $LASTEXITCODE
+    # Wrapped in try/catch so CommandNotFoundException (npm not on PATH) returns
+    # false cleanly instead of aborting the script with a terminating error.
+    try {
+        $output = npm install -g $installSpec --no-fund --no-audit 2>&1
+        $exitCode = $LASTEXITCODE
+    } catch {
+        Write-Host "npm not found or failed to launch: $_" -Level error
+        return $false
+    }
 
     if ($exitCode -eq 0) {
         Write-Host "OpenClaw installed" -Level success
@@ -231,14 +238,31 @@ function Install-OpenClawNpm {
         Write-Host "install only. Ensure you trust your network before proceeding." -Level warn
         Write-Host "" -Level info
 
+        # Detect non-interactive environments (CI, automation, -NonInteractive flag).
+        # In those contexts Read-Host raises a terminating error, so we skip the
+        # prompt and abort with guidance instead of hanging or crashing.
+        $isInteractive = [Environment]::UserInteractive -and
+                         -not ([Console]::IsInputRedirected) -and
+                         ($Host.UI.RawUI -ne $null)
+        if (-not $isInteractive) {
+            Write-Host "Non-interactive environment detected. Aborting TLS fallback." -Level error
+            Write-Host "To install in CI with a corporate proxy, set npm cafile or pass --strict-ssl=false explicitly." -Level info
+            return $false
+        }
+
         $response = Read-Host "Retry installation with --strict-ssl=false? [y/N]"
         if ($response -notmatch '^[Yy]$') {
             Write-Host "Aborted. To fix permanently, update your root CA certificates or run: npm config set cafile <path-to-ca-bundle.pem>" -Level info
             return $false
         }
 
-        $retryOutput = npm install -g $installSpec --no-fund --no-audit --strict-ssl=false 2>&1
-        $retryExitCode = $LASTEXITCODE
+        try {
+            $retryOutput = npm install -g $installSpec --no-fund --no-audit --strict-ssl=false 2>&1
+            $retryExitCode = $LASTEXITCODE
+        } catch {
+            Write-Host "npm not found or failed to launch during retry: $_" -Level error
+            return $false
+        }
 
         if ($retryExitCode -eq 0) {
             Write-Host "OpenClaw installed (TLS fallback used)" -Level success
@@ -249,11 +273,11 @@ function Install-OpenClawNpm {
             return $true
         }
 
-        Write-Host "npm install failed even with --strict-ssl=false: $($retryOutput -join `"`n`")" -Level error
+        Write-Host "npm install failed even with --strict-ssl=false:`n$($retryOutput -join `"`n`")" -Level error
         return $false
     }
 
-    Write-Host "npm install failed: $($output -join `"`n`")" -Level error
+    Write-Host "npm install failed:`n$($output -join `"`n`")" -Level error
     return $false
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -225,11 +225,17 @@ function Install-OpenClawNpm {
         Write-Host "" -Level info
         Write-Host "TLS certificate verification failed during npm install." -Level warn
         Write-Host "This is common on Windows when a corporate proxy or outdated root CA" -Level warn
-        Write-Host "intercepts HTTPS traffic. Retrying with --strict-ssl=false..." -Level warn
+        Write-Host "intercepts HTTPS traffic." -Level warn
         Write-Host "" -Level info
         Write-Host "NOTE: --strict-ssl=false disables SSL certificate verification for this" -Level warn
         Write-Host "install only. Ensure you trust your network before proceeding." -Level warn
         Write-Host "" -Level info
+
+        $response = Read-Host "Retry installation with --strict-ssl=false? [y/N]"
+        if ($response -notmatch '^[Yy]$') {
+            Write-Host "Aborted. To fix permanently, update your root CA certificates or run: npm config set cafile <path-to-ca-bundle.pem>" -Level info
+            return $false
+        }
 
         $retryOutput = npm install -g $installSpec --no-fund --no-audit --strict-ssl=false 2>&1
         $retryExitCode = $LASTEXITCODE
@@ -243,11 +249,11 @@ function Install-OpenClawNpm {
             return $true
         }
 
-        Write-Host "npm install failed even with --strict-ssl=false: $($retryOutput -join ' ')" -Level error
+        Write-Host "npm install failed even with --strict-ssl=false: $($retryOutput -join `"`n`")" -Level error
         return $false
     }
 
-    Write-Host "npm install failed: $($output -join ' ')" -Level error
+    Write-Host "npm install failed: $($output -join `"`n`")" -Level error
     return $false
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -206,15 +206,49 @@ function Install-OpenClawNpm {
     
     Write-Host "Installing OpenClaw ($installSpec)..." -Level info
     
-    try {
-        # Use -ExecutionPolicy Bypass to handle restricted execution policy
-        npm install -g $installSpec --no-fund --no-audit 2>&1
+    # First attempt: standard install with SSL verification enabled (default/safe)
+    $output = npm install -g $installSpec --no-fund --no-audit 2>&1
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
         Write-Host "OpenClaw installed" -Level success
         return $true
-    } catch {
-        Write-Host "npm install failed: $_" -Level error
+    }
+
+    # Check if failure is caused by a TLS certificate verification error
+    # This can happen on Windows when corporate proxies or outdated root CAs
+    # cause UNABLE_TO_VERIFY_LEAF_SIGNATURE or CERT_UNTRUSTED errors.
+    $outputStr = $output -join "`n"
+    $tlsError = $outputStr -match "UNABLE_TO_VERIFY_LEAF_SIGNATURE|CERT_UNTRUSTED|SELF_SIGNED_CERT|unable to verify the first certificate"
+
+    if ($tlsError) {
+        Write-Host "" -Level info
+        Write-Host "TLS certificate verification failed during npm install." -Level warn
+        Write-Host "This is common on Windows when a corporate proxy or outdated root CA" -Level warn
+        Write-Host "intercepts HTTPS traffic. Retrying with --strict-ssl=false..." -Level warn
+        Write-Host "" -Level info
+        Write-Host "NOTE: --strict-ssl=false disables SSL certificate verification for this" -Level warn
+        Write-Host "install only. Ensure you trust your network before proceeding." -Level warn
+        Write-Host "" -Level info
+
+        $retryOutput = npm install -g $installSpec --no-fund --no-audit --strict-ssl=false 2>&1
+        $retryExitCode = $LASTEXITCODE
+
+        if ($retryExitCode -eq 0) {
+            Write-Host "OpenClaw installed (TLS fallback used)" -Level success
+            Write-Host "" -Level info
+            Write-Host "To avoid this warning in future, update your system's root CA certificates" -Level info
+            Write-Host "or configure npm to use your corporate CA:" -Level info
+            Write-Host "  npm config set cafile <path-to-your-ca-bundle.pem>" -Level info
+            return $true
+        }
+
+        Write-Host "npm install failed even with --strict-ssl=false: $($retryOutput -join ' ')" -Level error
         return $false
     }
+
+    Write-Host "npm install failed: $($output -join ' ')" -Level error
+    return $false
 }
 
 function Install-OpenClawGit {


### PR DESCRIPTION
## Summary

Fixes #48117 — Windows install script fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` when running `iwr -useb https://openclaw.ai/install.ps1 | iex`.

## Root Cause

On Windows, npm's default strict SSL verification rejects certificates from intercepting corporate proxies or systems with incomplete/outdated root CA bundles. This throws errors like:
- `UNABLE_TO_VERIFY_LEAF_SIGNATURE`
- `CERT_UNTRUSTED`
- `SELF_SIGNED_CERT`
- `unable to verify the first certificate`

This is especially common in enterprise Windows environments.

## What the Fix Does

- **Default behavior unchanged** — SSL verification remains strict on first attempt
- If the first `npm install` fails with a TLS-related error, the script **detects the specific error pattern** and retries automatically with `--strict-ssl=false`
- Displays a clear warning to the user explaining:
  - What went wrong (TLS cert issue)
  - That `--strict-ssl=false` is being used for **this install only**
  - How to permanently fix the underlying CA issue (`npm config set cafile`)
- If the retry also fails, reports the error and exits

This approach avoids silently disabling SSL globally while still allowing installation on affected Windows machines, with full transparency.

## Changes

- `scripts/install.ps1`: Modified `Install-OpenClawNpm` to capture exit code and output from the first npm install attempt, detect TLS error patterns, and retry with `--strict-ssl=false` if detected.

## Testing

Logic verified by code inspection. This is a Windows-only PowerShell path; no automated tests exist for the installer. The TLS detection regex covers the known error strings reported in #48117 and related issues.

## AI Disclosure

Fix implemented with Claude claude-sonnet-4-6. Approach reviewed and understood; matches the pattern requested in issue #48117.