### PR TITLE
fix(doctor): clarify best-effort config note

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -70,6 +70,25 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("clarifies that best-effort config does not unblock gateway startup", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      await runDoctorConfigWithInput({
+        config: {
+          gateway: { auth: { mode: "token", token: 123 } },
+        },
+        run: loadAndMaybeMigrateDoctorConfig,
+      });
+
+      expect(noteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Gateway startup remains blocked until the config is fixed."),
+        "Config",
+      );
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("does not warn on mutable account allowlists when dangerous name matching is inherited", async () => {
     const doctorWarnings = await collectDoctorWarnings({
       channels: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1675,7 +1675,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let shouldWriteConfig = false;
   const fixHints: string[] = [];
   if (snapshot.exists && !snapshot.valid && snapshot.legacyIssues.length === 0) {
-    note("Config invalid; doctor will run with best-effort config.", "Config");
+    note(
+      "Config invalid; doctor will run with best-effort config for diagnostics only. Gateway startup remains blocked until the config is fixed.",
+      "Config",
+    );
     noteIncludeConfinementWarning(snapshot);
   }
   const warnings = snapshot.warnings ?? [];


### PR DESCRIPTION
## Summary
- clarify that doctor's best-effort config path is diagnostics-only
- explicitly state that gateway startup stays blocked until the config is fixed
- add a regression test for the note text

Fixes #40651.

## Testing
- pnpm -C /tmp/openclaw-main-40651 exec vitest run src/commands/doctor-config-flow.test.ts
- git -C /tmp/openclaw-main-40651 diff --check