### PR TITLE
Fix provider-qualified context window resolution

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -288,6 +288,8 @@ export async function runMemoryFlushIfNeeded(params: {
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    providerId: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -461,8 +461,12 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
+      resolveContextTokensForModel({
+        cfg,
+        provider: providerUsed,
+        model: modelUsed,
+        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+      }) ??
       DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -213,7 +213,15 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens:
+      agentCfg?.contextTokens ??
+      resolveContextTokensForModel({
+        cfg,
+        provider,
+        model,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ??
+      DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -260,8 +260,12 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const contextTokensUsed =
         agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
-        sessionEntry?.contextTokens ??
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: fallbackProvider,
+          model: modelUsed,
+          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+        }) ??
         DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -419,7 +419,9 @@ export async function resolveReplyDirectives(params: {
   }
 
   let contextTokens = resolveContextTokens({
+    cfg,
     agentCfg,
+    provider,
     model,
   });
 

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   DEFAULT_MEMORY_FLUSH_PROMPT,
+  resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushPromptForRun,
   resolveMemoryFlushRelativePathForRun,
 } from "./memory-flush.js";
@@ -60,5 +61,30 @@ describe("DEFAULT_MEMORY_FLUSH_PROMPT", () => {
     // Agents must not create YYYY-MM-DD-HHMM.md variants alongside the canonical file
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("timestamped variant");
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("YYYY-MM-DD.md");
+  });
+});
+
+describe("resolveMemoryFlushContextWindowTokens", () => {
+  it("prefers provider-qualified context windows when duplicate model ids exist", () => {
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "claude-opus-4-6", contextWindow: 200_000 }],
+          },
+          "custom-synai996-space": {
+            models: [{ id: "claude-opus-4-6", contextWindow: 16_000 }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveMemoryFlushContextWindowTokens({
+      cfg,
+      providerId: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+
+    expect(result).toBe(200_000);
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,4 +1,4 @@
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../agents/pi-settings.js";
@@ -159,11 +159,20 @@ function ensureMemoryFlushSafetyHints(text: string): string {
 }
 
 export function resolveMemoryFlushContextWindowTokens(params: {
+  cfg?: OpenClawConfig;
+  providerId?: string;
   modelId?: string;
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfgContextTokens ??
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.providerId,
+      model: params.modelId,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { createModelSelectionState } from "./model-selection.js";
+import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn(async () => [
@@ -262,6 +262,32 @@ describe("createModelSelectionState respects session model override", () => {
 
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe("deepseek-v3-4bit-mlx");
+  });
+});
+
+describe("resolveContextTokens", () => {
+  it("prefers provider-qualified context windows when duplicate model ids exist", () => {
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "claude-opus-4-6", contextWindow: 200_000 }],
+          },
+          "custom-synai996-space": {
+            models: [{ id: "claude-opus-4-6", contextWindow: 16_000 }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveContextTokens({
+      cfg,
+      agentCfg: undefined,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result).toBe(200_000);
   });
 });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,5 +1,5 @@
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
@@ -601,10 +601,19 @@ export function resolveModelDirectiveSelection(params: {
 }
 
 export function resolveContextTokens(params: {
+  cfg: OpenClawConfig;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  provider: string;
   model: string;
 }): number {
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ??
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/commands/sessions.model-resolution.test.ts
+++ b/src/commands/sessions.model-resolution.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mockSessionsConfig, runSessionsJson, writeStore } from "./sessions.test-helpers.js";
+import {
+  mockSessionsConfig,
+  resetMockSessionsConfig,
+  runSessionsJson,
+  setMockSessionsConfig,
+  writeStore,
+} from "./sessions.test-helpers.js";
 
 mockSessionsConfig();
 
@@ -9,6 +15,7 @@ type SessionsJsonPayload = {
   sessions?: Array<{
     key: string;
     model?: string | null;
+    contextTokens?: number | null;
   }>;
 };
 
@@ -39,6 +46,7 @@ describe("sessionsCommand model resolution", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    resetMockSessionsConfig();
   });
 
   it("prefers runtime model fields for subagent sessions in JSON output", async () => {
@@ -59,5 +67,44 @@ describe("sessionsCommand model resolution", () => {
       "subagent-2",
     );
     expect(model).toBe("gpt-5.3-codex");
+  });
+
+  it("uses provider-qualified context windows in JSON output when model ids collide", async () => {
+    setMockSessionsConfig({
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "claude-opus-4-6", contextWindow: 200_000 }],
+          },
+          "custom-synai996-space": {
+            models: [{ id: "claude-opus-4-6", contextWindow: 16_000 }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+    });
+
+    const store = writeStore(
+      {
+        "agent:research:subagent:demo": {
+          sessionId: "subagent-3",
+          updatedAt: Date.now() - 2 * 60_000,
+          modelProvider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+      },
+      "sessions-context-collision",
+    );
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === "agent:research:subagent:demo");
+
+    expect(row?.model).toBe("claude-opus-4-6");
+    expect(row?.contextTokens).toBe(200_000);
   });
 });

--- a/src/commands/sessions.test-helpers.ts
+++ b/src/commands/sessions.test-helpers.ts
@@ -5,22 +5,36 @@ import path from "node:path";
 import { vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 
+const DEFAULT_SESSIONS_CONFIG = {
+  agents: {
+    defaults: {
+      model: { primary: "pi:opus" },
+      models: { "pi:opus": {} },
+      contextTokens: 32000,
+    },
+  },
+};
+
+let sessionsConfig: unknown = DEFAULT_SESSIONS_CONFIG;
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => sessionsConfig,
+  };
+});
+
 export function mockSessionsConfig() {
-  vi.mock("../config/config.js", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("../config/config.js")>();
-    return {
-      ...actual,
-      loadConfig: () => ({
-        agents: {
-          defaults: {
-            model: { primary: "pi:opus" },
-            models: { "pi:opus": {} },
-            contextTokens: 32000,
-          },
-        },
-      }),
-    };
-  });
+  resetMockSessionsConfig();
+}
+
+export function resetMockSessionsConfig() {
+  sessionsConfig = DEFAULT_SESSIONS_CONFIG;
+}
+
+export function setMockSessionsConfig(next: unknown) {
+  sessionsConfig = next;
 }
 
 export function makeRuntime(params?: { throwOnError?: boolean }): {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,8 +1,9 @@
-import { lookupContextTokens } from "../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
-import { classifySessionKey } from "../gateway/session-utils.js";
+import { classifySessionKey, resolveSessionModelRef } from "../gateway/session-utils.js";
 import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -91,9 +92,19 @@ export async function sessionsCommand(
   const aggregateAgents = opts.allAgents === true;
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
+  const configuredDefaultModel = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
   const configContextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(displayDefaults.model) ??
+    resolveContextTokensForModel({
+      cfg,
+      provider: configuredDefaultModel.provider,
+      model: configuredDefaultModel.model,
+      contextTokensOverride: cfg.agents?.defaults?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ??
     DEFAULT_CONTEXT_TOKENS;
   const targets = resolveSessionStoreTargetsOrExit({
     cfg,
@@ -156,14 +167,23 @@ export async function sessionsCommand(
           count: rows.length,
           activeMinutes: activeMinutes ?? null,
           sessions: rows.map((r) => {
-            const model = resolveSessionDisplayModel(cfg, r, displayDefaults);
+            const resolvedModel = resolveSessionModelRef(cfg, r, r.agentId);
+            const model = resolvedModel.model ?? resolveSessionDisplayModel(cfg, r, displayDefaults);
             return {
               ...r,
               totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
               totalTokensFresh:
                 typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
               contextTokens:
-                r.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null,
+                r.contextTokens ??
+                resolveContextTokensForModel({
+                  cfg,
+                  provider: resolvedModel.provider,
+                  model,
+                  fallbackContextTokens: configContextTokens ?? undefined,
+                }) ??
+                configContextTokens ??
+                null,
               model,
             };
           }),
@@ -206,8 +226,17 @@ export async function sessionsCommand(
   runtime.log(rich ? theme.heading(header) : header);
 
   for (const row of rows) {
-    const model = resolveSessionDisplayModel(cfg, row, displayDefaults);
-    const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
+    const resolvedModel = resolveSessionModelRef(cfg, row, row.agentId);
+    const model = resolvedModel.model ?? resolveSessionDisplayModel(cfg, row, displayDefaults);
+    const contextTokens =
+      row.contextTokens ??
+      resolveContextTokensForModel({
+        cfg,
+        provider: resolvedModel.provider,
+        model,
+        fallbackContextTokens: configContextTokens,
+      }) ??
+      configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const line = [

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,7 +9,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
@@ -742,7 +742,14 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = finalRunResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = finalRunResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      agentCfg?.contextTokens ??
+      resolveContextTokensForModel({
+        cfg: cfgWithAgentDefaults,
+        provider: providerUsed,
+        model: modelUsed,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ??
+      DEFAULT_CONTEXT_TOKENS;
 
     setSessionRuntimeModel(cronSession.sessionEntry, {
       provider: providerUsed,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -10,6 +10,7 @@ import {
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
+  getSessionDefaults,
   listAgentsForGateway,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
@@ -121,6 +122,33 @@ describe("gateway session utils", () => {
     // Mixed-case main alias must also resolve to the configured mainKey (idempotent)
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:MAIN" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "MAIN" })).toBe("agent:ops:work");
+  });
+
+  test("getSessionDefaults prefers provider-qualified context windows when model ids collide", () => {
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "claude-opus-4-6", contextWindow: 200_000 }],
+          },
+          "custom-synai996-space": {
+            models: [{ id: "claude-opus-4-6", contextWindow: 16_000 }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(getSessionDefaults(cfg)).toMatchObject({
+      modelProvider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 200_000,
+    });
   });
 
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { lookupContextTokens } from "../agents/context.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
   inferUniqueProviderFromConfiguredModels,
@@ -743,7 +743,12 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
+    resolveContextTokensForModel({
+      cfg,
+      provider: resolved.provider,
+      model: resolved.model,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ??
     DEFAULT_CONTEXT_TOKENS;
   return {
     modelProvider: resolved.provider ?? null,


### PR DESCRIPTION
## Summary
- resolve context windows with `provider + model` when the provider is known instead of looking up by bare `modelId`
- apply the fix consistently across reply persistence, followup runs, memory flush, session defaults, cron isolated runs, and the `sessions` command
- add regression coverage for duplicate model ids that exist under different providers

## Problem
When two providers expose the same model id, OpenClaw can resolve the wrong `contextTokens` value because several code paths only call the bare-model lookup.

A concrete repro is:
- `anthropic/claude-opus-4-6` with `contextWindow: 200000`
- `custom-synai996-space/claude-opus-4-6` with `contextWindow: 16000`

If a session/run is actually using `anthropic/claude-opus-4-6`, some paths still resolve `16000` because they ignore the provider once a model id is available. That produces incorrect session metadata and misleading ctx percentages in the UI.

## What changed
- use `resolveContextTokensForModel(...)` in places that already know the provider
- keep agent-level `contextTokens` overrides taking precedence
- resolve `sessions` output against the session's provider/model pair instead of the bare display model

## Tests
- `corepack pnpm exec vitest run src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/memory-flush.test.ts src/gateway/session-utils.test.ts src/commands/sessions.model-resolution.test.ts src/commands/sessions.test.ts`

