### PR TITLE
fix(security): respect top-level restriction for Telegram group allowFrom wildcard

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -761,8 +761,9 @@ export async function collectChannelSecurityFindings(params: {
         target: invalidTelegramAllowFromEntries,
       });
       let anyGroupOverride = false;
+      const groupLevelWildcards: string[] = [];
       if (groups) {
-        for (const value of Object.values(groups)) {
+        for (const [groupId, value] of Object.entries(groups)) {
           if (!value || typeof value !== "object") {
             continue;
           }
@@ -770,6 +771,9 @@ export async function collectChannelSecurityFindings(params: {
           const allowFrom = Array.isArray(group.allowFrom) ? group.allowFrom : [];
           if (allowFrom.length > 0) {
             anyGroupOverride = true;
+            if (allowFrom.some((v) => String(v).trim() === "*")) {
+              groupLevelWildcards.push(`channels.telegram.groups.${groupId}.allowFrom`);
+            }
             await collectInvalidTelegramAllowFromEntries({
               entries: allowFrom,
               target: invalidTelegramAllowFromEntries,
@@ -779,7 +783,7 @@ export async function collectChannelSecurityFindings(params: {
           if (!topics || typeof topics !== "object") {
             continue;
           }
-          for (const topicValue of Object.values(topics as Record<string, unknown>)) {
+          for (const [topicId, topicValue] of Object.entries(topics as Record<string, unknown>)) {
             if (!topicValue || typeof topicValue !== "object") {
               continue;
             }
@@ -787,6 +791,9 @@ export async function collectChannelSecurityFindings(params: {
             const topicAllow = Array.isArray(topic.allowFrom) ? topic.allowFrom : [];
             if (topicAllow.length > 0) {
               anyGroupOverride = true;
+              if (topicAllow.some((v) => String(v).trim() === "*")) {
+                groupLevelWildcards.push(`channels.telegram.groups.${groupId}.topics.${topicId}.allowFrom`);
+              }
             }
             await collectInvalidTelegramAllowFromEntries({
               entries: topicAllow,
@@ -798,6 +805,36 @@ export async function collectChannelSecurityFindings(params: {
 
       const hasAnySenderAllowlist =
         storeAllowFrom.length > 0 || groupAllowFrom.length > 0 || anyGroupOverride;
+
+      const hasTopLevelRestriction =
+        (groupAllowFrom.length > 0 && !groupAllowFromHasWildcard) ||
+        (storeAllowFrom.length > 0 && !storeHasWildcard);
+
+      if (storeHasWildcard || groupAllowFromHasWildcard) {
+        findings.push({
+          checkId: "channels.telegram.groups.allowFrom.wildcard",
+          severity: "critical",
+          title: "Telegram group allowlist contains wildcard",
+          detail:
+            'Telegram group sender allowlist contains "*", which allows any group member to run /… commands and control directives.',
+          remediation:
+            'Remove "*" from channels.telegram.groupAllowFrom and pairing store; prefer explicit numeric Telegram user IDs.',
+        });
+        continue;
+      }
+
+      if (groupLevelWildcards.length > 0 && !hasTopLevelRestriction) {
+        findings.push({
+          checkId: "channels.telegram.groups.group_allowFrom.wildcard",
+          severity: "critical",
+          title: "Telegram group allowlist contains wildcard",
+          detail:
+            `Per-group sender allowlist contains "*" at:\n${groupLevelWildcards.map((p) => `- ${p}`).join("\n")}\n` +
+            'This allows any group member to run /… commands and control directives.',
+          remediation:
+            'Remove "*" from per-group allowFrom, or set channels.telegram.groupAllowFrom to restrict access globally.',
+        });
+      }
 
       if (invalidTelegramAllowFromEntries.size > 0) {
         const examples = Array.from(invalidTelegramAllowFromEntries).slice(0, 5);
@@ -815,19 +852,6 @@ export async function collectChannelSecurityFindings(params: {
           remediation:
             "Replace @username entries with numeric Telegram user IDs (use setup to resolve), then re-run the audit.",
         });
-      }
-
-      if (storeHasWildcard || groupAllowFromHasWildcard) {
-        findings.push({
-          checkId: "channels.telegram.groups.allowFrom.wildcard",
-          severity: "critical",
-          title: "Telegram group allowlist contains wildcard",
-          detail:
-            'Telegram group sender allowlist contains "*", which allows any group member to run /… commands and control directives.',
-          remediation:
-            'Remove "*" from channels.telegram.groupAllowFrom and pairing store; prefer explicit numeric Telegram user IDs.',
-        });
-        continue;
       }
 
       if (!hasAnySenderAllowlist) {

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -807,8 +807,25 @@ export async function collectChannelSecurityFindings(params: {
         storeAllowFrom.length > 0 || groupAllowFrom.length > 0 || anyGroupOverride;
 
       const hasTopLevelRestriction =
-        (groupAllowFrom.length > 0 && !groupAllowFromHasWildcard) ||
-        (storeAllowFrom.length > 0 && !storeHasWildcard);
+        groupAllowFrom.length > 0 && !groupAllowFromHasWildcard;
+
+      if (invalidTelegramAllowFromEntries.size > 0) {
+        const examples = Array.from(invalidTelegramAllowFromEntries).slice(0, 5);
+        const more =
+          invalidTelegramAllowFromEntries.size > examples.length
+            ? ` (+${invalidTelegramAllowFromEntries.size - examples.length} more)`
+            : "";
+        findings.push({
+          checkId: "channels.telegram.allowFrom.invalid_entries",
+          severity: "warn",
+          title: "Telegram allowlist contains non-numeric entries",
+          detail:
+            "Telegram sender authorization requires numeric Telegram user IDs. " +
+            `Found non-numeric allowFrom entries: ${examples.join(", ")}${more}.`,
+          remediation:
+            "Replace @username entries with numeric Telegram user IDs (use setup to resolve), then re-run the audit.",
+        });
+      }
 
       if (storeHasWildcard || groupAllowFromHasWildcard) {
         findings.push({
@@ -834,24 +851,7 @@ export async function collectChannelSecurityFindings(params: {
           remediation:
             'Remove "*" from per-group allowFrom, or set channels.telegram.groupAllowFrom to restrict access globally.',
         });
-      }
-
-      if (invalidTelegramAllowFromEntries.size > 0) {
-        const examples = Array.from(invalidTelegramAllowFromEntries).slice(0, 5);
-        const more =
-          invalidTelegramAllowFromEntries.size > examples.length
-            ? ` (+${invalidTelegramAllowFromEntries.size - examples.length} more)`
-            : "";
-        findings.push({
-          checkId: "channels.telegram.allowFrom.invalid_entries",
-          severity: "warn",
-          title: "Telegram allowlist contains non-numeric entries",
-          detail:
-            "Telegram sender authorization requires numeric Telegram user IDs. " +
-            `Found non-numeric allowFrom entries: ${examples.join(", ")}${more}.`,
-          remediation:
-            "Replace @username entries with numeric Telegram user IDs (use setup to resolve), then re-run the audit.",
-        });
+        continue;
       }
 
       if (!hasAnySenderAllowlist) {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2723,6 +2723,77 @@ description: test skill
     });
   });
 
+  it("does not flag Telegram group-level allowFrom wildcard when top-level groupAllowFrom is restricted", async () => {
+    await withChannelSecurityStateDir(async () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: "t",
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["123456"],
+            groups: {
+              "-100123": {
+                requireMention: true,
+                allowFrom: ["*"],
+              },
+            },
+          },
+        },
+      };
+
+      const res = await runSecurityAudit({
+        config: cfg,
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+        plugins: [telegramPlugin],
+      });
+
+      expect(
+        res.findings.find(
+          (f) =>
+            f.checkId === "channels.telegram.groups.group_allowFrom.wildcard",
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  it("flags Telegram group-level allowFrom wildcard as critical when no top-level restriction", async () => {
+    await withChannelSecurityStateDir(async () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: "t",
+            groupPolicy: "allowlist",
+            groups: {
+              "-100123": {
+                requireMention: true,
+                allowFrom: ["*"],
+              },
+            },
+          },
+        },
+      };
+
+      const res = await runSecurityAudit({
+        config: cfg,
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+        plugins: [telegramPlugin],
+      });
+
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            checkId: "channels.telegram.groups.group_allowFrom.wildcard",
+            severity: "critical",
+          }),
+        ]),
+      );
+    });
+  });
+
   it("adds probe_failed warnings for deep probe failure modes", async () => {
     const cfg: OpenClawConfig = { gateway: { mode: "local" } };
     const cases: Array<{


### PR DESCRIPTION
## Summary

- Security audit now correctly handles per-group `allowFrom` wildcard when top-level `groupAllowFrom` is already restricted
- Previously, the audit only checked top-level wildcards but missed group-level ones
- Fixes false CRITICAL alerts for intentional configurations where group-level wildcard is safe due to top-level restriction

## Changes

1. Added detection of wildcard in `groups.<id>.allowFrom` and `groups.<id>.topics.<topicId>.allowFrom`
2. Added `hasTopLevelRestriction` check to verify if top-level `groupAllowFrom` or pairing store restricts access
3. Only report CRITICAL for group-level wildcard when no top-level restriction exists

## Test plan

- Added test: verifies no CRITICAL when top-level `groupAllowFrom` is restricted
- Added test: verifies CRITICAL when no top-level restriction exists

Closes #48687