### PR TITLE
edit: add tool-specific hints to parameter validation errors

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -8,8 +8,20 @@ export type RequiredParamGroup = {
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
 
-function parameterValidationError(message: string): Error {
-  return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
+/**
+ * Tool-specific hints appended to parameter validation errors so the caller
+ * knows what the tool expects and which alternative tool might be better.
+ */
+const TOOL_PARAM_HINTS: Readonly<Record<string, string>> = {
+  edit: "The edit tool requires 'path' (or 'file_path'), 'oldText' (or 'old_string') with the exact text to find, and 'newText' (or 'new_string') with the replacement text. For full-file rewrites, consider using 'write' instead.",
+  write: "The write tool requires 'path' (or 'file_path') and 'content' (full file content).",
+  read: "The read tool requires 'path' (or 'file_path').",
+};
+
+function parameterValidationError(message: string, toolName?: string): Error {
+  const hint = toolName ? TOOL_PARAM_HINTS[toolName] : undefined;
+  const suffix = hint ? ` Hint: ${hint}` : "";
+  return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}${suffix}`);
 }
 
 export const CLAUDE_PARAM_GROUPS = {
@@ -171,7 +183,7 @@ export function assertRequiredParams(
   toolName: string,
 ): void {
   if (!record || typeof record !== "object") {
-    throw parameterValidationError(`Missing parameters for ${toolName}`);
+    throw parameterValidationError(`Missing parameters for ${toolName}`, toolName);
   }
 
   const missingLabels: string[] = [];
@@ -199,7 +211,7 @@ export function assertRequiredParams(
   if (missingLabels.length > 0) {
     const joined = missingLabels.join(", ");
     const noun = missingLabels.length === 1 ? "parameter" : "parameters";
-    throw parameterValidationError(`Missing required ${noun}: ${joined}`);
+    throw parameterValidationError(`Missing required ${noun}: ${joined}`, toolName);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds tool-specific hint messages to edit/write/read parameter validation errors so callers get actionable guidance on what params are required and when to use an alternative tool (e.g. `write` instead of `edit` for full-file rewrites).
- The existing generic error (`Missing required parameter: newText`) now includes a contextual hint explaining all required params and suggesting alternatives.

Fixes #24553

## Test plan

- [x] Verified `npx oxfmt --check` passes on the changed file.
- [x] Verified existing edit-related tests (`pi-tools.read.host-edit-access`, `pi-tools.read.host-edit-recovery`) still pass.
- [x] Confirmed pre-existing test failures in `pi-tools.create-openclaw-coding-tools` are not related to this change (same failures on `main`).