### PR TITLE
test(gateway): consolidate deriveSessionTitle tests into dedicated module

### DIFF
--- a/src/gateway/session-title.test.ts
+++ b/src/gateway/session-title.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { deriveSessionTitle } from "./session-title.js";
+
+describe("deriveSessionTitle", () => {
+  test("returns undefined for undefined entry", () => {
+    expect(deriveSessionTitle(undefined)).toBeUndefined();
+  });
+
+  test("prefers displayName when set", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      displayName: "My Custom Session",
+      subject: "Group Chat",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("My Custom Session");
+  });
+
+  test("falls back to subject when displayName is missing", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      subject: "Dev Team Chat",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Dev Team Chat");
+  });
+
+  test("prefers session label over first user message when present", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      label: "My App - Dashboard",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "heartbeat")).toBe("My App - Dashboard");
+  });
+
+  test("keeps displayName ahead of label", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      displayName: "Override",
+      label: "Should Not Appear",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Override");
+  });
+
+  test("keeps subject ahead of label", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      subject: "Room Title",
+      label: "Should Not Appear",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Room Title");
+  });
+
+  test("falls back to origin label only when no transcript or explicit label exists", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      origin: { label: "Discord: Engineering" },
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "heartbeat")).toBe("heartbeat");
+  });
+
+  test("uses origin label when no first user message and no explicit label", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      origin: { label: "Discord: Engineering" },
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, null)).toBe("Discord: Engineering");
+  });
+
+  test("uses first user message when displayName, subject, and labels are missing", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "Hello, how are you?")).toBe("Hello, how are you?");
+  });
+
+  test("truncates long first user message to 60 chars with ellipsis", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    const longMsg =
+      "This is a very long message that exceeds sixty characters and should be truncated appropriately";
+    const result = deriveSessionTitle(entry, longMsg);
+    expect(result).toBeDefined();
+    expect(result!.length).toBeLessThanOrEqual(60);
+    expect(result!.endsWith("…")).toBe(true);
+  });
+
+  test("falls back to sessionId prefix with date", () => {
+    const entry = {
+      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("abcd1234 (2024-03-15)");
+  });
+
+  test("truncates at word boundary when possible", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    const longMsg = "This message has many words and should be truncated at a word boundary nicely";
+    const result = deriveSessionTitle(entry, longMsg);
+    expect(result).toBeDefined();
+    expect(result!.endsWith("…")).toBe(true);
+    expect(result!.includes("  ")).toBe(false);
+  });
+
+  test("falls back to sessionId prefix without date when updatedAt is zero", () => {
+    const entry = {
+      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: 0,
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("abcd1234");
+  });
+});

--- a/src/gateway/session-title.test.ts
+++ b/src/gateway/session-title.test.ts
@@ -26,11 +26,12 @@ describe("deriveSessionTitle", () => {
     expect(deriveSessionTitle(entry)).toBe("Dev Team Chat");
   });
 
-  test("prefers session label over first user message when present", () => {
+  test("prefers session label over first user message and origin label when present", () => {
     const entry = {
       sessionId: "abc123",
       updatedAt: Date.now(),
       label: "My App - Dashboard",
+      origin: { label: "Discord: Engineering" },
     } as SessionEntry;
     expect(deriveSessionTitle(entry, "heartbeat")).toBe("My App - Dashboard");
   });
@@ -55,7 +56,7 @@ describe("deriveSessionTitle", () => {
     expect(deriveSessionTitle(entry)).toBe("Room Title");
   });
 
-  test("falls back to origin label only when no transcript or explicit label exists", () => {
+  test("keeps origin label behind first user message", () => {
     const entry = {
       sessionId: "abc123",
       updatedAt: Date.now(),
@@ -114,7 +115,7 @@ describe("deriveSessionTitle", () => {
     expect(result!.includes("  ")).toBe(false);
   });
 
-  test("falls back to sessionId prefix without date when updatedAt is zero", () => {
+  test("omits date from sessionId fallback when updatedAt is zero", () => {
     const entry = {
       sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
       updatedAt: 0,

--- a/src/gateway/session-title.ts
+++ b/src/gateway/session-title.ts
@@ -1,0 +1,61 @@
+import type { SessionEntry } from "../config/sessions.js";
+
+const DERIVED_TITLE_MAX_LEN = 60;
+
+function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
+  const prefix = sessionId.slice(0, 8);
+  if (updatedAt && updatedAt > 0) {
+    const d = new Date(updatedAt);
+    const date = d.toISOString().slice(0, 10);
+    return `${prefix} (${date})`;
+  }
+  return prefix;
+}
+
+function truncateTitle(text: string, maxLen: number): string {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  const cut = text.slice(0, maxLen - 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  if (lastSpace > maxLen * 0.6) {
+    return cut.slice(0, lastSpace) + "…";
+  }
+  return cut + "…";
+}
+
+export function deriveSessionTitle(
+  entry: SessionEntry | undefined,
+  firstUserMessage?: string | null,
+): string | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.displayName?.trim()) {
+    return entry.displayName.trim();
+  }
+
+  if (entry.subject?.trim()) {
+    return entry.subject.trim();
+  }
+
+  if (entry.label?.trim()) {
+    return entry.label.trim();
+  }
+
+  if (firstUserMessage?.trim()) {
+    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
+    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
+  }
+
+  if (entry.origin?.label?.trim()) {
+    return entry.origin.label.trim();
+  }
+
+  if (entry.sessionId) {
+    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
+  }
+
+  return undefined;
+}

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -82,13 +82,6 @@ function createModelDefaultsConfig(params: {
   } as OpenClawConfig;
 }
 
-function requireString(value: string | undefined, label: string): string {
-  if (!value) {
-    throw new Error(`expected ${label}`);
-  }
-  return value;
-}
-
 function expectFields(value: unknown, expected: Record<string, unknown>): void {
   if (!value || typeof value !== "object") {
     throw new Error("expected fields object");
@@ -2405,8 +2398,19 @@ describe("resolveSessionDisplayModelIdentityRef", () => {
 });
 
 describe("deriveSessionTitle compatibility re-export", () => {
-  test("deriveSessionTitle is re-exported from session-utils", () => {
+  test("deriveSessionTitle is re-exported from session-utils with gateway precedence", () => {
     expect(typeof deriveSessionTitle).toBe("function");
+    expect(
+      deriveSessionTitle(
+        {
+          sessionId: "abc123",
+          updatedAt: Date.now(),
+          label: "Pinned session",
+          origin: { label: "openclaw-tui" },
+        } as SessionEntry,
+        "heartbeat",
+      ),
+    ).toBe("Pinned session");
   });
 });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2404,96 +2404,9 @@ describe("resolveSessionDisplayModelIdentityRef", () => {
   });
 });
 
-describe("deriveSessionTitle", () => {
-  test("returns undefined for undefined entry", () => {
-    expect(deriveSessionTitle(undefined)).toBeUndefined();
-  });
-
-  test("prefers displayName when set", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "My Custom Session",
-      subject: "Group Chat",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("My Custom Session");
-  });
-
-  test("falls back to subject when displayName is missing", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      subject: "Dev Team Chat",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Dev Team Chat");
-  });
-
-  test("uses first user message when displayName and subject missing", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry, "Hello, how are you?")).toBe("Hello, how are you?");
-  });
-
-  test("truncates long first user message to 60 chars with ellipsis", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    const longMsg =
-      "This is a very long message that exceeds sixty characters and should be truncated appropriately";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "truncated session title");
-    expect(result.length).toBeLessThanOrEqual(60);
-    expect(result.endsWith("…")).toBe(true);
-  });
-
-  test("truncates at word boundary when possible", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    const longMsg = "This message has many words and should be truncated at a word boundary nicely";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "word-boundary session title");
-    expect(result.endsWith("…")).toBe(true);
-    expect(result.includes("  ")).toBe(false);
-  });
-
-  test("falls back to sessionId prefix with date", () => {
-    const entry = {
-      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
-      updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
-    } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234 (2024-03-15)");
-  });
-
-  test("falls back to sessionId prefix without date when updatedAt missing", () => {
-    const entry = {
-      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
-      updatedAt: 0,
-    } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234");
-  });
-
-  test("trims whitespace from displayName", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "  Padded Name  ",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Padded Name");
-  });
-
-  test("ignores empty displayName and falls through", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "   ",
-      subject: "Actual Subject",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Actual Subject");
+describe("deriveSessionTitle compatibility re-export", () => {
+  test("deriveSessionTitle is re-exported from session-utils", () => {
+    expect(typeof deriveSessionTitle).toBe("function");
   });
 });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -76,13 +76,6 @@ function createModelDefaultsConfig(params: {
   } as OpenClawConfig;
 }
 
-function requireString(value: string | undefined, label: string): string {
-  if (!value) {
-    throw new Error(`expected ${label}`);
-  }
-  return value;
-}
-
 describe("gateway session utils", () => {
   afterEach(() => {
     resetConfigRuntimeState();
@@ -1753,96 +1746,9 @@ describe("resolveSessionDisplayModelIdentityRef", () => {
   });
 });
 
-describe("deriveSessionTitle", () => {
-  test("returns undefined for undefined entry", () => {
-    expect(deriveSessionTitle(undefined)).toBeUndefined();
-  });
-
-  test("prefers displayName when set", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "My Custom Session",
-      subject: "Group Chat",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("My Custom Session");
-  });
-
-  test("falls back to subject when displayName is missing", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      subject: "Dev Team Chat",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Dev Team Chat");
-  });
-
-  test("uses first user message when displayName and subject missing", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry, "Hello, how are you?")).toBe("Hello, how are you?");
-  });
-
-  test("truncates long first user message to 60 chars with ellipsis", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    const longMsg =
-      "This is a very long message that exceeds sixty characters and should be truncated appropriately";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "truncated session title");
-    expect(result.length).toBeLessThanOrEqual(60);
-    expect(result.endsWith("…")).toBe(true);
-  });
-
-  test("truncates at word boundary when possible", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-    } as SessionEntry;
-    const longMsg = "This message has many words and should be truncated at a word boundary nicely";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "word-boundary session title");
-    expect(result.endsWith("…")).toBe(true);
-    expect(result.includes("  ")).toBe(false);
-  });
-
-  test("falls back to sessionId prefix with date", () => {
-    const entry = {
-      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
-      updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
-    } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234 (2024-03-15)");
-  });
-
-  test("falls back to sessionId prefix without date when updatedAt missing", () => {
-    const entry = {
-      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
-      updatedAt: 0,
-    } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234");
-  });
-
-  test("trims whitespace from displayName", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "  Padded Name  ",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Padded Name");
-  });
-
-  test("ignores empty displayName and falls through", () => {
-    const entry = {
-      sessionId: "abc123",
-      updatedAt: Date.now(),
-      displayName: "   ",
-      subject: "Actual Subject",
-    } as SessionEntry;
-    expect(deriveSessionTitle(entry)).toBe("Actual Subject");
+describe("deriveSessionTitle compatibility re-export", () => {
+  test("deriveSessionTitle is re-exported from session-utils", () => {
+    expect(typeof deriveSessionTitle).toBe("function");
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -91,6 +91,7 @@ import {
   readSessionTitleFieldsFromTranscriptAsync,
   readSessionTitleFieldsFromTranscript,
 } from "./session-utils.fs.js";
+import { deriveSessionTitle } from "./session-title.js";
 import type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -123,6 +124,7 @@ export {
 } from "./session-utils.fs.js";
 export type { ReadSessionMessagesAsyncOptions } from "./session-utils.fs.js";
 export { canonicalizeSpawnedByForAgent, resolveSessionStoreKey } from "./session-store-key.js";
+export { deriveSessionTitle } from "./session-title.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -132,8 +134,6 @@ export type {
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";
-
-const DERIVED_TITLE_MAX_LEN = 60;
 
 function tryResolveExistingPath(value: string): string | null {
   try {
@@ -189,56 +189,6 @@ function resolveIdentityAvatarUrl(
   } catch {
     return undefined;
   }
-}
-
-function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
-  const prefix = sessionId.slice(0, 8);
-  if (updatedAt && updatedAt > 0) {
-    const d = new Date(updatedAt);
-    const date = d.toISOString().slice(0, 10);
-    return `${prefix} (${date})`;
-  }
-  return prefix;
-}
-
-function truncateTitle(text: string, maxLen: number): string {
-  if (text.length <= maxLen) {
-    return text;
-  }
-  const cut = text.slice(0, maxLen - 1);
-  const lastSpace = cut.lastIndexOf(" ");
-  if (lastSpace > maxLen * 0.6) {
-    return cut.slice(0, lastSpace) + "…";
-  }
-  return cut + "…";
-}
-
-export function deriveSessionTitle(
-  entry: SessionEntry | undefined,
-  firstUserMessage?: string | null,
-): string | undefined {
-  if (!entry) {
-    return undefined;
-  }
-
-  if (normalizeOptionalString(entry.displayName)) {
-    return normalizeOptionalString(entry.displayName);
-  }
-
-  if (normalizeOptionalString(entry.subject)) {
-    return normalizeOptionalString(entry.subject);
-  }
-
-  if (firstUserMessage?.trim()) {
-    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
-    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
-  }
-
-  if (entry.sessionId) {
-    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
-  }
-
-  return undefined;
 }
 
 function resolveSessionRuntimeMs(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -103,6 +103,7 @@ import {
   readSessionTitleFieldsFromTranscriptAsync as readScopedSessionTitleFieldsFromTranscriptAsync,
   readSessionTitleFieldsFromTranscript as readScopedSessionTitleFieldsFromTranscript,
 } from "./session-transcript-readers.js";
+import { deriveSessionTitle } from "./session-title.js";
 import type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -142,6 +143,7 @@ export type {
   SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
 export { canonicalizeSpawnedByForAgent, resolveSessionStoreKey } from "./session-store-key.js";
+export { deriveSessionTitle } from "./session-title.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -151,8 +153,6 @@ export type {
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";
-
-const DERIVED_TITLE_MAX_LEN = 60;
 
 function tryResolveExistingPath(value: string): string | null {
   try {
@@ -210,56 +210,6 @@ function resolveIdentityAvatarUrl(
   } catch {
     return undefined;
   }
-}
-
-function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
-  const prefix = sessionId.slice(0, 8);
-  if (updatedAt && updatedAt > 0) {
-    const d = new Date(updatedAt);
-    const date = d.toISOString().slice(0, 10);
-    return `${prefix} (${date})`;
-  }
-  return prefix;
-}
-
-function truncateTitle(text: string, maxLen: number): string {
-  if (text.length <= maxLen) {
-    return text;
-  }
-  const cut = text.slice(0, maxLen - 1);
-  const lastSpace = cut.lastIndexOf(" ");
-  if (lastSpace > maxLen * 0.6) {
-    return cut.slice(0, lastSpace) + "…";
-  }
-  return cut + "…";
-}
-
-export function deriveSessionTitle(
-  entry: SessionEntry | undefined,
-  firstUserMessage?: string | null,
-): string | undefined {
-  if (!entry) {
-    return undefined;
-  }
-
-  if (normalizeOptionalString(entry.displayName)) {
-    return normalizeOptionalString(entry.displayName);
-  }
-
-  if (normalizeOptionalString(entry.subject)) {
-    return normalizeOptionalString(entry.subject);
-  }
-
-  if (firstUserMessage?.trim()) {
-    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
-    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
-  }
-
-  if (entry.sessionId) {
-    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
-  }
-
-  return undefined;
 }
 
 function resolveSessionRuntimeMs(


### PR DESCRIPTION
## Summary

This PR fixes an issue where heartbeat polls could overwrite explicit user-labeled session titles with transcript-derived titles like `"heartbeat"`.

## Changes

- Extracts `deriveSessionTitle` to `session-title.ts` with a dedicated test module.
- Preserves explicit session labels before transcript-derived fallbacks.
- Keeps auto-populated `origin.label` behind `firstUserMessage` so unlabeled inbound DMs can still use transcript-derived titles.
- Keeps `session-utils.ts` as a compatibility re-export site.
- Clarifies the zero timestamp test name to describe the actual `updatedAt: 0` input.

## Title precedence

1. `displayName`
2. `subject`
3. explicit `entry.label`
4. `firstUserMessage` (truncated)
5. auto-populated `entry.origin?.label`
6. `sessionId` prefix fallback

## Real behavior proof

Behavior or issue addressed: explicit session labels should survive heartbeat-style transcript summaries, while auto-populated origin labels should not override a real first user message.

Real environment tested: local OpenClaw checkout on this branch after rebasing onto current `main`.

Exact steps or command run after this patch:

```bash
node --import tsx --eval 'import { deriveSessionTitle } from "./src/gateway/session-title.ts";
const cases = {
  explicitLabelBeatsHeartbeat: deriveSessionTitle({ sessionId: "abc123", updatedAt: Date.now(), label: "My App - Dashboard" }, "heartbeat"),
  transcriptBeatsAutoOriginLabel: deriveSessionTitle({ sessionId: "abc123", updatedAt: Date.now(), origin: { label: "Discord: Engineering" } }, "Need help with deployment"),
  originLabelFallbackWithoutTranscript: deriveSessionTitle({ sessionId: "abc123", updatedAt: Date.now(), origin: { label: "Discord: Engineering" } }, null),
  zeroUpdatedAtFallback: deriveSessionTitle({ sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv", updatedAt: 0 }),
};
console.log(JSON.stringify(cases, null, 2));'
```

Evidence after fix:

```json
{
  "explicitLabelBeatsHeartbeat": "My App - Dashboard",
  "transcriptBeatsAutoOriginLabel": "Need help with deployment",
  "originLabelFallbackWithoutTranscript": "Discord: Engineering",
  "zeroUpdatedAtFallback": "abcd1234"
}
```

Observed result after fix: explicit labels win over heartbeat transcript text; transcript text wins over auto-populated origin labels; origin labels still act as fallback when there is no transcript; zero `updatedAt` keeps the session-id-only fallback.

What was not tested: full gateway UI rendering was not manually opened; this proof covers the extracted title derivation behavior directly.

## Validation

- `pnpm test src/gateway/session-title.test.ts src/gateway/session-utils.test.ts`
- `git diff --check upstream/main...HEAD`
