### PR TITLE
fix(loop-detection): block browser search storms

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -20,6 +20,7 @@ Enable it only where needed, because it can block legitimate repeated calls with
 - Detect repetitive sequences that do not make progress.
 - Detect high-frequency no-result loops (same tool, same inputs, repeated errors).
 - Detect specific repeated-call patterns for known polling tools.
+- Detect browser search storms where the agent keeps opening search-result pages while changing queries or engines.
 
 ## Configuration block
 
@@ -33,11 +34,14 @@ Global defaults:
       historySize: 30,
       warningThreshold: 10,
       criticalThreshold: 20,
+      browserSearchWarningThreshold: 4,
+      browserSearchCriticalThreshold: 8,
       globalCircuitBreakerThreshold: 30,
       detectors: {
         genericRepeat: true,
         knownPollNoProgress: true,
         pingPong: true,
+        browserSearchStorm: true,
       },
     },
   },
@@ -71,20 +75,27 @@ Per-agent override (optional):
 - `historySize`: number of recent tool calls kept for analysis.
 - `warningThreshold`: threshold before classifying a pattern as warning-only.
 - `criticalThreshold`: threshold for blocking repetitive loop patterns.
+- `browserSearchWarningThreshold`: warning threshold for browser search storms across changing queries.
+- `browserSearchCriticalThreshold`: critical threshold for browser search storms across changing queries.
 - `globalCircuitBreakerThreshold`: global no-progress breaker threshold.
 - `detectors.genericRepeat`: detects repeated same-tool + same-params patterns.
 - `detectors.knownPollNoProgress`: detects known polling-like patterns with no state change.
 - `detectors.pingPong`: detects alternating ping-pong patterns.
+- `detectors.browserSearchStorm`: detects repeated browser opens/navigations to search-result pages across changing queries or engines.
 
 ## Recommended setup
 
 - Start with `enabled: true`, defaults unchanged.
 - Keep thresholds ordered as `warningThreshold < criticalThreshold < globalCircuitBreakerThreshold`.
+- Keep browser-search thresholds ordered as `browserSearchWarningThreshold < browserSearchCriticalThreshold`.
 - If false positives occur:
   - raise `warningThreshold` and/or `criticalThreshold`
+  - raise `browserSearchWarningThreshold` and/or `browserSearchCriticalThreshold`
   - (optionally) raise `globalCircuitBreakerThreshold`
   - disable only the detector causing issues
   - reduce `historySize` for less strict historical context
+
+Browser-search thresholds are intentionally lower than generic-repeat thresholds because real search loops often interleave `browser open` / `browser navigate` with `browser snapshot`, so waiting for the generic defaults can be too late.
 
 ## Logs and expected behavior
 
@@ -93,6 +104,7 @@ This protects users from runaway token spend and lockups while preserving normal
 
 - Prefer warning and temporary suppression first.
 - Escalate only when repeated evidence accumulates.
+- Browser-search storms become especially risky when they fan out into many real network requests from a small number of tool calls.
 
 ## Notes
 

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -7,7 +7,12 @@ import {
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
+import {
+  BROWSER_SEARCH_CRITICAL_THRESHOLD,
+  BROWSER_SEARCH_WARNING_THRESHOLD,
+  CRITICAL_THRESHOLD,
+  GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+} from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 vi.mock("../plugins/hook-runner-global.js");
@@ -132,10 +137,28 @@ describe("before_tool_call loop detection behavior", () => {
     };
   }
 
+  function createBrowserSearchFixture() {
+    const execute = vi
+      .fn()
+      .mockImplementation(async (_toolCallId: string, params: { url: string }) => {
+        return {
+          content: [{ type: "text", text: `results for ${params.url}` }],
+          details: { url: params.url },
+        };
+      });
+    return {
+      tool: createWrappedTool("browser", execute),
+      paramsForQuery: (query: string, host = "www.google.com") => ({
+        action: "open",
+        url: `https://${host}/search?q=${encodeURIComponent(query)}`,
+      }),
+    };
+  }
+
   function expectCriticalLoopEvent(
     loopEvent: DiagnosticToolLoopEvent | undefined,
     params: {
-      detector: "ping_pong" | "known_poll_no_progress";
+      detector: "ping_pong" | "known_poll_no_progress" | "browser_search_storm";
       toolName: string;
       count?: number;
     },
@@ -191,6 +214,71 @@ describe("before_tool_call loop detection behavior", () => {
         tool.execute(`poll-progress-${i}`, params, undefined, undefined),
       ).resolves.toBeDefined();
     }
+  });
+
+  it("emits structured warning diagnostic events for browser search storms", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        await tool.execute(
+          `browser-search-${i}`,
+          paramsForQuery(`openclaw issue ${i}`),
+          undefined,
+          undefined,
+        );
+      }
+
+      await tool.execute(
+        `browser-search-${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        paramsForQuery(`openclaw issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`),
+        undefined,
+        undefined,
+      );
+
+      const browserWarns = emitted.filter(
+        (evt) => evt.level === "warning" && evt.detector === "browser_search_storm",
+      );
+      expect(browserWarns).toHaveLength(1);
+      const loopEvent = browserWarns[0];
+      expect(loopEvent?.type).toBe("tool.loop");
+      expect(loopEvent?.level).toBe("warning");
+      expect(loopEvent?.action).toBe("warn");
+      expect(loopEvent?.detector).toBe("browser_search_storm");
+      expect(loopEvent?.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      expect(loopEvent?.toolName).toBe("browser");
+    });
+  });
+
+  it("blocks browser search storms at critical threshold and emits critical diagnostic events", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD; i += 1) {
+        await tool.execute(
+          `browser-search-critical-${i}`,
+          paramsForQuery(`openclaw fix ${i}`, i % 2 === 0 ? "www.google.com" : "www.bing.com"),
+          undefined,
+          undefined,
+        );
+      }
+
+      await expect(
+        tool.execute(
+          `browser-search-critical-${BROWSER_SEARCH_CRITICAL_THRESHOLD}`,
+          paramsForQuery(`openclaw fix ${BROWSER_SEARCH_CRITICAL_THRESHOLD}`, "www.bing.com"),
+          undefined,
+          undefined,
+        ),
+      ).rejects.toThrow("CRITICAL");
+
+      const loopEvent = emitted.at(-1);
+      expectCriticalLoopEvent(loopEvent, {
+        detector: "browser_search_storm",
+        toolName: "browser",
+        count: BROWSER_SEARCH_CRITICAL_THRESHOLD,
+      });
+    });
   });
 
   it("keeps generic repeated calls warn-only below global breaker", async () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -44,7 +44,7 @@ function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: n
     state.toolLoopWarningBuckets = new Map();
   }
   const bucket = Math.floor(count / LOOP_WARNING_BUCKET_SIZE);
-  const lastBucket = state.toolLoopWarningBuckets.get(warningKey) ?? 0;
+  const lastBucket = state.toolLoopWarningBuckets.get(warningKey) ?? -1;
   if (bucket <= lastBucket) {
     return false;
   }

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -44,6 +44,7 @@ function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: n
     state.toolLoopWarningBuckets = new Map();
   }
   const bucket = Math.floor(count / LOOP_WARNING_BUCKET_SIZE);
+  // Use -1 so the first warning in bucket 0 can emit once instead of being suppressed.
   const lastBucket = state.toolLoopWarningBuckets.get(warningKey) ?? -1;
   if (bucket <= lastBucket) {
     return false;

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
+  BROWSER_SEARCH_CRITICAL_THRESHOLD,
+  BROWSER_SEARCH_WARNING_THRESHOLD,
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   TOOL_CALL_HISTORY_SIZE,
@@ -92,6 +94,40 @@ function createPingPongFixture() {
     readParams: { path: "/a.txt" },
     listParams: { dir: "/workspace" },
   };
+}
+
+function createBrowserSearchFixture(query: string, host = "www.google.com") {
+  const url = `https://${host}/search?q=${encodeURIComponent(query)}`;
+  return {
+    toolName: "browser",
+    params: { action: "open", url },
+    result: {
+      content: [{ type: "text", text: `results for ${query}` }],
+      details: { url },
+    },
+  } as const;
+}
+
+function recordSuccessfulBrowserSearchCalls(params: {
+  state: SessionState;
+  queries: string[];
+  hostAtIndex?: (index: number) => string;
+  startIndex?: number;
+}) {
+  const startIndex = params.startIndex ?? 0;
+  for (let i = 0; i < params.queries.length; i += 1) {
+    const fixture = createBrowserSearchFixture(
+      params.queries[i] ?? `query-${i}`,
+      params.hostAtIndex?.(i) ?? "www.google.com",
+    );
+    recordSuccessfulCall(
+      params.state,
+      fixture.toolName,
+      fixture.params,
+      fixture.result,
+      startIndex + i,
+    );
+  }
 }
 
 function detectLoopAfterRepeatedCalls(params: {
@@ -425,6 +461,82 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "process", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("warns on browser search storms across changing queries", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: Array.from(
+          { length: BROWSER_SEARCH_WARNING_THRESHOLD },
+          (_, index) => `openclaw issue ${index}`,
+        ),
+      });
+
+      const current = createBrowserSearchFixture("openclaw issue next");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+        expect(loopResult.message).toContain("Browser search pages have been opened");
+      }
+    });
+
+    it("blocks browser search storms at critical threshold", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: Array.from(
+          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD },
+          (_, index) => `openclaw loop detection ${index}`,
+        ),
+        hostAtIndex: (index) => (index % 2 === 0 ? "www.google.com" : "www.bing.com"),
+      });
+
+      const current = createBrowserSearchFixture("openclaw loop detection next", "www.bing.com");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_CRITICAL_THRESHOLD);
+        expect(loopResult.message).toContain("CRITICAL");
+      }
+    });
+
+    it("does not flag normal browser page opens as a browser search storm", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        recordSuccessfulCall(
+          state,
+          "browser",
+          { action: "open", url: `https://example.com/page-${i}` },
+          { content: [{ type: "text", text: `page ${i}` }], details: { ok: true } },
+          i,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "browser",
+        { action: "open", url: "https://example.com/final" },
+        enabledLoopDetectionConfig,
+      );
       expect(loopResult.stuck).toBe(false);
     });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -475,7 +475,7 @@ describe("tool-loop-detection", () => {
       recordSuccessfulBrowserSearchCalls({
         state,
         queries: Array.from(
-          { length: BROWSER_SEARCH_WARNING_THRESHOLD - 1 },
+          { length: BROWSER_SEARCH_WARNING_THRESHOLD },
           (_, index) => `openclaw issue ${index}`,
         ),
       });
@@ -502,7 +502,7 @@ describe("tool-loop-detection", () => {
       recordSuccessfulBrowserSearchCalls({
         state,
         queries: Array.from(
-          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD - 1 },
+          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD },
           (_, index) => `openclaw loop detection ${index}`,
         ),
         hostAtIndex: (index) => (index % 2 === 0 ? "www.google.com" : "www.bing.com"),
@@ -527,7 +527,7 @@ describe("tool-loop-detection", () => {
 
     it("matches Yandex search pages with a trailing slash", () => {
       const state = createState();
-      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD - 1; i += 1) {
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
         const fixture = createBrowserSearchFixture(`yandex issue ${i}`, "yandex.com", {
           path: "/search/",
           queryParam: "text",

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -553,6 +553,48 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("does not treat google.evil.com search pages as Google search hops", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        const fixture = createBrowserSearchFixture(`evil google issue ${i}`, "google.evil.com");
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("evil google issue next", "google.evil.com");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("does not treat yandex.evil.com search pages as Yandex search hops", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        const fixture = createBrowserSearchFixture(`evil yandex issue ${i}`, "yandex.evil.com", {
+          path: "/search/",
+          queryParam: "text",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("evil yandex issue next", "yandex.evil.com", {
+        path: "/search/",
+        queryParam: "text",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("does not flag normal browser page opens as a browser search storm", () => {
       const state = createState();
       for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -96,8 +96,14 @@ function createPingPongFixture() {
   };
 }
 
-function createBrowserSearchFixture(query: string, host = "www.google.com") {
-  const url = `https://${host}/search?q=${encodeURIComponent(query)}`;
+function createBrowserSearchFixture(
+  query: string,
+  host = "www.google.com",
+  options?: { path?: string; queryParam?: string },
+) {
+  const path = options?.path ?? "/search";
+  const queryParam = options?.queryParam ?? "q";
+  const url = `https://${host}${path}?${queryParam}=${encodeURIComponent(query)}`;
   return {
     toolName: "browser",
     params: { action: "open", url },
@@ -469,7 +475,7 @@ describe("tool-loop-detection", () => {
       recordSuccessfulBrowserSearchCalls({
         state,
         queries: Array.from(
-          { length: BROWSER_SEARCH_WARNING_THRESHOLD },
+          { length: BROWSER_SEARCH_WARNING_THRESHOLD - 1 },
           (_, index) => `openclaw issue ${index}`,
         ),
       });
@@ -496,7 +502,7 @@ describe("tool-loop-detection", () => {
       recordSuccessfulBrowserSearchCalls({
         state,
         queries: Array.from(
-          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD },
+          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD - 1 },
           (_, index) => `openclaw loop detection ${index}`,
         ),
         hostAtIndex: (index) => (index % 2 === 0 ? "www.google.com" : "www.bing.com"),
@@ -516,6 +522,34 @@ describe("tool-loop-detection", () => {
         expect(loopResult.detector).toBe("browser_search_storm");
         expect(loopResult.count).toBe(BROWSER_SEARCH_CRITICAL_THRESHOLD);
         expect(loopResult.message).toContain("CRITICAL");
+      }
+    });
+
+    it("matches Yandex search pages with a trailing slash", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD - 1; i += 1) {
+        const fixture = createBrowserSearchFixture(`yandex issue ${i}`, "yandex.com", {
+          path: "/search/",
+          queryParam: "text",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("yandex issue next", "yandex.com", {
+        path: "/search/",
+        queryParam: "text",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -494,7 +494,7 @@ function getBrowserSearchStormStats(
   uniqueQueries.add(currentSearch.queryHash);
 
   return {
-    count: recentSearches.length + 1,
+    count: recentSearches.length,
     uniqueHosts: uniqueHosts.size,
     uniqueQueries: uniqueQueries.size,
   };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -179,14 +179,17 @@ type BrowserSearchLoopRecord = NonNullable<
   NonNullable<ToolCallRecord["loopHint"]>["browserSearch"]
 >;
 
+const GOOGLE_SEARCH_HOST_PATTERN = /(^|\.)google\.(?:com|[a-z]{2,3}|co\.[a-z]{2}|com\.[a-z]{2})$/;
+const YANDEX_SEARCH_HOST_PATTERN = /(^|\.)yandex\.(?:com|ru|by|kz|ua|net)$/;
+
 const BROWSER_SEARCH_MATCHERS: BrowserSearchMatcher[] = [
-  { hostPattern: /(^|\.)google\./, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: GOOGLE_SEARCH_HOST_PATTERN, pathPattern: /^\/search$/, queryParam: "q" },
   { hostPattern: /(^|\.)bing\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
   { hostPattern: /(^|\.)search\.brave\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
   { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html)?\/?$/, queryParam: "q" },
   { hostPattern: /(^|\.)baidu\.com$/, pathPattern: /^\/s$/, queryParam: "wd" },
   { hostPattern: /(^|\.)yahoo\.com$/, pathPattern: /^\/search$/, queryParam: "p" },
-  { hostPattern: /(^|\.)yandex\./, pathPattern: /^\/search\/?$/, queryParam: "text" },
+  { hostPattern: YANDEX_SEARCH_HOST_PATTERN, pathPattern: /^\/search\/?$/, queryParam: "text" },
 ];
 
 function normalizeHostname(hostname: string): string {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -186,7 +186,7 @@ const BROWSER_SEARCH_MATCHERS: BrowserSearchMatcher[] = [
   { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html)?\/?$/, queryParam: "q" },
   { hostPattern: /(^|\.)baidu\.com$/, pathPattern: /^\/s$/, queryParam: "wd" },
   { hostPattern: /(^|\.)yahoo\.com$/, pathPattern: /^\/search$/, queryParam: "p" },
-  { hostPattern: /(^|\.)yandex\./, pathPattern: /^\/search$/, queryParam: "text" },
+  { hostPattern: /(^|\.)yandex\./, pathPattern: /^\/search\/?$/, queryParam: "text" },
 ];
 
 function normalizeHostname(hostname: string): string {
@@ -494,7 +494,7 @@ function getBrowserSearchStormStats(
   uniqueQueries.add(currentSearch.queryHash);
 
   return {
-    count: recentSearches.length,
+    count: recentSearches.length + 1,
     uniqueHosts: uniqueHosts.size,
     uniqueQueries: uniqueQueries.size,
   };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -238,7 +238,7 @@ function extractBrowserSearchLoopHint(
     }
     const rawQuery = parsedUrl.searchParams.get(matcher.queryParam)?.trim();
     if (!rawQuery) {
-      return undefined;
+      continue;
     }
     return {
       host,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
-import type { SessionState } from "../logging/diagnostic-session-state.js";
+import type { SessionState, ToolCallRecord } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPlainObject } from "../utils.js";
 
@@ -10,7 +10,8 @@ export type LoopDetectorKind =
   | "generic_repeat"
   | "known_poll_no_progress"
   | "global_circuit_breaker"
-  | "ping_pong";
+  | "ping_pong"
+  | "browser_search_storm";
 
 export type LoopDetectionResult =
   | { stuck: false }
@@ -27,17 +28,22 @@ export type LoopDetectionResult =
 export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
+export const BROWSER_SEARCH_WARNING_THRESHOLD = 4;
+export const BROWSER_SEARCH_CRITICAL_THRESHOLD = 8;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
+  browserSearchWarningThreshold: BROWSER_SEARCH_WARNING_THRESHOLD,
+  browserSearchCriticalThreshold: BROWSER_SEARCH_CRITICAL_THRESHOLD,
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   detectors: {
     genericRepeat: true,
     knownPollNoProgress: true,
     pingPong: true,
+    browserSearchStorm: true,
   },
 };
 
@@ -46,11 +52,14 @@ type ResolvedLoopDetectionConfig = {
   historySize: number;
   warningThreshold: number;
   criticalThreshold: number;
+  browserSearchWarningThreshold: number;
+  browserSearchCriticalThreshold: number;
   globalCircuitBreakerThreshold: number;
   detectors: {
     genericRepeat: boolean;
     knownPollNoProgress: boolean;
     pingPong: boolean;
+    browserSearchStorm: boolean;
   };
 };
 
@@ -70,6 +79,14 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     config?.criticalThreshold,
     DEFAULT_LOOP_DETECTION_CONFIG.criticalThreshold,
   );
+  let browserSearchWarningThreshold = asPositiveInt(
+    config?.browserSearchWarningThreshold,
+    DEFAULT_LOOP_DETECTION_CONFIG.browserSearchWarningThreshold,
+  );
+  let browserSearchCriticalThreshold = asPositiveInt(
+    config?.browserSearchCriticalThreshold,
+    DEFAULT_LOOP_DETECTION_CONFIG.browserSearchCriticalThreshold,
+  );
   let globalCircuitBreakerThreshold = asPositiveInt(
     config?.globalCircuitBreakerThreshold,
     DEFAULT_LOOP_DETECTION_CONFIG.globalCircuitBreakerThreshold,
@@ -77,6 +94,9 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
 
   if (criticalThreshold <= warningThreshold) {
     criticalThreshold = warningThreshold + 1;
+  }
+  if (browserSearchCriticalThreshold <= browserSearchWarningThreshold) {
+    browserSearchCriticalThreshold = browserSearchWarningThreshold + 1;
   }
   if (globalCircuitBreakerThreshold <= criticalThreshold) {
     globalCircuitBreakerThreshold = criticalThreshold + 1;
@@ -87,6 +107,8 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     historySize: asPositiveInt(config?.historySize, DEFAULT_LOOP_DETECTION_CONFIG.historySize),
     warningThreshold,
     criticalThreshold,
+    browserSearchWarningThreshold,
+    browserSearchCriticalThreshold,
     globalCircuitBreakerThreshold,
     detectors: {
       genericRepeat:
@@ -95,6 +117,9 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
         config?.detectors?.knownPollNoProgress ??
         DEFAULT_LOOP_DETECTION_CONFIG.detectors.knownPollNoProgress,
       pingPong: config?.detectors?.pingPong ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.pingPong,
+      browserSearchStorm:
+        config?.detectors?.browserSearchStorm ??
+        DEFAULT_LOOP_DETECTION_CONFIG.detectors.browserSearchStorm,
     },
   };
 }
@@ -142,6 +167,91 @@ function stableStringifyFallback(value: unknown): string {
     }
     return Object.prototype.toString.call(value);
   }
+}
+
+type BrowserSearchMatcher = {
+  hostPattern: RegExp;
+  pathPattern: RegExp;
+  queryParam: string;
+};
+
+type BrowserSearchLoopRecord = NonNullable<
+  NonNullable<ToolCallRecord["loopHint"]>["browserSearch"]
+>;
+
+const BROWSER_SEARCH_MATCHERS: BrowserSearchMatcher[] = [
+  { hostPattern: /(^|\.)google\./, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)bing\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)search\.brave\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html)?\/?$/, queryParam: "q" },
+  { hostPattern: /(^|\.)baidu\.com$/, pathPattern: /^\/s$/, queryParam: "wd" },
+  { hostPattern: /(^|\.)yahoo\.com$/, pathPattern: /^\/search$/, queryParam: "p" },
+  { hostPattern: /(^|\.)yandex\./, pathPattern: /^\/search$/, queryParam: "text" },
+];
+
+function normalizeHostname(hostname: string): string {
+  const lowered = hostname.toLowerCase();
+  return lowered.startsWith("www.") ? lowered.slice(4) : lowered;
+}
+
+function extractBrowserSearchLoopHint(
+  toolName: string,
+  params: unknown,
+): BrowserSearchLoopRecord | undefined {
+  if (toolName !== "browser" || !isPlainObject(params)) {
+    return undefined;
+  }
+  const action = params.action;
+  if (action !== "open" && action !== "navigate") {
+    return undefined;
+  }
+
+  const rawUrl =
+    typeof params.targetUrl === "string"
+      ? params.targetUrl
+      : typeof params.url === "string"
+        ? params.url
+        : undefined;
+  if (!rawUrl) {
+    return undefined;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    return undefined;
+  }
+
+  const host = normalizeHostname(parsedUrl.hostname);
+  const path = parsedUrl.pathname.toLowerCase();
+  for (const matcher of BROWSER_SEARCH_MATCHERS) {
+    if (!matcher.hostPattern.test(host) || !matcher.pathPattern.test(path)) {
+      continue;
+    }
+    const rawQuery = parsedUrl.searchParams.get(matcher.queryParam)?.trim();
+    if (!rawQuery) {
+      return undefined;
+    }
+    return {
+      host,
+      queryHash: digestStable(rawQuery.toLowerCase()),
+    };
+  }
+
+  return undefined;
+}
+
+function extractToolCallLoopHint(toolName: string, params: unknown): ToolCallRecord["loopHint"] {
+  const browserSearch = extractBrowserSearchLoopHint(toolName, params);
+  if (browserSearch) {
+    return { browserSearch };
+  }
+  return undefined;
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {
@@ -365,6 +475,31 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
   return [signatureA, signatureB].toSorted().join("|");
 }
 
+function getBrowserSearchStormStats(
+  history: ToolCallRecord[],
+  currentSearch: BrowserSearchLoopRecord,
+): {
+  count: number;
+  uniqueHosts: number;
+  uniqueQueries: number;
+} {
+  const recentSearches = history
+    .map((record) => record.loopHint?.browserSearch)
+    .filter((search): search is BrowserSearchLoopRecord => Boolean(search));
+
+  const uniqueHosts = new Set(recentSearches.map((search) => search.host));
+  uniqueHosts.add(currentSearch.host);
+
+  const uniqueQueries = new Set(recentSearches.map((search) => search.queryHash));
+  uniqueQueries.add(currentSearch.queryHash);
+
+  return {
+    count: recentSearches.length,
+    uniqueHosts: uniqueHosts.size,
+    uniqueQueries: uniqueQueries.size,
+  };
+}
+
 /**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
@@ -385,6 +520,7 @@ export function detectToolCallLoop(
   const noProgressStreak = noProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
+  const browserSearch = extractBrowserSearchLoopHint(toolName, params);
 
   if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
@@ -470,6 +606,45 @@ export function detectToolCallLoop(
     };
   }
 
+  if (browserSearch && resolvedConfig.detectors.browserSearchStorm) {
+    const browserSearchStats = getBrowserSearchStormStats(history, browserSearch);
+    const hasVariedSearches =
+      browserSearchStats.uniqueQueries >= 2 || browserSearchStats.uniqueHosts >= 2;
+    if (
+      hasVariedSearches &&
+      browserSearchStats.count >= resolvedConfig.browserSearchCriticalThreshold
+    ) {
+      log.error(
+        `Critical browser search storm detected: repeated search-page opens count=${browserSearchStats.count}`,
+      );
+      return {
+        stuck: true,
+        level: "critical",
+        detector: "browser_search_storm",
+        count: browserSearchStats.count,
+        message: `CRITICAL: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. This appears to be a browser search storm. Session execution blocked to prevent runaway browsing and network amplification.`,
+        warningKey: "browser-search:storm",
+      };
+    }
+
+    if (
+      hasVariedSearches &&
+      browserSearchStats.count >= resolvedConfig.browserSearchWarningThreshold
+    ) {
+      log.warn(
+        `Browser search storm warning: repeated search-page opens count=${browserSearchStats.count}`,
+      );
+      return {
+        stuck: true,
+        level: "warning",
+        detector: "browser_search_storm",
+        count: browserSearchStats.count,
+        message: `WARNING: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. Stop broad browser searching and either narrow the task, use web_search/web_fetch, or report failure.`,
+        warningKey: "browser-search:storm",
+      };
+    }
+  }
+
   // Generic detector: warn-only for repeated identical calls.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
@@ -514,6 +689,7 @@ export function recordToolCall(
     toolName,
     argsHash: hashToolCall(toolName, params),
     toolCallId,
+    loopHint: extractToolCallLoopHint(toolName, params),
     timestamp: Date.now(),
   });
 
@@ -578,6 +754,7 @@ export function recordToolCallOutcome(
       argsHash,
       toolCallId: params.toolCallId,
       resultHash,
+      loopHint: extractToolCallLoopHint(params.toolName, params.toolParams),
       timestamp: Date.now(),
     });
   }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -611,6 +611,8 @@ export function detectToolCallLoop(
 
   if (browserSearch && resolvedConfig.detectors.browserSearchStorm) {
     const browserSearchStats = getBrowserSearchStormStats(history, browserSearch);
+    // TODO: This detector only sees browser-search entries still present in the bounded history
+    // window, so interspersed non-search calls can evict older search hops before thresholds trip.
     const hasVariedSearches =
       browserSearchStats.uniqueQueries >= 2 || browserSearchStats.uniqueHosts >= 2;
     if (

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -523,7 +523,9 @@ export function detectToolCallLoop(
   const noProgressStreak = noProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
-  const browserSearch = extractBrowserSearchLoopHint(toolName, params);
+  const browserSearch = resolvedConfig.detectors.browserSearchStorm
+    ? extractBrowserSearchLoopHint(toolName, params)
+    : undefined;
 
   if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -290,6 +290,31 @@ describe("config schema", () => {
     }
   });
 
+  it("rejects browser search loop detection config when thresholds are below 2", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchWarningThreshold: 1,
+        browserSearchCriticalThreshold: 1,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchWarningThreshold"],
+            message: "tools.loopDetection.browserSearchWarningThreshold must be at least 2.",
+          }),
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchCriticalThreshold"],
+            message: "tools.loopDetection.browserSearchCriticalThreshold must be at least 2.",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("keeps tags in the allowed taxonomy", () => {
     const withTags = applyDerivedTags({
       "gateway.auth.token": {},

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -246,6 +246,28 @@ describe("config schema", () => {
     ).toThrow();
   });
 
+  it("accepts browser search loop detection config in the runtime zod schema", () => {
+    const parsed = ToolsSchema.parse({
+      loopDetection: {
+        enabled: true,
+        browserSearchWarningThreshold: 4,
+        browserSearchCriticalThreshold: 8,
+        detectors: {
+          browserSearchStorm: true,
+        },
+      },
+    });
+
+    expect(parsed?.loopDetection).toMatchObject({
+      enabled: true,
+      browserSearchWarningThreshold: 4,
+      browserSearchCriticalThreshold: 8,
+      detectors: {
+        browserSearchStorm: true,
+      },
+    });
+  });
+
   it("keeps tags in the allowed taxonomy", () => {
     const withTags = applyDerivedTags({
       "gateway.auth.token": {},

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -268,6 +268,28 @@ describe("config schema", () => {
     });
   });
 
+  it("rejects browser search loop detection config when warning threshold is not lower than critical", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchWarningThreshold: 8,
+        browserSearchCriticalThreshold: 4,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchCriticalThreshold"],
+            message:
+              "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("keeps tags in the allowed taxonomy", () => {
     const withTags = applyDerivedTags({
       "gateway.auth.token": {},

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -148,6 +148,8 @@ export type ToolLoopDetectionDetectorConfig = {
   knownPollNoProgress?: boolean;
   /** Enable warning/blocking for no-progress ping-pong alternating patterns. */
   pingPong?: boolean;
+  /** Enable warning/blocking for repeated browser search-page opens across changing queries. */
+  browserSearchStorm?: boolean;
 };
 
 export type ToolLoopDetectionConfig = {
@@ -159,6 +161,10 @@ export type ToolLoopDetectionConfig = {
   warningThreshold?: number;
   /** Critical threshold for blocking repetitive loops (default: 20). */
   criticalThreshold?: number;
+  /** Warning threshold for browser search storms across changing queries (default: 4). */
+  browserSearchWarningThreshold?: number;
+  /** Critical threshold for browser search storms across changing queries (default: 8). */
+  browserSearchCriticalThreshold?: number;
   /** Global no-progress breaker threshold (default: 30). */
   globalCircuitBreakerThreshold?: number;
   /** Detector toggles. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -460,6 +460,7 @@ const ToolLoopDetectionDetectorSchema = z
     genericRepeat: z.boolean().optional(),
     knownPollNoProgress: z.boolean().optional(),
     pingPong: z.boolean().optional(),
+    browserSearchStorm: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -470,6 +471,8 @@ const ToolLoopDetectionSchema = z
     historySize: z.number().int().positive().optional(),
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
+    browserSearchWarningThreshold: z.number().int().positive().optional(),
+    browserSearchCriticalThreshold: z.number().int().positive().optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -471,8 +471,16 @@ const ToolLoopDetectionSchema = z
     historySize: z.number().int().positive().optional(),
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
-    browserSearchWarningThreshold: z.number().int().positive().optional(),
-    browserSearchCriticalThreshold: z.number().int().positive().optional(),
+    browserSearchWarningThreshold: z
+      .number()
+      .int()
+      .min(2, "tools.loopDetection.browserSearchWarningThreshold must be at least 2.")
+      .optional(),
+    browserSearchCriticalThreshold: z
+      .number()
+      .int()
+      .min(2, "tools.loopDetection.browserSearchCriticalThreshold must be at least 2.")
+      .optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -490,6 +490,18 @@ const ToolLoopDetectionSchema = z
       });
     }
     if (
+      value.browserSearchWarningThreshold !== undefined &&
+      value.browserSearchCriticalThreshold !== undefined &&
+      value.browserSearchWarningThreshold >= value.browserSearchCriticalThreshold
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["browserSearchCriticalThreshold"],
+        message:
+          "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
+      });
+    }
+    if (
       value.criticalThreshold !== undefined &&
       value.globalCircuitBreakerThreshold !== undefined &&
       value.criticalThreshold >= value.globalCircuitBreakerThreshold

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -141,7 +141,12 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   toolName: string;
   level: "warning" | "critical";
   action: "warn" | "block";
-  detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+  detector:
+    | "generic_repeat"
+    | "known_poll_no_progress"
+    | "global_circuit_breaker"
+    | "ping_pong"
+    | "browser_search_storm";
   count: number;
   message: string;
   pairedToolName?: string;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -11,11 +11,21 @@ export type SessionState = {
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
 };
 
+export type BrowserSearchLoopHint = {
+  host: string;
+  queryHash: string;
+};
+
+export type ToolCallLoopHint = {
+  browserSearch?: BrowserSearchLoopHint;
+};
+
 export type ToolCallRecord = {
   toolName: string;
   argsHash: string;
   toolCallId?: string;
   resultHash?: string;
+  loopHint?: ToolCallLoopHint;
   timestamp: number;
 };
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -286,7 +286,12 @@ export function logToolLoopAction(
     toolName: string;
     level: "warning" | "critical";
     action: "warn" | "block";
-    detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+    detector:
+      | "generic_repeat"
+      | "known_poll_no_progress"
+      | "global_circuit_breaker"
+      | "ping_pong"
+      | "browser_search_storm";
     count: number;
     message: string;
     pairedToolName?: string;


### PR DESCRIPTION
## Summary

- Problem: tool-loop detection catches repeated identical calls, known no-progress polling, and ping-pong patterns, but it misses browser-driven search storms when the agent keeps changing search queries or search engines.
- Why it matters: a relatively small number of browser tool calls can fan out into a large number of real network requests on search, captcha, and result pages.
- What changed: adds a `browser_search_storm` detector, low browser-search thresholds, loop-history metadata for browser search calls, and test/doc coverage.
- What did NOT change (scope boundary): this PR does not change browser networking, `web_search` provider selection, or fallback policy after missing search-provider keys.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `tools.loopDetection` now supports `detectors.browserSearchStorm`.
- `tools.loopDetection` now supports `browserSearchWarningThreshold` and `browserSearchCriticalThreshold`.
- Browser search storms across changing queries/engines can now be warned/blocked even when generic-repeat detection does not match.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local shell + GitHub API workspace
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `tools.loopDetection.enabled=true`

### Steps

1. Enable `browser` and `tools.loopDetection`.
2. Trigger a task that keeps searching for sources/official links through browser result pages while varying queries or engines.
3. Observe repeated `browser open` / `browser navigate` calls to search-result pages.

### Expected

- Loop detection should classify repeated browser search-result opens across changing queries/engines as a search storm and block it after a small threshold.

### Actual

- Changing URLs/queries bypass current detectors, so the session can keep opening search pages.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `oxlint` on the touched files; reviewed unit/e2e coverage for warning + block behavior.
- Edge cases checked: normal non-search browser page opens do not trigger the new detector; warning emission still coalesces after the first warning.
- What you did **not** verify: full repo `pnpm test` / `pnpm lint` / `pnpm build` were not run in this environment because a full working checkout was not available locally.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `tools.loopDetection.detectors.browserSearchStorm=false` or revert this PR.
- Files/config to restore: `src/agents/tool-loop-detection.ts`, `src/agents/pi-tools.before-tool-call.ts`, related tests/docs.
- Known bad symptoms reviewers should watch for: false positives during legitimate browser-heavy research sessions that repeatedly open search result pages.

## Risks and Mitigations

- Risk:
  - Lower browser-search thresholds may warn/block some legitimate research-heavy sessions.
- Mitigation:
  - The detector is separately configurable and can be disabled or retuned without affecting the existing generic/poll/ping-pong detectors.