### PR TITLE
feat(slack): inject timestamp + position metadata annotations on images in thread history

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,8 +1,9 @@
+import { buildImageAnnotation } from "../../../../../src/auto-reply/annotate-thread-images.js";
 import { formatInboundEnvelope } from "../../../../../src/auto-reply/envelope.js";
 import { readSessionUpdatedAt } from "../../../../../src/config/sessions.js";
 import { logVerbose } from "../../../../../src/globals.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
-import type { SlackMessageEvent } from "../../types.js";
+import type { SlackFile, SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
 import {
   resolveSlackMedia,
@@ -10,6 +11,18 @@ import {
   type SlackMediaResult,
   type SlackThreadStarter,
 } from "../media.js";
+
+/** Image MIME type prefixes that indicate a visual image file. */
+const IMAGE_MIME_PREFIX = "image/";
+
+/** Check whether a Slack file looks like an image based on its MIME type or name. */
+function isImageFile(file: SlackFile): boolean {
+  if (file.mimetype?.toLowerCase().startsWith(IMAGE_MIME_PREFIX)) {
+    return true;
+  }
+  const name = file.name?.toLowerCase() ?? "";
+  return /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|svg)$/.test(name);
+}
 
 export type SlackThreadContextData = {
   threadStarterBody: string | undefined;
@@ -71,6 +84,7 @@ export async function resolveSlackThreadContextData(params: {
   }
 
   const threadInitialHistoryLimit = params.account.config?.thread?.initialHistoryLimit ?? 20;
+  const annotateImages = params.account.config?.thread?.annotateImages ?? true;
   threadSessionPreviousTimestamp = readSessionUpdatedAt({
     storePath: params.storePath,
     sessionKey: params.sessionKey,
@@ -101,14 +115,34 @@ export async function resolveSlackThreadContextData(params: {
         }),
       );
 
+      const totalMessages = threadHistory.length;
       const historyParts: string[] = [];
-      for (const historyMsg of threadHistory) {
+      for (const [msgIndex, historyMsg] of threadHistory.entries()) {
         const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
         const msgSenderName =
           msgUser?.name ?? (historyMsg.botId ? `Bot (${historyMsg.botId})` : "Unknown");
         const isBot = Boolean(historyMsg.botId);
         const role = isBot ? "assistant" : "user";
-        const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
+
+        // Build image annotation lines for messages with image file attachments.
+        let imageAnnotation = "";
+        if (annotateImages && historyMsg.files && historyMsg.files.length > 0) {
+          const imageFiles = historyMsg.files.filter(isImageFile);
+          if (imageFiles.length > 0) {
+            const annotations = imageFiles.map(() =>
+              buildImageAnnotation({
+                totalMessages,
+                messageIndex: msgIndex + 1,
+                timestamp: historyMsg.ts,
+                author: `${msgSenderName} (${role})`,
+                timezone: params.envelopeOptions?.timezone ?? "UTC",
+              }),
+            );
+            imageAnnotation = "\n" + annotations.join("\n");
+          }
+        }
+
+        const msgWithId = `${historyMsg.text}${imageAnnotation}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
         historyParts.push(
           formatInboundEnvelope({
             channel: "Slack",

--- a/src/auto-reply/annotate-thread-images.test.ts
+++ b/src/auto-reply/annotate-thread-images.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { buildImageAnnotation, normalizeTimestamp } from "./annotate-thread-images.js";
+
+describe("normalizeTimestamp", () => {
+  it("parses Slack-style decimal-seconds string", () => {
+    const date = normalizeTimestamp("1710590400.123456");
+    expect(date).toBeInstanceOf(Date);
+    // 1710590400 seconds = Sat Mar 16 2024 12:00:00 UTC
+    expect(date!.getUTCFullYear()).toBe(2024);
+  });
+
+  it("parses Unix seconds integer", () => {
+    const date = normalizeTimestamp(1710590400);
+    expect(date).toBeInstanceOf(Date);
+    expect(date!.getUTCFullYear()).toBe(2024);
+  });
+
+  it("parses Unix milliseconds integer", () => {
+    const date = normalizeTimestamp(1710590400000);
+    expect(date).toBeInstanceOf(Date);
+    expect(date!.getUTCFullYear()).toBe(2024);
+  });
+
+  it("parses ISO 8601 string", () => {
+    const date = normalizeTimestamp("2026-03-16T10:50:00.000Z");
+    expect(date).toBeInstanceOf(Date);
+    expect(date!.getUTCFullYear()).toBe(2026);
+  });
+
+  it("returns null for undefined", () => {
+    expect(normalizeTimestamp(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(normalizeTimestamp(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeTimestamp("")).toBeNull();
+  });
+
+  it("returns null for NaN", () => {
+    expect(normalizeTimestamp(NaN)).toBeNull();
+  });
+
+  it("returns null for Infinity", () => {
+    expect(normalizeTimestamp(Infinity)).toBeNull();
+  });
+});
+
+describe("buildImageAnnotation", () => {
+  it("formats Slack-style decimal string timestamp correctly", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 8,
+      messageIndex: 1,
+      timestamp: "1710590400.123456",
+      author: "alice (user)",
+      timezone: "America/New_York",
+    });
+    expect(result).toMatch(/^\[Image — sent .+\]$/);
+    expect(result).toContain("message 1 of 8 in thread");
+    expect(result).toContain("from alice (user)");
+    // Should contain a formatted date, not "unknown time"
+    expect(result).not.toContain("unknown time");
+  });
+
+  it("handles missing timestamp gracefully", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+      timestamp: undefined,
+    });
+    expect(result).toContain("unknown time");
+    expect(result).not.toContain("undefined");
+    expect(result).not.toContain("NaN");
+    expect(result).toContain("message 2 of 3 in thread");
+  });
+
+  it("omits author clause when author is absent", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+      timestamp: "1710590400",
+    });
+    expect(result).not.toContain("from");
+  });
+
+  it("omits author clause when author is empty string", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+      timestamp: "1710590400",
+      author: "  ",
+    });
+    expect(result).not.toContain("from");
+  });
+
+  it('shows "standalone message" for single-message threads', () => {
+    const result = buildImageAnnotation({
+      totalMessages: 1,
+      messageIndex: 1,
+      timestamp: "1710590400",
+      author: "bob",
+    });
+    expect(result).toContain("standalone message");
+    expect(result).not.toContain("of 1 in thread");
+  });
+
+  it("handles Unix seconds integer timestamp", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 5,
+      messageIndex: 3,
+      timestamp: 1710590400,
+    });
+    expect(result).not.toContain("unknown time");
+    expect(result).toContain("message 3 of 5 in thread");
+  });
+
+  it("handles ISO string timestamp", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 4,
+      messageIndex: 2,
+      timestamp: "2026-03-16T10:50:00.000Z",
+      timezone: "UTC",
+    });
+    expect(result).not.toContain("unknown time");
+    expect(result).toContain("message 2 of 4 in thread");
+  });
+
+  it("defaults to UTC when timezone is not provided", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 2,
+      messageIndex: 1,
+      timestamp: 1710590400,
+    });
+    expect(result).toContain("UTC");
+  });
+
+  it("falls back to UTC for invalid timezone", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 2,
+      messageIndex: 1,
+      timestamp: 1710590400,
+      timezone: "Invalid/Timezone",
+    });
+    // Should not crash, should fall back to UTC
+    expect(result).not.toContain("unknown time");
+  });
+});

--- a/src/auto-reply/annotate-thread-images.ts
+++ b/src/auto-reply/annotate-thread-images.ts
@@ -1,0 +1,108 @@
+/**
+ * Injects a human-readable metadata annotation for images referenced in thread
+ * history. This gives the model temporal and positional context to assess image
+ * freshness relative to the current message in the conversation.
+ *
+ * Example annotation:
+ *   [Image — sent Sat 3/16/2026, 10:50 AM EDT, message 2 of 8 in thread, from alice (user)]
+ */
+
+export interface ImageAnnotationOptions {
+  /** Total number of messages in the thread. */
+  totalMessages: number;
+  /** 1-based index of this message in the thread. */
+  messageIndex: number;
+  /** Timestamp — Unix seconds (number or Slack decimal string) or ISO string. */
+  timestamp?: number | string;
+  /** Display name or identifier of the message author. */
+  author?: string;
+  /** IANA timezone string, e.g. "America/New_York". Falls back to UTC. */
+  timezone?: string;
+}
+
+/**
+ * Normalizes a raw timestamp value (Slack decimal-seconds string, Unix seconds
+ * integer, Unix milliseconds integer, or ISO string) into a Date object.
+ * Returns null for invalid or missing input.
+ */
+export function normalizeTimestamp(raw: number | string | undefined | null): Date | null {
+  if (raw == null) {
+    return null;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return null;
+    }
+    // Slack uses decimal-second strings like "1710590400.123456"
+    const parsed = Number(trimmed);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      const date = new Date(parsed * 1000);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    // Try ISO 8601 / other parseable string formats
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof raw === "number") {
+    if (!Number.isFinite(raw)) {
+      return null;
+    }
+    // Heuristic: values > 1e12 are likely milliseconds, otherwise seconds
+    const ms = raw > 1e12 ? raw : raw * 1000;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+/**
+ * Formats the metadata annotation line injected before image references in
+ * thread history text.
+ */
+export function buildImageAnnotation(opts: ImageAnnotationOptions): string {
+  const { totalMessages, messageIndex, timestamp, author, timezone = "UTC" } = opts;
+
+  const date = normalizeTimestamp(timestamp);
+
+  let timeStr = "unknown time";
+  if (date) {
+    try {
+      timeStr = date.toLocaleString("en-US", {
+        timeZone: timezone,
+        weekday: "short",
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZoneName: "short",
+      });
+    } catch {
+      // Invalid timezone — fall back to UTC
+      try {
+        timeStr = date.toLocaleString("en-US", {
+          timeZone: "UTC",
+          weekday: "short",
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZoneName: "short",
+        });
+      } catch {
+        timeStr = "unknown time";
+      }
+    }
+  }
+
+  const positionStr =
+    totalMessages === 1
+      ? "standalone message"
+      : `message ${messageIndex} of ${totalMessages} in thread`;
+
+  const authorStr = author?.trim() ? `, from ${author.trim()}` : "";
+
+  return `[Image — sent ${timeStr}, ${positionStr}${authorStr}]`;
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -748,6 +748,8 @@ export const FIELD_HELP: Record<string, string> = {
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
   "channels.slack.thread.initialHistoryLimit":
     "Maximum number of existing Slack thread messages to fetch when starting a new thread session (default: 20, set to 0 to disable).",
+  "channels.slack.thread.annotateImages":
+    "When true (default), inject timestamp and position metadata annotations before image references in thread history so the model can reason about image age relative to the current message.",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -820,6 +820,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
   "channels.slack.thread.initialHistoryLimit": "Slack Thread Initial History Limit",
+  "channels.slack.thread.annotateImages": "Slack Thread Image Annotations",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.configWrites": "Mattermost Config Writes",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -82,6 +82,8 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
   /** Maximum number of thread messages to fetch as context when starting a new thread session (default: 20). Set to 0 to disable thread history fetching. */
   initialHistoryLimit?: number;
+  /** When true (default), inject timestamp + position metadata annotations before image references in thread history. Helps the model reason about image age relative to the current message. */
+  annotateImages?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -822,6 +822,7 @@ export const SlackThreadSchema = z
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
     initialHistoryLimit: z.number().int().min(0).optional(),
+    annotateImages: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

When assembling Slack thread history for the model, images are included with zero metadata about
when they were sent or where they appear in the conversation. This causes the model to treat a
screenshot from message 1 of an 8-message thread as equally "current" as the latest message.

This PR injects a plain-text annotation line before each image reference in the assembled
thread history, like:

[Image — sent Sat, 3/16/2024, 12:00:00 PM EDT, message 2 of 8 in thread, from @alice (user)]


The annotation includes timestamp, position (N of M), and author — giving the model the context
it needs to reason about image freshness.

Resolves #48321

## Changes

### New files
- **[src/auto-reply/annotate-thread-images.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/auto-reply/annotate-thread-images.ts:0:0-0:0)** — [buildImageAnnotation()](cci:1://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/auto-reply/annotate-thread-images.ts:58:0-107:1) and [normalizeTimestamp()](cci:1://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/auto-reply/annotate-thread-images.ts:22:0-56:1) utilities. Handles Slack decimal-seconds, Unix seconds/ms, and ISO strings.
- **[src/auto-reply/annotate-thread-images.test.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/auto-reply/annotate-thread-images.test.ts:0:0-0:0)** — 18 unit tests covering all timestamp formats, edge cases (missing data, invalid inputs), and output expectations.

### Modified files
- **[extensions/slack/src/monitor/message-handler/prepare-thread-context.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts:0:0-0:0)** — Calls [buildImageAnnotation()](cci:1://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/auto-reply/annotate-thread-images.ts:58:0-107:1) for each image file in thread history messages. Filters files by MIME type or extension. Controlled by the new `annotateImages` config flag.
- **[src/config/types.slack.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/config/types.slack.ts:0:0-0:0)** — Added `annotateImages?: boolean` to [SlackThreadConfig](cci:2://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/config/types.slack.ts:77:0-86:2).
- **[src/config/zod-schema.providers-core.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/config/zod-schema.providers-core.ts:0:0-0:0)** — Added zod validation for the new field.
- **[src/config/schema.help.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/config/schema.help.ts:0:0-0:0)** — Added help text for `channels.slack.thread.annotateImages`.
- **[src/config/schema.labels.ts](cci:7://file:///Users/divitsinghal/Desktop/Internship%20Projects/Open%20source/openclaw/src/config/schema.labels.ts:0:0-0:0)** — Added UI label `"Slack Thread Image Annotations"`.

## Configuration

Enabled by default (`true`). To opt out:

```yaml
channels:
  slack:
    thread:
      annotateImages: false
      
```
Testing
 18 new unit tests for the annotation utility (

normalizeTimestamp
 + 

buildImageAnnotation
)
 All 67 tests pass across 6 related test files with 0 regressions
 Lightly tested — no live Slack instance available; verified through unit tests and existing integration test suite
