### PR TITLE
docs(gateway): add silent-exit recovery guide and AGENTS.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,21 @@
   `pkill -9 -f openclaw-gateway || true; nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &`
 - Verify: `openclaw channels status --probe`, `ss -ltnp | rg 18789`, `tail -n 120 /tmp/openclaw-gateway.log`.
 
+## Gateway Recovery (macOS multi-worktree)
+
+If the main gateway is down and not responding — **before spending time debugging** — check the runbook first: `docs/gateway/troubleshooting.md` section "Gateway starts but exits silently after a few minutes".
+
+The most common silent-exit pattern on macOS dev setups:
+
+1. **Config-reload triggered `process.exit()`**: The gateway's file watcher detected a config change, built a reload plan with `restartGateway=true`, and called `process.exit()`. If the LaunchAgent is disabled, no restart happens and the gateway stays down silently.
+   - Fix: `openclaw config set gateway.reload.mode hot` then `openclaw gateway install` to re-enable the service.
+
+2. **Wrong gateway owns the runtime**: In a multi-worktree setup, a worktree gateway may have grabbed the main config lock. Check lock files at `$TMPDIR/openclaw-$(id -u)/gateway.*.lock` — each contains the `configPath` and PID. Only kill the process whose `configPath` matches `~/.openclaw/openclaw.json`; leave worktree gateways (different configPaths/ports) alone.
+
+3. **LaunchAgent disabled**: Run `openclaw gateway install` — do NOT use manual `launchctl enable` from a shell (fails with error 125 from a non-GUI session). If a stale lock blocks startup, add `--force`.
+
+Verify recovery: `openclaw gateway status --deep` and `openclaw channels status --probe`.
+
 ## Build, Test, and Development Commands
 
 - Runtime baseline: Node **22+** (keep Node + Bun paths working).

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -303,6 +303,80 @@ Related:
 - [/tools/browser-linux-troubleshooting](/tools/browser-linux-troubleshooting)
 - [/tools/browser](/tools/browser)
 
+## Gateway starts but exits silently after a few minutes
+
+Use this when the gateway process starts, passes health checks, then dies a few minutes later with no error in the logs and no crash message.
+
+```bash
+openclaw gateway status
+openclaw logs --follow
+openclaw doctor
+```
+
+Look for:
+
+- Process exits cleanly (exit code 0) — no crash, just a quiet stop.
+- Log lines like `config change detected; evaluating reload` or `config reload requires gateway restart` shortly before the exit.
+- Service manager (LaunchAgent on macOS, systemd on Linux) not active or not enabled, so the process is never restarted after exit.
+
+### Root cause
+
+The gateway watches its config file for changes using a file watcher (`src/gateway/config-reload.ts`). When a change is detected, it builds a reload plan. For changes in the `channels` category (or any other path that sets `restartGateway = true`), the default reload mode (`hybrid`) calls `process.exit()` and expects the service manager to restart the process.
+
+If the service manager is disabled or not running, the gateway exits and stays down silently.
+
+Common triggers for a config-change-induced exit:
+
+- Another process (including your own CLI) wrote to the config file.
+- The gateway itself updated internal fields on startup.
+- A worktree-based gateway process was sharing or watching the same config file.
+
+### Fix option 1: set hot-reload mode (recommended for dev)
+
+```bash
+openclaw config set gateway.reload.mode hot
+```
+
+With `mode = "hot"`, the gateway logs a warning for changes that normally require a restart but does **not** exit. Channels are hot-reloaded where possible. This keeps the process alive when the service manager is unavailable.
+
+### Fix option 2: ensure the service manager is enabled
+
+On macOS, reinstall and enable the LaunchAgent:
+
+```bash
+openclaw gateway install
+```
+
+Verify it is loaded and running:
+
+```bash
+launchctl print gui/$UID | grep openclaw
+openclaw gateway status --deep
+```
+
+### Multi-worktree caution
+
+If you have multiple git worktrees each running their own gateway, confirm which process owns the main config before restarting anything.
+
+Each gateway holds a lock file at `$TMPDIR/openclaw-<uid>/gateway.*.lock` containing the `configPath` and PID it was started with. Check the lock files to identify which process owns which config:
+
+```bash
+ls /private/var/folders/*/*/T/openclaw-$(id -u)/gateway.*.lock 2>/dev/null || \
+  ls /tmp/openclaw-$(id -u)/gateway.*.lock 2>/dev/null
+```
+
+Only kill the process whose `configPath` matches the config you want to restart. Use `--force` if a stale lock remains after a previous crash:
+
+```bash
+openclaw gateway run --bind loopback --port 18789 --force
+```
+
+Related:
+
+- [/gateway/background-process](/gateway/background-process)
+- [/gateway/configuration-reference](/gateway/configuration-reference)
+- [/gateway/gateway-lock](/gateway/gateway-lock)
+
 ## If you upgraded and something suddenly broke
 
 Most post-upgrade breakage is config drift or stricter defaults now being enforced.


### PR DESCRIPTION
## Summary

- Adds a new troubleshooting section "Gateway starts but exits silently after a few minutes" to `docs/gateway/troubleshooting.md` documenting the config-reload-triggered silent exit pattern
- Adds a "Gateway Recovery (macOS multi-worktree)" section to `AGENTS.md` with a direct pointer to the runbook and key safety rules for multi-worktree dev setups

## What problem does this fix

The default `gateway.reload.mode` (`hybrid`) calls `process.exit()` when it detects a config change requiring a restart. If the LaunchAgent is disabled, the process exits and stays down silently — no crash, no error, just a dead gateway. Non-obvious pattern that cost significant debugging time.

The docs now cover:
- Root cause: file watcher → `restartGateway=true` → `process.exit()` → no service manager → stays dead
- Fix 1: `openclaw config set gateway.reload.mode hot`
- Fix 2: `openclaw gateway install` to re-enable the LaunchAgent
- Multi-worktree safety: inspect lock files before killing any process
- Footgun: use `openclaw gateway install`, NOT manual `launchctl enable` (fails error 125 from non-GUI shell)

## Test plan

- [ ] Docs render correctly (no broken anchors in new section heading)
- [ ] AGENTS.md pointer references the correct section path