### PR TITLE
docs(browser): use wss for Browserless CDP URL

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -225,7 +225,7 @@ Notes:
 Some hosted browser services expose a **direct WebSocket** endpoint rather than
 the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
 
-- **HTTP(S) endpoints** (e.g. Browserless) — OpenClaw calls `/json/version` to
+- **HTTP(S) endpoints** — OpenClaw calls `/json/version` to
   discover the WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -191,7 +191,7 @@ Notes:
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
+CDP endpoints over WebSocket. You can point an OpenClaw browser profile at a
 Browserless region endpoint and authenticate with your API key.
 
 Example:
@@ -205,7 +205,7 @@ Example:
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },
@@ -217,6 +217,8 @@ Notes:
 
 - Replace `<BROWSERLESS_API_KEY>` with your real Browserless token.
 - Choose the region endpoint that matches your Browserless account (see their docs).
+- Use `wss://` for `cdpUrl`; Browserless REST endpoints may use `https://`, but
+  Chrome DevTools Protocol connections must use WebSocket.
 
 ## Direct WebSocket CDP providers
 

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -152,7 +152,7 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
 
 ## Browserless（托管远程 CDP）
 
-[Browserless](https://browserless.io) 是一个托管的 Chromium 服务，通过 HTTPS 暴露 CDP 端点。你可以将 OpenClaw 浏览器配置文件指向 Browserless 区域端点，并使用你的 API 密钥进行认证。
+[Browserless](https://browserless.io) 是一个托管的 Chromium 服务，通过 WebSocket 暴露 CDP 端点。你可以将 OpenClaw 浏览器配置文件指向 Browserless 区域端点，并使用你的 API 密钥进行认证。
 
 示例：
 
@@ -165,7 +165,7 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },
@@ -177,6 +177,8 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
 
 - 将 `<BROWSERLESS_API_KEY>` 替换为你真实的 Browserless 令牌。
 - 选择与你的 Browserless 账户匹配的区域端点（请参阅其文档）。
+- `cdpUrl` 需要使用 `wss://`；Browserless 的 REST 接口可能是 `https://`，
+  但 Chrome DevTools Protocol 连接必须走 WebSocket。
 
 ## 安全性
 


### PR DESCRIPTION
## Summary
- switch the Browserless CDP example from https:// to wss:// in EN and zh-CN docs
- clarify that Browserless REST endpoints may use HTTPS while CDP connections must use WebSocket

Fixes #44992.

## Testing
- git -C /tmp/openclaw-main-44992 diff --check