### PR TITLE
fix(doctor): include darwin in startup optimization target detection (issue #47273)

### DIFF
--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -174,7 +174,11 @@ export function noteStartupOptimizationHints(
   const isArmHost = arch === "arm" || arch === "arm64";
   const isLowMemoryLinux =
     platform === "linux" && totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
-  const isStartupTuneTarget = platform === "linux" && (isArmHost || isLowMemoryLinux);
+  const isLowMemoryDarwin =
+    platform === "darwin" && totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
+  const isStartupTuneTarget =
+    (platform === "linux" || platform === "darwin") &&
+    (isArmHost || isLowMemoryLinux || isLowMemoryDarwin);
   if (!isStartupTuneTarget) {
     return;
   }


### PR DESCRIPTION
## Summary
- Include darwin platform in startup optimization target detection
- Previously only linux was checked, leaving macOS users without optimization hints

## Testing
- pnpm lint passes