### PR TITLE
fix(telegram): retry 421 misdirected request responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - CLI/help: keep `gateway`, `doctor`, `status`, and `health` help registration out of action/runtime imports so subcommand `--help` stays lightweight in constrained terminals. Fixes #83228. Thanks @dfguerrerom.
 - Cron/Discord: keep explicit announce runs in message-tool-only source-reply mode so scheduled agent turns post once instead of also echoing through automatic visible replies. Fixes #83261. Thanks @Theralley.
 - Telegram: preserve forum-topic origin targets in inbound, audio-preflight, and skipped-message hook contexts so follow-up delivery stays bound to the originating topic. Fixes #83302. Thanks @M00zyx.
+- Telegram: retry HTTP 421 Misdirected Request send failures on a fresh fallback transport so transient edge-node routing errors no longer drop outbound replies. Fixes #48892. (#48908) Thanks @MarsDoge.
 - Telegram: fail topic sends closed when Telegram reports `message thread not found` instead of retrying without `message_thread_id` into the base chat. Refs #83302.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -246,6 +246,44 @@ describe("createTelegramBot fetch abort", () => {
     vi.useRealTimers();
   });
 
+  it("retries Telegram 421 responses after forcing transport fallback", async () => {
+    const forceFallback = vi.fn(() => true);
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("Misdirected Request", { status: 421 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
+      fetch: fetchSpy as typeof fetch,
+      forceFallback,
+    });
+
+    const result = await clientFetch("https://api.telegram.org/bot123456:ABC/sendMessage");
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(200);
+    expect(forceFallback).toHaveBeenCalledWith("misdirected-request");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries Telegram 421 fetch errors after forcing transport fallback", async () => {
+    const forceFallback = vi.fn(() => true);
+    const fetchSpy = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("421 Misdirected Request"), { status: 421 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
+      fetch: fetchSpy as typeof fetch,
+      forceFallback,
+    });
+
+    const result = await clientFetch("https://api.telegram.org/bot123456:ABC/sendMessage");
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(200);
+    expect(forceFallback).toHaveBeenCalledWith("misdirected-request");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("preserves the original fetch error when tagging cannot attach metadata", async () => {
     const frozenError = Object.freeze(
       Object.assign(new TypeError("fetch failed"), {

--- a/extensions/telegram/src/client-fetch.ts
+++ b/extensions/telegram/src/client-fetch.ts
@@ -1,7 +1,7 @@
 import type { ApiClientOptions } from "grammy";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramTransport } from "./fetch.js";
-import { tagTelegramNetworkError } from "./network-errors.js";
+import { isTelegramMisdirectedRequestError, tagTelegramNetworkError } from "./network-errors.js";
 import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 
 type TelegramFetchInput = Parameters<NonNullable<ApiClientOptions["fetch"]>>[0];
@@ -135,6 +135,11 @@ export function createTelegramClientFetch(params: {
       : undefined;
     const requestSignal = isTelegramAbortSignalLike(init?.signal) ? init.signal : undefined;
 
+    const canForceTransportFallback = (reason: string) =>
+      !shutdownSignal?.aborted &&
+      !requestSignal?.aborted &&
+      params.transport?.forceFallback?.(reason) === true;
+
     const runFetch = async () => {
       const controller = new AbortController();
       const abortWith = (signal: Pick<TelegramAbortSignalLike, "reason">) =>
@@ -195,14 +200,22 @@ export function createTelegramClientFetch(params: {
     };
 
     try {
-      return await runFetch();
+      const response = await runFetch();
+      if (response.status === 421 && canForceTransportFallback("misdirected-request")) {
+        return await runFetch();
+      }
+      return response;
     } catch (err) {
       if (
         requestTimeoutMs &&
         shouldRetryTimedOutTelegramControlRequest(method) &&
-        !shutdownSignal?.aborted &&
-        !requestSignal?.aborted &&
-        params.transport?.forceFallback?.("request-timeout")
+        canForceTransportFallback("request-timeout")
+      ) {
+        return await runFetch();
+      }
+      if (
+        isTelegramMisdirectedRequestError(err) &&
+        canForceTransportFallback("misdirected-request")
       ) {
         return await runFetch();
       }

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -202,6 +202,36 @@ describe("isSafeToRetrySendError", () => {
     const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", fetchError);
     expect(isSafeToRetrySendError(wrapped)).toBe(true);
   });
+
+  it.each([
+    ["status", Object.assign(new Error("Misdirected Request"), { status: 421 })],
+    ["statusCode", Object.assign(new Error("Misdirected Request"), { statusCode: "421" })],
+    ["error_code", errorWithTelegramCode("Misdirected Request", 421)],
+    ["message", new Error("421 Misdirected Request")],
+    [
+      "nested cause",
+      Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+        cause: Object.assign(new Error("Misdirected Request"), { status: 421 }),
+      }),
+    ],
+    [
+      "grammY HttpError",
+      new MockHttpError(
+        "Network request for 'sendMessage' failed!",
+        Object.assign(new Error("Misdirected Request"), { status: 421 }),
+      ),
+    ],
+  ])("treats Telegram 421 Misdirected Request as safe to retry via %s", (_name, err) => {
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("does not parse malformed status strings as Telegram 421", () => {
+    expect(
+      isSafeToRetrySendError(
+        Object.assign(new Error("Misdirected Request"), { statusCode: "421abc" }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("isTelegramServerError", () => {

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -253,6 +253,36 @@ describe("isSafeToRetrySendError", () => {
     );
     expect(isSafeToRetrySendError(wrapped)).toBe(false);
   });
+
+  it.each([
+    ["status", Object.assign(new Error("Misdirected Request"), { status: 421 })],
+    ["statusCode", Object.assign(new Error("Misdirected Request"), { statusCode: "421" })],
+    ["error_code", errorWithTelegramCode("Misdirected Request", 421)],
+    ["message", new Error("421 Misdirected Request")],
+    [
+      "nested cause",
+      Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+        cause: Object.assign(new Error("Misdirected Request"), { status: 421 }),
+      }),
+    ],
+    [
+      "grammY HttpError",
+      new MockHttpError(
+        "Network request for 'sendMessage' failed!",
+        Object.assign(new Error("Misdirected Request"), { status: 421 }),
+      ),
+    ],
+  ])("treats Telegram 421 Misdirected Request as safe to retry via %s", (_name, err) => {
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("does not parse malformed status strings as Telegram 421", () => {
+    expect(
+      isSafeToRetrySendError(
+        Object.assign(new Error("Misdirected Request"), { statusCode: "421abc" }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("isTelegramServerError", () => {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -103,6 +103,40 @@ function getErrorCode(err: unknown): string | undefined {
   return undefined;
 }
 
+function getNumericHttpStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as { error_code?: unknown; status?: unknown; statusCode?: unknown };
+  for (const value of [candidate.error_code, candidate.status, candidate.statusCode]) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (/^\d+$/.test(trimmed)) {
+        return Number.parseInt(trimmed, 10);
+      }
+    }
+  }
+  return undefined;
+}
+
+function isTelegramMisdirectedRequestError(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code === "421" || getNumericHttpStatus(candidate) === 421) {
+      return true;
+    }
+
+    const message = normalizeLowercaseStringOrEmpty(formatErrorMessage(candidate));
+    if (/\b421\b/.test(message) && message.includes("misdirected request")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
 export type TelegramNetworkErrorOrigin = {
   method?: string | null;
@@ -161,6 +195,9 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
 export function isSafeToRetrySendError(err: unknown): boolean {
   if (!err) {
     return false;
+  }
+  if (isTelegramMisdirectedRequestError(err)) {
+    return true;
   }
   for (const candidate of collectTelegramErrorCandidates(err)) {
     const code = normalizeCode(getErrorCode(candidate));

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -103,6 +103,40 @@ function getErrorCode(err: unknown): string | undefined {
   return undefined;
 }
 
+function getNumericHttpStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as { error_code?: unknown; status?: unknown; statusCode?: unknown };
+  for (const value of [candidate.error_code, candidate.status, candidate.statusCode]) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (/^\d+$/.test(trimmed)) {
+        return Number.parseInt(trimmed, 10);
+      }
+    }
+  }
+  return undefined;
+}
+
+export function isTelegramMisdirectedRequestError(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code === "421" || getNumericHttpStatus(candidate) === 421) {
+      return true;
+    }
+
+    const message = normalizeLowercaseStringOrEmpty(formatErrorMessage(candidate));
+    if (/\b421\b/.test(message) && message.includes("misdirected request")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
 export type TelegramNetworkErrorOrigin = {
   method?: string | null;
@@ -161,6 +195,9 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
 export function isSafeToRetrySendError(err: unknown): boolean {
   if (!err) {
     return false;
+  }
+  if (isTelegramMisdirectedRequestError(err)) {
+    return true;
   }
   for (const candidate of collectTelegramErrorCandidates(err)) {
     const code = normalizeCode(getErrorCode(candidate));

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -160,6 +160,24 @@ describe("createChannelApiRetryRunner", () => {
     });
   });
 
+  describe("default retry behavior", () => {
+    it("retries misdirected request errors from Telegram edge nodes", async () => {
+      await runRetryCase({
+        runnerOptions: { retry: ZERO_DELAY_RETRY },
+        fnSteps: [
+          {
+            type: "reject" as const,
+            value: Object.assign(new Error("421 Misdirected Request"), {
+              status: 421,
+            }),
+          },
+        ],
+        expectedCalls: 3,
+        expectedError: "421 Misdirected Request",
+      });
+    });
+  });
+
   it("honors nested retry_after hints before retrying", async () => {
     vi.useFakeTimers();
 

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -11,7 +11,8 @@ export const CHANNEL_API_RETRY_DEFAULTS = {
   jitter: 0.1,
 };
 
-const CHANNEL_API_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
+const CHANNEL_API_RETRY_RE =
+  /429|421|timeout|connect|reset|closed|unavailable|temporarily|misdirected request/i;
 const log = createSubsystemLogger("retry-policy");
 
 function resolveChannelApiShouldRetry(params: {


### PR DESCRIPTION
"Summary\n- treat Telegram HTTP 421 / \"Misdirected Request\" responses as retryable transport failures\n- wire 421 handling into the strict Telegram outbound send retry path used by non-idempotent send operations\n- keep the default channel API retry regex coverage for non-strict retry callers\n- add regression coverage for both default retry behavior and the strict send retry predicate\n- closes #48892\n\nChange Type\n- bug fix\n\nScope\n- src/infra/retry-policy.ts\n- src/infra/retry-policy.test.ts\n- extensions/telegram/src/network-errors.ts\n- extensions/telegram/src/network-errors.test.ts\n\nUser-visible / Behavior Changes\n- Telegram outbound sends such as sendMessage/media sends can retry transient HTTP 421 Misdirected Request responses instead of failing on the first attempt\n- The strict send retry path remains conservative for non-idempotent operations and does not broadly retry ambiguous network errors that could duplicate messages\n\nReview Notes\n- Addresses Codex feedback by adding 421 detection to `isSafeToRetrySendError`, which is the predicate used by the strict Telegram send path\n- The non-strict channel API retry regex also recognizes HTTP 421 because it is a transport/routing-level misdirection response and is safe to retry in the default retry path\n- Tightens string status parsing so malformed values such as `421abc` are not treated as HTTP 421\n- Moves the default retry-policy 421 regression case out of the `strictShouldRetry` suite\n\nTest plan\n- pnpm install --frozen-lockfile\n- pnpm exec vitest run --config vitest.unit.config.ts src/infra/retry-policy.test.ts extensions/telegram/src/network-errors.test.ts"

## Real behavior proof

Behavior addressed: Telegram bot transport and outbound reply path still work after adding HTTP 421/Misdirected Request retry classification and fresh fallback transport retry. The exact intermittent Telegram edge-node 421 was not live-triggered; that path is covered by injected 421 response/error regression tests in this PR.

Real environment tested: Real Telegram test group using driver bot `foremanclawbot` and SUT bot `cameronclawbot`, with an OpenClaw gateway started from this PR worktree at commit `565616b` and mock OpenAI configured for model isolation.

Exact steps or command run after this patch: `PATH="/tmp/openclaw-pnpm-shim:$PATH" node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --gateway-port 21179 --mock-port 21182 --text '/status' --any-sut-reply --expect '' --timeout-ms 60000`

Evidence after fix: terminal output from the bot-to-bot run:

```json
{
  "ok": true,
  "sent": { "messageId": 13064, "text": "/status@cameronclawbot" },
  "reply": {
    "messageId": 13065,
    "fromUsername": "cameronclawbot",
    "replyToMessageId": 13064,
    "text": "OpenClaw 2026.5.17 (565616b) ... Model: openai/gpt-5.5 ... Session: agent:main:telegram:group:-1003825137325:topic:1"
  },
  "observedCount": 1,
  "rttMs": 2176,
  "mockRequests": 0,
  "drained": { "webhookUrlSet": false, "pendingBefore": 0, "drained": 0, "pendingAfter": 0 }
}
```

Observed result after fix: The driver bot sent `/status@cameronclawbot` as Telegram message `13064`; the SUT bot replied in the same group as message `13065`, threaded back to `13064`, within `2176ms`.

What was not tested: A naturally occurring live Telegram HTTP 421 edge-node response was not reproduced. The 421-specific behavior was tested with focused regression tests that inject 421 response/error shapes and assert forced transport fallback before retry.
