### PR TITLE
fix(errors): avoid leaking raw model failures

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,7 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  GENERIC_MODEL_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -38,6 +38,8 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
 }
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
+export const GENERIC_MODEL_ERROR_USER_MESSAGE =
+  "⚠️ I hit a model error before replying. Please try again.";
 
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GENERIC_MODEL_ERROR_USER_MESSAGE } from "../agents/pi-embedded-helpers.js";
 import { loadSessionStore, resolveSessionKey } from "../config/sessions.js";
 import { registerGroupIntroPromptCases } from "./reply.triggers.group-intro-prompts.cases.js";
 import { registerTriggerHandlingUsageSummaryCases } from "./reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.js";
@@ -153,7 +154,7 @@ describe("trigger handling", () => {
       const errorCases = [
         {
           error: "sandbox is not defined.",
-          expected: "⚠️ I hit a model error before replying. Please try again.",
+          expected: GENERIC_MODEL_ERROR_USER_MESSAGE,
         },
         {
           error: "Context window exceeded",

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -153,8 +153,7 @@ describe("trigger handling", () => {
       const errorCases = [
         {
           error: "sandbox is not defined.",
-          expected:
-            "⚠️ Agent failed before reply: sandbox is not defined.\nLogs: openclaw logs --follow",
+          expected: "⚠️ I hit a model error before replying. Please try again.",
         },
         {
           error: "Context window exceeded",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -621,17 +621,13 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
-      const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling
         ? BILLING_ERROR_USER_MESSAGE
         : isContextOverflow
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : "⚠️ I hit a model error before replying. Please try again.";
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,6 +7,7 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
+  GENERIC_MODEL_ERROR_USER_MESSAGE,
   isCompactionFailureError,
   isContextOverflowError,
   isBillingErrorMessage,
@@ -627,7 +628,7 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : "⚠️ I hit a model error before replying. Please try again.";
+            : GENERIC_MODEL_ERROR_USER_MESSAGE;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GENERIC_MODEL_ERROR_USER_MESSAGE } from "../../agents/pi-embedded-helpers.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import * as sessions from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
@@ -1485,7 +1486,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const res = await run();
 
       expect(res).toMatchObject({
-        text: "⚠️ I hit a model error before replying. Please try again.",
+        text: GENERIC_MODEL_ERROR_USER_MESSAGE,
       });
       expect(sessionStore.main).toBeDefined();
       await expect(fs.access(transcriptPath)).resolves.toBeUndefined();

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1485,7 +1485,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const res = await run();
 
       expect(res).toMatchObject({
-        text: expect.stringContaining("Agent failed before reply"),
+        text: "⚠️ I hit a model error before replying. Please try again.",
       });
       expect(sessionStore.main).toBeDefined();
       await expect(fs.access(transcriptPath)).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

- Problem: generic embedded-agent failures were surfaced to end users with raw backend error text plus an internal `openclaw logs --follow` hint.
- Why it matters: external chat users should get a stable, user-facing error message rather than provider/runtime internals.
- What changed: generic pre-reply failures now return a fixed safe fallback message via a shared `GENERIC_MODEL_ERROR_USER_MESSAGE` constant, and the narrow regression tests now assert against that shared constant.
- What did NOT change (scope boundary): this PR does not change billing/context-overflow/role-ordering handling, session reset behavior, or the separate image-path concerns discussed in #48430.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48430
- Replaces #48630 (auto-closed due active PR limit)

## User-visible / Behavior Changes

- Generic model/provider failures no longer echo raw backend error strings to end users on external chat channels.
- Users now receive: `⚠️ I hit a model error before replying. Please try again.`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0
- Runtime/container: local repo checkout
- Model/provider: mocked embedded agent failure
- Integration/channel (if any): shared external-channel fallback path
- Relevant config (redacted): default test harness config

### Steps

1. Trigger a generic embedded-agent pre-reply failure (for example `INVALID_ARGUMENT: some other failure`).
2. Let the shared fallback path build the final user-facing reply.
3. Observe the delivered text.

### Expected

- End users receive a generic safe fallback message without raw provider/runtime internals.

### Actual

- Before this change, users received `Agent failed before reply: <raw error>\nLogs: openclaw logs --follow`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: updated the shared generic fallback string; `pnpm test -- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "keeps sessions intact on other errors"` passed; `pnpm build` previously passed for the original scoped change; the extracted-constant follow-up passed lints/formatting on changed files.
- Edge cases checked: billing/context-overflow/role-ordering branches were left unchanged.
- What you did **not** verify: a live channel repro; the trigger-handling test file still hangs in this environment; `pnpm check` currently fails in unrelated files on `origin/main`, and local `codex review --base origin/main` was unavailable because the `codex` CLI is not installed in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8742f6c2f`.
- Files/config to restore: `src/agents/pi-embedded-helpers.ts`, `src/agents/pi-embedded-helpers/errors.ts`, `src/auto-reply/reply/agent-runner-execution.ts`, and the two updated regression tests.
- Known bad symptoms reviewers should watch for: generic provider failures exposing raw backend text again or tests drifting from the shared fallback wording.

## Risks and Mitigations

- Risk: the new generic message could hide details operators relied on in external chat surfaces.
- Mitigation: the raw failure is still logged internally via `defaultRuntime.error`, so operator diagnostics remain available without exposing internals to end users.

AI-assisted: yes.
Testing: lightly tested locally.

Made with [Cursor](https://cursor.com)