### PR TITLE
fix(ui): prioritize source over bundled in skills grouping (issue #47139)

### DIFF
--- a/ui/src/ui/views/skills-grouping.ts
+++ b/ui/src/ui/views/skills-grouping.ts
@@ -21,9 +21,10 @@ export function groupSkills(skills: SkillStatusEntry[]): SkillGroup[] {
   const builtInGroup = SKILL_SOURCE_GROUPS.find((group) => group.id === "built-in");
   const other: SkillGroup = { id: "other", label: "Other Skills", skills: [] };
   for (const skill of skills) {
-    const match = skill.bundled
-      ? builtInGroup
-      : SKILL_SOURCE_GROUPS.find((group) => group.sources.includes(skill.source));
+    // Priority: check source first, fallback to bundled only if source doesn't match any group
+    const match =
+      SKILL_SOURCE_GROUPS.find((group) => group.sources.includes(skill.source)) ??
+      (skill.bundled ? builtInGroup : undefined);
     if (match) {
       groups.get(match.id)?.skills.push(skill);
     } else {


### PR DESCRIPTION
## Summary
- Change grouping logic to check source first, fallback to bundled only if source doesn't match
- Fixes misgrouping of workspace skills with bundled:true into built-in group

## Testing
- pnpm lint passes