### PR TITLE
Improve comments and README clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ openclaw message send --to +1234567890 --message "Hello from OpenClaw"
 openclaw agent --message "Ship checklist" --thinking high
 ```
 
-Upgrading? [Updating guide](https://docs.openclaw.ai/install/updating) (and run `openclaw doctor`).
+Upgrading? See the [Updating guide](https://docs.openclaw.ai/install/updating) and run `openclaw doctor` afterward.
 
 ## Development channels
 
@@ -113,7 +113,7 @@ Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` pro
 
 OpenClaw connects to real messaging surfaces. Treat inbound DMs as **untrusted input**.
 
-Full security guide: [Security](https://docs.openclaw.ai/gateway/security)
+Full security guide: [Security](https://docs.openclaw.ai/gateway/security).
 
 Default behavior on Telegram/WhatsApp/Signal/iMessage/Microsoft Teams/Discord/Google Chat/Slack:
 
@@ -482,8 +482,7 @@ Use these when you’re past the onboarding flow and want the deeper reference.
 
 ## Molty
 
-OpenClaw was built for **Molty**, a space lobster AI assistant. 🦞
-by Peter Steinberger and the community.
+OpenClaw was built for **Molty**, a space lobster AI assistant, by Peter Steinberger and the community. 🦞
 
 - [openclaw.ai](https://openclaw.ai)
 - [soul.md](https://soul.md)

--- a/src/cli/parse-bytes.ts
+++ b/src/cli/parse-bytes.ts
@@ -2,6 +2,7 @@ export type BytesParseOptions = {
   defaultUnit?: "b" | "kb" | "mb" | "gb" | "tb";
 };
 
+/** How many bytes each unit suffix represents. Both short (k, m, g, t) and full (kb, mb, gb, tb) forms are accepted. */
 const UNIT_MULTIPLIERS: Record<string, number> = {
   b: 1,
   kb: 1024,

--- a/src/cli/parse-duration.ts
+++ b/src/cli/parse-duration.ts
@@ -2,6 +2,7 @@ export type DurationMsParseOptions = {
   defaultUnit?: "ms" | "s" | "m" | "h" | "d";
 };
 
+/** How many milliseconds each unit suffix represents (e.g. "s" = 1000ms, "m" = 60000ms). */
 const DURATION_MULTIPLIERS: Record<string, number> = {
   ms: 1,
   s: 1000,

--- a/src/cli/parse-timeout.ts
+++ b/src/cli/parse-timeout.ts
@@ -17,6 +17,11 @@ export function parseTimeoutMs(raw: unknown): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
+/**
+ * Same as parseTimeoutMs, but always returns a number instead of undefined.
+ * - If the value is missing or the wrong type, returns fallbackMs instead.
+ * - If the value is present but not a valid positive number, throws an error.
+ */
 export function parseTimeoutMsWithFallback(
   raw: unknown,
   fallbackMs: number,

--- a/src/cli/parse-timeout.ts
+++ b/src/cli/parse-timeout.ts
@@ -19,7 +19,8 @@ export function parseTimeoutMs(raw: unknown): number | undefined {
 
 /**
  * Same as parseTimeoutMs, but always returns a number instead of undefined.
- * - If the value is missing or the wrong type, returns fallbackMs instead.
+ * - If the value is missing (undefined/null) or empty string, returns fallbackMs.
+ * - If the value is the wrong type, returns fallbackMs by default; throws if options.invalidType is "error".
  * - If the value is present but not a valid positive number, throws an error.
  */
 export function parseTimeoutMsWithFallback(

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -8,6 +8,7 @@ import {
 import { theme } from "../terminal/theme.js";
 
 const DEFAULT_DELAY_MS = 0;
+/** Counts how many progress bars are currently showing. If this is greater than 0, new bars are skipped to avoid two bars fighting over the same output line. */
 let activeProgress = 0;
 
 type ProgressOptions = {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -16,9 +16,11 @@ export type WizardStep = {
   initialValue?: unknown;
   placeholder?: string;
   sensitive?: boolean;
+  /** Who handles this step: "gateway" means the server processes it, "client" means the UI displays it to the user. */
   executor?: "gateway" | "client";
 };
 
+/** Tracks the state of a wizard session. Starts as "running", then ends as "done" (finished normally), "cancelled" (user quit), or "error" (something went wrong). */
 export type WizardSessionStatus = "running" | "done" | "cancelled" | "error";
 
 export type WizardNextResult = {
@@ -34,6 +36,11 @@ type Deferred<T> = {
   reject: (err: unknown) => void;
 };
 
+/**
+ * Creates a promise you can resolve or reject from outside.
+ * One part of the code waits on the promise; another part calls resolve() or reject() when it has a result,
+ * such as when the user submits an answer to a wizard step.
+ */
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (err: unknown) => void;
@@ -163,6 +170,7 @@ class WizardSessionPrompter implements WizardPrompter {
 export class WizardSession {
   private currentStep: WizardStep | null = null;
   private stepDeferred: Deferred<WizardStep | null> | null = null;
+  /** Holds a pending promise for each active step, keyed by the step's ID. Resolved when the user submits an answer for that step. */
   private answerDeferred = new Map<string, Deferred<unknown>>();
   private status: WizardSessionStatus = "running";
   private error: string | undefined;
@@ -199,6 +207,7 @@ export class WizardSession {
     deferred.resolve(value);
   }
 
+  /** Stops the wizard immediately. Any steps the user was waiting on will receive a cancellation error instead of an answer. */
   cancel() {
     if (this.status !== "running") {
       return;
@@ -235,6 +244,7 @@ export class WizardSession {
     }
   }
 
+  /** Shows a step to the user and pauses until answer() is called with their response. */
   async awaitAnswer(step: WizardStep): Promise<unknown> {
     if (this.status !== "running") {
       throw new Error("wizard: session not running");


### PR DESCRIPTION
## Summary

- Problem: Several non-obvious helpers and type definitions lacked explanatory comments, and three README sentences had minor clarity issues.
- Why it matters: New contributors reading the wizard, CLI parser, or progress code had no inline guidance on intent.
- What changed: Added JSDoc and inline comments to six files; fixed a missing period, merged a two-line sentence, and reworded one README line.
- What did NOT change: No logic, behavior, types, or exports were modified.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open any of the six changed files.
2. Read the added comments.

### Expected

- Comments are present and accurate.

### Actual

- Comments are present and accurate.

## Evidence

- [x] Trace/log snippets

Diff reviewed locally; all added lines are comments only.

## Human Verification (required)

- Verified scenarios: Confirmed each changed file contains only comment additions or README text fixes with no logic touched.
- Edge cases checked: Confirmed no exports, function signatures, or runtime behavior were altered.
- What you did not verify: CI test run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: README.md, src/wizard/session.ts, src/cli/parse-bytes.ts, src/cli/parse-duration.ts, src/cli/parse-timeout.ts, src/cli/progress.ts
- Known bad symptoms reviewers should watch for: None expected; changes are comments only.

## Risks and Mitigations

None.