### PR TITLE
fix(cli): patch qrcode-terminal octal escapes for Node 25 compatibility (#48035)

### DIFF
--- a/package.json
+++ b/package.json
@@ -501,6 +501,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "qrcode-terminal@0.12.0": "patches/qrcode-terminal@0.12.0.patch"
     }
   }
 }

--- a/patches/qrcode-terminal@0.12.0.patch
+++ b/patches/qrcode-terminal@0.12.0.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/main.js b/lib/main.js
+index 488cc1aea9802b3d6ae13aee27556403bec55d1c..263d68a1520dd9402ef4231d30bc74c3aba5c821 100644
+--- a/lib/main.js
++++ b/lib/main.js
+@@ -1,7 +1,7 @@
+ var QRCode = require('./../vendor/QRCode'),
+     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
+-    black = "\033[40m  \033[0m",
+-    white = "\033[47m  \033[0m",
++    black = "\x1b[40m  \x1b[0m",
++    white = "\x1b[47m  \x1b[0m",
+     toCell = function (isBlack) {
+         return isBlack ? black : white;
+     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  qrcode-terminal@0.12.0:
+    hash: 68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e
+    path: patches/qrcode-terminal@0.12.0.patch
+
 importers:
 
   .:
@@ -178,7 +183,7 @@ importers:
         version: 1.58.2
       qrcode-terminal:
         specifier: ^0.12.0
-        version: 0.12.0
+        version: 0.12.0(patch_hash=68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -12925,7 +12930,7 @@ snapshots:
       osc-progress: 0.3.0
       pdfjs-dist: 5.5.207
       playwright-core: 1.58.2
-      qrcode-terminal: 0.12.0
+      qrcode-terminal: 0.12.0(patch_hash=68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e)
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       tar: 7.5.11
@@ -13362,7 +13367,7 @@ snapshots:
       '@thi.ng/bitstream': 2.4.43
     optional: true
 
-  qrcode-terminal@0.12.0: {}
+  qrcode-terminal@0.12.0(patch_hash=68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e): {}
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #48035.

`qrcode-terminal@0.12.0` uses legacy octal escape sequences (`\033`) in its ANSI colour constants, which Node 25+ rejects as a parse error.

## Root cause

`qrcode-terminal/lib/main.js` lines 3–4:
```js
black = "\033[40m  \033[0m",
white = "\033[47m  \033[0m",
```
These octal literals are deprecated and rejected by Node 25's stricter parser.

## Fix

pnpm patch replacing `\033` with `\x1b` (equivalent hex escape, universally supported). Patch committed to `patches/qrcode-terminal@0.12.0.patch` and registered in `package.json` under `pnpm.patchedDependencies`.

## Testing

Patch verified correct — two characters changed, nothing else. No functional change.

## AI disclosure

Generated with Claude (Sonnet) via OpenClaw. Fix reviewed and understood before submission.