### PR TITLE
fix(install): install gateway daemon service for fresh installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2420,9 +2420,10 @@ main() {
     # Install gateway daemon for fresh installs (not upgrades)
     if [[ "$is_upgrade" != "true" ]]; then
         install_gateway_daemon_if_needed
+    else
+        # Only refresh gateway service on upgrades (not fresh installs)
+        refresh_gateway_service_if_loaded
     fi
-
-    refresh_gateway_service_if_loaded
 
     # Step 6: Run doctor for migrations on upgrades and git installs
     local run_doctor_after=false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2221,6 +2221,45 @@ refresh_gateway_service_if_loaded() {
     run_quiet_step "Probing gateway service" "$claw" gateway status --deep || true
 }
 
+install_gateway_daemon_if_needed() {
+    if [[ "${SKIP_GATEWAY_DAEMON:-0}" == "1" ]]; then
+        ui_info "Skipping gateway daemon installation (SKIP_GATEWAY_DAEMON=1)"
+        return 0
+    fi
+    
+    local claw="${OPENCLAW_BIN:-}"
+    if [[ -z "$claw" ]]; then
+        claw="$(resolve_openclaw_bin || true)"
+    fi
+    if [[ -z "$claw" ]]; then
+        ui_info "Skipping gateway daemon install (openclaw not on PATH yet)"
+        return 0
+    fi
+
+    if is_gateway_daemon_loaded "$claw"; then
+        ui_info "Gateway daemon already installed; skipping install"
+        return 0
+    fi
+
+    ui_info "Installing gateway daemon service"
+    if run_quiet_step "Installing gateway daemon" "$claw" daemon install; then
+        ui_success "Gateway daemon service installed"
+    else
+        ui_warn "Gateway daemon install failed; user can run 'openclaw daemon install' manually"
+        return 0
+    fi
+
+    if run_quiet_step "Starting gateway daemon" "$claw" daemon start; then
+        ui_success "Gateway daemon service started"
+    else
+        ui_warn "Gateway daemon start failed; user can run 'openclaw daemon start' manually"
+        return 0
+    fi
+
+    sleep 2
+    run_quiet_step "Probing gateway daemon" "$claw" daemon status --deep || true
+}
+
 verify_installation() {
     if [[ "${VERIFY_INSTALL}" != "1" ]]; then
         return 0
@@ -2376,6 +2415,11 @@ main() {
         if [[ -x "$HOME/.local/bin/openclaw" ]]; then
             warn_shell_path_missing_dir "$HOME/.local/bin" "user-local bin dir (~/.local/bin)"
         fi
+    fi
+
+    # Install gateway daemon for fresh installs (not upgrades)
+    if [[ "$is_upgrade" != "true" ]]; then
+        install_gateway_daemon_if_needed
     fi
 
     refresh_gateway_service_if_loaded


### PR DESCRIPTION
## Summary

Fixes #48272 - Install script did not install gateway daemon

## Root Cause

The install script only refreshed the gateway service if it was already loaded, but never installed it for fresh installs.

## Fix

1. Add `install_gateway_daemon_if_needed()` function
2. Call `daemon install` and `daemon start` for new installs
3. Skip for upgrades (existing behavior)

## Testing

- [x] Verified gateway daemon installs on fresh install
- [x] Verified upgrade path unchanged
- [x] No breaking changes

## Related Issue

Fixes #48272