### PR TITLE
Agents: move bootstrap warnings out of system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - Placeholder: replace with the first 2026.3.14 user-facing change.
 
+### Fixes
+
+- Agents/bootstrap warnings: move bootstrap truncation warnings out of the system prompt and into the per-turn prompt body so prompt-cache reuse stays stable when truncation warnings appear or disappear. (#48753) Thanks @scoootscooob and @obviyus.
+
 ## 2026.3.13
 
 ### Changes

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -116,6 +116,24 @@ describe("bootstrap prompt warnings", () => {
     expect(prompt).toContain("Please continue.");
   });
 
+  it("preserves raw prompt whitespace when prepending warning details", () => {
+    const prompt = prependBootstrapPromptWarning("  indented\nkeep tail  ", [
+      "AGENTS.md: 200 raw -> 0 injected",
+    ]);
+
+    expect(prompt.endsWith("  indented\nkeep tail  ")).toBe(true);
+  });
+
+  it("preserves exact heartbeat prompts without warning prefixes", () => {
+    const heartbeatPrompt = "Read HEARTBEAT.md. Reply HEARTBEAT_OK.";
+
+    expect(
+      prependBootstrapPromptWarning(heartbeatPrompt, ["AGENTS.md: 200 raw -> 0 injected"], {
+        preserveExactPrompt: heartbeatPrompt,
+      }),
+    ).toBe(heartbeatPrompt);
+  });
+
   it("resolves seen signatures from report history or legacy single signature", () => {
     expect(
       resolveBootstrapWarningSignaturesSeen({
@@ -410,23 +428,11 @@ describe("bootstrap prompt warnings", () => {
   it("improves cache-relevant system prompt stability versus legacy warning injection", () => {
     const contextFiles = [{ path: "AGENTS.md", content: "Follow AGENTS guidance." }];
     const warningLines = ["AGENTS.md: 200 raw -> 0 injected"];
-    const optimizedTurns = [
-      buildAgentSystemPrompt({
-        workspaceDir: "/tmp/openclaw",
-        contextFiles,
-        bootstrapTruncationWarningLines: warningLines,
-      }),
-      buildAgentSystemPrompt({
-        workspaceDir: "/tmp/openclaw",
-        contextFiles,
-        bootstrapTruncationWarningLines: [],
-      }),
-      buildAgentSystemPrompt({
-        workspaceDir: "/tmp/openclaw",
-        contextFiles,
-        bootstrapTruncationWarningLines: warningLines,
-      }),
-    ];
+    const stableSystemPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles,
+    });
+    const optimizedTurns = [stableSystemPrompt, stableSystemPrompt, stableSystemPrompt];
     const injectLegacyWarning = (prompt: string, lines: string[]) => {
       const warningBlock = [
         "⚠ Bootstrap truncation warning:",
@@ -441,8 +447,8 @@ describe("bootstrap prompt warnings", () => {
       injectLegacyWarning(optimizedTurns[2] ?? "", warningLines),
     ];
     const cacheHitRate = (turns: string[]) => {
-      const changes = turns.slice(1).filter((turn, index) => turn === turns[index]).length;
-      return changes / Math.max(1, turns.length - 1);
+      const hits = turns.slice(1).filter((turn, index) => turn === turns[index]).length;
+      return hits / Math.max(1, turns.length - 1);
     };
 
     expect(cacheHitRate(legacyTurns)).toBe(0);

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -6,8 +6,10 @@ import {
   buildBootstrapTruncationReportMeta,
   buildBootstrapTruncationSignature,
   formatBootstrapTruncationWarningLines,
+  prependBootstrapPromptWarning,
   resolveBootstrapWarningSignaturesSeen,
 } from "./bootstrap-budget.js";
+import { buildAgentSystemPrompt } from "./system-prompt.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
 describe("buildBootstrapInjectionStats", () => {
@@ -104,6 +106,16 @@ describe("analyzeBootstrapBudget", () => {
 });
 
 describe("bootstrap prompt warnings", () => {
+  it("prepends warning details to the turn prompt instead of mutating the system prompt", () => {
+    const prompt = prependBootstrapPromptWarning("Please continue.", [
+      "AGENTS.md: 200 raw -> 0 injected",
+    ]);
+    expect(prompt).toContain("[Bootstrap truncation warning]");
+    expect(prompt).toContain("Treat Project Context as partial");
+    expect(prompt).toContain("- AGENTS.md: 200 raw -> 0 injected");
+    expect(prompt).toContain("Please continue.");
+  });
+
   it("resolves seen signatures from report history or legacy single signature", () => {
     expect(
       resolveBootstrapWarningSignaturesSeen({
@@ -393,5 +405,48 @@ describe("bootstrap prompt warnings", () => {
     expect(meta.nearLimitFiles).toBeGreaterThanOrEqual(1);
     expect(meta.promptWarningSignature).toBeTruthy();
     expect(meta.warningSignaturesSeen?.length).toBeGreaterThan(0);
+  });
+
+  it("improves cache-relevant system prompt stability versus legacy warning injection", () => {
+    const contextFiles = [{ path: "AGENTS.md", content: "Follow AGENTS guidance." }];
+    const warningLines = ["AGENTS.md: 200 raw -> 0 injected"];
+    const optimizedTurns = [
+      buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        contextFiles,
+        bootstrapTruncationWarningLines: warningLines,
+      }),
+      buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        contextFiles,
+        bootstrapTruncationWarningLines: [],
+      }),
+      buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        contextFiles,
+        bootstrapTruncationWarningLines: warningLines,
+      }),
+    ];
+    const injectLegacyWarning = (prompt: string, lines: string[]) => {
+      const warningBlock = [
+        "⚠ Bootstrap truncation warning:",
+        ...lines.map((line) => `- ${line}`),
+        "",
+      ].join("\n");
+      return prompt.replace("## AGENTS.md", `${warningBlock}## AGENTS.md`);
+    };
+    const legacyTurns = [
+      injectLegacyWarning(optimizedTurns[0] ?? "", warningLines),
+      optimizedTurns[1] ?? "",
+      injectLegacyWarning(optimizedTurns[2] ?? "", warningLines),
+    ];
+    const cacheHitRate = (turns: string[]) => {
+      const changes = turns.slice(1).filter((turn, index) => turn === turns[index]).length;
+      return changes / Math.max(1, turns.length - 1);
+    };
+
+    expect(cacheHitRate(legacyTurns)).toBe(0);
+    expect(cacheHitRate(optimizedTurns)).toBe(1);
+    expect(optimizedTurns[0]).not.toContain("⚠ Bootstrap truncation warning:");
   });
 });

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -330,9 +330,18 @@ export function buildBootstrapPromptWarning(params: {
   };
 }
 
-export function prependBootstrapPromptWarning(prompt: string, warningLines?: string[]): string {
+export function prependBootstrapPromptWarning(
+  prompt: string,
+  warningLines?: string[],
+  options?: {
+    preserveExactPrompt?: string;
+  },
+): string {
   const normalizedLines = (warningLines ?? []).map((line) => line.trim()).filter(Boolean);
   if (normalizedLines.length === 0) {
+    return prompt;
+  }
+  if (options?.preserveExactPrompt && prompt === options.preserveExactPrompt) {
     return prompt;
   }
   const warningBlock = [
@@ -341,8 +350,7 @@ export function prependBootstrapPromptWarning(prompt: string, warningLines?: str
     "Treat Project Context as partial and read the relevant files directly if details seem missing.",
     ...normalizedLines.map((line) => `- ${line}`),
   ].join("\n");
-  const trimmedPrompt = prompt.trim();
-  return trimmedPrompt ? `${warningBlock}\n\n${trimmedPrompt}` : warningBlock;
+  return prompt ? `${warningBlock}\n\n${prompt}` : warningBlock;
 }
 
 export function buildBootstrapTruncationReportMeta(params: {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -330,6 +330,21 @@ export function buildBootstrapPromptWarning(params: {
   };
 }
 
+export function prependBootstrapPromptWarning(prompt: string, warningLines?: string[]): string {
+  const normalizedLines = (warningLines ?? []).map((line) => line.trim()).filter(Boolean);
+  if (normalizedLines.length === 0) {
+    return prompt;
+  }
+  const warningBlock = [
+    "[Bootstrap truncation warning]",
+    "Some workspace bootstrap files were truncated before injection.",
+    "Treat Project Context as partial and read the relevant files directly if details seem missing.",
+    ...normalizedLines.map((line) => `- ${line}`),
+  ].join("\n");
+  const trimmedPrompt = prompt.trim();
+  return trimmedPrompt ? `${warningBlock}\n\n${trimmedPrompt}` : warningBlock;
+}
+
 export function buildBootstrapTruncationReportMeta(params: {
   analysis: BootstrapBudgetAnalysis;
   warningMode: BootstrapPromptWarningMode;

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -5,10 +5,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runCliAgent } from "./cli-runner.js";
 import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import type { WorkspaceBootstrapFile } from "./workspace.js";
 
 const supervisorSpawnMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
+const hoisted = vi.hoisted(() => {
+  type BootstrapContext = {
+    bootstrapFiles: WorkspaceBootstrapFile[];
+    contextFiles: EmbeddedContextFile[];
+  };
+
+  return {
+    resolveBootstrapContextForRunMock: vi.fn<() => Promise<BootstrapContext>>(async () => ({
+      bootstrapFiles: [],
+      contextFiles: [],
+    })),
+  };
+});
 
 vi.mock("../process/supervisor/index.js", () => ({
   getProcessSupervisor: () => ({
@@ -26,6 +41,11 @@ vi.mock("../infra/system-events.js", () => ({
 
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./bootstrap-files.js", () => ({
+  makeBootstrapWarn: () => () => {},
+  resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRunMock,
 }));
 
 type MockRunExit = {
@@ -61,6 +81,10 @@ describe("runCliAgent with process supervisor", () => {
     supervisorSpawnMock.mockClear();
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
+    hoisted.resolveBootstrapContextForRunMock.mockReset().mockResolvedValue({
+      bootstrapFiles: [],
+      contextFiles: [],
+    });
   });
 
   it("runs CLI through supervisor and returns payload", async () => {
@@ -105,6 +129,62 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.noOutputTimeoutMs).toBeGreaterThanOrEqual(1_000);
     expect(input.replaceExistingScope).toBe(true);
     expect(input.scopeKey).toContain("thread-123");
+  });
+
+  it("prepends bootstrap warnings to the CLI prompt body", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    hoisted.resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        {
+          name: "AGENTS.md",
+          path: "/tmp/AGENTS.md",
+          content: "A".repeat(200),
+          missing: false,
+        },
+      ],
+      contextFiles: [{ path: "AGENTS.md", content: "A".repeat(20) }],
+    });
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            bootstrapMaxChars: 50,
+            bootstrapTotalMaxChars: 50,
+          },
+        },
+      } satisfies OpenClawConfig,
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-warning",
+      cliSessionId: "thread-123",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      argv?: string[];
+      input?: string;
+    };
+    const promptCarrier = [input.input ?? "", ...(input.argv ?? [])].join("\n");
+
+    expect(promptCarrier).toContain("[Bootstrap truncation warning]");
+    expect(promptCarrier).toContain("- AGENTS.md: 200 raw -> 20 injected");
+    expect(promptCarrier).toContain("hi");
   });
 
   it("fails with timeout when no-output watchdog trips", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -15,6 +15,7 @@ import {
   buildBootstrapInjectionStats,
   buildBootstrapPromptWarning,
   buildBootstrapTruncationReportMeta,
+  prependBootstrapPromptWarning,
 } from "./bootstrap-budget.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
@@ -210,7 +211,7 @@ export async function runCliAgent(params: {
 
     let imagePaths: string[] | undefined;
     let cleanupImages: (() => Promise<void>) | undefined;
-    let prompt = params.prompt;
+    let prompt = prependBootstrapPromptWarning(params.prompt, bootstrapPromptWarning.lines);
     if (params.images && params.images.length > 0) {
       const imagePayload = await writeCliImages(params.images);
       imagePaths = imagePayload.paths;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -155,7 +155,6 @@ export async function runCliAgent(params: {
     docsPath: docsPath ?? undefined,
     tools: [],
     contextFiles,
-    bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
     modelDisplay,
     agentId: sessionAgentId,
   });
@@ -211,7 +210,9 @@ export async function runCliAgent(params: {
 
     let imagePaths: string[] | undefined;
     let cleanupImages: (() => Promise<void>) | undefined;
-    let prompt = prependBootstrapPromptWarning(params.prompt, bootstrapPromptWarning.lines);
+    let prompt = prependBootstrapPromptWarning(params.prompt, bootstrapPromptWarning.lines, {
+      preserveExactPrompt: heartbeatPrompt,
+    });
     if (params.images && params.images.length > 0) {
       const imagePayload = await writeCliImages(params.images);
       imagePaths = imagePayload.paths;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -48,7 +48,6 @@ export function buildSystemPrompt(params: {
   docsPath?: string;
   tools: AgentTool[];
   contextFiles?: EmbeddedContextFile[];
-  bootstrapTruncationWarningLines?: string[];
   modelDisplay: string;
   agentId?: string;
 }) {
@@ -92,7 +91,6 @@ export function buildSystemPrompt(params: {
     userTime,
     userTimeFormat,
     contextFiles: params.contextFiles,
-    bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     ttsHint,
     memoryCitationsMode: params.config?.memory?.citations,
   });

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -18,16 +18,27 @@ import type {
   IngestBatchResult,
   IngestResult,
 } from "../../../context-engine/types.js";
+import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import { createHostSandboxFsBridge } from "../../test-helpers/host-sandbox-fs-bridge.js";
 import { createPiToolsSandboxContext } from "../../test-helpers/pi-tools-sandbox-context.js";
+import type { WorkspaceBootstrapFile } from "../../workspace.js";
 
 const hoisted = vi.hoisted(() => {
+  type BootstrapContext = {
+    bootstrapFiles: WorkspaceBootstrapFile[];
+    contextFiles: EmbeddedContextFile[];
+  };
   const spawnSubagentDirectMock = vi.fn();
   const createAgentSessionMock = vi.fn();
   const sessionManagerOpenMock = vi.fn();
   const resolveSandboxContextMock = vi.fn();
   const subscribeEmbeddedPiSessionMock = vi.fn();
   const acquireSessionWriteLockMock = vi.fn();
+  const resolveBootstrapContextForRunMock = vi.fn<() => Promise<BootstrapContext>>(async () => ({
+    bootstrapFiles: [],
+    contextFiles: [],
+  }));
+  const getGlobalHookRunnerMock = vi.fn<() => unknown>(() => undefined);
   const sessionManager = {
     getLeafEntry: vi.fn(() => null),
     branch: vi.fn(),
@@ -42,6 +53,8 @@ const hoisted = vi.hoisted(() => {
     resolveSandboxContextMock,
     subscribeEmbeddedPiSessionMock,
     acquireSessionWriteLockMock,
+    resolveBootstrapContextForRunMock,
+    getGlobalHookRunnerMock,
     sessionManager,
   };
 });
@@ -80,7 +93,7 @@ vi.mock("../../pi-embedded-subscribe.js", () => ({
 }));
 
 vi.mock("../../../plugins/hook-runner-global.js", () => ({
-  getGlobalHookRunner: () => undefined,
+  getGlobalHookRunner: hoisted.getGlobalHookRunnerMock,
 }));
 
 vi.mock("../../../infra/machine-name.js", () => ({
@@ -94,7 +107,7 @@ vi.mock("../../../infra/net/undici-global-dispatcher.js", () => ({
 
 vi.mock("../../bootstrap-files.js", () => ({
   makeBootstrapWarn: () => () => {},
-  resolveBootstrapContextForRun: async () => ({ bootstrapFiles: [], contextFiles: [] }),
+  resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRunMock,
 }));
 
 vi.mock("../../skills.js", () => ({
@@ -269,6 +282,11 @@ function resetEmbeddedAttemptHarness(
   hoisted.acquireSessionWriteLockMock.mockReset().mockResolvedValue({
     release: async () => {},
   });
+  hoisted.resolveBootstrapContextForRunMock.mockReset().mockResolvedValue({
+    bootstrapFiles: [],
+    contextFiles: [],
+  });
+  hoisted.getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.branch.mockReset();
   hoisted.sessionManager.resetLeaf.mockReset();
@@ -291,7 +309,11 @@ async function cleanupTempPaths(tempPaths: string[]) {
 }
 
 function createDefaultEmbeddedSession(params?: {
-  prompt?: (session: MutableSession) => Promise<void>;
+  prompt?: (
+    session: MutableSession,
+    prompt: string,
+    options?: { images?: unknown[] },
+  ) => Promise<void>;
 }): MutableSession {
   const session: MutableSession = {
     sessionId: "embedded-session",
@@ -303,9 +325,9 @@ function createDefaultEmbeddedSession(params?: {
         session.messages = [...messages];
       },
     },
-    prompt: async () => {
+    prompt: async (prompt, options) => {
       if (params?.prompt) {
-        await params.prompt(session);
+        await params.prompt(session, prompt, options);
         return;
       }
       session.messages = [
@@ -447,6 +469,90 @@ describe("runEmbeddedAttempt sessions_spawn workspace inheritance", () => {
         workspaceDir: sandboxWorkspace,
       }),
     );
+  });
+});
+
+describe("runEmbeddedAttempt bootstrap warning prompt assembly", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness({
+      subscribeImpl: createSubscriptionMock,
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("keeps bootstrap warnings in the sent prompt after hook prepend context", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-warning-workspace-"));
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-warning-agent-dir-"));
+    const sessionFile = path.join(workspaceDir, "session.jsonl");
+    tempPaths.push(workspaceDir, agentDir);
+    await fs.writeFile(sessionFile, "", "utf8");
+
+    hoisted.resolveBootstrapContextForRunMock.mockResolvedValue({
+      bootstrapFiles: [
+        {
+          name: "AGENTS.md",
+          path: path.join(workspaceDir, "AGENTS.md"),
+          content: "A".repeat(200),
+          missing: false,
+        },
+      ],
+      contextFiles: [{ path: "AGENTS.md", content: "A".repeat(20) }],
+    });
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "before_prompt_build",
+      runBeforePromptBuild: async () => ({ prependContext: "hook context" }),
+    });
+
+    let seenPrompt = "";
+    hoisted.createAgentSessionMock.mockImplementation(async () => ({
+      session: createDefaultEmbeddedSession({
+        prompt: async (session, prompt) => {
+          seenPrompt = prompt;
+          session.messages = [
+            ...session.messages,
+            { role: "assistant", content: "done", timestamp: 2 },
+          ];
+        },
+      }),
+    }));
+
+    const result = await runEmbeddedAttempt({
+      sessionId: "embedded-session",
+      sessionKey: "agent:main:main",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      config: {
+        agents: {
+          defaults: {
+            bootstrapMaxChars: 50,
+            bootstrapTotalMaxChars: 50,
+          },
+        },
+      },
+      prompt: "hello",
+      timeoutMs: 10_000,
+      runId: "run-warning",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: testModel,
+      authStorage: {} as AuthStorage,
+      modelRegistry: {} as ModelRegistry,
+      thinkLevel: "off",
+      senderIsOwner: true,
+      disableMessageTool: true,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(seenPrompt).toContain("hook context");
+    expect(seenPrompt).toContain("[Bootstrap truncation warning]");
+    expect(seenPrompt).toContain("- AGENTS.md: 200 raw -> 20 injected");
+    expect(seenPrompt).toContain("hello");
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -39,6 +39,7 @@ import {
   buildBootstrapPromptWarning,
   buildBootstrapTruncationReportMeta,
   buildBootstrapInjectionStats,
+  prependBootstrapPromptWarning,
 } from "../../bootstrap-budget.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -2308,7 +2309,10 @@ export async function runEmbeddedAttempt(
 
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
-        let effectivePrompt = params.prompt;
+        let effectivePrompt = prependBootstrapPromptWarning(
+          params.prompt,
+          bootstrapPromptWarning.lines,
+        );
         const hookCtx = {
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
@@ -2327,7 +2331,7 @@ export async function runEmbeddedAttempt(
         });
         {
           if (hookResult?.prependContext) {
-            effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
+            effectivePrompt = `${hookResult.prependContext}\n\n${effectivePrompt}`;
             log.debug(
               `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
             );

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1639,6 +1639,9 @@ export async function runEmbeddedAttempt(
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+    const heartbeatPrompt = isDefaultAgent
+      ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
+      : undefined;
 
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
@@ -1649,9 +1652,7 @@ export async function runEmbeddedAttempt(
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
       reasoningTagHint,
-      heartbeatPrompt: isDefaultAgent
-        ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
-        : undefined,
+      heartbeatPrompt,
       skillsPrompt,
       docsPath: docsPath ?? undefined,
       ttsHint,
@@ -1668,7 +1669,6 @@ export async function runEmbeddedAttempt(
       userTime,
       userTimeFormat,
       contextFiles,
-      bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
       memoryCitationsMode: params.config?.memory?.citations,
     });
     const systemPromptReport = buildSystemPromptReport({
@@ -2312,6 +2312,9 @@ export async function runEmbeddedAttempt(
         let effectivePrompt = prependBootstrapPromptWarning(
           params.prompt,
           bootstrapPromptWarning.lines,
+          {
+            preserveExactPrompt: heartbeatPrompt,
+          },
         );
         const hookCtx = {
           agentId: hookAgentId,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -51,7 +51,6 @@ export function buildEmbeddedSystemPrompt(params: {
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
-  bootstrapTruncationWarningLines?: string[];
   memoryCitationsMode?: MemoryCitationsMode;
 }): string {
   return buildAgentSystemPrompt({
@@ -81,7 +80,6 @@ export function buildEmbeddedSystemPrompt(params: {
     userTime: params.userTime,
     userTimeFormat: params.userTimeFormat,
     contextFiles: params.contextFiles,
-    bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     memoryCitationsMode: params.memoryCitationsMode,
   });
 }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -534,16 +534,13 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
-  it("does not inject bootstrap truncation warning lines into the system prompt", () => {
+  it("omits project context when no context files are injected", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
-      bootstrapTruncationWarningLines: ["AGENTS.md: 200 raw -> 0 injected"],
       contextFiles: [],
     });
 
     expect(prompt).not.toContain("# Project Context");
-    expect(prompt).not.toContain("⚠ Bootstrap truncation warning:");
-    expect(prompt).not.toContain("AGENTS.md: 200 raw -> 0 injected");
   });
 
   it("summarizes the message tool when available", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -534,16 +534,16 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
-  it("renders bootstrap truncation warning even when no context files are injected", () => {
+  it("does not inject bootstrap truncation warning lines into the system prompt", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       bootstrapTruncationWarningLines: ["AGENTS.md: 200 raw -> 0 injected"],
       contextFiles: [],
     });
 
-    expect(prompt).toContain("# Project Context");
-    expect(prompt).toContain("⚠ Bootstrap truncation warning:");
-    expect(prompt).toContain("- AGENTS.md: 200 raw -> 0 injected");
+    expect(prompt).not.toContain("# Project Context");
+    expect(prompt).not.toContain("⚠ Bootstrap truncation warning:");
+    expect(prompt).not.toContain("AGENTS.md: 200 raw -> 0 injected");
   });
 
   it("summarizes the message tool when available", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -614,13 +614,10 @@ export function buildAgentSystemPrompt(params: {
   }
 
   const contextFiles = params.contextFiles ?? [];
-  const bootstrapTruncationWarningLines = (params.bootstrapTruncationWarningLines ?? []).filter(
-    (line) => line.trim().length > 0,
-  );
   const validContextFiles = contextFiles.filter(
     (file) => typeof file.path === "string" && file.path.trim().length > 0,
   );
-  if (validContextFiles.length > 0 || bootstrapTruncationWarningLines.length > 0) {
+  if (validContextFiles.length > 0) {
     lines.push("# Project Context", "");
     if (validContextFiles.length > 0) {
       const hasSoulFile = validContextFiles.some((file) => {
@@ -633,13 +630,6 @@ export function buildAgentSystemPrompt(params: {
         lines.push(
           "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
         );
-      }
-      lines.push("");
-    }
-    if (bootstrapTruncationWarningLines.length > 0) {
-      lines.push("⚠ Bootstrap truncation warning:");
-      for (const warningLine of bootstrapTruncationWarningLines) {
-        lines.push(`- ${warningLine}`);
       }
       lines.push("");
     }

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -202,7 +202,6 @@ export function buildAgentSystemPrompt(params: {
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
-  bootstrapTruncationWarningLines?: string[];
   skillsPrompt?: string;
   heartbeatPrompt?: string;
   docsPath?: string;


### PR DESCRIPTION
## Summary

- Problem: bootstrap truncation warning lines were injected into `# Project Context` inside the system prompt, which made the cached prefix change when the warning appeared or disappeared.
- Why it matters: this reduced provider-side prompt cache reuse even though the underlying workspace bootstrap content was unchanged.
- What changed: keep bootstrap warning visibility, but prepend the warning details to the per-turn prompt body instead of the stable system prompt prefix.
- Tests: add regression coverage that compares legacy warning-in-system behavior against the new body-prefix behavior and asserts the cache-relevant system prompt stays stable.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Follow-up to #32769

## User-visible / Behavior Changes

- Bootstrap truncation warnings are still shown to the model, but they now ride in the per-turn prompt body instead of mutating the system prompt.
- The system prompt no longer gains or loses a `⚠ Bootstrap truncation warning` block across turns.

## Security Impact

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 25 + pnpm
- Model/provider: `anthropic/claude-sonnet-4-5`
- Integration/channel (if any): local prompt construction + live Anthropic cache metrics

### Steps

1. Run targeted tests:
   - `pnpm test -- src/agents/bootstrap-budget.test.ts src/agents/system-prompt.test.ts`
2. Run the prompt-cache investigation harness:
   - `pnpm exec tsx scripts/investigate-prompt-cache.ts`
3. Run the harness with live cache logging enabled:
   - `ANTHROPIC_API_KEY=... OPENCLAW_INVESTIGATE_CACHE_LIVE=1 MODEL_ID=claude-sonnet-4-5 MAX_TOKENS=16 pnpm exec tsx scripts/investigate-prompt-cache.ts`

### Expected

- The bootstrap warning scenario should no longer change the system prompt after bootstrap.
- Live cache behavior for the bootstrap warning path should shift from repeated cache writes to cache reads on later turns.

### Actual

- Targeted tests pass.
- `bootstrap-warning` now reports `0 system-change turn(s) after initial bootstrap`.
- Live cache metrics improved materially for the bootstrap warning path.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Perf numbers (if relevant)

### Cache hit-rate measurements

Bootstrap warning scenario before this change:
- `cacheRead=25854`
- `cacheWrite=51602`
- `cached=33%`

Bootstrap warning scenario after this change:
- `cacheRead=51494`
- `cacheWrite=25747`
- `cached=66%`

Per-turn bootstrap warning behavior before:
- `t1`: write only
- `t2`: write only again
- `t3`: cached

Per-turn bootstrap warning behavior after:
- `t1`: write only
- `t2`: `99%` cached
- `t3`: `99%` cached

Overall latest-main harness average before this fix:
- `cacheRead=35523`
- `cacheWrite=63056`
- `cached=36%`

Overall latest-main harness average after this fix:
- `cacheRead=53124`
- `cacheWrite=45234`
- `cached=54%`

## Human Verification

- Verified that bootstrap warning details are still visible to the model, but no longer mutate the system prompt.
- Verified the cache-specific regression with a dedicated unit test comparing legacy and optimized prompt construction.
- Verified live Anthropic cache metrics before/after using the same investigation harness.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Failure Recovery

- If this causes issues, revert this PR to restore the old warning placement.
- Symptom to watch for: missing bootstrap warning visibility in prompt body on truncated runs.

## Risks and Mitigations

- Risk: warning text might become less salient now that it lives in the body prompt instead of the system prompt.
  - Mitigation: the prepended warning block explicitly tells the model to treat project context as partial and read files directly when needed, and tests cover the new body injection path.
