### PR TITLE
fix(mattermost): add fetch timeout to file upload

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -256,13 +256,22 @@ export async function uploadMattermostFile(
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 
-  const res = await fetch(`${client.apiBaseUrl}/files`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${client.token}`,
-    },
-    body: form,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${client.apiBaseUrl}/files`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${client.token}`,
+      },
+      body: form,
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
+    throw new Error(
+      `Mattermost file upload failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   if (!res.ok) {
     const detail = await readMattermostError(res);


### PR DESCRIPTION
lobster-biscuit

## Problem

`uploadMattermostFile()` POSTs binary file data to the Mattermost API with no timeout. A slow or unresponsive server would stall the upload pipeline indefinitely.

The probe endpoint in the same extension already uses an `AbortController` pattern, but the file upload function was missed.

## Solution

Add a 60-second `AbortSignal.timeout` to the file upload fetch call (file uploads need a longer timeout than typical API calls). Wrapped in try/catch with `{ cause: err }` to preserve the cause chain.

## Changes

- `extensions/mattermost/src/mattermost/client.ts` — add `AbortSignal.timeout(60_000)` to `uploadMattermostFile()`

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Mattermost file upload works end-to-end (requires Mattermost instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)