### PR TITLE
feat(slack): trigger AI response when bot joins a new channel

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -194,6 +194,21 @@ export type SlackAccountConfig = {
   ackReaction?: string;
   /** Reaction emoji added while processing a reply (e.g. "hourglass_flowing_sand"). Removed when done. Useful as a typing indicator fallback when assistant mode is not enabled. */
   typingReaction?: string;
+  /**
+   * Configuration for automatic AI response when the bot is added to a new channel.
+   * When enabled, the bot will trigger an AI run upon joining a channel, allowing
+   * it to greet users and ask about configuration preferences (e.g. requireMention,
+   * user allowlists) without requiring a manual first message.
+   */
+  onBotJoinChannel?: {
+    /** If true, trigger an AI response when the bot joins a new channel. Default: false. */
+    enabled?: boolean;
+    /**
+     * Custom prompt used to seed the AI response on join.
+     * Defaults to a greeting + configuration preference prompt.
+     */
+    prompt?: string;
+  };
 };
 
 export type SlackConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -901,6 +901,13 @@ export const SlackAccountSchema = z
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
     typingReaction: z.string().optional(),
+    onBotJoinChannel: z
+      .object({
+        enabled: z.boolean().optional(),
+        prompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value) => {

--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -20,7 +20,12 @@ export function registerSlackMonitorEvents(params: {
     handleSlackMessage: params.handleSlackMessage,
   });
   registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackMemberEvents({
+    ctx: params.ctx,
+    trackEvent: params.trackEvent,
+    account: params.account,
+    handleSlackMessage: params.handleSlackMessage,
+  });
   registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackInteractionEvents({ ctx: params.ctx });

--- a/src/slack/monitor/events/members.test.ts
+++ b/src/slack/monitor/events/members.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackAccount } from "../../accounts.js";
 import { registerSlackMemberEvents } from "./members.js";
 import {
   createSlackSystemEventTestHarness as initSlackHarness,
   type SlackSystemEventTestOverrides as MemberOverrides,
 } from "./system-event-test-harness.js";
+
+const stubAccount: ResolvedSlackAccount = {
+  accountId: "default",
+  enabled: true,
+  botTokenSource: "config",
+  appTokenSource: "config",
+  userTokenSource: "none",
+  config: {},
+} as ResolvedSlackAccount;
 
 const memberMocks = vi.hoisted(() => ({
   enqueue: vi.fn(),
@@ -47,7 +57,11 @@ function getMemberHandlers(params: {
   if (params.shouldDropMismatchedSlackEvent) {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
-  registerSlackMemberEvents({ ctx: harness.ctx, trackEvent: params.trackEvent });
+  registerSlackMemberEvents({
+    ctx: harness.ctx,
+    trackEvent: params.trackEvent,
+    account: stubAccount,
+  });
   return {
     joined: harness.getHandler("member_joined_channel") as MemberHandler | null,
     left: harness.getHandler("member_left_channel") as MemberHandler | null,

--- a/src/slack/monitor/events/members.ts
+++ b/src/slack/monitor/events/members.ts
@@ -1,15 +1,26 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import { danger } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
+import type { ResolvedSlackAccount } from "../../accounts.js";
+import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
+import type { SlackMessageHandler } from "../message-handler.js";
 import type { SlackMemberChannelEvent } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
+
+const DEFAULT_BOT_JOIN_PROMPT =
+  "I've just been added to this channel. I'd like to set myself up properly here. " +
+  "Could you let me know: " +
+  "1) Should I require a direct @mention to respond, or respond to all messages in this channel? " +
+  "2) Should I respond to messages from everyone, or only specific users?";
 
 export function registerSlackMemberEvents(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  account: ResolvedSlackAccount;
+  handleSlackMessage?: SlackMessageHandler;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, trackEvent, account, handleSlackMessage } = params;
 
   const handleMemberChannelEvent = async (params: {
     verb: "joined" | "left";
@@ -25,6 +36,31 @@ export function registerSlackMemberEvents(params: {
       const channelId = payload.channel;
       const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : {};
       const channelType = payload.channel_type ?? channelInfo?.type;
+      // When the bot itself joins a channel and onBotJoinChannel is enabled,
+      // trigger an AI response before the normal system-event auth gate so
+      // the bot-join greeting works even in channels with user allowlists
+      // (the bot's own ID would otherwise be blocked by the allowlist check).
+      if (params.verb === "joined") {
+        const isBotJoin = Boolean(ctx.botUserId && payload.user === ctx.botUserId);
+        const onBotJoinCfg = account.config.onBotJoinChannel;
+        if (isBotJoin && onBotJoinCfg?.enabled && handleSlackMessage && channelId) {
+          const prompt = onBotJoinCfg.prompt?.trim() || DEFAULT_BOT_JOIN_PROMPT;
+          const syntheticMessage: SlackMessageEvent = {
+            type: "message",
+            channel: channelId,
+            channel_type: (channelType ?? "channel") as SlackMessageEvent["channel_type"],
+            user: ctx.botUserId,
+            text: prompt,
+            ts: payload.event_ts ?? String(Date.now() / 1000),
+          };
+          await handleSlackMessage(syntheticMessage, {
+            source: "app_mention",
+            wasMentioned: true,
+            bypassUserAuth: true,
+          });
+        }
+      }
+
       const ingressContext = await authorizeAndResolveSlackSystemEventContext({
         ctx,
         senderId: payload.user,

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -12,7 +12,7 @@ import { createSlackThreadTsResolver } from "./thread-resolution.js";
 
 export type SlackMessageHandler = (
   message: SlackMessageEvent,
-  opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
+  opts: { source: "message" | "app_mention"; wasMentioned?: boolean; bypassUserAuth?: boolean },
 ) => Promise<void>;
 
 const APP_MENTION_RETRY_TTL_MS = 60_000;
@@ -96,7 +96,7 @@ export function createSlackMessageHandler(params: {
   const { ctx, account, trackEvent } = params;
   const { debounceMs, debouncer } = createChannelInboundDebouncer<{
     message: SlackMessageEvent;
-    opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
+    opts: { source: "message" | "app_mention"; wasMentioned?: boolean; bypassUserAuth?: boolean };
   }>({
     cfg: ctx.cfg,
     channel: "slack",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -319,7 +319,7 @@ export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
   message: SlackMessageEvent;
-  opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
+  opts: { source: "message" | "app_mention"; wasMentioned?: boolean; bypassUserAuth?: boolean };
 }): Promise<PreparedSlackMessage | null> {
   const { ctx, account, message, opts } = params;
   const cfg = ctx.cfg;
@@ -407,14 +407,16 @@ export async function prepareSlackMessage(params: {
   };
   const senderNameForAuth = ctx.allowNameMatching ? await resolveSenderName() : undefined;
 
-  const channelUserAuthorized = isRoom
-    ? resolveSlackUserAllowed({
-        allowList: channelConfig?.users,
-        userId: senderId,
-        userName: senderNameForAuth,
-        allowNameMatching: ctx.allowNameMatching,
-      })
-    : true;
+  const channelUserAuthorized = opts.bypassUserAuth
+    ? true
+    : isRoom
+      ? resolveSlackUserAllowed({
+          allowList: channelConfig?.users,
+          userId: senderId,
+          userName: senderNameForAuth,
+          allowNameMatching: ctx.allowNameMatching,
+        })
+      : true;
   if (isRoom && !channelUserAuthorized) {
     logVerbose(`Blocked unauthorized slack sender ${senderId} (not in channel users)`);
     return null;


### PR DESCRIPTION
## Summary

- When the bot joins a Slack channel and `onBotJoinChannel.enabled` is set, automatically trigger an AI response to greet users and ask about channel configuration (requireMention, user allowlists, etc.)
- Injects a synthetic message via the existing message handler with `bypassUserAuth` so the greeting works even in channels with user allowlists
- Uses `payload.event_ts` as the synthetic message `ts` for stable deduplication across Slack retries
- Uses the already-resolved `channelType` from Slack's API instead of a simplistic `D` vs non-`D` prefix check

Replaces #33873 (submitted from the wrong account — using primary identity instead).

Co-authored-by: peteradams2026 <peteradams2026@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)