### PR TITLE
fix: exclude transient fields from sessions.json serialization

### DIFF
--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isPrimarySessionTranscriptFileName, isSessionArchiveArtifactName } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
+import { SESSION_STORE_SERIALIZATION_REPLACER } from "./store-serialization.js";
 import type { SessionEntry } from "./types.js";
 
 export type SessionDiskBudgetConfig = {
@@ -48,11 +49,15 @@ function canonicalizePathForComparison(filePath: string): string {
 }
 
 function measureStoreBytes(store: Record<string, SessionEntry>): number {
-  return Buffer.byteLength(JSON.stringify(store, null, 2), "utf-8");
+  return Buffer.byteLength(JSON.stringify(store, SESSION_STORE_SERIALIZATION_REPLACER, 2), "utf-8");
 }
 
 function measureStoreEntryChunkBytes(key: string, entry: SessionEntry): number {
-  const singleEntryStore = JSON.stringify({ [key]: entry }, null, 2);
+  const singleEntryStore = JSON.stringify(
+    { [key]: entry },
+    SESSION_STORE_SERIALIZATION_REPLACER,
+    2,
+  );
   if (!singleEntryStore.startsWith("{\n") || !singleEntryStore.endsWith("\n}")) {
     return measureStoreBytes({ [key]: entry }) - 4;
   }

--- a/src/config/sessions/store-serialization.ts
+++ b/src/config/sessions/store-serialization.ts
@@ -2,6 +2,9 @@
  * JSON.stringify replacer that excludes transient per-session fields which are
  * rebuilt from scratch on every gateway start.  Keeping them out of the on-disk
  * store prevents sessions.json from ballooning to tens of megabytes.
+ *
+ * NOTE: `systemPromptReport` is intentionally preserved because it carries
+ * `bootstrapTruncation.warningSignaturesSeen` used for dedupe across restarts.
  */
 export const SESSION_STORE_SERIALIZATION_REPLACER = (key: string, value: unknown): unknown =>
-  key === "skillsSnapshot" || key === "systemPromptReport" ? undefined : value;
+  key === "skillsSnapshot" ? undefined : value;

--- a/src/config/sessions/store-serialization.ts
+++ b/src/config/sessions/store-serialization.ts
@@ -1,0 +1,7 @@
+/**
+ * JSON.stringify replacer that excludes transient per-session fields which are
+ * rebuilt from scratch on every gateway start.  Keeping them out of the on-disk
+ * store prevents sessions.json from ballooning to tens of megabytes.
+ */
+export const SESSION_STORE_SERIALIZATION_REPLACER = (key: string, value: unknown): unknown =>
+  key === "skillsSnapshot" || key === "systemPromptReport" ? undefined : value;

--- a/src/config/sessions/store.serialization.test.ts
+++ b/src/config/sessions/store.serialization.test.ts
@@ -1,0 +1,153 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { SESSION_STORE_SERIALIZATION_REPLACER } from "./store-serialization.js";
+import { clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
+
+// Keep tests deterministic: never read a real openclaw.json.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+let fixtureRoot = "";
+let fixtureCount = 0;
+
+beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-serialization-test-"));
+});
+
+afterAll(async () => {
+  await fs.rm(fixtureRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  clearSessionStoreCacheForTest();
+});
+
+afterEach(() => {
+  clearSessionStoreCacheForTest();
+});
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: crypto.randomUUID(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+async function createCaseDir(prefix: string): Promise<string> {
+  const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+describe("SESSION_STORE_SERIALIZATION_REPLACER", () => {
+  it("strips skillsSnapshot from serialized output", () => {
+    const obj = { foo: "bar", skillsSnapshot: { skills: ["a", "b"] } };
+    const json = JSON.stringify(obj, SESSION_STORE_SERIALIZATION_REPLACER, 2);
+    const parsed = JSON.parse(json);
+    expect(parsed.foo).toBe("bar");
+    expect(parsed.skillsSnapshot).toBeUndefined();
+  });
+
+  it("strips systemPromptReport from serialized output", () => {
+    const obj = { foo: "bar", systemPromptReport: { tokens: 5000, sections: [] } };
+    const json = JSON.stringify(obj, SESSION_STORE_SERIALIZATION_REPLACER, 2);
+    const parsed = JSON.parse(json);
+    expect(parsed.foo).toBe("bar");
+    expect(parsed.systemPromptReport).toBeUndefined();
+  });
+
+  it("strips nested occurrences inside session entries", () => {
+    const store = {
+      "session-1": {
+        sessionId: "abc",
+        updatedAt: 1000,
+        skillsSnapshot: { skills: [{ name: "test", definition: "x".repeat(500) }] },
+        systemPromptReport: { tokens: 9999, text: "y".repeat(500) },
+      },
+    };
+    const json = JSON.stringify(store, SESSION_STORE_SERIALIZATION_REPLACER, 2);
+    const parsed = JSON.parse(json);
+    expect(parsed["session-1"].sessionId).toBe("abc");
+    expect(parsed["session-1"].updatedAt).toBe(1000);
+    expect(parsed["session-1"].skillsSnapshot).toBeUndefined();
+    expect(parsed["session-1"].systemPromptReport).toBeUndefined();
+  });
+
+  it("preserves all other fields unchanged", () => {
+    const entry = {
+      sessionId: "test-id",
+      updatedAt: 12345,
+      channel: "discord",
+      lastTo: "user@example.com",
+    };
+    const json = JSON.stringify(entry, SESSION_STORE_SERIALIZATION_REPLACER, 2);
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual(entry);
+  });
+});
+
+describe("saveSessionStore excludes transient fields from disk", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("serialization");
+    storePath = path.join(testDir, "sessions.json");
+  });
+
+  it("does not write skillsSnapshot or systemPromptReport to disk", async () => {
+    const store: Record<string, SessionEntry> = {
+      "test-session": makeEntry({
+        skillsSnapshot: {
+          skills: [{ name: "big-skill", definition: "x".repeat(1000) }],
+        } as unknown as SessionEntry["skillsSnapshot"],
+        systemPromptReport: {
+          tokens: 5000,
+          sections: [],
+        } as unknown as SessionEntry["systemPromptReport"],
+      }),
+    };
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+    const raw = await fs.readFile(storePath, "utf-8");
+    const written = JSON.parse(raw);
+    expect(written["test-session"].sessionId).toBeDefined();
+    expect(written["test-session"].updatedAt).toBeDefined();
+    expect(written["test-session"].skillsSnapshot).toBeUndefined();
+    expect(written["test-session"].systemPromptReport).toBeUndefined();
+    // Verify the raw JSON string doesn't contain the field names at all
+    expect(raw).not.toContain("skillsSnapshot");
+    expect(raw).not.toContain("systemPromptReport");
+  });
+
+  it("round-trips all non-transient fields correctly", async () => {
+    const store: Record<string, SessionEntry> = {
+      "session-a": makeEntry({
+        channel: "discord",
+        lastTo: "user1",
+        skillsSnapshot: { huge: "data" } as unknown as SessionEntry["skillsSnapshot"],
+      }),
+      "session-b": makeEntry({
+        channel: "telegram",
+        lastTo: "user2",
+      }),
+    };
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+    clearSessionStoreCacheForTest();
+    const loaded = loadSessionStore(storePath);
+
+    expect(loaded["session-a"].channel).toBe("discord");
+    expect(loaded["session-a"].lastTo).toBe("user1");
+    expect(loaded["session-a"].skillsSnapshot).toBeUndefined();
+    expect(loaded["session-b"].channel).toBe("telegram");
+    expect(loaded["session-b"].lastTo).toBe("user2");
+  });
+});

--- a/src/config/sessions/store.serialization.test.ts
+++ b/src/config/sessions/store.serialization.test.ts
@@ -54,15 +54,16 @@ describe("SESSION_STORE_SERIALIZATION_REPLACER", () => {
     expect(parsed.skillsSnapshot).toBeUndefined();
   });
 
-  it("strips systemPromptReport from serialized output", () => {
-    const obj = { foo: "bar", systemPromptReport: { tokens: 5000, sections: [] } };
+  it("preserves systemPromptReport (carries warning dedupe state)", () => {
+    const report = { tokens: 5000, bootstrapTruncation: { warningSignaturesSeen: ["sig1"] } };
+    const obj = { foo: "bar", systemPromptReport: report };
     const json = JSON.stringify(obj, SESSION_STORE_SERIALIZATION_REPLACER, 2);
     const parsed = JSON.parse(json);
     expect(parsed.foo).toBe("bar");
-    expect(parsed.systemPromptReport).toBeUndefined();
+    expect(parsed.systemPromptReport).toEqual(report);
   });
 
-  it("strips nested occurrences inside session entries", () => {
+  it("strips skillsSnapshot but keeps systemPromptReport inside session entries", () => {
     const store = {
       "session-1": {
         sessionId: "abc",
@@ -76,7 +77,7 @@ describe("SESSION_STORE_SERIALIZATION_REPLACER", () => {
     expect(parsed["session-1"].sessionId).toBe("abc");
     expect(parsed["session-1"].updatedAt).toBe(1000);
     expect(parsed["session-1"].skillsSnapshot).toBeUndefined();
-    expect(parsed["session-1"].systemPromptReport).toBeUndefined();
+    expect(parsed["session-1"].systemPromptReport).toBeDefined();
   });
 
   it("preserves all other fields unchanged", () => {
@@ -101,15 +102,14 @@ describe("saveSessionStore excludes transient fields from disk", () => {
     storePath = path.join(testDir, "sessions.json");
   });
 
-  it("does not write skillsSnapshot or systemPromptReport to disk", async () => {
+  it("strips skillsSnapshot but preserves systemPromptReport on disk", async () => {
     const store: Record<string, SessionEntry> = {
       "test-session": makeEntry({
         skillsSnapshot: {
           skills: [{ name: "big-skill", definition: "x".repeat(1000) }],
         } as unknown as SessionEntry["skillsSnapshot"],
         systemPromptReport: {
-          tokens: 5000,
-          sections: [],
+          bootstrapTruncation: { warningSignaturesSeen: ["sig-abc"] },
         } as unknown as SessionEntry["systemPromptReport"],
       }),
     };
@@ -121,10 +121,9 @@ describe("saveSessionStore excludes transient fields from disk", () => {
     expect(written["test-session"].sessionId).toBeDefined();
     expect(written["test-session"].updatedAt).toBeDefined();
     expect(written["test-session"].skillsSnapshot).toBeUndefined();
-    expect(written["test-session"].systemPromptReport).toBeUndefined();
-    // Verify the raw JSON string doesn't contain the field names at all
+    expect(written["test-session"].systemPromptReport).toBeDefined();
     expect(raw).not.toContain("skillsSnapshot");
-    expect(raw).not.toContain("systemPromptReport");
+    expect(raw).toContain("systemPromptReport");
   });
 
   it("round-trips all non-transient fields correctly", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -36,12 +36,14 @@ import {
   type SessionMaintenanceWarning,
 } from "./store-maintenance.js";
 import { applySessionStoreMigrations } from "./store-migrations.js";
+import { SESSION_STORE_SERIALIZATION_REPLACER } from "./store-serialization.js";
 import {
   mergeSessionEntry,
   mergeSessionEntryPreserveActivity,
   normalizeSessionRuntimeModelFields,
   type SessionEntry,
 } from "./types.js";
+export { SESSION_STORE_SERIALIZATION_REPLACER } from "./store-serialization.js";
 
 const log = createSubsystemLogger("sessions/store");
 
@@ -455,7 +457,7 @@ async function saveSessionStoreUnlocked(
   }
 
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
-  const json = JSON.stringify(store, null, 2);
+  const json = JSON.stringify(store, SESSION_STORE_SERIALIZATION_REPLACER, 2);
   if (getSerializedSessionStore(storePath) === json) {
     updateSessionStoreWriteCaches({ storePath, store, serialized: json });
     return;


### PR DESCRIPTION
## Problem

`skillsSnapshot` is stored per-session on every write to `sessions.json`, bloating it from KBs to tens of MBs. This field is **transient** — rebuilt from scratch on every gateway start — yet it gets serialized to disk unconditionally.

With 200+ sessions and skills enabled, the file grows to 13-38MB, causing:
- Dashboard freezes (browser parses the entire file synchronously)
- Event loop blocks (one user reported **543 seconds**)
- Lock contention and gateway slowdowns

## Fix

Add a `JSON.stringify` replacer that excludes `skillsSnapshot` during disk serialization. The field remains in memory for runtime operations — only the write path is affected.

`systemPromptReport` is intentionally **preserved** because it carries `bootstrapTruncation.warningSignaturesSeen`, which is used for dedupe of once-mode bootstrap warnings across restarts.

### Changed files

- **`src/config/sessions/store-serialization.ts`** — new shared module exporting the replacer constant (avoids circular dependency between `store.ts` and `disk-budget.ts`)
- **`src/config/sessions/store.ts`** — use replacer in `saveSessionStoreUnlocked()` serialization
- **`src/config/sessions/disk-budget.ts`** — use replacer in `measureStoreBytes()` and `measureStoreEntryChunkBytes()` so size estimates match actual disk size
- **`src/config/sessions/store.serialization.test.ts`** — 6 new tests covering replacer behavior and round-trip persistence

### Why this is safe

- `skillsSnapshot` is already `optional` (`?`) on `SessionEntry`
- It is rebuilt on gateway start from live config — no data loss
- `loadSessionStore` handles its absence (already the case for new/migrated sessions)
- `systemPromptReport` is preserved to maintain warning dedupe state
- Zero architectural changes, no new dependencies

### Real-world data

Our instance went from **13.6MB → 235KB** with this fix applied to the compiled dist. We've been running it in production for weeks with no issues.

## Related issues

Closes #15145
Closes #45718
Closes #23232
Closes #15413

## Test plan

- [x] New test: replacer strips `skillsSnapshot` from serialized output
- [x] New test: replacer preserves `systemPromptReport` (warning dedupe state)
- [x] New test: replacer strips skillsSnapshot but keeps systemPromptReport inside entries
- [x] New test: replacer preserves all other fields unchanged
- [x] New test: `saveSessionStore` strips skillsSnapshot but preserves systemPromptReport on disk
- [x] New test: round-trip load/save preserves all non-transient fields
- [x] Existing `"persists latest systemPromptReport for downstream warning dedupe"` test passes
- [x] Existing pruning and disk-budget tests still pass
- [x] `pnpm build` succeeds
- [x] `pnpm check` passes (lint + format + typecheck)