### PR TITLE
fix(models): preserve current Gemini 3.1 Google IDs (#48086) [AI-assisted]

### DIFF
--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -9,7 +9,10 @@ const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 // gemini-3-pro-preview was shut down on March 9, 2026; list the active
 // gemini-3.1-pro-preview first so it is always tried before the stale entry.
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
-const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+// Include both the new 3.1 preview ID (preferred) and the older 3.0 preview as
+// a fallback so forward-compat resolution works regardless of which entry the
+// registry carries after a catalog refresh.
+const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3.1-flash-preview", "gemini-3-flash-preview"] as const;
 
 function cloneFirstTemplateModel(params: {
   providerId: string;

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -6,7 +6,9 @@ import type {
 
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+// gemini-3-pro-preview was shut down on March 9, 2026; list the active
+// gemini-3.1-pro-preview first so it is always tried before the stale entry.
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
 
 function cloneFirstTemplateModel(params: {

--- a/src/agents/model-id-normalization.ts
+++ b/src/agents/model-id-normalization.ts
@@ -13,5 +13,12 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-flash-lite") {
     return "gemini-3.1-flash-lite-preview";
   }
+  // Preserve compatibility with earlier OpenClaw docs/config that pointed at a
+  // non-existent Gemini Flash preview ID. The bare shorthand `gemini-3.1-flash`
+  // is not a real Google model string; map it to the correct preview slug.
+  // Note: `gemini-3.1-flash-preview` is now a real model ID — do NOT remap it.
+  if (id === "gemini-3.1-flash") {
+    return "gemini-3-flash-preview";
+  }
   return id;
 }

--- a/src/agents/model-id-normalization.ts
+++ b/src/agents/model-id-normalization.ts
@@ -13,11 +13,5 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-flash-lite") {
     return "gemini-3.1-flash-lite-preview";
   }
-  // Preserve compatibility with earlier OpenClaw docs/config that pointed at a
-  // non-existent Gemini Flash preview ID. Google's current Flash text model is
-  // `gemini-3-flash-preview`.
-  if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
-    return "gemini-3-flash-preview";
-  }
   return id;
 }

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -49,9 +49,12 @@ describe("normalizeAntigravityModelId", () => {
 });
 
 describe("normalizeGoogleModelId", () => {
-  it("maps the deprecated 3.1 flash alias to the real preview model", () => {
+  it("maps the deprecated 3.1 flash shorthand to the real preview model", () => {
     expect(normalizeGoogleModelId("gemini-3.1-flash")).toBe("gemini-3-flash-preview");
-    expect(normalizeGoogleModelId("gemini-3.1-flash-preview")).toBe("gemini-3-flash-preview");
+  });
+
+  it("passes gemini-3.1-flash-preview through unchanged (it is now a real model ID)", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-flash-preview")).toBe("gemini-3.1-flash-preview");
   });
 
   it("adds the preview suffix for gemini 3.1 flash-lite", () => {


### PR DESCRIPTION
## Summary

Google Gemini 3.1 model IDs were being rewritten to older template IDs in a couple of compatibility paths. That could send OpenClaw to the wrong Google model string and produce `404 Not Found` responses even when the user's manual API call succeeded.

## Root cause

Two compatibility layers had gone stale after Google's Gemini 3.1 rollout:

1. `normalizeGoogleModelId()` still rewrote `gemini-3.1-flash-preview` to `gemini-3-flash-preview`.
2. The Google provider's 3.1 forward-compat templates still depended on `gemini-3-pro-preview` alone, even though Google shut that model down on March 9, 2026 in favor of `gemini-3.1-pro-preview`.

## Fix

- Keep the shorthand alias `gemini-3.1-flash -> gemini-3-flash-preview` for backward compatibility.
- Stop rewriting `gemini-3.1-flash-preview`; pass it through unchanged so Google receives the configured 3.1 model ID.
- Let Google 3.1 forward-compat template lookup fall back to current 3.1 template IDs as well as the older 3.0-era preview templates.
- Update model-selection, models-config, and media-understanding tests to reflect the current canonical IDs.

## Testing

- `pnpm check`

## AI disclosure

This PR was prepared with AI assistance (OpenAI GPT-5.4 via OpenClaw). I reviewed the issue, traced the Google model normalization and dynamic model resolution paths, and understood the resulting changes before opening this PR.
