### PR TITLE
Plugins: suppress false-positive duplicate warning for bundled plugins

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -136,7 +136,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("suppresses duplicate warning for auto-discovered bundled duplicates", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -148,6 +148,29 @@ describe("loadPluginManifestRegistry", () => {
         idHint: "test-plugin",
         rootDir: dirA,
         origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "test-plugin",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("emits duplicate warning for truly distinct non-bundled plugins with same id", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "test-plugin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "test-plugin",
+        rootDir: dirA,
+        origin: "workspace",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -239,7 +262,7 @@ describe("loadPluginManifestRegistry", () => {
     ]);
   });
 
-  it("reports bundled plugins as the duplicate winner for auto-discovered globals", () => {
+  it("suppresses duplicate warning for auto-discovered global duplicating bundled plugin", () => {
     const bundledDir = makeTempDir();
     const globalDir = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };
@@ -262,14 +285,10 @@ describe("loadPluginManifestRegistry", () => {
       ],
     });
 
-    expect(
-      registry.diagnostics.some((diag) =>
-        diag.message.includes("global plugin will be overridden by bundled plugin"),
-      ),
-    ).toBe(true);
+    expect(countDuplicateWarnings(registry)).toBe(0);
   });
 
-  it("reports bundled plugins as the duplicate winner for workspace duplicates", () => {
+  it("suppresses duplicate warning for workspace duplicating bundled plugin", () => {
     const bundledDir = makeTempDir();
     const workspaceDir = makeTempDir();
     const manifest = { id: "shadowed", configSchema: { type: "object" } };
@@ -292,11 +311,7 @@ describe("loadPluginManifestRegistry", () => {
       ],
     });
 
-    expect(
-      registry.diagnostics.some((diag) =>
-        diag.message.includes("workspace plugin will be overridden by bundled plugin"),
-      ),
-    ).toBe(true);
+    expect(countDuplicateWarnings(registry)).toBe(0);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -368,7 +368,28 @@ export function loadPluginManifestRegistry(
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
         return Boolean(existingReal && candidateReal && existingReal === candidateReal);
       })();
-      if (samePlugin) {
+      // When one candidate is bundled, only warn if the non-bundled copy was
+      // explicitly configured (origin=config or has a plugins.installs record).
+      // Auto-discovered duplicates of bundled plugins are expected (e.g. channels
+      // config auto-enabling a bundled extension) and should resolve silently.
+      const isBundledDuplicate =
+        existing.candidate.origin === "bundled" || candidate.origin === "bundled";
+      const isExplicitOverride =
+        isBundledDuplicate &&
+        (() => {
+          const nonBundled =
+            existing.candidate.origin === "bundled" ? candidate : existing.candidate;
+          return (
+            nonBundled.origin === "config" ||
+            matchesInstalledPluginRecord({
+              pluginId: manifest.id,
+              candidate: nonBundled,
+              config,
+              env,
+            })
+          );
+        })();
+      if (samePlugin || (isBundledDuplicate && !isExplicitOverride)) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
         if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -111,6 +111,8 @@ function buildCacheKey(params: {
   const bundledRoot = roots.stock ?? "";
   // The manifest registry only depends on where plugins are discovered from (workspace + load paths).
   // It does not depend on allow/deny/entries enable-state, so exclude those for higher cache hit rates.
+  // Note: plugins.installs is also excluded; the duplicate-suppression path reads it at resolve time,
+  // but the 1-second TTL keeps staleness to a narrow window that is acceptable for diagnostics.
   return `${workspaceKey}::${configExtensionsRoot}::${bundledRoot}::${JSON.stringify(loadPaths)}`;
 }
 
@@ -373,7 +375,7 @@ export function loadPluginManifestRegistry(
       // Auto-discovered duplicates of bundled plugins are expected (e.g. channels
       // config auto-enabling a bundled extension) and should resolve silently.
       const isBundledDuplicate =
-        existing.candidate.origin === "bundled" || candidate.origin === "bundled";
+        (existing.candidate.origin === "bundled") !== (candidate.origin === "bundled");
       const isExplicitOverride =
         isBundledDuplicate &&
         (() => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -391,7 +391,7 @@ export function loadPluginManifestRegistry(
             })
           );
         })();
-      if (samePlugin || (isBundledDuplicate && !isExplicitOverride)) {
+      if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
         if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
@@ -412,26 +412,31 @@ export function loadPluginManifestRegistry(
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message:
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate,
-            config,
-            env,
-          }) <
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate: existing.candidate,
-            config,
-            env,
-          })
-            ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
-            : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${candidate.source})`,
-      });
+      // When one candidate is bundled and the other is auto-discovered
+      // (not explicitly configured or installed), suppress the warning.
+      // The loader resolves precedence correctly via resolveCandidateDuplicateRank.
+      if (!(isBundledDuplicate && !isExplicitOverride)) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message:
+            resolveDuplicatePrecedenceRank({
+              pluginId: manifest.id,
+              candidate,
+              config,
+              env,
+            }) <
+            resolveDuplicatePrecedenceRank({
+              pluginId: manifest.id,
+              candidate: existing.candidate,
+              config,
+              env,
+            })
+              ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
+              : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Summary

- Problem: When channels config enables a bundled extension (e.g. `channels.bluebubbles`), the plugin registry emits a `duplicate plugin id detected` warning on every config reload/heartbeat cycle. This happens because the same plugin is discovered via both the bundled extensions scan and auto-discovery in global/workspace directories.
- Why it matters: The warnings flood logs (hundreds per hour), making real errors hard to spot, and confuse users into thinking they have a misconfiguration.
- What changed: Auto-discovered duplicates of bundled plugins are now silently resolved (higher-precedence copy wins). Warnings are preserved when the non-bundled copy is explicitly referenced in config (origin=config or has a `plugins.installs` record).
- What did NOT change (scope boundary): Duplicate warnings for two non-bundled plugins with the same ID are unchanged. Explicitly installed plugins that override bundled ones still produce warnings. Plugin loading order and precedence logic are unchanged.

> AI-assisted: This PR was authored with AI assistance (GitHub Copilot).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20478

## User-visible / Behavior Changes

- `duplicate plugin id detected` warnings no longer appear for auto-discovered duplicates of bundled plugins (global/workspace copies overlapping with bundled extensions).
- Warnings still appear when a non-bundled copy is explicitly configured (via `plugins.load.paths` or `plugins.installs`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Any channel with bundled extension (bluebubbles, feishu, line, etc.)
- Relevant config (redacted): `channels.bluebubbles.enabled: true`, no `plugins.entries` or `plugins.installs`

### Steps

1. Enable `channels.bluebubbles` in config
2. Remove any `plugins.entries` and `plugins.installs` for bluebubbles
3. Start gateway
4. Observe logs

### Expected

- No duplicate plugin warnings for auto-discovered bundled extensions

### Actual

- `duplicate plugin id detected` warning logged on every config reload/heartbeat

## Evidence

- [x] Failing test/log before + passing after

Updated 3 existing tests to verify warnings are now suppressed for bundled duplicates:
- `suppresses duplicate warning for auto-discovered bundled duplicates`
- `suppresses duplicate warning for auto-discovered global duplicating bundled plugin`
- `suppresses duplicate warning for workspace duplicating bundled plugin`

Added 1 new test verifying warnings ARE still emitted for non-bundled duplicates:
- `emits duplicate warning for truly distinct non-bundled plugins with same id`

Existing test preserved for explicitly installed globals overriding bundled:
- `reports explicit installed globals as the effective duplicate winner`

Test run:
```
pnpm test -- src/plugins/manifest-registry.test.ts
22 passed (22)
```

## Human Verification (required)

- Verified scenarios: All 22 manifest-registry tests pass. Lint/format checks pass (`pnpm check`).
- Edge cases checked: (1) Explicitly installed global overriding bundled still warns, (2) Two non-bundled duplicates still warn, (3) Bundled+global auto-discovered silently resolves, (4) Bundled+workspace silently resolves.
- What you did **not** verify: Live gateway with multiple Feishu/BlueBubbles accounts (no channel credentials available).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; duplicate warnings will resume for bundled plugin overlaps.
- Files/config to restore: `src/plugins/manifest-registry.ts`
- Known bad symptoms reviewers should watch for: Missing warnings for genuinely conflicting plugin installations.

## Risks and Mitigations

- Risk: Suppressing warnings could hide genuinely conflicting global plugin installations.
  - Mitigation: Warnings are only suppressed when one candidate is bundled AND the other is not explicitly configured. Explicitly installed plugins (via `plugins.installs`) still produce warnings.