### PR TITLE
perf(plugins): increase discovery cache TTL to reduce redundant filesystem scans during startup

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -48,7 +48,9 @@ export type PluginDiscoveryResult = {
 const discoveryCache = new Map<string, { expiresAt: number; result: PluginDiscoveryResult }>();
 
 // Keep a short cache window to collapse bursty reloads during startup flows.
-const DEFAULT_DISCOVERY_CACHE_MS = 1000;
+// 5 seconds covers the full gateway startup sequence while remaining short enough
+// to pick up changes during explicit config-reload scenarios.
+const DEFAULT_DISCOVERY_CACHE_MS = 5000;
 
 export function clearPluginDiscoveryCache(): void {
   discoveryCache.clear();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -689,12 +689,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
+      logger.debug?.(`[plugins] registry cache hit (${cached.plugins.length} plugins)`);
       if (shouldActivate) {
         activatePluginRegistry(cached, cacheKey);
       }
       return cached;
     }
   }
+  const loadStartMs = Date.now();
 
   // Clear previously registered plugin commands before reloading.
   // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
@@ -1240,6 +1242,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     env,
   });
 
+  if (logger.debug) {
+    const enabledCount = registry.plugins.filter((p) => p.enabled).length;
+    const cacheLabel = cacheEnabled ? "cache miss" : "cache disabled";
+    logger.debug(
+      `[plugins] loaded ${enabledCount}/${registry.plugins.length} plugins in ${Date.now() - loadStartMs}ms (${cacheLabel})`,
+    );
+  }
   if (cacheEnabled) {
     setCachedPluginRegistry(cacheKey, registry);
   }


### PR DESCRIPTION
## Summary

Partially mitigates #48380 (discovery-layer caching only)

The 1-second plugin discovery cache TTL (`DEFAULT_DISCOVERY_CACHE_MS`) expired mid-startup when the gateway boot sequence took longer than 1 second, causing redundant filesystem scans for 71+ plugin directories during startup.

This PR does **not** address the registry-level cache-key divergence described in #48380 — that requires changes to the startup call sites in `server-plugins.ts`, `runtime-plugins.ts`, and `channel-resolution.ts` to unify cache keys or apply `onlyPluginIds` filtering. That work should be tracked separately.

## Changes

### `src/plugins/discovery.ts`
- Bump `DEFAULT_DISCOVERY_CACHE_MS` from 1000 to 5000
- 5 seconds covers the full gateway startup sequence while remaining short enough to pick up changes during explicit config-reload scenarios
- The existing `OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS` and `OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE` env var overrides continue to work

### `src/plugins/loader.ts`
- Add `debug`-level diagnostic logs for plugin registry cache hits and misses
  - Cache hit: logs plugin count
  - Cache miss: logs enabled/total plugin counts and elapsed load time
- These logs help diagnose startup performance regressions by revealing how many full load cycles actually occur

## Testing

- All existing tests pass (`discovery.test.ts`, `loader.test.ts`, `server-plugins.test.ts`)
- 1 pre-existing test failure on `upstream/main` (`does not prefer setupEntry for configured channel loads without startup opt-in`) is unrelated to this change

## Scope

This is a **partial mitigation** targeting the discovery layer only. The deeper root cause — registry-level cache key divergence caused by different callers passing different `preferSetupRuntimeForChannelPlugins` / `onlyPluginIds` combinations — requires a separate effort to unify the startup call sites.
