### PR TITLE
CI: add built plugin singleton smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,9 @@ jobs:
       - name: Smoke test CLI launcher status json
         run: node openclaw.mjs status --json --timeout 1
 
+      - name: Smoke test built bundled plugin singleton
+        run: pnpm test:build:singleton
+
       - name: Check CLI startup memory
         run: pnpm test:startup:memory
 

--- a/package.json
+++ b/package.json
@@ -564,6 +564,7 @@
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:auth:compat": "vitest run --config vitest.gateway.config.ts src/gateway/server.auth.compat-baseline.test.ts src/gateway/client.test.ts src/gateway/reconnect-gating.test.ts src/gateway/protocol/connect-error-details.test.ts",
+    "test:build:singleton": "node scripts/test-built-plugin-singleton.mjs",
     "test:channels": "vitest run --config vitest.channels.config.ts",
     "test:contracts": "pnpm test:contracts:channels && pnpm test:contracts:plugins",
     "test:contracts:channels": "OPENCLAW_TEST_PROFILE=low pnpm test -- src/channels/plugins/contracts",

--- a/scripts/test-built-plugin-singleton.mjs
+++ b/scripts/test-built-plugin-singleton.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const smokeEntryPath = path.join(repoRoot, "dist", "plugins", "build-smoke-entry.js");
+assert.ok(fs.existsSync(smokeEntryPath), `missing build output: ${smokeEntryPath}`);
+
+const { clearPluginCommands, getPluginCommandSpecs, loadOpenClawPlugins, matchPluginCommand } =
+  await import(pathToFileURL(smokeEntryPath).href);
+
+assert.equal(typeof loadOpenClawPlugins, "function", "built loader export missing");
+assert.equal(typeof clearPluginCommands, "function", "clearPluginCommands missing");
+assert.equal(typeof getPluginCommandSpecs, "function", "getPluginCommandSpecs missing");
+assert.equal(typeof matchPluginCommand, "function", "matchPluginCommand missing");
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-build-smoke-"));
+
+function cleanup() {
+  clearPluginCommands();
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
+
+const pluginId = "build-smoke-plugin";
+const distPluginDir = path.join(tempRoot, "dist", "extensions", pluginId);
+fs.mkdirSync(distPluginDir, { recursive: true });
+fs.writeFileSync(path.join(tempRoot, "package.json"), '{ "type": "module" }\n', "utf8");
+fs.writeFileSync(
+  path.join(distPluginDir, "package.json"),
+  JSON.stringify(
+    {
+      name: "@openclaw/build-smoke-plugin",
+      type: "module",
+      openclaw: {
+        extensions: ["./index.js"],
+      },
+    },
+    null,
+    2,
+  ),
+  "utf8",
+);
+fs.writeFileSync(
+  path.join(distPluginDir, "openclaw.plugin.json"),
+  JSON.stringify(
+    {
+      id: pluginId,
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+    },
+    null,
+    2,
+  ),
+  "utf8",
+);
+fs.writeFileSync(
+  path.join(distPluginDir, "index.js"),
+  [
+    "import sdk from 'openclaw/plugin-sdk';",
+    "const { emptyPluginConfigSchema } = sdk;",
+    "",
+    "export default {",
+    `  id: ${JSON.stringify(pluginId)},`,
+    "  configSchema: emptyPluginConfigSchema(),",
+    "  register(api) {",
+    "    api.registerCommand({",
+    "      name: 'pair',",
+    "      description: 'Pair a device',",
+    "      acceptsArgs: true,",
+    "      nativeNames: { telegram: 'pair', discord: 'pair' },",
+    "      async handler({ args }) {",
+    "        return { text: `paired:${args ?? ''}` };",
+    "      },",
+    "    });",
+    "  },",
+    "};",
+    "",
+  ].join("\n"),
+  "utf8",
+);
+
+stageBundledPluginRuntime({ repoRoot: tempRoot });
+
+const runtimeEntryPath = path.join(tempRoot, "dist-runtime", "extensions", pluginId, "index.js");
+assert.ok(fs.existsSync(runtimeEntryPath), "runtime overlay entry missing");
+assert.equal(
+  fs.existsSync(path.join(tempRoot, "dist-runtime", "plugins", "commands.js")),
+  false,
+  "dist-runtime must not stage a duplicate commands module",
+);
+
+clearPluginCommands();
+
+const registry = loadOpenClawPlugins({
+  cache: false,
+  workspaceDir: tempRoot,
+  env: {
+    ...process.env,
+    OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(tempRoot, "dist-runtime", "extensions"),
+    OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+  },
+  config: {
+    plugins: {
+      enabled: true,
+      allow: [pluginId],
+      entries: {
+        [pluginId]: { enabled: true },
+      },
+    },
+  },
+});
+
+const record = registry.plugins.find((entry) => entry.id === pluginId);
+assert.ok(record, "smoke plugin missing from registry");
+assert.equal(record.status, "loaded", record.error ?? "smoke plugin failed to load");
+
+assert.deepEqual(getPluginCommandSpecs("telegram"), [
+  { name: "pair", description: "Pair a device", acceptsArgs: true },
+]);
+
+const match = matchPluginCommand("/pair now");
+assert.ok(match, "canonical built command registry did not receive the command");
+assert.equal(match.args, "now");
+const result = await match.command.handler({ args: match.args });
+assert.deepEqual(result, { text: "paired:now" });
+
+process.stdout.write("[build-smoke] built plugin singleton smoke passed\n");

--- a/src/plugins/build-smoke-entry.ts
+++ b/src/plugins/build-smoke-entry.ts
@@ -1,0 +1,7 @@
+export {
+  clearPluginCommands,
+  executePluginCommand,
+  getPluginCommandSpecs,
+  matchPluginCommand,
+} from "./commands.js";
+export { loadOpenClawPlugins } from "./loader.js";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -171,6 +171,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "line/accounts": "src/line/accounts.ts",
     "line/send": "src/line/send.ts",
     "line/template-messages": "src/line/template-messages.ts",
+    "plugins/build-smoke-entry": "src/plugins/build-smoke-entry.ts",
     "plugins/runtime/index": "src/plugins/runtime/index.ts",
     "llm-slug-generator": "src/hooks/llm-slug-generator.ts",
   };


### PR DESCRIPTION
## Summary

- Problem: the existing source-level tests covered the dist-runtime singleton fix, but CI did not run a post-build smoke that proves bundled plugins loaded from `dist-runtime` still register commands onto the canonical built runtime graph.
- Why it matters: the original regression broke bundled plugin commands like `/pair`, `/phone`, and `/voice` in built environments. Without a built smoke, future build-layout or loader changes could regress that path without being caught by unit tests alone.
- What changed: renamed the post-build `startup-memory` lane to `build-smoke`, added `pnpm test:build:singleton`, added a stable built smoke entrypoint at `dist/plugins/build-smoke-entry.js`, and added a smoke script that stages a temp bundled plugin through `dist-runtime`, imports `openclaw/plugin-sdk`, loads it through the built loader, and asserts the canonical built command registry sees `/pair`.
- What did NOT change (scope boundary): this does not change plugin runtime behavior, plugin manifests, or command semantics outside of adding a stronger CI regression check.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48595

## User-visible / Behavior Changes

- None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / local repo build
- Model/provider: N/A
- Integration/channel (if any): bundled plugins, dist-runtime build smoke
- Relevant config (redacted): local repo build with default `dist/` and `dist-runtime/`

### Steps

1. Run `pnpm build`.
2. Run `pnpm test:build:singleton`.
3. Run `pnpm test:startup:memory`.

### Expected

- The built smoke entrypoint is emitted into `dist/plugins/build-smoke-entry.js`.
- A temp bundled plugin loaded from `dist-runtime` through the built loader can import `openclaw/plugin-sdk` and still register `/pair` onto the canonical built command registry.
- The existing startup memory smoke still passes under the renamed post-build lane.

### Actual

- `pnpm build` emitted the stable smoke entrypoint.
- `pnpm test:build:singleton` passed and verified the built loader + canonical command registry path.
- `pnpm test:startup:memory` passed after the lane rename.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm build`; verified `dist/plugins/build-smoke-entry.js` exists; ran `pnpm test:build:singleton`; ran `pnpm test:startup:memory`.
- Edge cases checked: the singleton smoke fixture now imports `openclaw/plugin-sdk` so the check covers the built root-alias/native-loading path in addition to canonical command registration.
- What you did **not** verify: I did not run a live Telegram session or other channel end-to-end flow; this PR is limited to a post-build regression smoke.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR, or remove the new `pnpm test:build:singleton` step from the `build-smoke` lane.
- Files/config to restore: `.github/workflows/ci.yml`, `package.json`, `tsdown.config.ts`, `src/plugins/build-smoke-entry.ts`, `scripts/test-built-plugin-singleton.mjs`
- Known bad symptoms reviewers should watch for: build smoke failing to locate the stable built entrypoint, the bundled temp plugin failing to import `openclaw/plugin-sdk`, or `/pair` not appearing in the canonical built command registry during the smoke.

## Risks and Mitigations

- Risk: the new smoke could become coupled to build internals and fail on unrelated bundle-layout churn.
- Mitigation: the smoke now imports a stable source-owned built entrypoint (`dist/plugins/build-smoke-entry.js`) rather than scraping hashed chunks.

- Risk: the smoke could prove only direct `api.registerCommand` behavior and miss the built `openclaw/plugin-sdk` alias path.
- Mitigation: the fixture imports `openclaw/plugin-sdk` and uses `emptyPluginConfigSchema()`, so the smoke covers the actual alias/native-loading path involved in the original regression.
