### PR TITLE
test: normalize Windows plugin path assertions

### DIFF
--- a/src/hooks/plugin-hooks.test.ts
+++ b/src/hooks/plugin-hooks.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -95,8 +94,15 @@ describe("bundle plugin hooks", () => {
     };
   }
 
+  function normalizeAssertionPath(value: string | undefined): string | undefined {
+    if (!value) {
+      return value;
+    }
+    return value.replace(/\\/g, "/").toLowerCase();
+  }
+
   it("exposes enabled bundle hook dirs as plugin-managed hook entries", async () => {
-    const bundleRoot = await writeBundleHookFixture();
+    await writeBundleHookFixture();
 
     const entries = loadWorkspaceHookEntries(workspaceDir, {
       config: createConfig(true),
@@ -106,8 +112,10 @@ describe("bundle plugin hooks", () => {
     expect(entries[0]?.hook.name).toBe("bundle-hook");
     expect(entries[0]?.hook.source).toBe("openclaw-plugin");
     expect(entries[0]?.hook.pluginId).toBe("sample-bundle");
-    expect(entries[0]?.hook.baseDir).toBe(
-      fs.realpathSync.native(path.join(bundleRoot, "hooks", "bundle-hook")),
+    expect(entries[0]?.hook.baseDir).toBeDefined();
+    expect(path.isAbsolute(String(entries[0]?.hook.baseDir))).toBe(true);
+    expect(normalizeAssertionPath(entries[0]?.hook.baseDir)).toContain(
+      "/.openclaw/extensions/sample-bundle/hooks/bundle-hook",
     );
     expect(entries[0]?.metadata?.events).toEqual(["command:new"]);
   });

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -22,6 +22,13 @@ afterEach(async () => {
   );
 });
 
+function normalizeAssertionPath(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+  return value.replace(/\\/g, "/").toLowerCase();
+}
+
 describe("loadEnabledBundleMcpConfig", () => {
   it("loads enabled Claude bundle MCP config and absolutizes relative args", async () => {
     const env = captureEnv(["HOME", "USERPROFILE", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
@@ -72,11 +79,15 @@ describe("loadEnabledBundleMcpConfig", () => {
         workspaceDir,
         cfg: config,
       });
-      const resolvedServerPath = await fs.realpath(serverPath);
-
       expect(loaded.diagnostics).toEqual([]);
       expect(loaded.config.mcpServers.bundleProbe?.command).toBe("node");
-      expect(loaded.config.mcpServers.bundleProbe?.args).toEqual([resolvedServerPath]);
+      const args = loaded.config.mcpServers.bundleProbe?.args;
+      expect(args).toHaveLength(1);
+      expect(args?.[0]).toBeDefined();
+      expect(path.isAbsolute(String(args?.[0]))).toBe(true);
+      expect(normalizeAssertionPath(String(args?.[0]))).toContain(
+        "/.openclaw/extensions/bundle-probe/servers/probe.mjs",
+      );
     } finally {
       env.restore();
     }

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -19,6 +19,13 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   }
 }
 
+function normalizeAssertionPath(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+  return value.replace(/\\/g, "/").toLowerCase();
+}
+
 describe("marketplace plugins", () => {
   afterEach(() => {
     installPluginFromPathMock.mockReset();
@@ -45,21 +52,21 @@ describe("marketplace plugins", () => {
 
       const { listMarketplacePlugins } = await import("./marketplace.js");
       const result = await listMarketplacePlugins({ marketplace: rootDir });
-      expect(result).toEqual({
-        ok: true,
-        sourceLabel: expect.stringContaining(".claude-plugin/marketplace.json"),
-        manifest: {
-          name: "Example Marketplace",
-          version: "1.0.0",
-          plugins: [
-            {
-              name: "frontend-design",
-              version: "0.1.0",
-              description: "Design system bundle",
-              source: { kind: "path", path: "./plugins/frontend-design" },
-            },
-          ],
-        },
+      expect(result.ok).toBe(true);
+      expect(normalizeAssertionPath(result.sourceLabel)).toContain(
+        ".claude-plugin/marketplace.json",
+      );
+      expect(result.manifest).toEqual({
+        name: "Example Marketplace",
+        version: "1.0.0",
+        plugins: [
+          {
+            name: "frontend-design",
+            version: "0.1.0",
+            description: "Design system bundle",
+            source: { kind: "path", path: "./plugins/frontend-design" },
+          },
+        ],
       });
     });
   });
@@ -103,8 +110,10 @@ describe("marketplace plugins", () => {
         ok: true,
         pluginId: "frontend-design",
         marketplacePlugin: "frontend-design",
-        marketplaceSource: path.join(rootDir, ".claude-plugin", "marketplace.json"),
       });
+      expect(normalizeAssertionPath(result.marketplaceSource)).toBe(
+        normalizeAssertionPath(path.join(rootDir, ".claude-plugin", "marketplace.json")),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Normalize Windows-sensitive path assertions in plugin-related tests.

## Problem

Several Windows CI failures are caused by exact path string assertions that compare:
- `runneradmin`
- `RUNNER~1`

Those are equivalent filesystem locations on the runner, but the tests currently treat them as different strings.

## Change

This patch narrows the fix to tests only:
- `src/plugins/bundle-mcp.test.ts`
- `src/hooks/plugin-hooks.test.ts`
- `src/plugins/marketplace.test.ts`

Instead of asserting exact full path strings, the tests now assert:
- the path is absolute when needed
- the normalized path contains the expected stable suffix
- comparisons use slash-normalized lowercase forms where appropriate

## Why this is low risk

- test-only change
- no production behavior changes
- only relaxes brittle runner-path assumptions

## Verification

```bash
npx pnpm@10.23.0 exec vitest run src/plugins/bundle-mcp.test.ts
npx pnpm@10.23.0 exec vitest run src/hooks/plugin-hooks.test.ts
npx pnpm@10.23.0 exec vitest run src/plugins/marketplace.test.ts
```
