### PR TITLE
fix(plugins): normalize speech plugin package ids

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -219,6 +219,46 @@ describe("discoverOpenClawPlugins", () => {
     expect(ids).not.toContain("ollama-provider");
   });
 
+  it("normalizes bundled speech package ids to canonical plugin ids", async () => {
+    const stateDir = makeTempDir();
+    const extensionsDir = path.join(stateDir, "extensions");
+    const elevenlabsDir = path.join(extensionsDir, "elevenlabs-speech-pack");
+    const microsoftDir = path.join(extensionsDir, "microsoft-speech-pack");
+
+    mkdirSafe(path.join(elevenlabsDir, "src"));
+    mkdirSafe(path.join(microsoftDir, "src"));
+
+    writePluginPackageManifest({
+      packageDir: elevenlabsDir,
+      packageName: "@openclaw/elevenlabs-speech",
+      extensions: ["./src/index.ts"],
+    });
+    writePluginPackageManifest({
+      packageDir: microsoftDir,
+      packageName: "@openclaw/microsoft-speech",
+      extensions: ["./src/index.ts"],
+    });
+
+    fs.writeFileSync(
+      path.join(elevenlabsDir, "src", "index.ts"),
+      "export default function () {}",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(microsoftDir, "src", "index.ts"),
+      "export default function () {}",
+      "utf-8",
+    );
+
+    const { candidates } = await discoverWithStateDir(stateDir, {});
+
+    const ids = candidates.map((c) => c.idHint);
+    expect(ids).toContain("elevenlabs");
+    expect(ids).toContain("microsoft");
+    expect(ids).not.toContain("elevenlabs-speech");
+    expect(ids).not.toContain("microsoft-speech");
+  });
+
   it("treats configured directory paths as plugin packages", async () => {
     const stateDir = makeTempDir();
     const packDir = path.join(stateDir, "packs", "demo-plugin-dir");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -16,6 +16,14 @@ import type { PluginBundleFormat, PluginDiagnostic, PluginFormat, PluginOrigin }
 
 const EXTENSION_EXTS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
 
+const CANONICAL_PACKAGE_ID_ALIASES: Record<string, string> = {
+  "elevenlabs-speech": "elevenlabs",
+  "microsoft-speech": "microsoft",
+  "ollama-provider": "ollama",
+  "sglang-provider": "sglang",
+  "vllm-provider": "vllm",
+};
+
 export type PluginCandidate = {
   idHint: string;
   source: string;
@@ -337,12 +345,7 @@ function deriveIdHint(params: {
   const unscoped = rawPackageName.includes("/")
     ? (rawPackageName.split("/").pop() ?? rawPackageName)
     : rawPackageName;
-  const canonicalPackageId =
-    {
-      "ollama-provider": "ollama",
-      "sglang-provider": "sglang",
-      "vllm-provider": "vllm",
-    }[unscoped] ?? unscoped;
+  const canonicalPackageId = CANONICAL_PACKAGE_ID_ALIASES[unscoped] ?? unscoped;
 
   if (!params.hasMultipleExtensions) {
     return canonicalPackageId;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled speech plugins are packaged as `@openclaw/elevenlabs-speech` and `@openclaw/microsoft-speech`, but plugin discovery derived entry hints directly from those package names.
- Why it matters: manifest validation warns on startup because the manifests use canonical ids `elevenlabs` and `microsoft`, and `openclaw doctor --fix` cannot repair runtime discovery mismatches.
- What changed: extended package-id normalization in `src/plugins/discovery.ts` so the speech package names map back to their canonical plugin ids, and added a regression test in `src/plugins/discovery.test.ts`.
- What did NOT change (scope boundary): plugin manifests, plugin runtime registration, and doctor fixup logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`openclaw doctor` and config validation no longer emit false `plugin id mismatch` warnings for the bundled `elevenlabs` and `microsoft` speech plugins.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3 / Darwin 25.3.0 (local and remote validation)
- Runtime/container: Node v25.4.0, pnpm 10.28.0
- Model/provider: N/A
- Integration/channel (if any): bundled speech plugins (`elevenlabs`, `microsoft`)
- Relevant config (redacted): existing `~/.openclaw` config on the reporter's mac-mini

### Steps

1. On the affected setup, run `pnpm openclaw doctor` from the repo checkout.
2. Observe warnings for `plugins.entries.elevenlabs` and `plugins.entries.microsoft` reporting manifest/entry-hint mismatches.
3. Apply this patch and rerun `pnpm openclaw doctor` against the same `~/.openclaw` state.

### Expected

- No mismatch warnings for the bundled speech plugins.

### Actual

- Before the fix, `doctor` reported `entry hints "elevenlabs-speech"` and `"microsoft-speech"`.
- After the fix, those warnings disappear while the rest of the doctor output remains unchanged aside from unrelated existing warnings.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local `pnpm build`; local `pnpm test -- src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`; remote mac-mini repro with `pnpm openclaw doctor`; remote isolated retest in `/tmp/openclaw-codex-test` after applying this patch.
- Edge cases checked: canonical provider aliases still covered by the existing `ollama-provider` normalization test, and the new test covers both bundled speech package names.
- What you did **not** verify: full end-to-end plugin loading beyond the existing `doctor` output, and unrelated existing `discord` plugin errors on the reporter's machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4196d784ff` or remove the two new alias mappings in `src/plugins/discovery.ts`.
- Files/config to restore: `src/plugins/discovery.ts`, `src/plugins/discovery.test.ts`
- Known bad symptoms reviewers should watch for: canonical ids regressing back to package-name suffixed ids during discovery.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: future capability-specific package suffixes could hit the same mismatch pattern if they are added without alias coverage.
  - Mitigation: the alias map is centralized now, and the regression test captures the current speech-package case explicitly.
