### PR TITLE
fix(models): respect auth.order for implicit github-copilot

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -17,6 +17,7 @@ import {
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
 } from "./auth-profiles.js";
+import { findNormalizedProviderValue } from "./model-selection.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
 import { normalizeGoogleModelId } from "./model-id-normalization.js";
 import { resolveOllamaApiBase } from "./models-config.providers.discovery.js";
@@ -897,7 +898,6 @@ export async function resolveImplicitCopilotProvider(params: {
     }
     return "";
   };
-
   let selectedGithubToken = githubToken;
   if (!selectedGithubToken && hasProfile) {
     // Respect auth.order when picking a discovery profile, but continue to

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -3,14 +3,24 @@ import {
   QIANFAN_DEFAULT_MODEL_ID,
 } from "../../extensions/qianfan/provider-catalog.js";
 import { XIAOMI_DEFAULT_MODEL_ID } from "../../extensions/xiaomi/provider-catalog.js";
+import {
+  DEFAULT_COPILOT_API_BASE_URL,
+  resolveCopilotApiToken,
+} from "../../extensions/github-copilot/token.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
-import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  resolveAuthProfileEligibility,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
 import { normalizeGoogleModelId } from "./model-id-normalization.js";
 import { resolveOllamaApiBase } from "./models-config.providers.discovery.js";
+import { findNormalizedProviderValue } from "./provider-id.js";
 export { buildKimiCodingProvider } from "../../extensions/kimi-coding/provider-catalog.js";
 export { buildKilocodeProvider } from "../../extensions/kilocode/provider-catalog.js";
 export {
@@ -793,6 +803,16 @@ export async function resolveImplicitProviders(
   mergeImplicitProviderSet(providers, await resolvePluginImplicitProviders(context, "paired"));
   mergeImplicitProviderSet(providers, await resolvePluginImplicitProviders(context, "late"));
 
+  if (!providers["github-copilot"]) {
+    const implicitCopilot = await resolveImplicitCopilotProvider({
+      agentDir: params.agentDir,
+      config: params.config,
+      env,
+    });
+    if (implicitCopilot) {
+      providers["github-copilot"] = implicitCopilot;
+    }
+  }
   const implicitBedrock = await resolveImplicitBedrockProvider({
     agentDir: params.agentDir,
     config: params.config,
@@ -815,6 +835,128 @@ export async function resolveImplicitProviders(
   return providers;
 }
 
+export async function resolveImplicitCopilotProvider(params: {
+  agentDir: string;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ProviderConfig | null> {
+  const env = params.env ?? process.env;
+  const authStore = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const profileIds = listProfilesForProvider(authStore, "github-copilot");
+  const hasProfile = profileIds.length > 0;
+  const envToken = env.COPILOT_GITHUB_TOKEN ?? env.GH_TOKEN ?? env.GITHUB_TOKEN;
+  const githubToken = (envToken ?? "").trim();
+
+  if (!hasProfile && !githubToken) {
+    return null;
+  }
+
+  const isEligibleProfileId = (profileId: string): boolean =>
+    resolveAuthProfileEligibility({
+      cfg: params.config,
+      store: authStore,
+      provider: "github-copilot",
+      profileId,
+    }).eligible;
+
+  const resolveCopilotTokenFromProfileId = (profileId: string): string => {
+    const profile = authStore.profiles[profileId];
+    if (!profile || profile.type !== "token") {
+      return "";
+    }
+    const inlineToken = profile.token?.trim() ?? "";
+    if (inlineToken) {
+      return inlineToken;
+    }
+    const tokenRef = coerceSecretRef(profile.tokenRef);
+    if (tokenRef?.source === "env" && tokenRef.id.trim()) {
+      return (env[tokenRef.id] ?? process.env[tokenRef.id] ?? "").trim();
+    }
+    return "";
+  };
+
+  const takeResolvableCopilotToken = (
+    candidateProfileIds: string[],
+    options?: { skipEligibilityCheck?: boolean; seenProfileIds?: Set<string> },
+  ): string => {
+    const seenProfileIds = options?.seenProfileIds;
+    for (const profileId of candidateProfileIds) {
+      if (seenProfileIds?.has(profileId)) {
+        continue;
+      }
+      seenProfileIds?.add(profileId);
+      if (!options?.skipEligibilityCheck && !isEligibleProfileId(profileId)) {
+        continue;
+      }
+      const resolvedToken = resolveCopilotTokenFromProfileId(profileId);
+      if (resolvedToken) {
+        return resolvedToken;
+      }
+    }
+    return "";
+  };
+
+  let selectedGithubToken = githubToken;
+  if (!selectedGithubToken && hasProfile) {
+    // Respect auth.order when picking a discovery profile, but continue to
+    // other eligible candidates if the preferred token cannot be resolved.
+    const orderedProfileIds = resolveAuthProfileOrder({
+      cfg: params.config,
+      store: authStore,
+      provider: "github-copilot",
+    });
+    const configuredOrder =
+      orderedProfileIds.length === 0
+        ? (findNormalizedProviderValue(params.config?.auth?.order, "github-copilot") ?? []).filter(
+            isEligibleProfileId,
+          )
+        : [];
+    const orderedCandidates =
+      orderedProfileIds.length > 0
+        ? orderedProfileIds
+        : configuredOrder.length > 0
+          ? configuredOrder
+          : profileIds;
+    const seenProfileIds = new Set<string>();
+    const orderedCandidatesAlreadyEligible =
+      orderedProfileIds.length > 0 || configuredOrder.length > 0;
+
+    selectedGithubToken = takeResolvableCopilotToken(orderedCandidates, {
+      skipEligibilityCheck: orderedCandidatesAlreadyEligible,
+      seenProfileIds,
+    });
+
+    if (!selectedGithubToken && orderedCandidatesAlreadyEligible) {
+      selectedGithubToken = takeResolvableCopilotToken(profileIds, { seenProfileIds });
+    }
+  }
+
+  let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+  if (selectedGithubToken) {
+    try {
+      const token = await resolveCopilotApiToken({
+        githubToken: selectedGithubToken,
+        env,
+      });
+      baseUrl = token.baseUrl;
+    } catch {
+      baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+    }
+  }
+
+  // We deliberately do not write pi-coding-agent auth.json here.
+  // OpenClaw keeps auth in auth-profiles and resolves runtime availability from that store.
+
+  // We intentionally do NOT define custom models for Copilot in models.json.
+  // pi-coding-agent treats providers with models as replacements requiring apiKey.
+  // We only override baseUrl; the model list comes from pi-ai built-ins.
+  return {
+    baseUrl,
+    models: [],
+  } satisfies ProviderConfig;
+}
 export async function resolveImplicitBedrockProvider(params: {
   agentDir: string;
   config?: OpenClawConfig;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -21,7 +21,6 @@ import { findNormalizedProviderValue } from "./model-selection.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
 import { normalizeGoogleModelId } from "./model-id-normalization.js";
 import { resolveOllamaApiBase } from "./models-config.providers.discovery.js";
-import { findNormalizedProviderValue } from "./provider-id.js";
 export { buildKimiCodingProvider } from "../../extensions/kimi-coding/provider-catalog.js";
 export { buildKilocodeProvider } from "../../extensions/kilocode/provider-catalog.js";
 export {

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -27,7 +27,41 @@ function expectBearerAuthHeader(fetchMock: { mock: { calls: unknown[][] } }, tok
 }
 
 describe("models-config", () => {
-  it("uses the first github-copilot profile when env tokens are missing", async () => {
+  it("uses auth.order for github-copilot profile selection when env tokens are missing", async () => {
+    await withTempHome(async (home) => {
+      await withUnsetCopilotTokenEnv(async () => {
+        const fetchMock = mockCopilotTokenExchangeSuccess();
+        const agentDir = path.join(home, "agent-profiles");
+        await writeAuthProfiles(agentDir, {
+          "github-copilot:alpha": {
+            type: "token",
+            provider: "github-copilot",
+            token: "alpha-token",
+          },
+          "github-copilot:beta": {
+            type: "token",
+            provider: "github-copilot",
+            token: "beta-token",
+          },
+        });
+
+        await ensureOpenClawModelsJson(
+          {
+            auth: {
+              order: {
+                "github-copilot": ["github-copilot:beta", "github-copilot:alpha"],
+              },
+            },
+            models: { providers: {} },
+          },
+          agentDir,
+        );
+        expectBearerAuthHeader(fetchMock, "beta-token");
+      });
+    });
+  });
+
+  it("falls back to the first github-copilot profile when auth.order is missing", async () => {
     await withTempHome(async (home) => {
       await withUnsetCopilotTokenEnv(async () => {
         const fetchMock = mockCopilotTokenExchangeSuccess();

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -13,11 +13,15 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
 
 installModelsConfigTestHooks({ restoreFetch: true });
 
-async function writeAuthProfiles(agentDir: string, profiles: Record<string, unknown>) {
+async function writeAuthProfiles(
+  agentDir: string,
+  profiles: Record<string, unknown>,
+  order?: Record<string, string[]>,
+) {
   await fs.mkdir(agentDir, { recursive: true });
   await fs.writeFile(
     path.join(agentDir, "auth-profiles.json"),
-    JSON.stringify({ version: 1, profiles }, null, 2),
+    JSON.stringify({ version: 1, ...(order ? { order } : {}), profiles }, null, 2),
   );
 }
 
@@ -130,6 +134,134 @@ describe("models-config", () => {
           expectBearerAuthHeader(fetchMock, "token-from-ref-env");
         } finally {
           delete process.env.COPILOT_REF_TOKEN;
+        }
+      });
+    });
+  });
+
+  it("falls back past ordered github-copilot profiles that are unresolved at runtime", async () => {
+    await withTempHome(async (home) => {
+      await withUnsetCopilotTokenEnv(async () => {
+        const fetchMock = mockCopilotTokenExchangeSuccess();
+        const agentDir = path.join(home, "agent-profiles");
+        try {
+          delete process.env.MISSING_COPILOT_REF_TOKEN;
+          await writeAuthProfiles(agentDir, {
+            "github-copilot:preferred": {
+              type: "token",
+              provider: "github-copilot",
+              tokenRef: { source: "env", provider: "default", id: "MISSING_COPILOT_REF_TOKEN" },
+            },
+            "github-copilot:backup": {
+              type: "token",
+              provider: "github-copilot",
+              token: "backup-token",
+            },
+          });
+
+          await ensureOpenClawModelsJson(
+            {
+              auth: {
+                order: {
+                  "github-copilot": ["github-copilot:preferred", "github-copilot:backup"],
+                },
+              },
+              models: { providers: {} },
+            },
+            agentDir,
+          );
+          expectBearerAuthHeader(fetchMock, "backup-token");
+        } finally {
+          delete process.env.MISSING_COPILOT_REF_TOKEN;
+        }
+      });
+    });
+  });
+
+  it("falls back to config auth.order when stored github-copilot order is stale", async () => {
+    await withTempHome(async (home) => {
+      await withUnsetCopilotTokenEnv(async () => {
+        const fetchMock = mockCopilotTokenExchangeSuccess();
+        const agentDir = path.join(home, "agent-profiles");
+        await writeAuthProfiles(
+          agentDir,
+          {
+            "github-copilot:alpha": {
+              type: "token",
+              provider: "github-copilot",
+              token: "alpha-token",
+            },
+            "github-copilot:beta": {
+              type: "token",
+              provider: "github-copilot",
+              token: "beta-token",
+            },
+          },
+          {
+            "github-copilot": ["github-copilot:missing"],
+          },
+        );
+
+        await ensureOpenClawModelsJson(
+          {
+            auth: {
+              order: {
+                "github-copilot": ["github-copilot:beta"],
+              },
+            },
+            models: { providers: {} },
+          },
+          agentDir,
+        );
+        expectBearerAuthHeader(fetchMock, "beta-token");
+      });
+    });
+  });
+
+  it("falls back to stored github-copilot profiles when config-ordered tokenRefs stay unresolved", async () => {
+    await withTempHome(async (home) => {
+      await withUnsetCopilotTokenEnv(async () => {
+        const fetchMock = mockCopilotTokenExchangeSuccess();
+        const agentDir = path.join(home, "agent-profiles");
+        try {
+          delete process.env.MISSING_PREFERRED_COPILOT_TOKEN;
+          await writeAuthProfiles(
+            agentDir,
+            {
+              "github-copilot:preferred": {
+                type: "token",
+                provider: "github-copilot",
+                tokenRef: {
+                  source: "env",
+                  provider: "default",
+                  id: "MISSING_PREFERRED_COPILOT_TOKEN",
+                },
+              },
+              "github-copilot:backup": {
+                type: "token",
+                provider: "github-copilot",
+                token: "backup-token",
+              },
+            },
+            {
+              "github-copilot": ["github-copilot:missing"],
+            },
+          );
+
+          await ensureOpenClawModelsJson(
+            {
+              auth: {
+                order: {
+                  "github-copilot": ["github-copilot:preferred"],
+                },
+              },
+              models: { providers: {} },
+            },
+            agentDir,
+          );
+          expectBearerAuthHeader(fetchMock, "backup-token");
+        } finally {
+          delete process.env.MISSING_PREFERRED_COPILOT_TOKEN;
         }
       });
     });

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -178,6 +178,49 @@ describe("models-config", () => {
     });
   });
 
+  it("falls back to stored github-copilot profiles when ordered tokenRefs stay unresolved", async () => {
+    await withTempHome(async (home) => {
+      await withUnsetCopilotTokenEnv(async () => {
+        const fetchMock = mockCopilotTokenExchangeSuccess();
+        const agentDir = path.join(home, "agent-profiles");
+        try {
+          delete process.env.MISSING_ORDERED_COPILOT_TOKEN;
+          await writeAuthProfiles(agentDir, {
+            "github-copilot:preferred": {
+              type: "token",
+              provider: "github-copilot",
+              tokenRef: {
+                source: "env",
+                provider: "default",
+                id: "MISSING_ORDERED_COPILOT_TOKEN",
+              },
+            },
+            "github-copilot:backup": {
+              type: "token",
+              provider: "github-copilot",
+              token: "backup-token",
+            },
+          });
+
+          await ensureOpenClawModelsJson(
+            {
+              auth: {
+                order: {
+                  "github-copilot": ["github-copilot:preferred"],
+                },
+              },
+              models: { providers: {} },
+            },
+            agentDir,
+          );
+          expectBearerAuthHeader(fetchMock, "backup-token");
+        } finally {
+          delete process.env.MISSING_ORDERED_COPILOT_TOKEN;
+        }
+      });
+    });
+  });
+
   it("falls back to config auth.order when stored github-copilot order is stale", async () => {
     await withTempHome(async (home) => {
       await withUnsetCopilotTokenEnv(async () => {


### PR DESCRIPTION
## Summary

- Problem: implicit `github-copilot` provider discovery ignored `auth.order` and could pick the wrong stored Copilot profile.
- Why it matters: users with multiple Copilot profiles could resolve discovery against the wrong token/base URL.
- What changed: implicit Copilot discovery now respects `auth.order`, falls through ordered candidates when a preferred token cannot be resolved, and falls back more safely when stored order is stale.
- What did NOT change (scope boundary): environment token precedence is unchanged, explicit `models.providers["github-copilot"]` config is unchanged, and plugin enable/disable behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #46031

## User-visible / Behavior Changes

Implicit `github-copilot` provider discovery now honors `auth.order` when multiple Copilot profiles are configured, including fallback behavior when the preferred token cannot be resolved.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: Docker (`node:22`)
- Provider: `github-copilot`

### Steps

1. Configure multiple stored `github-copilot` profiles.
2. Set `auth.order` to prefer a non-first stored profile.
3. Generate `models.json` via implicit provider discovery.

### Expected

- Discovery uses the first eligible profile from `auth.order`, and falls back safely if that token is unresolved.

### Actual

- Before this change, discovery could pick the first stored profile instead, or stop too early on an unresolved preferred token.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified `auth.order` takes precedence for implicit Copilot discovery.
- Verified fallback to later ordered candidates when a preferred `tokenRef` is unresolved.
- Verified fallback to config `auth.order` when stored order is stale.
- Verified fallback to stored eligible profiles when config-ordered tokenRefs stay unresolved.
- Ran targeted tests in Docker:
  - `pnpm test -- src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts src/agents/models-config.falls-back-default-baseurl-token-exchange-fails.test.ts`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/agents/models-config.providers.ts`
- Known bad symptoms reviewers should watch for: implicit Copilot discovery selecting an unexpected profile

## Risks and Mitigations

- Risk: fallback logic becomes harder to follow.
- Mitigation: targeted regression coverage was added for each fallback path.

## Transparency

This PR is AI-assisted. I reviewed the final code, validated the root cause, and ran the targeted regression tests above.
