### PR TITLE
feat(media): allow home and Desktop in default local roots

### DIFF
--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -1,0 +1,24 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveStateDir } from "../config/paths.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { getDefaultMediaLocalRoots } from "./local-roots.js";
+
+describe("getDefaultMediaLocalRoots", () => {
+  it("includes the user home and Desktop directories by default", () => {
+    const homeDir = path.resolve(os.homedir());
+    const stateDir = resolveStateDir();
+    const roots = getDefaultMediaLocalRoots();
+
+    expect(roots).toEqual(
+      expect.arrayContaining([
+        resolvePreferredOpenClawTmpDir(),
+        homeDir,
+        path.join(homeDir, "Desktop"),
+        path.join(stateDir, "media"),
+        path.join(stateDir, "workspace"),
+      ]),
+    );
+  });
+});

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -23,13 +24,17 @@ function buildMediaLocalRoots(
 ): string[] {
   const resolvedStateDir = path.resolve(stateDir);
   const preferredTmpDir = options.preferredTmpDir ?? resolveCachedPreferredTmpDir();
-  return [
+  const homeDir = path.resolve(os.homedir());
+  const desktopDir = path.join(homeDir, "Desktop");
+  return [...new Set([
     preferredTmpDir,
+    homeDir,
+    desktopDir,
     path.join(resolvedStateDir, "media"),
     path.join(resolvedStateDir, "agents"),
     path.join(resolvedStateDir, "workspace"),
     path.join(resolvedStateDir, "sandboxes"),
-  ];
+  ])];
 }
 
 export function getDefaultMediaLocalRoots(): readonly string[] {


### PR DESCRIPTION
## Summary
- include the user home directory and Desktop in the default media local roots
- keep the existing OpenClaw state and temp roots unchanged
- add unit coverage for the new default roots

## Testing
- git diff --check
- pnpm exec vitest run src/media/local-roots.test.ts

Fixes #48833