### PR TITLE
fix(ui): ensure all agents appear in webchat session dropdown after switching

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -847,6 +847,18 @@ export function resolveSessionOptionGroups(
   }
   addOption(sessionKey);
 
+  // Ensure all configured agents appear as groups even when they have no
+  // persisted sessions yet.  Without this, switching away from a fresh agent
+  // removes it from the dropdown because the session store does not contain an
+  // entry for it.
+  const agents = state.agentsList?.agents ?? [];
+  for (const agent of agents) {
+    const groupId = `agent:${agent.id.toLowerCase()}`;
+    if (!groups.has(groupId)) {
+      addOption(`agent:${agent.id}:main`);
+    }
+  }
+
   for (const group of groups.values()) {
     const counts = new Map<string, number>();
     for (const option of group.options) {


### PR DESCRIPTION
## Summary

- The webchat session dropdown groups sessions by agent, but agents without persisted sessions disappear from the dropdown after switching away. This happens because freshly created agents that have not yet received a message have no entry in the session store, so `resolveSessionOptionGroups` never creates a group for them.
- After building session groups from persisted sessions and the current session key, iterate `state.agentsList` and add the main session key for any agent that does not already have a group. This keeps all configured agents visible in the dropdown regardless of session store state.

Fixes #48634

## Test plan

- [ ] Create a new agent (`openclaw agents add test-agent ...`) and restart gateway
- [ ] Open webchat and verify both agents appear in the session dropdown
- [ ] Switch from test-agent to main using the dropdown
- [ ] Verify both agents still appear in the dropdown after the switch
- [ ] Verify switching back to test-agent works correctly
- [ ] Verify existing sessions for agents with persisted sessions still display correctly