### PR TITLE
docs(logging): document logging.maxFileBytes config option

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -22,6 +22,7 @@ OpenClaw has two log “surfaces”:
 - The log file path and level can be configured via `~/.openclaw/openclaw.json`:
   - `logging.file`
   - `logging.level`
+  - `logging.maxFileBytes` — maximum single-file size in bytes before writes are suppressed (default: 500 MB)
 
 The file format is one JSON object per line.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -105,6 +105,7 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
   "logging": {
     "level": "info",
     "file": "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
+    "maxFileBytes": 524288000,
     "consoleLevel": "info",
     "consoleStyle": "pretty",
     "redactSensitive": "tools",
@@ -121,6 +122,20 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g. `OPENCLAW_LOG_LEVEL=debug`). The env var takes precedence over the config file, so you can raise verbosity for a single run without editing `openclaw.json`. You can also pass the global CLI option **`--log-level <level>`** (for example, `openclaw --log-level debug gateway run`), which overrides the environment variable for that command.
 
 `--verbose` only affects console output; it does not change file log levels.
+
+### File size cap
+
+`logging.maxFileBytes`: maximum size (in bytes) of a single daily log file. When the file exceeds this limit, further writes are silently suppressed until the next day's file rotates in. Default: `524288000` (500 MB).
+
+To raise the cap to 1 GB:
+
+```json
+{
+  "logging": {
+    "maxFileBytes": 1073741824
+  }
+}
+```
 
 ### Console styles
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -125,7 +125,7 @@ You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g
 
 ### File size cap
 
-`logging.maxFileBytes`: maximum size (in bytes) of a single daily log file. When the file exceeds this limit, further writes are suppressed until the next day's file rotates in (a one-time warning is written to the log file and `stderr` when the cap is first reached). Default: `524288000` (500 MB).
+`logging.maxFileBytes`: maximum size (in bytes) of a single log file. When the file exceeds this limit, further writes are suppressed (a one-time warning is written to the log file and `stderr` when the cap is first reached). With the default dated filename (`openclaw-YYYY-MM-DD.log`), logging resumes automatically the next day when a new file is created. If you set a fixed `logging.file` path, suppression persists until the process restarts or the file is truncated/removed. Default: `524288000` (500 MB).
 
 To raise the cap to 1 GB:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -125,7 +125,7 @@ You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g
 
 ### File size cap
 
-`logging.maxFileBytes`: maximum size (in bytes) of a single daily log file. When the file exceeds this limit, further writes are silently suppressed until the next day's file rotates in. Default: `524288000` (500 MB).
+`logging.maxFileBytes`: maximum size (in bytes) of a single daily log file. When the file exceeds this limit, further writes are suppressed until the next day's file rotates in (a one-time warning is written to the log file and `stderr` when the cap is first reached). Default: `524288000` (500 MB).
 
 To raise the cap to 1 GB:
 


### PR DESCRIPTION
## Summary

The `logging.maxFileBytes` config option exists in code (`src/config/types.base.ts` and `src/logging/logger.ts`) but was missing from documentation. This PR adds it to both `docs/logging.md` and `docs/gateway/logging.md`.

**What it does:** Controls the maximum size (in bytes) of a single daily log file before writes are silently suppressed until the next day's file rotates in. Default: 524288000 (500 MB).

## Files changed

- `docs/logging.md` — added `maxFileBytes` to the JSON config example and a new "File size cap" subsection explaining the option with a usage example
- `docs/gateway/logging.md` — added `logging.maxFileBytes` bullet in the "File-based logger" config list

## Test plan

- [ ] Verify docs render correctly on Mintlify
- [ ] Confirm JSON examples are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)