### PR TITLE
fix(telegram): improve error messages for 403 bot not member errors

### DIFF
--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -491,7 +491,20 @@ function createTelegramRequestWithDiag(params: {
 }
 
 function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; input: string }) {
-  if (!CHAT_NOT_FOUND_RE.test(formatErrorMessage(err))) {
+  const errorMsg = formatErrorMessage(err);
+  
+  // Check for 403 "bot is not a member" error
+  if (/403.*bot.*not.*member|bot.*blocked/i.test(errorMsg)) {
+    return new Error(
+      [
+        `Telegram send failed: bot is not a member of the chat (chat_id=${params.chatId}).`,
+        "Fix: Add the bot to the channel/group, or ensure it has not been removed/blocked.",
+        `Input was: ${JSON.stringify(params.input)}.`,
+      ].join(" "),
+    );
+  }
+  
+  if (!CHAT_NOT_FOUND_RE.test(errorMsg)) {
     return err;
   }
   return new Error(

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -493,12 +493,12 @@ function createTelegramRequestWithDiag(params: {
 function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; input: string }) {
   const errorMsg = formatErrorMessage(err);
   
-  // Check for 403 "bot is not a member" error
-  if (/403.*bot.*not.*member|bot.*blocked/i.test(errorMsg)) {
+  // Check for 403 "bot is not a member" or "bot was blocked" errors
+  if (/403.*(bot.*not.*member|bot was blocked)/i.test(errorMsg)) {
     return new Error(
       [
-        `Telegram send failed: bot is not a member of the chat (chat_id=${params.chatId}).`,
-        "Fix: Add the bot to the channel/group, or ensure it has not been removed/blocked.",
+        `Telegram send failed: bot is not a member of the chat or was blocked (chat_id=${params.chatId}).`,
+        "Fix: Add the bot to the channel/group, or ensure it has not been removed/blocked by the user.",
         `Input was: ${JSON.stringify(params.input)}.`,
       ].join(" "),
     );

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -492,9 +492,9 @@ function createTelegramRequestWithDiag(params: {
 
 function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; input: string }) {
   const errorMsg = formatErrorMessage(err);
-  
+
   // Check for 403 "bot is not a member" or "bot was blocked" errors
-  if (/403.*(bot.*not.*member|bot was blocked)/i.test(errorMsg)) {
+  if (/403.*(bot.*not.*member|bot.*blocked)/i.test(errorMsg)) {
     return new Error(
       [
         `Telegram send failed: bot is not a member of the chat or was blocked (chat_id=${params.chatId}).`,
@@ -503,7 +503,7 @@ function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; i
       ].join(" "),
     );
   }
-  
+
   if (!CHAT_NOT_FOUND_RE.test(errorMsg)) {
     return err;
   }


### PR DESCRIPTION
## Summary

Fixes #48273 - Telegram outbound sendMessage fails with 403 error

## Root Cause

When a Telegram bot tries to send a message to a channel/group it's not a member of, the API returns 403 'bot is not a member of the channel chat'. The error message was not clear about how to fix this.

## Fix

1. Detect 403 errors in wrapTelegramChatNotFoundError
2. Provide clear error message explaining the issue
3. Suggest adding the bot to the channel/group

## Testing

- [x] Verified error message is clear and actionable
- [x] No breaking changes to existing error handling
- [x] Other error types unchanged

## Related Issue

Fixes #48273