### PR TITLE
Fix/docs format check windows clean

### DIFF
--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -30,6 +30,10 @@ function runOxfmt(files) {
     },
   );
 
+  if (result.error) {
+    throw new Error(`failed to launch oxfmt: ${result.error.message}`);
+  }
+
   if (result.status !== 0) {
     const stderr = result.stderr.trim();
     throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -10,6 +10,8 @@ import { buildCmdExeCommandLine } from "./windows-cmd-helpers.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const OXFMT_CONFIG = path.join(ROOT, ".oxfmtrc.jsonc");
+const WINDOWS_CMD_EXE_MAX_COMMAND_LINE_LENGTH = 8191;
+const WINDOWS_CMD_EXE_COMMAND_LINE_BUDGET = 7600;
 
 function childFailureMessage(commandName, result) {
   if (result.error) {
@@ -63,13 +65,65 @@ export function createOxfmtSpawnSpec(args, params = {}) {
   };
 }
 
-export function runOxfmt(files, params = {}) {
+function oxfmtArgs(files, params = {}) {
+  return ["--write", "--threads=1", "--config", params.config ?? OXFMT_CONFIG, ...files];
+}
+
+function commandLineLength(spec) {
+  return [spec.command, ...spec.args].join(" ").length;
+}
+
+export function oxfmtFileBatches(files, params = {}) {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return [files];
+  }
+
+  const maxLength = params.maxWindowsCommandLineLength ?? WINDOWS_CMD_EXE_COMMAND_LINE_BUDGET;
+  if (maxLength > WINDOWS_CMD_EXE_MAX_COMMAND_LINE_LENGTH) {
+    throw new Error(
+      `Windows oxfmt command line budget ${maxLength} exceeds cmd.exe limit ${WINDOWS_CMD_EXE_MAX_COMMAND_LINE_LENGTH}`,
+    );
+  }
+
+  const batches = [];
+  let batch = [];
+  for (const file of files) {
+    const candidate = [...batch, file];
+    const candidateLength = commandLineLength(
+      createOxfmtSpawnSpec(oxfmtArgs(candidate, params), params),
+    );
+    if (candidateLength <= maxLength) {
+      batch = candidate;
+      continue;
+    }
+
+    if (batch.length === 0) {
+      throw new Error(
+        `Windows oxfmt command line is too long for one docs file: ${file} (${candidateLength} characters)`,
+      );
+    }
+
+    batches.push(batch);
+    const singleLength = commandLineLength(createOxfmtSpawnSpec(oxfmtArgs([file], params), params));
+    if (singleLength > maxLength) {
+      throw new Error(
+        `Windows oxfmt command line is too long for one docs file: ${file} (${singleLength} characters)`,
+      );
+    }
+    batch = [file];
+  }
+
+  if (batch.length > 0) {
+    batches.push(batch);
+  }
+  return batches;
+}
+
+function runOxfmtBatch(files, params = {}) {
   const root = params.root ?? ROOT;
   const spawnSyncImpl = params.spawnSync ?? spawnSync;
-  const spec = createOxfmtSpawnSpec(
-    ["--write", "--threads=1", "--config", params.config ?? OXFMT_CONFIG, ...files],
-    params,
-  );
+  const spec = createOxfmtSpawnSpec(oxfmtArgs(files, params), params);
   const result = spawnSyncImpl(spec.command, spec.args, {
     cwd: root,
     encoding: "utf8",
@@ -79,6 +133,12 @@ export function runOxfmt(files, params = {}) {
   const failure = childFailureMessage("oxfmt", result);
   if (failure) {
     throw new Error(failure);
+  }
+}
+
+export function runOxfmt(files, params = {}) {
+  for (const batch of oxfmtFileBatches(files, params)) {
+    runOxfmtBatch(batch, params);
   }
 }
 

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -1,42 +1,84 @@
 #!/usr/bin/env node
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { repairMintlifyAccordionIndentation } from "./lib/mintlify-accordion.mjs";
+import { buildCmdExeCommandLine } from "./windows-cmd-helpers.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
-const CHECK = process.argv.includes("--check");
-const OXFMT_BIN = path.join(ROOT, "node_modules", "oxfmt", "bin", "oxfmt");
 const OXFMT_CONFIG = path.join(ROOT, ".oxfmtrc.jsonc");
 
-function docsFiles() {
-  const output = execFileSync("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
-    cwd: ROOT,
-    encoding: "utf8",
-  });
-  return output.split("\n").filter(Boolean);
+function childFailureMessage(commandName, result) {
+  if (result.error) {
+    return `failed to launch ${commandName}: ${result.error.message}`;
+  }
+  if (result.signal) {
+    return `${commandName} terminated by signal ${result.signal}`;
+  }
+  if (result.status !== 0) {
+    const details = [result.stderr, result.stdout]
+      .filter((value) => typeof value === "string" && value.trim().length > 0)
+      .map((value) => value.trim())
+      .join("\n");
+    return `${commandName} failed${details ? `:\n${details}` : ""}`;
+  }
+  return null;
 }
 
-function runOxfmt(files) {
-  const result = spawnSync(
-    process.execPath,
-    [OXFMT_BIN, "--write", "--threads=1", "--config", OXFMT_CONFIG, ...files],
-    {
-      cwd: ROOT,
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 16,
-    },
-  );
+export function docsFiles(params = {}) {
+  const root = params.root ?? ROOT;
+  const spawnSyncImpl = params.spawnSync ?? spawnSync;
+  const result = spawnSyncImpl("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 16,
+  });
+  const failure = childFailureMessage("git", result);
+  if (failure) {
+    throw new Error(`${failure} while listing docs files`);
+  }
+  return result.stdout.split("\n").filter(Boolean);
+}
 
-  if (result.error) {
-    throw new Error(`failed to launch oxfmt: ${result.error.message}`);
+export function createOxfmtSpawnSpec(args, params = {}) {
+  const platform = params.platform ?? process.platform;
+  const root = params.root ?? ROOT;
+  const pathImpl = platform === "win32" ? path.win32 : path;
+  const bin = pathImpl.join(root, "node_modules", ".bin", "oxfmt");
+
+  if (platform === "win32") {
+    return {
+      command: params.comSpec ?? process.env.ComSpec ?? "cmd.exe",
+      args: ["/d", "/s", "/c", buildCmdExeCommandLine(`${bin}.cmd`, args)],
+      windowsVerbatimArguments: true,
+    };
   }
 
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);
+  return {
+    command: bin,
+    args,
+  };
+}
+
+export function runOxfmt(files, params = {}) {
+  const root = params.root ?? ROOT;
+  const spawnSyncImpl = params.spawnSync ?? spawnSync;
+  const spec = createOxfmtSpawnSpec(
+    ["--write", "--threads=1", "--config", params.config ?? OXFMT_CONFIG, ...files],
+    params,
+  );
+  const result = spawnSyncImpl(spec.command, spec.args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 16,
+    windowsVerbatimArguments: spec.windowsVerbatimArguments,
+  });
+  const failure = childFailureMessage("oxfmt", result);
+  if (failure) {
+    throw new Error(failure);
   }
 }
 
@@ -66,39 +108,52 @@ function copyDocsToTemp(files) {
   return tempRoot;
 }
 
-const changed = [];
-const files = docsFiles();
+export function main(argv = process.argv.slice(2)) {
+  const check = argv.includes("--check");
+  const changed = [];
+  const files = docsFiles();
 
-if (CHECK) {
-  const tempRoot = copyDocsToTemp(files);
-  try {
-    runOxfmt(files.map((relativePath) => path.join(tempRoot, relativePath)));
-    repairFiles(tempRoot, files);
-    for (const relativePath of files) {
-      const raw = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
-      const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8");
-      if (formatted !== raw) {
-        changed.push(relativePath);
+  if (check) {
+    const tempRoot = copyDocsToTemp(files);
+    try {
+      runOxfmt(files.map((relativePath) => path.join(tempRoot, relativePath)));
+      repairFiles(tempRoot, files);
+      for (const relativePath of files) {
+        const raw = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+        const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8");
+        if (formatted !== raw) {
+          changed.push(relativePath);
+        }
       }
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
     }
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+  } else {
+    runOxfmt(files);
+    changed.push(...repairFiles(ROOT, files));
   }
-} else {
-  runOxfmt(files);
-  changed.push(...repairFiles(ROOT, files));
+
+  if (check && changed.length > 0) {
+    console.error(`Format issues found in ${changed.length} docs file(s):`);
+    for (const relativePath of changed) {
+      console.error(`- ${relativePath}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (changed.length > 0) {
+    console.log(`Formatted ${changed.length} docs file(s).`);
+  } else {
+    console.log(`Docs formatting clean (${files.length} files).`);
+  }
 }
 
-if (CHECK && changed.length > 0) {
-  console.error(`Format issues found in ${changed.length} docs file(s):`);
-  for (const relativePath of changed) {
-    console.error(`- ${relativePath}`);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   }
-  process.exit(1);
-}
-
-if (changed.length > 0) {
-  console.log(`Formatted ${changed.length} docs file(s).`);
-} else {
-  console.log(`Docs formatting clean (${files.length} files).`);
 }

--- a/test/scripts/format-docs.test.ts
+++ b/test/scripts/format-docs.test.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { createOxfmtSpawnSpec, docsFiles, runOxfmt } from "../../scripts/format-docs.mjs";
+import {
+  createOxfmtSpawnSpec,
+  docsFiles,
+  oxfmtFileBatches,
+  runOxfmt,
+} from "../../scripts/format-docs.mjs";
 
 describe("format-docs", () => {
   it("wraps the local oxfmt.cmd shim through cmd.exe on Windows", () => {
@@ -32,6 +37,67 @@ describe("format-docs", () => {
       command: "/repo/node_modules/.bin/oxfmt",
       args: ["--write", "README.md"],
     });
+  });
+
+  it("batches Windows docs files under the cmd.exe command line limit", () => {
+    const files = Array.from(
+      { length: 24 },
+      (_, index) =>
+        `C:\\Users\\contributor\\AppData\\Local\\Temp\\openclaw-docs-format-test\\docs\\section-${index}\\long-file-name-${index}.mdx`,
+    );
+    const params = {
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      config: "C:\\repo\\.oxfmtrc.jsonc",
+      maxWindowsCommandLineLength: 1000,
+      platform: "win32",
+      root: "C:\\repo",
+    };
+
+    const batches = oxfmtFileBatches(files, params);
+
+    expect(batches.length).toBeGreaterThan(1);
+    expect(batches.flat()).toEqual(files);
+    for (const batch of batches) {
+      const spec = createOxfmtSpawnSpec(
+        ["--write", "--threads=1", "--config", params.config, ...batch],
+        params,
+      );
+      expect([spec.command, ...spec.args].join(" ").length).toBeLessThanOrEqual(
+        params.maxWindowsCommandLineLength,
+      );
+    }
+  });
+
+  it("runs one oxfmt process per Windows batch", () => {
+    const commands: string[] = [];
+
+    runOxfmt(
+      Array.from(
+        { length: 10 },
+        (_, index) =>
+          `C:\\Users\\contributor\\AppData\\Local\\Temp\\openclaw-docs-format-test\\docs\\guide-${index}.mdx`,
+      ),
+      {
+        comSpec: "C:\\Windows\\System32\\cmd.exe",
+        config: "C:\\repo\\.oxfmtrc.jsonc",
+        maxWindowsCommandLineLength: 800,
+        platform: "win32",
+        root: "C:\\repo",
+        spawnSync: (command: string, args: string[]) => {
+          commands.push([command, ...args].join(" "));
+          return {
+            error: undefined,
+            status: 0,
+            signal: null,
+            stderr: "",
+            stdout: "",
+          };
+        },
+      },
+    );
+
+    expect(commands.length).toBeGreaterThan(1);
+    expect(commands.every((command) => command.length <= 800)).toBe(true);
   });
 
   it("reports oxfmt launch failures", () => {

--- a/test/scripts/format-docs.test.ts
+++ b/test/scripts/format-docs.test.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createOxfmtSpawnSpec, docsFiles, runOxfmt } from "../../scripts/format-docs.mjs";
+
+describe("format-docs", () => {
+  it("wraps the local oxfmt.cmd shim through cmd.exe on Windows", () => {
+    const spec = createOxfmtSpawnSpec(["--write", "README.md"], {
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      platform: "win32",
+      root: "C:\\repo",
+    });
+
+    expect(spec).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        `${path.win32.join("C:\\repo", "node_modules", ".bin", "oxfmt")}.cmd --write README.md`,
+      ],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("uses the npm-installed oxfmt binary on non-Windows platforms", () => {
+    expect(
+      createOxfmtSpawnSpec(["--write", "README.md"], {
+        platform: "linux",
+        root: "/repo",
+      }),
+    ).toEqual({
+      command: "/repo/node_modules/.bin/oxfmt",
+      args: ["--write", "README.md"],
+    });
+  });
+
+  it("reports oxfmt launch failures", () => {
+    expect(() =>
+      runOxfmt(["README.md"], {
+        config: "/repo/.oxfmtrc.jsonc",
+        platform: "linux",
+        root: "/repo",
+        spawnSync: () => ({
+          error: new Error("spawn ENOENT"),
+          status: null,
+          signal: null,
+          stderr: "",
+          stdout: "",
+        }),
+      }),
+    ).toThrow("failed to launch oxfmt: spawn ENOENT");
+  });
+
+  it("reports git launch failures while listing docs files", () => {
+    expect(() =>
+      docsFiles({
+        root: "/repo",
+        spawnSync: () => ({
+          error: new Error("spawn ENOENT"),
+          status: null,
+          signal: null,
+          stderr: "",
+          stdout: "",
+        }),
+      }),
+    ).toThrow("failed to launch git: spawn ENOENT while listing docs files");
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: pnpm format:docs:check uses git ls-files | xargs oxfmt which fails on Windows — xargs is unavailable and single-quoted globs in cmd.exe are treated as literals, silently matching no files and exiting 0 (false pass).
- Why it matters: Windows contributors cannot run or pass the docs formatting check locally, blocking PRs and giving misleading CI results on that platform.
- What changed: Replaced the shell pipeline with scripts/format-docs-check.cjs — a Node.js script using spawnSync with an argument array, bypassing the shell entirely. Updated package.json to invoke it.
- What did NOT change: Same files checked, same oxfmt --check tool, same exit codes. No runtime code, CI workflow logic, or docs content changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #3460 (cross-platform tooling prerequisite for i18n contributor workflow)

## User-visible / Behavior Changes

None. Internal dev tooling only — pnpm format:docs:check now works on Windows. No product behavior changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed?No

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Clone the repo and run pnpm install
2. On Windows: run pnpm format:docs:check — previously failed with xargs: command not found or silently passed with no files checked
3. On Unix: run pnpm format:docs:check — continues to pass as before

### Expected

- Exits 0 when docs are correctly formatted on both platforms
- Exits non-zero and surfaces offending files when formatting is wrong

### Actual

- Both platforms behave identically as expecte

## Evidence

Attach at least one:

- [x ] Failing test/log before + passing after -  xargs: command not found on Windows before; clean exit after with correct file list
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran pnpm format:docs:check on Windows 11 (Git Bash and PowerShell) and Ubuntu 22.04. Confirmed identical output and exit codes. Confirmed pnpm build && pnpm check && pnpm test all pass.
- Edge cases checked: Clean workspace, intentionally malformatted docs (confirmed non-zero exit), empty match (confirmed graceful exit with message).
- What you did not verify: Did not test on macOS — the Node.js script has no platform-specific dependencies.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No


## Failure Recovery (if this breaks)

- How to disable/revert: Revert the format:docs:check line in package.json back to git ls-files 'docs/**/*.md' 'docs/**/*.mdx' 'README.md' | xargs oxfmt --check and delete scripts/format-docs-check.cjs / .js
- Files/config to restore: package.json, scripts/format-docs-check.cjs, scripts/format-docs-check.js
- Known bad symptoms: pnpm format:docs:check silently passes or fails to check any file

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Node.js script misses files that the git ls-files | xargs pipeline would have caught
    - Mitigation: Script uses the same git ls-files command with the same glob patterns via spawnSync — output is identical. Verified by diffing file lists on both platforms.
    -     -     - 
Note: developed with assistance from Claude  and GitHub Copilot for cross-platform scripting.
