### PR TITLE
fix: exact-match exec allowlist prevents allow-always privilege escalation

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -118,48 +118,72 @@ struct ExecAllowlistRejectedEntry: Equatable {
 struct ExecAllowlistEntry: Codable, Hashable, Identifiable {
     var id: UUID
     var pattern: String
+    var args: [String]?
+    var matchMode: String?
     var lastUsedAt: Double?
     var lastUsedCommand: String?
     var lastResolvedPath: String?
+    var createdAt: Double?
+    var createdFrom: String?
 
     init(
         id: UUID = UUID(),
         pattern: String,
+        args: [String]? = nil,
+        matchMode: String? = nil,
         lastUsedAt: Double? = nil,
         lastUsedCommand: String? = nil,
-        lastResolvedPath: String? = nil)
+        lastResolvedPath: String? = nil,
+        createdAt: Double? = nil,
+        createdFrom: String? = nil)
     {
         self.id = id
         self.pattern = pattern
+        self.args = args
+        self.matchMode = matchMode
         self.lastUsedAt = lastUsedAt
         self.lastUsedCommand = lastUsedCommand
         self.lastResolvedPath = lastResolvedPath
+        self.createdAt = createdAt
+        self.createdFrom = createdFrom
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case pattern
+        case args
+        case matchMode
         case lastUsedAt
         case lastUsedCommand
         case lastResolvedPath
+        case createdAt
+        case createdFrom
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         self.pattern = try container.decode(String.self, forKey: .pattern)
+        self.args = try container.decodeIfPresent([String].self, forKey: .args)
+        self.matchMode = try container.decodeIfPresent(String.self, forKey: .matchMode)
         self.lastUsedAt = try container.decodeIfPresent(Double.self, forKey: .lastUsedAt)
         self.lastUsedCommand = try container.decodeIfPresent(String.self, forKey: .lastUsedCommand)
         self.lastResolvedPath = try container.decodeIfPresent(String.self, forKey: .lastResolvedPath)
+        self.createdAt = try container.decodeIfPresent(Double.self, forKey: .createdAt)
+        self.createdFrom = try container.decodeIfPresent(String.self, forKey: .createdFrom)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.id, forKey: .id)
         try container.encode(self.pattern, forKey: .pattern)
+        try container.encodeIfPresent(self.args, forKey: .args)
+        try container.encodeIfPresent(self.matchMode, forKey: .matchMode)
         try container.encodeIfPresent(self.lastUsedAt, forKey: .lastUsedAt)
         try container.encodeIfPresent(self.lastUsedCommand, forKey: .lastUsedCommand)
         try container.encodeIfPresent(self.lastResolvedPath, forKey: .lastResolvedPath)
+        try container.encodeIfPresent(self.createdAt, forKey: .createdAt)
+        try container.encodeIfPresent(self.createdFrom, forKey: .createdFrom)
     }
 }
 
@@ -450,7 +474,11 @@ enum ExecApprovalsStore {
     }
 
     @discardableResult
-    static func addAllowlistEntry(agentId: String?, pattern: String) -> ExecAllowlistPatternValidationReason? {
+    static func addAllowlistEntry(
+        agentId: String?,
+        pattern: String,
+        args: [String]? = nil
+    ) -> ExecAllowlistPatternValidationReason? {
         let normalizedPattern: String
         switch ExecApprovalHelpers.validateAllowlistPattern(pattern) {
         case let .valid(validPattern):
@@ -464,10 +492,20 @@ enum ExecApprovalsStore {
             var agents = file.agents ?? [:]
             var entry = agents[key] ?? ExecApprovalsAgent()
             var allowlist = entry.allowlist ?? []
-            if allowlist.contains(where: { $0.pattern == normalizedPattern }) { return }
+            // Dedup key includes args when present.
+            let isDuplicate = allowlist.contains { existing in
+                guard existing.pattern == normalizedPattern else { return false }
+                return existing.args == args
+            }
+            if isDuplicate { return }
+            let now = Date().timeIntervalSince1970 * 1000
             allowlist.append(ExecAllowlistEntry(
                 pattern: normalizedPattern,
-                lastUsedAt: Date().timeIntervalSince1970 * 1000))
+                args: args,
+                matchMode: args != nil ? "exact" : nil,
+                lastUsedAt: now,
+                createdAt: now,
+                createdFrom: "allow-always"))
             entry.allowlist = allowlist
             agents[key] = entry
             file.agents = agents
@@ -754,9 +792,24 @@ enum ExecApprovalHelpers {
         return false
     }
 
+    struct AllowAlwaysResolvedEntry {
+        let pattern: String
+        let args: [String]?
+    }
+
     static func allowlistPattern(command: [String], resolution: ExecCommandResolution?) -> String? {
         let pattern = resolution?.resolvedPath ?? resolution?.rawExecutable ?? command.first ?? ""
         return pattern.isEmpty ? nil : pattern
+    }
+
+    static func allowlistEntry(command: [String], resolution: ExecCommandResolution?) -> AllowAlwaysResolvedEntry? {
+        guard let pattern = self.allowlistPattern(command: command, resolution: resolution) else {
+            return nil
+        }
+        // Extract args (everything after the binary) from the effective command.
+        let effective = ExecEnvInvocationUnwrapper.unwrapDispatchWrappersForResolution(command)
+        let args: [String]? = effective.count > 1 ? Array(effective.dropFirst()) : nil
+        return AllowAlwaysResolvedEntry(pattern: pattern, args: args)
     }
 
     private static func containsPathComponent(_ pattern: String) -> Bool {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -461,16 +461,22 @@ private enum ExecHostExecutor {
         context: ExecApprovalContext)
     {
         guard decision == .allowAlways, context.security == .allowlist else { return }
-        var seenPatterns = Set<String>()
+        var seenKeys = Set<String>()
         for candidate in context.allowlistResolutions {
-            guard let pattern = ExecApprovalHelpers.allowlistPattern(
+            guard let entry = ExecApprovalHelpers.allowlistEntry(
                 command: context.command,
                 resolution: candidate)
             else {
                 continue
             }
-            if seenPatterns.insert(pattern).inserted {
-                ExecApprovalsStore.addAllowlistEntry(agentId: context.agentId, pattern: pattern)
+            let key = entry.args != nil
+                ? "\(entry.pattern)\0\(entry.args!)"
+                : entry.pattern
+            if seenKeys.insert(key).inserted {
+                ExecApprovalsStore.addAllowlistEntry(
+                    agentId: context.agentId,
+                    pattern: entry.pattern,
+                    args: entry.args)
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -799,13 +799,19 @@ extension MacNodeRuntime {
         allowlistResolutions: [ExecCommandResolution])
     {
         guard persistAllowlist, security == .allowlist else { return }
-        var seenPatterns = Set<String>()
+        var seenKeys = Set<String>()
         for candidate in allowlistResolutions {
-            guard let pattern = ExecApprovalHelpers.allowlistPattern(command: command, resolution: candidate) else {
+            guard let entry = ExecApprovalHelpers.allowlistEntry(command: command, resolution: candidate) else {
                 continue
             }
-            if seenPatterns.insert(pattern).inserted {
-                ExecApprovalsStore.addAllowlistEntry(agentId: agentId, pattern: pattern)
+            let key = entry.args != nil
+                ? "\(entry.pattern)\0\(entry.args!)"
+                : entry.pattern
+            if seenKeys.insert(key).inserted {
+                ExecApprovalsStore.addAllowlistEntry(
+                    agentId: agentId,
+                    pattern: entry.pattern,
+                    args: entry.args)
             }
         }
     }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -225,15 +225,15 @@ export async function processGatewayAllowlist(
       } else if (decision === "allow-always") {
         approvedByAsk = true;
         if (hostSecurity === "allowlist") {
-          const patterns = resolveAllowAlwaysPatterns({
+          const entries = resolveAllowAlwaysPatterns({
             segments: allowlistEval.segments,
             cwd: params.workdir,
             env: params.env,
             platform: process.platform,
           });
-          for (const pattern of patterns) {
-            if (pattern) {
-              addAllowlistEntry(approvals.file, params.agentId, pattern);
+          for (const entry of entries) {
+            if (entry.pattern) {
+              addAllowlistEntry(approvals.file, params.agentId, entry.pattern, entry.args);
             }
           }
         }

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -7,6 +7,7 @@ import {
   requiresExecApproval,
   resolveAllowAlwaysPatterns,
   resolveSafeBins,
+  type AllowAlwaysResolvedEntry,
 } from "./exec-approvals.js";
 
 describe("resolveAllowAlwaysPatterns", () => {
@@ -57,11 +58,16 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: params.env,
       safeBins,
     });
-    expect(persisted).toEqual([params.persistedPattern]);
+    expect(persisted.map((e) => e.pattern)).toEqual([params.persistedPattern]);
 
+    // Build allowlist entries from resolved entries (with exact-match args).
+    const allowlist = persisted.map((e) => ({
+      pattern: e.pattern,
+      ...(e.args != null ? { args: e.args, matchMode: "exact" as const } : {}),
+    }));
     const second = evaluateShellAllowlist({
       command: params.secondCommand,
-      allowlist: [{ pattern: params.persistedPattern }],
+      allowlist,
       safeBins,
       cwd: params.dir,
       env: params.env,
@@ -102,11 +108,16 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: params.env,
       safeBins: params.safeBins,
     });
-    expect(persisted).toEqual([params.script]);
+    expect(persisted.map((e) => e.pattern)).toEqual([params.script]);
 
+    // Build allowlist entries from resolved entries (with exact-match args).
+    const allowlist = persisted.map((e) => ({
+      pattern: e.pattern,
+      ...(e.args != null ? { args: e.args, matchMode: "exact" as const } : {}),
+    }));
     const second = evaluateShellAllowlist({
       command: params.command,
-      allowlist: [{ pattern: params.script }],
+      allowlist,
       safeBins: params.safeBins,
       cwd: params.dir,
       env: params.env,
@@ -117,7 +128,7 @@ describe("resolveAllowAlwaysPatterns", () => {
 
   it("returns direct executable paths for non-shell segments", () => {
     const exe = path.join("/tmp", "openclaw-tool");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: exe,
@@ -126,7 +137,7 @@ describe("resolveAllowAlwaysPatterns", () => {
         },
       ],
     });
-    expect(patterns).toEqual([exe]);
+    expect(entries).toEqual([{ pattern: exe, args: null }]);
   });
 
   it("unwraps shell wrappers and persists the inner executable instead", () => {
@@ -135,7 +146,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     }
     const dir = makeTempDir();
     const whoami = makeExecutable(dir, "whoami");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "/bin/zsh -lc 'whoami'",
@@ -151,8 +162,8 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: makePathEnv(dir),
       platform: process.platform,
     });
-    expect(patterns).toEqual([whoami]);
-    expect(patterns).not.toContain("/bin/zsh");
+    expect(entries.map((e) => e.pattern)).toEqual([whoami]);
+    expect(entries.map((e) => e.pattern)).not.toContain("/bin/zsh");
   });
 
   it("extracts all inner binaries from shell chains and deduplicates", () => {
@@ -162,7 +173,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     const dir = makeTempDir();
     const whoami = makeExecutable(dir, "whoami");
     const ls = makeExecutable(dir, "ls");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "/bin/zsh -lc 'whoami && ls && whoami'",
@@ -178,7 +189,7 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: makePathEnv(dir),
       platform: process.platform,
     });
-    expect(new Set(patterns)).toEqual(new Set([whoami, ls]));
+    expect(new Set(entries.map((e) => e.pattern))).toEqual(new Set([whoami, ls]));
   });
 
   it("persists shell script paths for wrapper invocations without inline commands", () => {
@@ -250,7 +261,7 @@ describe("resolveAllowAlwaysPatterns", () => {
   });
 
   it("does not persist broad shell binaries when no inner command can be derived", () => {
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "/bin/zsh -s",
@@ -264,7 +275,7 @@ describe("resolveAllowAlwaysPatterns", () => {
       ],
       platform: process.platform,
     });
-    expect(patterns).toEqual([]);
+    expect(entries).toEqual([]);
   });
 
   it("detects shell wrappers even when unresolved executableName is a full path", () => {
@@ -273,7 +284,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     }
     const dir = makeTempDir();
     const whoami = makeExecutable(dir, "whoami");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "/usr/local/bin/zsh -lc whoami",
@@ -289,7 +300,7 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: makePathEnv(dir),
       platform: process.platform,
     });
-    expect(patterns).toEqual([whoami]);
+    expect(entries.map((e) => e.pattern)).toEqual([whoami]);
   });
 
   it("unwraps known dispatch wrappers before shell wrappers", () => {
@@ -298,7 +309,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     }
     const dir = makeTempDir();
     const whoami = makeExecutable(dir, "whoami");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "/usr/bin/nice /bin/zsh -lc whoami",
@@ -314,8 +325,8 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: makePathEnv(dir),
       platform: process.platform,
     });
-    expect(patterns).toEqual([whoami]);
-    expect(patterns).not.toContain("/usr/bin/nice");
+    expect(entries.map((e) => e.pattern)).toEqual([whoami]);
+    expect(entries.map((e) => e.pattern)).not.toContain("/usr/bin/nice");
   });
 
   it("unwraps busybox/toybox shell applets and persists inner executables", () => {
@@ -327,7 +338,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     makeExecutable(dir, "toybox");
     const whoami = makeExecutable(dir, "whoami");
     const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: `${busybox} sh -lc whoami`,
@@ -343,8 +354,8 @@ describe("resolveAllowAlwaysPatterns", () => {
       env,
       platform: process.platform,
     });
-    expect(patterns).toEqual([whoami]);
-    expect(patterns).not.toContain(busybox);
+    expect(entries.map((e) => e.pattern)).toEqual([whoami]);
+    expect(entries.map((e) => e.pattern)).not.toContain(busybox);
   });
 
   it("fails closed for unsupported busybox/toybox applets", () => {
@@ -353,7 +364,7 @@ describe("resolveAllowAlwaysPatterns", () => {
     }
     const dir = makeTempDir();
     const busybox = makeExecutable(dir, "busybox");
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: `${busybox} sed -n 1p`,
@@ -369,11 +380,11 @@ describe("resolveAllowAlwaysPatterns", () => {
       env: makePathEnv(dir),
       platform: process.platform,
     });
-    expect(patterns).toEqual([]);
+    expect(entries).toEqual([]);
   });
 
   it("fails closed for unresolved dispatch wrappers", () => {
-    const patterns = resolveAllowAlwaysPatterns({
+    const entries = resolveAllowAlwaysPatterns({
       segments: [
         {
           raw: "sudo /bin/zsh -lc whoami",
@@ -387,7 +398,7 @@ describe("resolveAllowAlwaysPatterns", () => {
       ],
       platform: process.platform,
     });
-    expect(patterns).toEqual([]);
+    expect(entries).toEqual([]);
   });
 
   it("prevents allow-always bypass for busybox shell applets", () => {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -224,7 +224,7 @@ function evaluateSegments(
       candidatePath && segment.resolution
         ? { ...segment.resolution, resolvedPath: candidatePath }
         : segment.resolution;
-    const executableMatch = matchAllowlist(params.allowlist, candidateResolution);
+    const executableMatch = matchAllowlist(params.allowlist, candidateResolution, effectiveArgv);
     const inlineCommand = extractShellWrapperInlineCommand(allowlistSegment.argv);
     const shellScriptCandidatePath =
       inlineCommand === null
@@ -238,7 +238,7 @@ function evaluateSegments(
           rawExecutable: shellScriptCandidatePath,
           resolvedPath: shellScriptCandidatePath,
           executableName: path.basename(shellScriptCandidatePath),
-        })
+        }, effectiveArgv)
       : null;
     const match = executableMatch ?? shellScriptMatch;
     if (match) {
@@ -414,20 +414,32 @@ function resolveShellWrapperScriptCandidatePath(params: {
   return path.resolve(base, expanded);
 }
 
-function collectAllowAlwaysPatterns(params: {
+export type AllowAlwaysResolvedEntry = {
+  pattern: string;
+  args: string[] | null;
+};
+
+function allowAlwaysEntryKey(entry: AllowAlwaysResolvedEntry): string {
+  return entry.args != null
+    ? `${entry.pattern}\0${JSON.stringify(entry.args)}`
+    : entry.pattern;
+}
+
+function collectAllowAlwaysEntries(params: {
   segment: ExecCommandSegment;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   platform?: string | null;
   depth: number;
-  out: Set<string>;
+  out: AllowAlwaysResolvedEntry[];
+  seen: Set<string>;
 }) {
   if (params.depth >= 3) {
     return;
   }
 
   const recurseWithArgv = (argv: string[]): void => {
-    collectAllowAlwaysPatterns({
+    collectAllowAlwaysEntries({
       segment: {
         raw: argv.join(" "),
         argv,
@@ -438,7 +450,18 @@ function collectAllowAlwaysPatterns(params: {
       platform: params.platform,
       depth: params.depth + 1,
       out: params.out,
+      seen: params.seen,
     });
+  };
+
+  const addEntry = (pattern: string, argv: string[]): void => {
+    const args = argv.length > 1 ? argv.slice(1) : null;
+    const entry: AllowAlwaysResolvedEntry = { pattern, args };
+    const key = allowAlwaysEntryKey(entry);
+    if (!params.seen.has(key)) {
+      params.seen.add(key);
+      params.out.push(entry);
+    }
   };
 
   if (isDispatchWrapperSegment(params.segment)) {
@@ -463,8 +486,16 @@ function collectAllowAlwaysPatterns(params: {
   if (!candidatePath) {
     return;
   }
+
+  // Resolve the effective argv for the segment (after dispatch wrapper unwrapping etc.)
+  const effectiveArgv =
+    params.segment.resolution?.effectiveArgv &&
+    params.segment.resolution.effectiveArgv.length > 0
+      ? params.segment.resolution.effectiveArgv
+      : params.segment.argv;
+
   if (!isShellWrapperSegment(params.segment)) {
-    params.out.add(candidatePath);
+    addEntry(candidatePath, effectiveArgv);
     return;
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
@@ -474,7 +505,10 @@ function collectAllowAlwaysPatterns(params: {
       cwd: params.cwd,
     });
     if (scriptPath) {
-      params.out.add(scriptPath);
+      // For shell script wrapper invocations (e.g. `bash scripts/foo.sh`),
+      // the pattern is the script path itself. Args are not meaningful here
+      // because the approval is for the script, not the shell binary.
+      addEntry(scriptPath, [scriptPath]);
     }
     return;
   }
@@ -488,40 +522,47 @@ function collectAllowAlwaysPatterns(params: {
     return;
   }
   for (const nestedSegment of nested.segments) {
-    collectAllowAlwaysPatterns({
+    collectAllowAlwaysEntries({
       segment: nestedSegment,
       cwd: params.cwd,
       env: params.env,
       platform: params.platform,
       depth: params.depth + 1,
       out: params.out,
+      seen: params.seen,
     });
   }
 }
 
 /**
- * Derive persisted allowlist patterns for an "allow always" decision.
+ * Derive persisted allowlist entries for an "allow always" decision.
  * When a command is wrapped in a shell (for example `zsh -lc "<cmd>"`),
  * persist the inner executable(s) rather than the shell binary.
+ *
+ * Each entry includes the binary path and the frozen argument tail so that
+ * "allow always" for `python3 safe.py` does NOT blanket-allow all `python3`
+ * invocations.
  */
 export function resolveAllowAlwaysPatterns(params: {
   segments: ExecCommandSegment[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   platform?: string | null;
-}): string[] {
-  const patterns = new Set<string>();
+}): AllowAlwaysResolvedEntry[] {
+  const out: AllowAlwaysResolvedEntry[] = [];
+  const seen = new Set<string>();
   for (const segment of params.segments) {
-    collectAllowAlwaysPatterns({
+    collectAllowAlwaysEntries({
       segment,
       cwd: params.cwd,
       env: params.env,
       platform: params.platform,
       depth: 0,
-      out: patterns,
+      out,
+      seen,
     });
   }
-  return Array.from(patterns);
+  return out;
 }
 
 /**

--- a/src/infra/exec-approvals-exact-match.test.ts
+++ b/src/infra/exec-approvals-exact-match.test.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir, makePathEnv } from "./exec-approvals-test-helpers.js";
+import {
+  addAllowlistEntry,
+  ensureExecApprovals,
+  evaluateShellAllowlist,
+  matchAllowlist,
+  resolveAllowAlwaysPatterns,
+  resolveSafeBins,
+  type ExecAllowlistEntry,
+  type ExecApprovalsFile,
+} from "./exec-approvals.js";
+
+const tempDirs: string[] = [];
+const originalOpenClawHome = process.env.OPENCLAW_HOME;
+
+beforeEach(() => {});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalOpenClawHome === undefined) {
+    delete process.env.OPENCLAW_HOME;
+  } else {
+    process.env.OPENCLAW_HOME = originalOpenClawHome;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createHomeDir(): string {
+  const dir = makeTempDir();
+  tempDirs.push(dir);
+  process.env.OPENCLAW_HOME = dir;
+  return dir;
+}
+
+function approvalsFilePath(homeDir: string): string {
+  return path.join(homeDir, ".openclaw", "exec-approvals.json");
+}
+
+function readApprovalsFile(homeDir: string): ExecApprovalsFile {
+  return JSON.parse(fs.readFileSync(approvalsFilePath(homeDir), "utf8")) as ExecApprovalsFile;
+}
+
+describe("exact-match allowlist entries", () => {
+  const baseResolution = {
+    rawExecutable: "python3",
+    resolvedPath: "/usr/bin/python3",
+    executableName: "python3",
+  };
+
+  it("exact-match entry matches only when path AND args match", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: ["safe.py"],
+      matchMode: "exact",
+    };
+    const match = matchAllowlist([entry], baseResolution, ["python3", "safe.py"]);
+    expect(match).toBe(entry);
+  });
+
+  it("exact-match entry rejects when args differ", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: ["safe.py"],
+      matchMode: "exact",
+    };
+    const match = matchAllowlist([entry], baseResolution, ["python3", "evil.py"]);
+    expect(match).toBeNull();
+  });
+
+  it("exact-match entry rejects when arg count differs", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: ["safe.py"],
+      matchMode: "exact",
+    };
+    // Extra args
+    const match1 = matchAllowlist([entry], baseResolution, ["python3", "safe.py", "--verbose"]);
+    expect(match1).toBeNull();
+    // No args
+    const match2 = matchAllowlist([entry], baseResolution, ["python3"]);
+    expect(match2).toBeNull();
+  });
+
+  it("path-only entries (no matchMode) match any args for backward compat", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+    };
+    expect(matchAllowlist([entry], baseResolution, ["python3", "safe.py"])).toBe(entry);
+    expect(matchAllowlist([entry], baseResolution, ["python3", "evil.py"])).toBe(entry);
+    expect(matchAllowlist([entry], baseResolution, ["python3"])).toBe(entry);
+  });
+
+  it("exact-match entry with null args matches any args (like path-only)", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: null,
+      matchMode: "exact",
+    };
+    expect(matchAllowlist([entry], baseResolution, ["python3", "safe.py"])).toBe(entry);
+    expect(matchAllowlist([entry], baseResolution, ["python3", "evil.py"])).toBe(entry);
+  });
+
+  it("exact-match entry with empty args matches only bare binary invocation", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: [],
+      matchMode: "exact",
+    };
+    expect(matchAllowlist([entry], baseResolution, ["python3"])).toBe(entry);
+    expect(matchAllowlist([entry], baseResolution, ["python3", "safe.py"])).toBeNull();
+  });
+
+  it("exact-match respects order and content of all args", () => {
+    const entry: ExecAllowlistEntry = {
+      pattern: "/usr/bin/python3",
+      args: ["-m", "pytest", "tests/"],
+      matchMode: "exact",
+    };
+    expect(matchAllowlist([entry], baseResolution, ["python3", "-m", "pytest", "tests/"])).toBe(
+      entry,
+    );
+    expect(
+      matchAllowlist([entry], baseResolution, ["python3", "pytest", "-m", "tests/"]),
+    ).toBeNull();
+  });
+});
+
+describe("exact-match with shell wrapper unwrapping", () => {
+  function makeExecutable(dir: string, name: string): string {
+    const fileName = process.platform === "win32" ? `${name}.exe` : name;
+    const exe = path.join(dir, fileName);
+    fs.writeFileSync(exe, "");
+    fs.chmodSync(exe, 0o755);
+    return exe;
+  }
+
+  it("shell wrapper unwrapping preserves inner args", () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir();
+    const python3 = makeExecutable(dir, "python3");
+    const entries = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "/bin/zsh -lc 'python3 safe.py'",
+          argv: ["/bin/zsh", "-lc", "python3 safe.py"],
+          resolution: {
+            rawExecutable: "/bin/zsh",
+            resolvedPath: "/bin/zsh",
+            executableName: "zsh",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(entries).toEqual([{ pattern: python3, args: ["safe.py"] }]);
+  });
+
+  it("dispatch wrapper unwrapping preserves inner args", () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir();
+    const python3 = makeExecutable(dir, "python3");
+    const entries = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "/usr/bin/nice python3 safe.py",
+          argv: ["/usr/bin/nice", "python3", "safe.py"],
+          resolution: {
+            rawExecutable: "/usr/bin/nice",
+            resolvedPath: "/usr/bin/nice",
+            executableName: "nice",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(entries).toEqual([{ pattern: python3, args: ["safe.py"] }]);
+  });
+
+  it("chain (&&) creates separate exact entries per segment", () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir();
+    const python3 = makeExecutable(dir, "python3");
+    const rg = makeExecutable(dir, "rg");
+    const entries = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "/bin/zsh -lc 'python3 safe.py && rg needle'",
+          argv: ["/bin/zsh", "-lc", "python3 safe.py && rg needle"],
+          resolution: {
+            rawExecutable: "/bin/zsh",
+            resolvedPath: "/bin/zsh",
+            executableName: "zsh",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(entries).toEqual([
+      { pattern: python3, args: ["safe.py"] },
+      { pattern: rg, args: ["needle"] },
+    ]);
+  });
+});
+
+describe("dedup on pattern+args combo", () => {
+  it("deduplicates entries with same pattern and args", () => {
+    const dir = createHomeDir();
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+
+    const approvals = ensureExecApprovals();
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3", ["safe.py"]);
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3", ["safe.py"]);
+
+    const file = readApprovalsFile(dir);
+    expect(file.agents?.worker?.allowlist).toHaveLength(1);
+    expect(file.agents?.worker?.allowlist?.[0]).toEqual(
+      expect.objectContaining({
+        pattern: "/usr/bin/python3",
+        args: ["safe.py"],
+        matchMode: "exact",
+      }),
+    );
+  });
+
+  it("allows separate entries for same binary with different args", () => {
+    const dir = createHomeDir();
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+
+    const approvals = ensureExecApprovals();
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3", ["safe.py"]);
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3", ["other.py"]);
+
+    const file = readApprovalsFile(dir);
+    expect(file.agents?.worker?.allowlist).toHaveLength(2);
+    expect(file.agents?.worker?.allowlist?.[0]?.args).toEqual(["safe.py"]);
+    expect(file.agents?.worker?.allowlist?.[1]?.args).toEqual(["other.py"]);
+  });
+
+  it("allows path-only and exact-match entries for same binary", () => {
+    const dir = createHomeDir();
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+
+    const approvals = ensureExecApprovals();
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3");
+    addAllowlistEntry(approvals, "worker", "/usr/bin/python3", ["safe.py"]);
+
+    const file = readApprovalsFile(dir);
+    expect(file.agents?.worker?.allowlist).toHaveLength(2);
+    expect(file.agents?.worker?.allowlist?.[0]?.matchMode).toBeUndefined();
+    expect(file.agents?.worker?.allowlist?.[1]?.matchMode).toBe("exact");
+  });
+});
+
+describe("exact-match integration with evaluateShellAllowlist", () => {
+  function makeExecutable(dir: string, name: string): string {
+    const fileName = process.platform === "win32" ? `${name}.exe` : name;
+    const exe = path.join(dir, fileName);
+    fs.writeFileSync(exe, "");
+    fs.chmodSync(exe, 0o755);
+    return exe;
+  }
+
+  it("python3 safe.py allow-always does NOT approve python3 evil.py", () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir();
+    const python3 = makeExecutable(dir, "python3");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    // Resolve allow-always entries for python3 safe.py
+    const firstAnalysis = evaluateShellAllowlist({
+      command: "python3 safe.py",
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const entries = resolveAllowAlwaysPatterns({
+      segments: firstAnalysis.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(entries).toEqual([{ pattern: python3, args: ["safe.py"] }]);
+
+    // Build allowlist from resolved entries
+    const allowlist: ExecAllowlistEntry[] = entries.map((e) => ({
+      pattern: e.pattern,
+      ...(e.args != null ? { args: e.args, matchMode: "exact" as const } : {}),
+    }));
+
+    // Same command should match
+    const sameCmd = evaluateShellAllowlist({
+      command: "python3 safe.py",
+      allowlist,
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(sameCmd.allowlistSatisfied).toBe(true);
+
+    // Different args should NOT match
+    const differentCmd = evaluateShellAllowlist({
+      command: "python3 evil.py",
+      allowlist,
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(differentCmd.allowlistSatisfied).toBe(false);
+  });
+});

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -148,6 +148,8 @@ describe("exec approvals store helpers", () => {
       expect.objectContaining({
         pattern: "/usr/bin/rg",
         lastUsedAt: 123_456,
+        createdAt: 123_456,
+        createdFrom: "allow-always",
       }),
     ]);
     expect(readApprovalsFile(dir).agents?.worker?.allowlist?.[0]?.id).toMatch(/^[0-9a-f-]{36}$/i);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -106,9 +106,13 @@ export type ExecApprovalsDefaults = {
 export type ExecAllowlistEntry = {
   id?: string;
   pattern: string;
+  args?: string[] | null;
+  matchMode?: "path-only" | "exact";
   lastUsedAt?: number;
   lastUsedCommand?: string;
   lastResolvedPath?: string;
+  createdAt?: number;
+  createdFrom?: "allow-always" | "manual" | "rule-promotion";
 };
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
@@ -180,8 +184,14 @@ function mergeLegacyAgent(
   const allowlist: ExecAllowlistEntry[] = [];
   const seen = new Set<string>();
   const pushEntry = (entry: ExecAllowlistEntry) => {
-    const key = normalizeAllowlistPattern(entry.pattern);
-    if (!key || seen.has(key)) {
+    const patternKey = normalizeAllowlistPattern(entry.pattern);
+    if (!patternKey) {
+      return;
+    }
+    const key = entry.args != null
+      ? `${patternKey}\0${JSON.stringify(entry.args)}`
+      : patternKey;
+    if (seen.has(key)) {
       return;
     }
     seen.add(key);
@@ -526,6 +536,7 @@ export function addAllowlistEntry(
   approvals: ExecApprovalsFile,
   agentId: string | undefined,
   pattern: string,
+  args?: string[] | null,
 ) {
   const target = agentId ?? DEFAULT_AGENT_ID;
   const agents = approvals.agents ?? {};
@@ -535,10 +546,32 @@ export function addAllowlistEntry(
   if (!trimmed) {
     return;
   }
-  if (allowlist.some((entry) => entry.pattern === trimmed)) {
+  // Dedup key includes args when present so `python3 foo.py` and `python3 bar.py`
+  // produce distinct entries.
+  const dedupKey = args != null
+    ? `${trimmed}\0${JSON.stringify(args)}`
+    : trimmed;
+  if (allowlist.some((entry) => {
+    const entryKey = entry.args != null
+      ? `${entry.pattern}\0${JSON.stringify(entry.args)}`
+      : entry.pattern;
+    return entryKey === dedupKey;
+  })) {
     return;
   }
-  allowlist.push({ id: crypto.randomUUID(), pattern: trimmed, lastUsedAt: Date.now() });
+  const now = Date.now();
+  const newEntry: ExecAllowlistEntry = {
+    id: crypto.randomUUID(),
+    pattern: trimmed,
+    lastUsedAt: now,
+    createdAt: now,
+    createdFrom: "allow-always",
+  };
+  if (args != null) {
+    newEntry.args = args;
+    newEntry.matchMode = "exact";
+  }
+  allowlist.push(newEntry);
   agents[target] = { ...existing, allowlist };
   approvals.agents = agents;
   saveExecApprovals(approvals);

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -143,6 +143,7 @@ export function resolveAllowlistCandidatePath(
 export function matchAllowlist(
   entries: ExecAllowlistEntry[],
   resolution: CommandResolution | null,
+  effectiveArgv?: string[],
 ): ExecAllowlistEntry | null {
   if (!entries.length) {
     return null;
@@ -168,6 +169,16 @@ export function matchAllowlist(
       continue;
     }
     if (matchesExecAllowlistPattern(pattern, resolvedPath)) {
+      // For exact-match entries, also require args to match element-by-element.
+      if (entry.matchMode === "exact" && entry.args != null) {
+        const commandArgs = effectiveArgv ? effectiveArgv.slice(1) : [];
+        if (
+          entry.args.length !== commandArgs.length ||
+          !entry.args.every((a, i) => a === commandArgs[i])
+        ) {
+          continue;
+        }
+      }
       return entry;
     }
   }

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -489,15 +489,15 @@ async function executeSystemRunPhase(
 
   if (phase.policy.approvalDecision === "allow-always" && phase.security === "allowlist") {
     if (phase.policy.analysisOk) {
-      const patterns = resolveAllowAlwaysPatterns({
+      const entries = resolveAllowAlwaysPatterns({
         segments: phase.segments,
         cwd: phase.cwd,
         env: phase.env,
         platform: process.platform,
       });
-      for (const pattern of patterns) {
-        if (pattern) {
-          addAllowlistEntry(phase.approvals.file, phase.agentId, pattern);
+      for (const entry of entries) {
+        if (entry.pattern) {
+          addAllowlistEntry(phase.approvals.file, phase.agentId, entry.pattern, entry.args);
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Security fix**: "Always Allow" now stores the frozen argument tail alongside the binary path, so approving `python3 safe.py` no longer blanket-allows all `python3` invocations
- Extends `ExecAllowlistEntry` with `args`, `matchMode`, `createdAt`, `createdFrom` fields (backward compatible — absent fields = legacy path-only behavior)
- Updates `matchAllowlist()` to enforce exact element-by-element arg comparison when `matchMode: "exact"`
- Updates `resolveAllowAlwaysPatterns()` to return structured `AllowAlwaysResolvedEntry[]` capturing args from the resolved command
- Updates all 4 caller sites (TS gateway, TS node-host, Swift socket, Swift node runtime)

Closes #48532 (Phase 1)

## Test plan

- [x] 14 new tests in `exec-approvals-exact-match.test.ts` covering exact-match, rejection, backward compat, wrapper unwrapping, chain separation, dedup, and end-to-end integration
- [x] All 154 existing exec-approvals tests pass (updated assertions for structured return type)
- [x] Zero TypeScript errors (`tsc --noEmit`)
- [ ] Manual: set `security=allowlist`, run `python3 foo.py`, click "Always Allow", verify `exec-approvals.json` has `args: ["foo.py"]` and `matchMode: "exact"`, then run `python3 bar.py` and verify it requires approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)