### PR TITLE
fix(healthcheck): respect brew install update guidance

### DIFF
--- a/src/commands/status.update.test.ts
+++ b/src/commands/status.update.test.ts
@@ -109,6 +109,18 @@ describe("formatUpdateOneLiner", () => {
 
     expect(formatUpdateOneLiner(update)).toBe("Update: npm · npm latest unknown · deps missing");
   });
+
+  it("renders Homebrew installs as brew in package mode", () => {
+    const latestVersion = nextMajorVersion(VERSION);
+    const update = buildUpdate({
+      root: "/opt/homebrew/Cellar/openclaw/2026.3.13/libexec/lib/node_modules/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+      registry: { latestVersion },
+    });
+
+    expect(formatUpdateOneLiner(update)).toBe(`Update: brew · brew update ${latestVersion}`);
+  });
 });
 
 describe("formatUpdateAvailableHint", () => {
@@ -142,6 +154,34 @@ describe("formatUpdateAvailableHint", () => {
 
     expect(formatUpdateAvailableHint(update)).toBe(
       `Update available (git behind 2 · npm ${latestVersion}). Run: openclaw update`,
+    );
+  });
+
+  it("renders Homebrew-specific update guidance for package installs", () => {
+    const latestVersion = nextMajorVersion(VERSION);
+    const update = buildUpdate({
+      root: "/opt/homebrew/Cellar/openclaw/2026.3.13/libexec/lib/node_modules/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+      registry: { latestVersion },
+    });
+
+    expect(formatUpdateAvailableHint(update)).toBe(
+      `Update available (brew ${latestVersion}). Run: brew upgrade openclaw`,
+    );
+  });
+
+  it("renders pnpm-specific update guidance for package installs", () => {
+    const latestVersion = nextMajorVersion(VERSION);
+    const update = buildUpdate({
+      root: "/Users/test/.local/share/pnpm/global/5/node_modules/openclaw",
+      installKind: "package",
+      packageManager: "pnpm",
+      registry: { latestVersion },
+    });
+
+    expect(formatUpdateAvailableHint(update)).toBe(
+      `Update available (pnpm ${latestVersion}). Run: pnpm add -g openclaw@latest`,
     );
   });
 });

--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -3,6 +3,8 @@ import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import {
   checkUpdateStatus,
   compareSemverStrings,
+  formatPackageInstallLabel,
+  formatPackageUpdateCommand,
   type UpdateCheckResult,
 } from "../infra/update-check.js";
 import { VERSION } from "../version.js";
@@ -63,29 +65,43 @@ export function formatUpdateAvailableHint(update: UpdateCheckResult): string | n
     details.push(`git behind ${availability.gitBehind}`);
   }
   if (availability.hasRegistryUpdate && availability.latestVersion) {
-    details.push(`npm ${availability.latestVersion}`);
+    const registryLabel =
+      update.installKind === "package"
+        ? formatPackageInstallLabel({
+            root: update.root,
+            packageManager: update.packageManager,
+          })
+        : "npm";
+    details.push(`${registryLabel} ${availability.latestVersion}`);
   }
   const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
-  return `Update available${suffix}. Run: ${formatCliCommand("openclaw update")}`;
+  const updateCommand =
+    update.installKind === "package"
+      ? formatPackageUpdateCommand({
+          root: update.root,
+          packageManager: update.packageManager,
+        })
+      : "openclaw update";
+  return `Update available${suffix}. Run: ${formatCliCommand(updateCommand)}`;
 }
 
 export function formatUpdateOneLiner(update: UpdateCheckResult): string {
   const parts: string[] = [];
 
-  const appendRegistryUpdateSummary = () => {
+  const appendRegistryUpdateSummary = (registryLabel: string) => {
     if (update.registry?.latestVersion) {
       const cmp = compareSemverStrings(VERSION, update.registry.latestVersion);
       if (cmp === 0) {
-        parts.push(`npm latest ${update.registry.latestVersion}`);
+        parts.push(`${registryLabel} latest ${update.registry.latestVersion}`);
       } else if (cmp != null && cmp < 0) {
-        parts.push(`npm update ${update.registry.latestVersion}`);
+        parts.push(`${registryLabel} update ${update.registry.latestVersion}`);
       } else {
-        parts.push(`npm latest ${update.registry.latestVersion} (local newer)`);
+        parts.push(`${registryLabel} latest ${update.registry.latestVersion} (local newer)`);
       }
       return;
     }
     if (update.registry?.error) {
-      parts.push("npm latest unknown");
+      parts.push(`${registryLabel} latest unknown`);
     }
   };
 
@@ -112,10 +128,14 @@ export function formatUpdateOneLiner(update: UpdateCheckResult): string {
     if (update.git.fetchOk === false) {
       parts.push("fetch failed");
     }
-    appendRegistryUpdateSummary();
+    appendRegistryUpdateSummary("npm");
   } else {
-    parts.push(update.packageManager !== "unknown" ? update.packageManager : "pkg");
-    appendRegistryUpdateSummary();
+    const packageLabel = formatPackageInstallLabel({
+      root: update.root,
+      packageManager: update.packageManager,
+    });
+    parts.push(packageLabel);
+    appendRegistryUpdateSummary(packageLabel);
   }
 
   if (update.deps) {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -108,18 +108,20 @@ export function formatPackageInstallLabel(params: {
 export function formatPackageUpdateCommand(params: {
   root: string | null;
   packageManager: PackageManager;
+  tag?: string | null;
 }): string {
   if (detectPackageInstallSource(params.root) === "brew") {
     return "brew upgrade openclaw";
   }
+  const tag = params.tag?.trim() || "latest";
   if (params.packageManager === "pnpm") {
-    return "pnpm add -g openclaw@latest";
+    return `pnpm add -g openclaw@${tag}`;
   }
   if (params.packageManager === "npm") {
-    return "npm install -g openclaw@latest";
+    return `npm install -g openclaw@${tag}`;
   }
   if (params.packageManager === "bun") {
-    return "bun add -g openclaw@latest";
+    return `bun add -g openclaw@${tag}`;
   }
   return "openclaw update";
 }

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -48,6 +48,8 @@ export type UpdateCheckResult = {
   registry?: RegistryStatus;
 };
 
+export type PackageInstallSource = "brew" | "package" | "unknown";
+
 export function formatGitInstallLabel(update: UpdateCheckResult): string | null {
   if (update.installKind !== "git") {
     return null;
@@ -61,6 +63,65 @@ export function formatGitInstallLabel(update: UpdateCheckResult): string | null 
     shortSha ? `@ ${shortSha}` : null,
   ].filter(Boolean);
   return parts.join(" · ");
+}
+
+function normalizeRootForInstallSource(root: string | null): string | null {
+  if (!root) {
+    return null;
+  }
+  return path.resolve(root).replace(/\\/g, "/");
+}
+
+export function detectPackageInstallSource(root: string | null): PackageInstallSource {
+  const normalized = normalizeRootForInstallSource(root);
+  if (!normalized) {
+    return "unknown";
+  }
+
+  const brewMarkers = [
+    "/opt/homebrew/Cellar/openclaw/",
+    "/opt/homebrew/opt/openclaw/",
+    "/usr/local/Cellar/openclaw/",
+    "/usr/local/opt/openclaw/",
+    "/home/linuxbrew/.linuxbrew/Cellar/openclaw/",
+    "/home/linuxbrew/.linuxbrew/opt/openclaw/",
+    "/.linuxbrew/Cellar/openclaw/",
+    "/.linuxbrew/opt/openclaw/",
+  ];
+  if (brewMarkers.some((marker) => normalized.includes(marker))) {
+    return "brew";
+  }
+
+  return "package";
+}
+
+export function formatPackageInstallLabel(params: {
+  root: string | null;
+  packageManager: PackageManager;
+}): string {
+  if (detectPackageInstallSource(params.root) === "brew") {
+    return "brew";
+  }
+  return params.packageManager !== "unknown" ? params.packageManager : "pkg";
+}
+
+export function formatPackageUpdateCommand(params: {
+  root: string | null;
+  packageManager: PackageManager;
+}): string {
+  if (detectPackageInstallSource(params.root) === "brew") {
+    return "brew upgrade openclaw";
+  }
+  if (params.packageManager === "pnpm") {
+    return "pnpm add -g openclaw@latest";
+  }
+  if (params.packageManager === "npm") {
+    return "npm install -g openclaw@latest";
+  }
+  if (params.packageManager === "bun") {
+    return "bun add -g openclaw@latest";
+  }
+  return "openclaw update";
 }
 
 async function exists(p: string): Promise<boolean> {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -241,6 +241,26 @@ describe("update-startup", () => {
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("Run: brew upgrade openclaw"));
   });
 
+  it("keeps beta package installs on the beta tag in update hints", async () => {
+    mockPackageInstallStatus();
+    mockNpmChannelTag("beta", "2.0.0-beta.1");
+
+    const log = { info: vi.fn() };
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "beta" } },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("update available (beta): v2.0.0-beta.1"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Run: npm install -g openclaw@beta"),
+    );
+  });
+
   it("hydrates cached update from persisted state during throttle window", async () => {
     const statePath = path.join(tempDir, "update-check.json");
     await fs.writeFile(

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -9,7 +9,8 @@ vi.mock("./openclaw-root.js", () => ({
   resolveOpenClawPackageRoot: vi.fn(),
 }));
 
-vi.mock("./update-check.js", async () => {
+vi.mock("./update-check.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./update-check.js")>();
   const parse = (value: string) => value.split(".").map((part) => Number.parseInt(part, 10));
   const compareSemverStrings = (a: string, b: string) => {
     const left = parse(a);
@@ -25,6 +26,7 @@ vi.mock("./update-check.js", async () => {
   };
 
   return {
+    ...actual,
     checkUpdateStatus: vi.fn(),
     compareSemverStrings,
     resolveNpmChannelTag: vi.fn(),
@@ -215,6 +217,28 @@ describe("update-startup", () => {
     expect(parsed.lastNotifiedVersion).toBe("2.0.0");
     expect(parsed.lastAvailableVersion).toBe("2.0.0");
     expect(parsed.lastNotifiedTag).toBe("latest");
+  });
+
+  it("logs Homebrew update guidance for brew package installs", async () => {
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(
+      "/opt/homebrew/Cellar/openclaw/2.0.0/libexec/lib/node_modules/openclaw",
+    );
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/opt/homebrew/Cellar/openclaw/2.0.0/libexec/lib/node_modules/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    mockNpmChannelTag("latest", "2.0.0");
+
+    const log = { info: vi.fn() };
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "stable" } },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+    });
+
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("Run: brew upgrade openclaw"));
   });
 
   it("hydrates cached update from persisted state during throttle window", async () => {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -9,7 +9,12 @@ import { VERSION } from "../version.js";
 import { writeJsonAtomic } from "./json-files.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
-import { compareSemverStrings, resolveNpmChannelTag, checkUpdateStatus } from "./update-check.js";
+import {
+  checkUpdateStatus,
+  compareSemverStrings,
+  formatPackageUpdateCommand,
+  resolveNpmChannelTag,
+} from "./update-check.js";
 
 type UpdateCheckState = {
   lastCheckedAt?: string;
@@ -399,8 +404,12 @@ export async function runGatewayUpdateCheck(params: {
     const shouldNotify =
       state.lastNotifiedVersion !== resolved.version || state.lastNotifiedTag !== tag;
     if (shouldRunUpdateHints && shouldNotify) {
+      const updateCommand = formatPackageUpdateCommand({
+        root: status.root,
+        packageManager: status.packageManager,
+      });
       params.log.info(
-        `update available (${tag}): v${resolved.version} (current v${VERSION}). Run: ${formatCliCommand("openclaw update")}`,
+        `update available (${tag}): v${resolved.version} (current v${VERSION}). Run: ${formatCliCommand(updateCommand)}`,
       );
       nextState.lastNotifiedVersion = resolved.version;
       nextState.lastNotifiedTag = tag;

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -407,6 +407,7 @@ export async function runGatewayUpdateCheck(params: {
       const updateCommand = formatPackageUpdateCommand({
         root: status.root,
         packageManager: status.packageManager,
+        tag,
       });
       params.log.info(
         `update available (${tag}): v${resolved.version} (current v${VERSION}). Run: ${formatCliCommand(updateCommand)}`,


### PR DESCRIPTION
## Summary
- detect Homebrew package installs from the resolved OpenClaw package root
- show install-specific update guidance in status and startup hints for brew, npm, pnpm, and bun installs
- add regression coverage for brew/pnpm hint rendering and startup logging

Fixes #48691.

## Testing
- pnpm -C /tmp/openclaw-main-48691 exec vitest run src/commands/status.update.test.ts src/infra/update-startup.test.ts
- git -C /tmp/openclaw-main-48691 diff --check