### PR TITLE
fix: append file extension to WhatsApp document filename fallback

### DIFF
--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -6,6 +6,8 @@ import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import { markdownToWhatsApp } from "../../markdown/whatsapp.js";
 import { sleep } from "../../utils.js";
+import path from "node:path";
+import { extensionForMime } from "../../media/mime.js";
 import { loadWebMedia } from "../media.js";
 import { newConnectionId } from "../reconnect.js";
 import { formatError } from "../session.js";
@@ -138,8 +140,9 @@ export async function deliverWebReply(params: {
           "media:video",
         );
       } else {
-        const fileName = media.fileName ?? mediaUrl.split("/").pop() ?? "file";
         const mimetype = media.contentType ?? "application/octet-stream";
+        const rawName = media.fileName ?? mediaUrl.split("/").pop() ?? "file";
+        const fileName = path.extname(rawName) ? rawName : `${rawName}${extensionForMime(mimetype) ?? ""}`;
         await sendWithRetry(
           () =>
             msg.sendMedia({

--- a/src/web/inbound/send-api.test.ts
+++ b/src/web/inbound/send-api.test.ts
@@ -38,16 +38,30 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("falls back to default document filename when fileName is absent", async () => {
+  it("falls back to default document filename with extension when fileName is absent", async () => {
     const payload = Buffer.from("pdf");
     await api.sendMessage("+1555", "doc", payload, "application/pdf");
     expect(sendMessage).toHaveBeenCalledWith(
       "1555@s.whatsapp.net",
       expect.objectContaining({
         document: payload,
-        fileName: "file",
+        fileName: "file.pdf",
         caption: "doc",
         mimetype: "application/pdf",
+      }),
+    );
+  });
+
+  it("derives extension from MIME type dynamically (text/csv)", async () => {
+    const payload = Buffer.from("a,b,c");
+    await api.sendMessage("+1555", "csv data", payload, "text/csv");
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        document: payload,
+        fileName: "file.csv",
+        caption: "csv data",
+        mimetype: "text/csv",
       }),
     );
   });

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -1,6 +1,7 @@
 import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
 import type { ActiveWebSendOptions } from "../active-listener.js";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
+import { extensionForMime } from "../../media/mime.js";
 import { toWhatsappJid } from "../../utils.js";
 
 export function createWebSendApi(params: {
@@ -38,7 +39,7 @@ export function createWebSendApi(params: {
             ...(gifPlayback ? { gifPlayback: true } : {}),
           };
         } else {
-          const fileName = sendOptions?.fileName?.trim() || "file";
+          const fileName = sendOptions?.fileName?.trim() || `file${extensionForMime(mediaType) ?? ""}`;
           payload = {
             document: mediaBuffer,
             fileName,


### PR DESCRIPTION
## Summary
- When sending documents without an explicit filename, recipients received files named "file" with no extension
- Use `extensionForMime()` to derive the correct extension from the MIME type in both the auto-reply (`deliver-reply.ts`) and outbound send (`send-api.ts`) paths
- In `deliver-reply.ts`, also check if the raw filename already has an extension before appending one

## Test plan
- [x] Existing PDF fallback test updated to expect `"file.pdf"`
- [x] New `text/csv` test added expecting `"file.csv"` to verify dynamic extension derivation
- [x] All 3 tests in `send-api.test.ts` pass (`npx vitest run src/web/inbound/send-api.test.ts`)
- [x] Grepped for remaining bare `"file"` fallbacks — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)