### PR TITLE
fix(telegram): use proxy-aware fetch for media file downloads

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -128,7 +128,7 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.fetch,
+    fetchImpl: params.transport.sourceFetch,
     dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
     fallbackDispatcherPolicy: params.transport.fallbackPinnedDispatcherPolicy,
     shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -128,7 +128,7 @@ async function downloadAndSaveTelegramFile(params: {
   const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.sourceFetch,
+    fetchImpl: params.transport.fetch,
     dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
     fallbackDispatcherPolicy: params.transport.fallbackPinnedDispatcherPolicy,
     shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -419,7 +419,7 @@ export function resolveTelegramTransport(
   const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
   const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
   const sourceFetch = explicitProxyUrl
-    ? undiciSourceFetch
+    ? resolveWrappedFetch(proxyFetch as unknown as typeof fetch)
     : proxyFetch
       ? resolveWrappedFetch(proxyFetch)
       : undiciSourceFetch;


### PR DESCRIPTION
## Summary

When `channels.telegram.proxy` is configured, the proxy dispatcher is correctly applied to polling (`getUpdates`) via `transport.fetch`, but media file downloads used `transport.sourceFetch` — bare undici fetch without the proxy dispatcher.

In countries where Telegram API is blocked (e.g. Russia), this causes all media downloads to fail with `TypeError: fetch failed` while text messaging works fine.

**Root cause:** `downloadAndSaveTelegramFile()` in `delivery.resolve-media.ts` passes `params.transport.sourceFetch` to `fetchRemoteMedia()`. When an explicit proxy URL is configured, `sourceFetch` is set to raw undici fetch (see `fetch.ts` lines 420-425), while the proxy `ProxyAgent` dispatcher is only injected in the `transport.fetch` wrapper.

**Fix:** Use `transport.fetch` instead of `transport.sourceFetch` for media downloads, so the `ProxyAgent` dispatcher is applied to file download requests.

## Error log (before fix)

```
MediaFetchError: Failed to fetch media from
https://api.telegram.org/file/bot.../photos/file_188.jpg: TypeError: fetch failed
```

## Test plan

- [x] Verified on a live instance in Russia with `channels.telegram.proxy` configured
- [x] Photo messages are now downloaded and processed correctly
- [x] Text messages and polling continue to work as before