### PR TITLE
feat(slack): add exec approval buttons via Block Kit

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -43,6 +43,11 @@ import {
 } from "./accounts.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
+import {
+  isSlackExecApprovalClientEnabled,
+  resolveSlackExecApprovalTarget,
+  shouldSuppressLocalSlackExecApprovalPrompt,
+} from "./exec-approvals.js";
 import { isSlackInteractiveRepliesEnabled } from "./interactive-replies.js";
 import { handleSlackMessageAction } from "./message-action-dispatch.js";
 import { extractSlackToolSend, listSlackMessageActions } from "./message-actions.js";
@@ -735,6 +740,23 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         ...base,
         ...projectCredentialSnapshotFields(account),
       };
+    },
+  },
+  execApprovals: {
+    getInitiatingSurfaceState: ({ cfg, accountId }) =>
+      isSlackExecApprovalClientEnabled({ cfg, accountId })
+        ? { kind: "enabled" }
+        : { kind: "disabled" },
+    shouldSuppressLocalPrompt: ({ cfg, accountId, payload }) =>
+      shouldSuppressLocalSlackExecApprovalPrompt({ cfg, accountId, payload }),
+    hasConfiguredDmRoute: ({ cfg }) => {
+      return listSlackAccountIds(cfg).some((accountId) => {
+        if (!isSlackExecApprovalClientEnabled({ cfg, accountId })) {
+          return false;
+        }
+        const target = resolveSlackExecApprovalTarget({ cfg, accountId });
+        return target === "dm" || target === "both";
+      });
     },
   },
   gateway: {

--- a/extensions/slack/src/exec-approvals-handler.ts
+++ b/extensions/slack/src/exec-approvals-handler.ts
@@ -1,0 +1,418 @@
+import type { WebClient } from "@slack/web-api";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { GatewayClient } from "../../../src/gateway/client.js";
+import { createOperatorApprovalsGatewayClient } from "../../../src/gateway/operator-approvals-client.js";
+import type { EventFrame } from "../../../src/gateway/protocol/index.js";
+import { resolveExecApprovalCommandDisplay } from "../../../src/infra/exec-approval-command-display.js";
+import {
+  buildExecApprovalPendingReplyPayload,
+  type ExecApprovalPendingReplyParams,
+} from "../../../src/infra/exec-approval-reply.js";
+import { resolveExecApprovalSessionTarget } from "../../../src/infra/exec-approval-session-target.js";
+import type {
+  ExecApprovalRequest,
+  ExecApprovalResolved,
+} from "../../../src/infra/exec-approvals.js";
+import { createSubsystemLogger } from "../../../src/logging/subsystem.js";
+import { normalizeAccountId, parseAgentSessionKey } from "../../../src/routing/session-key.js";
+import type { RuntimeEnv } from "../../../src/runtime.js";
+import { compileSafeRegex, testRegexWithBoundedInput } from "../../../src/security/safe-regex.js";
+import {
+  getSlackExecApprovalApprovers,
+  resolveSlackExecApprovalConfig,
+  resolveSlackExecApprovalTarget,
+} from "./exec-approvals.js";
+
+const log = createSubsystemLogger("slack/exec-approvals");
+
+export const SLACK_EXEC_APPROVAL_ACTION_PREFIX = "openclaw:exec_approval:";
+
+type PendingMessage = {
+  channelId: string;
+  ts: string;
+};
+
+type PendingApproval = {
+  timeoutId: NodeJS.Timeout;
+  messages: PendingMessage[];
+};
+
+type SlackApprovalTarget = {
+  /** User ID for DM or channel ID for channel target. */
+  id: string;
+  kind: "user" | "channel";
+  threadTs?: string;
+};
+
+export type SlackExecApprovalHandlerOpts = {
+  botToken: string;
+  accountId: string;
+  cfg: OpenClawConfig;
+  client: WebClient;
+  gatewayUrl?: string;
+  runtime?: RuntimeEnv;
+};
+
+export type SlackExecApprovalHandlerDeps = {
+  nowMs?: () => number;
+};
+
+function matchesFilters(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  request: ExecApprovalRequest;
+}): boolean {
+  const config = resolveSlackExecApprovalConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (!config?.enabled) {
+    return false;
+  }
+  const approvers = getSlackExecApprovalApprovers({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (approvers.length === 0) {
+    return false;
+  }
+  if (config.agentFilter?.length) {
+    const agentId =
+      params.request.request.agentId ??
+      parseAgentSessionKey(params.request.request.sessionKey)?.agentId;
+    if (!agentId || !config.agentFilter.includes(agentId)) {
+      return false;
+    }
+  }
+  if (config.sessionFilter?.length) {
+    const sessionKey = params.request.request.sessionKey;
+    if (!sessionKey) {
+      return false;
+    }
+    const matches = config.sessionFilter.some((pattern) => {
+      if (sessionKey.includes(pattern)) {
+        return true;
+      }
+      const regex = compileSafeRegex(pattern);
+      return regex ? testRegexWithBoundedInput(regex, sessionKey) : false;
+    });
+    if (!matches) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isHandlerConfigured(params: { cfg: OpenClawConfig; accountId: string }): boolean {
+  const config = resolveSlackExecApprovalConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (!config?.enabled) {
+    return false;
+  }
+  return (
+    getSlackExecApprovalApprovers({
+      cfg: params.cfg,
+      accountId: params.accountId,
+    }).length > 0
+  );
+}
+
+function resolveSlackSourceTarget(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  request: ExecApprovalRequest;
+}): SlackApprovalTarget | null {
+  const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase() || "";
+  const turnSourceTo = params.request.request.turnSourceTo?.trim() || "";
+  const turnSourceAccountId = params.request.request.turnSourceAccountId?.trim() || "";
+  if (turnSourceChannel === "slack" && turnSourceTo) {
+    if (
+      turnSourceAccountId &&
+      normalizeAccountId(turnSourceAccountId) !== normalizeAccountId(params.accountId)
+    ) {
+      return null;
+    }
+    return { id: turnSourceTo, kind: "channel" };
+  }
+
+  const sessionTarget = resolveExecApprovalSessionTarget({
+    cfg: params.cfg,
+    request: params.request,
+    turnSourceChannel: params.request.request.turnSourceChannel ?? undefined,
+    turnSourceTo: params.request.request.turnSourceTo ?? undefined,
+    turnSourceAccountId: params.request.request.turnSourceAccountId ?? undefined,
+    turnSourceThreadId: params.request.request.turnSourceThreadId ?? undefined,
+  });
+  if (!sessionTarget || sessionTarget.channel !== "slack") {
+    return null;
+  }
+  if (
+    sessionTarget.accountId &&
+    normalizeAccountId(sessionTarget.accountId) !== normalizeAccountId(params.accountId)
+  ) {
+    return null;
+  }
+  return { id: sessionTarget.to, kind: "channel" };
+}
+
+function dedupeTargets(targets: SlackApprovalTarget[]): SlackApprovalTarget[] {
+  const seen = new Set<string>();
+  const deduped: SlackApprovalTarget[] = [];
+  for (const target of targets) {
+    const key = `${target.kind}:${target.id}:${target.threadTs ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(target);
+  }
+  return deduped;
+}
+
+function buildSlackExecApprovalBlocks(params: {
+  approvalId: string;
+  text: string;
+}): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: params.text,
+      },
+    },
+    {
+      type: "actions",
+      block_id: `openclaw_exec_approval_${params.approvalId.slice(0, 8)}`,
+      elements: [
+        {
+          type: "button",
+          action_id: `${SLACK_EXEC_APPROVAL_ACTION_PREFIX}allow-once`,
+          text: { type: "plain_text", text: "Allow Once", emoji: true },
+          style: "primary",
+          value: params.approvalId,
+        },
+        {
+          type: "button",
+          action_id: `${SLACK_EXEC_APPROVAL_ACTION_PREFIX}allow-always`,
+          text: { type: "plain_text", text: "Allow Always", emoji: true },
+          value: params.approvalId,
+        },
+        {
+          type: "button",
+          action_id: `${SLACK_EXEC_APPROVAL_ACTION_PREFIX}deny`,
+          text: { type: "plain_text", text: "Deny", emoji: true },
+          style: "danger",
+          value: params.approvalId,
+        },
+      ],
+    },
+  ];
+}
+
+export class SlackExecApprovalHandler {
+  private gatewayClient: GatewayClient | null = null;
+  private pending = new Map<string, PendingApproval>();
+  private started = false;
+  private readonly nowMs: () => number;
+
+  constructor(
+    private readonly opts: SlackExecApprovalHandlerOpts,
+    deps: SlackExecApprovalHandlerDeps = {},
+  ) {
+    this.nowMs = deps.nowMs ?? Date.now;
+  }
+
+  shouldHandle(request: ExecApprovalRequest): boolean {
+    return matchesFilters({
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+      request,
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
+    if (!isHandlerConfigured({ cfg: this.opts.cfg, accountId: this.opts.accountId })) {
+      return;
+    }
+
+    this.gatewayClient = await createOperatorApprovalsGatewayClient({
+      config: this.opts.cfg,
+      gatewayUrl: this.opts.gatewayUrl,
+      clientDisplayName: `Slack Exec Approvals (${this.opts.accountId})`,
+      onEvent: (evt) => this.handleGatewayEvent(evt),
+      onConnectError: (err) => {
+        log.error(`slack exec approvals: connect error: ${err.message}`);
+      },
+    });
+    this.gatewayClient.start();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    this.started = false;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeoutId);
+    }
+    this.pending.clear();
+    this.gatewayClient?.stop();
+    this.gatewayClient = null;
+  }
+
+  async handleRequested(request: ExecApprovalRequest): Promise<void> {
+    if (!this.shouldHandle(request)) {
+      return;
+    }
+
+    const targetMode = resolveSlackExecApprovalTarget({
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+    });
+    const targets: SlackApprovalTarget[] = [];
+    const sourceTarget = resolveSlackSourceTarget({
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+      request,
+    });
+    let fallbackToDm = false;
+    if (targetMode === "channel" || targetMode === "both") {
+      if (sourceTarget) {
+        targets.push(sourceTarget);
+      } else {
+        fallbackToDm = true;
+      }
+    }
+    if (targetMode === "dm" || targetMode === "both" || fallbackToDm) {
+      for (const approver of getSlackExecApprovalApprovers({
+        cfg: this.opts.cfg,
+        accountId: this.opts.accountId,
+      })) {
+        targets.push({ id: approver, kind: "user" });
+      }
+    }
+
+    const resolvedTargets = dedupeTargets(targets);
+    if (resolvedTargets.length === 0) {
+      return;
+    }
+
+    const payloadParams: ExecApprovalPendingReplyParams = {
+      approvalId: request.id,
+      approvalSlug: request.id.slice(0, 8),
+      approvalCommandId: request.id,
+      command: resolveExecApprovalCommandDisplay(request.request).commandText,
+      cwd: request.request.cwd ?? undefined,
+      host: request.request.host === "node" ? "node" : "gateway",
+      nodeId: request.request.nodeId ?? undefined,
+      expiresAtMs: request.expiresAtMs,
+      nowMs: this.nowMs(),
+    };
+    const payload = buildExecApprovalPendingReplyPayload(payloadParams);
+    const messageText = payload.text ?? "Exec approval required.";
+    const blocks = buildSlackExecApprovalBlocks({
+      approvalId: request.id,
+      text: messageText,
+    });
+    const sentMessages: PendingMessage[] = [];
+
+    for (const target of resolvedTargets) {
+      try {
+        let channelId: string;
+        if (target.kind === "user") {
+          // Open a DM channel with the approver.
+          const dmResponse = await this.opts.client.conversations.open({ users: target.id });
+          channelId = dmResponse.channel?.id ?? "";
+          if (!channelId) {
+            log.error(
+              `slack exec approvals: failed to open DM for user ${target.id} request ${request.id}`,
+            );
+            continue;
+          }
+        } else {
+          channelId = target.id;
+        }
+
+        const result = await this.opts.client.chat.postMessage({
+          channel: channelId,
+          text: messageText,
+          blocks: blocks as never[],
+          ...(target.threadTs ? { thread_ts: target.threadTs } : {}),
+        });
+        if (result.ts) {
+          sentMessages.push({ channelId, ts: result.ts });
+        }
+      } catch (err) {
+        log.error(`slack exec approvals: failed to send request ${request.id}: ${String(err)}`);
+      }
+    }
+
+    if (sentMessages.length === 0) {
+      return;
+    }
+
+    const timeoutMs = Math.max(0, request.expiresAtMs - this.nowMs());
+    const timeoutId = setTimeout(() => {
+      void this.handleResolved({ id: request.id, decision: "deny", ts: Date.now() });
+    }, timeoutMs);
+    timeoutId.unref?.();
+
+    this.pending.set(request.id, {
+      timeoutId,
+      messages: sentMessages,
+    });
+  }
+
+  async handleResolved(resolved: ExecApprovalResolved): Promise<void> {
+    const pending = this.pending.get(resolved.id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeoutId);
+    this.pending.delete(resolved.id);
+
+    const decisionLabel =
+      resolved.decision === "allow-once"
+        ? "Allowed (once)"
+        : resolved.decision === "allow-always"
+          ? "Allowed (always)"
+          : "Denied";
+
+    await Promise.allSettled(
+      pending.messages.map(async (message) => {
+        await this.opts.client.chat.update({
+          channel: message.channelId,
+          ts: message.ts,
+          text: `Exec approval resolved: ${decisionLabel}`,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `:white_check_mark: Exec approval resolved: *${decisionLabel}*`,
+              },
+            },
+          ],
+        });
+      }),
+    );
+  }
+
+  private handleGatewayEvent(evt: EventFrame): void {
+    if (evt.event === "exec.approval.requested") {
+      void this.handleRequested(evt.payload as ExecApprovalRequest);
+      return;
+    }
+    if (evt.event === "exec.approval.resolved") {
+      void this.handleResolved(evt.payload as ExecApprovalResolved);
+    }
+  }
+}

--- a/extensions/slack/src/exec-approvals.ts
+++ b/extensions/slack/src/exec-approvals.ts
@@ -1,0 +1,60 @@
+import type { ReplyPayload } from "../../../src/auto-reply/types.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type { SlackExecApprovalConfig } from "../../../src/config/types.slack.js";
+import { getExecApprovalReplyMetadata } from "../../../src/infra/exec-approval-reply.js";
+import { resolveSlackAccount } from "./accounts.js";
+
+export function resolveSlackExecApprovalConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): SlackExecApprovalConfig | undefined {
+  return resolveSlackAccount(params).config.execApprovals;
+}
+
+export function getSlackExecApprovalApprovers(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] {
+  return (resolveSlackExecApprovalConfig(params)?.approvers ?? [])
+    .map((id) => String(id).trim())
+    .filter(Boolean);
+}
+
+export function isSlackExecApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const config = resolveSlackExecApprovalConfig(params);
+  return Boolean(config?.enabled && getSlackExecApprovalApprovers(params).length > 0);
+}
+
+export function isSlackExecApprovalApprover(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  senderId?: string | null;
+}): boolean {
+  const senderId = params.senderId?.trim();
+  if (!senderId) {
+    return false;
+  }
+  const approvers = getSlackExecApprovalApprovers(params);
+  return approvers.includes(senderId);
+}
+
+export function resolveSlackExecApprovalTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): "dm" | "channel" | "both" {
+  return resolveSlackExecApprovalConfig(params)?.target ?? "dm";
+}
+
+export function shouldSuppressLocalSlackExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+}): boolean {
+  return (
+    isSlackExecApprovalClientEnabled(params) &&
+    getExecApprovalReplyMetadata(params.payload) !== null
+  );
+}

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -1,5 +1,6 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
+import { callGateway } from "../../../../../src/gateway/call.js";
 import { enqueueSystemEvent } from "../../../../../src/infra/system-events.js";
 import {
   buildPluginBindingResolvedText,
@@ -7,7 +8,13 @@ import {
   resolvePluginConversationBindingApproval,
 } from "../../../../../src/plugins/conversation-binding.js";
 import { dispatchPluginInteractiveHandler } from "../../../../../src/plugins/interactive.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../../src/utils/message-channel.js";
 import { SLACK_REPLY_BUTTON_ACTION_ID, SLACK_REPLY_SELECT_ACTION_ID } from "../../blocks-render.js";
+import { SLACK_EXEC_APPROVAL_ACTION_PREFIX } from "../../exec-approvals-handler.js";
+import { isSlackExecApprovalApprover } from "../../exec-approvals.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
@@ -698,6 +705,82 @@ async function updateSlackLegacyBlockAction(params: {
   }
 }
 
+async function handleSlackExecApprovalAction(params: {
+  ctx: SlackMonitorContext;
+  parsed: ParsedSlackBlockAction;
+  respond?: SlackBlockActionRespond;
+}): Promise<boolean> {
+  const { parsed } = params;
+  if (!parsed.actionId.startsWith(SLACK_EXEC_APPROVAL_ACTION_PREFIX)) {
+    return false;
+  }
+  const decision = parsed.actionId.slice(SLACK_EXEC_APPROVAL_ACTION_PREFIX.length);
+  if (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") {
+    return false;
+  }
+  const approvalId = parsed.actionSummary.value?.trim();
+  if (!approvalId) {
+    return false;
+  }
+
+  // Only configured approvers can use these buttons.
+  if (
+    !isSlackExecApprovalApprover({
+      cfg: params.ctx.cfg,
+      accountId: params.ctx.accountId,
+      senderId: parsed.userId,
+    })
+  ) {
+    await respondEphemeral(params.respond, "You are not authorized to approve exec requests.");
+    return true;
+  }
+
+  const resolvedBy = `slack:${parsed.userId}`;
+  try {
+    await callGateway({
+      method: "exec.approval.resolve",
+      params: { id: approvalId, decision, resolvedBy },
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: `Slack approval (${resolvedBy})`,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+    });
+  } catch (err) {
+    await respondEphemeral(params.respond, `Failed to submit approval: ${String(err)}`);
+    return true;
+  }
+
+  const decisionLabel =
+    decision === "allow-once"
+      ? "Allowed (once)"
+      : decision === "allow-always"
+        ? "Allowed (always)"
+        : "Denied";
+
+  // Update the message to remove buttons and show result.
+  try {
+    await updateSlackInteractionMessage({
+      ctx: params.ctx,
+      channelId: parsed.channelId,
+      messageTs: parsed.messageTs,
+      text: `Exec approval resolved: ${decisionLabel}`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `:white_check_mark: Exec approval resolved: *${escapeSlackMrkdwn(decisionLabel)}* by <@${parsed.userId}>`,
+          },
+        },
+      ],
+    });
+  } catch {
+    // Best-effort message update.
+  }
+
+  await respondEphemeral(params.respond, `Exec approval ${decision} submitted.`);
+  return true;
+}
+
 async function handleSlackBlockAction(params: {
   ctx: SlackMonitorContext;
   args: SlackActionMiddlewareArgs;
@@ -717,6 +800,19 @@ async function handleSlackBlockAction(params: {
   if (!parsed) {
     return;
   }
+
+  // Handle exec approval buttons before auth gating so we can do our own
+  // approver-specific authorization.
+  if (
+    await handleSlackExecApprovalAction({
+      ctx: params.ctx,
+      parsed,
+      respond,
+    })
+  ) {
+    return;
+  }
+
   const auth = await authorizeSlackBlockAction({
     ctx: params.ctx,
     parsed,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -27,6 +27,7 @@ import { createNonExitingRuntime, type RuntimeEnv } from "../../../../src/runtim
 import { normalizeStringEntries } from "../../../../src/shared/string-normalization.js";
 import { resolveSlackAccount } from "../accounts.js";
 import { resolveSlackWebClientOptions } from "../client.js";
+import { SlackExecApprovalHandler } from "../exec-approvals-handler.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../resolve-users.js";
@@ -313,6 +314,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     );
   }
 
+  const execApprovalsHandler = new SlackExecApprovalHandler({
+    botToken,
+    accountId: account.accountId,
+    cfg,
+    client: app.client,
+    runtime,
+  });
+  await execApprovalsHandler.start();
+
   const ctx = createSlackMonitorContext({
     cfg,
     accountId: account.accountId,
@@ -567,6 +577,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   } finally {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterHttpHandler?.();
+    await execApprovalsHandler.stop().catch(() => {});
     await app.stop().catch(() => undefined);
   }
 }

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -1,6 +1,10 @@
 import { callGateway } from "../../gateway/call.js";
 import { logVerbose } from "../../globals.js";
 import {
+  isSlackExecApprovalApprover,
+  isSlackExecApprovalClientEnabled,
+} from "../../plugin-sdk-internal/slack.js";
+import {
   isTelegramExecApprovalApprover,
   isTelegramExecApprovalClientEnabled,
 } from "../../plugin-sdk-internal/telegram.js";
@@ -111,6 +115,27 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
       return {
         shouldContinue: false,
         reply: { text: "❌ You are not authorized to approve exec requests on Telegram." },
+      };
+    }
+  }
+
+  if (params.command.channel === "slack") {
+    if (!isSlackExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.ctx.AccountId })) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ Slack exec approvals are not enabled for this bot account." },
+      };
+    }
+    if (
+      !isSlackExecApprovalApprover({
+        cfg: params.cfg,
+        accountId: params.ctx.AccountId,
+        senderId: params.command.senderId,
+      })
+    ) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ You are not authorized to approve exec requests on Slack." },
       };
     }
   }

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -56,6 +56,21 @@ export type SlackCapabilitiesConfig =
       interactiveReplies?: boolean;
     };
 
+export type SlackExecApprovalTarget = "dm" | "channel" | "both";
+
+export type SlackExecApprovalConfig = {
+  /** Enable Slack exec approvals for this account. Default: false. */
+  enabled?: boolean;
+  /** Slack user IDs allowed to approve exec requests. Required if enabled. */
+  approvers?: string[];
+  /** Only forward approvals for these agent IDs. Omit = all agents. */
+  agentFilter?: string[];
+  /** Only forward approvals matching these session key patterns (substring or regex). */
+  sessionFilter?: string[];
+  /** Where to send approval prompts. Default: "dm". */
+  target?: SlackExecApprovalTarget;
+};
+
 export type SlackActionConfig = {
   reactions?: boolean;
   messages?: boolean;
@@ -171,6 +186,8 @@ export type SlackAccountConfig = {
   /** Thread session behavior. */
   thread?: SlackThreadConfig;
   actions?: SlackActionConfig;
+  /** Slack-native exec approval delivery + approver authorization. */
+  execApprovals?: SlackExecApprovalConfig;
   slashCommand?: SlackSlashCommandConfig;
   /**
    * Alias for dm.policy (prefer this so it inherits cleanly via base->account shallow merge).

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -148,21 +148,21 @@ export function buildExecApprovalUnavailableReplyPayload(
       `Exec approval is required, but chat exec approvals are not enabled on ${params.channelLabel ?? "this platform"}.`,
     );
     lines.push(
-      "Approve it from the Web UI or terminal UI, or from Discord or Telegram if those approval clients are enabled.",
+      "Approve it from the Web UI or terminal UI, or from Discord, Telegram, or Slack if those approval clients are enabled.",
     );
   } else if (params.reason === "initiating-platform-unsupported") {
     lines.push(
       `Exec approval is required, but ${params.channelLabel ?? "this platform"} does not support chat exec approvals.`,
     );
     lines.push(
-      "Approve it from the Web UI or terminal UI, or from Discord or Telegram if those approval clients are enabled.",
+      "Approve it from the Web UI or terminal UI, or from Discord, Telegram, or Slack if those approval clients are enabled.",
     );
   } else {
     lines.push(
       "Exec approval is required, but no interactive approval client is currently available.",
     );
     lines.push(
-      "Open the Web UI or terminal UI, or enable Discord or Telegram exec approvals, then retry the command.",
+      "Open the Web UI or terminal UI, or enable Discord, Telegram, or Slack exec approvals, then retry the command.",
     );
   }
 

--- a/src/plugin-sdk-internal/slack.ts
+++ b/src/plugin-sdk-internal/slack.ts
@@ -66,3 +66,7 @@ export { slackSetupWizard } from "../../extensions/slack/src/setup-surface.js";
 export { SlackConfigSchema } from "../config/zod-schema.providers-core.js";
 
 export { handleSlackMessageAction } from "../plugin-sdk/slack-message-actions.js";
+export {
+  isSlackExecApprovalApprover,
+  isSlackExecApprovalClientEnabled,
+} from "../../extensions/slack/src/exec-approvals.js";


### PR DESCRIPTION
## Summary

- Adds Slack-native exec approval buttons using Block Kit interactive components, matching the existing Telegram and Discord implementations
- Implements `SlackExecApprovalHandler` that subscribes to gateway exec approval events and sends Block Kit messages with **Allow Once** / **Allow Always** / **Deny** buttons
- Supports approver DMs, originating channel, or both delivery targets via `channels.slack.execApprovals` config
- Adds approver authorization for both button clicks and `/approve` text commands on Slack

## Configuration

```yaml
channels:
  slack:
    execApprovals:
      enabled: true
      approvers: ["U12345678"]
      agentFilter: ["main"]  # optional
      target: "dm"           # dm | channel | both
```

## Changes

- `src/config/types.slack.ts`: Add `SlackExecApprovalConfig` type and `execApprovals` field to `SlackAccountConfig`
- `extensions/slack/src/exec-approvals.ts`: Config resolution helpers (enabled check, approver lookup, target resolution)
- `extensions/slack/src/exec-approvals-handler.ts`: Gateway event handler with Block Kit button sending, message updates on resolve/expire
- `extensions/slack/src/channel.ts`: Register `execApprovals` adapter on channel plugin (surface state, DM route, suppress local prompt)
- `extensions/slack/src/monitor/provider.ts`: Wire handler into provider lifecycle (start/stop)
- `extensions/slack/src/monitor/events/interactions.block-actions.ts`: Handle exec approval button clicks with approver auth and gateway resolution
- `src/auto-reply/reply/commands-approve.ts`: Add Slack-specific authorization checks for `/approve` text command
- `src/infra/exec-approval-reply.ts`: Update fallback messages to mention Slack as a supported approval client
- `src/plugin-sdk-internal/slack.ts`: Export exec approval helpers

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` type check passes clean
- [x] `pnpm test -- extensions/slack/src` — all 52 test files pass (391 tests)
- [x] `pnpm test -- src/infra/exec-approval-reply.test.ts` — 7 tests pass
- [x] `pnpm format` passes
- [ ] Manual: configure `channels.slack.execApprovals` and verify buttons appear in DMs
- [ ] Manual: click Allow Once / Allow Always / Deny and verify message updates + approval resolves
- [ ] Manual: verify unauthorized users see ephemeral denial on button click

Closes #48529

🤖 Generated with [Claude Code](https://claude.com/claude-code)