### PR TITLE
fix(nextcloud-talk): add fetch timeout to message and reaction sends

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -101,16 +101,25 @@ export async function sendMessageNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${roomToken}/message`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
-    },
-    body: bodyStr,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body: bodyStr,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Nextcloud Talk send failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
@@ -184,16 +193,25 @@ export async function sendReactionNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${normalizedToken}/reaction/${messageId}`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
-    },
-    body,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Nextcloud Talk reaction failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");


### PR DESCRIPTION
lobster-biscuit

## Problem

`sendMessageNextcloudTalk()` and `sendReactionNextcloudTalk()` POST to self-hosted Nextcloud instances with no timeout. A slow or unresponsive server would stall the outbound message pipeline indefinitely.

Self-hosted instances are particularly prone to this since they often lack the CDN-level timeouts that cloud services provide.

## Solution

Add a 30-second `AbortSignal.timeout` to both fetch calls. Both are wrapped in try/catch with `{ cause: err }` to preserve the cause chain.

30 seconds is chosen because outbound sends to self-hosted servers may be slower than typical API metadata calls, but should not take longer than half a minute.

## Changes

- `extensions/nextcloud-talk/src/send.ts` — add `AbortSignal.timeout(30_000)` to both `sendMessageNextcloudTalk()` and `sendReactionNextcloudTalk()`

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Nextcloud Talk send and reaction work end-to-end (requires Nextcloud instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)