### PR TITLE
fix(googlechat): add fetch timeout to certificate verification endpoint

### DIFF
--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -79,7 +79,17 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
   if (cachedCerts && now - cachedCerts.fetchedAt < 10 * 60 * 1000) {
     return cachedCerts.certs;
   }
-  const res = await fetch(CHAT_CERTS_URL);
+  let res: Response;
+  try {
+    res = await fetch(CHAT_CERTS_URL, {
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Google Chat cert fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   if (!res.ok) {
     throw new Error(`Failed to fetch Chat certs (${res.status})`);
   }


### PR DESCRIPTION
lobster-biscuit

## Problem

`fetchChatCerts()` fetches Google's public x509 certificates for webhook signature verification with no timeout. On a cache miss (every 10 minutes), a slow or unresponsive Google endpoint would stall the entire inbound webhook verification pipeline indefinitely.

## Solution

Add a 10-second `AbortSignal.timeout` to the fetch call and wrap it in a try/catch that preserves the cause chain via `{ cause: err }`.

## Changes

- `extensions/googlechat/src/auth.ts` — add `AbortSignal.timeout(10_000)` to `fetchChatCerts()`

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Google Chat webhook verification works end-to-end (requires Google Workspace setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)