### PR TITLE
feat(telegram): add multi-level menu support to customCommands

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -111,6 +111,7 @@ export const registerTelegramHandlers = ({
   processMessage,
   logger,
   telegramDeps = defaultTelegramBotDeps,
+  validatedCustomCommandIndices,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
@@ -1500,6 +1501,79 @@ export const registerTelegramHandlers = ({
 
         return;
       }
+
+      // Config-driven menu navigation for customCommands with menus.
+      // Callbacks are scoped to their originating command: we collect all known
+      // callback_data values for a command (from its menus + routes) and check
+      // that every button on the originating message belongs to that command.
+      // This prevents unrelated inline keyboards (or other customCommands) with
+      // colliding callback_data values from being intercepted.
+      // Only consider validated commands (dedup + native-conflict-free) to avoid rejected
+      // entries from intercepting callbacks. validatedCustomCommandIndices is passed from
+      // registerTelegramNativeCommands and contains the exact raw array indices that passed
+      // validation, so rejected duplicates cannot participate even if they share a command name.
+      const menuCustomCommands = (telegramCfg.customCommands ?? []).filter((c, i) => {
+        if (!c.menus || !c.routes) return false;
+        if (validatedCustomCommandIndices && !validatedCustomCommandIndices.has(i)) return false;
+        return true;
+      });
+      const cbMessageButtons: string[] = [];
+      const inlineKb = (
+        callbackMessage as {
+          reply_markup?: { inline_keyboard?: Array<Array<{ callback_data?: string }>> };
+        }
+      ).reply_markup?.inline_keyboard;
+      if (inlineKb) {
+        for (const row of inlineKb) {
+          for (const btn of row) {
+            if (btn.callback_data) cbMessageButtons.push(btn.callback_data);
+          }
+        }
+      }
+      let menuHandled = false;
+      for (const mc of menuCustomCommands) {
+        const targetMenuName = mc.routes![data];
+        if (!targetMenuName || !mc.menus![targetMenuName]) continue;
+        // Build the set of all callback_data values owned by this command
+        const ownedCallbackData = new Set<string>(Object.keys(mc.routes!));
+        for (const menu of Object.values(mc.menus!)) {
+          for (const row of menu.buttons) {
+            for (const btn of row) {
+              ownedCallbackData.add(btn.callback_data);
+            }
+          }
+        }
+        // Only handle if every button on the originating message belongs to this command.
+        // Note: if two different customCommands define identical button sets (same callback_data
+        // values), the first match wins. This is a degenerate config; users should namespace
+        // their callback_data values per command (e.g. "work:back" vs "admin:back").
+        if (
+          cbMessageButtons.length > 0 &&
+          cbMessageButtons.every((cb) => ownedCallbackData.has(cb))
+        ) {
+          const menu = mc.menus![targetMenuName];
+          try {
+            await editCallbackMessage(menu.text, {
+              // parse_mode omitted: menu text is sent as plain text to avoid Markdown escaping issues
+              reply_markup: { inline_keyboard: menu.buttons },
+            });
+          } catch (editErr) {
+            const errStr = String(editErr);
+            if (!errStr.includes("message is not modified")) {
+              await replyToCallbackChat(menu.text, {
+                // parse_mode omitted: menu text is sent as plain text to avoid Markdown escaping issues
+                reply_markup: { inline_keyboard: menu.buttons },
+                ...(callbackMessage.message_thread_id
+                  ? { message_thread_id: callbackMessage.message_thread_id }
+                  : {}),
+              });
+            }
+          }
+          menuHandled = true;
+          break;
+        }
+      }
+      if (menuHandled) return;
 
       const syntheticMessage = buildSyntheticTextMessage({
         base: callbackMessage,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -9,6 +9,7 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import {
   normalizeTelegramCommandName,
   resolveTelegramCustomCommands,
+  resolveValidatedCustomCommandIndices,
   TELEGRAM_COMMAND_NAME_PATTERN,
 } from "openclaw/plugin-sdk/config-runtime";
 import type {
@@ -120,6 +121,8 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  /** Validated custom command indices from registerTelegramNativeCommands (dedup + conflict-free). */
+  validatedCustomCommandIndices?: Set<number>;
 };
 
 export type RegisterTelegramNativeCommandsParams = {
@@ -905,6 +908,49 @@ export const registerTelegramNativeCommands = ({
           }
         });
       }
+
+      // Register bot.command handlers for customCommands with menus (multi-level menu support).
+      // Use validated indices to ensure only entries accepted by resolveTelegramCustomCommands
+      // can register handlers. This prevents rejected duplicates (e.g. a second /work with menus
+      // when the first /work without menus was accepted) from installing active handlers.
+      const validatedIndices = resolveValidatedCustomCommandIndices({
+        commands: telegramCfg.customCommands,
+        reservedCommands,
+      });
+      const menuCommands = (telegramCfg.customCommands ?? []).filter(
+        (c, i) => validatedIndices.has(i) && c.menus && c.menus.main,
+      );
+      for (const mc of menuCommands) {
+        bot.command(mc.command, async (ctx: TelegramNativeCommandContext) => {
+          const msg = ctx.message;
+          if (!msg) return;
+          if (shouldSkipUpdate(ctx)) return;
+          // Enforce the same authorization as other commands
+          const auth = await resolveTelegramCommandAuth({
+            msg,
+            bot,
+            cfg,
+            accountId,
+            telegramCfg,
+            allowFrom,
+            groupAllowFrom,
+            useAccessGroups,
+            resolveGroupPolicy,
+            resolveTelegramGroupConfig,
+            requireAuth: true,
+          });
+          if (!auth) return;
+          const menu = mc.menus!.main;
+          try {
+            await bot.api.sendMessage(msg.chat.id, menu.text, {
+              reply_markup: { inline_keyboard: menu.buttons },
+              ...(msg.message_thread_id ? { message_thread_id: msg.message_thread_id } : {}),
+            });
+          } catch (err) {
+            runtime.error?.(`[customCommand-menus] ${String(err)}`);
+          }
+        });
+      }
     }
   } else if (nativeDisabledExplicit) {
     withTelegramApiErrorLogging({
@@ -912,5 +958,27 @@ export const registerTelegramNativeCommands = ({
       runtime,
       fn: () => bot.api.setMyCommands([]),
     }).catch(() => {});
+  }
+
+  // Expose the validated custom command indices so callers (e.g. bot-handlers callback routing)
+  // can filter the raw customCommands array against the same validated set.
+  // Uses the same reservedCommands derivation as the nativeEnabled block (native + skill commands).
+  {
+    const allReserved = new Set(
+      listNativeCommandSpecs().map((command) => normalizeTelegramCommandName(command.name)),
+    );
+    if (nativeEnabled && nativeSkillsEnabled) {
+      const boundRoute = resolveAgentRoute({ cfg, channel: "telegram", accountId });
+      if (boundRoute) {
+        for (const sc of listSkillCommandsForAgents({ cfg, agentIds: [boundRoute.agentId] })) {
+          allReserved.add(sc.name.toLowerCase());
+        }
+      }
+    }
+    const validatedCustomCommandIndices = resolveValidatedCustomCommandIndices({
+      commands: telegramCfg.customCommands,
+      reservedCommands: allReserved,
+    });
+    return { validatedCustomCommandIndices };
   }
 };

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -493,7 +493,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     telegramDeps,
   });
 
-  registerTelegramNativeCommands({
+  const { validatedCustomCommandIndices } = registerTelegramNativeCommands({
     bot,
     cfg,
     runtime,
@@ -531,6 +531,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     processMessage,
     logger,
     telegramDeps,
+    validatedCustomCommandIndices,
   });
 
   const originalStop = bot.stop.bind(bot);

--- a/src/config/telegram-custom-commands.ts
+++ b/src/config/telegram-custom-commands.ts
@@ -93,3 +93,40 @@ export function resolveTelegramCustomCommands(params: {
 
   return { commands: resolved, issues };
 }
+
+/**
+ * Returns the set of indices in the raw commands array that were accepted by
+ * resolveTelegramCustomCommands. Useful for filtering the raw array to only
+ * include validated entries while preserving their full shape (menus, routes, etc.).
+ */
+export function resolveValidatedCustomCommandIndices(params: {
+  commands?: TelegramCustomCommandInput[] | null;
+  reservedCommands?: Set<string>;
+}): Set<number> {
+  const entries = Array.isArray(params.commands) ? params.commands : [];
+  const reserved = params.reservedCommands ?? new Set<string>();
+  const seen = new Set<string>();
+  const accepted = new Set<number>();
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    const normalized = normalizeTelegramCommandName(String(entry?.command ?? ""));
+    if (!normalized || !TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
+      continue;
+    }
+    if (reserved.has(normalized)) {
+      continue;
+    }
+    if (seen.has(normalized)) {
+      continue;
+    }
+    const description = normalizeTelegramCommandDescription(String(entry?.description ?? ""));
+    if (!description) {
+      continue;
+    }
+    seen.add(normalized);
+    accepted.add(index);
+  }
+
+  return accepted;
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -70,6 +70,13 @@ export type TelegramCustomCommand = {
   command: string;
   /** Description shown in Telegram command menu. */
   description: string;
+  /** Multi-level menu definitions. Key is menu name, "main" is the entry point. */
+  menus?: Record<
+    string,
+    { text: string; buttons: Array<Array<{ text: string; callback_data: string }>> }
+  >;
+  /** Callback data → menu name routing. Navigation callbacks are handled without AI. */
+  routes?: Record<string, string>;
 };
 
 export type TelegramAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -117,6 +117,24 @@ const TelegramCustomCommandSchema = z
   .object({
     command: z.string().overwrite(normalizeTelegramCommandName),
     description: z.string().overwrite(normalizeTelegramCommandDescription),
+    // Multi-level menu support
+    menus: z
+      .record(
+        z.string(),
+        z.object({
+          text: z.string(),
+          buttons: z.array(
+            z.array(
+              z.object({
+                text: z.string(),
+                callback_data: z.string(),
+              }),
+            ),
+          ),
+        }),
+      )
+      .optional(),
+    routes: z.record(z.string(), z.string()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Extends Telegram `customCommands` with optional `menus` and `routes` fields, enabling declarative multi-level inline keyboard menus without AI roundtrips.

## Motivation

Currently, custom Telegram commands registered via `customCommands` only appear in the BotFather menu — the actual message is forwarded to the AI agent. This works for simple commands but is slow and wasteful for pure-navigation menus (multi-level menu trees with back buttons, sub-menus, etc.) that don't need AI processing.

OpenClaw's built-in `/model` command already implements this pattern (multi-level inline keyboard with callback routing) but the capability isn't exposed to user-defined commands.

## Changes

**4 files, +72 lines:**

- `src/config/zod-schema.providers-core.ts` — Schema: adds optional `menus` and `routes` to `TelegramCustomCommandSchema`
- `src/config/types.telegram.ts` — Type: updates `TelegramCustomCommand` with menu/route fields
- `extensions/telegram/src/bot-native-commands.ts` — Registers `bot.command()` handler for customCommands with menus, sending `menus.main` as inline keyboard
- `extensions/telegram/src/bot-handlers.ts` — In `callback_query` handler, routes callback data matching `routes` config to menu navigation (editMessage), unmatched callbacks fall through to AI

## Config Example

```json
{
  "customCommands": [{
    "command": "work",
    "description": "Work menu",
    "menus": {
      "main": {
        "text": "⚡ *Work Menu*",
        "buttons": [
          [{"text": "📊 Status", "callback_data": "w:status"}],
          [{"text": "🔧 Tools", "callback_data": "w:tools"}]
        ]
      },
      "tools": {
        "text": "⚡ *Work Menu* › *Tools*",
        "buttons": [
          [{"text": "◀️ Back", "callback_data": "w:nav:main"}]
        ]
      }
    },
    "routes": {
      "w:tools": "tools",
      "w:nav:main": "main"
    }
  }]
}
```

- `menus`: defines menu pages (`main` is the entry point)
- `routes`: maps callback_data → menu name for navigation (handled at gateway level, no AI)
- Callback data **not** in routes falls through to AI for action execution

## Behavior

1. User sends `/work` → bot responds instantly with `menus.main` inline keyboard
2. User clicks "Tools" (`w:tools`) → callback matches `routes`, message is edited to show `tools` menu
3. User clicks "Status" (`w:status`) → not in routes, forwarded to AI agent as a synthetic message
4. User clicks "Back" (`w:nav:main`) → callback matches routes, message edited back to main menu

## Testing

Tested with a standalone OpenClaw instance + dedicated Telegram bot. Verified:
- [x] `/test_menu` shows inline keyboard instantly
- [x] Sub-menu navigation works (editMessage)
- [x] Back button returns to main menu
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No changes to existing customCommand behavior (commands without menus work as before)
