### PR TITLE
Fix launcher startup regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,12 @@ jobs:
       - name: Build dist
         run: pnpm build
 
+      - name: Smoke test CLI launcher help
+        run: node openclaw.mjs --help
+
+      - name: Smoke test CLI launcher status json
+        run: node openclaw.mjs status --json --timeout 1
+
       - name: Check CLI startup memory
         run: pnpm test:startup:memory
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,18 +455,23 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
-        env:
-          CI_EVENT_NAME: ${{ github.event_name }}
-          CI_PUSH_BASE_SHA: ${{ github.event.before || '' }}
-          CI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "$CI_EVENT_NAME" = "push" ]; then
-            BASE="$CI_PUSH_BASE_SHA"
-          else
-            BASE="$CI_PR_BASE_SHA"
-          fi
+          BASE="$(
+            python - <<'PY'
+            import json
+            import os
+
+            with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as fh:
+                event = json.load(fh)
+
+            if os.environ["GITHUB_EVENT_NAME"] == "push":
+                print(event["before"])
+            else:
+                print(event["pull_request"]["base"]["sha"])
+            PY
+          )"
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
           if [ "${#workflow_files[@]}" -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,13 +455,17 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_PUSH_BASE_SHA: ${{ github.event.before || '' }}
+          CI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$CI_EVENT_NAME" = "push" ]; then
+            BASE="$CI_PUSH_BASE_SHA"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$CI_PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -62,6 +62,32 @@ const cases = [
   },
 ];
 
+function formatFixGuidance(testCase, details) {
+  const command = `node ${testCase.args.join(" ")}`;
+  const guidance = [
+    "[startup-memory] Fix guidance",
+    `Case: ${testCase.label}`,
+    `Command: ${command}`,
+    "Next steps:",
+    `1. Run \`${command}\` locally on the built tree.`,
+    "2. If this is an RSS overage, compare the startup import graph against the last passing commit and look for newly eager imports, bootstrap side effects, or plugin loading on the command path.",
+    "3. If this is a non-zero exit, inspect the first transitive import/config error in stderr and fix that root cause before re-checking memory.",
+    "LLM prompt:",
+    `"OpenClaw startup-memory CI failed for '${testCase.label}'. Analyze this failure, identify the first runtime/import side effect that makes startup heavier or broken, and propose the smallest safe patch. Failure output:\n${details}"`,
+  ];
+  return `${guidance.join("\n")}\n`;
+}
+
+function formatFailure(testCase, message, details = "") {
+  const trimmedDetails = details.trim();
+  const sections = [message];
+  if (trimmedDetails) {
+    sections.push(trimmedDetails);
+  }
+  sections.push(formatFixGuidance(testCase, trimmedDetails || message));
+  return sections.join("\n\n");
+}
+
 function parseMaxRssMb(stderr) {
   const matches = [...stderr.matchAll(new RegExp(`^${MAX_RSS_MARKER}(\\d+)\\s*$`, "gm"))];
   const lastMatch = matches.at(-1);
@@ -120,18 +146,27 @@ function runCase(testCase) {
 
   if (result.status !== 0) {
     throw new Error(
-      `${testCase.label} exited with ${String(result.status)}\n${stderr.trim() || result.stdout || ""}`,
+      formatFailure(
+        testCase,
+        `${testCase.label} exited with ${String(result.status)}`,
+        stderr.trim() || result.stdout || "",
+      ),
     );
   }
   if (maxRssMb == null) {
-    throw new Error(`${testCase.label} did not report max RSS\n${stderr.trim()}`);
+    throw new Error(formatFailure(testCase, `${testCase.label} did not report max RSS`, stderr));
   }
   if (matrixBootstrapWarning) {
-    throw new Error(`${testCase.label} triggered Matrix crypto bootstrap during startup`);
+    throw new Error(
+      formatFailure(testCase, `${testCase.label} triggered Matrix crypto bootstrap during startup`),
+    );
   }
   if (maxRssMb > testCase.limitMb) {
     throw new Error(
-      `${testCase.label} used ${maxRssMb.toFixed(1)} MB RSS (limit ${testCase.limitMb} MB)`,
+      formatFailure(
+        testCase,
+        `${testCase.label} used ${maxRssMb.toFixed(1)} MB RSS (limit ${testCase.limitMb} MB)`,
+      ),
     );
   }
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -43,7 +43,7 @@ if (
 } else {
   const { installGaxiosFetchCompat } = await import("./infra/gaxios-fetch-compat.js");
 
-  installGaxiosFetchCompat();
+  await installGaxiosFetchCompat();
   process.title = "openclaw";
   ensureOpenClawExecMarkerOnProcess();
   installProcessWarningFilter();

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export async function runLegacyCliEntry(argv: string[] = process.argv): Promise<
     import("./cli/run-main.js"),
   ]);
 
-  installGaxiosFetchCompat();
+  await installGaxiosFetchCompat();
   await runCli(argv);
 }
 

--- a/src/infra/gaxios-fetch-compat.test.ts
+++ b/src/infra/gaxios-fetch-compat.test.ts
@@ -2,8 +2,11 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import { ProxyAgent } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const TEST_GAXIOS_CONSTRUCTOR_OVERRIDE = "__OPENCLAW_TEST_GAXIOS_CONSTRUCTOR__";
+
 describe("gaxios fetch compat", () => {
   afterEach(() => {
+    Reflect.deleteProperty(globalThis as object, TEST_GAXIOS_CONSTRUCTOR_OVERRIDE);
     vi.resetModules();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -26,30 +29,24 @@ describe("gaxios fetch compat", () => {
     });
 
     vi.stubGlobal("fetch", fetchMock);
-    vi.doMock("node-fetch", () => {
-      throw new Error("node-fetch should not load");
-    });
-    vi.doMock("gaxios", () => {
-      class MockGaxios {
-        _defaultAdapter!: (config: MockRequestConfig) => Promise<Response>;
+    class MockGaxios {
+      _defaultAdapter!: (config: MockRequestConfig) => Promise<Response>;
 
-        async request(config: MockRequestConfig) {
-          const response = await this._defaultAdapter(config);
-          return {
-            ...(response as object),
-            data: await response.text(),
-          };
-        }
+      async request(config: MockRequestConfig) {
+        const response = await this._defaultAdapter(config);
+        return {
+          ...(response as object),
+          data: await response.text(),
+        };
       }
-      MockGaxiosCtor = MockGaxios;
+    }
+    MockGaxiosCtor = MockGaxios;
 
-      MockGaxios.prototype._defaultAdapter = async (config: MockRequestConfig) => {
-        const fetchImplementation = config.fetchImplementation ?? fetch;
-        return await fetchImplementation(config.url, config);
-      };
-
-      return { Gaxios: MockGaxios };
-    });
+    MockGaxios.prototype._defaultAdapter = async (config: MockRequestConfig) => {
+      const fetchImplementation = config.fetchImplementation ?? fetch;
+      return await fetchImplementation(config.url, config);
+    };
+    (globalThis as Record<string, unknown>)[TEST_GAXIOS_CONSTRUCTOR_OVERRIDE] = MockGaxios;
 
     const { installGaxiosFetchCompat } = await import("./gaxios-fetch-compat.js");
 
@@ -67,14 +64,9 @@ describe("gaxios fetch compat", () => {
 
   it("falls back to a legacy window fetch shim when gaxios is unavailable", async () => {
     const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>());
     Reflect.deleteProperty(globalThis as object, "window");
-    vi.doMock("gaxios", () => ({
-      get Gaxios() {
-        throw Object.assign(new Error("Cannot find package 'gaxios'"), {
-          code: "ERR_MODULE_NOT_FOUND",
-        });
-      },
-    }));
+    (globalThis as Record<string, unknown>)[TEST_GAXIOS_CONSTRUCTOR_OVERRIDE] = null;
     const { installGaxiosFetchCompat } = await import("./gaxios-fetch-compat.js");
 
     try {

--- a/src/infra/gaxios-fetch-compat.test.ts
+++ b/src/infra/gaxios-fetch-compat.test.ts
@@ -10,6 +10,14 @@ describe("gaxios fetch compat", () => {
   });
 
   it("uses native fetch without defining window or importing node-fetch", async () => {
+    type MockRequestConfig = RequestInit & {
+      fetchImplementation?: typeof fetch;
+      responseType?: string;
+      url: string;
+    };
+    let MockGaxiosCtor!: new () => {
+      request(config: MockRequestConfig): Promise<{ data: string } & object>;
+    };
     const fetchMock = vi.fn<typeof fetch>(async () => {
       return new Response("ok", {
         headers: { "content-type": "text/plain" },
@@ -23,18 +31,19 @@ describe("gaxios fetch compat", () => {
     });
     vi.doMock("gaxios", () => {
       class MockGaxios {
-        async request(config: RequestInit & { responseType?: string; url: string }) {
-          const response = await MockGaxios.prototype._defaultAdapter.call(this, config);
+        _defaultAdapter!: (config: MockRequestConfig) => Promise<Response>;
+
+        async request(config: MockRequestConfig) {
+          const response = await this._defaultAdapter(config);
           return {
             ...(response as object),
-            data: await (response as Response).text(),
+            data: await response.text(),
           };
         }
       }
+      MockGaxiosCtor = MockGaxios;
 
-      MockGaxios.prototype._defaultAdapter = async (
-        config: RequestInit & { fetchImplementation?: typeof fetch; url: string },
-      ) => {
+      MockGaxios.prototype._defaultAdapter = async (config: MockRequestConfig) => {
         const fetchImplementation = config.fetchImplementation ?? fetch;
         return await fetchImplementation(config.url, config);
       };
@@ -43,11 +52,10 @@ describe("gaxios fetch compat", () => {
     });
 
     const { installGaxiosFetchCompat } = await import("./gaxios-fetch-compat.js");
-    const { Gaxios } = await import("gaxios");
 
     await installGaxiosFetchCompat();
 
-    const res = await new Gaxios().request({
+    const res = await new MockGaxiosCtor().request({
       responseType: "text",
       url: "https://example.com",
     });

--- a/src/infra/gaxios-fetch-compat.test.ts
+++ b/src/infra/gaxios-fetch-compat.test.ts
@@ -21,11 +21,31 @@ describe("gaxios fetch compat", () => {
     vi.doMock("node-fetch", () => {
       throw new Error("node-fetch should not load");
     });
+    vi.doMock("gaxios", () => {
+      class MockGaxios {
+        async request(config: RequestInit & { responseType?: string; url: string }) {
+          const response = await MockGaxios.prototype._defaultAdapter.call(this, config);
+          return {
+            ...(response as object),
+            data: await (response as Response).text(),
+          };
+        }
+      }
+
+      MockGaxios.prototype._defaultAdapter = async (
+        config: RequestInit & { fetchImplementation?: typeof fetch; url: string },
+      ) => {
+        const fetchImplementation = config.fetchImplementation ?? fetch;
+        return await fetchImplementation(config.url, config);
+      };
+
+      return { Gaxios: MockGaxios };
+    });
 
     const { installGaxiosFetchCompat } = await import("./gaxios-fetch-compat.js");
     const { Gaxios } = await import("gaxios");
 
-    installGaxiosFetchCompat();
+    await installGaxiosFetchCompat();
 
     const res = await new Gaxios().request({
       responseType: "text",
@@ -35,6 +55,30 @@ describe("gaxios fetch compat", () => {
     expect(res.data).toBe("ok");
     expect(fetchMock).toHaveBeenCalledOnce();
     expect("window" in globalThis).toBe(false);
+  });
+
+  it("falls back to a legacy window fetch shim when gaxios is unavailable", async () => {
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Reflect.deleteProperty(globalThis as object, "window");
+    vi.doMock("gaxios", () => ({
+      get Gaxios() {
+        throw Object.assign(new Error("Cannot find package 'gaxios'"), {
+          code: "ERR_MODULE_NOT_FOUND",
+        });
+      },
+    }));
+    const { installGaxiosFetchCompat } = await import("./gaxios-fetch-compat.js");
+
+    try {
+      await expect(installGaxiosFetchCompat()).resolves.toBeUndefined();
+      expect((globalThis as { window?: { fetch?: typeof fetch } }).window?.fetch).toBe(fetch);
+      await expect(installGaxiosFetchCompat()).resolves.toBeUndefined();
+    } finally {
+      Reflect.deleteProperty(globalThis as object, "window");
+      if (originalWindowDescriptor) {
+        Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+      }
+    }
   });
 
   it("translates proxy agents into undici dispatchers for native fetch", async () => {

--- a/src/infra/gaxios-fetch-compat.ts
+++ b/src/infra/gaxios-fetch-compat.ts
@@ -200,7 +200,11 @@ function isDirectGaxiosImportMiss(err: unknown): boolean {
   if (!isModuleNotFoundError(err)) {
     return false;
   }
-  return typeof err.message === "string" && err.message.includes("Cannot find package 'gaxios'");
+  return (
+    typeof err.message === "string" &&
+    (err.message.includes("Cannot find package 'gaxios'") ||
+      err.message.includes("Cannot find module 'gaxios'"))
+  );
 }
 
 async function loadGaxiosConstructor(): Promise<GaxiosConstructor | null> {

--- a/src/infra/gaxios-fetch-compat.ts
+++ b/src/infra/gaxios-fetch-compat.ts
@@ -35,7 +35,9 @@ type GaxiosConstructor = {
   prototype: GaxiosPrototype;
 };
 
-let installState: "not-installed" | "shimmed" | "installed" = "not-installed";
+const TEST_GAXIOS_CONSTRUCTOR_OVERRIDE = "__OPENCLAW_TEST_GAXIOS_CONSTRUCTOR__";
+
+let installState: "not-installed" | "installing" | "shimmed" | "installed" = "not-installed";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -179,6 +181,21 @@ function hasGaxiosConstructorShape(value: unknown): value is GaxiosConstructor {
   );
 }
 
+function getTestGaxiosConstructorOverride(): GaxiosConstructor | null | undefined {
+  const testGlobal = globalThis as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(testGlobal, TEST_GAXIOS_CONSTRUCTOR_OVERRIDE)) {
+    return undefined;
+  }
+  const override = testGlobal[TEST_GAXIOS_CONSTRUCTOR_OVERRIDE];
+  if (override === null) {
+    return null;
+  }
+  if (hasGaxiosConstructorShape(override)) {
+    return override;
+  }
+  throw new Error("invalid gaxios test constructor override");
+}
+
 function isDirectGaxiosImportMiss(err: unknown): boolean {
   if (!isModuleNotFoundError(err)) {
     return false;
@@ -187,6 +204,11 @@ function isDirectGaxiosImportMiss(err: unknown): boolean {
 }
 
 async function loadGaxiosConstructor(): Promise<GaxiosConstructor | null> {
+  const testOverride = getTestGaxiosConstructorOverride();
+  if (testOverride !== undefined) {
+    return testOverride;
+  }
+
   try {
     const require = createRequire(import.meta.url);
     const resolvedPath = require.resolve("gaxios");
@@ -244,29 +266,36 @@ export async function installGaxiosFetchCompat(): Promise<void> {
     return;
   }
 
-  const Gaxios = await loadGaxiosConstructor();
-  if (!Gaxios) {
-    installLegacyWindowFetchShim();
-    installState = "shimmed";
-    return;
-  }
+  installState = "installing";
 
-  const prototype = Gaxios.prototype;
-  const originalDefaultAdapter = prototype._defaultAdapter;
-  const compatFetch = createGaxiosCompatFetch();
-
-  prototype._defaultAdapter = function patchedDefaultAdapter(
-    this: unknown,
-    config: GaxiosFetchRequestInit,
-  ): Promise<unknown> {
-    if (config.fetchImplementation) {
-      return originalDefaultAdapter.call(this, config);
+  try {
+    const Gaxios = await loadGaxiosConstructor();
+    if (!Gaxios) {
+      installLegacyWindowFetchShim();
+      installState = "shimmed";
+      return;
     }
-    return originalDefaultAdapter.call(this, {
-      ...config,
-      fetchImplementation: compatFetch,
-    });
-  };
 
-  installState = "installed";
+    const prototype = Gaxios.prototype;
+    const originalDefaultAdapter = prototype._defaultAdapter;
+    const compatFetch = createGaxiosCompatFetch();
+
+    prototype._defaultAdapter = function patchedDefaultAdapter(
+      this: unknown,
+      config: GaxiosFetchRequestInit,
+    ): Promise<unknown> {
+      if (config.fetchImplementation) {
+        return originalDefaultAdapter.call(this, config);
+      }
+      return originalDefaultAdapter.call(this, {
+        ...config,
+        fetchImplementation: compatFetch,
+      });
+    };
+
+    installState = "installed";
+  } catch (err) {
+    installState = "not-installed";
+    throw err;
+  }
 }

--- a/src/infra/gaxios-fetch-compat.ts
+++ b/src/infra/gaxios-fetch-compat.ts
@@ -1,4 +1,6 @@
+import { createRequire } from "node:module";
 import type { ConnectionOptions } from "node:tls";
+import { pathToFileURL } from "node:url";
 import type { Dispatcher } from "undici";
 import { Agent as UndiciAgent, ProxyAgent } from "undici";
 
@@ -165,8 +167,15 @@ function buildDispatcher(init: GaxiosFetchRequestInit, url: URL): Dispatcher | u
 }
 
 function isModuleNotFoundError(err: unknown): err is NodeJS.ErrnoException {
+  return isRecord(err) && (err.code === "ERR_MODULE_NOT_FOUND" || err.code === "MODULE_NOT_FOUND");
+}
+
+function hasGaxiosConstructorShape(value: unknown): value is GaxiosConstructor {
   return (
-    Boolean(err) && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND"
+    typeof value === "function" &&
+    "prototype" in value &&
+    isRecord(value.prototype) &&
+    typeof value.prototype._defaultAdapter === "function"
   );
 }
 
@@ -179,12 +188,14 @@ function isDirectGaxiosImportMiss(err: unknown): boolean {
 
 async function loadGaxiosConstructor(): Promise<GaxiosConstructor | null> {
   try {
-    const mod = await import("gaxios");
-    const candidate = mod.Gaxios;
-    if (typeof candidate !== "function" || !("prototype" in candidate)) {
+    const require = createRequire(import.meta.url);
+    const resolvedPath = require.resolve("gaxios");
+    const mod = await import(pathToFileURL(resolvedPath).href);
+    const candidate = isRecord(mod) ? mod.Gaxios : undefined;
+    if (!hasGaxiosConstructorShape(candidate)) {
       throw new Error("gaxios: missing Gaxios export");
     }
-    return candidate as GaxiosConstructor;
+    return candidate;
   } catch (err) {
     if (isDirectGaxiosImportMiss(err)) {
       return null;
@@ -245,7 +256,7 @@ export async function installGaxiosFetchCompat(): Promise<void> {
   const compatFetch = createGaxiosCompatFetch();
 
   prototype._defaultAdapter = function patchedDefaultAdapter(
-    this: Gaxios,
+    this: unknown,
     config: GaxiosFetchRequestInit,
   ): Promise<unknown> {
     if (config.fetchImplementation) {

--- a/src/infra/gaxios-fetch-compat.ts
+++ b/src/infra/gaxios-fetch-compat.ts
@@ -1,5 +1,4 @@
 import type { ConnectionOptions } from "node:tls";
-import { Gaxios } from "gaxios";
 import type { Dispatcher } from "undici";
 import { Agent as UndiciAgent, ProxyAgent } from "undici";
 
@@ -27,10 +26,14 @@ type TlsAgentLike = {
 };
 
 type GaxiosPrototype = {
-  _defaultAdapter: (this: Gaxios, config: GaxiosFetchRequestInit) => Promise<unknown>;
+  _defaultAdapter: (this: unknown, config: GaxiosFetchRequestInit) => Promise<unknown>;
 };
 
-let installState: "not-installed" | "installed" = "not-installed";
+type GaxiosConstructor = {
+  prototype: GaxiosPrototype;
+};
+
+let installState: "not-installed" | "shimmed" | "installed" = "not-installed";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -161,6 +164,45 @@ function buildDispatcher(init: GaxiosFetchRequestInit, url: URL): Dispatcher | u
   return undefined;
 }
 
+function isModuleNotFoundError(err: unknown): err is NodeJS.ErrnoException {
+  return (
+    Boolean(err) && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND"
+  );
+}
+
+function isDirectGaxiosImportMiss(err: unknown): boolean {
+  if (!isModuleNotFoundError(err)) {
+    return false;
+  }
+  return typeof err.message === "string" && err.message.includes("Cannot find package 'gaxios'");
+}
+
+async function loadGaxiosConstructor(): Promise<GaxiosConstructor | null> {
+  try {
+    const mod = await import("gaxios");
+    const candidate = mod.Gaxios;
+    if (typeof candidate !== "function" || !("prototype" in candidate)) {
+      throw new Error("gaxios: missing Gaxios export");
+    }
+    return candidate as GaxiosConstructor;
+  } catch (err) {
+    if (isDirectGaxiosImportMiss(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function installLegacyWindowFetchShim(): void {
+  if (
+    typeof globalThis.fetch !== "function" ||
+    typeof (globalThis as Record<string, unknown>).window !== "undefined"
+  ) {
+    return;
+  }
+  (globalThis as Record<string, unknown>).window = { fetch: globalThis.fetch };
+}
+
 export function createGaxiosCompatFetch(baseFetch: typeof fetch = globalThis.fetch): typeof fetch {
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const gaxiosInit = (init ?? {}) as GaxiosFetchRequestInit;
@@ -186,12 +228,19 @@ export function createGaxiosCompatFetch(baseFetch: typeof fetch = globalThis.fet
   };
 }
 
-export function installGaxiosFetchCompat(): void {
-  if (installState === "installed" || typeof globalThis.fetch !== "function") {
+export async function installGaxiosFetchCompat(): Promise<void> {
+  if (installState !== "not-installed" || typeof globalThis.fetch !== "function") {
     return;
   }
 
-  const prototype = Gaxios.prototype as unknown as GaxiosPrototype;
+  const Gaxios = await loadGaxiosConstructor();
+  if (!Gaxios) {
+    installLegacyWindowFetchShim();
+    installState = "shimmed";
+    return;
+  }
+
+  const prototype = Gaxios.prototype;
   const originalDefaultAdapter = prototype._defaultAdapter;
   const compatFetch = createGaxiosCompatFetch();
 

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+async function makeLauncherFixture(): Promise<string> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launcher-"));
+  await fs.copyFile(
+    path.resolve(process.cwd(), "openclaw.mjs"),
+    path.join(fixtureRoot, "openclaw.mjs"),
+  );
+  await fs.mkdir(path.join(fixtureRoot, "dist"), { recursive: true });
+  return fixtureRoot;
+}
+
+describe("openclaw launcher", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      fixtureRoots.splice(0).map(async (fixtureRoot) => {
+        await fs.rm(fixtureRoot, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  it("surfaces transitive entry import failures instead of masking them as missing dist", async () => {
+    const fixtureRoot = await makeLauncherFixture();
+    fixtureRoots.push(fixtureRoot);
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "entry.js"),
+      'import "missing-openclaw-launcher-dep";\nexport {};\n',
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs"), "--help"], {
+      cwd: fixtureRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("missing-openclaw-launcher-dep");
+    expect(result.stderr).not.toContain("missing dist/entry.(m)js");
+  });
+
+  it("keeps the friendly launcher error for a truly missing entry build output", async () => {
+    const fixtureRoot = await makeLauncherFixture();
+    fixtureRoots.push(fixtureRoot);
+
+    const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs"), "--help"], {
+      cwd: fixtureRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("missing dist/entry.(m)js");
+  });
+});

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -4,8 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-async function makeLauncherFixture(): Promise<string> {
+async function makeLauncherFixture(fixtureRoots: string[]): Promise<string> {
   const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launcher-"));
+  fixtureRoots.push(fixtureRoot);
   await fs.copyFile(
     path.resolve(process.cwd(), "openclaw.mjs"),
     path.join(fixtureRoot, "openclaw.mjs"),
@@ -26,8 +27,7 @@ describe("openclaw launcher", () => {
   });
 
   it("surfaces transitive entry import failures instead of masking them as missing dist", async () => {
-    const fixtureRoot = await makeLauncherFixture();
-    fixtureRoots.push(fixtureRoot);
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "entry.js"),
       'import "missing-openclaw-launcher-dep";\nexport {};\n',
@@ -45,8 +45,7 @@ describe("openclaw launcher", () => {
   });
 
   it("keeps the friendly launcher error for a truly missing entry build output", async () => {
-    const fixtureRoot = await makeLauncherFixture();
-    fixtureRoots.push(fixtureRoot);
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
 
     const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs"), "--help"], {
       cwd: fixtureRoot,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw.mjs` startup could fail after build when a transitive import was missing, and the launcher incorrectly reported that `dist/entry.(m)js` was missing.
- Why it matters: this broke the `startup-memory` CI lane at the launcher boundary and hid the real root cause from developers.
- What changed: made gaxios compat lazy/optional with a safe fallback, hardened the launcher to preserve transitive import errors, added launcher smoke coverage in CI, and added startup-memory failure guidance with an LLM-ready prompt.
- What did NOT change (scope boundary): this PR does not change the separate startup RSS budget or reduce command memory usage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `node openclaw.mjs --help` now surfaces real transitive import failures instead of always collapsing them into a generic missing-build-output error.
- `startup-memory` CI failures now print a short local repro path and an LLM-ready prompt.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.14.0 for build/help verification; local shell for targeted tests
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local config; one unrelated stale plugin warning observed during `status --json`

### Steps

1. `pnpm build`
2. `node openclaw.mjs --help`
3. `pnpm test:startup:memory`

### Expected

- Built launcher commands succeed.
- Missing transitive imports surface the real error.
- `startup-memory` failures emit actionable guidance.

### Actual

- Verified locally after the patch: launcher smoke commands succeed and `startup-memory` passes on this branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/infra/gaxios-fetch-compat.test.ts test/openclaw-launcher.e2e.test.ts src/index.test.ts`, `pnpm build`, `node openclaw.mjs --help`, `node openclaw.mjs status --json --timeout 1`, and `pnpm test:startup:memory`.
- Edge cases checked: missing direct `gaxios` resolution falls back to the legacy fetch shim; launcher preserves transitive `ERR_MODULE_NOT_FOUND`; true missing build output still reports the friendly launcher message.
- What you did **not** verify: full GitHub Actions execution on Linux runners.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `aa8180156c`.
- Files/config to restore: `openclaw.mjs`, `src/entry.ts`, `src/index.ts`, `src/infra/gaxios-fetch-compat.ts`, `.github/workflows/ci.yml`, `scripts/check-cli-startup-memory.mjs`.
- Known bad symptoms reviewers should watch for: `openclaw.mjs --help` failing after build, generic missing-dist errors masking transitive import failures, or startup-memory failures without remediation guidance.

## Risks and Mitigations

- Risk: the fallback compat path could diverge from the directly patched `gaxios` path in nested dependency layouts.
  - Mitigation: targeted compat tests now cover both direct patching and fallback shim behavior.
