### PR TITLE
fix(healthcheck): use local timestamp context for cron alerts

### DIFF
--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -176,6 +176,7 @@ After OpenClaw install or first hardening pass, run at least one baseline audit 
 
 Ongoing monitoring is recommended. Use the OpenClaw cron tool/CLI to schedule periodic audits (Gateway scheduler). Do not create scheduled tasks without explicit approval. Store outputs in a user-approved location and avoid secrets in logs.
 When scheduling headless cron runs, include a note in the output that instructs the user to call `healthcheck` so issues can be fixed.
+If the scheduled output includes a timestamped heading (for example, security alerts or update notices), use the local timestamp from the injected `Current time:` line and avoid UTC-only headings unless the user explicitly asked for UTC.
 
 ### Required prompt to schedule (always)
 

--- a/src/agents/current-time.test.ts
+++ b/src/agents/current-time.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { appendCronStyleCurrentTimeLine, resolveCronStyleNow } from "./current-time.js";
+
+describe("resolveCronStyleNow", () => {
+  it("includes a compact local timestamp with offset for cron prompts", () => {
+    const cfg = {
+      agents: { defaults: { userTimezone: "America/New_York", timeFormat: "12" } },
+    } as OpenClawConfig;
+
+    const result = resolveCronStyleNow(cfg, Date.UTC(2026, 2, 3, 14, 0, 0));
+
+    expect(result.userTimezone).toBe("America/New_York");
+    expect(result.formattedTime).toBe("Tuesday, March 3rd, 2026 — 9:00 AM");
+    expect(result.timeLine).toBe(
+      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / Local: 2026-03-03 09:00 EST (-05:00) / UTC: 2026-03-03 14:00 UTC",
+    );
+  });
+
+  it("uses the configured timezone offset for Asia/Shanghai", () => {
+    const cfg = {
+      agents: { defaults: { userTimezone: "Asia/Shanghai", timeFormat: "24" } },
+    } as OpenClawConfig;
+
+    const result = resolveCronStyleNow(cfg, Date.UTC(2026, 2, 15, 6, 0, 0));
+
+    expect(result.timeLine).toContain("Current time: Sunday, March 15th, 2026 — 14:00");
+    expect(result.timeLine).toContain("(Asia/Shanghai)");
+    expect(result.timeLine).toContain("UTC: 2026-03-15 06:00 UTC");
+    expect(result.timeLine).toMatch(/Local: 2026-03-15 14:00 .+ \(\+08:00\)/);
+  });
+});
+
+describe("appendCronStyleCurrentTimeLine", () => {
+  it("does not append duplicate current-time lines", () => {
+    const cfg = {
+      agents: { defaults: { userTimezone: "America/New_York", timeFormat: "12" } },
+    } as OpenClawConfig;
+
+    const prompt = appendCronStyleCurrentTimeLine(
+      "Do the thing\nCurrent time: already present",
+      cfg,
+      Date.UTC(2026, 2, 3, 14, 0, 0),
+    );
+
+    expect(prompt).toBe("Do the thing\nCurrent time: already present");
+  });
+});

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -4,6 +4,8 @@ import {
   resolveUserTimeFormat,
   resolveUserTimezone,
 } from "./date-time.js";
+import { formatZonedTimestamp } from "../infra/format-time/format-datetime.js";
+import { formatLocalIsoWithOffset } from "../logging/timestamps.js";
 
 export type CronStyleNow = {
   userTimezone: string;
@@ -21,12 +23,20 @@ type TimeConfigLike = {
 };
 
 export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronStyleNow {
+  const now = new Date(nowMs);
   const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
   const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
   const formattedTime =
-    formatUserTime(new Date(nowMs), userTimezone, userTimeFormat) ?? new Date(nowMs).toISOString();
-  const utcTime = new Date(nowMs).toISOString().replace("T", " ").slice(0, 16) + " UTC";
-  const timeLine = `Current time: ${formattedTime} (${userTimezone}) / ${utcTime}`;
+    formatUserTime(now, userTimezone, userTimeFormat) ?? now.toISOString();
+  const compactLocalTime = formatZonedTimestamp(now, { timeZone: userTimezone });
+  const localIsoWithOffset = formatLocalIsoWithOffset(now, userTimezone);
+  const offset = localIsoWithOffset.match(/([+-]\d{2}:\d{2})$/)?.[1];
+  const localTimeDetail =
+    compactLocalTime && offset
+      ? `${compactLocalTime} (${offset})`
+      : compactLocalTime ?? localIsoWithOffset;
+  const utcTime = now.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  const timeLine = `Current time: ${formattedTime} (${userTimezone}) / Local: ${localTimeDetail} / UTC: ${utcTime}`;
   return { userTimezone, formattedTime, timeLine };
 }
 

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -25,7 +25,7 @@ describe("resolveMemoryFlushPromptForRun", () => {
 
     expect(prompt).toContain("memory/2026-02-16.md");
     expect(prompt).toContain(
-      "Current time: Monday, February 16th, 2026 — 10:00 AM (America/New_York) / 2026-02-16 15:00 UTC",
+      "Current time: Monday, February 16th, 2026 — 10:00 AM (America/New_York) / Local: 2026-02-16 10:00 EST (-05:00) / UTC: 2026-02-16 15:00 UTC",
     );
   });
 

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -212,7 +212,7 @@ Never modify memory/YYYY-MM-DD.md destructively.
     expect(result).toContain("memory/2026-03-03.md");
     expect(result).not.toContain("memory/YYYY-MM-DD.md");
     expect(result).toContain(
-      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / 2026-03-03 14:00 UTC",
+      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / Local: 2026-03-03 09:00 EST (-05:00) / UTC: 2026-03-03 14:00 UTC",
     );
   });
 

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -17,7 +17,7 @@ describe("buildBareSessionResetPrompt", () => {
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(cfg, nowMs);
     expect(prompt).toContain(
-      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / 2026-03-03 14:00 UTC",
+      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / Local: 2026-03-03 09:00 EST (-05:00) / UTC: 2026-03-03 14:00 UTC",
     );
   });
 

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -279,7 +279,9 @@ describe("runCronIsolatedAgentTurn", () => {
       const lines = call?.prompt?.split("\n") ?? [];
       expect(lines[0]).toContain("[cron:job-1");
       expect(lines[0]).toContain("do it");
-      expect(lines[1]).toMatch(/^Current time: .+ \(.+\) \/ \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/);
+      expect(lines[1]).toMatch(
+        /^Current time: .+ \(.+\) \/ Local: \d{4}-\d{2}-\d{2} \d{2}:\d{2}.+ \([+-]\d{2}:\d{2}\) \/ UTC: \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- add a compact local timestamp with offset to the cron-injected `Current time:` context so scheduled healthcheck runs expose a copyable local wall-clock time
- update the `healthcheck` skill guidance to prefer that local timestamp for scheduled alert/update headings instead of UTC-only headings
- cover the new timestamp shape with focused tests and update downstream prompt assertions

Closes #48688.

## Testing
- `pnpm -C /tmp/openclaw-main-48688 exec vitest run src/agents/current-time.test.ts src/auto-reply/reply/session-reset-prompt.test.ts src/auto-reply/reply/post-compaction-context.test.ts src/auto-reply/reply/memory-flush.test.ts`

## Notes
- `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts` and `src/gateway/server-methods/server-methods.test.ts` hit existing import-time failures in this environment (`formatDocsLink` / `formatCliCommand` missing from extension setup surfaces) before their own test cases run. That noise is unrelated to this timestamp change.
