### PR TITLE
UI: Fix token stats display to use totalTokens (#48787)

### DIFF
--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -37,7 +37,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
           key: "main",
           kind: "direct",
           updatedAt: null,
-          inputTokens: 3_800,
+          totalTokens: 3_800,
           contextTokens: 4_000,
         },
       ],

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,7 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  const used = session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary

- **Problem**: Token stats display in webchat UI showed historical cumulative input tokens instead of current context usage
- **Why it matters**: Users were confused seeing "893.9k / 200k tokens" and thought they exceeded context limits, when actual context usage was only 117k (58%)
- **What changed**: Fixed `renderContextNotice` function to use `totalTokens` (current context usage) instead of `inputTokens` (cumulative historical value)
- **What did NOT change**: No changes to data structures, API, or backend logic

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48787

## User-visible / Behavior Changes

- Webchat UI now displays actual current context usage instead of cumulative historical input tokens
- Users will see accurate context percentage (e.g., "58% context used" instead of confusing "447%")

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (VPS)
- Runtime/container: OpenClaw 2026.3.13
- Model/provider: minimax-cn/MiniMax-M2.5-highspeed
- Integration/channel: webchat

### Steps

1. Open webchat interface
2. Observe token stats display (was showing "893.9k / 200k")
3. Use `session_status` command to verify actual context usage (117k / 200k = 58%)
4. Numbers were inconsistent, causing user confusion

### Expected

- UI displays current context usage matching `session_status` output

### Actual

- Before fix: UI showed cumulative input tokens (893.9k) instead of current context (117k)
- After fix: UI correctly shows current context usage

## Evidence

- [x] Code change verified against `src/auto-reply/status.ts` which correctly uses `totalTokens`

## Human Verification (required)

- Verified scenarios: Code logic matches the correct implementation in `src/auto-reply/status.ts`
- Edge cases checked: Both `inputTokens` and `totalTokens` are `number | undefined`, so `?? 0` fallback remains valid
- What you did **not** verify: Live UI testing (requires deployment)

## Review Conversations

- [x] No bot review conversations to address yet

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Context notice might not display if `totalTokens` is 0 or undefined (expected behavior)

## Risks and Mitigations

- Risk: If `totalTokens` is undefined/0, context notice won't display
  - Mitigation: This is expected behavior - same as before when `inputTokens` was 0