### PR TITLE
fix: healthcheck skill uses UTC instead of user's local timezone

### DIFF
--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -19,6 +19,7 @@ Assess and harden the host running OpenClaw, then align it to a user-defined ris
 - If role/identity is unknown, provide recommendations only.
 - Formatting: every set of user choices must be numbered so the user can reply with a single digit.
 - System-level backups are recommended; try to verify status.
+- All timestamps in alerts, reports, and logs must use the user's local timezone (from the `Current time:` line provided by the cron system, or from `agents.defaults.userTimezone` in the config). Never display raw UTC timestamps to the user.
 
 ## Workflow (follow in order)
 


### PR DESCRIPTION
## Summary

Fixes #48688 — the `healthcheck:security-audit` cron sends alert messages with UTC timestamps, ignoring the user's configured timezone.

## Root Cause

The healthcheck SKILL.md didn't instruct the agent to use the user's local timezone for timestamps. The cron system already provides local time via the `Current time:` line, but the agent defaulted to UTC when formatting its own output.

## Fix

Added a core rule to the healthcheck skill instructing the agent to always use the user's local timezone (from the cron system's `Current time:` line or `agents.defaults.userTimezone`) for all timestamps in alerts, reports, and logs.

**Before:** `🚨 Security Alert (2026-03-15 06:00 UTC)`
**After:** `🚨 Security Alert (2026-03-15 14:00 CST)`