### PR TITLE
fix: explicitly configure EnvHttpProxyAgent with HTTP_PROXY/HTTPS_PROXY URLs

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,7 +1,7 @@
 import { EnvHttpProxyAgent, type Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
 import { bindAbortRelay } from "../../utils/fetch-timeout.js";
-import { hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasProxyEnvConfigured, resolveEnvHttpProxyUrl } from "./proxy-env.js";
 import {
   closeDispatcher,
   createPinnedDispatcher,
@@ -196,7 +196,12 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
       if (canUseTrustedEnvProxy) {
-        dispatcher = new EnvHttpProxyAgent();
+        const httpProxy = resolveEnvHttpProxyUrl("http");
+        const httpsProxy = resolveEnvHttpProxyUrl("https");
+        dispatcher = new EnvHttpProxyAgent({
+          ...(httpProxy ? { httpProxy } : {}),
+          ...(httpsProxy ? { httpsProxy } : {}),
+        });
       } else if (params.pinDns !== false) {
         dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy);
       }


### PR DESCRIPTION
## Summary

Fixes #48436

The EnvHttpProxyAgent from undici was being created without explicit proxy configuration, which caused it to not properly use the HTTP_PROXY and HTTPS_PROXY environment variables in some environments.

## Changes

- Modified `src/infra/net/fetch-guard.ts` to explicitly resolve proxy URLs from environment variables
- Pass the resolved HTTP and HTTPS proxy URLs to the EnvHttpProxyAgent constructor
- Added import for `resolveEnvHttpProxyUrl` from `./proxy-env.js`

## Testing

This fix ensures that when `HTTP_PROXY` or `HTTPS_PROXY` environment variables are set, the Gemini search provider (and other web tools using `withTrustedWebToolsEndpoint`) will correctly route requests through the configured proxy.

## Related Issues

- Fixes #48436: Gemini search doesn't work with HTTP proxy