### PR TITLE
fix(gateway): respect models.mode "replace" in dashboard model dropdown

### DIFF
--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -25,12 +25,36 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
+
+      // When models.mode is "replace", restrict the catalog to only models
+      // from explicitly configured providers (cfg.models.providers).  This
+      // mirrors the CLI behavior and prevents the dashboard dropdown from
+      // showing all 600+ built-in models.  (#48483)
+      const effectiveCatalog = (() => {
+        if (cfg.models?.mode !== "replace") {
+          return catalog;
+        }
+        const configuredProviders = cfg.models?.providers;
+        if (!configuredProviders || typeof configuredProviders !== "object") {
+          return catalog;
+        }
+        const providerKeys = new Set(
+          Object.keys(configuredProviders).map((p) => p.toLowerCase().trim()),
+        );
+        if (providerKeys.size === 0) {
+          return catalog;
+        }
+        return catalog.filter((entry) =>
+          providerKeys.has(entry.provider.toLowerCase().trim()),
+        );
+      })();
+
       const { allowedCatalog } = buildAllowedModelSet({
         cfg,
-        catalog,
+        catalog: effectiveCatalog,
         defaultProvider: DEFAULT_PROVIDER,
       });
-      const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      const models = allowedCatalog.length > 0 ? allowedCatalog : effectiveCatalog;
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));


### PR DESCRIPTION
## Summary

When `models.mode` is set to `"replace"` in `openclaw.json`, the CLI correctly shows only the configured providers' models. However, the Control UI (dashboard) model dropdown still shows all ~600+ built-in models from every provider, making it unusable for users with local-only setups.

## Changes

- Filter the gateway model catalog in the `models.list` WS handler when `models.mode === "replace"`
- Only models from providers listed in `cfg.models.providers` are included
- The filtered catalog is used both as input to `buildAllowedModelSet` and as the fallback
- This makes the dashboard dropdown match the CLI behavior

## Testing

Before: Dashboard model dropdown shows ~600+ models from all built-in providers
After: Dashboard model dropdown shows only models from configured providers (e.g., 2 local models)

Tested with:
```json
{
  "models": {
    "mode": "replace",
    "providers": {
      "bat00": { "api": "ollama", "baseUrl": "http://bat00.local:11434", ... },
      "isaac": { "api": "openai-responses", "baseUrl": "http://isaac.local:11437", ... }
    }
  }
}
```

CLI shows 2 models. Dashboard now also shows only these 2 models + "Default" option.

Fixes #48483
Related: #4349 (TUI model picker — same issue, different surface)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)