### PR TITLE
fix: preserve provider's original model ID format (dots vs dashes)

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1041,4 +1041,24 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect(result.model?.baseUrl).toBe("https://api.anthropic.com");
   });
+
+  it("resolves inline model when config uses dots but query uses dashes", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "copilot-proxy": {
+            baseUrl: "http://localhost:4141/v1",
+            api: "openai-completions",
+            models: [{ id: "claude-haiku-4.5", name: "Claude Haiku 4.5" }],
+          },
+        },
+      },
+    };
+    // Query with dashes (normalized form), config has dots
+    const result = resolveModel("copilot-proxy", "claude-haiku-4-5", "/tmp/agent", cfg);
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    // The resolved model should preserve the provider's original dot notation
+    expect(result.model?.id).toBe("claude-haiku-4.5");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -12,6 +12,8 @@ import {
   buildSuppressedBuiltInModelError,
   shouldSuppressBuiltInModel,
 } from "../model-suppression.js";
+import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
+import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 
 /**
  * Compare model IDs treating dots and dashes as equivalent.
@@ -21,8 +23,6 @@ import {
 function modelIdMatchesDotDash(a: string, b: string): boolean {
   return a === b || a.replace(/\./g, "-") === b.replace(/\./g, "-");
 }
-import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
-import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
   provider: string;
@@ -194,16 +194,16 @@ export function resolveModelWithRegistry(params: {
   const providers = cfg?.models?.providers ?? {};
   const inlineModels = buildInlineProviderModels(providers);
   const normalizedProvider = normalizeProviderId(provider);
-  const inlineMatch = inlineModels.find(
-    (entry) =>
-      normalizeProviderId(entry.provider) === normalizedProvider &&
-      modelIdMatchesDotDash(entry.id, modelId),
+  // Prefer exact ID match first, then fall back to dot/dash-insensitive match.
+  // This ensures providers with genuinely distinct model IDs aren't mismatched.
+  const providerInline = inlineModels.filter(
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider,
   );
+  const inlineMatch =
+    providerInline.find((entry) => entry.id === modelId) ??
+    providerInline.find((entry) => modelIdMatchesDotDash(entry.id, modelId));
   if (inlineMatch?.api) {
-    // Preserve the provider's original model ID (e.g., dots for copilot-proxy)
-    // so the dispatched API call uses the format the provider expects.
-    const model = { ...inlineMatch, id: inlineMatch.id } as Model<Api>;
-    return normalizeResolvedModel({ provider, model });
+    return normalizeResolvedModel({ provider, model: inlineMatch as Model<Api> });
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -12,6 +12,15 @@ import {
   buildSuppressedBuiltInModelError,
   shouldSuppressBuiltInModel,
 } from "../model-suppression.js";
+
+/**
+ * Compare model IDs treating dots and dashes as equivalent.
+ * Anthropic uses dashes (`claude-haiku-4-5`) but copilot-proxy and
+ * other providers may use dots (`claude-haiku-4.5`).
+ */
+function modelIdMatchesDotDash(a: string, b: string): boolean {
+  return a === b || a.replace(/\./g, "-") === b.replace(/\./g, "-");
+}
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 
@@ -81,7 +90,9 @@ function applyConfiguredProviderOverrides(params: {
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
     };
   }
-  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel = providerConfig.models?.find((candidate) =>
+    modelIdMatchesDotDash(candidate.id, modelId),
+  );
   const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
     stripSecretRefMarkers: true,
   });
@@ -184,10 +195,15 @@ export function resolveModelWithRegistry(params: {
   const inlineModels = buildInlineProviderModels(providers);
   const normalizedProvider = normalizeProviderId(provider);
   const inlineMatch = inlineModels.find(
-    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
+    (entry) =>
+      normalizeProviderId(entry.provider) === normalizedProvider &&
+      modelIdMatchesDotDash(entry.id, modelId),
   );
   if (inlineMatch?.api) {
-    return normalizeResolvedModel({ provider, model: inlineMatch as Model<Api> });
+    // Preserve the provider's original model ID (e.g., dots for copilot-proxy)
+    // so the dispatched API call uses the format the provider expects.
+    const model = { ...inlineMatch, id: inlineMatch.id } as Model<Api>;
+    return normalizeResolvedModel({ provider, model });
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -90,9 +90,9 @@ function applyConfiguredProviderOverrides(params: {
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
     };
   }
-  const configuredModel = providerConfig.models?.find((candidate) =>
-    modelIdMatchesDotDash(candidate.id, modelId),
-  );
+  const configuredModel =
+    providerConfig.models?.find((candidate) => candidate.id === modelId) ??
+    providerConfig.models?.find((candidate) => modelIdMatchesDotDash(candidate.id, modelId));
   const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
     stripSecretRefMarkers: true,
   });


### PR DESCRIPTION
## Summary

- **Problem:** Model name normalization converts dots to dashes (`claude-haiku-4.5` → `claude-haiku-4-5`), breaking providers like copilot-proxy that only accept dot notation (HTTP 400 "model not supported").
- **Root cause:** `resolveModelWithRegistry` uses strict equality when matching against inline provider models, failing when the normalized ID (dashes) doesn't match the configured ID (dots).
- **Fix:** Add dot-dash insensitive matching (`modelIdMatchesDotDash`) for inline model lookup and configured model overrides. The provider's original model ID format is preserved in the resolved Model object.

## Change Type

- [x] Bug fix

## Scope

- [x] Model providers
- [x] Stability

## Linked Issue

Closes #48458

## User-visible / Behavior Changes

- Providers configured with dot-notation model IDs (e.g., `claude-haiku-4.5`) now work correctly as fallbacks. The API dispatch uses the provider's configured format instead of the globally normalized form.

## Security Impact (required)

- Does this change how permissions are checked or enforced? **No**
- Does this change handle, store, or transmit secrets/credentials? **No**
- Does this change modify network access or API surface? **No**
- Does this change affect code execution surface? **No**
- Does this change modify data access patterns? **No**

## Repro + Verification

**Before fix:**
1. Configure copilot-proxy with model `claude-haiku-4.5` (dots)
2. Trigger fallback to copilot-proxy
3. Gateway dispatches `claude-haiku-4-5` (dashes) → HTTP 400

**After fix:**
3. Gateway dispatches `claude-haiku-4.5` (dots, matching provider config) → HTTP 200

## Evidence

All 46 tests pass (45 existing + 1 new):
```
Test Files  1 passed (1)
     Tests  46 passed (46)
```

New test: `resolves inline model when config uses dots but query uses dashes`

## Human Verification (required)

- [x] `modelIdMatchesDotDash` correctly handles: exact match, dot→dash, dash→dot
- [x] Inline model match preserves original `entry.id` in returned Model object
- [x] `configuredModel` lookup in `applyConfiguredProviderOverrides` also uses fuzzy match
- [x] `normalizeResolvedModel` does not re-normalize the model ID (only changes transport)

## Review Conversations

- [x] I have reviewed and replied to all automated review comments
- [x] I have resolved all automated review conversations

## Compatibility / Migration

- **Backward compatible:** Yes — exact match still tried first, fuzzy match only as fallback
- **Existing behavior:** Models that already match exactly are unaffected

## Failure Recovery

- **Revert:** Single commit revert
- **Watch for:** Model ID mismatches in dispatch logs

## Risks and Mitigations

- **Risk:** False positive match (two genuinely different models that only differ by dots vs dashes). **Mitigation:** Extremely unlikely in practice — model naming conventions don't create such ambiguity.

---

*AI-assisted PR. Code changes reviewed and tested.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)