### PR TITLE
fix(image-gen): add fetch timeout to OpenAI image generation

### DIFF
--- a/src/image-generation/providers/openai.ts
+++ b/src/image-generation/providers/openai.ts
@@ -39,19 +39,28 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProviderPlu
         throw new Error("OpenAI API key missing");
       }
 
-      const response = await fetch(`${resolveOpenAIBaseUrl(req.cfg)}/images/generations`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${auth.apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: req.model || DEFAULT_OPENAI_IMAGE_MODEL,
-          prompt: req.prompt,
-          n: req.count ?? 1,
-          size: req.size ?? DEFAULT_SIZE,
-        }),
-      });
+      let response: Response;
+      try {
+        response = await fetch(`${resolveOpenAIBaseUrl(req.cfg)}/images/generations`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${auth.apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: req.model || DEFAULT_OPENAI_IMAGE_MODEL,
+            prompt: req.prompt,
+            n: req.count ?? 1,
+            size: req.size ?? DEFAULT_SIZE,
+          }),
+          signal: AbortSignal.timeout(120_000),
+        });
+      } catch (err) {
+        throw new Error(
+          `OpenAI image generation request failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
 
       if (!response.ok) {
         const text = await response.text().catch(() => "");


### PR DESCRIPTION
lobster-biscuit

## Problem

The OpenAI image generation provider calls `/images/generations` with no timeout. Image generation typically takes 30-60+ seconds, but a hanging endpoint would stall the request indefinitely with no feedback to the user.

The Google image generation provider already uses `timeoutMs: 60_000` via the SDK, but the OpenAI provider uses raw `fetch()` with no equivalent protection.

## Solution

Add a 120-second `AbortSignal.timeout` to the fetch call (generous for image generation workloads) and wrap it in a try/catch that preserves the cause chain via `{ cause: err }`.

The existing `!res.ok` error path already uses `.catch(() => "")` on the body read, so no change needed there.

## Changes

- `src/image-generation/providers/openai.ts` — add `AbortSignal.timeout(120_000)` + try/catch wrapper

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] OpenAI image generation works end-to-end (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)