### PR TITLE
fix(feishu): await HTTP server close before clearing state references

### DIFF
--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -134,19 +134,19 @@ export function recordWebhookStatus(
 
 const SERVER_CLOSE_TIMEOUT_MS = 5_000;
 
-function closeHttpServer(server: http.Server): Promise<void> {
-  return Promise.race([
-    new Promise<void>((resolve) => {
-      (server.closeAllConnections as (() => void) | undefined)?.();
-      server.close(() => resolve());
-    }),
-    new Promise<void>((resolve) => {
-      setTimeout(() => {
-        console.warn("feishu: HTTP server close timed out, continuing cleanup");
-        resolve();
-      }, SERVER_CLOSE_TIMEOUT_MS);
-    }),
-  ]);
+export function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn("feishu: HTTP server close timed out, continuing cleanup");
+      resolve();
+    }, SERVER_CLOSE_TIMEOUT_MS);
+
+    (server.closeAllConnections as (() => void) | undefined)?.();
+    server.close(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 }
 
 export async function stopFeishuMonitorState(accountId?: string): Promise<void> {

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -141,11 +141,11 @@ export function closeHttpServer(server: http.Server): Promise<void> {
       resolve();
     }, SERVER_CLOSE_TIMEOUT_MS);
 
-    (server.closeAllConnections as (() => void) | undefined)?.();
     server.close(() => {
       clearTimeout(timer);
       resolve();
     });
+    (server.closeAllConnections as (() => void) | undefined)?.();
   });
 }
 

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -132,12 +132,29 @@ export function recordWebhookStatus(
   });
 }
 
-export function stopFeishuMonitorState(accountId?: string): void {
+const SERVER_CLOSE_TIMEOUT_MS = 5_000;
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return Promise.race([
+    new Promise<void>((resolve) => {
+      (server.closeAllConnections as (() => void) | undefined)?.();
+      server.close(() => resolve());
+    }),
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        console.warn("feishu: HTTP server close timed out, continuing cleanup");
+        resolve();
+      }, SERVER_CLOSE_TIMEOUT_MS);
+    }),
+  ]);
+}
+
+export async function stopFeishuMonitorState(accountId?: string): Promise<void> {
   if (accountId) {
     wsClients.delete(accountId);
     const server = httpServers.get(accountId);
     if (server) {
-      server.close();
+      await closeHttpServer(server);
       httpServers.delete(accountId);
     }
     botOpenIds.delete(accountId);
@@ -146,9 +163,7 @@ export function stopFeishuMonitorState(accountId?: string): void {
   }
 
   wsClients.clear();
-  for (const server of httpServers.values()) {
-    server.close();
-  }
+  await Promise.all([...httpServers.values()].map((server) => closeHttpServer(server)));
   httpServers.clear();
   botOpenIds.clear();
   botNames.clear();

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -230,8 +230,9 @@ export async function monitorWebhook({
   httpServers.set(accountId, server);
 
   return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      server.close();
+    const cleanup = async () => {
+      (server.closeAllConnections as (() => void) | undefined)?.();
+      await new Promise<void>((cb) => server.close(() => cb()));
       httpServers.delete(accountId);
       botOpenIds.delete(accountId);
       botNames.delete(accountId);
@@ -239,13 +240,11 @@ export async function monitorWebhook({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
-      cleanup();
-      resolve();
+      void cleanup().then(() => resolve());
     };
 
     if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+      void cleanup().then(() => resolve());
       return;
     }
 

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -14,6 +14,7 @@ import {
   FEISHU_WEBHOOK_BODY_TIMEOUT_MS,
   FEISHU_WEBHOOK_MAX_BODY_BYTES,
   feishuWebhookRateLimiter,
+  closeHttpServer,
   httpServers,
   recordWebhookStatus,
   wsClients,
@@ -231,8 +232,7 @@ export async function monitorWebhook({
 
   return new Promise((resolve, reject) => {
     const cleanup = async () => {
-      (server.closeAllConnections as (() => void) | undefined)?.();
-      await new Promise<void>((cb) => server.close(() => cb()));
+      await closeHttpServer(server);
       httpServers.delete(accountId);
       botOpenIds.delete(accountId);
       botNames.delete(accountId);
@@ -240,11 +240,11 @@ export async function monitorWebhook({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
-      void cleanup().then(() => resolve());
+      void cleanup().then(() => resolve(), reject);
     };
 
     if (abortSignal?.aborted) {
-      void cleanup().then(() => resolve());
+      void cleanup().then(() => resolve(), reject);
       return;
     }
 


### PR DESCRIPTION
## Summary

Prevents port leaks (EADDRINUSE) and memory leaks caused by premature HTTP server reference cleanup during Feishu plugin shutdown/restart.

## Root Cause

`stopFeishuMonitorState()` calls `server.close()` then immediately deletes the server from the `httpServers` Map. Since `server.close()` is asynchronous, the port may still be bound when the reference is removed — causing EADDRINUSE on restart and leaking server objects. The same pattern exists in `monitor.transport.ts`'s cleanup function.

## Fix

- Add `closeHttpServer()` helper: calls `closeAllConnections()` (Node 18.2+) then awaits `server.close()` callback, with a 5-second timeout fallback
- Change `stopFeishuMonitorState()` to async: await server close before deleting Map entries (single-account and full-cleanup paths)
- Fix `monitor.transport.ts` cleanup: await `server.close()` before clearing state
- Backward compatible: callers can still fire-and-forget (no signature change needed at call sites)

## Changes

- `extensions/feishu/src/monitor.state.ts`: 22 lines added, 5 removed
- `extensions/feishu/src/monitor.transport.ts`: 5 lines added, 6 removed

Fixes #48183