### PR TITLE
docs(provider): point claude-max-api-proxy links to maintained fork

### DIFF
--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -138,8 +138,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## Links
 
 - **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/atalovesyou/claude-max-api-proxy](https://github.com/atalovesyou/claude-max-api-proxy)
-- **Issues:** [https://github.com/atalovesyou/claude-max-api-proxy/issues](https://github.com/atalovesyou/claude-max-api-proxy/issues)
+- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 

--- a/docs/zh-CN/providers/claude-max-api-proxy.md
+++ b/docs/zh-CN/providers/claude-max-api-proxy.md
@@ -139,8 +139,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## 链接
 
 - **npm:** https://www.npmjs.com/package/claude-max-api-proxy
-- **GitHub:** https://github.com/atalovesyou/claude-max-api-proxy
-- **Issues:** https://github.com/atalovesyou/claude-max-api-proxy/issues
+- **GitHub:** https://github.com/wende/claude-max-api-proxy
+- **Issues:** https://github.com/wende/claude-max-api-proxy/issues
 
 ## 注意事项
 


### PR DESCRIPTION
## Summary
- update the Claude Max API Proxy provider docs to point GitHub and Issues links at the maintained fork
- mirror the link fix in the zh-CN provider page

Fixes #20260.

## Testing
- git -C /tmp/openclaw-main-20260 diff --check