### PR TITLE
Cron: constrain main-session system events

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -253,7 +253,7 @@ export function buildAgentSystemPrompt(params: {
     browser: "Control web browser",
     canvas: "Present/eval/snapshot the Canvas",
     nodes: "List/describe/notify/camera/screen on paired nodes",
-    cron: "Manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+    cron: 'Manage cron jobs and wake events (prefer sessionTarget="isolated" with payload.kind="agentTurn" for reminders or follow-ups; reserve main-session systemEvent payloads for short internal wake tokens only, not reminder prose; include recent context only in isolated follow-up prompts when appropriate)',
     message: "Send messages and channel actions",
     gateway: "Restart, apply config, or run updates on the running OpenClaw process",
     agents_list: acpSpawnRuntimeEnabled
@@ -438,7 +438,7 @@ export function buildAgentSystemPrompt(params: {
           "- browser: control OpenClaw's dedicated browser",
           "- canvas: present/eval/snapshot the Canvas",
           "- nodes: list/describe/notify/camera/screen on paired nodes",
-          "- cron: manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+          '- cron: manage cron jobs and wake events (prefer sessionTarget="isolated" with payload.kind="agentTurn" for reminders or follow-ups; reserve main-session systemEvent payloads for short internal wake tokens only, not reminder prose; include recent context only in isolated follow-up prompts when appropriate)',
           "- sessions_list: list sessions",
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -89,7 +89,11 @@ describe("cron tool", () => {
     return payload?.sessionKey;
   }
 
-  async function executeAddWithContextMessages(callId: string, contextMessages: number) {
+  async function executeAddWithContextMessages(
+    callId: string,
+    contextMessages: number,
+    jobOverrides: Record<string, unknown>,
+  ) {
     const tool = createCronTool({ agentSessionKey: "main" });
     await tool.execute(callId, {
       action: "add",
@@ -97,7 +101,7 @@ describe("cron tool", () => {
       job: {
         name: "reminder",
         schedule: { at: new Date(123).toISOString() },
-        payload: { kind: "systemEvent", text: "Reminder: the thing." },
+        ...jobOverrides,
       },
     });
   }
@@ -223,7 +227,7 @@ describe("cron tool", () => {
     expect(sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
   });
 
-  it("adds recent context for systemEvent reminders when contextMessages > 0", async () => {
+  it("adds recent context for isolated agentTurn reminders when contextMessages > 0", async () => {
     callGatewayMock
       .mockResolvedValueOnce({
         messages: [
@@ -237,7 +241,10 @@ describe("cron tool", () => {
       })
       .mockResolvedValueOnce({ ok: true });
 
-    await executeAddWithContextMessages("call3", 3);
+    await executeAddWithContextMessages("call3", 3, {
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "Review the latest status" },
+    });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(2);
     const historyCall = readGatewayCall(0);
@@ -245,11 +252,12 @@ describe("cron tool", () => {
 
     const cronCall = readGatewayCall(1);
     expect(cronCall.method).toBe("cron.add");
-    const text = readCronPayloadText(1);
-    expect(text).toContain("Recent context:");
-    expect(text).toContain("User: Discussed Q2 budget");
-    expect(text).toContain("Assistant: We agreed to review on Tuesday.");
-    expect(text).toContain("User: Remind me about the thing at 2pm");
+    const params = cronCall.params as { payload?: { message?: string } } | undefined;
+    const message = params?.payload?.message ?? "";
+    expect(message).toContain("Recent context:");
+    expect(message).toContain("User: Discussed Q2 budget");
+    expect(message).toContain("Assistant: We agreed to review on Tuesday.");
+    expect(message).toContain("User: Remind me about the thing at 2pm");
   });
 
   it("caps contextMessages at 10", async () => {
@@ -259,7 +267,10 @@ describe("cron tool", () => {
     }));
     callGatewayMock.mockResolvedValueOnce({ messages }).mockResolvedValueOnce({ ok: true });
 
-    await executeAddWithContextMessages("call5", 20);
+    await executeAddWithContextMessages("call5", 20, {
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "Review the latest status" },
+    });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(2);
     const historyCall = readGatewayCall(0);
@@ -267,11 +278,26 @@ describe("cron tool", () => {
     const historyParams = historyCall.params as { limit?: number } | undefined;
     expect(historyParams?.limit).toBe(10);
 
-    const text = readCronPayloadText(1);
-    expect(text).not.toMatch(/Message 1\\b/);
-    expect(text).not.toMatch(/Message 2\\b/);
-    expect(text).toContain("Message 3");
-    expect(text).toContain("Message 12");
+    const params = readGatewayCall(1).params as { payload?: { message?: string } } | undefined;
+    const message = params?.payload?.message ?? "";
+    expect(message).not.toMatch(/Message 1\\b/);
+    expect(message).not.toMatch(/Message 2\\b/);
+    expect(message).toContain("Message 3");
+    expect(message).toContain("Message 12");
+  });
+
+  it("does not add context to main-session wake tokens", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await executeAddWithContextMessages("call-main-token", 3, {
+      payload: { kind: "systemEvent", text: "wake up" },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const cronCall = readGatewayCall(0);
+    expect(cronCall.method).toBe("cron.add");
+    const text = readCronPayloadText(0);
+    expect(text).toBe("wake up");
   });
 
   it("does not add context when contextMessages is 0 (default)", async () => {
@@ -283,7 +309,7 @@ describe("cron tool", () => {
       job: {
         name: "reminder",
         schedule: { at: new Date(123).toISOString() },
-        payload: { text: "Reminder: the thing." },
+        payload: { kind: "systemEvent", text: "wake up" },
       },
     });
 
@@ -305,7 +331,7 @@ describe("cron tool", () => {
         name: "reminder",
         schedule: { at: new Date(123).toISOString() },
         agentId: null,
-        payload: { kind: "systemEvent", text: "Reminder: the thing." },
+        payload: { kind: "systemEvent", text: "wake up" },
       },
     });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -236,7 +236,7 @@ JOB SCHEMA (for add action):
 }
 
 SESSION TARGET OPTIONS:
-- "main": Run in the main session (requires payload.kind="systemEvent")
+- "main": Run in the main session with a short internal wake token (requires payload.kind="systemEvent")
 - "isolated": Run in an ephemeral isolated session (requires payload.kind="agentTurn")
 - "current": Bind to the current session where the cron is created (resolved at creation time)
 - "session:<custom-id>": Run in a persistent named session (e.g., "session:project-alpha-daily")
@@ -257,7 +257,7 @@ SCHEDULE TYPES (schedule.kind):
 ISO timestamps without an explicit timezone are treated as UTC.
 
 PAYLOAD TYPES (payload.kind):
-- "systemEvent": Injects text as system event into session
+- "systemEvent": Injects short internal wake text into the main session
   { "kind": "systemEvent", "text": "<message>" }
 - "agentTurn": Runs agent with message (isolated sessions only)
   { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
@@ -272,6 +272,7 @@ DELIVERY (top-level):
 CRITICAL CONSTRAINTS:
 - sessionTarget="main" REQUIRES payload.kind="systemEvent"
 - sessionTarget="isolated" | "current" | "session:xxx" REQUIRES payload.kind="agentTurn"
+- main-session systemEvent text must stay a short internal wake token; use isolated agentTurn jobs for rich reminder/follow-up prose
 - For webhook callbacks, use delivery.mode="webhook" with delivery.to set to a URL.
 Default: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.
 
@@ -279,7 +280,7 @@ WAKE MODES (for wake action):
 - "next-heartbeat" (default): Wake on next heartbeat
 - "now": Wake immediately
 
-Use jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.`,
+Use jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to isolated agentTurn job text.`,
     parameters: CronToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -425,14 +426,23 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             typeof params.contextMessages === "number" && Number.isFinite(params.contextMessages)
               ? params.contextMessages
               : 0;
+          const sessionTarget =
+            job && typeof job === "object" && "sessionTarget" in job
+              ? (job as { sessionTarget?: string }).sessionTarget
+              : undefined;
+          const isIsolatedLikeSession =
+            sessionTarget === "isolated" ||
+            sessionTarget === "current" ||
+            (typeof sessionTarget === "string" && sessionTarget.startsWith("session:"));
           if (
             job &&
             typeof job === "object" &&
             "payload" in job &&
-            (job as { payload?: { kind?: string; text?: string } }).payload?.kind === "systemEvent"
+            isIsolatedLikeSession &&
+            (job as { payload?: { kind?: string; message?: string } }).payload?.kind === "agentTurn"
           ) {
-            const payload = (job as { payload: { kind: string; text: string } }).payload;
-            if (typeof payload.text === "string" && payload.text.trim()) {
+            const payload = (job as { payload: { kind: string; message: string } }).payload;
+            if (typeof payload.message === "string" && payload.message.trim()) {
               const contextLines = await buildReminderContextLines({
                 agentSessionKey: opts?.agentSessionKey,
                 gatewayOpts,
@@ -440,8 +450,8 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 callGatewayTool: callGateway,
               });
               if (contextLines.length > 0) {
-                const baseText = stripExistingContext(payload.text);
-                payload.text = `${baseText}${REMINDER_CONTEXT_MARKER}${contextLines.join("\n")}`;
+                const baseText = stripExistingContext(payload.message);
+                payload.message = `${baseText}${REMINDER_CONTEXT_MARKER}${contextLines.join("\n")}`;
               }
             }
           }

--- a/src/cron/main-session-system-event.ts
+++ b/src/cron/main-session-system-event.ts
@@ -1,0 +1,73 @@
+const MAIN_SESSION_SYSTEM_EVENT_MAX_LEN = 80;
+const MAIN_SESSION_SYSTEM_EVENT_MAX_WORDS = 12;
+
+const BLOCKED_MAIN_SESSION_PATTERNS = [
+  /\brelay\b/i,
+  /\bremind(?:er)?\b/i,
+  /\brecent context\b/i,
+  /\bfriendly\b/i,
+  /\binspect the current\b/i,
+  /\bprogress update\b/i,
+  /\b(send|tell|message)\b.{0,32}\buser\b/i,
+  /\buser\b.{0,32}\b(send|tell|message)\b/i,
+] as const;
+
+export const MAIN_SESSION_SYSTEM_EVENT_ERROR =
+  'cron main-session systemEvent text must be a short internal wake token; use sessionTarget="isolated" with payload.kind="agentTurn" for rich reminders or follow-up prose';
+
+export const MAIN_SESSION_SYSTEM_EVENT_FALLBACK_TOKEN = "cron wake";
+
+export function normalizeMainSessionSystemEventText(raw: string): string {
+  return raw.trim();
+}
+
+export function isSafeMainSessionSystemEventText(raw: string): boolean {
+  const text = normalizeMainSessionSystemEventText(raw);
+  if (!text) {
+    return false;
+  }
+  if (text.length > MAIN_SESSION_SYSTEM_EVENT_MAX_LEN) {
+    return false;
+  }
+  if (/[\r\n]/.test(text)) {
+    return false;
+  }
+  if (/[.!?]/.test(text)) {
+    return false;
+  }
+  const words = text.split(/\s+/u).filter(Boolean);
+  if (words.length > MAIN_SESSION_SYSTEM_EVENT_MAX_WORDS) {
+    return false;
+  }
+  return !BLOCKED_MAIN_SESSION_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function assertSafeMainSessionSystemEventText(raw: string): string {
+  const text = normalizeMainSessionSystemEventText(raw);
+  if (!isSafeMainSessionSystemEventText(text)) {
+    throw new Error(MAIN_SESSION_SYSTEM_EVENT_ERROR);
+  }
+  return text;
+}
+
+export function toMainSessionSystemEventToken(raw: string): string | undefined {
+  const text = normalizeMainSessionSystemEventText(raw);
+  if (!text) {
+    return undefined;
+  }
+  return isSafeMainSessionSystemEventText(text) ? text : MAIN_SESSION_SYSTEM_EVENT_FALLBACK_TOKEN;
+}
+
+export function collectMainSessionSystemEventTokens(events: string[]): string[] {
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const event of events) {
+    const token = toMainSessionSystemEventToken(event);
+    if (!token || seen.has(token)) {
+      continue;
+    }
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
+}

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -359,6 +359,32 @@ describe("normalizeCronJobCreate", () => {
     expect(typeof normalized.name).toBe("string");
   });
 
+  it("rejects rich main-session systemEvent reminder prose", () => {
+    expect(() =>
+      normalizeCronJobCreate({
+        name: "rich-main",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "systemEvent",
+          text: "Please relay this reminder to the user in a helpful and friendly way.",
+        },
+      }),
+    ).toThrow(
+      'cron main-session systemEvent text must be a short internal wake token; use sessionTarget="isolated" with payload.kind="agentTurn" for rich reminders or follow-up prose',
+    );
+  });
+
+  it("accepts short main-session wake tokens", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "wake-token",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: { kind: "systemEvent", text: "wake up" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("main");
+    expect((normalized.payload as Record<string, unknown>).text).toBe("wake up");
+  });
+
   it("maps top-level model/thinking/timeout into payload for legacy add params", () => {
     const normalized = normalizeCronJobCreate({
       name: "legacy root fields",
@@ -498,5 +524,18 @@ describe("normalizeCronJobPatch", () => {
 
     const schedule = normalized.schedule as Record<string, unknown>;
     expect(schedule.staggerMs).toBe(30_000);
+  });
+
+  it("rejects rich systemEvent payload patches", () => {
+    expect(() =>
+      normalizeCronJobPatch({
+        payload: {
+          kind: "systemEvent",
+          text: "Reminder: review the whole conversation and send the user an update",
+        },
+      }),
+    ).toThrow(
+      'cron main-session systemEvent text must be a short internal wake token; use sessionTarget="isolated" with payload.kind="agentTurn" for rich reminders or follow-up prose',
+    );
   });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,6 +1,7 @@
 import { sanitizeAgentId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
 import { normalizeLegacyDeliveryInput } from "./legacy-delivery.js";
+import { assertSafeMainSessionSystemEventText } from "./main-session-system-event.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { migrateLegacyCronPayload } from "./payload-migration.js";
 import { inferLegacyName } from "./service/normalize.js";
@@ -313,6 +314,25 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.provider;
 }
 
+function assertNormalizedMainSessionSystemEvent(next: UnknownRecord) {
+  const payload = next.payload;
+  if (!isRecord(payload)) {
+    return;
+  }
+  const kind = typeof payload.kind === "string" ? payload.kind : "";
+  if (kind !== "systemEvent") {
+    return;
+  }
+  const text = typeof payload.text === "string" ? payload.text : "";
+  if (!text.trim()) {
+    return;
+  }
+  const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
+  if (sessionTarget === "" || sessionTarget === "main") {
+    payload.text = assertSafeMainSessionSystemEventText(text);
+  }
+}
+
 export function normalizeCronJobInput(
   raw: unknown,
   options: NormalizeOptions = DEFAULT_OPTIONS,
@@ -522,6 +542,8 @@ export function normalizeCronJobInput(
       next.delivery = { mode: "announce" };
     }
   }
+
+  assertNormalizedMainSessionSystemEvent(next);
 
   return next;
 }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -70,6 +70,26 @@ describe("applyJobPatch", () => {
     expect(job.delivery).toEqual({ mode: "webhook", to: "https://example.invalid/cron" });
   });
 
+  it("rejects rich main-session systemEvent payloads when switching targets", () => {
+    const job = createIsolatedAgentTurnJob("job-rich-main", {
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+
+    expect(() =>
+      applyJobPatch(job, {
+        sessionTarget: "main",
+        payload: {
+          kind: "systemEvent",
+          text: "Please relay this reminder to the user in a helpful and friendly way",
+        },
+      }),
+    ).toThrow(
+      'cron main-session systemEvent text must be a short internal wake token; use sessionTarget="isolated" with payload.kind="agentTurn" for rich reminders or follow-up prose',
+    );
+  });
+
   it("maps legacy payload delivery updates onto delivery", () => {
     const job = createIsolatedAgentTurnJob("job-2", {
       mode: "announce",
@@ -419,6 +439,21 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
     );
   });
 
+  it("rejects rich main-session systemEvent text at creation time", () => {
+    const state = createMockState(now, { defaultAgentId: "main" });
+    expect(() =>
+      createJob(state, {
+        ...mainJobInput("main"),
+        payload: {
+          kind: "systemEvent",
+          text: "Reminder: check the transcript and send the user a friendly update",
+        },
+      }),
+    ).toThrow(
+      'cron main-session systemEvent text must be a short internal wake token; use sessionTarget="isolated" with payload.kind="agentTurn" for rich reminders or follow-up prose',
+    );
+  });
+
   it("rejects main-session job for non-default agent even without explicit defaultAgentId", () => {
     const state = createMockState(now);
     expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
@@ -437,6 +472,24 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
         wakeMode: "now",
         payload: { kind: "agentTurn", message: "do it" },
         agentId: "custom-agent",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows isolated rich follow-up prompts", () => {
+    const state = createMockState(now, { defaultAgentId: "main" });
+    expect(() =>
+      createJob(state, {
+        name: "isolated-follow-up",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message:
+            "Review the current session state, decide whether a user update is needed, and send one only if warranted.",
+        },
       }),
     ).not.toThrow();
   });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,5 +1,9 @@
 import crypto from "node:crypto";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import {
+  assertSafeMainSessionSystemEventText,
+  toMainSessionSystemEventToken,
+} from "../main-session-system-event.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
   coerceFiniteScheduleNumber,
@@ -136,8 +140,11 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
     job.sessionTarget === "isolated" ||
     job.sessionTarget === "current" ||
     job.sessionTarget.startsWith("session:");
-  if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
-    throw new Error('main cron jobs require payload.kind="systemEvent"');
+  if (job.sessionTarget === "main") {
+    if (job.payload.kind !== "systemEvent") {
+      throw new Error('main cron jobs require payload.kind="systemEvent"');
+    }
+    assertSafeMainSessionSystemEventText(job.payload.text);
   }
   if (isIsolatedLike && job.payload.kind !== "agentTurn") {
     throw new Error('isolated/current/session cron jobs require payload.kind="agentTurn"');
@@ -905,5 +912,5 @@ export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {
     return undefined;
   }
   const text = normalizePayloadToSystemText(job.payload);
-  return text.trim() ? text : undefined;
+  return toMainSessionSystemEventToken(text);
 }

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -9,30 +9,39 @@ import {
 describe("heartbeat event prompts", () => {
   it.each([
     {
-      name: "builds user-relay cron prompt by default",
+      name: "builds minimal cron wake prompt with safe token text",
       events: ["Cron: rotate logs"],
-      expected: ["Cron: rotate logs", "Please relay this reminder to the user"],
-      unexpected: ["Handle this reminder internally", "Reply HEARTBEAT_OK."],
+      expected: [
+        "SYSTEM_WAKE source=cron",
+        "token=Cron: rotate logs",
+        "Reply HEARTBEAT_OK unless session context requires follow-up.",
+      ],
+      unexpected: [
+        "A scheduled reminder has been triggered",
+        "Please relay this reminder to the user",
+        "Handle this reminder internally",
+      ],
     },
     {
-      name: "builds internal-only cron prompt when delivery is disabled",
-      events: ["Cron: rotate logs"],
-      opts: { deliverToUser: false },
-      expected: ["Cron: rotate logs", "Handle this reminder internally"],
-      unexpected: ["Please relay this reminder to the user"],
+      name: "redacts unsafe reminder prose from cron wake prompt",
+      events: [
+        "Reminder: rotate logs.",
+        "Please relay this reminder to the user in a helpful and friendly way.",
+      ],
+      expected: [
+        "SYSTEM_WAKE source=cron",
+        "Reply HEARTBEAT_OK unless session context requires follow-up.",
+      ],
+      unexpected: ["Reminder: rotate logs.", "Please relay this reminder to the user", "token="],
     },
     {
-      name: "falls back to bare heartbeat reply when cron content is empty",
+      name: "uses minimal fallback when cron content is empty",
       events: ["", "   "],
-      expected: ["Reply HEARTBEAT_OK."],
-      unexpected: ["Handle this reminder internally"],
-    },
-    {
-      name: "uses internal empty-content fallback when delivery is disabled",
-      events: ["", "   "],
-      opts: { deliverToUser: false },
-      expected: ["Handle this internally", "HEARTBEAT_OK when nothing needs user-facing follow-up"],
-      unexpected: ["Please relay this reminder to the user"],
+      expected: [
+        "SYSTEM_WAKE source=cron",
+        "Reply HEARTBEAT_OK unless session context requires follow-up.",
+      ],
+      unexpected: ["token=", "Please relay this reminder to the user"],
     },
   ])("$name", ({ events, opts, expected, unexpected }) => {
     const prompt = buildCronEventPrompt(events, opts);

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -1,40 +1,27 @@
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
+import {
+  collectMainSessionSystemEventTokens,
+  MAIN_SESSION_SYSTEM_EVENT_FALLBACK_TOKEN,
+} from "../cron/main-session-system-event.js";
 
-// Build a dynamic prompt for cron events by embedding the actual event content.
-// This ensures the model sees the reminder text directly instead of relying on
-// "shown in the system messages above" which may not be visible in context.
+// Main-session cron wakes should stay internal-only. Keep only short safe
+// tokens in the prompt and redact richer event text.
 export function buildCronEventPrompt(
   pendingEvents: string[],
-  opts?: {
+  _opts?: {
     deliverToUser?: boolean;
   },
 ): string {
-  const deliverToUser = opts?.deliverToUser ?? true;
-  const eventText = pendingEvents.join("\n").trim();
-  if (!eventText) {
-    if (!deliverToUser) {
-      return (
-        "A scheduled cron event was triggered, but no event content was found. " +
-        "Handle this internally and reply HEARTBEAT_OK when nothing needs user-facing follow-up."
-      );
+  const tokens = collectMainSessionSystemEventTokens(pendingEvents);
+  const lines = ["SYSTEM_WAKE source=cron"];
+  for (const token of tokens) {
+    if (token === MAIN_SESSION_SYSTEM_EVENT_FALLBACK_TOKEN) {
+      continue;
     }
-    return (
-      "A scheduled cron event was triggered, but no event content was found. " +
-      "Reply HEARTBEAT_OK."
-    );
+    lines.push(`token=${token}`);
   }
-  if (!deliverToUser) {
-    return (
-      "A scheduled reminder has been triggered. The reminder content is:\n\n" +
-      eventText +
-      "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested."
-    );
-  }
-  return (
-    "A scheduled reminder has been triggered. The reminder content is:\n\n" +
-    eventText +
-    "\n\nPlease relay this reminder to the user in a helpful and friendly way."
-  );
+  lines.push("Reply HEARTBEAT_OK unless session context requires follow-up.");
+  return lines.join("\n");
 }
 
 export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -66,13 +66,20 @@ describe("Ghost reminder bug (issue #13317)", () => {
       Provider?: string;
       Body?: string;
     } | null,
-    reminderText: string,
+    tokenText?: string,
   ) => {
     expect(calledCtx).not.toBeNull();
     expect(calledCtx?.Provider).toBe("cron-event");
-    expect(calledCtx?.Body).toContain("scheduled reminder has been triggered");
-    expect(calledCtx?.Body).toContain(reminderText);
-    expect(calledCtx?.Body).not.toContain("HEARTBEAT_OK");
+    expect(calledCtx?.Body).toContain("SYSTEM_WAKE source=cron");
+    if (tokenText) {
+      expect(calledCtx?.Body).toContain(`token=${tokenText}`);
+    }
+    expect(calledCtx?.Body).toContain(
+      "Reply HEARTBEAT_OK unless session context requires follow-up.",
+    );
+    expect(calledCtx?.Body).not.toContain("A scheduled reminder has been triggered");
+    expect(calledCtx?.Body).not.toContain("Please relay this reminder");
+    expect(calledCtx?.Body).not.toContain("Handle this reminder internally");
     expect(calledCtx?.Body).not.toContain("heartbeat poll");
   };
 
@@ -148,7 +155,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(result.status).toBe("ran");
     expect(replyCallCount).toBe(1);
     expect(calledCtx?.Provider).toBe("heartbeat");
-    expect(calledCtx?.Body).not.toContain("scheduled reminder has been triggered");
+    expect(calledCtx?.Body).not.toContain("A scheduled reminder has been triggered");
     expect(calledCtx?.Body).not.toContain("relay this reminder");
     expect(sendTelegram).toHaveBeenCalled();
   });
@@ -161,7 +168,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
       },
     );
     expect(result.status).toBe("ran");
-    expectCronEventPrompt(calledCtx, "Reminder: Check Base Scout results");
+    expectCronEventPrompt(calledCtx);
     expect(sendTelegram).toHaveBeenCalled();
   });
 
@@ -174,7 +181,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
       },
     );
     expect(result.status).toBe("ran");
-    expectCronEventPrompt(calledCtx, "Reminder: Check Base Scout results");
+    expectCronEventPrompt(calledCtx);
     expect(sendTelegram).toHaveBeenCalled();
   });
 
@@ -193,8 +200,8 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(result.status).toBe("ran");
     expect(replyCallCount).toBe(1);
     expect(calledCtx?.Provider).toBe("cron-event");
-    expect(calledCtx?.Body).toContain("scheduled reminder has been triggered");
-    expect(calledCtx?.Body).toContain("Cron: QMD maintenance completed");
+    expect(calledCtx?.Body).toContain("SYSTEM_WAKE source=cron");
+    expect(calledCtx?.Body).toContain("token=Cron: QMD maintenance completed");
     expect(calledCtx?.Body).not.toContain("Read HEARTBEAT.md");
     expect(sendTelegram).toHaveBeenCalled();
   });
@@ -212,7 +219,11 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
     expect(result.status).toBe("ran");
     expect(calledCtx?.Provider).toBe("cron-event");
-    expect(calledCtx?.Body).toContain("Handle this reminder internally");
+    expect(calledCtx?.Body).toContain("SYSTEM_WAKE source=cron");
+    expect(calledCtx?.Body).toContain(
+      "Reply HEARTBEAT_OK unless session context requires follow-up.",
+    );
+    expect(calledCtx?.Body).not.toContain("Handle this reminder internally");
     expect(sendTelegram).not.toHaveBeenCalled();
   });
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1269,7 +1269,10 @@ describe("runHeartbeatOnce", () => {
         if (testCase.expectCronContext) {
           const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
           expect(calledCtx.Provider, testCase.name).toBe("cron-event");
-          expect(calledCtx.Body, testCase.name).toContain("scheduled reminder has been triggered");
+          expect(calledCtx.Body, testCase.name).toContain("SYSTEM_WAKE source=cron");
+          expect(calledCtx.Body, testCase.name).toContain(
+            "Reply HEARTBEAT_OK unless session context requires follow-up.",
+          );
         }
       } finally {
         replySpy.mockRestore();
@@ -1325,7 +1328,11 @@ describe("runHeartbeatOnce", () => {
       expect(sendWhatsApp).toHaveBeenCalledTimes(0);
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
       expect(calledCtx.Provider).toBe("cron-event");
-      expect(calledCtx.Body).toContain("Handle this reminder internally");
+      expect(calledCtx.Body).toContain("SYSTEM_WAKE source=cron");
+      expect(calledCtx.Body).toContain("token=Cron: rotate logs");
+      expect(calledCtx.Body).toContain(
+        "Reply HEARTBEAT_OK unless session context requires follow-up.",
+      );
       expect(calledCtx.Body).not.toContain("Please relay this reminder to the user");
     } finally {
       replySpy.mockRestore();


### PR DESCRIPTION
# PR Body — cron-wrapper remediation

## Summary
This PR ships a narrow safety remediation for the Telegram/main-session contamination class caused by cron/systemEvent reminder handling.

Specifically, it fixes two linked bottlenecks:
1. dangerous relay-style wrapper prose entering the main-session prompt path for cron reminders
2. rich `sessionTarget:"main"` `systemEvent` reminder/follow-up prose being accepted on the main-session path

The patch is intentionally narrow and keeps isolated follow-up flows intact.

---

## Problem
A prior incident showed that rich main-session cron/systemEvent reminder text could be wrapped into natural-language relay-style prompt content and then persist as transcript residue in a long-lived main Telegram session.

That contamination, combined with compaction timeout/fallback behavior, contributed to repeated stale-response behavior.

This PR addresses the transcript-contaminating reminder path directly, without reopening the broader compaction-guard architecture.

---

## What changed
### 1) Neutralize dangerous main-session reminder wrapper text
The heartbeat/cron event prompt path no longer emits the old relay-style reminder prose.
Instead, main-session cron wakes now use a much more minimal internal wake shape.

### 2) Constrain rich main-session `systemEvent` text
Main-session cron `systemEvent` text is now constrained/rejected when it looks like reminder/relay/follow-up prose.
Unsafe legacy-ish main-session text degrades to a safe wake token path rather than replaying rich prose into the main transcript.

### 3) Preserve safe isolated flows
Rich follow-up behavior is still supported through isolated `agentTurn` jobs, which remain the preferred path.

---

## Key touched surfaces
- `src/infra/heartbeat-events-filter.ts`
- `src/cron/main-session-system-event.ts`
- `src/cron/normalize.ts`
- `src/cron/service/jobs.ts`
- `src/agents/tools/cron-tool.ts`
- focused tests around cron/heartbeat/main-session behavior

---

## Validation
Targeted Vitest suites pass:
- **153 / 153 tests passed**
- 6 focused test files

Final review outcome on the restacked branch: **ready**

---

## Compatibility / behavior notes
- rich main-session `systemEvent` reminder prose is intentionally no longer supported
- unsafe legacy-ish main-session text degrades to a safe wake token path
- rich follow-ups should use isolated `agentTurn` jobs instead of main-session prose wakes

---

## Why this patch is narrow
This branch is restacked onto `main` as a single narrow remediation unit focused on cron/heartbeat/main-session safety, rather than bundling the earlier compaction-guard stack.
