### PR TITLE
Telegram: fix named-account DM topic session keys

### DIFF
--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -64,7 +64,10 @@ import {
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
+import {
+  resolveTelegramConversationBaseSessionKey,
+  resolveTelegramConversationRoute,
+} from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import {
   isTelegramExecApprovalApprover,
@@ -331,7 +334,13 @@ export const registerTelegramHandlers = ({
       senderId: params.senderId,
       topicAgentId: topicConfig?.agentId,
     });
-    const baseSessionKey = route.sessionKey;
+    const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+      cfg,
+      route,
+      chatId: params.chatId,
+      isGroup: params.isGroup,
+      senderId: params.senderId,
+    });
     const threadKeys =
       dmThreadId != null
         ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${params.chatId}:${dmThreadId}` })

--- a/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
+++ b/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
@@ -6,9 +6,13 @@ import {
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 
 const recordInboundSessionMock = vi.fn().mockResolvedValue(undefined);
-vi.mock("../../../src/channels/session.js", () => ({
-  recordInboundSession: (...args: unknown[]) => recordInboundSessionMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/channel-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-runtime")>();
+  return {
+    ...actual,
+    recordInboundSession: (...args: unknown[]) => recordInboundSessionMock(...args),
+  };
+});
 
 describe("buildTelegramMessageContext named-account DM fallback", () => {
   const baseCfg = {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -9,7 +9,7 @@ import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramDirectConfig, TelegramGroupConfig } from "openclaw/plugin-sdk/config-runtime";
 import { ensureConfiguredAcpRouteReady } from "openclaw/plugin-sdk/conversation-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
-import { buildAgentSessionKey, deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
+import { deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
 import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -17,12 +17,11 @@ import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from 
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
 import { buildTelegramInboundContextPayload } from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
+import { buildTypingThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
 import {
-  buildTypingThreadParams,
-  resolveTelegramDirectPeerId,
-  resolveTelegramThreadSpec,
-} from "./bot/helpers.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
+  resolveTelegramConversationBaseSessionKey,
+  resolveTelegramConversationRoute,
+} from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
 import {
@@ -224,22 +223,13 @@ export const buildTelegramMessageContext = async ({
     return false;
   };
 
-  const baseSessionKey = isNamedAccountFallback
-    ? buildAgentSessionKey({
-        agentId: route.agentId,
-        channel: "telegram",
-        accountId: route.accountId,
-        peer: {
-          kind: "direct",
-          id: resolveTelegramDirectPeerId({
-            chatId,
-            senderId,
-          }),
-        },
-        dmScope: "per-account-channel-peer",
-        identityLinks: freshCfg.session?.identityLinks,
-      }).toLowerCase()
-    : route.sessionKey;
+  const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+    cfg: freshCfg,
+    route,
+    chatId,
+    isGroup,
+    senderId,
+  });
   // DMs: use thread suffix for session isolation (works regardless of dmScope)
   const threadKeys =
     dmThreadId != null

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -63,7 +63,10 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
+import {
+  resolveTelegramConversationBaseSessionKey,
+  resolveTelegramConversationRoute,
+} from "./conversation-route.js";
 import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import type { TelegramTransport } from "./fetch.js";
 import {
@@ -650,7 +653,13 @@ export const registerTelegramNativeCommands = ({
             });
             return;
           }
-          const baseSessionKey = route.sessionKey;
+          const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+            cfg,
+            route,
+            chatId,
+            isGroup,
+            senderId,
+          });
           // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
           const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
           const threadKeys =

--- a/extensions/telegram/src/conversation-route.base-session-key.test.ts
+++ b/extensions/telegram/src/conversation-route.base-session-key.test.ts
@@ -1,0 +1,64 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+import { describe, expect, it } from "vitest";
+import { resolveTelegramConversationBaseSessionKey } from "./conversation-route.js";
+
+describe("resolveTelegramConversationBaseSessionKey", () => {
+  const cfg: OpenClawConfig = {};
+
+  it("keeps the routed session key for the default account", () => {
+    expect(
+      resolveTelegramConversationBaseSessionKey({
+        cfg,
+        route: {
+          agentId: "main",
+          accountId: "default",
+          matchedBy: "default",
+          sessionKey: "agent:main:main",
+        },
+        chatId: 12345,
+        isGroup: false,
+        senderId: 12345,
+      }),
+    ).toBe("agent:main:main");
+  });
+
+  it("uses the per-account fallback key for named-account DMs without an explicit binding", () => {
+    expect(
+      resolveTelegramConversationBaseSessionKey({
+        cfg,
+        route: {
+          agentId: "main",
+          accountId: "personal",
+          matchedBy: "default",
+          sessionKey: "agent:main:main",
+        },
+        chatId: 12345,
+        isGroup: false,
+        senderId: 12345,
+      }),
+    ).toBe("agent:main:telegram:personal:direct:12345");
+  });
+
+  it("keeps DM topic isolation on the named-account fallback key", () => {
+    const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+      cfg,
+      route: {
+        agentId: "main",
+        accountId: "personal",
+        matchedBy: "default",
+        sessionKey: "agent:main:main",
+      },
+      chatId: 12345,
+      isGroup: false,
+      senderId: 12345,
+    });
+
+    expect(
+      resolveThreadSessionKeys({
+        baseSessionKey,
+        threadId: "12345:99",
+      }).sessionKey,
+    ).toBe("agent:main:telegram:personal:direct:12345:thread:12345:99");
+  });
+});

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/routing";
 import {
   buildAgentMainSessionKey,
+  DEFAULT_ACCOUNT_ID,
   resolveAgentIdFromSessionKey,
   sanitizeAgentId,
 } from "openclaw/plugin-sdk/routing";
@@ -147,4 +148,35 @@ export function resolveTelegramConversationRoute(params: {
     configuredBinding,
     configuredBindingSessionKey,
   };
+}
+
+export function resolveTelegramConversationBaseSessionKey(params: {
+  cfg: OpenClawConfig;
+  route: Pick<
+    ReturnType<typeof resolveTelegramConversationRoute>["route"],
+    "agentId" | "accountId" | "matchedBy" | "sessionKey"
+  >;
+  chatId: number | string;
+  isGroup: boolean;
+  senderId?: string | number | null;
+}): string {
+  const isNamedAccountFallback =
+    params.route.accountId !== DEFAULT_ACCOUNT_ID && params.route.matchedBy === "default";
+  if (!isNamedAccountFallback || params.isGroup) {
+    return params.route.sessionKey;
+  }
+  return buildAgentSessionKey({
+    agentId: params.route.agentId,
+    channel: "telegram",
+    accountId: params.route.accountId,
+    peer: {
+      kind: "direct",
+      id: resolveTelegramDirectPeerId({
+        chatId: params.chatId,
+        senderId: params.senderId,
+      }),
+    },
+    dmScope: "per-account-channel-peer",
+    identityLinks: params.cfg.session?.identityLinks,
+  }).toLowerCase();
 }


### PR DESCRIPTION
## Summary

- Problem: Telegram named-account DM topics could route normal messages to the per-account session while native `/status` still targeted `agent:main:main:thread:...`, creating a phantom empty session.
- Why it matters: `/status` would show `0` usage/context for a live thread even when the real session had token data.
- What changed: extracted a shared Telegram base-session-key resolver and used it in inbound message context building, native command routing, and Telegram session-state lookup.
- What did NOT change (scope boundary): no session-store migration, no cross-channel routing changes, no changes to default-account Telegram DM behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48204
- Related #9561

## User-visible / Behavior Changes

- Telegram named-account DM topics now resolve `/status` and related session lookups against the same canonical session key as inbound message handling.
- This avoids phantom `agent:main:main:thread:...` sessions winning over the real per-account Telegram session.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Vitest channel config
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): non-default Telegram account DM fallback with DM topics

### Steps

1. Configure a non-default Telegram account without an explicit DM binding.
2. Use a Telegram DM topic so inbound traffic lands on a thread session.
3. Run `/status` in that topic.

### Expected

- `/status` resolves the same canonical per-account Telegram thread session used by normal inbound message handling.

### Actual

- Before this change, native command routing could target `agent:main:main:thread:...` while normal traffic used `agent:main:telegram:<account>:direct:...:thread:...`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: named-account DM fallback key selection, DM topic thread suffixing, existing named-account DM message-context coverage.
- Edge cases checked: default account still keeps `agent:main:main`; named-account group traffic still does not use the DM fallback path.
- What you did **not** verify: full GitHub CI matrix and live Telegram roundtrip against a real bot.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous `route.sessionKey` call sites in Telegram routing.
- Files/config to restore: `extensions/telegram/src/conversation-route.ts`, `extensions/telegram/src/bot-message-context.ts`, `extensions/telegram/src/bot-native-commands.ts`, `extensions/telegram/src/bot-handlers.ts`
- Known bad symptoms reviewers should watch for: Telegram named-account DM topics resolving to the wrong session key again, or default-account DMs unexpectedly leaving `agent:main:main`.

## Risks and Mitigations

- Risk: another Telegram code path may still read `route.sessionKey` directly when it should use the normalized named-account DM base key.
  - Mitigation: centralize the fallback logic in `resolveTelegramConversationBaseSessionKey` and add targeted regression coverage for the helper and message-context path.
