### PR TITLE
fix(openai-responses): strip prompt_cache_key for non-OpenAI endpoints (#48155)

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -44336,6 +44336,16 @@
       "hasChildren": false
     },
     {
+      "path": "models.providers.*.models.*.compat.supportsPromptCacheKey",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "models.providers.*.models.*.compat.supportsReasoningEffort",
       "kind": "core",
       "type": "boolean",

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5104}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5105}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3931,6 +3931,7 @@
 {"recordType":"path","path":"models.providers.*.models.*.compat.requiresThinkingAsText","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.requiresToolResultName","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.supportsDeveloperRole","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"models.providers.*.models.*.compat.supportsPromptCacheKey","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.supportsReasoningEffort","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.supportsStore","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.supportsStrictMode","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2215,4 +2215,102 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  // prompt_cache_key stripping for non-OpenAI openai-responses endpoints (#48155)
+
+  it("strips prompt_cache_key and prompt_cache_retention for non-OpenAI openai-responses endpoint (Volcano Engine)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "volces",
+      applyModelId: "deepseek-v3-2-251201",
+      model: {
+        api: "openai-responses",
+        provider: "volces",
+        id: "deepseek-v3-2-251201",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-abc",
+        prompt_cache_retention: "24h",
+      },
+    });
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+    expect(payload).not.toHaveProperty("prompt_cache_retention");
+  });
+
+  it("strips prompt_cache_key for arbitrary non-OpenAI openai-responses endpoints", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-proxy",
+      applyModelId: "some-model",
+      model: {
+        api: "openai-responses",
+        provider: "custom-proxy",
+        id: "some-model",
+        baseUrl: "https://my-proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-xyz",
+      },
+    });
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+  });
+
+  it("keeps prompt_cache_key for direct OpenAI openai-responses endpoint", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "https://api.openai.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-123",
+        prompt_cache_retention: "24h",
+      },
+    });
+    expect(payload.prompt_cache_key).toBe("session-123");
+    expect(payload.prompt_cache_retention).toBe("24h");
+  });
+
+  it("respects compat.supportsPromptCacheKey=true opt-in for non-OpenAI endpoints", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-openai-responses",
+      applyModelId: "my-model",
+      model: {
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        id: "my-model",
+        baseUrl: "https://my-proxy.example.com/v1",
+        compat: { supportsPromptCacheKey: true },
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-opt-in",
+      },
+    });
+    expect(payload.prompt_cache_key).toBe("session-opt-in");
+  });
+
+  it("respects compat.supportsPromptCacheKey=false opt-out for direct OpenAI endpoints", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "https://api.openai.com/v1",
+        compat: { supportsPromptCacheKey: false },
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-opt-out",
+      },
+    });
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+  });
 });

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -119,10 +119,42 @@ function shouldStripResponsesStore(
   return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsStore === false;
 }
 
+/**
+ * Returns true when the model uses the openai-responses API but is NOT pointing to a direct
+ * OpenAI/Azure endpoint. Non-OpenAI providers (e.g. Volcano Engine, BytePlus, custom proxies)
+ * do not support the `prompt_cache_key` and `prompt_cache_retention` fields that pi-ai
+ * unconditionally injects for openai-responses payloads, causing 400 errors.
+ *
+ * A `compat.supportsPromptCacheKey` override allows per-model opt-in/opt-out.
+ */
+function shouldStripResponsesPromptCacheKey(model: {
+  api?: unknown;
+  baseUrl?: unknown;
+  compat?: unknown;
+}): boolean {
+  if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
+    return false;
+  }
+  // Explicit compat override takes highest precedence.
+  const supportsPromptCacheKey =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as Record<string, unknown>).supportsPromptCacheKey
+      : undefined;
+  if (supportsPromptCacheKey === true) {
+    return false;
+  }
+  if (supportsPromptCacheKey === false) {
+    return true;
+  }
+  // Default: only allow prompt_cache_key for direct OpenAI/Azure endpoints.
+  return !isDirectOpenAIBaseUrl(model.baseUrl);
+}
+
 function applyOpenAIResponsesPayloadOverrides(params: {
   payloadObj: Record<string, unknown>;
   forceStore: boolean;
   stripStore: boolean;
+  stripPromptCacheKey: boolean;
   useServerCompaction: boolean;
   compactThreshold: number;
 }): void {
@@ -131,6 +163,10 @@ function applyOpenAIResponsesPayloadOverrides(params: {
   }
   if (params.stripStore) {
     delete params.payloadObj.store;
+  }
+  if (params.stripPromptCacheKey) {
+    delete params.payloadObj.prompt_cache_key;
+    delete params.payloadObj.prompt_cache_retention;
   }
   if (params.useServerCompaction && params.payloadObj.context_management === undefined) {
     params.payloadObj.context_management = [
@@ -262,7 +298,8 @@ export function createOpenAIResponsesContextManagementWrapper(
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
     const stripStore = shouldStripResponsesStore(model, forceStore);
-    if (!forceStore && !useServerCompaction && !stripStore) {
+    const stripPromptCacheKey = shouldStripResponsesPromptCacheKey(model);
+    if (!forceStore && !useServerCompaction && !stripStore && !stripPromptCacheKey) {
       return underlying(model, context, options);
     }
 
@@ -278,6 +315,7 @@ export function createOpenAIResponsesContextManagementWrapper(
             payloadObj: payload as Record<string, unknown>,
             forceStore,
             stripStore,
+            stripPromptCacheKey,
             useServerCompaction,
             compactThreshold,
           });

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -130,16 +130,13 @@ function shouldStripResponsesStore(
 function shouldStripResponsesPromptCacheKey(model: {
   api?: unknown;
   baseUrl?: unknown;
-  compat?: unknown;
+  compat?: { supportsPromptCacheKey?: boolean };
 }): boolean {
   if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
     return false;
   }
   // Explicit compat override takes highest precedence.
-  const supportsPromptCacheKey =
-    model.compat && typeof model.compat === "object"
-      ? (model.compat as Record<string, unknown>).supportsPromptCacheKey
-      : undefined;
+  const supportsPromptCacheKey = model.compat?.supportsPromptCacheKey;
   if (supportsPromptCacheKey === true) {
     return false;
   }

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -144,6 +144,11 @@ function shouldStripResponsesPromptCacheKey(model: {
     return true;
   }
   // Default: only allow prompt_cache_key for direct OpenAI/Azure endpoints.
+  // An empty/undefined baseUrl means the client defaults to api.openai.com directly,
+  // so treat it the same as a direct OpenAI endpoint and keep the cache fields.
+  if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {
+    return false;
+  }
   return !isDirectOpenAIBaseUrl(model.baseUrl);
 }
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -15,6 +15,7 @@ export type ModelApi = (typeof MODEL_APIS)[number];
 
 export type ModelCompatConfig = {
   supportsStore?: boolean;
+  supportsPromptCacheKey?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -183,6 +183,7 @@ export const ModelApiSchema = z.enum(MODEL_APIS);
 export const ModelCompatSchema = z
   .object({
     supportsStore: z.boolean().optional(),
+    supportsPromptCacheKey: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Non-OpenAI providers that expose the `openai-responses` API type (e.g. Volcano Engine/`volces`, BytePlus, custom proxies) do not support the `prompt_cache_key` and `prompt_cache_retention` fields. Since pi-ai 0.58.0, these fields are unconditionally injected into every `openai-responses` payload, causing 400 errors on affected endpoints.

Closes #48155

## Root Cause

pi-ai 0.58.0 sets `prompt_cache_key: options?.sessionId` (and optionally `prompt_cache_retention`) in its `openai-responses` provider unconditionally. The gateway had no hook to strip these fields for non-OpenAI endpoints. A user configuring a custom `openai-responses` provider pointing to `ark.cn-beijing.volces.com` (Volcano Engine) will receive a 400 error: `unknown field "prompt_cache_key"`.

## Fix

- Added `shouldStripResponsesPromptCacheKey()` in `openai-stream-wrappers.ts` that returns `true` when the model's `api` is `openai-responses` but the `baseUrl` is not a direct OpenAI/Azure endpoint
- The existing `onPayload` hook in `createOpenAIResponsesContextManagementWrapper()` now strips both `prompt_cache_key` and `prompt_cache_retention` before the request reaches the provider API
- A `compat.supportsPromptCacheKey` boolean override is exposed for per-model opt-in (`true`) or forced opt-out (`false`), falling back to URL-based auto-detection
- Added `supportsPromptCacheKey` to `ModelCompatSchema` (Zod) and `ModelCompatConfig` (TypeScript) for config-level overrides
- Regenerated config-baseline after schema change

## Testing

5 new tests in `pi-embedded-runner-extraparams.test.ts`:
- Strips `prompt_cache_key` + `prompt_cache_retention` for Volcano Engine endpoint
- Strips for arbitrary non-OpenAI `openai-responses` endpoints
- Keeps fields for direct OpenAI endpoint (`api.openai.com`)
- Respects `compat.supportsPromptCacheKey=true` opt-in for non-OpenAI endpoints
- Respects `compat.supportsPromptCacheKey=false` opt-out for direct OpenAI endpoints

`pnpm check` passes (TypeScript, lint, format).

## AI disclosure

Fix designed and implemented with Claude claude-sonnet-4-6 (OpenClaw subagent). Logic reviewed: `shouldStripResponsesPromptCacheKey` follows the same URL-detection pattern already used for `shouldForceResponsesStore`/`isDirectOpenAIBaseUrl`. The approach is consistent with PR #42627 (same issue class, different root provider).