### PR TITLE
feat: heartbeat.timeoutSeconds — per-heartbeat embedded run timeout

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -269,6 +269,14 @@ export type AgentDefaultsConfig = {
      * Default: false (only the final heartbeat payload is delivered).
      */
     includeReasoning?: boolean;
+    /**
+     * Max timeout in seconds for a heartbeat embedded run.
+     * Allows heartbeats to fail fast (e.g., 60s) when a model hangs,
+     * without affecting the global agents.defaults.timeoutSeconds (default 600s).
+     *
+     * Default: undefined (inherits agents.defaults.timeoutSeconds).
+     */
+    timeoutSeconds?: number;
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -35,6 +35,7 @@ export const HeartbeatSchema = z
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),
     isolatedSession: z.boolean().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
   })
   .strict()
   .superRefine((val, ctx) => {

--- a/src/infra/heartbeat-runner.timeout.test.ts
+++ b/src/infra/heartbeat-runner.timeout.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import { setTelegramRuntime } from "../../extensions/telegram/src/runtime.js";
+import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
+import { setWhatsAppRuntime } from "../../extensions/whatsapp/src/runtime.js";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+beforeEach(() => {
+  const runtime = createPluginRuntime();
+  setTelegramRuntime(runtime);
+  setWhatsAppRuntime(runtime);
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    ]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("heartbeat timeoutSeconds config", () => {
+  it("should accept timeoutSeconds in heartbeat config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+            timeoutSeconds: 60,
+          },
+        },
+      },
+    };
+
+    expect(cfg.agents?.defaults?.heartbeat?.timeoutSeconds).toBe(60);
+  });
+
+  it("should accept timeoutSeconds in per-agent heartbeat config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            heartbeat: {
+              every: "1h",
+              timeoutSeconds: 90,
+            },
+          },
+        ],
+      },
+    };
+
+    const opsAgent = cfg.agents?.list?.[0];
+    expect(opsAgent?.heartbeat?.timeoutSeconds).toBe(90);
+  });
+
+  it("should allow timeoutSeconds override at agent level", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+            timeoutSeconds: 60,
+          },
+        },
+        list: [
+          {
+            id: "research",
+            heartbeat: {
+              timeoutSeconds: 120,
+            },
+          },
+        ],
+      },
+    };
+
+    const researchAgent = cfg.agents?.list?.[0];
+    expect(researchAgent?.heartbeat?.timeoutSeconds).toBe(120);
+  });
+
+  it("should work without timeoutSeconds (backward compatible)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+            model: "anthropic/claude-sonnet-4-5",
+          },
+        },
+      },
+    };
+
+    expect(cfg.agents?.defaults?.heartbeat?.timeoutSeconds).toBeUndefined();
+  });
+});
+
+describe("runHeartbeatOnce – timeoutOverrideSeconds passthrough", () => {
+  async function runDefaultsHeartbeat(params: { timeoutSeconds?: number }) {
+    return withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "whatsapp",
+                ...(params.timeoutSeconds !== undefined && {
+                  timeoutSeconds: params.timeoutSeconds,
+                }),
+              },
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+        await seedSessionStore(storePath, sessionKey, {
+          updatedAt: 0,
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+1555",
+        });
+
+        const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        return replySpy.mock.calls[0]?.[1];
+      },
+      { prefix: "openclaw-hb-timeout-" },
+    );
+  }
+
+  it("passes timeoutOverrideSeconds when heartbeat.timeoutSeconds is set", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ timeoutSeconds: 45 });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        timeoutOverrideSeconds: 45,
+      }),
+    );
+  });
+
+  it("does not pass timeoutOverrideSeconds when heartbeat.timeoutSeconds is unset", async () => {
+    const replyOpts = await runDefaultsHeartbeat({});
+    expect(replyOpts?.timeoutOverrideSeconds).toBeUndefined();
+  });
+
+  it("passes per-agent timeoutSeconds override", async () => {
+    return withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              heartbeat: {
+                every: "30m",
+                timeoutSeconds: 60,
+              },
+            },
+            list: [
+              { id: "main", default: true },
+              {
+                id: "ops",
+                workspace: tmpDir,
+                heartbeat: {
+                  every: "5m",
+                  target: "whatsapp",
+                  timeoutSeconds: 90,
+                },
+              },
+            ],
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+        await seedSessionStore(storePath, sessionKey, {
+          updatedAt: 0,
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+1555",
+        });
+
+        const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        await runHeartbeatOnce({
+          cfg,
+          agentId: "ops",
+          deps: {
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            isHeartbeat: true,
+            timeoutOverrideSeconds: 90,
+          }),
+          cfg,
+        );
+      },
+      { prefix: "openclaw-hb-timeout-per-agent-" },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.timeout.test.ts
+++ b/src/infra/heartbeat-runner.timeout.test.ts
@@ -5,7 +5,7 @@ import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
 import { setWhatsAppRuntime } from "../../extensions/whatsapp/src/runtime.js";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveMainSessionKey } from "../config/sessions.js";
+import { resolveAgentMainSessionKey, resolveMainSessionKey } from "../config/sessions.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -198,7 +198,7 @@ describe("runHeartbeatOnce – timeoutOverrideSeconds passthrough", () => {
           channels: { whatsapp: { allowFrom: ["*"] } },
           session: { store: storePath },
         };
-        const sessionKey = resolveMainSessionKey(cfg);
+        const sessionKey = resolveAgentMainSessionKey({ cfg, agentId: "ops" });
         await seedSessionStore(storePath, sessionKey, {
           updatedAt: 0,
           lastChannel: "whatsapp",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -721,14 +721,17 @@ export async function runHeartbeatOnce(opts: {
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
-    const replyOpts = heartbeatModelOverride
-      ? {
-          isHeartbeat: true,
-          heartbeatModelOverride,
-          suppressToolErrorWarnings,
-          bootstrapContextMode,
-        }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+    const timeoutOverrideSeconds = heartbeat?.timeoutSeconds;
+    const replyOpts =
+      heartbeatModelOverride || timeoutOverrideSeconds !== undefined
+        ? {
+            isHeartbeat: true,
+            heartbeatModelOverride,
+            suppressToolErrorWarnings,
+            bootstrapContextMode,
+            ...(timeoutOverrideSeconds !== undefined && { timeoutOverrideSeconds }),
+          }
+        : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -726,7 +726,7 @@ export async function runHeartbeatOnce(opts: {
       heartbeatModelOverride || timeoutOverrideSeconds !== undefined
         ? {
             isHeartbeat: true,
-            heartbeatModelOverride,
+            ...(heartbeatModelOverride !== undefined && { heartbeatModelOverride }),
             suppressToolErrorWarnings,
             bootstrapContextMode,
             ...(timeoutOverrideSeconds !== undefined && { timeoutOverrideSeconds }),


### PR DESCRIPTION
## Summary

Add `timeoutSeconds` config field to `agents.defaults.heartbeat` and `agents.list[].heartbeat` to allow heartbeat runs to fail fast when a model hangs, without affecting interactive agent turn timeouts.

## Motivation

**Real incident** (2026-03-15 ~11:02 EDT): Heartbeat configured with `openrouter/google/gemini-2.5-flash-lite` silently hung for 600s. The native model-fallback correctly recovered (flash-lite → opus), but only after the full timeout elapsed. A 60s heartbeat timeout would have triggered failover in 1/10th the time.

**Problem**: Heartbeat embedded runs inherit `agents.defaults.timeoutSeconds` (default 600s). When a heartbeat's model hangs (e.g., OpenRouter proxy silent timeout), the entire embedded run blocks for 10 minutes before failover kicks in.

Heartbeats are lightweight status checks — they should fail fast (30-60s), not consume a 10-minute timeout designed for complex interactive agent turns.

## Changes

### 1. Schema Updates
- **File**: `src/config/zod-schema.agent-runtime.ts`
- Added `timeoutSeconds` field to `HeartbeatSchema`

### 2. Type Definitions
- **File**: `src/config/types.agent-defaults.ts`
- Added `timeoutSeconds` to heartbeat config type with documentation

### 3. Runtime Integration
- **File**: `src/infra/heartbeat-runner.ts`
- Modified `runHeartbeatOnce` to read and pass `timeoutOverrideSeconds` to `getReplyFromConfig`

### 4. Tests
- **File**: `src/infra/heartbeat-runner.timeout.test.ts`
- Added 7 tests: 4 type-level config tests + 3 runtime passthrough tests
- Tests verify `timeoutOverrideSeconds` correctly flows to `getReplyFromConfig`
- ✅ All tests pass

## Configuration Examples

### Global default for all heartbeats
```json5
{
  agents: {
    defaults: {
      heartbeat: {
        every: "30m",
        timeoutSeconds: 60, // Fail fast after 1 minute
      },
    },
  },
}
```

### Per-agent override
```json5
{
  agents: {
    defaults: {
      heartbeat: {
        every: "30m",
        timeoutSeconds: 60,
      },
    },
    list: [
      {
        id: "ops",
        heartbeat: {
          every: "1h",
          timeoutSeconds: 90, // Ops agent gets 90s timeout
        },
      },
    ],
  },
}
```

### Precedence
`agents.list[].heartbeat.timeoutSeconds` > `agents.defaults.heartbeat.timeoutSeconds` > `agents.defaults.timeoutSeconds` (existing 600s default)

## Impact

- **Affected users**: All users with heartbeat configured, especially those using third-party proxies (OpenRouter, etc.) prone to silent timeouts
- **Severity**: Medium — currently causes 10x slower failover when heartbeat models hang
- **Frequency**: Intermittent — triggered when proxy/model silently times out without error signal
- **Consequence**: Wasted time waiting for failover, delayed heartbeat recovery, potential cascading missed heartbeat cycles

## Backward Compatibility

✅ Fully backward compatible:
- Field is optional
- When not set, inherits existing behavior (uses `agents.defaults.timeoutSeconds`)
- No breaking changes to existing configs

## Testing

```bash
pnpm test src/infra/heartbeat-runner.timeout.test.ts
# ✓ 7 tests passed
```

## Related Issues

Closes #47456

## Checklist

- [x] Schema updated with validation
- [x] Type definitions updated with documentation
- [x] Runtime integration complete
- [x] Tests added and passing (runtime tests included)
- [x] Backward compatible