### PR TITLE
fix(infra): respect OPENCLAW_LOG_DIR and OPENCLAW_TMP_DIR environment variablesFix log dir env

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -145,11 +145,24 @@ export function resolvePreferredOpenClawTmpDir(
   // even if the default directory already exists.
   if (process.env.OPENCLAW_TMP_DIR) {
     const overridePath = process.env.OPENCLAW_TMP_DIR;
+    const state = resolveDirState(overridePath);
+    if (state === "available") {
+      return overridePath;
+    }
+    if (state === "invalid") {
+      if (tryRepairWritableBits(overridePath)) {
+        return overridePath;
+      }
+      throw new Error(`Unsafe OPENCLAW_TMP_DIR: ${overridePath}`);
+    }
     try {
       mkdirSync(overridePath, { recursive: true, mode: 0o700 });
       chmodSync(overridePath, 0o700);
     } catch {
       throw new Error(`Unable to create OPENCLAW_TMP_DIR: ${overridePath}`);
+    }
+    if (resolveDirState(overridePath) !== "available" && !tryRepairWritableBits(overridePath)) {
+      throw new Error(`Unsafe OPENCLAW_TMP_DIR: ${overridePath}`);
     }
     return overridePath;
   }

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -148,10 +148,10 @@ export function resolvePreferredOpenClawTmpDir(
     try {
       mkdirSync(overridePath, { recursive: true, mode: 0o700 });
       chmodSync(overridePath, 0o700);
-      return overridePath;
     } catch {
-      // Fall through to default logic if override path is invalid/unwritable
+      throw new Error(`Unable to create OPENCLAW_TMP_DIR: ${overridePath}`);
     }
+    return overridePath;
   }
 
   const existingPreferredState = resolveDirState(POSIX_OPENCLAW_TMP_DIR);

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -140,6 +140,20 @@ export function resolvePreferredOpenClawTmpDir(
     return fallbackPath;
   };
 
+  // Allow overriding the temporary directory via environment variable
+  // This must be checked BEFORE the default logic to ensure the override is respected
+  // even if the default directory already exists.
+  if (process.env.OPENCLAW_TMP_DIR) {
+    const overridePath = process.env.OPENCLAW_TMP_DIR;
+    try {
+      mkdirSync(overridePath, { recursive: true, mode: 0o700 });
+      chmodSync(overridePath, 0o700);
+      return overridePath;
+    } catch {
+      // Fall through to default logic if override path is invalid/unwritable
+    }
+  }
+
   const existingPreferredState = resolveDirState(POSIX_OPENCLAW_TMP_DIR);
   if (existingPreferredState === "available") {
     return POSIX_OPENCLAW_TMP_DIR;
@@ -152,14 +166,6 @@ export function resolvePreferredOpenClawTmpDir(
   }
 
   try {
-    // Allow overriding the temporary directory via environment variable
-    if (process.env.OPENCLAW_TMP_DIR) {
-      const overridePath = process.env.OPENCLAW_TMP_DIR;
-      mkdirSync(overridePath, { recursive: true, mode: 0o700 });
-      chmodSync(overridePath, 0o700);
-      return overridePath;
-    }
-
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -152,6 +152,14 @@ export function resolvePreferredOpenClawTmpDir(
   }
 
   try {
+    // Allow overriding the temporary directory via environment variable
+    if (process.env.OPENCLAW_TMP_DIR) {
+      const overridePath = process.env.OPENCLAW_TMP_DIR;
+      mkdirSync(overridePath, { recursive: true, mode: 0o700 });
+      chmodSync(overridePath, 0o700);
+      return overridePath;
+    }
+
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -31,15 +31,19 @@ function canUseNodeFs(): boolean {
   }
 }
 
-function resolveDefaultLogDir(): string {
+export function resolveDefaultLogDir(): string {
   if (process.env.OPENCLAW_LOG_DIR) {
     return process.env.OPENCLAW_LOG_DIR;
   }
   return canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : POSIX_OPENCLAW_TMP_DIR;
 }
 
+export function resolveDefaultLogFile(): string {
+  return path.join(resolveDefaultLogDir(), "openclaw.log");
+}
+
 export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
-export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "openclaw.log"); // legacy single-file path
+export const DEFAULT_LOG_FILE = resolveDefaultLogFile(); // legacy single-file path
 
 const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
@@ -100,7 +104,7 @@ function resolveSettings(): ResolvedSettings {
   if (!canUseNodeFs()) {
     return {
       level: "silent",
-      file: DEFAULT_LOG_FILE,
+      file: resolveDefaultLogFile(),
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
     };
   }
@@ -342,7 +346,7 @@ function formatLocalDate(date: Date): string {
 
 function defaultRollingPathForToday(): string {
   const today = formatLocalDate(new Date());
-  return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+  return path.join(resolveDefaultLogDir(), `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }
 
 function isRollingPath(file: string): boolean {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -32,6 +32,9 @@ function canUseNodeFs(): boolean {
 }
 
 function resolveDefaultLogDir(): string {
+  if (process.env.OPENCLAW_LOG_DIR) {
+    return process.env.OPENCLAW_LOG_DIR;
+  }
   return canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : POSIX_OPENCLAW_TMP_DIR;
 }
 


### PR DESCRIPTION
## Description

Currently, OpenClaw hardcodes the resolution of the default log directory and temporary directory to use system defaults (like `/tmp/openclaw` or `%LocalAppData%\Temp\openclaw`), ignoring user-provided environment variables. This causes issues in portable environments or custom deployments (e.g., using `start.bat` on Windows) where users need to redirect logs and temporary files to a specific `data` folder.

This PR fixes the issue by explicitly checking and respecting `process.env.OPENCLAW_LOG_DIR` and `process.env.OPENCLAW_TMP_DIR` before falling back to the default behavior.

## Changes
- Modified `src/logging/logger.ts` to respect `OPENCLAW_LOG_DIR`.
- Modified `src/infra/tmp-openclaw-dir.ts` to respect `OPENCLAW_TMP_DIR`.

## How to test
1. Set `OPENCLAW_LOG_DIR=/path/to/custom/logs` and `OPENCLAW_TMP_DIR=/path/to/custom/tmp`.
2. Start the gateway.
3. Verify that the log file is created in `/path/to/custom/logs` and temporary files are written to `/path/to/custom/tmp`.