### PR TITLE
fix(feishu): restore naming paths and split control UI context notices

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2315,7 +2315,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "oc-group ? root starter",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2358,7 +2358,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: undefined,
         ThreadHistoryBody: undefined,
-        ThreadLabel: "oc-group ? root starter",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2428,7 +2428,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "oc-group ? root starter",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1585,6 +1585,12 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("routes topic sessions and parentPeer when groupSessionScope=group_topic_sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_root_topic",
+      chatId: "oc-group",
+      content: "Role-Task-Routing",
+      contentType: "text",
+    });
 
     const cfg: ClawdbotConfig = {
       channels: {
@@ -1617,6 +1623,12 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         peer: { kind: "group", id: "oc-group:topic:om_root_topic:sender:ou-topic-user" },
         parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MessageThreadId: "om_root_topic",
+        ThreadLabel: expect.stringContaining("Role-Task-Routing"),
       }),
     );
   });
@@ -1811,6 +1823,11 @@ describe("handleFeishuMessage command authorization", () => {
         parentPeer: { kind: "group", id: "oc-group" },
       }),
     );
+    const lastContext = mockFinalizeInboundContext.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(lastContext?.ThreadLabel).toBeUndefined();
+    expect(lastContext?.MessageThreadId).toBeUndefined();
   });
 
   it("keeps topic session key stable after first turn creates a thread", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2315,7 +2315,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: "oc-group ? root starter",
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2358,7 +2358,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: undefined,
         ThreadHistoryBody: undefined,
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: "oc-group ? root starter",
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2428,7 +2428,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: "oc-group ? root starter",
         MessageThreadId: "om_topic_root",
       }),
     );

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -649,6 +649,175 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("uses chatMembers API for direct display names", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "ShouldNotUse" } } });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-direct-review-user-members-only",
+            name: "SenderFromMembersOnly",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-review-user-members-only",
+          user_id: "fouser_12345",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-enabled",
+        chat_id: "oc-dm-direct-display",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm display" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-display" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromMembersOnly (ou-direct-review-user-members-only)",
+      }),
+    );
+  });
+
+  it("keeps open_id when direct member lookup has no matching name", async () => {
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-someone-else",
+            name: "SomeoneElse",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-no-member-name",
+        },
+      },
+      message: {
+        message_id: "msg-direct-no-member-name",
+        chat_id: "oc-dm-direct-no-member-name",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm no member name" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-no-member-name" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "ou-direct-no-member-name",
+      }),
+    );
+  });
+
+  it("prefers sender user_id lookup for group sender resolution when available", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "SenderByUserId" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chat: { get: vi.fn().mockResolvedValue({ code: 0, data: { name: "GroupName" } }) } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["oc-group"],
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user",
+          user_id: "fouser_group_user",
+        },
+      },
+      message: {
+        message_id: "msg-group-user-id-name",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group user id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getUser).toHaveBeenCalledWith({
+      path: { user_id: "fouser_group_user" },
+      params: { user_id_type: "user_id" },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderByUserId",
+      }),
+    );
+  });
+
   it("propagates parent/root message ids into inbound context for reply reconstruction", async () => {
     mockGetMessageFeishu.mockResolvedValueOnce({
       messageId: "om_parent_001",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -106,6 +106,11 @@ function extractPermissionError(err: unknown): PermissionError | null {
 // Cache display names by sender id (open_id/user_id) to avoid an API call on every message.
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const GROUP_NAME_TTL_MS = 10 * 60 * 1000;
+const groupNameCache = new Map<string, { name: string; expireAt: number }>();
+const TOPIC_LABEL_TTL_MS = 10 * 60 * 1000;
+const TOPIC_LABEL_MAX_CHARS = 48;
+const topicLabelCache = new Map<string, { label: string; expireAt: number }>();
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -181,6 +186,126 @@ async function resolveFeishuSenderName(params: {
     log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
     return {};
   }
+}
+
+async function resolveFeishuGroupName(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, log } = params;
+  if (!account.configured) return undefined;
+
+  const normalizedChatId = chatId.trim();
+  if (!normalizedChatId) return undefined;
+
+  const cacheKey = `${account.accountId}:${normalizedChatId}`;
+  const cached = groupNameCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) return cached.name;
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChat = client?.im?.chat?.get;
+    if (typeof getChat !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChat({ path: { chat_id: normalizedChatId } });
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve group name for ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
+      );
+      return undefined;
+    }
+
+    const name =
+      typeof res?.data?.name === "string" && res.data.name.trim().length > 0
+        ? res.data.name.trim()
+        : undefined;
+    if (name) {
+      groupNameCache.set(cacheKey, { name, expireAt: now + GROUP_NAME_TTL_MS });
+      return name;
+    }
+  } catch (err) {
+    log(`feishu: failed to resolve group name for ${normalizedChatId}: ${String(err)}`);
+  }
+
+  return undefined;
+}
+
+function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
+  const normalizedChatId = params.chatId.trim();
+  const name = params.groupName?.trim();
+
+  if (!name) return normalizedChatId;
+  if (!normalizedChatId) return name;
+  if (name.includes(normalizedChatId)) return name;
+  return `${name} (${normalizedChatId})`;
+}
+
+function truncateFeishuTopicLabel(raw: string): string {
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  if (normalized.length <= TOPIC_LABEL_MAX_CHARS) return normalized;
+  return `${normalized.slice(0, TOPIC_LABEL_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+async function resolveFeishuTopicLabel(params: {
+  cfg: ClawdbotConfig;
+  account: ResolvedFeishuAccount;
+  topicRootId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { cfg, account, topicRootId, log } = params;
+  const normalizedTopicRootId = topicRootId.trim();
+  if (!normalizedTopicRootId) return undefined;
+
+  const cacheKey = `${account.accountId}:${normalizedTopicRootId}`;
+  const cached = topicLabelCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) {
+    return cached.label;
+  }
+
+  try {
+    const rootMessage = await getMessageFeishu({
+      cfg,
+      messageId: normalizedTopicRootId,
+      accountId: account.accountId,
+    });
+    const label = truncateFeishuTopicLabel(rootMessage?.content ?? "");
+    if (!label) return undefined;
+    topicLabelCache.set(cacheKey, {
+      label,
+      expireAt: now + TOPIC_LABEL_TTL_MS,
+    });
+    return label;
+  } catch (err) {
+    log(`feishu: failed to resolve topic label for ${normalizedTopicRootId}: ${String(err)}`);
+    return undefined;
+  }
+}
+
+function shortFeishuTopicId(raw: string): string {
+  const normalized = raw.trim();
+  if (normalized.length <= 16) return normalized;
+  return `${normalized.slice(0, 8)}…${normalized.slice(-6)}`;
+}
+
+function buildFeishuTopicThreadLabel(params: {
+  groupDisplayName?: string;
+  chatId: string;
+  topicLabel?: string;
+  topicThreadId: string;
+}): string {
+  const groupLabel =
+    params.groupDisplayName?.trim() || buildFeishuGroupDisplayName({ chatId: params.chatId });
+  const topic = params.topicLabel?.trim();
+  if (topic) {
+    return `${groupLabel} › ${topic}`;
+  }
+  return `${groupLabel} › topic:${shortFeishuTopicId(params.topicThreadId)}`;
 }
 
 export type FeishuMessageEvent = {
@@ -989,8 +1114,19 @@ export async function handleFeishuMessage(params: {
     }
   }
 
+  const groupDisplayName = isGroup
+    ? buildFeishuGroupDisplayName({
+        chatId: ctx.chatId,
+        groupName: await resolveFeishuGroupName({
+          account,
+          chatId: ctx.chatId,
+          log,
+        }),
+      })
+    : undefined;
+
   log(
-    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${ctx.chatId} (${ctx.chatType})`,
+    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${groupDisplayName ?? ctx.chatId} (${ctx.chatType})`,
   );
 
   // Log mention targets if detected
@@ -1319,7 +1455,7 @@ export async function handleFeishuMessage(params: {
 
     const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
-      ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
+      ? `Feishu[${account.accountId}] message in group ${groupDisplayName ?? ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
 
     // Do not enqueue inbound user previews as system events.
@@ -1417,6 +1553,7 @@ export async function handleFeishuMessage(params: {
           }))
         : undefined;
 
+<<<<<<< HEAD
     const threadContextBySessionKey = new Map<
       string,
       {
@@ -1551,6 +1688,33 @@ export async function handleFeishuMessage(params: {
       threadContextBySessionKey.set(agentSessionKey, threadContext);
       return threadContext;
     };
+=======
+    const topicThreadId = isGroup
+      ? ctx.rootId?.trim() || ctx.threadId?.trim() || undefined
+      : undefined;
+    const isTopicScopedSession =
+      isGroup &&
+      (groupSession?.groupSessionScope === "group_topic" ||
+        groupSession?.groupSessionScope === "group_topic_sender");
+    const topicLabel =
+      isTopicScopedSession && ctx.rootId
+        ? await resolveFeishuTopicLabel({
+            cfg,
+            account,
+            topicRootId: ctx.rootId,
+            log,
+          })
+        : undefined;
+    const topicThreadLabel =
+      isTopicScopedSession && topicThreadId
+        ? buildFeishuTopicThreadLabel({
+            groupDisplayName,
+            chatId: ctx.chatId,
+            topicLabel,
+            topicThreadId,
+          })
+        : undefined;
+>>>>>>> 526f0a4100 (feat(feishu): 恢复群名与话题标签显示)
 
     // --- Shared context builder for dispatch ---
     const buildCtxPayloadForAgent = async (
@@ -1573,7 +1737,9 @@ export async function handleFeishuMessage(params: {
         SessionKey: agentSessionKey,
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
-        GroupSubject: isGroup ? ctx.chatId : undefined,
+        GroupSubject: isGroup ? groupDisplayName : undefined,
+        ThreadLabel: topicThreadLabel,
+        MessageThreadId: topicThreadId,
         SenderName: ctx.senderName ?? ctx.senderOpenId,
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1823,9 +1823,7 @@ export async function handleFeishuMessage(params: {
 
         threadContext.threadStarterBody = threadStarterBody;
         threadContext.threadHistoryBody =
-          historyParts.length > 0 ? historyParts.join("
-
-") : undefined;
+          historyParts.length > 0 ? historyParts.join("\n\n") : undefined;
         log(
           `feishu[${account.accountId}]: populated thread bootstrap with starter=${threadStarterBody ? "yes" : "no"} history=${historyMessages.length}`,
         );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -136,37 +136,63 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
 async function resolveFeishuSenderName(params: {
   account: ResolvedFeishuAccount;
   senderId: string;
+  senderUserId?: string;
   log: (...args: any[]) => void;
 }): Promise<SenderNameResult> {
-  const { account, senderId, log } = params;
+  const { account, senderId, senderUserId, log } = params;
   if (!account.configured) return {};
 
-  const normalizedSenderId = senderId.trim();
-  if (!normalizedSenderId) return {};
+  const candidateIds = [senderUserId?.trim(), senderId.trim()].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  if (candidateIds.length === 0) return {};
 
-  const cached = senderNameCache.get(normalizedSenderId);
   const now = Date.now();
-  if (cached && cached.expireAt > now) return { name: cached.name };
+  for (const candidateId of candidateIds) {
+    const cached = senderNameCache.get(candidateId);
+    if (cached && cached.expireAt > now) return { name: cached.name };
+  }
 
   try {
     const client = createFeishuClient(account);
-    const userIdType = resolveSenderLookupIdType(normalizedSenderId);
 
-    // contact/v3/users/:user_id?user_id_type=<open_id|user_id|union_id>
-    const res: any = await client.contact.user.get({
-      path: { user_id: normalizedSenderId },
-      params: { user_id_type: userIdType },
-    });
+    for (const candidateId of candidateIds) {
+      const userIdType = resolveSenderLookupIdType(candidateId);
 
-    const name: string | undefined =
-      res?.data?.user?.name ||
-      res?.data?.user?.display_name ||
-      res?.data?.user?.nickname ||
-      res?.data?.user?.en_name;
+      // contact/v3/users/:user_id?user_id_type=<open_id|user_id|union_id>
+      const res: any = await client.contact.user.get({
+        path: { user_id: candidateId },
+        params: { user_id_type: userIdType },
+      });
 
-    if (name && typeof name === "string") {
-      senderNameCache.set(normalizedSenderId, { name, expireAt: now + SENDER_NAME_TTL_MS });
-      return { name };
+      if (res?.code != null && res.code !== 0) {
+        const permErr = extractPermissionError(res);
+        if (permErr) {
+          if (shouldSuppressPermissionErrorNotice(permErr)) {
+            log(`feishu: ignoring stale permission scope error: ${permErr.message}`);
+            return {};
+          }
+          log(`feishu: permission error resolving sender name: code=${permErr.code}`);
+          return { permissionError: permErr };
+        }
+        log(
+          `feishu: sender name lookup failed for ${candidateId}: code=${String(res.code)} msg=${String(res?.msg ?? "")}`,
+        );
+        continue;
+      }
+
+      const name: string | undefined =
+        res?.data?.user?.name ||
+        res?.data?.user?.display_name ||
+        res?.data?.user?.nickname ||
+        res?.data?.user?.en_name;
+
+      if (name && typeof name === "string") {
+        for (const idForCache of candidateIds) {
+          senderNameCache.set(idForCache, { name, expireAt: now + SENDER_NAME_TTL_MS });
+        }
+        return { name };
+      }
     }
 
     return {};
@@ -183,7 +209,7 @@ async function resolveFeishuSenderName(params: {
     }
 
     // Best-effort. Don't fail message handling if name lookup fails.
-    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
+    log(`feishu: failed to resolve sender name for ${candidateIds.join(",")}: ${String(err)}`);
     return {};
   }
 }
@@ -234,6 +260,71 @@ async function resolveFeishuGroupName(params: {
   return undefined;
 }
 
+async function resolveFeishuDirectNameFromChatMember(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  senderOpenId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, senderOpenId, log } = params;
+  if (!account.configured) return undefined;
+
+  const normalizedSenderOpenId = senderOpenId.trim();
+  const normalizedChatId = chatId.trim();
+  if (!normalizedSenderOpenId || !normalizedChatId) return undefined;
+
+  const cached = senderNameCache.get(normalizedSenderOpenId);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) return cached.name;
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChatMembers = client?.im?.chatMembers?.get ?? client?.im?.chat?.members?.get;
+    if (typeof getChatMembers !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChatMembers({
+      path: { chat_id: normalizedChatId },
+      params: {
+        member_id_type: "open_id",
+        page_size: 50,
+      },
+    });
+
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: code=${String(
+          res?.code,
+        )} msg=${String(res?.msg ?? "")}`,
+      );
+      return undefined;
+    }
+
+    const item = Array.isArray(res?.data?.items)
+      ? res.data.items.find(
+          (entry: any) =>
+            typeof entry?.member_id === "string" && entry.member_id === normalizedSenderOpenId,
+        )
+      : undefined;
+
+    const name = typeof item?.name === "string" ? item.name.trim() : "";
+    if (name) {
+      senderNameCache.set(normalizedSenderOpenId, {
+        name,
+        expireAt: now + SENDER_NAME_TTL_MS,
+      });
+      return name;
+    }
+  } catch (err) {
+    log(
+      `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: ${String(err)}`,
+    );
+  }
+
+  return undefined;
+}
+
 function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
   const normalizedChatId = params.chatId.trim();
   const name = params.groupName?.trim();
@@ -242,6 +333,19 @@ function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: strin
   if (!normalizedChatId) return name;
   if (name.includes(normalizedChatId)) return name;
   return `${name} (${normalizedChatId})`;
+}
+
+function buildFeishuDirectDisplayName(params: {
+  senderOpenId: string;
+  senderName?: string;
+}): string {
+  const senderId = params.senderOpenId.trim();
+  const senderName = params.senderName?.trim();
+
+  if (!senderName) return senderId;
+  if (!senderId) return senderName;
+  if (senderName.includes(senderId)) return senderName;
+  return `${senderName} (${senderId})`;
 }
 
 function truncateFeishuTopicLabel(raw: string): string {
@@ -1090,13 +1194,33 @@ export async function handleFeishuMessage(params: {
     }
   }
 
-  // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
-  // Optimization: skip if disabled to save API quota (Feishu free tier limit).
+  // Resolve sender display name with channel-specific strategy:
+  // - direct chat: members-only lookup for stable peer naming
+  // - group chat: contact user lookup (with user_id/open_id fallback)
   let permissionErrorForAgent: PermissionError | undefined;
-  if (feishuCfg?.resolveSenderNames ?? true) {
+  if (isDirect) {
+    const directName = await resolveFeishuDirectNameFromChatMember({
+      account,
+      chatId: ctx.chatId,
+      senderOpenId: ctx.senderOpenId,
+      log,
+    });
+    if (directName) {
+      ctx = {
+        ...ctx,
+        senderName: buildFeishuDirectDisplayName({
+          senderOpenId: ctx.senderOpenId,
+          senderName: directName,
+        }),
+      };
+    }
+  }
+
+  if (isGroup && (feishuCfg?.resolveSenderNames ?? true)) {
     const senderResult = await resolveFeishuSenderName({
       account,
       senderId: ctx.senderOpenId,
+      senderUserId,
       log,
     });
     if (senderResult.name) ctx = { ...ctx, senderName: senderResult.name };

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1677,7 +1677,32 @@ export async function handleFeishuMessage(params: {
           }))
         : undefined;
 
-<<<<<<< HEAD
+    const topicThreadId = isGroup
+      ? ctx.rootId?.trim() || ctx.threadId?.trim() || undefined
+      : undefined;
+    const isTopicScopedSession =
+      isGroup &&
+      (groupSession?.groupSessionScope === "group_topic" ||
+        groupSession?.groupSessionScope === "group_topic_sender");
+    const topicLabel =
+      isTopicScopedSession && ctx.rootId
+        ? await resolveFeishuTopicLabel({
+            cfg,
+            account,
+            topicRootId: ctx.rootId,
+            log,
+          })
+        : undefined;
+    const topicThreadLabel =
+      isTopicScopedSession && topicThreadId
+        ? buildFeishuTopicThreadLabel({
+            groupDisplayName,
+            chatId: ctx.chatId,
+            topicLabel,
+            topicThreadId,
+          })
+        : undefined;
+
     const threadContextBySessionKey = new Map<
       string,
       {
@@ -1722,10 +1747,7 @@ export async function handleFeishuMessage(params: {
         threadHistoryBody?: string;
         threadLabel?: string;
       } = {
-        threadLabel:
-          (ctx.rootId || ctx.threadId) && isTopicSessionForThread
-            ? `Feishu thread in ${ctx.chatId}`
-            : undefined,
+        threadLabel: topicThreadLabel,
       };
 
       if (!(ctx.rootId || ctx.threadId) || !isTopicSessionForThread) {
@@ -1801,7 +1823,9 @@ export async function handleFeishuMessage(params: {
 
         threadContext.threadStarterBody = threadStarterBody;
         threadContext.threadHistoryBody =
-          historyParts.length > 0 ? historyParts.join("\n\n") : undefined;
+          historyParts.length > 0 ? historyParts.join("
+
+") : undefined;
         log(
           `feishu[${account.accountId}]: populated thread bootstrap with starter=${threadStarterBody ? "yes" : "no"} history=${historyMessages.length}`,
         );
@@ -1812,33 +1836,6 @@ export async function handleFeishuMessage(params: {
       threadContextBySessionKey.set(agentSessionKey, threadContext);
       return threadContext;
     };
-=======
-    const topicThreadId = isGroup
-      ? ctx.rootId?.trim() || ctx.threadId?.trim() || undefined
-      : undefined;
-    const isTopicScopedSession =
-      isGroup &&
-      (groupSession?.groupSessionScope === "group_topic" ||
-        groupSession?.groupSessionScope === "group_topic_sender");
-    const topicLabel =
-      isTopicScopedSession && ctx.rootId
-        ? await resolveFeishuTopicLabel({
-            cfg,
-            account,
-            topicRootId: ctx.rootId,
-            log,
-          })
-        : undefined;
-    const topicThreadLabel =
-      isTopicScopedSession && topicThreadId
-        ? buildFeishuTopicThreadLabel({
-            groupDisplayName,
-            chatId: ctx.chatId,
-            topicLabel,
-            topicThreadId,
-          })
-        : undefined;
->>>>>>> 526f0a4100 (feat(feishu): 恢复群名与话题标签显示)
 
     // --- Shared context builder for dispatch ---
     const buildCtxPayloadForAgent = async (
@@ -1862,8 +1859,6 @@ export async function handleFeishuMessage(params: {
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
         GroupSubject: isGroup ? groupDisplayName : undefined,
-        ThreadLabel: topicThreadLabel,
-        MessageThreadId: topicThreadId,
         SenderName: ctx.senderName ?? ctx.senderOpenId,
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -80,6 +80,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Control UI hosting settings including enablement, pathing, and browser-origin/auth hardening behavior. Keep UI exposure minimal and pair with strong auth controls before internet-facing deployments.",
   "gateway.controlUi.enabled":
     "Enables serving the gateway Control UI from the gateway HTTP process when true. Keep enabled for local administration, and disable when an external control surface replaces it.",
+  "gateway.controlUi.chat":
+    "Control UI chat-surface presentation settings. Use these to tune operator-facing notices without changing backend runtime semantics.",
+  "gateway.controlUi.chat.showPricingThreshold":
+    "Show model-specific higher-rate pricing threshold hints in chat context notices when available. Disable if you want only model-context usage/limit information in the chat header.",
   "gateway.auth":
     "Authentication policy for gateway HTTP/WebSocket access including mode, credentials, trusted-proxy behavior, and rate limiting. Keep auth enabled for every non-loopback deployment.",
   "gateway.auth.mode":

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -154,6 +154,17 @@ describe("sessions", () => {
     ).toBe("discord:friends-of-openclaw#general");
   });
 
+  it("keeps Feishu unicode group names and appends chat id", () => {
+    expect(
+      buildGroupDisplayName({
+        provider: "feishu",
+        subject: "私-openclaw 进化",
+        id: "oc_aa28b4a19f8b78b10167a989682cfe5f",
+        key: "feishu:group:oc_aa28b4a19f8b78b10167a989682cfe5f",
+      }),
+    ).toBe("feishu:私-openclaw 进化 (oc_aa28b4a19f8b78b10167a989682cfe5f)");
+  });
+
   const resolveSessionKeyCases = [
     {
       name: "keeps explicit provider when provided in group key",

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -38,6 +38,20 @@ export function buildGroupDisplayName(params: {
       : groupChannel || subject || space || "") || "";
   const fallbackId = params.id?.trim() || params.key;
   const rawLabel = detail || fallbackId;
+
+  if (providerKey === "feishu") {
+    if (!rawLabel) {
+      return providerKey;
+    }
+    if (!fallbackId || rawLabel === fallbackId || rawLabel.includes(fallbackId)) {
+      return `${providerKey}:${rawLabel}`;
+    }
+    if (rawLabel.toLowerCase().includes(" id:")) {
+      return `${providerKey}:${rawLabel}`;
+    }
+    return `${providerKey}:${rawLabel} (${fallbackId})`;
+  }
+
   let token = normalizeGroupLabel(rawLabel);
   if (!token) {
     token = normalizeGroupLabel(shortenGroupId(rawLabel));

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -105,6 +105,11 @@ export type GatewayControlUiConfig = {
   root?: string;
   /** Allowed browser origins for Control UI/WebChat websocket connections. */
   allowedOrigins?: string[];
+  /** Optional Control UI chat display preferences. */
+  chat?: {
+    /** Show model-specific higher-rate pricing threshold info in chat context notices (default: true). */
+    showPricingThreshold?: boolean;
+  };
   /**
    * DANGEROUS: Keep Host-header origin fallback behavior.
    * Supported long-term for deployments that intentionally rely on this policy.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -663,6 +663,12 @@ export const OpenClawSchema = z
             basePath: z.string().optional(),
             root: z.string().optional(),
             allowedOrigins: z.array(z.string()).optional(),
+            chat: z
+              .object({
+                showPricingThreshold: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
             dangerouslyAllowHostHeaderOriginFallback: z.boolean().optional(),
             allowInsecureAuth: z.boolean().optional(),
             dangerouslyDisableDeviceAuth: z.boolean().optional(),

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -6,4 +6,9 @@ export type ControlUiBootstrapConfig = {
   assistantAvatar: string;
   assistantAgentId: string;
   serverVersion?: string;
+  chat?: {
+    contextNotice?: {
+      showPricingThreshold?: boolean;
+    };
+  };
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -175,6 +175,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("</script><script>alert(1)//");
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+        expect(parsed.chat?.contextNotice?.showPricingThreshold).toBe(true);
       },
     });
   });
@@ -192,6 +193,7 @@ describe("handleControlUiHttpRequest", () => {
             config: {
               agents: { defaults: { workspace: tmp } },
               ui: { assistant: { name: "Ops", avatar: "ops.png" } },
+              gateway: { controlUi: { chat: { showPricingThreshold: false } } },
             },
           },
         );
@@ -201,6 +203,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("Ops");
         expect(parsed.assistantAvatar).toBe("/openclaw/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+        expect(parsed.chat?.contextNotice?.showPricingThreshold).toBe(false);
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -358,6 +358,12 @@ export function handleControlUiHttpRequest(
       assistantAvatar: avatarValue ?? identity.avatar,
       assistantAgentId: identity.agentId,
       serverVersion: resolveRuntimeServiceVersion(process.env),
+      chat: {
+        contextNotice: {
+          showPricingThreshold:
+            opts?.config?.gateway?.controlUi?.chat?.showPricingThreshold ?? true,
+        },
+      },
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1237,6 +1237,105 @@
   animation: fade-in 0.2s var(--ease-out);
 }
 
+.context-notices {
+  align-self: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.context-notice {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(100%, calc(100vw - 48px));
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--ctx-color, var(--warn)) 28%, transparent);
+  background: var(--ctx-bg, rgba(217, 119, 6, 0.08));
+  color: var(--ctx-color, var(--warn));
+  font-size: 13px;
+  line-height: 1.2;
+  user-select: none;
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.context-notice--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: min(100%, 560px);
+  padding: 10px 14px;
+  white-space: normal;
+}
+
+.context-notice__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.context-notice__summary-label {
+  color: color-mix(in srgb, var(--text) 72%, currentColor);
+  margin-right: 4px;
+}
+
+.context-notice__metric--used {
+  color: color-mix(in srgb, var(--text) 88%, #93c5fd);
+}
+
+.context-notice__metric--pricing {
+  color: rgb(217, 119, 6);
+}
+
+.context-notice__metric--limit {
+  color: rgb(96, 165, 250);
+}
+
+.context-notice__separator {
+  color: color-mix(in srgb, currentColor 40%, var(--text));
+}
+
+.context-notice__note {
+  font-size: 12px;
+  color: color-mix(in srgb, currentColor 72%, var(--text));
+}
+
+.context-notice__note--pricing {
+  color: rgb(217, 119, 6);
+}
+
+.context-notice__note--limit {
+  color: rgb(220, 38, 38);
+  font-weight: 600;
+}
+
+.context-notice__icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.context-notice__detail {
+  color: color-mix(in srgb, currentColor 72%, var(--text));
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
 .compaction-indicator svg {
   width: 16px;
   height: 16px;

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -127,6 +127,7 @@ function createHost() {
     assistantAvatar: null,
     assistantAgentId: null,
     serverVersion: null,
+    chatContextNoticeShowPricingThreshold: true,
     sessionKey: "main",
     chatMessages: [],
     chatToolMessages: [],

--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -51,6 +51,7 @@ function createHost() {
     assistantAvatar: null,
     assistantAgentId: null,
     serverVersion: null,
+    chatContextNoticeShowPricingThreshold: true,
     chatHasAutoScrolled: false,
     chatManualRefreshInFlight: false,
     chatLoading: false,

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -11,6 +11,7 @@ function createHost() {
     assistantName: "OpenClaw",
     assistantAvatar: null,
     assistantAgentId: null,
+    chatContextNoticeShowPricingThreshold: true,
     chatHasAutoScrolled: false,
     chatManualRefreshInFlight: false,
     chatLoading: false,

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -29,6 +29,7 @@ type LifecycleHost = {
   assistantAvatar: string | null;
   assistantAgentId: string | null;
   serverVersion: string | null;
+  chatContextNoticeShowPricingThreshold: boolean;
   chatHasAutoScrolled: boolean;
   chatManualRefreshInFlight: boolean;
   chatLoading: boolean;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1370,6 +1370,7 @@ export function renderApp(state: AppViewState) {
                 disabledReason: chatDisabledReason,
                 error: state.lastError,
                 sessions: state.sessionsResult,
+                showPricingThresholdNotice: state.chatContextNoticeShowPricingThreshold,
                 focusMode: chatFocus,
                 onRefresh: () => {
                   state.resetToolStream();

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -57,6 +57,7 @@ export type AppViewState = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  chatContextNoticeShowPricingThreshold: boolean;
   sessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -144,6 +144,7 @@ export class OpenClawApp extends LitElement {
   @state() assistantAvatar = bootAssistantIdentity.avatar;
   @state() assistantAgentId = bootAssistantIdentity.agentId ?? null;
   @state() serverVersion: string | null = null;
+  @state() chatContextNoticeShowPricingThreshold = true;
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;

--- a/ui/src/ui/chat-context-notice.browser.test.ts
+++ b/ui/src/ui/chat-context-notice.browser.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import "../styles.css";
+import { mountApp, registerAppMountHooks } from "./test-helpers/app-mount.ts";
+
+registerAppMountHooks();
+
+describe("chat context notice", () => {
+  it("renders the context warning as a compact stacked notice instead of an oversized block", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    app.sessionsResult = {
+      count: 1,
+      defaults: { contextTokens: 1000, model: "openai/gpt-5.2" },
+      sessions: [
+        {
+          key: "main",
+          inputTokens: 910,
+          contextTokens: 1000,
+          reasoningLevel: "off",
+          model: "openai/gpt-5.2",
+        },
+      ],
+    } as never;
+    app.requestUpdate();
+    await app.updateComplete;
+
+    const notice = app.querySelector<HTMLElement>(".context-notice");
+    expect(notice).not.toBeNull();
+    expect(getComputedStyle(notice!).display).toBe("flex");
+    expect(notice?.classList.contains("context-notice--stacked")).toBe(true);
+
+    const summary = notice?.querySelector<HTMLElement>(".context-notice__summary");
+    expect(summary?.textContent).toContain("Model context");
+    expect(summary?.textContent).toContain("Used 910");
+    expect(summary?.textContent).toContain("Limit 1k");
+  });
+
+  it("shows one summary row plus a pricing note for GPT-5.4 after the pricing threshold", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    app.sessionsResult = {
+      count: 1,
+      defaults: { contextTokens: 272000, model: "gpt-5.4" },
+      sessions: [
+        {
+          key: "main",
+          inputTokens: 351000,
+          contextTokens: 272000,
+          reasoningLevel: "off",
+          model: "gpt-5.4",
+          modelProvider: "openai-codex",
+        },
+      ],
+    } as never;
+    app.requestUpdate();
+    await app.updateComplete;
+
+    const notice = app.querySelector<HTMLElement>(".context-notice");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("Model context");
+    expect(notice?.textContent).toContain("Used 351k");
+    expect(notice?.textContent).toContain("Higher-rate 272k");
+    expect(notice?.textContent).toContain("Limit 1.1M");
+    expect(notice?.textContent).toContain("Higher-rate billing threshold crossed.");
+    expect(notice?.textContent).not.toContain(
+      "Estimated model context is at or beyond the ceiling",
+    );
+  });
+});

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -14,6 +14,7 @@ describe("loadControlUiBootstrapConfig", () => {
         assistantAvatar: "O",
         assistantAgentId: "main",
         serverVersion: "2026.3.7",
+        chat: { contextNotice: { showPricingThreshold: false } },
       }),
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
@@ -24,6 +25,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantAvatar: null,
       assistantAgentId: null,
       serverVersion: null,
+      chatContextNoticeShowPricingThreshold: true,
     };
 
     await loadControlUiBootstrapConfig(state);
@@ -36,6 +38,7 @@ describe("loadControlUiBootstrapConfig", () => {
     expect(state.assistantAvatar).toBe("O");
     expect(state.assistantAgentId).toBe("main");
     expect(state.serverVersion).toBe("2026.3.7");
+    expect(state.chatContextNoticeShowPricingThreshold).toBe(false);
 
     vi.unstubAllGlobals();
   });
@@ -50,6 +53,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantAvatar: null,
       assistantAgentId: null,
       serverVersion: null,
+      chatContextNoticeShowPricingThreshold: true,
     };
 
     await loadControlUiBootstrapConfig(state);
@@ -73,6 +77,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantAvatar: null,
       assistantAgentId: null,
       serverVersion: null,
+      chatContextNoticeShowPricingThreshold: true,
     };
 
     await loadControlUiBootstrapConfig(state);

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -11,6 +11,7 @@ export type ControlUiBootstrapState = {
   assistantAvatar: string | null;
   assistantAgentId: string | null;
   serverVersion: string | null;
+  chatContextNoticeShowPricingThreshold: boolean;
 };
 
 export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapState) {
@@ -45,6 +46,8 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     state.assistantAvatar = normalized.avatar;
     state.assistantAgentId = normalized.agentId ?? null;
     state.serverVersion = parsed.serverVersion ?? null;
+    state.chatContextNoticeShowPricingThreshold =
+      parsed.chat?.contextNotice?.showPricingThreshold ?? true;
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -75,6 +75,7 @@ export type ChatProps = {
   disabledReason: string | null;
   error: string | null;
   sessions: SessionsListResult | null;
+  showPricingThresholdNotice?: boolean;
   focusMode: boolean;
   sidebarOpen?: boolean;
   sidebarContent?: string | null;
@@ -247,38 +248,160 @@ function renderFallbackIndicator(status: FallbackIndicatorStatus | null | undefi
   `;
 }
 
+type ContextNoticeDefaults = {
+  model: string | null;
+  contextTokens: number | null;
+};
+
+type ContextThresholdMetadata = {
+  modelContextTokens?: number;
+  pricingThresholdTokens?: number;
+};
+
+const KNOWN_CONTEXT_THRESHOLDS: Record<string, ContextThresholdMetadata> = {
+  "openai/gpt-5.4": {
+    modelContextTokens: 1_050_000,
+    pricingThresholdTokens: 272_000,
+  },
+  "openai/gpt-5.4-pro": {
+    modelContextTokens: 1_050_000,
+    pricingThresholdTokens: 272_000,
+  },
+  "openai-codex/gpt-5.4": {
+    modelContextTokens: 1_050_000,
+    pricingThresholdTokens: 272_000,
+  },
+  "google/gemini-2.5-pro": {
+    pricingThresholdTokens: 200_000,
+  },
+  "google/gemini-3.1-pro-preview": {
+    pricingThresholdTokens: 200_000,
+  },
+  "google-gemini-cli/gemini-3.1-pro-preview": {
+    pricingThresholdTokens: 200_000,
+  },
+};
+
+function resolveKnownContextThresholds(
+  session: GatewaySessionRow | undefined,
+  defaults: ContextNoticeDefaults | null | undefined,
+): ContextThresholdMetadata | null {
+  const rawModel = (session?.model ?? defaults?.model ?? "").trim().toLowerCase();
+  const provider = (session?.modelProvider ?? "").trim().toLowerCase();
+  const candidates = new Set<string>();
+  if (rawModel) {
+    candidates.add(rawModel);
+    if (provider && !rawModel.includes("/")) {
+      candidates.add(`${provider}/${rawModel}`);
+    }
+  }
+  for (const key of candidates) {
+    const matched = KNOWN_CONTEXT_THRESHOLDS[key];
+    if (matched) {
+      return matched;
+    }
+  }
+  return null;
+}
+
+function resolveNoticeTone(ratio: number) {
+  if (ratio >= 0.95) {
+    return { color: "rgb(220, 38, 38)", bg: "rgba(220, 38, 38, 0.16)" };
+  }
+  if (ratio >= 0.85) {
+    return { color: "rgb(217, 119, 6)", bg: "rgba(217, 119, 6, 0.14)" };
+  }
+  return { color: "rgb(37, 99, 235)", bg: "rgba(37, 99, 235, 0.10)" };
+}
+
 /**
- * Compact notice when context usage reaches 85%+.
- * Progressively shifts from amber (85%) to red (90%+).
+ * Show separate pricing-threshold and model-context pills when we know both.
+ * Falls back to the legacy single warning when only a runtime limit is available.
  */
 function renderContextNotice(
   session: GatewaySessionRow | undefined,
-  defaultContextTokens: number | null,
+  defaults: ContextNoticeDefaults | null | undefined,
+  showPricingThresholdNotice = true,
 ) {
-  const used = session?.inputTokens ?? 0;
-  const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
-  if (!used || !limit) {
+  const inputUsed = session?.inputTokens ?? 0;
+  const contextUsed = Math.max(session?.totalTokens ?? 0, inputUsed);
+  const runtimeLimit = session?.contextTokens ?? defaults?.contextTokens ?? 0;
+  const known = resolveKnownContextThresholds(session, defaults);
+  const modelLimit = known?.modelContextTokens ?? runtimeLimit;
+  if (!contextUsed || !modelLimit) {
     return nothing;
   }
-  const ratio = used / limit;
-  if (ratio < 0.85) {
+
+  const modelRatio = contextUsed / modelLimit;
+  const shouldShowPricing =
+    showPricingThresholdNotice &&
+    typeof known?.pricingThresholdTokens === "number" &&
+    inputUsed >= known.pricingThresholdTokens;
+  const shouldShowModel = modelRatio >= 0.85 || shouldShowPricing;
+  if (!shouldShowPricing && !shouldShowModel) {
     return nothing;
   }
-  const pct = Math.min(Math.round(ratio * 100), 100);
-  // Lerp from amber (#d97706) at 85% to red (#dc2626) at 95%+
-  const t = Math.min(Math.max((ratio - 0.85) / 0.1, 0), 1);
-  // RGB: amber(217,119,6) → red(220,38,38)
-  const r = Math.round(217 + (220 - 217) * t);
-  const g = Math.round(119 + (38 - 119) * t);
-  const b = Math.round(6 + (38 - 6) * t);
-  const color = `rgb(${r}, ${g}, ${b})`;
-  const bgOpacity = 0.08 + 0.08 * t;
-  const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
+
+  const runtimeDiffers = runtimeLimit > 0 && runtimeLimit !== modelLimit;
+  const tone = resolveNoticeTone(modelRatio);
+  const pricingThreshold = showPricingThresholdNotice
+    ? (known?.pricingThresholdTokens ?? null)
+    : null;
+  const shouldShowModelWarning = contextUsed >= modelLimit;
+  const shouldShow = shouldShowPricing || shouldShowModelWarning || (!known && modelRatio >= 0.85);
+  if (!shouldShow) {
+    return nothing;
+  }
+
   return html`
-    <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
-      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-      <span>${pct}% context used</span>
-      <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
+    <div
+      class="context-notice context-notice--stacked"
+      role="status"
+      style="--ctx-color:${tone.color};--ctx-bg:${tone.bg}"
+      title=${
+        runtimeDiffers
+          ? `Model context window is ${formatTokensCompact(modelLimit)}; runtime currently budgets ${formatTokensCompact(runtimeLimit)} for compaction.`
+          : `Model context window: ${formatTokensCompact(modelLimit)}`
+      }
+    >
+      <div class="context-notice__summary">
+        <span class="context-notice__summary-label">Model context</span>
+        <span class="context-notice__metric context-notice__metric--used">
+          Used ${formatTokensCompact(contextUsed)}
+        </span>
+        ${
+          pricingThreshold
+            ? html`
+              <span class="context-notice__separator">/</span>
+              <span class="context-notice__metric context-notice__metric--pricing">
+                Higher-rate ${formatTokensCompact(pricingThreshold)}
+              </span>
+            `
+            : nothing
+        }
+        <span class="context-notice__separator">/</span>
+        <span class="context-notice__metric context-notice__metric--limit">
+          Limit ${formatTokensCompact(modelLimit)}
+        </span>
+      </div>
+      ${
+        shouldShowPricing && pricingThreshold
+          ? html`
+              <div class="context-notice__note context-notice__note--pricing">
+                Higher-rate billing threshold crossed.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        shouldShowModelWarning
+          ? html`
+              <div class="context-notice__note context-notice__note--limit">
+                Estimated model context is at or beyond the ceiling — auto-compaction or overflow is likely.
+              </div>
+            `
+          : nothing
+      }
     </div>
   `;
 }
@@ -1165,7 +1288,11 @@ export function renderChat(props: ChatProps) {
 
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
-      ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
+      ${renderContextNotice(
+        activeSession,
+        props.sessions?.defaults ?? null,
+        props.showPricingThresholdNotice ?? true,
+      )}
 
       ${
         props.showNewMessages


### PR DESCRIPTION
## Summary

This PR ports a small fork-maintained patch set onto current main to restore two Feishu UX/runtime behaviors and one Control UI visibility improvement:

1. restore Feishu group-name and topic/thread label display
2. restore Feishu direct-message sender-name fallback
3. split Control UI context notices between model context ceiling and higher-rate pricing threshold

## What changed

### Feishu

- preserve Feishu group display names instead of normalizing them into slug-like labels
- append the chat id only when it is not already visible in the label
- resolve topic labels from the root message and surface them in thread context labels
- use chatMembers for DM peer-name fallback
- prefer user_id before open_id when resolving group sender names

### Control UI

- add gateway.controlUi.chat.showPricingThreshold
- split the chat context notice into:
  - model context usage / limit
  - higher-rate pricing threshold
- wire the setting through gateway/bootstrap/UI layers
- add the corresponding tests

## Validation

Local validation on the upstream-port branch:

- passed: src/gateway/control-ui.http.test.ts
- passed: pnpm ui:build
- passed: newly added Feishu coverage for DM member-name fallback and group sender user_id fallback
- note: 3 ACP-routing tests in extensions/feishu/src/bot.test.ts also fail when re-run locally on current origin/main, so they are not introduced by this PR branch
- note: browser UI tests were not re-run in this temporary worktree because the local environment currently lacks @vitest/browser-playwright

## Scope

This PR only carries the functional patch set. It does not include any deploy/update automation or local runtime-management changes.
