### PR TITLE
chore: fix formatting drift in extension sources

### DIFF
--- a/extensions/discord/src/account-inspect.ts
+++ b/extensions/discord/src/account-inspect.ts
@@ -1,8 +1,8 @@
-import type { DiscordAccountConfig } from "../../../src/config/types.js";
 import {
   hasConfiguredSecretInput,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/config-runtime";
+import type { DiscordAccountConfig } from "../../../src/config/types.js";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,

--- a/extensions/discord/src/setup-core.ts
+++ b/extensions/discord/src/setup-core.ts
@@ -1,5 +1,3 @@
-import { createPatchedAccountSetupAdapter } from "../../../src/channels/plugins/setup-helpers.js";
-import { createAllowlistSetupWizardProxy } from "../../../src/channels/plugins/setup-wizard-proxy.js";
 import type { DiscordGuildEntry } from "openclaw/plugin-sdk/config-runtime";
 import {
   applyAccountNameToChannelSection,
@@ -19,6 +17,8 @@ import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup";
+import { createPatchedAccountSetupAdapter } from "../../../src/channels/plugins/setup-helpers.js";
+import { createAllowlistSetupWizardProxy } from "../../../src/channels/plugins/setup-wizard-proxy.js";
 import { formatDocsLink } from "../../../src/terminal/links.js";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { listDiscordAccountIds, resolveDiscordAccount } from "./accounts.js";

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -1,8 +1,8 @@
-import { cloneFirstTemplateModel } from "../../src/plugins/provider-model-helpers.js";
 import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/core";
+import { cloneFirstTemplateModel } from "../../src/plugins/provider-model-helpers.js";
 
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -178,7 +178,9 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
     chunkerMode: "text",
     textChunkLimit: 4000,
     sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
-      const result = await (await loadIMessageChannelRuntime()).sendIMessageOutbound({
+      const result = await (
+        await loadIMessageChannelRuntime()
+      ).sendIMessageOutbound({
         cfg,
         to,
         text,
@@ -189,7 +191,9 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
       return { channel: "imessage", ...result };
     },
     sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
-      const result = await (await loadIMessageChannelRuntime()).sendIMessageOutbound({
+      const result = await (
+        await loadIMessageChannelRuntime()
+      ).sendIMessageOutbound({
         cfg,
         to,
         text,

--- a/extensions/imessage/src/setup-surface.ts
+++ b/extensions/imessage/src/setup-surface.ts
@@ -1,6 +1,6 @@
-import { detectBinary } from "../../../src/commands/onboard-helpers.js";
 import { setSetupChannelEnabled } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { detectBinary } from "../../../src/commands/onboard-helpers.js";
 import { listIMessageAccountIds, resolveIMessageAccount } from "./accounts.js";
 import {
   createIMessageCliPathTextInput,

--- a/extensions/imessage/src/shared.ts
+++ b/extensions/imessage/src/shared.ts
@@ -3,18 +3,18 @@ import {
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/compat";
 import {
+  deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
+} from "../../../src/channels/plugins/config-helpers.js";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import type { ChannelPlugin } from "../../../src/channels/plugins/types.plugin.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { IMessageConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
+import {
   formatTrimmedAllowFromEntries,
   resolveIMessageConfigAllowFrom,
   resolveIMessageConfigDefaultTo,
 } from "../../../src/plugin-sdk/channel-config-helpers.js";
-import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
-import {
-  deleteAccountFromConfigSection,
-  setAccountEnabledInConfigSection,
-} from "../../../src/channels/plugins/config-helpers.js";
-import type { ChannelPlugin } from "../../../src/channels/plugins/types.plugin.js";
-import { getChatChannelMeta } from "../../../src/channels/registry.js";
-import { IMessageConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
 import {
   listIMessageAccountIds,

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -1,4 +1,3 @@
-import { formatCliCommand } from "../../../src/cli/command-format.js";
 import {
   applyAccountNameToChannelSection,
   DEFAULT_ACCOUNT_ID,
@@ -18,6 +17,7 @@ import type {
   ChannelSetupWizard,
   ChannelSetupWizardTextInput,
 } from "openclaw/plugin-sdk/setup";
+import { formatCliCommand } from "../../../src/cli/command-format.js";
 import { formatDocsLink } from "../../../src/terminal/links.js";
 import {
   listSignalAccountIds,

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -1,7 +1,7 @@
-import { detectBinary } from "../../../src/commands/onboard-helpers.js";
-import { installSignalCli } from "../../../src/commands/signal-install.js";
 import { setSetupChannelEnabled } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { detectBinary } from "../../../src/commands/onboard-helpers.js";
+import { installSignalCli } from "../../../src/commands/signal-install.js";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
 import {
   createSignalCliPathTextInput,

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -19,9 +19,9 @@ import {
   type ChannelSetupWizard,
   type ChannelSetupWizardAllowFromEntry,
 } from "openclaw/plugin-sdk/setup";
-import { formatDocsLink } from "../../../src/terminal/links.js";
 import { createPatchedAccountSetupAdapter } from "../../../src/channels/plugins/setup-helpers.js";
 import { createAllowlistSetupWizardProxy } from "../../../src/channels/plugins/setup-wizard-proxy.js";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { inspectSlackAccount } from "./account-inspect.js";
 import { listSlackAccountIds, resolveSlackAccount, type ResolvedSlackAccount } from "./accounts.js";
 import {

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -1,4 +1,3 @@
-import { formatCliCommand } from "../../../src/cli/command-format.js";
 import {
   applyAccountNameToChannelSection,
   DEFAULT_ACCOUNT_ID,
@@ -11,6 +10,7 @@ import {
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupAdapter, ChannelSetupDmPolicy } from "openclaw/plugin-sdk/setup";
+import { formatCliCommand } from "../../../src/cli/command-format.js";
 import { formatDocsLink } from "../../../src/terminal/links.js";
 import { resolveDefaultTelegramAccountId, resolveTelegramAccount } from "./accounts.js";
 import { fetchTelegramChatId } from "./api-fetch.js";

--- a/extensions/whatsapp/src/setup-surface.ts
+++ b/extensions/whatsapp/src/setup-surface.ts
@@ -1,6 +1,4 @@
 import path from "node:path";
-import { formatCliCommand } from "../../../src/cli/command-format.js";
-import type { DmPolicy } from "../../../src/config/types.js";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
@@ -12,6 +10,8 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { formatCliCommand } from "../../../src/cli/command-format.js";
+import type { DmPolicy } from "../../../src/config/types.js";
 import { formatDocsLink } from "../../../src/terminal/links.js";
 import { listWhatsAppAccountIds, resolveWhatsAppAuthDir } from "./accounts.js";
 import { loginWeb } from "./login.js";

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -3,20 +3,20 @@ import {
   collectAllowlistProviderGroupPolicyWarnings,
   collectOpenGroupPolicyRouteAllowlistWarnings,
 } from "openclaw/plugin-sdk/compat";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import {
+  resolveWhatsAppGroupRequireMention,
+  resolveWhatsAppGroupToolPolicy,
+} from "../../../src/channels/plugins/group-mentions.js";
+import type { ChannelPlugin } from "../../../src/channels/plugins/types.plugin.js";
+import { resolveWhatsAppGroupIntroHint } from "../../../src/channels/plugins/whatsapp-shared.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { WhatsAppConfigSchema } from "../../../src/config/zod-schema.providers-whatsapp.js";
 import {
   formatWhatsAppConfigAllowFromEntries,
   resolveWhatsAppConfigAllowFrom,
   resolveWhatsAppConfigDefaultTo,
 } from "../../../src/plugin-sdk/channel-config-helpers.js";
-import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
-import type { ChannelPlugin } from "../../../src/channels/plugins/types.plugin.js";
-import {
-  resolveWhatsAppGroupRequireMention,
-  resolveWhatsAppGroupToolPolicy,
-} from "../../../src/channels/plugins/group-mentions.js";
-import { resolveWhatsAppGroupIntroHint } from "../../../src/channels/plugins/whatsapp-shared.js";
-import { getChatChannelMeta } from "../../../src/channels/registry.js";
-import { WhatsAppConfigSchema } from "../../../src/config/zod-schema.providers-whatsapp.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
 import { normalizeE164 } from "../../../src/utils.js";
 import {

--- a/src/plugins/contracts/loader.contract.test.ts
+++ b/src/plugins/contracts/loader.contract.test.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withBundledPluginAllowlistCompat } from "../bundled-compat.js";
 import { __testing as providerTesting } from "../providers.js";
 import { resolvePluginWebSearchProviders } from "../web-search-providers.js";
-import {
-  providerContractPluginIds,
-  webSearchProviderContractRegistry,
-} from "./registry.js";
+import { providerContractPluginIds, webSearchProviderContractRegistry } from "./registry.js";
 
 function uniqueSortedPluginIds(values: string[]) {
   return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));


### PR DESCRIPTION
## What
This PR fixes source formatting drift in the extension files and contract test that are currently failing the repository's `oxfmt --check` gate on `main`.

## Why
These formatting errors are unrelated to feature work, but they cause CI noise and can block otherwise valid PRs from landing.

## Changes
- Reordered imports to match `oxfmt`
- Applied formatter line wrapping fixes
- Fixed extension source formatting drift
- Fixed plugin contract test formatting

## Testing
- `pnpm format:check`
- Expected: `All matched files use the correct format.`
