### PR TITLE
feat: add systemPrompt.identityLine and disabledSections config

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -679,6 +679,143 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Reactions");
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
+
+  // --- identityLine and disabledSections ---
+
+  it("produces identical output with no identityLine/disabledSections (regression)", () => {
+    const withDefaults = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw" });
+    const withEmptyOverrides = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      identityLine: undefined,
+      disabledSections: undefined,
+    });
+    const withEmptyArray = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      disabledSections: [],
+    });
+
+    expect(withEmptyOverrides).toBe(withDefaults);
+    expect(withEmptyArray).toBe(withDefaults);
+  });
+
+  it("replaces the identity line when identityLine is provided", () => {
+    const customLine = "You are Aria, an AI assistant.";
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      identityLine: customLine,
+    });
+
+    expect(prompt).toContain(customLine);
+    expect(prompt).not.toContain("You are a personal assistant running inside OpenClaw.");
+  });
+
+  it("uses identityLine in promptMode=none (returns just the custom line)", () => {
+    const customLine = "You are Aria, an AI assistant.";
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+      identityLine: customLine,
+    });
+
+    expect(prompt).toBe(customLine);
+  });
+
+  it("disabledSections=['safety'] omits the Safety section", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      disabledSections: ["safety"],
+    });
+
+    expect(prompt).not.toContain("## Safety");
+    expect(prompt).not.toContain("You have no independent goals");
+    // Other sections should still be present
+    expect(prompt).toContain("## OpenClaw CLI Quick Reference");
+  });
+
+  it("disabledSections=['cliReference'] omits the CLI Quick Reference section", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      disabledSections: ["cliReference"],
+    });
+
+    expect(prompt).not.toContain("## OpenClaw CLI Quick Reference");
+    expect(prompt).not.toContain("openclaw gateway restart");
+    // Safety should still be present
+    expect(prompt).toContain("## Safety");
+  });
+
+  it("disabledSections=['safety','cliReference'] omits both sections", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      disabledSections: ["safety", "cliReference"],
+    });
+
+    expect(prompt).not.toContain("## Safety");
+    expect(prompt).not.toContain("## OpenClaw CLI Quick Reference");
+  });
+
+  it("disabledSections=['nonexistent'] produces same output as no disabledSections", () => {
+    const baseline = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw" });
+    const withUnknown = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      disabledSections: ["nonexistent"],
+    });
+
+    expect(withUnknown).toBe(baseline);
+  });
+
+  it("disabledSections=['selfUpdate'] omits the Self-Update section even with gateway tool", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["gateway", "exec"],
+      disabledSections: ["selfUpdate"],
+    });
+
+    expect(prompt).not.toContain("## OpenClaw Self-Update");
+    // Other sections still present
+    expect(prompt).toContain("## Safety");
+  });
+
+  it("disabledSections=['modelAliases'] omits Model Aliases section", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      modelAliasLines: ["- Opus: anthropic/claude-opus-4-5"],
+      disabledSections: ["modelAliases"],
+    });
+
+    expect(prompt).not.toContain("## Model Aliases");
+  });
+
+  it("disabledSections=['documentation'] omits Documentation section even with docsPath", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      docsPath: "/tmp/openclaw/docs",
+      disabledSections: ["documentation"],
+    });
+
+    expect(prompt).not.toContain("## Documentation");
+  });
+
+  it("disabledSections=['skills'] omits Skills section even with skillsPrompt", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+      disabledSections: ["skills"],
+    });
+
+    expect(prompt).not.toContain("## Skills");
+  });
+
+  it("disabledSections=['memoryRecall'] omits Memory Recall section even with memory tools", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["memory_search", "memory_get"],
+      disabledSections: ["memoryRecall"],
+    });
+
+    expect(prompt).not.toContain("## Memory Recall");
+  });
 });
 
 describe("buildSubagentSystemPrompt", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -186,6 +186,17 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
   ];
 }
 
+/**
+ * Returns true when the named section should be included in the system prompt.
+ * A section is disabled if disabledSections is defined and contains the name.
+ */
+function isSectionEnabled(name: string, disabledSections?: string[]): boolean {
+  if (!disabledSections || disabledSections.length === 0) {
+    return true;
+  }
+  return !disabledSections.includes(name);
+}
+
 export function buildAgentSystemPrompt(params: {
   workspaceDir: string;
   defaultThinkLevel?: ThinkLevel;
@@ -210,6 +221,10 @@ export function buildAgentSystemPrompt(params: {
   ttsHint?: string;
   /** Controls which hardcoded sections to include. Defaults to "full". */
   promptMode?: PromptMode;
+  /** Override the default identity line ("You are a personal assistant running inside OpenClaw."). */
+  identityLine?: string;
+  /** Section names to skip from the system prompt (e.g. ["safety", "cliReference"]). Empty = all sections included. */
+  disabledSections?: string[];
   /** Whether ACP-specific routing guidance should be included. Defaults to true. */
   acpEnabled?: boolean;
   runtimeInfo?: {
@@ -416,11 +431,12 @@ export function buildAgentSystemPrompt(params: {
 
   // For "none" mode, return just the basic identity line
   if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
+    return params.identityLine ?? "You are a personal assistant running inside OpenClaw.";
   }
 
+  const disabledSections = params.disabledSections;
   const lines = [
-    "You are a personal assistant running inside OpenClaw.",
+    params.identityLine ?? "You are a personal assistant running inside OpenClaw.",
     "",
     "## Tooling",
     "Tool availability (filtered by policy):",
@@ -468,21 +484,27 @@ export function buildAgentSystemPrompt(params: {
     "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
     "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",
     "",
-    ...safetySection,
-    "## OpenClaw CLI Quick Reference",
-    "OpenClaw is controlled via subcommands. Do not invent commands.",
-    "To manage the Gateway daemon service (start/stop/restart):",
-    "- openclaw gateway status",
-    "- openclaw gateway start",
-    "- openclaw gateway stop",
-    "- openclaw gateway restart",
-    "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
-    "",
-    ...skillsSection,
-    ...memorySection,
-    // Skip self-update for subagent/none modes
-    hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",
-    hasGateway && !isMinimal
+    ...(isSectionEnabled("safety", disabledSections) ? safetySection : []),
+    ...(isSectionEnabled("cliReference", disabledSections)
+      ? [
+          "## OpenClaw CLI Quick Reference",
+          "OpenClaw is controlled via subcommands. Do not invent commands.",
+          "To manage the Gateway daemon service (start/stop/restart):",
+          "- openclaw gateway status",
+          "- openclaw gateway start",
+          "- openclaw gateway stop",
+          "- openclaw gateway restart",
+          "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
+          "",
+        ]
+      : []),
+    ...(isSectionEnabled("skills", disabledSections) ? skillsSection : []),
+    ...(isSectionEnabled("memoryRecall", disabledSections) ? memorySection : []),
+    // Skip self-update for subagent/none modes, and when disabled via disabledSections
+    hasGateway && !isMinimal && isSectionEnabled("selfUpdate", disabledSections)
+      ? "## OpenClaw Self-Update"
+      : "",
+    hasGateway && !isMinimal && isSectionEnabled("selfUpdate", disabledSections)
       ? [
           "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
@@ -491,19 +513,33 @@ export function buildAgentSystemPrompt(params: {
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",
-    hasGateway && !isMinimal ? "" : "",
+    hasGateway && !isMinimal && isSectionEnabled("selfUpdate", disabledSections) ? "" : "",
     "",
-    // Skip model aliases for subagent/none modes
-    params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
+    // Skip model aliases for subagent/none modes, and when disabled via disabledSections
+    params.modelAliasLines &&
+    params.modelAliasLines.length > 0 &&
+    !isMinimal &&
+    isSectionEnabled("modelAliases", disabledSections)
       ? "## Model Aliases"
       : "",
-    params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
+    params.modelAliasLines &&
+    params.modelAliasLines.length > 0 &&
+    !isMinimal &&
+    isSectionEnabled("modelAliases", disabledSections)
       ? "Prefer aliases when specifying model overrides; full provider/model is also accepted."
       : "",
-    params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
+    params.modelAliasLines &&
+    params.modelAliasLines.length > 0 &&
+    !isMinimal &&
+    isSectionEnabled("modelAliases", disabledSections)
       ? params.modelAliasLines.join("\n")
       : "",
-    params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
+    params.modelAliasLines &&
+    params.modelAliasLines.length > 0 &&
+    !isMinimal &&
+    isSectionEnabled("modelAliases", disabledSections)
+      ? ""
+      : "",
     userTimezone
       ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
       : "",
@@ -512,7 +548,7 @@ export function buildAgentSystemPrompt(params: {
     workspaceGuidance,
     ...workspaceNotes,
     "",
-    ...docsSection,
+    ...(isSectionEnabled("documentation", disabledSections) ? docsSection : []),
     params.sandboxInfo?.enabled ? "## Sandbox" : "",
     params.sandboxInfo?.enabled
       ? [

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -183,6 +183,13 @@ export type AgentDefaultsConfig = {
   };
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
+  /** System prompt customization. */
+  systemPrompt?: {
+    /** Override the default identity line ("You are a personal assistant running inside OpenClaw."). */
+    identityLine?: string;
+    /** Section names to skip from the system prompt (e.g. ["safety", "cliReference"]). Empty = all sections included. */
+    disabledSections?: string[];
+  };
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   /** Default verbose level when no /verbose directive is present. */

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,6 +10,11 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   };
 });
 
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
+
 // Ensure Vitest environment is properly set
 process.env.VITEST = "true";
 // Config validation walks plugin manifests; keep an aggressive cache in tests to avoid


### PR DESCRIPTION
Adds two new optional config fields under agents.defaults.systemPrompt:

- **identityLine**: Override the default identity line ('You are a personal assistant running inside OpenClaw.')
- **disabledSections**: Array of section names to skip from the system prompt

## Section Names

safety, cliReference, selfUpdate, documentation, modelAliases, skills, memoryRecall

## Backwards Compatible

Empty/missing values produce identical output to current behavior. All existing tests continue to pass.

## Changes

- `src/config/types.agent-defaults.ts`: Added `systemPrompt` field to `AgentDefaultsConfig`
- `src/agents/system-prompt.ts`: Added `isSectionEnabled()` helper and `identityLine` param threading
- `src/agents/system-prompt.test.ts`: Added tests for both new config options