### PR TITLE
fix(ui): add New Cron button to Cron Jobs UI (issue #48564)

### DIFF
--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -434,10 +434,15 @@ export function renderCron(props: CronProps) {
               <div class="card-title">${t("cron.jobs.title")}</div>
               <div class="card-sub">${t("cron.jobs.subtitle")}</div>
             </div>
-            <div class="muted">${t("cron.jobs.shownOf", {
-              shown: String(props.jobs.length),
-              total: String(props.jobsTotal),
-            })}</div>
+            <div class="row" style="gap: 8px; align-items: center;">
+              <div class="muted">${t("cron.jobs.shownOf", {
+                shown: String(props.jobs.length),
+                total: String(props.jobsTotal),
+              })}</div>
+              <button class="btn primary" @click=${props.onCancelEdit}>
+                ${t("cron.jobs.new") || "New Cron"}
+              </button>
+            </div>
           </div>
           <div class="filters" style="margin-top: 12px;">
             <label class="field cron-filter-search">


### PR DESCRIPTION
## Summary

This PR fixes issue #48564 - the missing "New Cron" button and stale data persistence in Cron Jobs UI.

## Changes

1. Add "New Cron" button to jobs list header
2. Reset form state when clicking New by calling onCancelEdit

## Testing

- pnpm lint passes (0 warnings, 0 errors)

## AI-ASSISTED