### PR TITLE
feat: support per-agent contextTokens override

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -102,6 +102,44 @@ describe("context-window-guard", () => {
     expect(guard.shouldBlock).toBe(false);
   });
 
+  it("caps with per-agent contextTokens overriding defaults", () => {
+    const cfg = {
+      agents: {
+        defaults: { contextTokens: 200_000 },
+        list: [{ id: "frontdesk", contextTokens: 131_000 }],
+      },
+    } satisfies OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "anthropic",
+      modelId: "whatever",
+      modelContextWindow: 200_000,
+      defaultTokens: 200_000,
+      agentId: "frontdesk",
+    });
+    expect(info.source).toBe("agentContextTokens");
+    expect(info.tokens).toBe(131_000);
+  });
+
+  it("falls back to defaults.contextTokens when agentId has no per-agent cap", () => {
+    const cfg = {
+      agents: {
+        defaults: { contextTokens: 100_000 },
+        list: [{ id: "frontdesk", contextTokens: 131_000 }],
+      },
+    } satisfies OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "anthropic",
+      modelId: "whatever",
+      modelContextWindow: 200_000,
+      defaultTokens: 200_000,
+      agentId: "reviewer",
+    });
+    expect(info.source).toBe("agentContextTokens");
+    expect(info.tokens).toBe(100_000);
+  });
+
   it("does not override when cap exceeds base window", () => {
     const cfg = {
       agents: { defaults: { contextTokens: 128_000 } },

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -24,6 +24,7 @@ export function resolveContextWindowInfo(params: {
   modelId: string;
   modelContextWindow?: number;
   defaultTokens: number;
+  agentId?: string;
 }): ContextWindowInfo {
   const fromModelsConfig = (() => {
     const providers = params.cfg?.models?.providers as
@@ -40,6 +41,17 @@ export function resolveContextWindowInfo(params: {
     : fromModel
       ? { tokens: fromModel, source: "model" as const }
       : { tokens: Math.floor(params.defaultTokens), source: "default" as const };
+
+  // Per-agent contextTokens override takes priority over global defaults.
+  const agentEntry = params.agentId
+    ? (
+        params.cfg?.agents?.list as Array<{ id?: string; contextTokens?: number }> | undefined
+      )?.find((a) => a?.id === params.agentId)
+    : undefined;
+  const perAgentCap = normalizePositiveInt(agentEntry?.contextTokens);
+  if (perAgentCap && perAgentCap < baseInfo.tokens) {
+    return { tokens: perAgentCap, source: "agentContextTokens" };
+  }
 
   const capTokens = normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);
   if (capTokens && capTokens < baseInfo.tokens) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -392,6 +392,7 @@ export async function runEmbeddedPiAgent(
         modelId,
         modelContextWindow: runtimeModel.contextWindow,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
+        agentId: params.agentId,
       });
       // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
       // threshold uses the effective limit, not the native context window.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -772,6 +772,7 @@ export const AgentEntrySchema = z
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
+    contextTokens: z.number().int().positive().optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),


### PR DESCRIPTION
## Summary
- Add `contextTokens` field to `AgentEntrySchema` so each agent in `agents.list` can specify its own context token cap
- Per-agent values take priority over `agents.defaults.contextTokens`, preventing fallback models from exceeding their context window limits
- Pass `agentId` through to `resolveContextWindowInfo` in the embedded runner

## Motivation
When agents use different model providers with varying context window sizes (e.g., frontdesk with 131K fallback vs architect with 196K fallback), a single global `contextTokens` cap is too coarse. Per-agent overrides let each agent stay within its fallback model's limits.

## Test plan
- [x] Added 2 new tests in `context-window-guard.test.ts`:
  - Per-agent cap overrides global defaults
  - Falls back to defaults when agent has no per-agent cap
- [x] All 11 tests pass (`pnpm test -- src/agents/context-window-guard.test.ts`)
- [x] `pnpm build` succeeds
- [x] `openclaw config validate` passes with per-agent contextTokens in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)