### PR TITLE
UI: Fix token stats display to use totalTokens (#48787)

### DIFF
--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -37,7 +37,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
           key: "main",
           kind: "direct",
           updatedAt: null,
-          inputTokens: 3_800,
+          totalTokens: 3_800,
           contextTokens: 4_000,
         },
       ],

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,7 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  const used = session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary

- **Problem**: Token stats display in webchat UI showed historical cumulative input tokens instead of current context usage
- **Why it matters**: Users were confused seeing "893.9k / 200k tokens" and thought they exceeded context limits, when actual context usage was only 117k (58%)
- **What changed**: Fixed `renderContextNotice` function to use `totalTokens` (current context usage) instead of `inputTokens` (cumulative historical value)
- **What did NOT change**: No changes to data structures, API, or backend logic

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Closes #48787

## Root Cause

The `renderContextNotice` function in `ui/src/ui/views/chat.ts` used `session?.inputTokens` which represents the cumulative input tokens over the entire session history. The correct field for displaying current context usage is `session?.totalTokens`.

This was confirmed by comparing with `src/auto-reply/status.ts` which correctly uses `totalTokens` for the same purpose.

## Fix

Changed one line in `renderContextNotice`:
```diff
- const used = session?.inputTokens ?? 0;
+ const used = session?.totalTokens ?? 0;
```

## Modified Files

- `ui/src/ui/views/chat.ts` - Core fix
- `ui/src/ui/views/chat.browser.test.ts` - Test data update

## Verification

- [x] `pnpm check` passed (0 warnings, 0 errors)
- [x] Code review passed
- [x] Minimal changes (2 files, 1 line each)

## Evidence

Before fix: UI showed "893.9k / 200k tokens" (incorrect - cumulative value)
After fix: UI shows actual context usage matching `session_status` command output

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No