### PR TITLE
fix(gateway): scope deferred channel plugin reload to avoid duplicate registration

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -174,6 +174,7 @@ export function loadGatewayPlugins(params: {
   coreGatewayHandlers: Record<string, GatewayRequestHandler>;
   baseMethods: string[];
   preferSetupRuntimeForChannelPlugins?: boolean;
+  onlyPluginIds?: string[];
   logDiagnostics?: boolean;
 }) {
   // Set the process-global gateway subagent runtime BEFORE loading plugins.
@@ -197,6 +198,7 @@ export function loadGatewayPlugins(params: {
       allowGatewaySubagentBinding: true,
     },
     preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+    onlyPluginIds: params.onlyPluginIds,
   });
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);
   const gatewayMethods = Array.from(new Set([...params.baseMethods, ...pluginMethods]));

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -986,16 +986,13 @@ export async function startGatewayServer(
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {
-    if (deferredConfiguredChannelPluginIds.length > 0) {
-      ({ pluginRegistry } = loadGatewayPlugins({
-        cfg: cfgAtStart,
-        workspaceDir: defaultWorkspaceDir,
-        log,
-        coreGatewayHandlers,
-        baseMethods,
-        logDiagnostics: false,
-      }));
-    }
+    // NOTE: The second loadGatewayPlugins() call that previously lived here
+    // was removed because it re-ran register() for *every* plugin (not just
+    // the deferred channel ones), creating duplicate closures.  Plugins that
+    // bind ports (e.g. voice-call) hit EADDRINUSE on the second pass.
+    // Channel plugins that need full runtime are now loaded eagerly in the
+    // first pass above; the preferSetupRuntimeForChannelPlugins optimisation
+    // is kept for the initial load but the post-listen reload is dropped.
     ({ browserControl, pluginServices } = await startGatewaySidecars({
       cfg: cfgAtStart,
       pluginRegistry,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -47,8 +47,13 @@ import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-plugin-ids.js";
-import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
+import {
+  getGlobalHookRunner,
+  initializeGlobalHookRunner,
+  runGlobalGatewayStopSafely,
+} from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
@@ -986,13 +991,53 @@ export async function startGatewayServer(
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {
-    // NOTE: The second loadGatewayPlugins() call that previously lived here
-    // was removed because it re-ran register() for *every* plugin (not just
-    // the deferred channel ones), creating duplicate closures.  Plugins that
-    // bind ports (e.g. voice-call) hit EADDRINUSE on the second pass.
-    // Channel plugins that need full runtime are now loaded eagerly in the
-    // first pass above; the preferSetupRuntimeForChannelPlugins optimisation
-    // is kept for the initial load but the post-listen reload is dropped.
+    if (deferredConfiguredChannelPluginIds.length > 0) {
+      // Reload only the deferred channel plugins with full runtime.  The
+      // first loadGatewayPlugins pass loaded them in setup-runtime mode;
+      // this pass gives them their complete register() call.  Scoping via
+      // onlyPluginIds prevents non-channel plugins (e.g. voice-call) from
+      // being re-registered, which would create duplicate closures and
+      // cause EADDRINUSE for plugins that bind ports.
+      const { pluginRegistry: deferredRegistry } = loadGatewayPlugins({
+        cfg: cfgAtStart,
+        workspaceDir: defaultWorkspaceDir,
+        log,
+        coreGatewayHandlers,
+        baseMethods,
+        onlyPluginIds: deferredConfiguredChannelPluginIds,
+        logDiagnostics: false,
+      });
+      // Merge deferred channel registrations into the existing registry so
+      // non-channel plugin services/tools/hooks from the first pass are
+      // preserved for startGatewaySidecars.
+      pluginRegistry = {
+        ...pluginRegistry,
+        plugins: [...pluginRegistry.plugins, ...deferredRegistry.plugins],
+        tools: [...pluginRegistry.tools, ...deferredRegistry.tools],
+        hooks: [...pluginRegistry.hooks, ...deferredRegistry.hooks],
+        typedHooks: [...pluginRegistry.typedHooks, ...deferredRegistry.typedHooks],
+        channels: [...pluginRegistry.channels, ...deferredRegistry.channels],
+        channelSetups: [...pluginRegistry.channelSetups, ...deferredRegistry.channelSetups],
+        providers: [...pluginRegistry.providers, ...deferredRegistry.providers],
+        webSearchProviders: [
+          ...pluginRegistry.webSearchProviders,
+          ...deferredRegistry.webSearchProviders,
+        ],
+        gatewayHandlers: {
+          ...pluginRegistry.gatewayHandlers,
+          ...deferredRegistry.gatewayHandlers,
+        },
+        httpRoutes: [...pluginRegistry.httpRoutes, ...deferredRegistry.httpRoutes],
+        cliRegistrars: [...pluginRegistry.cliRegistrars, ...deferredRegistry.cliRegistrars],
+        services: [...pluginRegistry.services, ...deferredRegistry.services],
+        commands: [...pluginRegistry.commands, ...deferredRegistry.commands],
+        diagnostics: [...pluginRegistry.diagnostics, ...deferredRegistry.diagnostics],
+      };
+      // Re-activate with the merged registry so global hooks cover both
+      // the initial-pass and the deferred channel plugins.
+      setActivePluginRegistry(pluginRegistry);
+      initializeGlobalHookRunner(pluginRegistry);
+    }
     ({ browserControl, pluginServices } = await startGatewaySidecars({
       cfg: cfgAtStart,
       pluginRegistry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -11,7 +11,7 @@ import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
-import { clearPluginCommands } from "./commands.js";
+import { clearPluginCommands, clearPluginCommandsForPlugin } from "./commands.js";
 import {
   applyTestPluginDefaults,
   normalizePluginsConfig,
@@ -21,7 +21,10 @@ import {
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
-import { clearPluginInteractiveHandlers } from "./interactive.js";
+import {
+  clearPluginInteractiveHandlers,
+  clearPluginInteractiveHandlersForPlugin,
+} from "./interactive.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -823,9 +826,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
   // Clear previously registered plugin commands before reloading.
   // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
+  // When scoped to specific plugins (onlyPluginIds), only clear commands/handlers for
+  // those plugins so non-scoped plugins retain their registrations.
   if (shouldActivate) {
-    clearPluginCommands();
-    clearPluginInteractiveHandlers();
+    if (onlyPluginIdSet) {
+      for (const id of onlyPluginIdSet) {
+        clearPluginCommandsForPlugin(id);
+        clearPluginInteractiveHandlersForPlugin(id);
+      }
+    } else {
+      clearPluginCommands();
+      clearPluginInteractiveHandlers();
+    }
   }
 
   // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).


### PR DESCRIPTION
## Summary

- Scope the post-listen `loadGatewayPlugins()` reload to only the deferred channel plugin IDs, preventing non-channel plugins from being re-registered
- When `onlyPluginIds` is set in the loader, clear commands/handlers only for scoped plugins instead of wiping all global state
- Merge the deferred channel registry into the existing one and re-activate with the merged result

## Root cause

Commit 1b234b910 ("Gateway: defer full channel plugins until after listen") added a second `loadGatewayPlugins()` call to upgrade deferred channel plugins from setup-runtime to full runtime. However, this call re-registered **all** plugins. Non-channel plugins like `voice-call` got a fresh `register()` closure with `runtime = null`, while the old closure's webhook server still held the port → EADDRINUSE.

## Changes

**`src/plugins/loader.ts`**
- When `onlyPluginIds` is set and `shouldActivate` is true, use `clearPluginCommandsForPlugin` / `clearPluginInteractiveHandlersForPlugin` instead of the global `clear*` functions, so non-scoped plugins retain their command/handler registrations across the reload.

**`src/gateway/server-plugins.ts`**
- Thread `onlyPluginIds` param through to `loadOpenClawPlugins`.

**`src/gateway/server.impl.ts`**
- Pass `onlyPluginIds: deferredConfiguredChannelPluginIds` to the second `loadGatewayPlugins()` call so only deferred channel plugins run `register()`.
- Merge the deferred registry into the existing one instead of overwriting it.
- Re-activate with the merged registry via `setActivePluginRegistry` + `initializeGlobalHookRunner`.

## Test plan

- [ ] `pnpm build` — type-check clean
- [ ] `pnpm test -- src/gateway/server-plugins.test.ts` — existing tests pass
- [ ] `pnpm test -- src/plugins/loader.test.ts` — existing tests pass  
- [ ] Voice-call plugin no longer hits EADDRINUSE when initiating calls after gateway boot
- [ ] Deferred channel plugins still load with full runtime after listen
- [ ] Non-channel plugin commands/hooks remain available after deferred reload

Fixes #46832
Supersedes #48616