### PR TITLE
docs(site): add zh-CN root redirect

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,6 +48,14 @@
   },
   "redirects": [
     {
+      "source": "/zh-CN",
+      "destination": "/zh-CN/index"
+    },
+    {
+      "source": "/zh-CN/",
+      "destination": "/zh-CN/index"
+    },
+    {
       "source": "/messages",
       "destination": "/concepts/messages"
     },


### PR DESCRIPTION
## Summary
- add redirects from `/zh-CN` and `/zh-CN/` to the localized homepage
- make the Chinese docs root resolve to the actual document entrypoint

## Testing
- git diff --check

Fixes #43598