### PR TITLE
fix(daemon): use disable+kill instead of bootout in gateway stop

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -414,7 +414,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -463,11 +463,7 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
 
   const kill = await execLaunchctl(["kill", "SIGTERM", serviceTarget]);
   if (kill.code !== 0 && !isLaunchctlNotLoaded(kill)) {
-    // Service may already be stopped; that's fine.
-    const detail = (kill.stderr || kill.stdout).trim();
-    if (!detail.toLowerCase().includes("no such process")) {
-      throw new Error(`launchctl kill failed: ${detail}`);
-    }
+    throw new Error(`launchctl kill failed: ${(kill.stderr || kill.stdout).trim()}`);
   }
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -451,11 +451,25 @@ function isUnsupportedGuiDomain(detail: string): boolean {
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+  const serviceTarget = `${domain}/${label}`;
+
+  // Disable the service so launchd won't auto-restart it, then send SIGTERM.
+  // Previously this used `bootout` which completely removes the service
+  // registration, making a subsequent `gateway start` (which calls `kickstart`)
+  // fail because the service is no longer known to launchd.
+  // Using disable + kill preserves the registration so start/restart work
+  // symmetrically. See: https://github.com/openclaw/openclaw/issues/48311
+  await execLaunchctl(["disable", serviceTarget]);
+
+  const kill = await execLaunchctl(["kill", "SIGTERM", serviceTarget]);
+  if (kill.code !== 0 && !isLaunchctlNotLoaded(kill)) {
+    // Service may already be stopped; that's fine.
+    const detail = (kill.stderr || kill.stdout).trim();
+    if (!detail.toLowerCase().includes("no such process")) {
+      throw new Error(`launchctl kill failed: ${detail}`);
+    }
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
 export async function installLaunchAgent({
@@ -557,6 +571,9 @@ export async function restartLaunchAgent({
   if (cleanupPort !== null) {
     cleanStaleGatewayProcessesSync(cleanupPort);
   }
+
+  // Re-enable the service in case it was disabled by a previous `gateway stop`.
+  await execLaunchctl(["enable", serviceTarget]);
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {


### PR DESCRIPTION
Fixes #48311

## Problem

`openclaw gateway stop` calls `launchctl bootout` which nukes the service registration entirely. After that, `openclaw gateway start` fails because `kickstart` needs the service to be registered — you have to run `gateway install` again to get things working.

## Fix

Replace `bootout` with `disable` + `kill SIGTERM` in `stopLaunchAgent`. This stops the process without destroying the registration, so `start`/`restart` just work afterwards.

Also added an `enable` call in `restartLaunchAgent` before the first `kickstart` attempt, so if a service was previously stopped (disabled), it gets re-enabled cleanly.

## Changes

- `src/daemon/launchd.ts`: `stopLaunchAgent` now uses `launchctl disable` + `launchctl kill SIGTERM` instead of `launchctl bootout`
- `src/daemon/launchd.ts`: `restartLaunchAgent` calls `enable` before `kickstart` to handle previously-disabled services

Tested locally: stop → start cycle works without needing reinstall.