### PR TITLE
fix(bluebubbles): restore TTS voice-bubble delivery

### DIFF
--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -1,6 +1,19 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { PluginRuntime } from "openclaw/plugin-sdk/bluebubbles";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
 import { downloadBlueBubblesAttachment, sendBlueBubblesAttachment } from "./attachments.js";
 import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
@@ -321,6 +334,17 @@ describe("sendBlueBubblesAttachment", () => {
     mockFetch.mockReset();
     fetchRemoteMediaMock.mockClear();
     setBlueBubblesRuntime(runtimeStub);
+    execFileMock.mockReset();
+    execFileMock.mockImplementation(async (_file, args, _options, callback) => {
+      const normalizedArgs = Array.isArray(args) ? [...args] : [];
+      const outputPath =
+        typeof normalizedArgs.at(-1) === "string" ? normalizedArgs.at(-1) : undefined;
+      if (typeof outputPath === "string") {
+        await fs.writeFile(outputPath, new Uint8Array([9, 8, 7]));
+      }
+      callback?.(null, "", "");
+      return {} as ReturnType<typeof execFileMock>;
+    });
     vi.mocked(getCachedBlueBubblesPrivateApiStatus).mockReset();
     mockBlueBubblesPrivateApiStatus(
       vi.mocked(getCachedBlueBubblesPrivateApiStatus),
@@ -360,7 +384,11 @@ describe("sendBlueBubblesAttachment", () => {
     });
 
     const bodyText = expectVoiceAttachmentBody();
-    expect(bodyText).toContain('filename="voice.mp3"');
+    expect(bodyText).toContain('filename="voice.caf"');
+    expect(bodyText).toContain('name="method"');
+    expect(bodyText).toContain("private-api");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0]?.[0]).toBe("ffmpeg");
   });
 
   it("normalizes mp3 filenames for voice memos", async () => {
@@ -379,8 +407,8 @@ describe("sendBlueBubblesAttachment", () => {
     });
 
     const bodyText = expectVoiceAttachmentBody();
-    expect(bodyText).toContain('filename="voice.mp3"');
-    expect(bodyText).toContain('name="voice.mp3"');
+    expect(bodyText).toContain('filename="voice.caf"');
+    expect(bodyText).toContain('name="voice.caf"');
   });
 
   it("throws when asVoice is true but media is not audio", async () => {
@@ -397,18 +425,26 @@ describe("sendBlueBubblesAttachment", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("throws when asVoice is true but audio is not mp3 or caf", async () => {
-    await expect(
-      sendBlueBubblesAttachment({
-        to: "chat_guid:iMessage;-;+15551234567",
-        buffer: new Uint8Array([1, 2, 3]),
-        filename: "voice.wav",
-        contentType: "audio/wav",
-        asVoice: true,
-        opts: { serverUrl: "http://localhost:1234", password: "test" },
-      }),
-    ).rejects.toThrow("require mp3 or caf");
-    expect(mockFetch).not.toHaveBeenCalled();
+  it("converts non-caf audio to CAF for voice memos", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messageId: "msg-2b" })),
+    });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.ogg",
+      contentType: "audio/ogg; codecs=opus",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    const body = mockFetch.mock.calls[0][1]?.body as Uint8Array;
+    const bodyText = decodeBody(body);
+    expect(bodyText).toContain('filename="voice.caf"');
+    expect(bodyText).toContain('name="isAudioMessage"');
+    expect(execFileMock.mock.calls[0]?.[1]).toEqual(expect.arrayContaining(["-f", "caf"]));
   });
 
   it("sanitizes filenames before sending", async () => {
@@ -455,6 +491,64 @@ describe("sendBlueBubblesAttachment", () => {
     expect(bodyText).not.toContain('name="method"');
     expect(bodyText).not.toContain('name="selectedMessageGuid"');
     expect(bodyText).not.toContain('name="partIndex"');
+  });
+
+  it("forces private-api method for voice memos even when private API cache is stale", async () => {
+    mockBlueBubblesPrivateApiStatusOnce(
+      vi.mocked(getCachedBlueBubblesPrivateApiStatus),
+      BLUE_BUBBLES_PRIVATE_API_STATUS.disabled,
+    );
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice-private" })),
+    });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    const body = mockFetch.mock.calls[0][1]?.body as Uint8Array;
+    const bodyText = decodeBody(body);
+    expect(bodyText).toContain('name="method"');
+    expect(bodyText).toContain("private-api");
+    expect(bodyText).toContain('name="isAudioMessage"');
+  });
+
+  it("warns and downgrades voice memos when CAF conversion fails", async () => {
+    const runtimeLog = vi.fn();
+    setBlueBubblesRuntime({
+      ...runtimeStub,
+      log: runtimeLog,
+    } as unknown as PluginRuntime);
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      callback?.(new Error("ffmpeg missing") as NodeJS.ErrnoException, "", "");
+      return {} as ReturnType<typeof execFileMock>;
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice-fallback" })),
+    });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.ogg",
+      contentType: "audio/ogg; codecs=opus",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    const body = mockFetch.mock.calls[0][1]?.body as Uint8Array;
+    const bodyText = decodeBody(body);
+    expect(bodyText).not.toContain('name="isAudioMessage"');
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("Voice message CAF conversion failed"),
+    );
   });
 
   it("warns and downgrades attachment reply threading when private API status is unknown", async () => {

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -384,11 +384,10 @@ describe("sendBlueBubblesAttachment", () => {
     });
 
     const bodyText = expectVoiceAttachmentBody();
-    expect(bodyText).toContain('filename="voice.caf"');
+    expect(bodyText).toContain('filename="voice.mp3"');
     expect(bodyText).toContain('name="method"');
     expect(bodyText).toContain("private-api");
-    expect(execFileMock).toHaveBeenCalledTimes(1);
-    expect(execFileMock.mock.calls[0]?.[0]).toBe("ffmpeg");
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it("normalizes mp3 filenames for voice memos", async () => {
@@ -407,8 +406,8 @@ describe("sendBlueBubblesAttachment", () => {
     });
 
     const bodyText = expectVoiceAttachmentBody();
-    expect(bodyText).toContain('filename="voice.caf"');
-    expect(bodyText).toContain('name="voice.caf"');
+    expect(bodyText).toContain('filename="voice.mp3"');
+    expect(bodyText).toContain('name="voice.mp3"');
   });
 
   it("throws when asVoice is true but media is not audio", async () => {

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -451,6 +451,58 @@ describe("sendBlueBubblesAttachment", () => {
     expect(execFileMock.mock.calls[0]?.[1]).toEqual(expect.arrayContaining(["-f", "caf"]));
   });
 
+  it.each(["voice.m4a", "voice.aac", "voice.wav"])(
+    "accepts %s voice memos without contentType",
+    async (filename) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice-ext" })),
+      });
+
+      await sendBlueBubblesAttachment({
+        to: "chat_guid:iMessage;-;+15551234567",
+        buffer: new Uint8Array([1, 2, 3]),
+        filename,
+        asVoice: true,
+        opts: { serverUrl: "http://localhost:1234", password: "test" },
+      });
+
+      const bodyText = expectVoiceAttachmentBody();
+      expect(bodyText).toContain('filename="voice.caf"');
+      const ffmpegArgs = execFileMock.mock.calls[0]?.[1] as string[] | undefined;
+      expect(path.extname(ffmpegArgs?.[2] ?? "")).toBe(path.extname(filename));
+      expect(ffmpegArgs).toContain("-f");
+      expect(ffmpegArgs).toContain("caf");
+    },
+  );
+
+  it.each([
+    ["audio/mp4", ".m4a"],
+    ["audio/aac", ".aac"],
+    ["audio/wav", ".wav"],
+  ])("maps %s voice memos to %s ffmpeg input extension", async (contentType, expectedExt) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice-mime" })),
+    });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice",
+      contentType,
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    const bodyText = expectVoiceAttachmentBody();
+    expect(bodyText).toContain('filename="voice.caf"');
+    const ffmpegArgs = execFileMock.mock.calls[0]?.[1] as string[] | undefined;
+    expect(path.extname(ffmpegArgs?.[2] ?? "")).toBe(expectedExt);
+    expect(ffmpegArgs).toContain("-f");
+    expect(ffmpegArgs).toContain("caf");
+  });
+
   it("sanitizes filenames before sending", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -648,6 +648,33 @@ describe("sendBlueBubblesAttachment", () => {
     );
   });
 
+  it("rejects voice memos when CAF conversion exceeds the media size limit", async () => {
+    execFileMock.mockImplementationOnce(async (_file, args, _options, callback) => {
+      const normalizedArgs = Array.isArray(args) ? [...args] : [];
+      const outputPath =
+        typeof normalizedArgs.at(-1) === "string" ? normalizedArgs.at(-1) : undefined;
+      if (typeof outputPath === "string") {
+        await fs.writeFile(outputPath, new Uint8Array(2 * 1024 * 1024));
+      }
+      callback?.(null, "", "");
+      return {} as ReturnType<typeof execFileMock>;
+    });
+
+    await expect(
+      sendBlueBubblesAttachment({
+        to: "chat_guid:iMessage;-;+15551234567",
+        buffer: new Uint8Array([1, 2, 3]),
+        filename: "voice.ogg",
+        contentType: "audio/ogg; codecs=opus",
+        asVoice: true,
+        maxBytes: 1024 * 1024,
+        opts: { serverUrl: "http://localhost:1234", password: "test" },
+      }),
+    ).rejects.toThrow("Media exceeds 1MB limit");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("warns and downgrades attachment reply threading when private API status is unknown", async () => {
     const runtimeLog = vi.fn();
     setBlueBubblesRuntime({

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -15,7 +15,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 import { downloadBlueBubblesAttachment, sendBlueBubblesAttachment } from "./attachments.js";
-import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
+import { fetchBlueBubblesServerInfo, getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
 import {
   BLUE_BUBBLES_PRIVATE_API_STATUS,
@@ -60,6 +60,8 @@ installBlueBubblesFetchTestHooks({
   mockFetch,
   privateApiStatusMock: vi.mocked(getCachedBlueBubblesPrivateApiStatus),
 });
+
+const fetchBlueBubblesServerInfoMock = vi.mocked(fetchBlueBubblesServerInfo);
 
 const runtimeStub = {
   channel: {
@@ -350,6 +352,9 @@ describe("sendBlueBubblesAttachment", () => {
       vi.mocked(getCachedBlueBubblesPrivateApiStatus),
       BLUE_BUBBLES_PRIVATE_API_STATUS.unknown,
     );
+    // When Private API status is unknown, probe returns enabled by default so voice tests pass.
+    fetchBlueBubblesServerInfoMock.mockReset();
+    fetchBlueBubblesServerInfoMock.mockResolvedValue({ private_api: true });
   });
 
   afterEach(() => {
@@ -492,7 +497,12 @@ describe("sendBlueBubblesAttachment", () => {
     expect(bodyText).not.toContain('name="partIndex"');
   });
 
-  it("forces private-api method for voice memos even when private API cache is stale", async () => {
+  it("downgrades voice memos when private API is disabled", async () => {
+    const runtimeLog = vi.fn();
+    setBlueBubblesRuntime({
+      ...runtimeStub,
+      log: runtimeLog,
+    } as unknown as PluginRuntime);
     mockBlueBubblesPrivateApiStatusOnce(
       vi.mocked(getCachedBlueBubblesPrivateApiStatus),
       BLUE_BUBBLES_PRIVATE_API_STATUS.disabled,
@@ -511,6 +521,42 @@ describe("sendBlueBubblesAttachment", () => {
       opts: { serverUrl: "http://localhost:1234", password: "test" },
     });
 
+    const body = mockFetch.mock.calls[0][1]?.body as Uint8Array;
+    const bodyText = decodeBody(body);
+    expect(bodyText).not.toContain('name="method"');
+    expect(bodyText).not.toContain('name="isAudioMessage"');
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("Voice bubbles require Private API"),
+    );
+  });
+
+  it("probes server info before forcing private-api voice uploads when cache is unknown", async () => {
+    mockBlueBubblesPrivateApiStatusOnce(
+      vi.mocked(getCachedBlueBubblesPrivateApiStatus),
+      BLUE_BUBBLES_PRIVATE_API_STATUS.unknown,
+    );
+    fetchBlueBubblesServerInfoMock.mockResolvedValueOnce({ private_api: true });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice-private" })),
+    });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test", accountId: "default" },
+    });
+
+    expect(fetchBlueBubblesServerInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        accountId: "default",
+      }),
+    );
     const body = mockFetch.mock.calls[0][1]?.body as Uint8Array;
     const bodyText = decodeBody(body);
     expect(bodyText).toContain('name="method"');

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -1,4 +1,7 @@
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
@@ -29,6 +32,9 @@ export type BlueBubblesAttachmentOpts = {
 const DEFAULT_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
 const AUDIO_MIME_MP3 = new Set(["audio/mpeg", "audio/mp3"]);
 const AUDIO_MIME_CAF = new Set(["audio/x-caf", "audio/caf"]);
+const AUDIO_MIME_OPUS = new Set(["audio/ogg", "audio/ogg; codecs=opus", "audio/opus"]);
+const VOICE_FFMPEG_TIMEOUT_MS = 15_000;
+const VOICE_FFMPEG_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 function sanitizeFilename(input: string | undefined, fallback: string): string {
   const trimmed = input?.trim() ?? "";
@@ -54,8 +60,78 @@ function resolveVoiceInfo(filename: string, contentType?: string) {
     extension === ".mp3" || (normalizedType ? AUDIO_MIME_MP3.has(normalizedType) : false);
   const isCaf =
     extension === ".caf" || (normalizedType ? AUDIO_MIME_CAF.has(normalizedType) : false);
-  const isAudio = isMp3 || isCaf || Boolean(normalizedType?.startsWith("audio/"));
-  return { isAudio, isMp3, isCaf };
+  const isOpus =
+    extension === ".ogg" ||
+    extension === ".opus" ||
+    (normalizedType ? AUDIO_MIME_OPUS.has(normalizedType) : false);
+  const isAudio = isMp3 || isCaf || isOpus || Boolean(normalizedType?.startsWith("audio/"));
+  return { isAudio, isMp3, isCaf, isOpus };
+}
+
+function resolveVoiceInputExtension(filename: string, contentType?: string): string {
+  const extension = path.extname(filename).toLowerCase();
+  if (extension && /^[.a-z0-9]+$/.test(extension)) {
+    return extension;
+  }
+  const normalizedType = contentType?.trim().toLowerCase();
+  if (normalizedType && AUDIO_MIME_CAF.has(normalizedType)) {
+    return ".caf";
+  }
+  if (normalizedType && AUDIO_MIME_MP3.has(normalizedType)) {
+    return ".mp3";
+  }
+  if (normalizedType && AUDIO_MIME_OPUS.has(normalizedType)) {
+    return normalizedType.includes("ogg") ? ".ogg" : ".opus";
+  }
+  return ".audio";
+}
+
+async function convertAudioBufferToCaf(
+  inputBuffer: Uint8Array,
+  inputExt: string,
+): Promise<Uint8Array> {
+  const tempDir = os.tmpdir();
+  const id = crypto.randomUUID().slice(0, 8);
+  const inputPath = path.join(tempDir, `openclaw-bb-voice-${id}${inputExt}`);
+  const outputPath = path.join(tempDir, `openclaw-bb-voice-${id}.caf`);
+  try {
+    await fs.writeFile(inputPath, inputBuffer);
+    await new Promise<void>((resolve, reject) => {
+      execFile(
+        "ffmpeg",
+        [
+          "-y",
+          "-i",
+          inputPath,
+          "-vn",
+          "-sn",
+          "-dn",
+          "-c:a",
+          "libopus",
+          "-b:a",
+          "24k",
+          "-f",
+          "caf",
+          outputPath,
+        ],
+        {
+          timeout: VOICE_FFMPEG_TIMEOUT_MS,
+          maxBuffer: VOICE_FFMPEG_MAX_BUFFER_BYTES,
+        },
+        (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+    return new Uint8Array(await fs.readFile(outputPath));
+  } finally {
+    await fs.unlink(inputPath).catch(() => {});
+    await fs.unlink(outputPath).catch(() => {});
+  }
 }
 
 function resolveAccount(params: BlueBubblesAttachmentOpts) {
@@ -136,7 +212,7 @@ export type SendBlueBubblesAttachmentResult = {
 /**
  * Send an attachment via BlueBubbles API.
  * Supports sending media files (images, videos, audio, documents) to a chat.
- * When asVoice is true, expects MP3/CAF audio and marks it as an iMessage voice memo.
+ * When asVoice is true, converts supported audio to an iMessage voice memo.
  */
 export async function sendBlueBubblesAttachment(params: {
   to: string;
@@ -159,23 +235,32 @@ export async function sendBlueBubblesAttachment(params: {
   const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
   const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
-  // Validate voice memo format when requested (BlueBubbles converts MP3 -> CAF when isAudioMessage).
-  const isAudioMessage = wantsVoice;
+  // Convert voice messages to iMessage-friendly CAF before upload.
+  let isAudioMessage = wantsVoice;
   if (isAudioMessage) {
     const voiceInfo = resolveVoiceInfo(filename, contentType);
     if (!voiceInfo.isAudio) {
-      throw new Error("BlueBubbles voice messages require audio media (mp3 or caf).");
+      throw new Error("BlueBubbles voice messages require audio media.");
     }
-    if (voiceInfo.isMp3) {
-      filename = ensureExtension(filename, ".mp3", fallbackName);
-      contentType = contentType ?? "audio/mpeg";
-    } else if (voiceInfo.isCaf) {
+    if (voiceInfo.isCaf) {
       filename = ensureExtension(filename, ".caf", fallbackName);
-      contentType = contentType ?? "audio/x-caf";
+      contentType = "audio/x-caf";
     } else {
-      throw new Error(
-        "BlueBubbles voice messages require mp3 or caf audio (convert before sending).",
-      );
+      try {
+        buffer = await convertAudioBufferToCaf(
+          buffer,
+          resolveVoiceInputExtension(filename, contentType),
+        );
+        filename = ensureExtension(filename, ".caf", fallbackName);
+        contentType = "audio/x-caf";
+      } catch (error) {
+        warnBlueBubbles(
+          `Voice message CAF conversion failed; sending as regular attachment instead: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        isAudioMessage = false;
+      }
     }
   }
 
@@ -226,7 +311,7 @@ export async function sendBlueBubblesAttachment(params: {
   addField("chatGuid", chatGuid);
   addField("name", filename);
   addField("tempGuid", `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`);
-  if (privateApiEnabled) {
+  if (privateApiEnabled || isAudioMessage) {
     addField("method", "private-api");
   }
 

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -98,6 +98,8 @@ async function convertAudioBufferToCaf(
   const outputPath = path.join(tempDir, `openclaw-bb-voice-${id}.caf`);
   try {
     await fs.writeFile(inputPath, inputBuffer, { mode: 0o600 });
+    // Pre-create output file with restricted permissions so ffmpeg inherits them
+    await fs.writeFile(outputPath, "", { mode: 0o600 });
     await new Promise<void>((resolve, reject) => {
       execFile(
         "ffmpeg",

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -39,6 +39,7 @@ const AUDIO_MIME_WAV = new Set(["audio/wav", "audio/x-wav", "audio/wave", "audio
 const AUDIO_MIME_OPUS = new Set(["audio/ogg", "audio/ogg; codecs=opus", "audio/opus"]);
 const VOICE_FFMPEG_TIMEOUT_MS = 15_000;
 const VOICE_FFMPEG_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const MB = 1024 * 1024;
 
 function sanitizeFilename(input: string | undefined, fallback: string): string {
   const trimmed = input?.trim() ?? "";
@@ -185,6 +186,31 @@ function readMediaFetchErrorCode(error: unknown): MediaFetchErrorCode | undefine
     : undefined;
 }
 
+function assertMediaWithinLimit(sizeBytes: number, maxBytes?: number): void {
+  if (typeof maxBytes !== "number" || maxBytes <= 0) {
+    return;
+  }
+  if (sizeBytes <= maxBytes) {
+    return;
+  }
+  const maxLabel = (maxBytes / MB).toFixed(0);
+  const sizeLabel = (sizeBytes / MB).toFixed(2);
+  const error = new Error(`Media exceeds ${maxLabel}MB limit (got ${sizeLabel}MB)`) as Error & {
+    code?: string;
+  };
+  error.code = "max_bytes";
+  throw error;
+}
+
+function isMediaLimitError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "max_bytes"
+  );
+}
+
 export async function downloadBlueBubblesAttachment(
   attachment: BlueBubblesAttachment,
   opts: BlueBubblesAttachmentOpts & { maxBytes?: number } = {},
@@ -249,10 +275,12 @@ export async function sendBlueBubblesAttachment(params: {
   replyToMessageGuid?: string;
   replyToPartIndex?: number;
   asVoice?: boolean;
+  maxBytes?: number;
   opts?: BlueBubblesAttachmentOpts;
 }): Promise<SendBlueBubblesAttachmentResult> {
   const { to, caption, replyToMessageGuid, replyToPartIndex, asVoice, opts = {} } = params;
   let { buffer, filename, contentType } = params;
+  const { maxBytes } = params;
   const wantsVoice = asVoice === true;
   const fallbackName = wantsVoice ? "Audio Message" : "attachment";
   filename = sanitizeFilename(filename, fallbackName);
@@ -298,9 +326,13 @@ export async function sendBlueBubblesAttachment(params: {
           buffer,
           resolveVoiceInputExtension(filename, contentType),
         );
+        assertMediaWithinLimit(buffer.byteLength, maxBytes);
         filename = ensureExtension(filename, ".caf", fallbackName);
         contentType = "audio/x-caf";
       } catch (error) {
+        if (isMediaLimitError(error)) {
+          throw error;
+        }
         warnBlueBubbles(
           `Voice message CAF conversion failed; sending as regular attachment instead: ${
             error instanceof Error ? error.message : String(error)

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
 import { assertMultipartActionOk, postMultipartFormData } from "./multipart.js";
 import {
+  fetchBlueBubblesServerInfo,
   getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
 } from "./probe.js";
@@ -236,11 +237,27 @@ export async function sendBlueBubblesAttachment(params: {
   filename = sanitizeFilename(filename, fallbackName);
   contentType = contentType?.trim() || undefined;
   const { baseUrl, password, accountId } = resolveAccount(opts);
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
+  let privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
+  if (wantsVoice && privateApiStatus === null) {
+    // Status not yet cached — probe server once so the method field is accurate.
+    const serverInfo = await fetchBlueBubblesServerInfo({
+      baseUrl,
+      password,
+      accountId,
+      timeoutMs: opts.timeoutMs,
+    });
+    if (typeof serverInfo?.private_api === "boolean") {
+      privateApiStatus = serverInfo.private_api;
+    }
+  }
   const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
   // Convert voice messages to iMessage-friendly CAF before upload.
   let isAudioMessage = wantsVoice;
+  if (isAudioMessage && privateApiStatus === false) {
+    warnBlueBubbles("Voice bubbles require Private API; sending as a regular attachment instead.");
+    isAudioMessage = false;
+  }
   if (isAudioMessage) {
     const voiceInfo = resolveVoiceInfo(filename, contentType);
     if (!voiceInfo.isAudio) {
@@ -320,7 +337,7 @@ export async function sendBlueBubblesAttachment(params: {
   addField("chatGuid", chatGuid);
   addField("name", filename);
   addField("tempGuid", `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`);
-  if (privateApiEnabled || isAudioMessage) {
+  if (privateApiEnabled) {
     addField("method", "private-api");
   }
 

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -56,16 +56,18 @@ function ensureExtension(filename: string, extension: string, fallbackBase: stri
 function resolveVoiceInfo(filename: string, contentType?: string) {
   const normalizedType = contentType?.trim().toLowerCase();
   const extension = path.extname(filename).toLowerCase();
-  const isMp3 =
-    extension === ".mp3" || (normalizedType ? AUDIO_MIME_MP3.has(normalizedType) : false);
   const isCaf =
     extension === ".caf" || (normalizedType ? AUDIO_MIME_CAF.has(normalizedType) : false);
-  const isOpus =
+  const isAudio =
+    isCaf ||
+    extension === ".mp3" ||
     extension === ".ogg" ||
     extension === ".opus" ||
-    (normalizedType ? AUDIO_MIME_OPUS.has(normalizedType) : false);
-  const isAudio = isMp3 || isCaf || isOpus || Boolean(normalizedType?.startsWith("audio/"));
-  return { isAudio, isMp3, isCaf, isOpus };
+    Boolean(normalizedType?.startsWith("audio/")) ||
+    (normalizedType
+      ? AUDIO_MIME_MP3.has(normalizedType) || AUDIO_MIME_OPUS.has(normalizedType)
+      : false);
+  return { isAudio, isCaf };
 }
 
 function resolveVoiceInputExtension(filename: string, contentType?: string): string {

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -303,8 +303,12 @@ export async function sendBlueBubblesAttachment(params: {
 
   // Convert voice messages to iMessage-friendly CAF before upload.
   let isAudioMessage = wantsVoice;
-  if (isAudioMessage && privateApiStatus === false) {
-    warnBlueBubbles("Voice bubbles require Private API; sending as a regular attachment instead.");
+  if (isAudioMessage && !privateApiEnabled) {
+    warnBlueBubbles(
+      privateApiStatus === null
+        ? "Private API probe failed; sending voice as a regular attachment instead."
+        : "Voice bubbles require Private API; sending as a regular attachment instead.",
+    );
     isAudioMessage = false;
   }
   if (isAudioMessage) {

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -58,16 +58,16 @@ function resolveVoiceInfo(filename: string, contentType?: string) {
   const extension = path.extname(filename).toLowerCase();
   const isCaf =
     extension === ".caf" || (normalizedType ? AUDIO_MIME_CAF.has(normalizedType) : false);
+  const isMp3 =
+    extension === ".mp3" || (normalizedType ? AUDIO_MIME_MP3.has(normalizedType) : false);
   const isAudio =
     isCaf ||
-    extension === ".mp3" ||
+    isMp3 ||
     extension === ".ogg" ||
     extension === ".opus" ||
     Boolean(normalizedType?.startsWith("audio/")) ||
-    (normalizedType
-      ? AUDIO_MIME_MP3.has(normalizedType) || AUDIO_MIME_OPUS.has(normalizedType)
-      : false);
-  return { isAudio, isCaf };
+    (normalizedType ? AUDIO_MIME_OPUS.has(normalizedType) : false);
+  return { isAudio, isCaf, isMp3 };
 }
 
 function resolveVoiceInputExtension(filename: string, contentType?: string): string {
@@ -97,7 +97,7 @@ async function convertAudioBufferToCaf(
   const inputPath = path.join(tempDir, `openclaw-bb-voice-${id}${inputExt}`);
   const outputPath = path.join(tempDir, `openclaw-bb-voice-${id}.caf`);
   try {
-    await fs.writeFile(inputPath, inputBuffer);
+    await fs.writeFile(inputPath, inputBuffer, { mode: 0o600 });
     await new Promise<void>((resolve, reject) => {
       execFile(
         "ffmpeg",
@@ -109,9 +109,9 @@ async function convertAudioBufferToCaf(
           "-sn",
           "-dn",
           "-c:a",
-          "libopus",
+          "aac",
           "-b:a",
-          "24k",
+          "32k",
           "-f",
           "caf",
           outputPath,
@@ -247,6 +247,11 @@ export async function sendBlueBubblesAttachment(params: {
     if (voiceInfo.isCaf) {
       filename = ensureExtension(filename, ".caf", fallbackName);
       contentType = "audio/x-caf";
+    } else if (voiceInfo.isMp3) {
+      // MP3 voice memos: BlueBubbles server converts MP3→CAF natively,
+      // so pass through without ffmpeg to avoid a hard dependency.
+      filename = ensureExtension(filename, ".mp3", fallbackName);
+      contentType = "audio/mpeg";
     } else {
       try {
         buffer = await convertAudioBufferToCaf(

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -33,6 +33,9 @@ export type BlueBubblesAttachmentOpts = {
 const DEFAULT_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
 const AUDIO_MIME_MP3 = new Set(["audio/mpeg", "audio/mp3"]);
 const AUDIO_MIME_CAF = new Set(["audio/x-caf", "audio/caf"]);
+const AUDIO_MIME_M4A = new Set(["audio/x-m4a", "audio/m4a", "audio/mp4"]);
+const AUDIO_MIME_AAC = new Set(["audio/aac"]);
+const AUDIO_MIME_WAV = new Set(["audio/wav", "audio/x-wav", "audio/wave", "audio/vnd.wave"]);
 const AUDIO_MIME_OPUS = new Set(["audio/ogg", "audio/ogg; codecs=opus", "audio/opus"]);
 const VOICE_FFMPEG_TIMEOUT_MS = 15_000;
 const VOICE_FFMPEG_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -61,9 +64,18 @@ function resolveVoiceInfo(filename: string, contentType?: string) {
     extension === ".caf" || (normalizedType ? AUDIO_MIME_CAF.has(normalizedType) : false);
   const isMp3 =
     extension === ".mp3" || (normalizedType ? AUDIO_MIME_MP3.has(normalizedType) : false);
+  const isM4a =
+    extension === ".m4a" || (normalizedType ? AUDIO_MIME_M4A.has(normalizedType) : false);
+  const isAac =
+    extension === ".aac" || (normalizedType ? AUDIO_MIME_AAC.has(normalizedType) : false);
+  const isWav =
+    extension === ".wav" || (normalizedType ? AUDIO_MIME_WAV.has(normalizedType) : false);
   const isAudio =
     isCaf ||
     isMp3 ||
+    isM4a ||
+    isAac ||
+    isWav ||
     extension === ".ogg" ||
     extension === ".opus" ||
     Boolean(normalizedType?.startsWith("audio/")) ||
@@ -82,6 +94,15 @@ function resolveVoiceInputExtension(filename: string, contentType?: string): str
   }
   if (normalizedType && AUDIO_MIME_MP3.has(normalizedType)) {
     return ".mp3";
+  }
+  if (normalizedType && AUDIO_MIME_M4A.has(normalizedType)) {
+    return ".m4a";
+  }
+  if (normalizedType && AUDIO_MIME_AAC.has(normalizedType)) {
+    return ".aac";
+  }
+  if (normalizedType && AUDIO_MIME_WAV.has(normalizedType)) {
+    return ".wav";
   }
   if (normalizedType && AUDIO_MIME_OPUS.has(normalizedType)) {
     return normalizedType.includes("ogg") ? ".ogg" : ".opus";

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -261,12 +261,13 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
     sendMedia: async (ctx) => {
       const runtime = await loadBlueBubblesChannelRuntime();
       const { cfg, to, text, mediaUrl, accountId, replyToId } = ctx;
-      const { mediaPath, mediaBuffer, contentType, filename, caption } = ctx as {
+      const { mediaPath, mediaBuffer, contentType, filename, caption, audioAsVoice } = ctx as {
         mediaPath?: string;
         mediaBuffer?: Uint8Array;
         contentType?: string;
         filename?: string;
         caption?: string;
+        audioAsVoice?: boolean;
       };
       const resolvedCaption = caption ?? text;
       const result = await runtime.sendBlueBubblesMedia({
@@ -280,6 +281,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
         caption: resolvedCaption ?? undefined,
         replyToId: replyToId ?? null,
         accountId: accountId ?? undefined,
+        asVoice: audioAsVoice ?? undefined,
       });
 
       return { channel: "bluebubbles", ...result };

--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -298,6 +298,7 @@ export async function sendBlueBubblesMedia(params: {
     contentType: resolvedContentType ?? undefined,
     replyToMessageGuid,
     asVoice,
+    maxBytes,
     opts: {
       cfg,
       accountId,

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1280,6 +1280,7 @@ export async function processMessage(
                   caption: caption ?? undefined,
                   replyToId: replyToMessageGuid || null,
                   accountId: account.accountId,
+                  asVoice: payload.audioAsVoice === true,
                 });
               } catch (err) {
                 forgetPendingOutboundMessageId(pendingId);

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
+import { getFileExtension, isAudioFileName, normalizeMimeType } from "../../../src/media/mime.js";
 import {
   DM_GROUP_ACCESS_REASON,
   createScopedPairingAccess,
@@ -90,12 +91,16 @@ function normalizeSnippet(value: string): string {
 }
 
 export function isAudioCompatibleMedia(params: { mediaType?: string; mediaUrl?: string }): boolean {
-  const mediaType = params.mediaType?.trim().toLowerCase();
-  if (mediaType?.startsWith("audio/")) {
+  const mediaType = normalizeMimeType(params.mediaType);
+  if (mediaType) {
+    return mediaType.startsWith("audio/");
+  }
+  const ext = getFileExtension(params.mediaUrl);
+  if (!ext) {
+    // No reliable signal yet; preserve voice mode and let fetch-time MIME detection decide.
     return true;
   }
-  const url = params.mediaUrl?.toLowerCase() ?? "";
-  return /\.(caf|mp3|m4a|aac|wav|ogg|opus)(?:$|[?#])/.test(url);
+  return isAudioFileName(params.mediaUrl);
 }
 
 function isBlueBubblesSelfChatMessage(

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/bluebubbles";
-import { getFileExtension, isAudioFileName, normalizeMimeType } from "../../../src/media/mime.js";
 import {
   DM_GROUP_ACCESS_REASON,
   createScopedPairingAccess,
@@ -18,6 +17,7 @@ import {
   stripMarkdown,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/bluebubbles";
+import { getFileExtension, isAudioFileName, normalizeMimeType } from "../../../src/media/mime.js";
 import { downloadBlueBubblesAttachment } from "./attachments.js";
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
 import { fetchBlueBubblesHistory } from "./history.js";

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -89,6 +89,15 @@ function normalizeSnippet(value: string): string {
   return stripMarkdown(value).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+export function isAudioCompatibleMedia(params: { mediaType?: string; mediaUrl?: string }): boolean {
+  const mediaType = params.mediaType?.trim().toLowerCase();
+  if (mediaType?.startsWith("audio/")) {
+    return true;
+  }
+  const url = params.mediaUrl?.toLowerCase() ?? "";
+  return /\.(caf|mp3|m4a|aac|wav|ogg|opus)(?:$|[?#])/.test(url);
+}
+
 function isBlueBubblesSelfChatMessage(
   message: NormalizedWebhookMessage,
   isGroup: boolean,
@@ -1248,6 +1257,11 @@ export async function processMessage(
             : payload.mediaUrl
               ? [payload.mediaUrl]
               : [];
+          const mediaTypeList = payload.mediaTypes?.length
+            ? payload.mediaTypes
+            : payload.mediaType
+              ? [payload.mediaType]
+              : [];
           if (mediaList.length > 0) {
             const tableMode = core.channel.text.resolveMarkdownTableMode({
               cfg: config,
@@ -1258,9 +1272,11 @@ export async function processMessage(
               core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode),
             );
             let first = true;
-            for (const mediaUrl of mediaList) {
+            for (const [index, mediaUrl] of mediaList.entries()) {
               const caption = first ? text : undefined;
               first = false;
+              const mediaType =
+                mediaTypeList[index] ?? (mediaList.length === 1 ? payload.mediaType : undefined);
               const cachedBody = (caption ?? "").trim() || "<media:attachment>";
               const pendingId = rememberPendingOutboundMessageId({
                 accountId: account.accountId,
@@ -1277,10 +1293,13 @@ export async function processMessage(
                   cfg: config,
                   to: outboundTarget,
                   mediaUrl,
+                  contentType: mediaType,
                   caption: caption ?? undefined,
                   replyToId: replyToMessageGuid || null,
                   accountId: account.accountId,
-                  asVoice: payload.audioAsVoice === true,
+                  asVoice:
+                    payload.audioAsVoice === true &&
+                    isAudioCompatibleMedia({ mediaType, mediaUrl }),
                 });
               } catch (err) {
                 forgetPendingOutboundMessageId(pendingId);

--- a/extensions/bluebubbles/src/monitor-processing.voice.test.ts
+++ b/extensions/bluebubbles/src/monitor-processing.voice.test.ts
@@ -12,6 +12,13 @@ describe("bluebubbles voice media gating", () => {
     expect(isAudioCompatibleMedia({ mediaUrl: "https://x.test/reply.opus?dl=1" })).toBe(true);
   });
 
+  it("preserves voice mode when media type and file extension are both unavailable", () => {
+    expect(isAudioCompatibleMedia({ mediaUrl: "https://x.test/download?id=voice-note" })).toBe(
+      true,
+    );
+    expect(isAudioCompatibleMedia({})).toBe(true);
+  });
+
   it("does not treat non-audio media as voice-compatible", () => {
     expect(isAudioCompatibleMedia({ mediaType: "image/png", mediaUrl: "/tmp/photo.png" })).toBe(
       false,

--- a/extensions/bluebubbles/src/monitor-processing.voice.test.ts
+++ b/extensions/bluebubbles/src/monitor-processing.voice.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isAudioCompatibleMedia } from "./monitor-processing.js";
+
+describe("bluebubbles voice media gating", () => {
+  it("treats audio mime types as voice-compatible", () => {
+    expect(isAudioCompatibleMedia({ mediaType: "audio/mpeg" })).toBe(true);
+    expect(isAudioCompatibleMedia({ mediaType: "audio/ogg; codecs=opus" })).toBe(true);
+  });
+
+  it("treats common audio file extensions as voice-compatible", () => {
+    expect(isAudioCompatibleMedia({ mediaUrl: "/tmp/reply.m4a" })).toBe(true);
+    expect(isAudioCompatibleMedia({ mediaUrl: "https://x.test/reply.opus?dl=1" })).toBe(true);
+  });
+
+  it("does not treat non-audio media as voice-compatible", () => {
+    expect(isAudioCompatibleMedia({ mediaType: "image/png", mediaUrl: "/tmp/photo.png" })).toBe(
+      false,
+    );
+    expect(isAudioCompatibleMedia({ mediaUrl: "https://x.test/photo.jpg" })).toBe(false);
+  });
+});

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -48,6 +48,7 @@ export function createBlueBubblesAccountsMockModule() {
 type BlueBubblesProbeMockModule = {
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
+  fetchBlueBubblesServerInfo: Mock<() => Promise<{ private_api?: boolean } | null>>;
 };
 
 export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
@@ -56,6 +57,7 @@ export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
       .fn()
       .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown),
     isBlueBubblesPrivateApiStatusEnabled: vi.fn((status: boolean | null) => status === true),
+    fetchBlueBubblesServerInfo: vi.fn().mockResolvedValue(null),
   };
 }
 

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -81,6 +81,8 @@ export type ReplyPayload = {
   btw?: {
     question: string;
   };
+  mediaType?: string;
+  mediaTypes?: string[];
   replyToId?: string;
   replyToTag?: boolean;
   /** True when [[reply_to_current]] was present but not yet mapped to a message id. */

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -123,6 +123,7 @@ export type ChannelOutboundContext = {
   to: string;
   text: string;
   mediaUrl?: string;
+  audioAsVoice?: boolean;
   mediaLocalRoots?: readonly string[];
   gifPlayback?: boolean;
   /** Send image as document to avoid Telegram compression. */

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -123,6 +123,7 @@ export type ChannelOutboundContext = {
   to: string;
   text: string;
   mediaUrl?: string;
+  contentType?: string;
   audioAsVoice?: boolean;
   mediaLocalRoots?: readonly string[];
   gifPlayback?: boolean;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1219,7 +1219,7 @@ describe("deliverOutboundPayloads", () => {
     ]);
   });
 
-  it("preserves audioAsVoice for extensionless media URLs when mime is not known yet", async () => {
+  it("downgrades audioAsVoice for extensionless media URLs when mime is not known yet", async () => {
     const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-audio" });
     setActivePluginRegistry(
       createTestRegistry([
@@ -1254,7 +1254,7 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMedia).toHaveBeenCalledTimes(1);
     expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({
       contentType: undefined,
-      audioAsVoice: true,
+      audioAsVoice: false,
     });
     expect(results).toEqual([{ channel: "matrix", messageId: "mx-audio" }]);
   });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1219,6 +1219,46 @@ describe("deliverOutboundPayloads", () => {
     ]);
   });
 
+  it("preserves audioAsVoice for extensionless media URLs when mime is not known yet", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-audio" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-text" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [
+        {
+          text: "voice note",
+          mediaUrls: ["https://example.com/download?id=voice-note"],
+          audioAsVoice: true,
+        },
+      ],
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({
+      contentType: undefined,
+      audioAsVoice: true,
+    });
+    expect(results).toEqual([{ channel: "matrix", messageId: "mx-audio" }]);
+  });
+
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {
     const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-2" });
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1165,6 +1165,54 @@ describe("deliverOutboundPayloads", () => {
     ]);
   });
 
+  it("uses mediaTypes as a fallback when audio media URLs have no extension", async () => {
+    const sendMedia = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-image" })
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-audio" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-text" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [
+        {
+          text: "mixed media",
+          mediaUrls: [
+            "https://example.com/photo?id=1",
+            "https://example.com/download?id=voice-note",
+          ],
+          mediaTypes: ["image/png", "audio/mpeg"],
+          audioAsVoice: true,
+        },
+      ],
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({ audioAsVoice: false });
+    expect(sendMedia.mock.calls[1]?.[0]).toMatchObject({ audioAsVoice: true });
+    expect(results).toEqual([
+      { channel: "matrix", messageId: "mx-image" },
+      { channel: "matrix", messageId: "mx-audio" },
+    ]);
+  });
+
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {
     const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-2" });
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1121,6 +1121,50 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "mx-voice" }]);
   });
 
+  it("only passes audioAsVoice to audio media entries in multi-media payloads", async () => {
+    const sendMedia = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-image" })
+      .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-audio" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-text" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [
+        {
+          text: "mixed media",
+          mediaUrls: ["https://example.com/photo.png", "https://example.com/voice.mp3"],
+          audioAsVoice: true,
+        },
+      ],
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({ audioAsVoice: false });
+    expect(sendMedia.mock.calls[1]?.[0]).toMatchObject({ audioAsVoice: true });
+    expect(results).toEqual([
+      { channel: "matrix", messageId: "mx-image" },
+      { channel: "matrix", messageId: "mx-audio" },
+    ]);
+  });
+
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {
     const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-2" });
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1078,6 +1078,49 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "mx-1" }]);
   });
 
+  it("passes audioAsVoice through plugin sendMedia context", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-voice" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-text" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [
+        {
+          text: "voice note",
+          mediaUrl: "https://example.com/voice.mp3",
+          audioAsVoice: true,
+        },
+      ],
+    });
+
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "voice note",
+        mediaUrl: "https://example.com/voice.mp3",
+        audioAsVoice: true,
+      }),
+    );
+    expect(results).toEqual([{ channel: "matrix", messageId: "mx-voice" }]);
+  });
+
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {
     const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-2" });
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1205,8 +1205,14 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(2);
-    expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({ audioAsVoice: false });
-    expect(sendMedia.mock.calls[1]?.[0]).toMatchObject({ audioAsVoice: true });
+    expect(sendMedia.mock.calls[0]?.[0]).toMatchObject({
+      contentType: "image/png",
+      audioAsVoice: false,
+    });
+    expect(sendMedia.mock.calls[1]?.[0]).toMatchObject({
+      contentType: "audio/mpeg",
+      audioAsVoice: true,
+    });
     expect(results).toEqual([
       { channel: "matrix", messageId: "mx-image" },
       { channel: "matrix", messageId: "mx-audio" },

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -26,7 +26,7 @@ import {
 import { hasReplyChannelData, hasReplyContent } from "../../interactive/payload.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { isAudioFileName, normalizeMimeType } from "../../media/mime.js";
+import { getFileExtension, isAudioFileName, normalizeMimeType } from "../../media/mime.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
@@ -45,6 +45,18 @@ export { normalizeOutboundPayloads } from "./payloads.js";
 export { resolveOutboundSendDep, type OutboundSendDeps } from "./send-deps.js";
 
 const log = createSubsystemLogger("outbound/deliver");
+
+function shouldPreserveAudioAsVoice(params: { mediaType?: string; mediaUrl?: string }): boolean {
+  const mediaType = normalizeMimeType(params.mediaType);
+  if (mediaType) {
+    return mediaType.startsWith("audio/");
+  }
+  const ext = getFileExtension(params.mediaUrl);
+  if (!ext) {
+    return true;
+  }
+  return isAudioFileName(params.mediaUrl);
+}
 
 export type OutboundDeliveryResult = {
   channel: Exclude<OutboundChannel, "none">;
@@ -745,7 +757,7 @@ async function deliverOutboundPayloadsCore(
           contentType: mediaType,
           audioAsVoice:
             sendOverrides.audioAsVoice &&
-            (normalizeMimeType(mediaType)?.startsWith("audio/") || isAudioFileName(url)),
+            shouldPreserveAudioAsVoice({ mediaType, mediaUrl: url }),
         };
         if (handler.sendFormattedMedia) {
           const delivery = await handler.sendFormattedMedia(caption, url, mediaSendOverrides);

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -104,6 +104,7 @@ type ChannelHandler = {
     overrides?: {
       replyToId?: string | null;
       threadId?: string | number | null;
+      audioAsVoice?: boolean;
     },
   ) => Promise<OutboundDeliveryResult>;
 };
@@ -155,10 +156,12 @@ function createPluginHandler(
   const resolveCtx = (overrides?: {
     replyToId?: string | null;
     threadId?: string | number | null;
+    audioAsVoice?: boolean;
   }): Omit<ChannelOutboundContext, "text" | "mediaUrl"> => ({
     ...baseCtx,
     replyToId: overrides?.replyToId ?? baseCtx.replyToId,
     threadId: overrides?.threadId ?? baseCtx.threadId,
+    audioAsVoice: overrides?.audioAsVoice,
   });
   return {
     chunker,
@@ -662,6 +665,7 @@ async function deliverOutboundPayloadsCore(
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
         forceDocument: params.forceDocument,
+        audioAsVoice: effectivePayload.audioAsVoice === true,
       };
       if (
         handler.sendPayload &&

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -26,6 +26,7 @@ import {
 import { hasReplyChannelData, hasReplyContent } from "../../interactive/payload.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { isAudioFileName } from "../../media/mime.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
@@ -731,12 +732,16 @@ async function deliverOutboundPayloadsCore(
         throwIfAborted(abortSignal);
         const caption = first ? payloadSummary.text : "";
         first = false;
+        const mediaSendOverrides = {
+          ...sendOverrides,
+          audioAsVoice: sendOverrides.audioAsVoice && isAudioFileName(url),
+        };
         if (handler.sendFormattedMedia) {
-          const delivery = await handler.sendFormattedMedia(caption, url, sendOverrides);
+          const delivery = await handler.sendFormattedMedia(caption, url, mediaSendOverrides);
           results.push(delivery);
           lastMessageId = delivery.messageId;
         } else {
-          const delivery = await handler.sendMedia(caption, url, sendOverrides);
+          const delivery = await handler.sendMedia(caption, url, mediaSendOverrides);
           results.push(delivery);
           lastMessageId = delivery.messageId;
         }

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -51,11 +51,9 @@ function shouldPreserveAudioAsVoice(params: { mediaType?: string; mediaUrl?: str
   if (mediaType) {
     return mediaType.startsWith("audio/");
   }
-  const ext = getFileExtension(params.mediaUrl);
-  if (!ext) {
-    return true;
-  }
-  return isAudioFileName(params.mediaUrl);
+  // This layer has no fetch-time MIME detection, so unknown URLs must downgrade to avoid
+  // forcing voice mode onto extensionless image/document links in mixed-media replies.
+  return Boolean(getFileExtension(params.mediaUrl)) && isAudioFileName(params.mediaUrl);
 }
 
 export type OutboundDeliveryResult = {
@@ -756,8 +754,7 @@ async function deliverOutboundPayloadsCore(
           ...sendOverrides,
           contentType: mediaType,
           audioAsVoice:
-            sendOverrides.audioAsVoice &&
-            shouldPreserveAudioAsVoice({ mediaType, mediaUrl: url }),
+            sendOverrides.audioAsVoice && shouldPreserveAudioAsVoice({ mediaType, mediaUrl: url }),
         };
         if (handler.sendFormattedMedia) {
           const delivery = await handler.sendFormattedMedia(caption, url, mediaSendOverrides);

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -105,6 +105,7 @@ type ChannelHandler = {
     overrides?: {
       replyToId?: string | null;
       threadId?: string | number | null;
+      contentType?: string;
       audioAsVoice?: boolean;
     },
   ) => Promise<OutboundDeliveryResult>;
@@ -157,11 +158,13 @@ function createPluginHandler(
   const resolveCtx = (overrides?: {
     replyToId?: string | null;
     threadId?: string | number | null;
+    contentType?: string;
     audioAsVoice?: boolean;
   }): Omit<ChannelOutboundContext, "text" | "mediaUrl"> => ({
     ...baseCtx,
     replyToId: overrides?.replyToId ?? baseCtx.replyToId,
     threadId: overrides?.threadId ?? baseCtx.threadId,
+    contentType: overrides?.contentType,
     audioAsVoice: overrides?.audioAsVoice,
   });
   return {
@@ -739,6 +742,7 @@ async function deliverOutboundPayloadsCore(
           (payloadSummary.mediaUrls.length === 1 ? payloadSummary.mediaType : undefined);
         const mediaSendOverrides = {
           ...sendOverrides,
+          contentType: mediaType,
           audioAsVoice:
             sendOverrides.audioAsVoice &&
             (normalizeMimeType(mediaType)?.startsWith("audio/") || isAudioFileName(url)),

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -26,7 +26,7 @@ import {
 import { hasReplyChannelData, hasReplyContent } from "../../interactive/payload.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { isAudioFileName } from "../../media/mime.js";
+import { isAudioFileName, normalizeMimeType } from "../../media/mime.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
@@ -344,6 +344,8 @@ function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
     text: payload.text ?? "",
     mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
     interactive: payload.interactive,
+    ...(payload.mediaType ? { mediaType: payload.mediaType } : {}),
+    ...(payload.mediaTypes?.length ? { mediaTypes: payload.mediaTypes } : {}),
     channelData: payload.channelData,
   };
 }
@@ -728,13 +730,18 @@ async function deliverOutboundPayloadsCore(
 
       let first = true;
       let lastMessageId: string | undefined;
-      for (const url of payloadSummary.mediaUrls) {
+      for (const [index, url] of payloadSummary.mediaUrls.entries()) {
         throwIfAborted(abortSignal);
         const caption = first ? payloadSummary.text : "";
         first = false;
+        const mediaType =
+          payloadSummary.mediaTypes?.[index] ??
+          (payloadSummary.mediaUrls.length === 1 ? payloadSummary.mediaType : undefined);
         const mediaSendOverrides = {
           ...sendOverrides,
-          audioAsVoice: sendOverrides.audioAsVoice && isAudioFileName(url),
+          audioAsVoice:
+            sendOverrides.audioAsVoice &&
+            (normalizeMimeType(mediaType)?.startsWith("audio/") || isAudioFileName(url)),
         };
         if (handler.sendFormattedMedia) {
           const delivery = await handler.sendFormattedMedia(caption, url, mediaSendOverrides);

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -16,6 +16,8 @@ export type NormalizedOutboundPayload = {
   text: string;
   mediaUrls: string[];
   interactive?: InteractiveReply;
+  mediaType?: string;
+  mediaTypes?: string[];
   channelData?: Record<string, unknown>;
 };
 
@@ -116,6 +118,8 @@ export function normalizeOutboundPayloads(
       text,
       mediaUrls,
       ...(hasInteractive ? { interactive } : {}),
+      ...(payload.mediaType ? { mediaType: payload.mediaType } : {}),
+      ...(payload.mediaTypes?.length ? { mediaTypes: payload.mediaTypes } : {}),
       ...(hasChannelData ? { channelData } : {}),
     });
   }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -213,7 +213,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp) and mp3 for others", () => {
+    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp/bluebubbles) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -235,6 +235,15 @@ describe("tts", () => {
         },
         {
           channel: "whatsapp",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "bluebubbles",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -213,7 +213,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp/bluebubbles) and mp3 for others", () => {
+    it("selects channel-specific voice formats for voice-bubble channels and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -245,9 +245,9 @@ describe("tts", () => {
         {
           channel: "bluebubbles",
           expected: {
-            openai: "opus",
-            elevenlabs: "opus_48000_64",
-            extension: ".opus",
+            openai: "mp3",
+            elevenlabs: "mp3_44100_128",
+            extension: ".mp3",
             voiceCompatible: true,
           },
         },

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -501,7 +501,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "bluebubbles"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -76,6 +76,13 @@ const TELEGRAM_OUTPUT = {
   voiceCompatible: true,
 };
 
+const BLUEBUBBLES_OUTPUT = {
+  openai: "mp3" as const,
+  elevenlabs: "mp3_44100_128",
+  extension: ".mp3",
+  voiceCompatible: true,
+};
+
 const DEFAULT_OUTPUT = {
   openai: "mp3" as const,
   elevenlabs: "mp3_44100_128",
@@ -504,6 +511,9 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "bluebubbles"]);
 
 function resolveOutputFormat(channelId?: string | null) {
+  if (channelId === "bluebubbles") {
+    return BLUEBUBBLES_OUTPUT;
+  }
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {
     return TELEGRAM_OUTPUT;
   }


### PR DESCRIPTION
## Summary

- propagate `audioAsVoice` through plugin outbound media delivery
- add BlueBubbles to the TTS voice-bubble channel set
- convert supported BlueBubbles voice audio inputs to CAF before upload
- keep voice sends on the private-api path, with graceful fallback to regular attachments if conversion fails

## Why

BlueBubbles voice replies were falling back to regular file attachments because the voice intent did not survive the outbound media path, and because BlueBubbles voice uploads need iMessage-friendly CAF audio to render as real voice bubbles.

Compared with the earlier larger PR, this version keeps the scope tighter:
- no unrelated formatter or CI churn
- no `.secrets.baseline` changes
- no merge commits
- no filename-pattern workaround in the delivery callback

## Test plan

- `pnpm test extensions/bluebubbles/src/attachments.test.ts src/tts/tts.test.ts src/infra/outbound/deliver.test.ts`

Closes #33377

