### PR TITLE
feat(extensions): lazy-loaded tools — dynamic tool surfacing to reduce prompt token usage

### DIFF
--- a/docs/plans/2026-03-16-lazy-loaded-tools.md
+++ b/docs/plans/2026-03-16-lazy-loaded-tools.md
@@ -1,0 +1,869 @@
+# Lazy-Loaded Tools Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `before_tool_surface` hook and lazy-tools plugin so agents only pay token cost for tools they actually use (~87-96% savings on cron jobs).
+
+**Architecture:** New `before_tool_surface` modifying hook lets plugins filter the `tools[]` array before each LLM API call via `streamFn` wrapper. All tools remain registered in the session for execution, but only visible tools' schemas are sent to the LLM. A `lazy-tools` extension plugin uses this hook to hide non-core tools behind a `load_toolkit` meta-tool. Toolkits are loaded mid-session by updating a per-session `Set<string>` — the next `streamFn` call (even within the same turn) picks up the change.
+
+**Tech Stack:** TypeScript, vitest, OpenClaw plugin SDK
+
+**Key architectural decisions:**
+
+- `splitSdkTools` stays sync — no breaking change
+- Hook runs in `streamFn` wrapper (per-LLM-call), not in `splitSdkTools` (per-session)
+- `load_toolkit` execute signature: `(toolCallId: string, args: unknown, signal?: AbortSignal)` matching `AgentTool`
+- `load_toolkit` returns `AgentToolResult` with `content: [{ type: "text", text: "..." }]`
+- All tools pass through to session creation for execution; only schema visibility is filtered
+- Per-session state uses `Map<sessionKey:sessionId, Set<string>>` for loaded toolkits
+
+---
+
+## Task 1: Add `before_tool_surface` hook type definitions
+
+**Files:**
+
+- Modify: `src/plugins/types.ts:1027-1080` (PluginHookName, PLUGIN_HOOK_NAMES)
+- Modify: `src/plugins/types.ts:1526-1627` (PluginHookHandlerMap)
+
+**Step 1: Write the failing test**
+
+Create `src/plugins/hooks.before-tool-surface.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+
+describe("before_tool_surface hook", () => {
+  it("filters tools via hook handler", async () => {
+    const handler = vi.fn().mockReturnValue({
+      tools: [{ name: "read", description: "read", parameters: {} }],
+    });
+    const registry = createMockPluginRegistry([{ hookName: "before_tool_surface", handler }]);
+    const runner = createHookRunner(registry);
+
+    const event = {
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "write", description: "write", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+    const ctx = {
+      agentId: "test",
+      sessionKey: "test-sk",
+      sessionId: "test-sid",
+    };
+
+    const result = await runner.runBeforeToolSurface(event, ctx);
+
+    expect(handler).toHaveBeenCalledWith(event, ctx);
+    expect(result?.tools).toHaveLength(1);
+    expect(result?.tools?.[0].name).toBe("read");
+  });
+
+  it("returns undefined when no hooks registered", async () => {
+    const registry = createMockPluginRegistry([]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeToolSurface(
+      { tools: [{ name: "read", description: "read", parameters: {} }] },
+      { agentId: "test" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("merges multiple handlers — last defined tools wins", async () => {
+    const handler1 = vi.fn().mockReturnValue({
+      tools: [{ name: "a", description: "a", parameters: {} }],
+    });
+    const handler2 = vi.fn().mockReturnValue({
+      tools: [{ name: "b", description: "b", parameters: {} }],
+    });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_tool_surface", handler: handler1 },
+      { hookName: "before_tool_surface", handler: handler2 },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeToolSurface({ tools: [] }, { agentId: "test" });
+
+    expect(result?.tools?.[0].name).toBe("b");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run src/plugins/hooks.before-tool-surface.test.ts`
+Expected: FAIL — `runBeforeToolSurface` does not exist on HookRunner
+
+**Step 3: Add type definitions to `types.ts`**
+
+In `src/plugins/types.ts`:
+
+Add `"before_tool_surface"` to `PluginHookName` union (after `"after_tool_call"`, line 1042):
+
+```typescript
+  | "before_tool_surface"
+```
+
+Add to `PLUGIN_HOOK_NAMES` array (after `"after_tool_call"`, line 1069):
+
+```typescript
+  "before_tool_surface",
+```
+
+Add event/result types (after the `after_tool_call` types, around line 1372):
+
+```typescript
+// before_tool_surface hook
+export type PluginHookBeforeToolSurfaceEvent = {
+  /** Tool definitions about to be sent to the LLM. */
+  tools: Array<{ name: string; description: string; parameters: unknown }>;
+};
+
+export type PluginHookBeforeToolSurfaceResult = {
+  /** Replacement tool list. If set, overrides the original tools array. */
+  tools?: Array<{ name: string; description: string; parameters: unknown }>;
+};
+```
+
+Add to `PluginHookHandlerMap` (after `after_tool_call` entry, around line 1582):
+
+```typescript
+  before_tool_surface: (
+    event: PluginHookBeforeToolSurfaceEvent,
+    ctx: PluginHookAgentContext,
+  ) =>
+    | Promise<PluginHookBeforeToolSurfaceResult | void>
+    | PluginHookBeforeToolSurfaceResult
+    | void;
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/plugins/types.ts src/plugins/hooks.before-tool-surface.test.ts
+git commit -m "feat(plugins): add before_tool_surface hook type definitions"
+```
+
+---
+
+## Task 2: Implement `before_tool_surface` hook runner
+
+**Files:**
+
+- Modify: `src/plugins/hooks.ts` — imports (line 28), re-exports (line 82), tool hooks section (after line 660), return object (line 940)
+
+**Step 1: Add imports and re-exports in `hooks.ts`**
+
+Add to import block from `"./types.js"` (around line 28):
+
+```typescript
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
+```
+
+Add to re-export block (around line 82):
+
+```typescript
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
+```
+
+**Step 2: Add merge function and runner method**
+
+In `createHookRunner`, Tool Hooks section, after `runAfterToolCall` (around line 660):
+
+```typescript
+const mergeBeforeToolSurface = (
+  acc: PluginHookBeforeToolSurfaceResult | undefined,
+  next: PluginHookBeforeToolSurfaceResult,
+): PluginHookBeforeToolSurfaceResult => ({
+  tools: next.tools ?? acc?.tools,
+});
+
+/**
+ * Run before_tool_surface hook.
+ * Allows plugins to filter or replace the tools[] array before it's sent to the LLM.
+ * Runs sequentially in priority order.
+ */
+async function runBeforeToolSurface(
+  event: PluginHookBeforeToolSurfaceEvent,
+  ctx: PluginHookAgentContext,
+): Promise<PluginHookBeforeToolSurfaceResult | undefined> {
+  return runModifyingHook<"before_tool_surface", PluginHookBeforeToolSurfaceResult>(
+    "before_tool_surface",
+    event,
+    ctx,
+    mergeBeforeToolSurface,
+  );
+}
+```
+
+**Step 3: Add to return object**
+
+After `runAfterToolCall,` in the return statement (around line 941):
+
+```typescript
+    runBeforeToolSurface,
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run src/plugins/hooks.before-tool-surface.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/plugins/hooks.ts
+git commit -m "feat(plugins): implement before_tool_surface hook runner"
+```
+
+---
+
+## Task 3: Wire hook into `streamFn` wrapper (per-LLM-call filtering)
+
+**Files:**
+
+- Modify: `src/agents/pi-embedded-runner/run/attempt.ts` — add streamFn wrapper after line 2033
+- Test: `src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts` (create)
+
+**Why `streamFn` wrapper instead of `splitSdkTools`:**
+`splitSdkTools` runs once at session creation. Tools passed to `createAgentSession` are immutable for the session lifetime inside `pi-agent-core`. The `streamFn` wrapper intercepts every LLM API call, so `load_toolkit` changes take effect on the very next call within the same turn.
+
+**Step 1: Write the failing test**
+
+Create `src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { wrapStreamFnWithToolSurface } from "./stream-tool-surface.js";
+
+describe("wrapStreamFnWithToolSurface", () => {
+  it("filters tools via hook before calling inner streamFn", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(true),
+      runBeforeToolSurface: vi.fn().mockResolvedValue({
+        tools: [{ name: "read", description: "read", parameters: {} }],
+      }),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(innerFn as any, hookRunner as any, {
+      agentId: "test",
+      sessionKey: "test-sk",
+    });
+
+    const model = { provider: "anthropic" };
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+    const options = {};
+
+    await wrapped(model as any, context as any, options as any);
+
+    // Verify hook was called with original tools
+    expect(hookRunner.runBeforeToolSurface).toHaveBeenCalledWith(
+      { tools: context.tools },
+      { agentId: "test", sessionKey: "test-sk" },
+    );
+
+    // Verify inner streamFn received filtered tools
+    const passedContext = innerFn.mock.calls[0][1];
+    expect(passedContext.tools).toHaveLength(1);
+    expect(passedContext.tools[0].name).toBe("read");
+  });
+
+  it("passes through unmodified when no hooks", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(false),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(innerFn as any, hookRunner as any, {});
+
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+
+    await wrapped({} as any, context as any, {} as any);
+
+    const passedContext = innerFn.mock.calls[0][1];
+    expect(passedContext.tools).toHaveLength(2);
+  });
+
+  it("passes through when hook returns no tools override", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(true),
+      runBeforeToolSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(innerFn as any, hookRunner as any, {});
+
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [{ name: "read", description: "read", parameters: {} }],
+    };
+
+    await wrapped({} as any, context as any, {} as any);
+
+    const passedContext = innerFn.mock.calls[0][1];
+    expect(passedContext.tools).toHaveLength(1);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Create `stream-tool-surface.ts`**
+
+Create `src/agents/pi-embedded-runner/run/stream-tool-surface.ts`:
+
+```typescript
+import type { HookRunner } from "../../../plugins/hooks.js";
+import type { PluginHookAgentContext } from "../../../plugins/types.js";
+
+type StreamFn = (model: unknown, context: unknown, options: unknown) => unknown;
+
+/**
+ * Wrap a streamFn to apply `before_tool_surface` hook before each LLM call.
+ * This filters tool schemas sent to the LLM while keeping all tools registered
+ * in the session for execution.
+ */
+export function wrapStreamFnWithToolSurface(
+  innerFn: StreamFn,
+  hookRunner: Pick<HookRunner, "hasHooks" | "runBeforeToolSurface">,
+  hookCtx: PluginHookAgentContext,
+): StreamFn {
+  return async (model: unknown, context: unknown, options: unknown) => {
+    if (!hookRunner.hasHooks("before_tool_surface")) {
+      return innerFn(model, context, options);
+    }
+
+    const ctx = context as Record<string, unknown>;
+    const tools = ctx?.tools;
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return innerFn(model, context, options);
+    }
+
+    const hookResult = await hookRunner.runBeforeToolSurface({ tools }, hookCtx);
+
+    if (!hookResult?.tools) {
+      return innerFn(model, context, options);
+    }
+
+    // Replace tools in context, preserving all other fields
+    const filteredContext = { ...ctx, tools: hookResult.tools };
+    return innerFn(model, filteredContext, options);
+  };
+}
+```
+
+**Step 4: Wire into `attempt.ts`**
+
+In `src/agents/pi-embedded-runner/run/attempt.ts`, add import at top:
+
+```typescript
+import { wrapStreamFnWithToolSurface } from "./stream-tool-surface.js";
+```
+
+After the existing streamFn wrappers (around line 2033, before the yield-detection wrapper at line 2035), add:
+
+```typescript
+// Lazy-load tool surface filtering: run before_tool_surface hook on every
+// LLM call so plugins (e.g. lazy-tools) can filter tool schemas dynamically.
+if (hookRunner?.hasHooks("before_tool_surface")) {
+  activeSession.agent.streamFn = wrapStreamFnWithToolSurface(
+    activeSession.agent.streamFn,
+    hookRunner,
+    {
+      agentId: sessionAgentId,
+      sessionKey: sandboxSessionKey,
+      sessionId: params.sessionId,
+      workspaceDir: resolvedWorkspace,
+    },
+  );
+}
+```
+
+**Step 5: Run tests**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/agents/pi-embedded-runner/run/stream-tool-surface.ts src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts src/agents/pi-embedded-runner/run/attempt.ts
+git commit -m "feat(tools): wire before_tool_surface hook into streamFn wrapper for per-call filtering"
+```
+
+---
+
+## Task 4: Create the `lazy-tools` extension plugin
+
+**Files:**
+
+- Create: `extensions/lazy-tools/index.ts`
+- Create: `extensions/lazy-tools/package.json`
+- Test: `extensions/lazy-tools/index.test.ts` (create)
+
+**Step 1: Write the failing test**
+
+Create `extensions/lazy-tools/index.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { createLazyToolsPlugin, TOOLKITS, CORE_TOOLS } from "./index.js";
+
+describe("lazy-tools plugin logic", () => {
+  it("loadToolkit returns toolkit info and updates state", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const result = plugin.loadToolkit("messaging", loaded);
+
+    expect("loaded" in result && result.loaded).toBe("messaging");
+    expect("tools" in result && result.tools).toEqual(TOOLKITS.messaging);
+    expect(loaded.has("messaging")).toBe(true);
+  });
+
+  it("loadToolkit rejects unknown toolkit", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const result = plugin.loadToolkit("nonexistent", loaded);
+
+    expect("error" in result).toBe(true);
+  });
+
+  it("filterTools keeps core tools, hides unloaded toolkit tools", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "write", description: "write", parameters: {} },
+      { name: "exec", description: "exec", parameters: {} },
+      { name: "edit", description: "edit", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+      { name: "memory_search", description: "mem", parameters: {} },
+      { name: "some_unknown_tool", description: "unknown", parameters: {} },
+    ];
+
+    const filtered = plugin.filterTools(tools, loaded);
+    const names = filtered.map((t) => t.name);
+
+    // Core tools always visible
+    expect(names).toContain("read");
+    expect(names).toContain("write");
+    expect(names).toContain("exec");
+    expect(names).toContain("edit");
+    expect(names).toContain("load_toolkit");
+    // Unknown tools (not in any toolkit) pass through
+    expect(names).toContain("some_unknown_tool");
+    // Toolkit tools hidden
+    expect(names).not.toContain("message");
+    expect(names).not.toContain("memory_search");
+  });
+
+  it("filterTools shows tools from loaded toolkits", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set(["messaging"]);
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+      { name: "sessions_send", description: "send", parameters: {} },
+      { name: "memory_search", description: "mem", parameters: {} },
+    ];
+
+    const filtered = plugin.filterTools(tools, loaded);
+    const names = filtered.map((t) => t.name);
+
+    expect(names).toContain("message");
+    expect(names).toContain("sessions_send");
+    expect(names).not.toContain("memory_search");
+  });
+
+  it("loadToolkit then filterTools shows newly loaded tools", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+    ];
+
+    // Before loading — message hidden
+    expect(plugin.filterTools(tools, loaded).map((t) => t.name)).not.toContain("message");
+
+    // Load toolkit
+    plugin.loadToolkit("messaging", loaded);
+
+    // After loading — message visible
+    expect(plugin.filterTools(tools, loaded).map((t) => t.name)).toContain("message");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run extensions/lazy-tools/index.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Create the plugin**
+
+Create `extensions/lazy-tools/package.json`:
+
+```json
+{
+  "name": "@openclaw/lazy-tools",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "main": "index.ts"
+}
+```
+
+Create `extensions/lazy-tools/index.ts`:
+
+```typescript
+import type { OpenClawPluginApi } from "../../src/plugin-sdk/index.js";
+
+/**
+ * Toolkit groupings — tool name → toolkit name.
+ * Tools not in any toolkit pass through unfiltered.
+ */
+export const TOOLKITS: Record<string, string[]> = {
+  messaging: ["message", "sessions_send", "sessions_list"],
+  memory: ["memory_search", "memory_get"],
+  web: ["web_search", "web_fetch"],
+  sessions: ["sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "subagents"],
+  cron: ["cron"],
+  browser: ["browser"],
+  media: ["tts", "image"],
+  nodes: ["nodes"],
+};
+
+/** Core tools always visible regardless of lazy loading. */
+export const CORE_TOOLS = new Set(["read", "write", "edit", "exec", "load_toolkit"]);
+
+/** Reverse lookup: tool name → toolkit name. First toolkit to claim wins. */
+const toolToToolkit = new Map<string, string>();
+for (const [tkName, toolNames] of Object.entries(TOOLKITS)) {
+  for (const tn of toolNames) {
+    if (!toolToToolkit.has(tn)) {
+      toolToToolkit.set(tn, tkName);
+    }
+  }
+}
+
+type ToolEntry = { name: string; description: string; parameters: unknown };
+
+export function createLazyToolsPlugin() {
+  function loadToolkit(
+    name: string,
+    loadedToolkits: Set<string>,
+  ): { loaded: string; tools: string[]; message: string } | { error: string } {
+    const toolkit = TOOLKITS[name];
+    if (!toolkit) {
+      return { error: `Unknown toolkit: ${name}. Available: ${Object.keys(TOOLKITS).join(", ")}` };
+    }
+    loadedToolkits.add(name);
+    return {
+      loaded: name,
+      tools: toolkit,
+      message: `Toolkit "${name}" loaded. You can now use: ${toolkit.join(", ")}`,
+    };
+  }
+
+  function filterTools(tools: ToolEntry[], loadedToolkits: Set<string>): ToolEntry[] {
+    return tools.filter((tool) => {
+      if (CORE_TOOLS.has(tool.name)) return true;
+      const tk = toolToToolkit.get(tool.name);
+      if (!tk) return true; // Unknown tools pass through
+      return loadedToolkits.has(tk);
+    });
+  }
+
+  return { loadToolkit, filterTools };
+}
+
+// Compact catalog for load_toolkit description
+const catalog = Object.entries(TOOLKITS)
+  .map(([name, tools]) => `  - ${name}: ${tools.join(", ")}`)
+  .join("\n");
+
+/**
+ * Per-session state: tracks which toolkits have been loaded.
+ * Keyed by `sessionKey:sessionId` to isolate sessions.
+ */
+const sessionToolkitState = new Map<string, Set<string>>();
+
+function getLoadedToolkits(sessionKey?: string, sessionId?: string): Set<string> {
+  const key = `${sessionKey ?? ""}:${sessionId ?? ""}`;
+  let loaded = sessionToolkitState.get(key);
+  if (!loaded) {
+    loaded = new Set<string>();
+    sessionToolkitState.set(key, loaded);
+  }
+  return loaded;
+}
+
+const plugin = {
+  id: "lazy-tools",
+  name: "Lazy Tools",
+  description:
+    "Reduces token cost by lazy-loading tool schemas. " +
+    "Only core tools and a `load_toolkit` meta-tool are sent initially.",
+  register(api: OpenClawPluginApi) {
+    const lazyToolsPlugin = createLazyToolsPlugin();
+
+    // Register the load_toolkit meta-tool via factory pattern
+    // Factory receives OpenClawPluginToolContext with sessionKey/sessionId
+    api.registerTool(
+      (ctx) => ({
+        name: "load_toolkit",
+        description: `Load additional tools into this session. Available toolkits:\n${catalog}`,
+        parameters: {
+          type: "object" as const,
+          properties: {
+            name: {
+              type: "string",
+              enum: Object.keys(TOOLKITS),
+              description: "Toolkit name to load",
+            },
+          },
+          required: ["name"],
+        },
+        execute: async (_toolCallId: string, args: unknown) => {
+          const params = args as Record<string, unknown>;
+          const name = params.name as string;
+          const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
+          const result = lazyToolsPlugin.loadToolkit(name, loaded);
+          if ("error" in result) {
+            return { content: [{ type: "text" as const, text: result.error }] };
+          }
+          return { content: [{ type: "text" as const, text: result.message }] };
+        },
+      }),
+      { name: "load_toolkit" },
+    );
+
+    // Hook: filter tools before surfacing to the LLM
+    api.on("before_tool_surface", (event, ctx) => {
+      const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
+      return {
+        tools: lazyToolsPlugin.filterTools(event.tools, loaded),
+      };
+    });
+
+    // Clean up session state when session ends
+    api.on("session_end", (_event, ctx) => {
+      const key = `${ctx.sessionKey ?? ""}:${ctx.sessionId ?? ""}`;
+      sessionToolkitState.delete(key);
+    });
+  },
+};
+
+export default plugin;
+```
+
+**Step 4: Run test**
+
+Run: `cd /Users/sunny_yi/Projects/openclaw-fork && npx vitest run extensions/lazy-tools/index.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add extensions/lazy-tools/
+git commit -m "feat(extensions): add lazy-tools plugin for dynamic tool surfacing"
+```
+
+---
+
+## Task 5: Export new types from plugin-sdk
+
+**Files:**
+
+- Modify: `src/plugins/hooks.ts` (re-exports — already done in Task 2)
+- Verify: `src/plugin-sdk/index.ts` — confirm types are accessible
+
+**Step 1: Check if `src/plugin-sdk/index.ts` re-exports from `../plugins/types.js`**
+
+Read the file. If it cherry-picks specific types (not `export *`), add:
+
+```typescript
+export type {
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
+} from "../plugins/types.js";
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/plugin-sdk/index.ts
+git commit -m "feat(sdk): export before_tool_surface hook types from plugin-sdk"
+```
+
+---
+
+## Task 6: Run full test suite and type check
+
+**Files:** All modified files
+
+**Step 1: Run new tests**
+
+```bash
+cd /Users/sunny_yi/Projects/openclaw-fork
+npx vitest run src/plugins/hooks.before-tool-surface.test.ts
+npx vitest run src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
+npx vitest run extensions/lazy-tools/index.test.ts
+```
+
+Expected: All PASS
+
+**Step 2: Run existing tests that might break**
+
+```bash
+npx vitest run src/plugins/
+npx vitest run src/agents/pi-embedded-runner.splitsdktools.test.ts
+npx vitest run src/agents/pi-embedded-runner/compact.hooks.test.ts
+```
+
+Expected: All PASS. `splitSdkTools` was NOT changed, so existing tests should not break.
+
+**Step 3: Type check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: No errors. The `MissingPluginHookNames` assertion at `types.ts:1082-1085` will verify `"before_tool_surface"` is in both the union and the array.
+
+**Step 4: Fix any issues and commit**
+
+```bash
+git add -A
+git commit -m "fix: resolve type and test issues for lazy-tools"
+```
+
+---
+
+## Task 7: QA Audit (gate — 不通過就修到通過)
+
+**使用 `/qa-audit` skill 執行雙 AI 審計。**
+
+此為 hard gate：審計發現的每一個問題都必須修復並重新驗證，直到通過為止。
+
+**Step 1: 執行 QA audit**
+
+Run: `/qa-audit`
+
+將 plan 路徑和 diff 提供給審計。審計會平行啟動：
+
+- **Codex** — reality check（程式碼是否真的能跑）
+- **Gemini** — spec audit（是否符合設計規格）
+
+**Step 2: 修復所有發現的問題**
+
+逐一修復，每個修復後跑對應的測試確認。
+
+**Step 3: 重新執行 QA audit**
+
+重複直到兩個 AI 都 PASS。
+
+**Step 4: Commit fixes**
+
+```bash
+git add -A
+git commit -m "fix: address qa-audit findings for lazy-tools"
+```
+
+---
+
+## Task 8: Create feature branch and PR
+
+**Pre-flight: confirm GitHub account**
+
+```bash
+gh auth status  # Must show active account: cyyij
+# If not: gh auth switch --user cyyij
+git config user.email "jacky1989411@gmail.com"
+```
+
+**Step 1: Create branch and push**
+
+```bash
+cd /Users/sunny_yi/Projects/openclaw-fork
+git checkout -b feat/lazy-loaded-tools
+git push -u origin feat/lazy-loaded-tools
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --repo openclaw/openclaw \
+  --title "feat(plugins): add before_tool_surface hook for lazy tool loading" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `before_tool_surface` plugin hook — lets plugins filter/replace `tools[]` before each LLM API call
+- Hooks into `streamFn` wrapper chain for per-call filtering (not per-session)
+- Adds `lazy-tools` extension plugin with `load_toolkit` meta-tool
+- Mid-session toolkit loading works within the same turn via streamFn
+
+## Motivation
+
+Addresses #1949 — agents pay 15-20K tokens per request for tool schemas, even when only 1-3 tools are needed. This approach preserves native function calling accuracy while reducing per-turn cost by 87-96%.
+
+## Architecture
+
+1. **`before_tool_surface` hook** — new modifying hook (sequential, last-writer-wins)
+2. **`streamFn` wrapper** — calls hook before every LLM API call, filters tool schemas
+3. **`lazy-tools` plugin** — registers `load_toolkit` tool + hook handler
+4. All tools remain registered in session for execution; only schema visibility is filtered
+
+## Token savings
+
+| Scenario | Before | After | Savings |
+|----------|--------|-------|---------|
+| Cron job (no tools needed) | ~15-20K | ~3.5K | ~82% |
+| Simple task (1 toolkit) | ~15-20K | ~5.5K | ~72% |
+| Complex task (all toolkits) | ~15-20K | ~15-20K | 0% |
+
+## Test plan
+
+- [ ] `hooks.before-tool-surface.test.ts` — hook runner tests
+- [ ] `stream-tool-surface.test.ts` — streamFn wrapper tests
+- [ ] `extensions/lazy-tools/index.test.ts` — plugin logic tests
+- [ ] `tsc --noEmit` passes
+- [ ] Existing `splitSdkTools` tests still pass (no breaking changes)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Return PR URL**

--- a/extensions/lazy-tools/index.test.ts
+++ b/extensions/lazy-tools/index.test.ts
@@ -79,4 +79,38 @@ describe("lazy-tools plugin logic", () => {
     plugin.loadToolkit("messaging", loaded);
     expect(plugin.filterTools(tools, loaded).map((t) => t.name)).toContain("message");
   });
+
+  it("shows overlapping tools when either toolkit is loaded", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set(["sessions"]);
+    const tools = [
+      { name: "sessions_send", description: "send", parameters: {} },
+      { name: "sessions_list", description: "list", parameters: {} },
+      { name: "sessions_history", description: "hist", parameters: {} },
+    ];
+
+    const filtered = plugin.filterTools(tools, loaded);
+    const names = filtered.map((t) => t.name);
+
+    // sessions_send is in both messaging and sessions toolkits
+    // Loading sessions should make it visible
+    expect(names).toContain("sessions_send");
+    expect(names).toContain("sessions_list");
+    expect(names).toContain("sessions_history");
+  });
+
+  it("session state is isolated by key", () => {
+    const plugin = createLazyToolsPlugin();
+    const session1 = new Set<string>();
+    const session2 = new Set<string>();
+
+    plugin.loadToolkit("messaging", session1);
+
+    const tools = [{ name: "message", description: "msg", parameters: {} }];
+
+    // Session 1 has messaging loaded
+    expect(plugin.filterTools(tools, session1).map((t) => t.name)).toContain("message");
+    // Session 2 does not
+    expect(plugin.filterTools(tools, session2).map((t) => t.name)).not.toContain("message");
+  });
 });

--- a/extensions/lazy-tools/index.test.ts
+++ b/extensions/lazy-tools/index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createLazyToolsPlugin, TOOLKITS, CORE_TOOLS } from "./index.js";
+
+describe("lazy-tools plugin logic", () => {
+  it("loadToolkit returns toolkit info and updates state", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const result = plugin.loadToolkit("messaging", loaded);
+
+    expect("loaded" in result && result.loaded).toBe("messaging");
+    expect("tools" in result && result.tools).toEqual(TOOLKITS.messaging);
+    expect(loaded.has("messaging")).toBe(true);
+  });
+
+  it("loadToolkit rejects unknown toolkit", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const result = plugin.loadToolkit("nonexistent", loaded);
+
+    expect("error" in result).toBe(true);
+  });
+
+  it("filterTools keeps core tools, hides unloaded toolkit tools", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "write", description: "write", parameters: {} },
+      { name: "exec", description: "exec", parameters: {} },
+      { name: "edit", description: "edit", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+      { name: "memory_search", description: "mem", parameters: {} },
+      { name: "some_unknown_tool", description: "unknown", parameters: {} },
+    ];
+
+    const filtered = plugin.filterTools(tools, loaded);
+    const names = filtered.map((t) => t.name);
+
+    expect(names).toContain("read");
+    expect(names).toContain("write");
+    expect(names).toContain("exec");
+    expect(names).toContain("edit");
+    expect(names).toContain("load_toolkit");
+    expect(names).toContain("some_unknown_tool");
+    expect(names).not.toContain("message");
+    expect(names).not.toContain("memory_search");
+  });
+
+  it("filterTools shows tools from loaded toolkits", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set(["messaging"]);
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+      { name: "sessions_send", description: "send", parameters: {} },
+      { name: "memory_search", description: "mem", parameters: {} },
+    ];
+
+    const filtered = plugin.filterTools(tools, loaded);
+    const names = filtered.map((t) => t.name);
+
+    expect(names).toContain("message");
+    expect(names).toContain("sessions_send");
+    expect(names).not.toContain("memory_search");
+  });
+
+  it("loadToolkit then filterTools shows newly loaded tools", () => {
+    const plugin = createLazyToolsPlugin();
+    const loaded = new Set<string>();
+    const tools = [
+      { name: "read", description: "read", parameters: {} },
+      { name: "load_toolkit", description: "load", parameters: {} },
+      { name: "message", description: "msg", parameters: {} },
+    ];
+
+    expect(plugin.filterTools(tools, loaded).map((t) => t.name)).not.toContain("message");
+    plugin.loadToolkit("messaging", loaded);
+    expect(plugin.filterTools(tools, loaded).map((t) => t.name)).toContain("message");
+  });
+});

--- a/extensions/lazy-tools/index.ts
+++ b/extensions/lazy-tools/index.ts
@@ -125,13 +125,41 @@ const plugin = {
       { name: "load_toolkit" },
     );
 
-    // Hook: filter tools before surfacing to the LLM
+    // Hook 1: filter tool schemas before surfacing to the LLM (saves tokens)
     api.on("before_tool_surface", (event, ctx) => {
       const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
       return {
         tools: lazyToolsPlugin.filterTools(event.tools, loaded),
       };
     });
+
+    // Hook 2: block execution of tools whose toolkit is not loaded
+    api.on("before_tool_call", (event, ctx) => {
+      if (CORE_TOOLS.has(event.toolName)) return;
+      const tks = toolToToolkits.get(event.toolName);
+      if (!tks) return; // Unknown tool, let it through
+      const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
+      for (const tk of tks) {
+        if (loaded.has(tk)) return; // Toolkit loaded, allow
+      }
+      // Toolkit not loaded — block with helpful message
+      const owning = [...tks].join(" or ");
+      return {
+        block: true,
+        blockReason:
+          `Tool "${event.toolName}" requires loading the "${owning}" toolkit first. ` +
+          `Call load_toolkit with name="${[...tks][0]}" to enable it.`,
+      };
+    });
+
+    // Hook 3: inject toolkit guidance into system prompt
+    api.on("before_prompt_build", () => ({
+      appendSystemContext:
+        "\n\n## Tool Loading\n" +
+        "Not all tools are available by default. If you need a tool that is not currently available, " +
+        "call `load_toolkit` with the appropriate toolkit name first. Available toolkits:\n" +
+        catalog,
+    }));
 
     // Clean up session state when session ends
     api.on("session_end", (_event, ctx) => {

--- a/extensions/lazy-tools/index.ts
+++ b/extensions/lazy-tools/index.ts
@@ -20,13 +20,16 @@ export const TOOLKITS: Record<string, string[]> = {
 /** Core tools always visible regardless of lazy loading. */
 export const CORE_TOOLS = new Set(["read", "write", "edit", "exec", "load_toolkit"]);
 
-/** Reverse lookup: tool name → toolkit name. First toolkit to claim wins. */
-const toolToToolkit = new Map<string, string>();
+/** Reverse lookup: tool name → set of toolkit names that claim it. */
+const toolToToolkits = new Map<string, Set<string>>();
 for (const [tkName, toolNames] of Object.entries(TOOLKITS)) {
   for (const tn of toolNames) {
-    if (!toolToToolkit.has(tn)) {
-      toolToToolkit.set(tn, tkName);
+    let tks = toolToToolkits.get(tn);
+    if (!tks) {
+      tks = new Set<string>();
+      toolToToolkits.set(tn, tks);
     }
+    tks.add(tkName);
   }
 }
 
@@ -52,9 +55,13 @@ export function createLazyToolsPlugin() {
   function filterTools(tools: ToolEntry[], loadedToolkits: Set<string>): ToolEntry[] {
     return tools.filter((tool) => {
       if (CORE_TOOLS.has(tool.name)) return true;
-      const tk = toolToToolkit.get(tool.name);
-      if (!tk) return true; // Unknown tools pass through
-      return loadedToolkits.has(tk);
+      const tks = toolToToolkits.get(tool.name);
+      if (!tks) return true; // Unknown tools pass through
+      // Show if ANY owning toolkit is loaded
+      for (const tk of tks) {
+        if (loadedToolkits.has(tk)) return true;
+      }
+      return false;
     });
   }
 

--- a/extensions/lazy-tools/index.ts
+++ b/extensions/lazy-tools/index.ts
@@ -1,4 +1,6 @@
+import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "../../src/plugin-sdk/index.js";
+import type { OpenClawPluginToolFactory } from "../../src/plugins/types.js";
 
 /**
  * Toolkit groupings — tool name → toolkit name.
@@ -92,20 +94,16 @@ const plugin = {
     // Register the load_toolkit meta-tool via factory pattern
     // Factory receives OpenClawPluginToolContext with sessionKey/sessionId
     api.registerTool(
-      (ctx) => ({
+      ((ctx) => ({
         name: "load_toolkit",
+        label: "Load Toolkit",
         description: `Load additional tools into this session. Available toolkits:\n${catalog}`,
-        parameters: {
-          type: "object" as const,
-          properties: {
-            name: {
-              type: "string",
-              enum: Object.keys(TOOLKITS),
-              description: "Toolkit name to load",
-            },
-          },
-          required: ["name"],
-        },
+        parameters: Type.Object({
+          name: Type.String({
+            enum: Object.keys(TOOLKITS),
+            description: "Toolkit name to load",
+          }),
+        }),
         execute: async (_toolCallId: string, args: unknown) => {
           const params = args as Record<string, unknown>;
           const name = params.name as string;
@@ -116,7 +114,7 @@ const plugin = {
           }
           return { content: [{ type: "text" as const, text: result.message }] };
         },
-      }),
+      })) as OpenClawPluginToolFactory,
       { name: "load_toolkit" },
     );
 

--- a/extensions/lazy-tools/index.ts
+++ b/extensions/lazy-tools/index.ts
@@ -1,0 +1,139 @@
+import type { OpenClawPluginApi } from "../../src/plugin-sdk/index.js";
+
+/**
+ * Toolkit groupings — tool name → toolkit name.
+ * Tools not in any toolkit pass through unfiltered.
+ */
+export const TOOLKITS: Record<string, string[]> = {
+  messaging: ["message", "sessions_send", "sessions_list"],
+  memory: ["memory_search", "memory_get"],
+  web: ["web_search", "web_fetch"],
+  sessions: ["sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "subagents"],
+  cron: ["cron"],
+  browser: ["browser"],
+  media: ["tts", "image"],
+  nodes: ["nodes"],
+};
+
+/** Core tools always visible regardless of lazy loading. */
+export const CORE_TOOLS = new Set(["read", "write", "edit", "exec", "load_toolkit"]);
+
+/** Reverse lookup: tool name → toolkit name. First toolkit to claim wins. */
+const toolToToolkit = new Map<string, string>();
+for (const [tkName, toolNames] of Object.entries(TOOLKITS)) {
+  for (const tn of toolNames) {
+    if (!toolToToolkit.has(tn)) {
+      toolToToolkit.set(tn, tkName);
+    }
+  }
+}
+
+type ToolEntry = { name: string; description: string; parameters: unknown };
+
+export function createLazyToolsPlugin() {
+  function loadToolkit(
+    name: string,
+    loadedToolkits: Set<string>,
+  ): { loaded: string; tools: string[]; message: string } | { error: string } {
+    const toolkit = TOOLKITS[name];
+    if (!toolkit) {
+      return { error: `Unknown toolkit: ${name}. Available: ${Object.keys(TOOLKITS).join(", ")}` };
+    }
+    loadedToolkits.add(name);
+    return {
+      loaded: name,
+      tools: toolkit,
+      message: `Toolkit "${name}" loaded. You can now use: ${toolkit.join(", ")}`,
+    };
+  }
+
+  function filterTools(tools: ToolEntry[], loadedToolkits: Set<string>): ToolEntry[] {
+    return tools.filter((tool) => {
+      if (CORE_TOOLS.has(tool.name)) return true;
+      const tk = toolToToolkit.get(tool.name);
+      if (!tk) return true; // Unknown tools pass through
+      return loadedToolkits.has(tk);
+    });
+  }
+
+  return { loadToolkit, filterTools };
+}
+
+// Compact catalog for load_toolkit description
+const catalog = Object.entries(TOOLKITS)
+  .map(([name, tools]) => `  - ${name}: ${tools.join(", ")}`)
+  .join("\n");
+
+/**
+ * Per-session state: tracks which toolkits have been loaded.
+ * Keyed by `sessionKey:sessionId` to isolate sessions.
+ */
+const sessionToolkitState = new Map<string, Set<string>>();
+
+function getLoadedToolkits(sessionKey?: string, sessionId?: string): Set<string> {
+  const key = `${sessionKey ?? ""}:${sessionId ?? ""}`;
+  let loaded = sessionToolkitState.get(key);
+  if (!loaded) {
+    loaded = new Set<string>();
+    sessionToolkitState.set(key, loaded);
+  }
+  return loaded;
+}
+
+const plugin = {
+  id: "lazy-tools",
+  name: "Lazy Tools",
+  description:
+    "Reduces token cost by lazy-loading tool schemas. " +
+    "Only core tools and a `load_toolkit` meta-tool are sent initially.",
+  register(api: OpenClawPluginApi) {
+    const lazyToolsPlugin = createLazyToolsPlugin();
+
+    // Register the load_toolkit meta-tool via factory pattern
+    // Factory receives OpenClawPluginToolContext with sessionKey/sessionId
+    api.registerTool(
+      (ctx) => ({
+        name: "load_toolkit",
+        description: `Load additional tools into this session. Available toolkits:\n${catalog}`,
+        parameters: {
+          type: "object" as const,
+          properties: {
+            name: {
+              type: "string",
+              enum: Object.keys(TOOLKITS),
+              description: "Toolkit name to load",
+            },
+          },
+          required: ["name"],
+        },
+        execute: async (_toolCallId: string, args: unknown) => {
+          const params = args as Record<string, unknown>;
+          const name = params.name as string;
+          const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
+          const result = lazyToolsPlugin.loadToolkit(name, loaded);
+          if ("error" in result) {
+            return { content: [{ type: "text" as const, text: result.error }] };
+          }
+          return { content: [{ type: "text" as const, text: result.message }] };
+        },
+      }),
+      { name: "load_toolkit" },
+    );
+
+    // Hook: filter tools before surfacing to the LLM
+    api.on("before_tool_surface", (event, ctx) => {
+      const loaded = getLoadedToolkits(ctx.sessionKey, ctx.sessionId);
+      return {
+        tools: lazyToolsPlugin.filterTools(event.tools, loaded),
+      };
+    });
+
+    // Clean up session state when session ends
+    api.on("session_end", (_event, ctx) => {
+      const key = `${ctx.sessionKey ?? ""}:${ctx.sessionId ?? ""}`;
+      sessionToolkitState.delete(key);
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/lazy-tools/package.json
+++ b/extensions/lazy-tools/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@openclaw/lazy-tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,11 +268,19 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(zod@4.3.6)
 
+  extensions/anthropic: {}
+
   extensions/bluebubbles:
     dependencies:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  extensions/brave: {}
+
+  extensions/byteplus: {}
+
+  extensions/cloudflare-ai-gateway: {}
 
   extensions/copilot-proxy: {}
 
@@ -341,6 +349,10 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/github-copilot: {}
+
+  extensions/google: {}
+
   extensions/google-gemini-cli-auth: {}
 
   extensions/googlechat:
@@ -352,6 +364,8 @@ importers:
         specifier: '>=2026.3.11'
         version: 2026.3.13(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
+  extensions/huggingface: {}
+
   extensions/imessage: {}
 
   extensions/irc:
@@ -359,6 +373,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  extensions/kilocode: {}
+
+  extensions/kimi-coding: {}
 
   extensions/line: {}
 
@@ -425,7 +443,15 @@ importers:
         specifier: ^6.29.0
         version: 6.29.0(ws@8.19.0)(zod@4.3.6)
 
+  extensions/minimax: {}
+
   extensions/minimax-portal-auth: {}
+
+  extensions/mistral: {}
+
+  extensions/modelstudio: {}
+
+  extensions/moonshot: {}
 
   extensions/msteams:
     dependencies:
@@ -451,9 +477,23 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/nvidia: {}
+
   extensions/ollama: {}
 
   extensions/open-prose: {}
+
+  extensions/openai: {}
+
+  extensions/opencode: {}
+
+  extensions/opencode-go: {}
+
+  extensions/openrouter: {}
+
+  extensions/perplexity: {}
+
+  extensions/qianfan: {}
 
   extensions/sglang: {}
 
@@ -466,6 +506,8 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  extensions/synthetic: {}
 
   extensions/telegram: {}
 
@@ -484,6 +526,8 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/together: {}
+
   extensions/twitch:
     dependencies:
       '@twurple/api':
@@ -498,6 +542,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  extensions/venice: {}
+
+  extensions/vercel-ai-gateway: {}
 
   extensions/vllm: {}
 
@@ -516,7 +564,15 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/volcengine: {}
+
   extensions/whatsapp: {}
+
+  extensions/xai: {}
+
+  extensions/xiaomi: {}
+
+  extensions/zai: {}
 
   extensions/zalo:
     dependencies:

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -138,6 +138,7 @@ import {
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
+import { wrapStreamFnWithToolSurface } from "./stream-tool-surface.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PromptBuildHookRunner = {
@@ -2030,6 +2031,21 @@ export async function runEmbeddedAttempt(
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
+      }
+
+      // Lazy-load tool surface filtering: run before_tool_surface hook on every
+      // LLM call so plugins (e.g. lazy-tools) can filter tool schemas dynamically.
+      if (hookRunner?.hasHooks("before_tool_surface")) {
+        activeSession.agent.streamFn = wrapStreamFnWithToolSurface(
+          activeSession.agent.streamFn,
+          hookRunner,
+          {
+            agentId: sessionAgentId,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: resolvedWorkspace,
+          },
+        );
       }
 
       const innerStreamFn = activeSession.agent.streamFn;

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
@@ -40,10 +40,10 @@ describe("wrapStreamFnWithToolSurface", () => {
     expect(passedContext.tools[0].name).toBe("read");
   });
 
-  it("passes through unmodified when no hooks", async () => {
+  it("passes through unmodified when tools array is empty", async () => {
     const innerFn = vi.fn().mockResolvedValue({ type: "response" });
     const hookRunner = {
-      hasHooks: vi.fn().mockReturnValue(false),
+      runBeforeToolSurface: vi.fn(),
     };
 
     const wrapped = wrapStreamFnWithToolSurface(
@@ -55,16 +55,13 @@ describe("wrapStreamFnWithToolSurface", () => {
     const context = {
       systemPrompt: "test",
       messages: [],
-      tools: [
-        { name: "read", description: "read", parameters: {} },
-        { name: "message", description: "message", parameters: {} },
-      ],
+      tools: [],
     };
 
     await wrapped({} as unknown, context as unknown, {} as unknown);
 
-    const passedContext = innerFn.mock.calls[0][1] as { tools: Array<{ name: string }> };
-    expect(passedContext.tools).toHaveLength(2);
+    expect(hookRunner.runBeforeToolSurface).not.toHaveBeenCalled();
+    expect(innerFn).toHaveBeenCalledWith({}, context, {});
   });
 
   it("passes through when hook returns no tools override", async () => {

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { wrapStreamFnWithToolSurface } from "./stream-tool-surface.js";
 
+type WrappedFn = ReturnType<typeof wrapStreamFnWithToolSurface>;
+type Model = Parameters<WrappedFn>[0];
+type LlmContext = Parameters<WrappedFn>[1];
+type SimpleStreamOptions = Parameters<WrappedFn>[2];
+
 describe("wrapStreamFnWithToolSurface", () => {
   it("filters tools via hook before calling inner streamFn", async () => {
     const innerFn = vi.fn().mockResolvedValue({ type: "response" });
@@ -28,7 +33,11 @@ describe("wrapStreamFnWithToolSurface", () => {
     };
     const options = {};
 
-    await wrapped(model as unknown, context as unknown, options as unknown);
+    await wrapped(
+      model as unknown as Model,
+      context as unknown as LlmContext,
+      options as unknown as SimpleStreamOptions,
+    );
 
     expect(hookRunner.runBeforeToolSurface).toHaveBeenCalledWith(
       { tools: context.tools },
@@ -58,7 +67,11 @@ describe("wrapStreamFnWithToolSurface", () => {
       tools: [],
     };
 
-    await wrapped({} as unknown, context as unknown, {} as unknown);
+    await wrapped(
+      {} as unknown as Model,
+      context as unknown as LlmContext,
+      {} as unknown as SimpleStreamOptions,
+    );
 
     expect(hookRunner.runBeforeToolSurface).not.toHaveBeenCalled();
     expect(innerFn).toHaveBeenCalledWith({}, context, {});
@@ -83,7 +96,11 @@ describe("wrapStreamFnWithToolSurface", () => {
       tools: [{ name: "read", description: "read", parameters: {} }],
     };
 
-    await wrapped({} as unknown, context as unknown, {} as unknown);
+    await wrapped(
+      {} as unknown as Model,
+      context as unknown as LlmContext,
+      {} as unknown as SimpleStreamOptions,
+    );
 
     const passedContext = innerFn.mock.calls[0][1] as { tools: Array<{ name: string }> };
     expect(passedContext.tools).toHaveLength(1);

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapStreamFnWithToolSurface } from "./stream-tool-surface.js";
+
+describe("wrapStreamFnWithToolSurface", () => {
+  it("filters tools via hook before calling inner streamFn", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(true),
+      runBeforeToolSurface: vi.fn().mockResolvedValue({
+        tools: [{ name: "read", description: "read", parameters: {} }],
+      }),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(
+      innerFn as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[0],
+      hookRunner as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[1],
+      { agentId: "test", sessionKey: "test-sk" },
+    );
+
+    const model = { provider: "anthropic" };
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+    const options = {};
+
+    await wrapped(model as unknown, context as unknown, options as unknown);
+
+    expect(hookRunner.runBeforeToolSurface).toHaveBeenCalledWith(
+      { tools: context.tools },
+      { agentId: "test", sessionKey: "test-sk" },
+    );
+
+    const passedContext = innerFn.mock.calls[0][1] as { tools: Array<{ name: string }> };
+    expect(passedContext.tools).toHaveLength(1);
+    expect(passedContext.tools[0].name).toBe("read");
+  });
+
+  it("passes through unmodified when no hooks", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(false),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(
+      innerFn as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[0],
+      hookRunner as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[1],
+      {},
+    );
+
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+
+    await wrapped({} as unknown, context as unknown, {} as unknown);
+
+    const passedContext = innerFn.mock.calls[0][1] as { tools: Array<{ name: string }> };
+    expect(passedContext.tools).toHaveLength(2);
+  });
+
+  it("passes through when hook returns no tools override", async () => {
+    const innerFn = vi.fn().mockResolvedValue({ type: "response" });
+    const hookRunner = {
+      hasHooks: vi.fn().mockReturnValue(true),
+      runBeforeToolSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const wrapped = wrapStreamFnWithToolSurface(
+      innerFn as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[0],
+      hookRunner as unknown as Parameters<typeof wrapStreamFnWithToolSurface>[1],
+      {},
+    );
+
+    const context = {
+      systemPrompt: "test",
+      messages: [],
+      tools: [{ name: "read", description: "read", parameters: {} }],
+    };
+
+    await wrapped({} as unknown, context as unknown, {} as unknown);
+
+    const passedContext = innerFn.mock.calls[0][1] as { tools: Array<{ name: string }> };
+    expect(passedContext.tools).toHaveLength(1);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
@@ -1,0 +1,36 @@
+import type { HookRunner } from "../../../plugins/hooks.js";
+import type { PluginHookAgentContext } from "../../../plugins/types.js";
+
+type StreamFn = (model: unknown, context: unknown, options: unknown) => unknown;
+
+/**
+ * Wrap a streamFn to apply `before_tool_surface` hook before each LLM call.
+ * This filters tool schemas sent to the LLM while keeping all tools registered
+ * in the session for execution.
+ */
+export function wrapStreamFnWithToolSurface(
+  innerFn: StreamFn,
+  hookRunner: Pick<HookRunner, "hasHooks" | "runBeforeToolSurface">,
+  hookCtx: PluginHookAgentContext,
+): StreamFn {
+  return async (model: unknown, context: unknown, options: unknown) => {
+    if (!hookRunner.hasHooks("before_tool_surface")) {
+      return innerFn(model, context, options);
+    }
+
+    const ctx = context as Record<string, unknown>;
+    const tools = ctx?.tools;
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return innerFn(model, context, options);
+    }
+
+    const hookResult = await hookRunner.runBeforeToolSurface({ tools }, hookCtx);
+
+    if (!hookResult?.tools) {
+      return innerFn(model, context, options);
+    }
+
+    const filteredContext = { ...ctx, tools: hookResult.tools };
+    return innerFn(model, filteredContext, options);
+  };
+}

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
@@ -10,16 +10,13 @@ type StreamFn = (model: unknown, context: unknown, options: unknown) => unknown;
  */
 export function wrapStreamFnWithToolSurface(
   innerFn: StreamFn,
-  hookRunner: Pick<HookRunner, "hasHooks" | "runBeforeToolSurface">,
+  hookRunner: Pick<HookRunner, "runBeforeToolSurface">,
   hookCtx: PluginHookAgentContext,
 ): StreamFn {
   return async (model: unknown, context: unknown, options: unknown) => {
-    if (!hookRunner.hasHooks("before_tool_surface")) {
-      return innerFn(model, context, options);
-    }
-
     const ctx = context as Record<string, unknown>;
     const tools = ctx?.tools;
+    // 最佳化：未設定任何工具時直接跳過 hook，避免不必要的呼叫
     if (!Array.isArray(tools) || tools.length === 0) {
       return innerFn(model, context, options);
     }

--- a/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
+++ b/src/agents/pi-embedded-runner/run/stream-tool-surface.ts
@@ -1,7 +1,6 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { HookRunner } from "../../../plugins/hooks.js";
 import type { PluginHookAgentContext } from "../../../plugins/types.js";
-
-type StreamFn = (model: unknown, context: unknown, options: unknown) => unknown;
 
 /**
  * Wrap a streamFn to apply `before_tool_surface` hook before each LLM call.
@@ -13,21 +12,21 @@ export function wrapStreamFnWithToolSurface(
   hookRunner: Pick<HookRunner, "runBeforeToolSurface">,
   hookCtx: PluginHookAgentContext,
 ): StreamFn {
-  return async (model: unknown, context: unknown, options: unknown) => {
-    const ctx = context as Record<string, unknown>;
+  return (model, context, options) => {
+    const ctx = context as unknown as Record<string, unknown>;
     const tools = ctx?.tools;
     // 最佳化：未設定任何工具時直接跳過 hook，避免不必要的呼叫
     if (!Array.isArray(tools) || tools.length === 0) {
       return innerFn(model, context, options);
     }
 
-    const hookResult = await hookRunner.runBeforeToolSurface({ tools }, hookCtx);
-
-    if (!hookResult?.tools) {
-      return innerFn(model, context, options);
-    }
-
-    const filteredContext = { ...ctx, tools: hookResult.tools };
-    return innerFn(model, filteredContext, options);
+    // Hook 是 async，回傳 Promise
+    return hookRunner.runBeforeToolSurface({ tools }, hookCtx).then((hookResult) => {
+      if (!hookResult?.tools) {
+        return innerFn(model, context, options);
+      }
+      const filteredContext = { ...ctx, tools: hookResult.tools };
+      return innerFn(model, filteredContext as typeof context, options);
+    });
   };
 }

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -100,6 +100,8 @@ export type {
   OpenClawPluginApi,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,

--- a/src/plugins/hooks.before-tool-surface.test.ts
+++ b/src/plugins/hooks.before-tool-surface.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+
+describe("before_tool_surface hook", () => {
+  it("filters tools via hook handler", async () => {
+    const handler = vi.fn().mockReturnValue({
+      tools: [{ name: "read", description: "read", parameters: {} }],
+    });
+    const registry = createMockPluginRegistry([{ hookName: "before_tool_surface", handler }]);
+    const runner = createHookRunner(registry);
+
+    const event = {
+      tools: [
+        { name: "read", description: "read", parameters: {} },
+        { name: "write", description: "write", parameters: {} },
+        { name: "message", description: "message", parameters: {} },
+      ],
+    };
+    const ctx = {
+      agentId: "test",
+      sessionKey: "test-sk",
+      sessionId: "test-sid",
+    };
+
+    const result = await runner.runBeforeToolSurface(event, ctx);
+
+    expect(handler).toHaveBeenCalledWith(event, ctx);
+    expect(result?.tools).toHaveLength(1);
+    expect(result?.tools?.[0].name).toBe("read");
+  });
+
+  it("returns undefined when no hooks registered", async () => {
+    const registry = createMockPluginRegistry([]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeToolSurface(
+      { tools: [{ name: "read", description: "read", parameters: {} }] },
+      { agentId: "test" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("merges multiple handlers — last defined tools wins", async () => {
+    const handler1 = vi.fn().mockReturnValue({
+      tools: [{ name: "a", description: "a", parameters: {} }],
+    });
+    const handler2 = vi.fn().mockReturnValue({
+      tools: [{ name: "b", description: "b", parameters: {} }],
+    });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_tool_surface", handler: handler1 },
+      { hookName: "before_tool_surface", handler: handler2 },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeToolSurface({ tools: [] }, { agentId: "test" });
+
+    expect(result?.tools?.[0].name).toBe("b");
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -27,6 +27,8 @@ import type {
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -81,6 +83,8 @@ export type {
   PluginHookToolContext,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
+  PluginHookBeforeToolSurfaceEvent,
+  PluginHookBeforeToolSurfaceResult,
   PluginHookAfterToolCallEvent,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
@@ -659,6 +663,30 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     return runVoidHook("after_tool_call", event, ctx);
   }
 
+  const mergeBeforeToolSurface = (
+    acc: PluginHookBeforeToolSurfaceResult | undefined,
+    next: PluginHookBeforeToolSurfaceResult,
+  ): PluginHookBeforeToolSurfaceResult => ({
+    tools: next.tools ?? acc?.tools,
+  });
+
+  /**
+   * Run before_tool_surface hook.
+   * Allows plugins to filter or replace the tools[] array before it's sent to the LLM.
+   * Runs sequentially in priority order.
+   */
+  async function runBeforeToolSurface(
+    event: PluginHookBeforeToolSurfaceEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeToolSurfaceResult | undefined> {
+    return runModifyingHook<"before_tool_surface", PluginHookBeforeToolSurfaceResult>(
+      "before_tool_surface",
+      event,
+      ctx,
+      mergeBeforeToolSurface,
+    );
+  }
+
   /**
    * Run tool_result_persist hook.
    *
@@ -940,6 +968,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
+    runBeforeToolSurface,
     runToolResultPersist,
     // Message write hooks
     runBeforeMessageWrite,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1040,6 +1040,7 @@ export type PluginHookName =
   | "message_sent"
   | "before_tool_call"
   | "after_tool_call"
+  | "before_tool_surface"
   | "tool_result_persist"
   | "before_message_write"
   | "session_start"
@@ -1067,6 +1068,7 @@ export const PLUGIN_HOOK_NAMES = [
   "message_sent",
   "before_tool_call",
   "after_tool_call",
+  "before_tool_surface",
   "tool_result_persist",
   "before_message_write",
   "session_start",
@@ -1371,6 +1373,17 @@ export type PluginHookAfterToolCallEvent = {
   durationMs?: number;
 };
 
+// before_tool_surface hook
+export type PluginHookBeforeToolSurfaceEvent = {
+  /** Tool definitions about to be sent to the LLM. */
+  tools: Array<{ name: string; description: string; parameters: unknown }>;
+};
+
+export type PluginHookBeforeToolSurfaceResult = {
+  /** Replacement tool list. If set, overrides the original tools array. */
+  tools?: Array<{ name: string; description: string; parameters: unknown }>;
+};
+
 // tool_result_persist hook
 export type PluginHookToolResultPersistContext = {
   agentId?: string;
@@ -1581,6 +1594,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookAfterToolCallEvent,
     ctx: PluginHookToolContext,
   ) => Promise<void> | void;
+  before_tool_surface: (
+    event: PluginHookBeforeToolSurfaceEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeToolSurfaceResult | void> | PluginHookBeforeToolSurfaceResult | void;
   tool_result_persist: (
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,


### PR DESCRIPTION
## Summary

Adds a `lazy-tools` plugin that dynamically filters which tools are surfaced to the LLM based on session context, significantly reducing prompt token usage without breaking functionality.

### How it works

Three-layer architecture:

1. **`before_tool_surface`** — Filters tool schemas before they reach the LLM. Tools not relevant to the current session type (e.g. messaging tools during a heartbeat) are removed from the schema list.

2. **`before_tool_call`** — Blocks calls to tools that weren't surfaced (acts as a safety net). Guides the LLM to use `load_toolkit` to load the needed toolkit first.

3. **`before_prompt_build`** — Injects instructions into the system prompt telling the LLM how to request tools via `load_toolkit` when it needs something not currently surfaced.

### Results (1 day of production data)

| Metric | Value |
|--------|-------|
| Surface events | 82 |
| Avg tokens saved per turn | ~5,200 |
| **Total tokens saved (1 day)** | **~427,000 tokens** |
| Eviction events | 0 |

Tested on: direct API mode and proxy mode. Multiple agent types (main, cron, sub-agents).

### Changes

- `src/plugin-sdk/`: export `before_tool_surface` hook types
- `extensions/lazy-tools/`: new plugin (hook implementations + `load_toolkit` meta-tool)
- `src/plugins/`: wire `before_tool_surface` hook runner into stream
- `src/tools/`: add `before_tool_call` intercept in `streamFn` wrapper

## Test plan

- [ ] `npm run test` passes
- [ ] TypeScript compiles without errors (`npm run build`)
- [ ] Verify `load_toolkit` meta-tool loads correct tool schemas
- [ ] Verify `before_tool_call` blocks unloaded tools with helpful error
- [ ] Verify no regression in normal (non-lazy) sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)