### PR TITLE
Tests: share provider registration helpers

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -32,7 +32,7 @@ import {
   ZAI_CODING_GLOBAL_BASE_URL,
 } from "../plugins/provider-model-definitions.js";
 import type { ProviderPlugin } from "../plugins/types.js";
-import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
+import { registerProviderPlugins } from "../test-utils/plugin-registration.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoice, resolvePreferredProviderForAuthChoice } from "./auth-choice.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL } from "./google-gemini-model-default.js";
@@ -82,8 +82,7 @@ type StoredAuthProfile = {
 };
 
 function createDefaultProviderPlugins() {
-  const captured = createCapturedPluginRegistration();
-  for (const plugin of [
+  return registerProviderPlugins(
     anthropicPlugin,
     cloudflareAiGatewayPlugin,
     googlePlugin,
@@ -106,10 +105,7 @@ function createDefaultProviderPlugins() {
     xaiPlugin,
     xiaomiPlugin,
     zaiPlugin,
-  ]) {
-    plugin.register(captured.api);
-  }
-  return captured.providers;
+  );
 }
 
 describe("applyAuthChoice", () => {

--- a/src/plugins/contracts/testkit.ts
+++ b/src/plugins/contracts/testkit.ts
@@ -1,25 +1,7 @@
-import { createCapturedPluginRegistration } from "../../test-utils/plugin-registration.js";
-import type { OpenClawPluginApi, ProviderPlugin } from "../types.js";
-
-type RegistrablePlugin = {
-  register(api: OpenClawPluginApi): void;
-};
-
-export function registerProviders(...plugins: RegistrablePlugin[]) {
-  const captured = createCapturedPluginRegistration();
-  for (const plugin of plugins) {
-    plugin.register(captured.api);
-  }
-  return captured.providers;
-}
-
-export function requireProvider(providers: ProviderPlugin[], providerId: string) {
-  const provider = providers.find((entry) => entry.id === providerId);
-  if (!provider) {
-    throw new Error(`provider ${providerId} missing`);
-  }
-  return provider;
-}
+export {
+  registerProviderPlugins as registerProviders,
+  requireRegisteredProvider as requireProvider,
+} from "../../test-utils/plugin-registration.js";
 
 export function uniqueSortedStrings(values: readonly string[]) {
   return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));

--- a/src/test-utils/plugin-registration.ts
+++ b/src/test-utils/plugin-registration.ts
@@ -3,6 +3,10 @@ import type { OpenClawPluginApi, ProviderPlugin } from "../plugins/types.js";
 
 export { createCapturedPluginRegistration };
 
+type RegistrablePlugin = {
+  register(api: OpenClawPluginApi): void;
+};
+
 export function registerSingleProviderPlugin(params: {
   register(api: OpenClawPluginApi): void;
 }): ProviderPlugin {
@@ -11,6 +15,22 @@ export function registerSingleProviderPlugin(params: {
   const provider = captured.providers[0];
   if (!provider) {
     throw new Error("provider registration missing");
+  }
+  return provider;
+}
+
+export function registerProviderPlugins(...plugins: RegistrablePlugin[]): ProviderPlugin[] {
+  const captured = createCapturedPluginRegistration();
+  for (const plugin of plugins) {
+    plugin.register(captured.api);
+  }
+  return captured.providers;
+}
+
+export function requireRegisteredProvider(providers: ProviderPlugin[], providerId: string) {
+  const provider = providers.find((entry) => entry.id === providerId);
+  if (!provider) {
+    throw new Error(`provider ${providerId} missing`);
   }
   return provider;
 }


### PR DESCRIPTION
## Summary

- Problem: provider registration helper logic still lived in both `src/test-utils/plugin-registration.ts`, the contract testkit, and `src/commands/auth-choice.test.ts`.
- Why it matters: that helper plumbing was already deduped for contract tests conceptually, but the actual registration code still had two owners.
- What changed: moved shared provider registration helpers into `src/test-utils/plugin-registration.ts` and rewired the contract testkit plus `src/commands/auth-choice.test.ts` to reuse them.
- What did NOT change (scope boundary): no runtime auth-choice behavior changed; this is test-helper cleanup only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48760

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: N/A
- Integration/channel (if any): provider auth-choice tests and contract test helpers
- Relevant config (redacted): default local dev config

### Steps

1. Move shared provider registration helper ownership into `src/test-utils/plugin-registration.ts`.
2. Point the contract testkit and `src/commands/auth-choice.test.ts` at the shared helper.
3. Run focused lint on the touched files.

### Expected

- The same provider registration helper logic should only exist in one shared test helper module.

### Actual

- `src/test-utils/plugin-registration.ts` now owns the reusable provider registration helpers.
- The contract testkit and `auth-choice.test.ts` now reuse those helpers.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: rebased onto latest `origin/main`; ran `pnpm exec oxlint src/test-utils/plugin-registration.ts src/plugins/contracts/testkit.ts src/commands/auth-choice.test.ts`.
- Edge cases checked: confirmed the branch diff against `origin/main` only contains this 3-file helper dedupe slice.
- What you did **not** verify: I did not run a completed Vitest lane for this slice.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/test-utils/plugin-registration.ts`, `src/plugins/contracts/testkit.ts`, and `src/commands/auth-choice.test.ts`.
- Known bad symptoms reviewers should watch for: auth-choice tests or provider contract tests failing to resolve registered provider fixtures.

## Risks and Mitigations

- Risk:
  - A subtle difference between the old local helpers and the shared helper could affect provider test fixture ordering.
  - Mitigation: the new helper preserves the same registration order and only centralizes the duplicated implementation.
