### PR TITLE
fix(auto-reply): pass sessionKey to deliverOutboundPayloads for internal hooks (fixes #29203)

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -505,6 +505,7 @@ describe("routeReply", () => {
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
+        sessionKey: "agent:main:main",
         mirror: expect.objectContaining({
           sessionKey: "agent:main:main",
           text: "hi",
@@ -527,6 +528,7 @@ describe("routeReply", () => {
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
+        sessionKey: "agent:main:main",
         mirror: undefined,
       }),
     );

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -180,6 +180,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      sessionKey: params.sessionKey,
       payloads: [externalPayload],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -262,6 +262,8 @@ type DeliverOutboundPayloadsCoreParams = {
   onPayload?: (payload: NormalizedOutboundPayload) => void;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
+  /** Top-level session key for internal hooks when mirror is disabled. */
+  sessionKey?: string;
   mirror?: DeliveryMirror;
   silent?: boolean;
 };
@@ -613,7 +615,8 @@ async function deliverOutboundPayloadsCore(
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
+  const sessionKeyForInternalHooks =
+    params.mirror?.sessionKey ?? params.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({


### PR DESCRIPTION
## Summary

When `mirror` is disabled, `deliverOutboundPayloads` was called without a top-level `sessionKey`, causing `sessionKeyForInternalHooks` to be `undefined` and internal hooks (`message:sent`, `command-logger`, `session-memory`) to be silently skipped in the auto-reply path (Telegram, Discord, WhatsApp, etc.).

## Changes

- Add `sessionKey` param to `DeliverOutboundPayloadsCoreParams`
- Use `params.sessionKey` as fallback in `sessionKeyForInternalHooks` computation
- Pass `sessionKey` from `routeReply` to `deliverOutboundPayloads`
- Add test assertions for `sessionKey` in mirror-on and mirror-off cases

## Testing

- `pnpm build` ✓
- `pnpm test src/infra/outbound/deliver.test.ts` ✓ (43 passed)
- `pnpm test src/auto-reply/reply/route-reply.test.ts -t "skips mirror"` ✓

Closes #29203

Made with [Cursor](https://cursor.com)