### PR TITLE
Feishu: close all connections before stopping HTTP servers

### DIFF
--- a/extensions/feishu/src/monitor.state.defaults.test.ts
+++ b/extensions/feishu/src/monitor.state.defaults.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import type * as http from "node:http";
+import { describe, expect, it, vi } from "vitest";
 import {
   resolveFeishuWebhookAnomalyDefaultsForTest,
   resolveFeishuWebhookRateLimitDefaultsForTest,
+  httpServers,
+  stopFeishuMonitorState,
 } from "./monitor.state.js";
 
 describe("feishu monitor state defaults", () => {
@@ -42,5 +45,40 @@ describe("feishu monitor state defaults", () => {
       ttlMs: 21_600_000,
       logEvery: 10,
     });
+  });
+});
+
+describe("feishu monitor state cleanup", () => {
+  function mockServer(): http.Server {
+    return {
+      close: vi.fn(),
+      closeAllConnections: vi.fn(),
+    } as unknown as http.Server;
+  }
+
+  it("calls closeAllConnections before close for a single account", () => {
+    const server = mockServer();
+    httpServers.set("test-account", server);
+
+    stopFeishuMonitorState("test-account");
+
+    expect(server.closeAllConnections).toHaveBeenCalled();
+    expect(server.close).toHaveBeenCalled();
+    expect(httpServers.has("test-account")).toBe(false);
+  });
+
+  it("calls closeAllConnections on all servers when no accountId given", () => {
+    const server1 = mockServer();
+    const server2 = mockServer();
+    httpServers.set("a", server1);
+    httpServers.set("b", server2);
+
+    stopFeishuMonitorState();
+
+    expect(server1.closeAllConnections).toHaveBeenCalled();
+    expect(server1.close).toHaveBeenCalled();
+    expect(server2.closeAllConnections).toHaveBeenCalled();
+    expect(server2.close).toHaveBeenCalled();
+    expect(httpServers.size).toBe(0);
   });
 });

--- a/extensions/feishu/src/monitor.state.defaults.test.ts
+++ b/extensions/feishu/src/monitor.state.defaults.test.ts
@@ -49,36 +49,36 @@ describe("feishu monitor state defaults", () => {
 });
 
 describe("feishu monitor state cleanup", () => {
-  function mockServer(): http.Server {
-    return {
-      close: vi.fn(),
-      closeAllConnections: vi.fn(),
-    } as unknown as http.Server;
-  }
-
   it("calls closeAllConnections before close for a single account", () => {
-    const server = mockServer();
+    const callOrder: string[] = [];
+    const server = {
+      close: vi.fn(() => callOrder.push("close")),
+      closeAllConnections: vi.fn(() => callOrder.push("closeAllConnections")),
+    } as unknown as http.Server;
     httpServers.set("test-account", server);
 
     stopFeishuMonitorState("test-account");
 
-    expect(server.closeAllConnections).toHaveBeenCalled();
-    expect(server.close).toHaveBeenCalled();
+    expect(callOrder).toEqual(["closeAllConnections", "close"]);
     expect(httpServers.has("test-account")).toBe(false);
   });
 
   it("calls closeAllConnections on all servers when no accountId given", () => {
-    const server1 = mockServer();
-    const server2 = mockServer();
+    const callOrder: string[] = [];
+    const server1 = {
+      close: vi.fn(() => callOrder.push("s1:close")),
+      closeAllConnections: vi.fn(() => callOrder.push("s1:closeAll")),
+    } as unknown as http.Server;
+    const server2 = {
+      close: vi.fn(() => callOrder.push("s2:close")),
+      closeAllConnections: vi.fn(() => callOrder.push("s2:closeAll")),
+    } as unknown as http.Server;
     httpServers.set("a", server1);
     httpServers.set("b", server2);
 
     stopFeishuMonitorState();
 
-    expect(server1.closeAllConnections).toHaveBeenCalled();
-    expect(server1.close).toHaveBeenCalled();
-    expect(server2.closeAllConnections).toHaveBeenCalled();
-    expect(server2.close).toHaveBeenCalled();
+    expect(callOrder).toEqual(["s1:closeAll", "s1:close", "s2:closeAll", "s2:close"]);
     expect(httpServers.size).toBe(0);
   });
 });

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -137,6 +137,7 @@ export function stopFeishuMonitorState(accountId?: string): void {
     wsClients.delete(accountId);
     const server = httpServers.get(accountId);
     if (server) {
+      server.closeAllConnections();
       server.close();
       httpServers.delete(accountId);
     }
@@ -147,6 +148,7 @@ export function stopFeishuMonitorState(accountId?: string): void {
 
   wsClients.clear();
   for (const server of httpServers.values()) {
+    server.closeAllConnections();
     server.close();
   }
   httpServers.clear();


### PR DESCRIPTION
## Summary

- Problem: `stopFeishuMonitorState()` calls `server.close()` without terminating active connections first. On repeated account reloads, lingering connections prevent the server from fully shutting down, leaking resources and potentially blocking ports.
- Why it matters: Gateways with multiple Feishu accounts or frequent config reloads accumulate server objects that are not properly released.
- What changed: Added `server.closeAllConnections()` before `server.close()` in both the single-account and clear-all paths.
- What did NOT change (scope boundary): No changes to WS client lifecycle, webhook handling, or rate limiting. No signature changes.

> AI-assisted: This PR was authored with AI assistance (GitHub Copilot).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48183

## User-visible / Behavior Changes

Feishu HTTP webhook servers now release all active connections on shutdown, preventing port-binding issues and resource leaks during account reloads.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any (Node.js 22+)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Multiple Feishu accounts configured

### Steps

1. Configure OpenClaw with multiple Feishu accounts
2. Start the gateway (Feishu monitor starts)
3. Repeatedly reload config or restart monitor
4. Observe that ports are not released until connections time out

### Expected

- All connections terminated and ports released immediately on monitor stop.

### Actual

- `server.close()` only stops accepting new connections; existing connections stay alive until they time out.

## Evidence

- [x] Failing test/log before + passing after

New tests verify `closeAllConnections()` is called before `close()` for both single-account and clear-all paths.

Test run:
```
pnpm test -- extensions/feishu/src/monitor.state.defaults.test.ts
4 passed (4)
```

## Human Verification (required)

- Verified scenarios: All 4 tests pass (2 existing + 2 new). Lint/format checks pass (`pnpm check`).
- Edge cases checked: Single-account cleanup and full clear-all cleanup both verified. Mock servers confirm both closeAllConnections and close are called.
- What you did **not** verify: Live multi-account Feishu gateway reload (no Feishu credentials available).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; servers will behave as before (close without force-terminating connections).
- Files/config to restore: `extensions/feishu/src/monitor.state.ts`
- Known bad symptoms reviewers should watch for: Unexpected connection drops during Feishu webhook processing (unlikely since this only fires on shutdown).

## Risks and Mitigations

- Risk: `closeAllConnections()` could terminate in-flight webhook requests during a config reload.
  - Mitigation: This is expected behavior during shutdown. The server is being stopped, so in-flight requests will not be processed anyway. The webhook sender (Feishu) will retry.