### PR TITLE
feat(feishu): enable /focus and /unfocus commands + fix ACP block delivery

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -210,6 +210,8 @@ export function spawnWithResolvedCommand(
     params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
   );
   childEnv.OPENCLAW_SHELL = "acp";
+  // Strip CLAUDECODE env var so spawned ACP processes don't inherit it.
+  delete childEnv.CLAUDECODE;
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -981,18 +981,24 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         accountId: ctx.accountId,
         kind: "subagent",
       });
+      let tbManager: Awaited<ReturnType<typeof createFeishuThreadBindingManager>> | null = null;
       if (threadBindingPolicy.enabled) {
-        createFeishuThreadBindingManager({
+        tbManager = createFeishuThreadBindingManager({
           accountId: ctx.accountId,
           cfg: ctx.cfg,
         });
       }
-      return monitorFeishuProvider({
-        config: ctx.cfg,
-        runtime: ctx.runtime,
-        abortSignal: ctx.abortSignal,
-        accountId: ctx.accountId,
-      });
+      try {
+        return await monitorFeishuProvider({
+          config: ctx.cfg,
+          runtime: ctx.runtime,
+          abortSignal: ctx.abortSignal,
+          accountId: ctx.accountId,
+        });
+      } catch (err) {
+        tbManager?.stop();
+        throw err;
+      }
     },
     stopAccount: async (ctx) => {
       const { getFeishuThreadBindingManager } = await import("./thread-bindings.js");

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -966,18 +966,40 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const { monitorFeishuProvider } = await import("./monitor.js");
+      const { createFeishuThreadBindingManager } = await import("./thread-bindings.js");
+      const { resolveThreadBindingSpawnPolicy } = await import("openclaw/plugin-sdk/feishu");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
       ctx.setStatus({ accountId: ctx.accountId, port });
       ctx.log?.info(
         `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
       );
+      // Initialize thread binding manager so /focus can bind sessions to Feishu conversations.
+      const threadBindingPolicy = resolveThreadBindingSpawnPolicy({
+        cfg: ctx.cfg,
+        channel: "feishu",
+        accountId: ctx.accountId,
+        kind: "subagent",
+      });
+      if (threadBindingPolicy.enabled) {
+        createFeishuThreadBindingManager({
+          accountId: ctx.accountId,
+          cfg: ctx.cfg,
+        });
+      }
       return monitorFeishuProvider({
         config: ctx.cfg,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         accountId: ctx.accountId,
       });
+    },
+    stopAccount: async (ctx) => {
+      const { getFeishuThreadBindingManager } = await import("./thread-bindings.js");
+      const manager = getFeishuThreadBindingManager(ctx.accountId);
+      if (manager) {
+        manager.stop();
+      }
     },
   },
 };

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -45,6 +45,10 @@ import { resolveFeishuOutboundSessionRoute } from "./session-route.js";
 import { feishuSetupAdapter } from "./setup-core.js";
 import { feishuSetupWizard } from "./setup-surface.js";
 import { normalizeFeishuTarget, looksLikeFeishuId, formatFeishuTarget } from "./targets.js";
+import {
+  createFeishuThreadBindingManager,
+  getFeishuThreadBindingManager,
+} from "./thread-bindings.js";
 import type { ResolvedFeishuAccount, FeishuConfig } from "./types.js";
 
 const meta: ChannelMeta = {
@@ -966,7 +970,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const { monitorFeishuProvider } = await import("./monitor.js");
-      const { createFeishuThreadBindingManager } = await import("./thread-bindings.js");
       const { resolveThreadBindingSpawnPolicy } = await import("openclaw/plugin-sdk/feishu");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
@@ -1001,7 +1004,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       }
     },
     stopAccount: async (ctx) => {
-      const { getFeishuThreadBindingManager } = await import("./thread-bindings.js");
       const manager = getFeishuThreadBindingManager(ctx.accountId);
       if (manager) {
         manager.stop();

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -70,6 +70,20 @@ const ChannelHeartbeatVisibilitySchema = z
   .optional();
 
 /**
+ * Thread binding configuration for /focus and session binding features.
+ */
+const ThreadBindingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    idleHours: z.number().nonnegative().optional(),
+    maxAgeHours: z.number().nonnegative().optional(),
+    spawnSubagentSessions: z.boolean().optional(),
+    spawnAcpSessions: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Dynamic agent creation configuration.
  * When enabled, a new agent is created for each unique DM user.
  */
@@ -182,6 +196,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  threadBindings: ThreadBindingsSchema,
 };
 
 /**

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -651,7 +651,16 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   try {
     const eventDispatcher = createEventDispatcher(account);
     const chatHistories = new Map<string, HistoryEntry[]>();
-    threadBindingManager = createFeishuThreadBindingManager({ accountId, cfg });
+    const { resolveThreadBindingSpawnPolicy } = await import("openclaw/plugin-sdk/feishu");
+    const tbPolicy = resolveThreadBindingSpawnPolicy({
+      cfg,
+      channel: "feishu",
+      accountId,
+      kind: "subagent",
+    });
+    if (tbPolicy.enabled) {
+      threadBindingManager = createFeishuThreadBindingManager({ accountId, cfg });
+    }
 
     registerEventHandlers(eventDispatcher, {
       cfg,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -384,10 +384,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               }
             }
             // When streaming is active, the block is consumed via streaming card
-            // update below. Otherwise suppress: block payloads from the normal
-            // inference pipeline are disabled via disableBlockStreaming and should
-            // not leak as plain messages.
+            // update below. Otherwise deliver as a plain message so ACP block
+            // payloads still reach the user even with disableBlockStreaming.
             if (!streaming?.isActive()) {
+              await sendChunkedTextReply({ text, useCard, infoKind: "block" });
               return;
             }
           }
@@ -478,13 +478,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
     });
 
-  // Feishu suppresses block payloads from the normal inference pipeline
-  // (disableBlockStreaming: true below). Tell ACP dispatch to promote its
-  // block chunks to finals so they reach the user instead of being dropped.
-  const feishuDispatcher = { ...dispatcher, promoteAcpBlocksToFinals: true as const };
-
   return {
-    dispatcher: feishuDispatcher,
+    dispatcher,
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -387,7 +387,42 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // update below. Otherwise deliver as a plain message so ACP block
             // payloads still reach the user even with disableBlockStreaming.
             if (!streaming?.isActive()) {
-              await sendChunkedTextReply({ text, useCard, infoKind: "block" });
+              await sendChunkedTextReply({
+                text,
+                useCard,
+                infoKind: "block",
+                sendChunk: async ({ chunk, isFirst }) => {
+                  if (useCard) {
+                    const cardHeader = resolveCardHeader(agentId, identity);
+                    const cardNote = resolveCardNote(
+                      agentId,
+                      identity,
+                      prefixContext.prefixContext,
+                    );
+                    await sendStructuredCardFeishu({
+                      cfg,
+                      to: chatId,
+                      text: chunk,
+                      replyToMessageId: sendReplyToMessageId,
+                      replyInThread: effectiveReplyInThread,
+                      mentions: isFirst ? mentionTargets : undefined,
+                      accountId,
+                      header: cardHeader,
+                      note: cardNote,
+                    });
+                  } else {
+                    await sendMessageFeishu({
+                      cfg,
+                      to: chatId,
+                      text: chunk,
+                      replyToMessageId: sendReplyToMessageId,
+                      replyInThread: effectiveReplyInThread,
+                      mentions: isFirst ? mentionTargets : undefined,
+                      accountId,
+                    });
+                  }
+                },
+              });
               return;
             }
           }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -377,14 +377,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
-              return;
+            if (streamingEnabled && useCard) {
+              startStreaming();
+              if (streamingStartPromise) {
+                await streamingStartPromise;
+              }
             }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
+            // When streaming is active, the block is consumed via streaming card
+            // update below. Otherwise suppress: block payloads from the normal
+            // inference pipeline are disabled via disableBlockStreaming and should
+            // not leak as plain messages.
+            if (!streaming?.isActive()) {
+              return;
             }
           }
 
@@ -474,8 +478,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
     });
 
+  // Feishu suppresses block payloads from the normal inference pipeline
+  // (disableBlockStreaming: true below). Tell ACP dispatch to promote its
+  // block chunks to finals so they reach the user instead of being dropped.
+  const feishuDispatcher = { ...dispatcher, promoteAcpBlocksToFinals: true as const };
+
   return {
-    dispatcher,
+    dispatcher: feishuDispatcher,
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -13,6 +13,8 @@ import {
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/text-runtime";
 
+const FEISHU_THREAD_BINDINGS_SWEEP_INTERVAL_MS = 60_000;
+
 type FeishuBindingTargetKind = "subagent" | "acp";
 
 type FeishuThreadBindingRecord = {
@@ -28,6 +30,8 @@ type FeishuThreadBindingRecord = {
   boundBy?: string;
   boundAt: number;
   lastActivityAt: number;
+  idleTimeoutMs?: number;
+  maxAgeMs?: number;
 };
 
 type FeishuThreadBindingManager = {
@@ -80,9 +84,16 @@ function toSessionBindingRecord(
   record: FeishuThreadBindingRecord,
   defaults: { idleTimeoutMs: number; maxAgeMs: number },
 ): SessionBindingRecord {
-  const idleExpiresAt =
-    defaults.idleTimeoutMs > 0 ? record.lastActivityAt + defaults.idleTimeoutMs : undefined;
-  const maxAgeExpiresAt = defaults.maxAgeMs > 0 ? record.boundAt + defaults.maxAgeMs : undefined;
+  const effectiveIdleMs =
+    typeof record.idleTimeoutMs === "number" && Number.isFinite(record.idleTimeoutMs)
+      ? record.idleTimeoutMs
+      : defaults.idleTimeoutMs;
+  const effectiveMaxAgeMs =
+    typeof record.maxAgeMs === "number" && Number.isFinite(record.maxAgeMs)
+      ? record.maxAgeMs
+      : defaults.maxAgeMs;
+  const idleExpiresAt = effectiveIdleMs > 0 ? record.lastActivityAt + effectiveIdleMs : undefined;
+  const maxAgeExpiresAt = effectiveMaxAgeMs > 0 ? record.boundAt + effectiveMaxAgeMs : undefined;
   const expiresAt =
     idleExpiresAt != null && maxAgeExpiresAt != null
       ? Math.min(idleExpiresAt, maxAgeExpiresAt)
@@ -110,15 +121,48 @@ function toSessionBindingRecord(
       deliveryTo: record.deliveryTo,
       deliveryThreadId: record.deliveryThreadId,
       lastActivityAt: record.lastActivityAt,
-      idleTimeoutMs: defaults.idleTimeoutMs,
-      maxAgeMs: defaults.maxAgeMs,
+      idleTimeoutMs: effectiveIdleMs,
+      maxAgeMs: effectiveMaxAgeMs,
     },
   };
+}
+
+function shouldExpireByIdle(params: {
+  now: number;
+  record: FeishuThreadBindingRecord;
+  defaultIdleTimeoutMs: number;
+}): boolean {
+  const idleTimeoutMs =
+    typeof params.record.idleTimeoutMs === "number"
+      ? Math.max(0, Math.floor(params.record.idleTimeoutMs))
+      : params.defaultIdleTimeoutMs;
+  if (idleTimeoutMs <= 0) {
+    return false;
+  }
+  return (
+    params.now >= Math.max(params.record.lastActivityAt, params.record.boundAt) + idleTimeoutMs
+  );
+}
+
+function shouldExpireByMaxAge(params: {
+  now: number;
+  record: FeishuThreadBindingRecord;
+  defaultMaxAgeMs: number;
+}): boolean {
+  const maxAgeMs =
+    typeof params.record.maxAgeMs === "number"
+      ? Math.max(0, Math.floor(params.record.maxAgeMs))
+      : params.defaultMaxAgeMs;
+  if (maxAgeMs <= 0) {
+    return false;
+  }
+  return params.now >= params.record.boundAt + maxAgeMs;
 }
 
 export function createFeishuThreadBindingManager(params: {
   accountId?: string;
   cfg: OpenClawConfig;
+  enableSweeper?: boolean;
 }): FeishuThreadBindingManager {
   const accountId = normalizeAccountId(params.accountId);
   const existing = MANAGERS_BY_ACCOUNT_ID.get(accountId);
@@ -136,6 +180,11 @@ export function createFeishuThreadBindingManager(params: {
     channel: "feishu",
     accountId,
   });
+
+  const listBindingsForAccount = () =>
+    [...BINDINGS_BY_ACCOUNT_CONVERSATION.values()].filter((entry) => entry.accountId === accountId);
+
+  let sweepTimer: NodeJS.Timeout | null = null;
 
   const manager: FeishuThreadBindingManager = {
     accountId,
@@ -225,13 +274,20 @@ export function createFeishuThreadBindingManager(params: {
       return removed;
     },
     stop: () => {
+      if (sweepTimer) {
+        clearInterval(sweepTimer);
+        sweepTimer = null;
+      }
       for (const key of [...BINDINGS_BY_ACCOUNT_CONVERSATION.keys()]) {
         if (key.startsWith(`${accountId}:`)) {
           BINDINGS_BY_ACCOUNT_CONVERSATION.delete(key);
         }
       }
-      MANAGERS_BY_ACCOUNT_ID.delete(accountId);
       unregisterSessionBindingAdapter({ channel: "feishu", accountId });
+      const existingManager = MANAGERS_BY_ACCOUNT_ID.get(accountId);
+      if (existingManager === manager) {
+        MANAGERS_BY_ACCOUNT_ID.delete(accountId);
+      }
     },
   };
 
@@ -292,6 +348,30 @@ export function createFeishuThreadBindingManager(params: {
     },
   });
 
+  const sweeperEnabled = params.enableSweeper !== false;
+  if (sweeperEnabled) {
+    sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const record of listBindingsForAccount()) {
+        const idleExpired = shouldExpireByIdle({
+          now,
+          record,
+          defaultIdleTimeoutMs: idleTimeoutMs,
+        });
+        const maxAgeExpired = shouldExpireByMaxAge({
+          now,
+          record,
+          defaultMaxAgeMs: maxAgeMs,
+        });
+        if (!idleExpired && !maxAgeExpired) {
+          continue;
+        }
+        manager.unbindConversation(record.conversationId);
+      }
+    }, FEISHU_THREAD_BINDINGS_SWEEP_INTERVAL_MS);
+    sweepTimer.unref?.();
+  }
+
   MANAGERS_BY_ACCOUNT_ID.set(accountId, manager);
   return manager;
 }
@@ -300,6 +380,60 @@ export function getFeishuThreadBindingManager(
   accountId?: string,
 ): FeishuThreadBindingManager | null {
   return MANAGERS_BY_ACCOUNT_ID.get(normalizeAccountId(accountId)) ?? null;
+}
+
+function normalizeDurationMs(raw: number, fallback: number): number {
+  return Number.isFinite(raw) && raw >= 0 ? Math.floor(raw) : fallback;
+}
+
+export function setFeishuThreadBindingIdleTimeoutBySessionKey(params: {
+  targetSessionKey: string;
+  accountId?: string;
+  idleTimeoutMs: number;
+}): FeishuThreadBindingRecord[] {
+  const manager = getFeishuThreadBindingManager(params.accountId);
+  if (!manager) {
+    return [];
+  }
+  const idleTimeoutMs = normalizeDurationMs(params.idleTimeoutMs, 0);
+  const now = Date.now();
+  const updated: FeishuThreadBindingRecord[] = [];
+  const entries = manager.listBySessionKey(params.targetSessionKey.trim());
+  for (const entry of entries) {
+    const key = resolveBindingKey({
+      accountId: manager.accountId,
+      conversationId: entry.conversationId,
+    });
+    const next = { ...entry, idleTimeoutMs, lastActivityAt: now };
+    BINDINGS_BY_ACCOUNT_CONVERSATION.set(key, next);
+    updated.push(next);
+  }
+  return updated;
+}
+
+export function setFeishuThreadBindingMaxAgeBySessionKey(params: {
+  targetSessionKey: string;
+  accountId?: string;
+  maxAgeMs: number;
+}): FeishuThreadBindingRecord[] {
+  const manager = getFeishuThreadBindingManager(params.accountId);
+  if (!manager) {
+    return [];
+  }
+  const maxAgeMs = normalizeDurationMs(params.maxAgeMs, 0);
+  const now = Date.now();
+  const updated: FeishuThreadBindingRecord[] = [];
+  const entries = manager.listBySessionKey(params.targetSessionKey.trim());
+  for (const entry of entries) {
+    const key = resolveBindingKey({
+      accountId: manager.accountId,
+      conversationId: entry.conversationId,
+    });
+    const next = { ...entry, maxAgeMs, lastActivityAt: now };
+    BINDINGS_BY_ACCOUNT_CONVERSATION.set(key, next);
+    updated.push(next);
+  }
+  return updated;
 }
 
 export const __testing = {

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -378,9 +378,18 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "unfocus",
       nativeName: "unfocus",
-      description: "Remove the current thread (Discord) or topic/conversation (Telegram) binding.",
+      description:
+        "Remove the current thread (Discord) or topic/conversation (Telegram, Feishu) binding.",
       textAlias: "/unfocus",
       category: "management",
+      args: [
+        {
+          name: "target",
+          description: "Ignored (unfocus always applies to the current conversation)",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
     }),
     defineChatCommand({
       key: "agents",

--- a/src/auto-reply/reply/channel-context.ts
+++ b/src/auto-reply/reply/channel-context.ts
@@ -24,6 +24,10 @@ export function isTelegramSurface(params: DiscordSurfaceParams): boolean {
   return resolveCommandSurfaceChannel(params) === "telegram";
 }
 
+export function isFeishuSurface(params: DiscordSurfaceParams): boolean {
+  return resolveCommandSurfaceChannel(params) === "feishu";
+}
+
 export function resolveCommandSurfaceChannel(params: DiscordSurfaceParams): string {
   const channel =
     params.ctx.OriginatingChannel ??

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -170,7 +170,7 @@ async function bindSpawnedAcpSessionToThread(params: {
     if (existingBinding && boundBy && boundBy !== "system" && senderId && senderId !== boundBy) {
       return {
         ok: false,
-        error: `Only ${boundBy} can rebind this ${channel === "telegram" ? "conversation" : "thread"}.`,
+        error: `Only ${boundBy} can rebind this ${channel === "telegram" || channel === "feishu" ? "conversation" : "thread"}.`,
       };
     }
   }
@@ -355,7 +355,10 @@ export async function handleAcpSpawnAction(
   if (binding) {
     const currentConversationId = resolveAcpCommandConversationId(params)?.trim() || "";
     const boundConversationId = binding.conversation.conversationId.trim();
-    const placementLabel = binding.conversation.channel === "telegram" ? "conversation" : "thread";
+    const placementLabel =
+      binding.conversation.channel === "telegram" || binding.conversation.channel === "feishu"
+        ? "conversation"
+        : "thread";
     if (currentConversationId && boundConversationId === currentConversationId) {
       parts.push(`Bound this ${placementLabel} to ${sessionKey}.`);
     } else {

--- a/src/auto-reply/reply/commands-session-lifecycle.test.ts
+++ b/src/auto-reply/reply/commands-session-lifecycle.test.ts
@@ -336,11 +336,11 @@ describe("/session idle and /session max-age", () => {
     expect(result?.reply?.text).toContain("Max age disabled");
   });
 
-  it("is unavailable outside discord and telegram", async () => {
+  it("is unavailable outside discord, telegram, and feishu", async () => {
     const params = buildCommandTestParams("/session idle 2h", baseCfg);
     const result = await handleSessionCommand(params, true);
     expect(result?.reply?.text).toContain(
-      "currently available for Discord and Telegram bound sessions",
+      "currently available for Discord, Telegram, and Feishu bound sessions",
     );
   });
 

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -25,7 +25,7 @@ import {
 import { handleAbortTrigger, handleStopCommand } from "./commands-session-abort.js";
 import { persistSessionEntry } from "./commands-session-store.js";
 import type { CommandHandler } from "./commands-types.js";
-import { resolveFeishuConversationId } from "./feishu-context.js";
+import { isFeishuSenderScopedTopic, resolveFeishuConversationId } from "./feishu-context.js";
 import { resolveTelegramConversationId } from "./telegram-context.js";
 
 const SESSION_COMMAND_PREFIX = "/session";
@@ -412,12 +412,15 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           conversationId: telegramConversationId,
         })
       : null;
-  // Feishu group_topic_sender bindings are keyed with :sender:<openId> suffix
-  // that resolveFeishuConversationId does not include. Prefer sender-scoped
-  // lookup so lifecycle changes target the user's own binding, not a shared
-  // topic-level configured binding.
+  // Only group_topic_sender scope uses sender-scoped conversation IDs.
+  // Prefer sender-scoped lookup so lifecycle changes target the user's own
+  // binding, not a shared topic-level configured binding.
   let feishuBinding: ReturnType<typeof sessionBindingService.resolveByConversation> = null;
-  if (onFeishu && feishuConversationId?.includes(":topic:")) {
+  if (
+    onFeishu &&
+    feishuConversationId &&
+    isFeishuSenderScopedTopic({ cfg: params.cfg, conversationId: feishuConversationId })
+  ) {
     const senderId = (params.command.senderId ?? "").trim();
     if (senderId) {
       feishuBinding = sessionBindingService.resolveByConversation({

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -12,10 +12,16 @@ import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
 import { normalizeFastMode, normalizeUsageDisplay, resolveResponseUsageMode } from "../thinking.js";
-import { isDiscordSurface, isTelegramSurface, resolveChannelAccountId } from "./channel-context.js";
+import {
+  isDiscordSurface,
+  isFeishuSurface,
+  isTelegramSurface,
+  resolveChannelAccountId,
+} from "./channel-context.js";
 import { handleAbortTrigger, handleStopCommand } from "./commands-session-abort.js";
 import { persistSessionEntry } from "./commands-session-store.js";
 import type { CommandHandler } from "./commands-types.js";
+import { resolveFeishuConversationId } from "./feishu-context.js";
 import { resolveTelegramConversationId } from "./telegram-context.js";
 
 const SESSION_COMMAND_PREFIX = "/session";
@@ -55,7 +61,7 @@ function formatSessionExpiry(expiresAt: number) {
   return new Date(expiresAt).toISOString();
 }
 
-function resolveTelegramBindingDurationMs(
+function resolveBindingDurationMs(
   binding: SessionBindingRecord,
   key: "idleTimeoutMs" | "maxAgeMs",
   fallbackMs: number,
@@ -67,7 +73,7 @@ function resolveTelegramBindingDurationMs(
   return Math.max(0, Math.floor(raw));
 }
 
-function resolveTelegramBindingLastActivityAt(binding: SessionBindingRecord): number {
+function resolveBindingLastActivityAt(binding: SessionBindingRecord): number {
   const raw = binding.metadata?.lastActivityAt;
   if (typeof raw !== "number" || !Number.isFinite(raw)) {
     return binding.boundAt;
@@ -75,7 +81,7 @@ function resolveTelegramBindingLastActivityAt(binding: SessionBindingRecord): nu
   return Math.max(Math.floor(raw), binding.boundAt);
 }
 
-function resolveTelegramBindingBoundBy(binding: SessionBindingRecord): string {
+function resolveBindingBoundBy(binding: SessionBindingRecord): string {
   const raw = binding.metadata?.boundBy;
   return typeof raw === "string" ? raw.trim() : "";
 }
@@ -364,11 +370,12 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
 
   const onDiscord = isDiscordSurface(params);
   const onTelegram = isTelegramSurface(params);
-  if (!onDiscord && !onTelegram) {
+  const onFeishu = isFeishuSurface(params);
+  if (!onDiscord && !onTelegram && !onFeishu) {
     return {
       shouldContinue: false,
       reply: {
-        text: "⚠️ /session idle and /session max-age are currently available for Discord and Telegram bound sessions.",
+        text: "⚠️ /session idle and /session max-age are currently available for Discord, Telegram, and Feishu bound sessions.",
       },
     };
   }
@@ -378,6 +385,7 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
   const threadId =
     params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
   const telegramConversationId = onTelegram ? resolveTelegramConversationId(params) : undefined;
+  const feishuConversationId = onFeishu ? resolveFeishuConversationId(params) : undefined;
   const channelRuntime = getChannelRuntime();
 
   const discordManager = onDiscord
@@ -398,6 +406,14 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           channel: "telegram",
           accountId,
           conversationId: telegramConversationId,
+        })
+      : null;
+  const feishuBinding =
+    onFeishu && feishuConversationId
+      ? sessionBindingService.resolveByConversation({
+          channel: "feishu",
+          accountId,
+          conversationId: feishuConversationId,
         })
       : null;
   if (onDiscord && !discordBinding) {
@@ -428,34 +444,51 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
       reply: { text: "ℹ️ This conversation is not currently focused." },
     };
   }
+  if (onFeishu && !feishuBinding) {
+    if (!feishuConversationId) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "⚠️ /session idle and /session max-age on Feishu require a DM or topic conversation.",
+        },
+      };
+    }
+    return {
+      shouldContinue: false,
+      reply: { text: "ℹ️ This conversation is not currently focused." },
+    };
+  }
+
+  // Resolve the active binding for the current channel.
+  const serviceBinding = telegramBinding ?? feishuBinding;
 
   const idleTimeoutMs = onDiscord
     ? channelRuntime.discord.threadBindings.resolveIdleTimeoutMs({
         record: discordBinding!,
         defaultIdleTimeoutMs: discordManager!.getIdleTimeoutMs(),
       })
-    : resolveTelegramBindingDurationMs(telegramBinding!, "idleTimeoutMs", 24 * 60 * 60 * 1000);
+    : resolveBindingDurationMs(serviceBinding!, "idleTimeoutMs", 24 * 60 * 60 * 1000);
   const idleExpiresAt = onDiscord
     ? channelRuntime.discord.threadBindings.resolveInactivityExpiresAt({
         record: discordBinding!,
         defaultIdleTimeoutMs: discordManager!.getIdleTimeoutMs(),
       })
     : idleTimeoutMs > 0
-      ? resolveTelegramBindingLastActivityAt(telegramBinding!) + idleTimeoutMs
+      ? resolveBindingLastActivityAt(serviceBinding!) + idleTimeoutMs
       : undefined;
   const maxAgeMs = onDiscord
     ? channelRuntime.discord.threadBindings.resolveMaxAgeMs({
         record: discordBinding!,
         defaultMaxAgeMs: discordManager!.getMaxAgeMs(),
       })
-    : resolveTelegramBindingDurationMs(telegramBinding!, "maxAgeMs", 0);
+    : resolveBindingDurationMs(serviceBinding!, "maxAgeMs", 0);
   const maxAgeExpiresAt = onDiscord
     ? channelRuntime.discord.threadBindings.resolveMaxAgeExpiresAt({
         record: discordBinding!,
         defaultMaxAgeMs: discordManager!.getMaxAgeMs(),
       })
     : maxAgeMs > 0
-      ? telegramBinding!.boundAt + maxAgeMs
+      ? serviceBinding!.boundAt + maxAgeMs
       : undefined;
 
   const durationArgRaw = tokens.slice(1).join("");
@@ -498,9 +531,7 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
   }
 
   const senderId = params.command.senderId?.trim() || "";
-  const boundBy = onDiscord
-    ? discordBinding!.boundBy
-    : resolveTelegramBindingBoundBy(telegramBinding!);
+  const boundBy = onDiscord ? discordBinding!.boundBy : resolveBindingBoundBy(serviceBinding!);
   if (boundBy && boundBy !== "system" && senderId && senderId !== boundBy) {
     return {
       shouldContinue: false,
@@ -522,7 +553,7 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
     };
   }
 
-  const updatedBindings = (() => {
+  const updatedBindings = await (async () => {
     if (onDiscord) {
       return action === SESSION_ACTION_IDLE
         ? channelRuntime.discord.threadBindings.setIdleTimeoutBySessionKey({
@@ -532,6 +563,20 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           })
         : channelRuntime.discord.threadBindings.setMaxAgeBySessionKey({
             targetSessionKey: discordBinding!.targetSessionKey,
+            accountId,
+            maxAgeMs: durationMs,
+          });
+    }
+    if (onFeishu) {
+      const feishuBindings = await import("../../../extensions/feishu/src/thread-bindings.js");
+      return action === SESSION_ACTION_IDLE
+        ? feishuBindings.setFeishuThreadBindingIdleTimeoutBySessionKey({
+            targetSessionKey: feishuBinding!.targetSessionKey,
+            accountId,
+            idleTimeoutMs: durationMs,
+          })
+        : feishuBindings.setFeishuThreadBindingMaxAgeBySessionKey({
+            targetSessionKey: feishuBinding!.targetSessionKey,
             accountId,
             maxAgeMs: durationMs,
           });

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -412,7 +412,9 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           conversationId: telegramConversationId,
         })
       : null;
-  const feishuBinding =
+  // Feishu group_topic_sender bindings are keyed with :sender:<openId> suffix
+  // that resolveFeishuConversationId does not include. Try sender-scoped first.
+  let feishuBinding =
     onFeishu && feishuConversationId
       ? sessionBindingService.resolveByConversation({
           channel: "feishu",
@@ -420,6 +422,16 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           conversationId: feishuConversationId,
         })
       : null;
+  if (!feishuBinding && onFeishu && feishuConversationId?.includes(":topic:")) {
+    const senderId = (params.command.senderId ?? "").trim();
+    if (senderId) {
+      feishuBinding = sessionBindingService.resolveByConversation({
+        channel: "feishu",
+        accountId,
+        conversationId: `${feishuConversationId}:sender:${senderId}`,
+      });
+    }
+  }
   if (onDiscord && !discordBinding) {
     if (onDiscord && !threadId) {
       return {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -413,16 +413,11 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
         })
       : null;
   // Feishu group_topic_sender bindings are keyed with :sender:<openId> suffix
-  // that resolveFeishuConversationId does not include. Try sender-scoped first.
-  let feishuBinding =
-    onFeishu && feishuConversationId
-      ? sessionBindingService.resolveByConversation({
-          channel: "feishu",
-          accountId,
-          conversationId: feishuConversationId,
-        })
-      : null;
-  if (!feishuBinding && onFeishu && feishuConversationId?.includes(":topic:")) {
+  // that resolveFeishuConversationId does not include. Prefer sender-scoped
+  // lookup so lifecycle changes target the user's own binding, not a shared
+  // topic-level configured binding.
+  let feishuBinding: ReturnType<typeof sessionBindingService.resolveByConversation> = null;
+  if (onFeishu && feishuConversationId?.includes(":topic:")) {
     const senderId = (params.command.senderId ?? "").trim();
     if (senderId) {
       feishuBinding = sessionBindingService.resolveByConversation({
@@ -431,6 +426,13 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
         conversationId: `${feishuConversationId}:sender:${senderId}`,
       });
     }
+  }
+  if (!feishuBinding && onFeishu && feishuConversationId) {
+    feishuBinding = sessionBindingService.resolveByConversation({
+      channel: "feishu",
+      accountId,
+      conversationId: feishuConversationId,
+    });
   }
   if (onDiscord && !discordBinding) {
     if (onDiscord && !threadId) {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -1,3 +1,7 @@
+import {
+  setFeishuThreadBindingIdleTimeoutBySessionKey,
+  setFeishuThreadBindingMaxAgeBySessionKey,
+} from "../../../extensions/feishu/src/thread-bindings.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { formatThreadBindingDurationLabel } from "../../channels/thread-bindings-messages.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
@@ -568,14 +572,13 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
           });
     }
     if (onFeishu) {
-      const feishuBindings = await import("../../../extensions/feishu/src/thread-bindings.js");
       return action === SESSION_ACTION_IDLE
-        ? feishuBindings.setFeishuThreadBindingIdleTimeoutBySessionKey({
+        ? setFeishuThreadBindingIdleTimeoutBySessionKey({
             targetSessionKey: feishuBinding!.targetSessionKey,
             accountId,
             idleTimeoutMs: durationMs,
           })
-        : feishuBindings.setFeishuThreadBindingMaxAgeBySessionKey({
+        : setFeishuThreadBindingMaxAgeBySessionKey({
             targetSessionKey: feishuBinding!.targetSessionKey,
             accountId,
             maxAgeMs: durationMs,

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -401,6 +401,6 @@ describe("/focus, /unfocus, /agents", () => {
   it("/focus rejects unsupported channels", async () => {
     const params = buildCommandTestParams("/focus codex-acp", baseCfg);
     const result = await handleSubagentsCommand(params, true);
-    expect(result?.reply?.text).toContain("only available on Discord and Telegram");
+    expect(result?.reply?.text).toContain("only available on Discord, Telegram, and Feishu");
   });
 });

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -16,17 +16,19 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
   resolveDiscordChannelIdForFocus,
+  resolveFeishuConversationId,
   resolveFocusTargetSession,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
 
 type FocusBindingContext = {
-  channel: "discord" | "telegram";
+  channel: "discord" | "telegram" | "feishu";
   accountId: string;
   conversationId: string;
   placement: "current" | "child";
@@ -65,6 +67,19 @@ function resolveFocusBindingContext(
       labelNoun: "conversation",
     };
   }
+  if (isFeishuSurface(params)) {
+    const conversationId = resolveFeishuConversationId(params);
+    if (!conversationId) {
+      return null;
+    }
+    return {
+      channel: "feishu",
+      accountId: resolveChannelAccountId(params),
+      conversationId,
+      placement: "current",
+      labelNoun: "conversation",
+    };
+  }
   return null;
 }
 
@@ -73,8 +88,8 @@ export async function handleSubagentsFocusAction(
 ): Promise<CommandHandlerResult> {
   const { params, runs, restTokens } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /focus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /focus is only available on Discord, Telegram, and Feishu.");
   }
 
   const token = restTokens.join(" ").trim();
@@ -89,7 +104,12 @@ export async function handleSubagentsFocusAction(
     accountId,
   });
   if (!capabilities.adapterAvailable || !capabilities.bindSupported) {
-    const label = channel === "discord" ? "Discord thread" : "Telegram conversation";
+    const label =
+      channel === "discord"
+        ? "Discord thread"
+        : channel === "feishu"
+          ? "Feishu conversation"
+          : "Telegram conversation";
     return stopWithText(`⚠️ ${label} bindings are unavailable for this account.`);
   }
 
@@ -103,6 +123,11 @@ export async function handleSubagentsFocusAction(
     if (channel === "telegram") {
       return stopWithText(
         "⚠️ /focus on Telegram requires a topic context in groups, or a direct-message conversation.",
+      );
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /focus on Feishu requires a topic thread in groups, or a direct-message conversation.",
       );
     }
     return stopWithText("⚠️ Could not resolve a Discord channel for /focus.");

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../channels/thread-bindings-policy.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import type { CommandHandlerResult } from "../commands-types.js";
+import { isFeishuSenderScopedTopic } from "../feishu-context.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
@@ -72,11 +73,11 @@ function resolveFocusBindingContext(
     if (!baseConversationId) {
       return null;
     }
-    // In group_topic_sender scope, inbound routing resolves a sender-scoped
-    // conversation ID (chatId:topic:topicId:sender:openId). Bind with the
-    // sender-scoped variant so the exact-match lookup in bot.ts succeeds.
+    // Only group_topic_sender scope uses sender-scoped conversation IDs
+    // (chatId:topic:topicId:sender:openId). group_topic scope routes by
+    // topic-only IDs, so the binding must match what inbound routing uses.
     let conversationId = baseConversationId;
-    if (baseConversationId.includes(":topic:")) {
+    if (isFeishuSenderScopedTopic({ cfg: params.cfg, conversationId: baseConversationId })) {
       const senderId = (params.command.senderId ?? "").trim();
       if (senderId) {
         conversationId = `${baseConversationId}:sender:${senderId}`;

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -68,9 +68,19 @@ function resolveFocusBindingContext(
     };
   }
   if (isFeishuSurface(params)) {
-    const conversationId = resolveFeishuConversationId(params);
-    if (!conversationId) {
+    const baseConversationId = resolveFeishuConversationId(params);
+    if (!baseConversationId) {
       return null;
+    }
+    // In group_topic_sender scope, inbound routing resolves a sender-scoped
+    // conversation ID (chatId:topic:topicId:sender:openId). Bind with the
+    // sender-scoped variant so the exact-match lookup in bot.ts succeeds.
+    let conversationId = baseConversationId;
+    if (baseConversationId.includes(":topic:")) {
+      const senderId = (params.command.senderId ?? "").trim();
+      if (senderId) {
+        conversationId = `${baseConversationId}:sender:${senderId}`;
+      }
     }
     return {
       channel: "feishu",

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -3,9 +3,11 @@ import type { CommandHandlerResult } from "../commands-types.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveChannelAccountId,
   resolveCommandSurfaceChannel,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
   stopWithText,
 } from "./shared.js";
@@ -15,8 +17,8 @@ export async function handleSubagentsUnfocusAction(
 ): Promise<CommandHandlerResult> {
   const { params } = ctx;
   const channel = resolveCommandSurfaceChannel(params);
-  if (channel !== "discord" && channel !== "telegram") {
-    return stopWithText("⚠️ /unfocus is only available on Discord and Telegram.");
+  if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    return stopWithText("⚠️ /unfocus is only available on Discord, Telegram, and Feishu.");
   }
 
   const accountId = resolveChannelAccountId(params);
@@ -30,12 +32,20 @@ export async function handleSubagentsUnfocusAction(
     if (isTelegramSurface(params)) {
       return resolveTelegramConversationId(params);
     }
+    if (isFeishuSurface(params)) {
+      return resolveFeishuConversationId(params);
+    }
     return undefined;
   })();
 
   if (!conversationId) {
     if (channel === "discord") {
       return stopWithText("⚠️ /unfocus must be run inside a Discord thread.");
+    }
+    if (channel === "feishu") {
+      return stopWithText(
+        "⚠️ /unfocus on Feishu requires a topic thread in groups, or a direct-message conversation.",
+      );
     }
     return stopWithText(
       "⚠️ /unfocus on Telegram requires a topic context in groups, or a direct-message conversation.",

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -38,6 +38,29 @@ export async function handleSubagentsUnfocusAction(
     return undefined;
   })();
 
+  // Feishu sender-scoped fallback: bindings in group_topic_sender scope are
+  // keyed with :sender:<openId>. Try sender-scoped lookup when topic-only misses.
+  const resolveFeishuBinding = () => {
+    if (channel !== "feishu" || !conversationId) {
+      return null;
+    }
+    const base = bindingService.resolveByConversation({ channel, accountId, conversationId });
+    if (base) {
+      return base;
+    }
+    if (conversationId.includes(":topic:")) {
+      const senderId = (params.command.senderId ?? "").trim();
+      if (senderId) {
+        return bindingService.resolveByConversation({
+          channel,
+          accountId,
+          conversationId: `${conversationId}:sender:${senderId}`,
+        });
+      }
+    }
+    return null;
+  };
+
   if (!conversationId) {
     if (channel === "discord") {
       return stopWithText("⚠️ /unfocus must be run inside a Discord thread.");
@@ -52,11 +75,10 @@ export async function handleSubagentsUnfocusAction(
     );
   }
 
-  const binding = bindingService.resolveByConversation({
-    channel,
-    accountId,
-    conversationId,
-  });
+  const binding =
+    channel === "feishu"
+      ? resolveFeishuBinding()
+      : bindingService.resolveByConversation({ channel, accountId, conversationId });
   if (!binding) {
     return stopWithText(
       channel === "discord"

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -1,5 +1,6 @@
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import type { CommandHandlerResult } from "../commands-types.js";
+import { isFeishuSenderScopedTopic } from "../feishu-context.js";
 import {
   type SubagentsCommandContext,
   isDiscordSurface,
@@ -38,14 +39,15 @@ export async function handleSubagentsUnfocusAction(
     return undefined;
   })();
 
-  // Feishu sender-scoped bindings: in group_topic_sender scope, bindings are
-  // keyed with :sender:<openId>. Prefer sender-scoped lookup so /unfocus removes
-  // the user's own binding rather than a shared topic-level configured binding.
+  // Feishu sender-scoped bindings: only group_topic_sender scope uses
+  // :sender:<openId> suffixed conversation IDs. Prefer sender-scoped lookup
+  // so /unfocus removes the user's own binding rather than a shared
+  // topic-level configured binding.
   const resolveFeishuBinding = () => {
     if (channel !== "feishu" || !conversationId) {
       return null;
     }
-    if (conversationId.includes(":topic:")) {
+    if (isFeishuSenderScopedTopic({ cfg: params.cfg, conversationId })) {
       const senderId = (params.command.senderId ?? "").trim();
       if (senderId) {
         const senderScoped = bindingService.resolveByConversation({

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -38,27 +38,27 @@ export async function handleSubagentsUnfocusAction(
     return undefined;
   })();
 
-  // Feishu sender-scoped fallback: bindings in group_topic_sender scope are
-  // keyed with :sender:<openId>. Try sender-scoped lookup when topic-only misses.
+  // Feishu sender-scoped bindings: in group_topic_sender scope, bindings are
+  // keyed with :sender:<openId>. Prefer sender-scoped lookup so /unfocus removes
+  // the user's own binding rather than a shared topic-level configured binding.
   const resolveFeishuBinding = () => {
     if (channel !== "feishu" || !conversationId) {
       return null;
     }
-    const base = bindingService.resolveByConversation({ channel, accountId, conversationId });
-    if (base) {
-      return base;
-    }
     if (conversationId.includes(":topic:")) {
       const senderId = (params.command.senderId ?? "").trim();
       if (senderId) {
-        return bindingService.resolveByConversation({
+        const senderScoped = bindingService.resolveByConversation({
           channel,
           accountId,
           conversationId: `${conversationId}:sender:${senderId}`,
         });
+        if (senderScoped) {
+          return senderScoped;
+        }
       }
     }
-    return null;
+    return bindingService.resolveByConversation({ channel, accountId, conversationId });
   };
 
   if (!conversationId) {

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -30,12 +30,14 @@ import {
 } from "../../../shared/subagents-format.js";
 import {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
 } from "../channel-context.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
+import { resolveFeishuConversationId } from "../feishu-context.js";
 import {
   formatRunLabel,
   formatRunStatus,
@@ -47,10 +49,12 @@ import { resolveTelegramConversationId } from "../telegram-context.js";
 export { extractAssistantText, stripToolMessages };
 export {
   isDiscordSurface,
+  isFeishuSurface,
   isTelegramSurface,
   resolveCommandSurfaceChannel,
   resolveDiscordAccountId,
   resolveChannelAccountId,
+  resolveFeishuConversationId,
   resolveTelegramConversationId,
 };
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -188,6 +188,8 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     // payloads from the normal inference pipeline (e.g. Feishu with
     // disableBlockStreaming). Promote blocks to finals so they reach the
     // user through the channel's normal final-reply path.
+    // Note: ACP blocks are cumulative (each contains all text so far), so
+    // the Feishu final-text dedupe set never silently drops content.
     return params.dispatcher.sendFinalReply(ttsPayload);
   };
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -181,9 +181,13 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     if (kind === "tool") {
       return params.dispatcher.sendToolResult(ttsPayload);
     }
-    if (kind === "block") {
+    if (kind === "block" && !params.dispatcher.promoteAcpBlocksToFinals) {
       return params.dispatcher.sendBlockReply(ttsPayload);
     }
+    // When promoteAcpBlocksToFinals is set, the channel suppresses block
+    // payloads from the normal inference pipeline (e.g. Feishu with
+    // disableBlockStreaming). Promote blocks to finals so they reach the
+    // user through the channel's normal final-reply path.
     return params.dispatcher.sendFinalReply(ttsPayload);
   };
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -181,15 +181,9 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     if (kind === "tool") {
       return params.dispatcher.sendToolResult(ttsPayload);
     }
-    if (kind === "block" && !params.dispatcher.promoteAcpBlocksToFinals) {
+    if (kind === "block") {
       return params.dispatcher.sendBlockReply(ttsPayload);
     }
-    // When promoteAcpBlocksToFinals is set, the channel suppresses block
-    // payloads from the normal inference pipeline (e.g. Feishu with
-    // disableBlockStreaming). Promote blocks to finals so they reach the
-    // user through the channel's normal final-reply path.
-    // Note: ACP blocks are cumulative (each contains all text so far), so
-    // the Feishu final-text dedupe set never silently drops content.
     return params.dispatcher.sendFinalReply(ttsPayload);
   };
 

--- a/src/auto-reply/reply/feishu-context.ts
+++ b/src/auto-reply/reply/feishu-context.ts
@@ -78,3 +78,36 @@ export function resolveFeishuConversationId(params: FeishuConversationParams): s
   );
   return undefined;
 }
+
+/**
+ * Check whether a Feishu topic conversation uses sender-scoped IDs based on
+ * the channel config. Only `group_topic_sender` scope appends
+ * `:sender:<openId>` to the conversation ID during inbound routing.
+ */
+export function isFeishuSenderScopedTopic(params: {
+  cfg: { channels?: Record<string, unknown> };
+  conversationId: string;
+}): boolean {
+  if (!params.conversationId.includes(":topic:")) {
+    return false;
+  }
+  const feishuCfg = params.cfg.channels?.feishu as Record<string, unknown> | undefined;
+  if (!feishuCfg) {
+    return false;
+  }
+  const chatId = params.conversationId.split(":topic:")[0];
+  // Resolve per-group config (exact match, case-insensitive, or wildcard).
+  const groups = feishuCfg.groups as Record<string, Record<string, unknown>> | undefined;
+  let groupConfig: Record<string, unknown> | undefined;
+  if (groups && chatId) {
+    groupConfig = groups[chatId];
+    if (!groupConfig) {
+      const lowered = chatId.toLowerCase();
+      const matchKey = Object.keys(groups).find((key) => key.toLowerCase() === lowered);
+      groupConfig = matchKey ? groups[matchKey] : groups["*"];
+    }
+  }
+  const scope =
+    (groupConfig?.groupSessionScope as string) ?? (feishuCfg.groupSessionScope as string);
+  return scope === "group_topic_sender";
+}

--- a/src/auto-reply/reply/feishu-context.ts
+++ b/src/auto-reply/reply/feishu-context.ts
@@ -1,0 +1,80 @@
+import { logVerbose } from "../../globals.js";
+
+type FeishuConversationParams = {
+  ctx: {
+    MessageThreadId?: string | number | null;
+    ChatType?: string;
+    OriginatingTo?: string;
+    To?: string;
+  };
+  command: {
+    to?: string;
+  };
+};
+
+function normalizeFeishuTarget(raw: string): string | null {
+  let trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  // Strip provider prefixes (feishu: / lark:) before target-type prefixes.
+  const providerMatch = /^(feishu|lark):/i.exec(trimmed);
+  if (providerMatch) {
+    trimmed = trimmed.slice(providerMatch[0].length).trim();
+    if (!trimmed) {
+      return null;
+    }
+  }
+  const lowered = trimmed.toLowerCase();
+  // Strip common Feishu target prefixes to get the raw ID.
+  for (const prefix of ["chat:", "group:", "channel:", "user:", "dm:", "open_id:"]) {
+    if (lowered.startsWith(prefix)) {
+      const id = trimmed.slice(prefix.length).trim();
+      return id || null;
+    }
+  }
+  return trimmed;
+}
+
+export function resolveFeishuConversationId(params: FeishuConversationParams): string | undefined {
+  const rawThreadId =
+    params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
+  const threadId = rawThreadId || undefined;
+  const toCandidates = [
+    typeof params.ctx.OriginatingTo === "string" ? params.ctx.OriginatingTo : "",
+    typeof params.command.to === "string" ? params.command.to : "",
+    typeof params.ctx.To === "string" ? params.ctx.To : "",
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const chatId = toCandidates
+    .map((candidate) => normalizeFeishuTarget(candidate))
+    .find((candidate) => candidate != null && candidate.length > 0);
+  if (!chatId) {
+    return undefined;
+  }
+  if (threadId) {
+    return `${chatId}:topic:${threadId}`;
+  }
+  // Direct messages are always focusable. Use ChatType when available, otherwise
+  // infer from the target prefix: user:ou_* targets are DMs, chat:oc_* are groups.
+  const chatType =
+    typeof params.ctx.ChatType === "string" ? params.ctx.ChatType.trim().toLowerCase() : "";
+  if (chatType === "direct" || chatType === "p2p" || chatType === "private") {
+    return chatId;
+  }
+  // Group chats (oc_ prefix) without a topic should not become globally focused.
+  if (chatType === "group" || chatId.toLowerCase().startsWith("oc_")) {
+    return undefined;
+  }
+  // For unrecognised ChatType, only allow known DM identifiers (ou_ prefix).
+  // Unknown or future chat types default to non-focusable to avoid accidentally
+  // binding group-like conversations.
+  if (chatId.toLowerCase().startsWith("ou_")) {
+    return chatId;
+  }
+  logVerbose(
+    `resolveFeishuConversationId: rejecting unknown chatType=${chatType || "(empty)"} chatId prefix=${chatId.slice(0, 3)}`,
+  );
+  return undefined;
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -81,6 +81,12 @@ export type ReplyDispatcher = {
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
+  /** When true, ACP dispatch promotes block payloads to finals so they
+   *  reach the user through the channel's normal final-reply path instead
+   *  of being dropped by a block-suppression filter. Channels that handle
+   *  block payloads natively (e.g. Discord draft streams) should leave this
+   *  unset (defaults to false). */
+  promoteAcpBlocksToFinals?: boolean;
 };
 
 type NormalizeReplyPayloadInternalOptions = Pick<

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -81,12 +81,6 @@ export type ReplyDispatcher = {
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
-  /** When true, ACP dispatch promotes block payloads to finals so they
-   *  reach the user through the channel's normal final-reply path instead
-   *  of being dropped by a block-suppression filter. Channels that handle
-   *  block payloads natively (e.g. Discord draft streams) should leave this
-   *  unset (defaults to false). */
-  promoteAcpBlocksToFinals?: boolean;
 };
 
 type NormalizeReplyPayloadInternalOptions = Pick<

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -40,6 +40,7 @@ import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
 import { parseDiscordParentChannelFromSessionKey } from "./discord-parent-channel.js";
+import { resolveFeishuConversationId } from "./feishu-context.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import {
@@ -104,6 +105,31 @@ function resolveAcpResetBindingContext(ctx: MsgContext): {
     }
     if (!conversationId) {
       return null;
+    }
+    return {
+      channel: channelRaw,
+      accountId,
+      conversationId,
+      ...(parentConversationId ? { parentConversationId } : {}),
+    };
+  }
+
+  if (channelRaw === "feishu") {
+    const conversationId = resolveFeishuConversationId({
+      ctx: {
+        MessageThreadId: normalizedThreadId || undefined,
+        ChatType: ctx.ChatType || undefined,
+        OriginatingTo: ctx.OriginatingTo || undefined,
+        To: ctx.To || undefined,
+      },
+      command: {},
+    });
+    if (!conversationId) {
+      return null;
+    }
+    let parentConversationId: string | undefined;
+    if (normalizedThreadId && conversationId.includes(":topic:")) {
+      parentConversationId = conversationId.split(":topic:")[0];
     }
     return {
       channel: channelRaw,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -40,7 +40,7 @@ import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
 import { parseDiscordParentChannelFromSessionKey } from "./discord-parent-channel.js";
-import { resolveFeishuConversationId } from "./feishu-context.js";
+import { isFeishuSenderScopedTopic, resolveFeishuConversationId } from "./feishu-context.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import {
@@ -192,9 +192,12 @@ function resolveBoundAcpSessionForReset(params: {
     skipConfiguredFallbackWhenActiveSessionNonAcp: true,
     fallbackToActiveAcpWhenUnbound: false,
   } as const;
-  // Feishu group_topic_sender bindings are keyed with :sender:<openId> suffix
-  // that resolveFeishuConversationId does not include. Try sender-scoped first.
-  if (bindingContext.channel === "feishu" && bindingContext.conversationId?.includes(":topic:")) {
+  // Only group_topic_sender scope uses sender-scoped conversation IDs.
+  if (
+    bindingContext.channel === "feishu" &&
+    bindingContext.conversationId &&
+    isFeishuSenderScopedTopic({ cfg: params.cfg, conversationId: bindingContext.conversationId })
+  ) {
     const senderId = normalizeConversationText(params.ctx.SenderId);
     if (senderId) {
       const senderScoped = resolveEffectiveResetTargetSessionKey({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -179,16 +179,36 @@ function resolveBoundAcpSessionForReset(params: {
 }): string | undefined {
   const activeSessionKey = normalizeConversationText(params.ctx.SessionKey);
   const bindingContext = resolveAcpResetBindingContext(params.ctx);
-  return resolveEffectiveResetTargetSessionKey({
+  if (!bindingContext) {
+    return undefined;
+  }
+  const resolveOpts = {
     cfg: params.cfg,
-    channel: bindingContext?.channel,
-    accountId: bindingContext?.accountId,
-    conversationId: bindingContext?.conversationId,
-    parentConversationId: bindingContext?.parentConversationId,
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    parentConversationId: bindingContext.parentConversationId,
     activeSessionKey,
     allowNonAcpBindingSessionKey: false,
     skipConfiguredFallbackWhenActiveSessionNonAcp: true,
     fallbackToActiveAcpWhenUnbound: false,
+  } as const;
+  // Feishu group_topic_sender bindings are keyed with :sender:<openId> suffix
+  // that resolveFeishuConversationId does not include. Try sender-scoped first.
+  if (bindingContext.channel === "feishu" && bindingContext.conversationId?.includes(":topic:")) {
+    const senderId = normalizeConversationText(params.ctx.SenderId);
+    if (senderId) {
+      const senderScoped = resolveEffectiveResetTargetSessionKey({
+        ...resolveOpts,
+        conversationId: `${bindingContext.conversationId}:sender:${senderId}`,
+      });
+      if (senderScoped) {
+        return senderScoped;
+      }
+    }
+  }
+  return resolveEffectiveResetTargetSessionKey({
+    ...resolveOpts,
+    conversationId: bindingContext.conversationId,
   });
 }
 

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -199,7 +199,7 @@ describe("session binding service", () => {
     });
   });
 
-  it("rejects duplicate adapter registration for the same channel account", () => {
+  it("allows idempotent re-registration for the same channel account", () => {
     registerSessionBindingAdapter({
       channel: "discord",
       accountId: "default",
@@ -208,6 +208,8 @@ describe("session binding service", () => {
       resolveByConversation: () => null,
     });
 
+    // Re-registration with a different adapter instance should not throw —
+    // dist vs jiti module copies produce different objects for the same adapter.
     expect(() =>
       registerSessionBindingAdapter({
         channel: "Discord",
@@ -216,6 +218,6 @@ describe("session binding service", () => {
         listBySession: () => [],
         resolveByConversation: () => null,
       }),
-    ).toThrow("Session binding adapter already registered for discord:default");
+    ).not.toThrow();
   });
 });

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -145,7 +145,19 @@ function resolveAdapterCapabilities(
   };
 }
 
-const ADAPTERS_BY_CHANNEL_ACCOUNT = new Map<string, SessionBindingAdapter>();
+// Use globalThis to share the adapter registry across module-loading boundaries
+// (built dist/ chunks and jiti-loaded extension source may each load this module
+// independently, resulting in separate module-level Maps).
+const GLOBAL_ADAPTERS_KEY = "__openclaw_session_binding_adapters__";
+const ADAPTERS_BY_CHANNEL_ACCOUNT: Map<string, SessionBindingAdapter> =
+  ((globalThis as Record<string, unknown>)[GLOBAL_ADAPTERS_KEY] as
+    | Map<string, SessionBindingAdapter>
+    | undefined) ??
+  (() => {
+    const map = new Map<string, SessionBindingAdapter>();
+    (globalThis as Record<string, unknown>)[GLOBAL_ADAPTERS_KEY] = map;
+    return map;
+  })();
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const normalizedAdapter = {

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -170,10 +170,10 @@ export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): v
     accountId: normalizedAdapter.accountId,
   });
   const existing = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
-  if (existing && existing !== adapter) {
-    throw new Error(
-      `Session binding adapter already registered for ${normalizedAdapter.channel}:${normalizedAdapter.accountId}`,
-    );
+  if (existing && existing !== adapter && existing.channel === normalizedAdapter.channel) {
+    // Allow idempotent re-registration across module-loading boundaries:
+    // dist-loaded and jiti-loaded copies produce different object instances
+    // for the same logical adapter.
   }
   ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, normalizedAdapter);
 }

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -90,3 +90,25 @@ export {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "./webhook-ingress.js";
 export { applyBasicWebhookRequestGuards } from "./webhook-ingress.js";
+
+// Thread bindings / session binding adapter support (used by extensions/feishu thread-bindings)
+export {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type BindingTargetKind,
+  type SessionBindingRecord,
+  type SessionBindingBindInput,
+  type SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
+export { resolveStateDir } from "../config/paths.js";
+export { logVerbose } from "../globals.js";
+export { writeJsonFileAtomically } from "./json-store.js";
+export { resolveThreadBindingConversationIdFromBindingId } from "../channels/thread-binding-id.js";
+export { formatThreadBindingDurationLabel } from "../channels/thread-bindings-messages.js";
+export {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+  resolveThreadBindingSpawnPolicy,
+} from "../channels/thread-bindings-policy.js";
+export { isAcpSessionKey } from "../sessions/session-key-utils.js";
+export { readAcpSessionEntry } from "../acp/runtime/session-meta.js";


### PR DESCRIPTION
## Summary

The core Feishu session binding adapter and subagent hooks were landed in #46819. This PR adds the remaining pieces to make `/focus` fully functional on Feishu:

- **`/focus` and `/unfocus` commands**: Allow Feishu as a valid channel, add `resolveFeishuFocusConversationId` for stable conversation binding (rejects group chats), update command registry
- **ACP block delivery fix**: Add `promoteAcpBlocksToFinals` dispatcher capability so Feishu can opt-in to promoting ACP blocks to finals (needed because Feishu suppresses block streaming), while preserving Discord's native block handling
- **Gateway lifecycle**: Initialize thread binding manager on `startAccount`, clean up on `stopAccount`
- **Config**: Add `threadBindings` schema (enabled, idleHours, maxAgeHours, spawnAcpSessions)
- **Plugin SDK**: Export thread-bindings helpers for Feishu
- **Provider prefix normalization**: Strip `feishu:`/`lark:` prefixes before resolving targets

## Changed files (16 files, +263/-18)

| Area | Files |
|------|-------|
| /focus commands | `action-focus.ts`, `action-unfocus.ts`, `shared.ts`, `feishu-context.ts` (new), `channel-context.ts`, `session.ts`, `commands-registry.data.ts` |
| ACP delivery | `dispatch-acp-delivery.ts`, `reply-dispatcher.ts`, `feishu/reply-dispatcher.ts` |
| Gateway/config | `feishu/channel.ts`, `feishu/config-schema.ts` |
| SDK/misc | `plugin-sdk/feishu.ts`, `session-binding-service.ts`, `acpx/process.ts` |

## Context

Supersedes #40936 (clean rebase, same changes).

## Test plan

- [x] `startup-memory` passes
- [x] Local typecheck + lint + format pass
- [x] `extension-fast (acpx)` passes
- [x] Manual test: `/focus` in Feishu DM binds ACP session
- [x] Manual test: ACP block replies reach Feishu user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>