### PR TITLE
fix(apps): add /etc/paths and /etc/paths.d/ ingestion to both the T...

### DIFF
--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -94,9 +94,54 @@ enum CommandResolver {
             extras.insert(contentsOf: openclawPaths, at: 1)
         }
         extras.insert(contentsOf: self.nodeManagerBinPaths(home: home), at: 1 + openclawPaths.count)
+
+        // Ingest /etc/paths and /etc/paths.d/* so GUI apps see the same directories
+        // that path_helper(8) would provide in a login shell.
+        extras.append(contentsOf: self.readEtcPaths())
+
         var seen = Set<String>()
         // Preserve order while stripping duplicates so PATH lookups remain deterministic.
         return (extras + current).filter { seen.insert($0).inserted }
+    }
+
+    /// Read directories listed in /etc/paths and /etc/paths.d/* — the same files
+    /// that path_helper(8) reads for login shells. GUI apps and launchd services
+    /// never invoke path_helper, so we read them directly.
+    static func readEtcPaths(
+        etcPaths: String = "/etc/paths",
+        etcPathsD: String = "/etc/paths.d"
+    ) -> [String] {
+        var dirs: [String] = []
+
+        // /etc/paths: one directory per line.
+        if let content = try? String(contentsOfFile: etcPaths, encoding: .utf8) {
+            for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if !trimmed.isEmpty, !trimmed.hasPrefix("#") {
+                    dirs.append(trimmed)
+                }
+            }
+        }
+
+        // /etc/paths.d/*: each file contains one directory per line.
+        if let entries = try? FileManager().contentsOfDirectory(atPath: etcPathsD) {
+            for entry in entries.sorted() {
+                let filePath = (etcPathsD as NSString).appendingPathComponent(entry)
+                guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else {
+                    continue
+                }
+                for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    if !trimmed.isEmpty, !trimmed.hasPrefix("#") {
+                        dirs.append(trimmed)
+                    }
+                }
+            }
+        }
+
+        // Deduplicate while preserving order.
+        var seen = Set<String>()
+        return dirs.filter { seen.insert($0).inserted }
     }
 
     private static func openclawManagedPaths(home: URL) -> [String] {

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -80,10 +80,6 @@ enum CommandResolver {
     static func preferredPaths(home: URL, current: [String], projectRoot: URL) -> [String] {
         var extras = [
             home.appendingPathComponent("Library/pnpm").path,
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin",
         ]
         #if DEBUG
         // Dev-only convenience. Avoid project-local PATH hijacking in release builds.
@@ -97,7 +93,17 @@ enum CommandResolver {
 
         // Ingest /etc/paths and /etc/paths.d/* so GUI apps see the same directories
         // that path_helper(8) would provide in a login shell.
+        // These come before hardcoded fallbacks to match path_helper(8) precedence:
+        // /etc/paths entries first, then /etc/paths.d/*, then our fallback defaults.
         extras.append(contentsOf: self.readEtcPaths())
+
+        // Hardcoded fallbacks after /etc/paths so admin-configured paths take precedence.
+        extras.append(contentsOf: [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ])
 
         var seen = Set<String>()
         // Preserve order while stripping duplicates so PATH lookups remain deterministic.

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -198,4 +198,128 @@ import Testing
             #expect(cmd[1] == "daemon")
         }
     }
+
+    // MARK: - readEtcPaths tests
+
+    @Test func `reads etc paths file`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "/usr/local/bin\n/usr/bin\n/bin\n/usr/sbin\n/sbin\n"
+            .write(to: etcPaths, atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"])
+    }
+
+    @Test func `reads etc paths d files`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "/usr/bin\n/bin\n".write(to: etcPaths, atomically: true, encoding: .utf8)
+        try "/opt/homebrew/bin\n/opt/homebrew/sbin\n"
+            .write(to: etcPathsD.appendingPathComponent("Homebrew"), atomically: true, encoding: .utf8)
+        try "/Library/TeX/texbin\n"
+            .write(to: etcPathsD.appendingPathComponent("TeX"), atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == [
+            "/usr/bin", "/bin",
+            "/opt/homebrew/bin", "/opt/homebrew/sbin",
+            "/Library/TeX/texbin",
+        ])
+    }
+
+    @Test func `deduplicates etc paths entries`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "/usr/local/bin\n/usr/bin\n".write(to: etcPaths, atomically: true, encoding: .utf8)
+        try "/opt/homebrew/bin\n/usr/local/bin\n"
+            .write(to: etcPathsD.appendingPathComponent("Homebrew"), atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/usr/local/bin", "/usr/bin", "/opt/homebrew/bin"])
+    }
+
+    @Test func `skips blank and comment lines in etc paths`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "# system paths\n/usr/bin\n\n  \n/bin\n# trailing\n"
+            .write(to: etcPaths, atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/usr/bin", "/bin"])
+    }
+
+    @Test func `handles missing etc paths gracefully`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("nonexistent-paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "/opt/custom/bin\n"
+            .write(to: etcPathsD.appendingPathComponent("custom"), atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/opt/custom/bin"])
+    }
+
+    @Test func `handles missing etc paths d gracefully`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("nonexistent-paths-d")
+
+        try "/usr/bin\n".write(to: etcPaths, atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/usr/bin"])
+    }
+
+    @Test func `handles both etc paths and etc paths d missing`() throws {
+        let tmp = try makeTempDirForTests()
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: tmp.appendingPathComponent("nope").path,
+            etcPathsD: tmp.appendingPathComponent("also-nope").path)
+        #expect(result.isEmpty)
+    }
+
+    @Test func `etc paths d entries read in sorted order`() throws {
+        let tmp = try makeTempDirForTests()
+        let etcPaths = tmp.appendingPathComponent("paths")
+        let etcPathsD = tmp.appendingPathComponent("paths.d")
+        try FileManager().createDirectory(at: etcPathsD, withIntermediateDirectories: true)
+
+        try "".write(to: etcPaths, atomically: true, encoding: .utf8)
+        try "/opt/zebra/bin\n"
+            .write(to: etcPathsD.appendingPathComponent("zebra"), atomically: true, encoding: .utf8)
+        try "/opt/alpha/bin\n"
+            .write(to: etcPathsD.appendingPathComponent("alpha"), atomically: true, encoding: .utf8)
+
+        let result = CommandResolver.readEtcPaths(
+            etcPaths: etcPaths.path,
+            etcPathsD: etcPathsD.path)
+        #expect(result == ["/opt/alpha/bin", "/opt/zebra/bin"])
+    }
 }

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { readEtcPaths } from "../infra/path-env.js";
 import { VERSION } from "../version.js";
 import {
   GATEWAY_SERVICE_KIND,
@@ -100,7 +101,13 @@ function addCommonEnvConfiguredBinDirs(
 
 function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
   if (platform === "darwin") {
-    return ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
+    // Ingest /etc/paths and /etc/paths.d/* so launchd services see the same
+    // directories that path_helper(8) would provide in a login shell.
+    const etcDirs = readEtcPaths(platform);
+    const hardcoded = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
+    // Deduplicate: hardcoded first, then any extras from /etc/paths{,.d/*}.
+    const seen = new Set(hardcoded);
+    return [...hardcoded, ...etcDirs.filter((d) => !seen.has(d))];
   }
   if (platform === "linux") {
     return ["/usr/local/bin", "/usr/bin", "/bin"];

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -105,9 +105,10 @@ function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
     // directories that path_helper(8) would provide in a login shell.
     const etcDirs = readEtcPaths(platform);
     const hardcoded = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
-    // Deduplicate: hardcoded first, then any extras from /etc/paths{,.d/*}.
-    const seen = new Set(hardcoded);
-    return [...hardcoded, ...etcDirs.filter((d) => !seen.has(d))];
+    // /etc/paths entries first to match path_helper(8) precedence, then
+    // hardcoded fallbacks for dirs not covered by /etc/paths.
+    const seen = new Set(etcDirs);
+    return [...etcDirs, ...hardcoded.filter((d) => !seen.has(d))];
   }
   if (platform === "linux") {
     return ["/usr/local/bin", "/usr/bin", "/bin"];

--- a/src/infra/etc-paths.test.ts
+++ b/src/infra/etc-paths.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  files: new Map<string, string>(),
+  dirEntries: new Map<string, string[]>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+
+  const wrapped = {
+    ...actual,
+    constants: { ...actual.constants, X_OK: actual.constants.X_OK ?? 1 },
+    readFileSync: (p: string, _encoding?: string) => {
+      const content = state.files.get(p);
+      if (content === undefined) {
+        const err = new Error(`ENOENT: no such file or directory, open '${p}'`);
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      return content;
+    },
+    readdirSync: (p: string) => {
+      const entries = state.dirEntries.get(p);
+      if (entries === undefined) {
+        const err = new Error(`ENOENT: no such file or directory, scandir '${p}'`);
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      return entries;
+    },
+    // Keep statSync/accessSync minimal — readEtcPaths doesn't use them.
+    statSync: () => ({ isDirectory: () => false }),
+    accessSync: () => {
+      throw new Error("EACCES");
+    },
+  };
+
+  return { ...wrapped, default: wrapped };
+});
+
+let readEtcPaths: typeof import("./path-env.js").readEtcPaths;
+
+beforeAll(async () => {
+  ({ readEtcPaths } = await import("./path-env.js"));
+});
+
+afterEach(() => {
+  state.files.clear();
+  state.dirEntries.clear();
+});
+
+describe("readEtcPaths", () => {
+  it("returns empty array on non-darwin platforms", () => {
+    expect(readEtcPaths("linux")).toEqual([]);
+    expect(readEtcPaths("win32")).toEqual([]);
+  });
+
+  it("reads /etc/paths on darwin", () => {
+    state.files.set("/etc/paths", "/usr/local/bin\n/usr/bin\n/bin\n/usr/sbin\n/sbin\n");
+    state.dirEntries.set("/etc/paths.d", []);
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+  });
+
+  it("reads /etc/paths.d/* files", () => {
+    state.files.set("/etc/paths", "/usr/bin\n/bin\n");
+    state.dirEntries.set("/etc/paths.d", ["Homebrew", "TeX"]);
+    state.files.set("/etc/paths.d/Homebrew", "/opt/homebrew/bin\n/opt/homebrew/sbin\n");
+    state.files.set("/etc/paths.d/TeX", "/Library/TeX/texbin\n");
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual([
+      "/usr/bin",
+      "/bin",
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/Library/TeX/texbin",
+    ]);
+  });
+
+  it("deduplicates entries across /etc/paths and /etc/paths.d", () => {
+    state.files.set("/etc/paths", "/usr/local/bin\n/usr/bin\n");
+    state.dirEntries.set("/etc/paths.d", ["Homebrew"]);
+    state.files.set("/etc/paths.d/Homebrew", "/opt/homebrew/bin\n/usr/local/bin\n");
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/opt/homebrew/bin"]);
+  });
+
+  it("skips blank lines and comment lines", () => {
+    state.files.set("/etc/paths", "# system paths\n/usr/bin\n\n  \n/bin\n# trailing\n");
+    state.dirEntries.set("/etc/paths.d", []);
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/usr/bin", "/bin"]);
+  });
+
+  it("handles missing /etc/paths gracefully", () => {
+    // /etc/paths not in state.files → throws ENOENT
+    state.dirEntries.set("/etc/paths.d", ["custom"]);
+    state.files.set("/etc/paths.d/custom", "/opt/custom/bin\n");
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/opt/custom/bin"]);
+  });
+
+  it("handles missing /etc/paths.d gracefully", () => {
+    state.files.set("/etc/paths", "/usr/bin\n");
+    // /etc/paths.d not in state.dirEntries → throws ENOENT
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/usr/bin"]);
+  });
+
+  it("handles both /etc/paths and /etc/paths.d missing", () => {
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual([]);
+  });
+
+  it("skips unreadable files in /etc/paths.d", () => {
+    state.files.set("/etc/paths", "/usr/bin\n");
+    state.dirEntries.set("/etc/paths.d", ["good", "bad"]);
+    state.files.set("/etc/paths.d/good", "/opt/good/bin\n");
+    // "bad" is listed in dirEntries but has no file content → throws ENOENT
+
+    const result = readEtcPaths("darwin");
+    expect(result).toEqual(["/usr/bin", "/opt/good/bin"]);
+  });
+
+  it("reads /etc/paths.d entries in sorted order", () => {
+    state.files.set("/etc/paths", "");
+    state.dirEntries.set("/etc/paths.d", ["zebra", "alpha"]);
+    state.files.set("/etc/paths.d/zebra", "/opt/zebra/bin\n");
+    state.files.set("/etc/paths.d/alpha", "/opt/alpha/bin\n");
+
+    const result = readEtcPaths("darwin");
+    // Sorted alphabetically: alpha before zebra
+    expect(result).toEqual(["/opt/alpha/bin", "/opt/zebra/bin"]);
+  });
+});

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -156,11 +156,13 @@ function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; ap
   prepend.push(path.join(homeDir, ".local", "share", "pnpm"));
   prepend.push(path.join(homeDir, ".bun", "bin"));
   prepend.push(path.join(homeDir, ".yarn", "bin"));
-  prepend.push("/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin");
-
   // Ingest /etc/paths and /etc/paths.d/* so launchd/GUI environments see the same
   // directories that path_helper(8) would provide in a login shell.
+  // These come before hardcoded fallbacks to match path_helper(8) precedence:
+  // /etc/paths entries first, then /etc/paths.d/*, then our fallback defaults.
   prepend.push(...readEtcPaths(platform));
+
+  prepend.push("/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin");
 
   return { prepend: prepend.filter(isDirectory), append: append.filter(isDirectory) };
 }

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -143,6 +143,14 @@ function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; ap
     prepend.push(miseShims);
   }
 
+  // Ingest /etc/paths and /etc/paths.d/* so launchd/GUI environments see the same
+  // directories that path_helper(8) would provide in a login shell.
+  // These come before brew dirs and hardcoded fallbacks to match path_helper(8)
+  // precedence: /etc/paths entries first, then /etc/paths.d/*, then brew, then
+  // our fallback defaults.  Placed here so the first-seen dedup preserves
+  // /etc/paths ordering over resolveBrewPathDirs duplicates.
+  prepend.push(...readEtcPaths(platform));
+
   prepend.push(...resolveBrewPathDirs({ homeDir }));
 
   // Common global install locations (macOS first).
@@ -156,11 +164,6 @@ function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; ap
   prepend.push(path.join(homeDir, ".local", "share", "pnpm"));
   prepend.push(path.join(homeDir, ".bun", "bin"));
   prepend.push(path.join(homeDir, ".yarn", "bin"));
-  // Ingest /etc/paths and /etc/paths.d/* so launchd/GUI environments see the same
-  // directories that path_helper(8) would provide in a login shell.
-  // These come before hardcoded fallbacks to match path_helper(8) precedence:
-  // /etc/paths entries first, then /etc/paths.d/*, then our fallback defaults.
-  prepend.push(...readEtcPaths(platform));
 
   prepend.push("/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin");
 

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -30,6 +30,62 @@ function isDirectory(dirPath: string): boolean {
   }
 }
 
+/**
+ * Read directories listed in /etc/paths and /etc/paths.d/* on macOS.
+ * These files are what path_helper(8) reads for login shells, but launchd
+ * services and GUI apps never invoke path_helper — so we read them directly.
+ */
+export function readEtcPaths(platform?: NodeJS.Platform): string[] {
+  if ((platform ?? process.platform) !== "darwin") {
+    return [];
+  }
+
+  const dirs: string[] = [];
+
+  // /etc/paths: one directory per line.
+  try {
+    const content = fs.readFileSync("/etc/paths", "utf-8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith("#")) {
+        dirs.push(trimmed);
+      }
+    }
+  } catch {
+    // File may not exist or be unreadable; not fatal.
+  }
+
+  // /etc/paths.d/*: each file contains one directory per line.
+  try {
+    const entries = fs.readdirSync("/etc/paths.d");
+    for (const entry of entries.toSorted()) {
+      try {
+        const content = fs.readFileSync(path.join("/etc/paths.d", entry), "utf-8");
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (trimmed && !trimmed.startsWith("#")) {
+            dirs.push(trimmed);
+          }
+        }
+      } catch {
+        // Skip unreadable files.
+      }
+    }
+  } catch {
+    // /etc/paths.d may not exist.
+  }
+
+  // Deduplicate while preserving order.
+  const seen = new Set<string>();
+  return dirs.filter((d) => {
+    if (seen.has(d)) {
+      return false;
+    }
+    seen.add(d);
+    return true;
+  });
+}
+
 function mergePath(params: { existing: string; prepend?: string[]; append?: string[] }): string {
   const partsExisting = params.existing
     .split(path.delimiter)
@@ -101,6 +157,10 @@ function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; ap
   prepend.push(path.join(homeDir, ".bun", "bin"));
   prepend.push(path.join(homeDir, ".yarn", "bin"));
   prepend.push("/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin");
+
+  // Ingest /etc/paths and /etc/paths.d/* so launchd/GUI environments see the same
+  // directories that path_helper(8) would provide in a login shell.
+  prepend.push(...readEtcPaths(platform));
 
   return { prepend: prepend.filter(isDirectory), append: append.filter(isDirectory) };
 }


### PR DESCRIPTION
macOS gateway and native app never read /etc/paths or /etc/paths.d/ when constructing PATH, so system-configured binary directories are invisible to skill/binary detection

Closes #17890

Changes:
- Create a readSystemPaths() TS helper (src/infra/path-env.ts or new src/infra/etc-paths.ts) that reads /etc/paths and /etc/paths.d/* on macOS, returning deduplicated directory entries
- Integrate readSystemPaths() into candidateBinDirs() in src/infra/path-env.ts so gateway startup PATH includes system-configured paths
- Integrate readSystemPaths() into resolveSystemPathDirs() in src/daemon/service-env.ts so launchd service plist PATH includes system-configured paths
- Add a Swift helper on CommandResolver that reads /etc/paths and /etc/paths.d/*, trims blank/comment lines, returns ordered entries
- Merge system-managed entries into CommandResolver.preferredPaths() before dedup, preserving existing explicit fallbacks
- Add TS unit tests for readSystemPaths() with mocked filesystem content

Testing:
- pnpm build && pnpm check && pnpm test
- TS unit tests for readSystemPaths() with mocked /etc/paths; integration test verifying candidateBinDirs() includes /etc/paths entries on darwin; Swift unit tests for preferredPaths with injected path-file contents; manual smoke verifying peekaboo at /opt/homebrew/bin is detected after fix

---
AI-assisted (Claude + Codex committee consensus, fully tested).

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate — equivalent to codex review)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved