### PR TITLE
Fixes #48314fix: clarify reasoning status in /status

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -605,7 +605,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("Reasoning: off");
     expect(prompt).toContain("/reasoning");
-    expect(prompt).toContain("/status shows Reasoning");
+    expect(prompt).toContain("/status shows the current Reasoning status");
   });
 
   it("builds runtime line with agent and channel details", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -671,7 +671,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows the current Reasoning status.`,
   );
 
   return lines.filter(Boolean).join("\n");

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { normalizeTestText } from "../../test/helpers/normalize-text.js";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { clearPluginCommands, registerPluginCommand } from "../plugins/commands.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { createSuccessfulImageMediaDecision } from "./media-understanding.test-fixtures.js";
 import {
@@ -13,18 +14,8 @@ import {
   buildStatusMessage,
 } from "./status.js";
 
-const { listPluginCommands } = vi.hoisted(() => ({
-  listPluginCommands: vi.fn(
-    (): Array<{ name: string; description: string; pluginId: string }> => [],
-  ),
-}));
-
-vi.mock("../plugins/commands.js", () => ({
-  listPluginCommands,
-}));
-
 afterEach(() => {
-  vi.restoreAllMocks();
+  clearPluginCommands();
 });
 
 describe("buildStatusMessage", () => {
@@ -765,9 +756,13 @@ describe("buildCommandsMessagePaginated", () => {
   });
 
   it("includes plugin commands in the paginated list", () => {
-    listPluginCommands.mockReturnValue([
-      { name: "plugin_cmd", description: "Plugin command", pluginId: "demo-plugin" },
-    ]);
+    expect(
+      registerPluginCommand("demo-plugin", {
+        name: "plugin_cmd",
+        description: "Plugin command",
+        handler: async () => ({ text: "ok" }),
+      }),
+    ).toEqual({ ok: true });
     const result = buildCommandsMessagePaginated(
       {
         commands: { config: false, debug: false },

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -86,6 +86,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("updated 10m ago");
     expect(normalized).toContain("Runtime: direct");
     expect(normalized).toContain("Think: medium");
+    expect(normalized).toContain("Reasoning: hidden");
     expect(normalized).not.toContain("verbose");
     expect(normalized).toContain("elevated");
     expect(normalized).toContain("Queue: collect");
@@ -110,7 +111,25 @@ describe("buildStatusMessage", () => {
 
     expect(normalized).toContain("Think: high");
     expect(normalized).toContain("verbose:full");
-    expect(normalized).toContain("Reasoning: on");
+    expect(normalized).toContain("Reasoning: visible");
+  });
+
+  it("shows reasoning stream mode distinctly from hidden visibility", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        reasoningLevel: "stream",
+      },
+      sessionKey: "agent:main:main",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Reasoning: stream");
   });
 
   it("shows fast mode when enabled", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -48,7 +48,13 @@ import {
 import type { CommandCategory } from "./commands-registry.types.js";
 import { resolveActiveFallbackState } from "./fallback-state.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
+import {
+  normalizeReasoningLevel,
+  type ElevatedLevel,
+  type ReasoningLevel,
+  type ThinkLevel,
+  type VerboseLevel,
+} from "./thinking.js";
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
 type AgentConfig = Partial<AgentDefaults> & {
@@ -216,6 +222,8 @@ const formatReasoningStatus = (reasoningLevel: ReasoningLevel): string => {
       return "visible";
     case "stream":
       return "stream";
+    default:
+      return "hidden";
   }
 };
 
@@ -523,7 +531,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const verboseLevel =
     args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
   const fastMode = args.resolvedFast ?? args.sessionEntry?.fastMode ?? false;
-  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
+  const reasoningLevel: ReasoningLevel =
+    args.resolvedReasoning ?? normalizeReasoningLevel(args.sessionEntry?.reasoningLevel) ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -208,6 +208,16 @@ const formatQueueDetails = (queue?: QueueStatus) => {
   return detailParts.length ? ` (${detailParts.join(" · ")})` : "";
 };
 
+const formatReasoningStatus = (reasoningLevel: ReasoningLevel) => {
+  if (reasoningLevel === "off") {
+    return "hidden";
+  }
+  if (reasoningLevel === "on") {
+    return "visible";
+  }
+  return "stream";
+};
+
 const readUsageFromSessionLog = (
   sessionId?: string,
   sessionEntry?: SessionEntry,
@@ -560,7 +570,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     `Think: ${thinkLevel}`,
     fastMode ? "Fast: on" : null,
     verboseLabel,
-    reasoningLevel !== "off" ? `Reasoning: ${reasoningLevel}` : null,
+    `Reasoning: ${formatReasoningStatus(reasoningLevel)}`,
     elevatedLabel,
   ];
   const optionsLine = optionParts.filter(Boolean).join(" · ");

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -208,14 +208,15 @@ const formatQueueDetails = (queue?: QueueStatus) => {
   return detailParts.length ? ` (${detailParts.join(" · ")})` : "";
 };
 
-const formatReasoningStatus = (reasoningLevel: ReasoningLevel) => {
-  if (reasoningLevel === "off") {
-    return "hidden";
+const formatReasoningStatus = (reasoningLevel: ReasoningLevel): string => {
+  switch (reasoningLevel) {
+    case "off":
+      return "hidden";
+    case "on":
+      return "visible";
+    case "stream":
+      return "stream";
   }
-  if (reasoningLevel === "on") {
-    return "visible";
-  }
-  return "stream";
 };
 
 const readUsageFromSessionLog = (


### PR DESCRIPTION
Fixes #48314

## Summary
- always show reasoning status in `/status`
- map reasoning modes to user-facing labels: `hidden`, `visible`, and `stream`
- keep think effort displayed separately as `Think: <level>`
- update regression tests and runtime prompt copy to match the new behavior

## Why
`/status` on current `main` already shows the think effort level separately, but it still hides the reasoning state when `/reasoning off` is active and exposes raw reasoning modes instead of user-facing visibility wording. This patch finishes that UX fix without changing command semantics or session storage.

## Verification
- `pnpm exec vitest run src/auto-reply/status.test.ts src/agents/system-prompt.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/status.ts src/auto-reply/status.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts`
