### PR TITLE
fix(plugins): suppress duplicate warning for npm-installed overrides

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -159,7 +159,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
   });
 
-  it("reports explicit installed globals as the effective duplicate winner", () => {
+  it("suppresses duplicate warning for npm-installed plugin overriding bundled", () => {
     const bundledDir = makeTempDir();
     const globalDir = makeTempDir();
     const manifest = { id: "zalouser", configSchema: { type: "object" } };
@@ -192,11 +192,10 @@ describe("loadPluginManifestRegistry", () => {
       ],
     });
 
-    expect(
-      registry.diagnostics.some((diag) =>
-        diag.message.includes("bundled plugin will be overridden by global plugin"),
-      ),
-    ).toBe(true);
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    // Exactly one record should exist — the npm-installed global wins.
+    expect(registry.plugins.filter((p) => p.id === "zalouser")).toHaveLength(1);
+    expect(registry.plugins.find((p) => p.id === "zalouser")?.origin).toBe("global");
   });
 
   it("preserves provider auth env metadata from plugin manifests", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -384,6 +384,60 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
+
+      // When one side is an explicitly npm-installed global plugin and the
+      // other is the bundled version with the same id, the user intentionally
+      // installed the override — suppress the noisy duplicate warning.
+      const candidateIsInstalled = matchesInstalledPluginRecord({
+        pluginId: manifest.id,
+        candidate,
+        config,
+        env,
+      });
+      const existingIsInstalled = matchesInstalledPluginRecord({
+        pluginId: manifest.id,
+        candidate: existing.candidate,
+        config,
+        env,
+      });
+      const isIntentionalOverride =
+        (candidateIsInstalled && existing.candidate.origin === "bundled") ||
+        (existingIsInstalled && candidate.origin === "bundled");
+
+      if (isIntentionalOverride) {
+        // Replace the existing record when the new candidate wins precedence;
+        // either way skip the push below to avoid a duplicate registry entry.
+        const newRank = resolveDuplicatePrecedenceRank({
+          pluginId: manifest.id,
+          candidate,
+          config,
+          env,
+        });
+        const existingRank = resolveDuplicatePrecedenceRank({
+          pluginId: manifest.id,
+          candidate: existing.candidate,
+          config,
+          env,
+        });
+        if (newRank < existingRank) {
+          records[existing.recordIndex] = isBundleRecord
+            ? buildBundleRecord({
+                manifest: manifest as Parameters<typeof buildBundleRecord>[0]["manifest"],
+                candidate,
+                manifestPath: manifestRes.manifestPath,
+              })
+            : buildRecord({
+                manifest: manifest as PluginManifest,
+                candidate,
+                manifestPath: manifestRes.manifestPath,
+                schemaCacheKey,
+                configSchema,
+              });
+          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+        }
+        continue;
+      }
+
       diagnostics.push({
         level: "warn",
         pluginId: manifest.id,


### PR DESCRIPTION
## Summary

- Suppress the "duplicate plugin id detected" warning when an npm-installed global plugin (tracked in `plugins.installs`) shares an id with a bundled extension. The user explicitly installed the override via `openclaw plugins install`, so the warning is noise rather than a useful signal.
- The duplicate warning still fires for truly unexpected duplicates (auto-discovered globals, workspace plugins, etc.).

Fixes #48605

## Test plan

- Updated existing `manifest-registry.test.ts` test to verify the warning is suppressed for npm-installed overrides (`plugins.installs` present).
- Existing tests for other duplicate scenarios (auto-discovered globals, workspace duplicates, symlink dedup) continue to pass.
- `pnpm test -- src/plugins/manifest-registry.test.ts` — 21/21 pass
- `pnpm test -- src/plugins/loader.test.ts` — 81/81 pass