### PR TITLE
feat(feishu): skip @-mention for thread follow-ups in topic-scoped sessions

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2644,3 +2644,229 @@ describe("broadcast dispatch", () => {
     expect(sessionKey).toBe("agent:susan:feishu:group:oc-broadcast-group");
   });
 });
+
+// ---------------------------------------------------------------------------
+// threadFollowUp — thread reply mention bypass (#40475)
+// ---------------------------------------------------------------------------
+describe("handleFeishuMessage threadFollowUp", () => {
+  const mockFinalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+  const mockDispatchReplyFromConfig = vi
+    .fn()
+    .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } });
+  const mockWithReplyDispatcher = vi.fn(
+    async ({
+      run,
+      dispatcher,
+      onSettled,
+    }: Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]) => {
+      try {
+        return await run();
+      } finally {
+        dispatcher.markComplete();
+        try {
+          await dispatcher.waitForIdle();
+        } finally {
+          await onSettled?.();
+        }
+      }
+    },
+  );
+
+  // Each test uses a unique prefix so the module-level active-topic map
+  // does not leak state between tests.
+  let testId = 0;
+  beforeEach(() => {
+    testId++;
+    vi.clearAllMocks();
+    mockGetMessageFeishu.mockReset().mockResolvedValue(null);
+    mockListFeishuThreadMessages.mockReset().mockResolvedValue([]);
+    mockReadSessionUpdatedAt.mockReturnValue(undefined);
+    mockResolveStorePath.mockReturnValue("/tmp/feishu-sessions.json");
+    mockResolveConfiguredAcpRoute
+      .mockReset()
+      .mockImplementation(
+        ({ route }: { route: unknown }) => ({ configuredBinding: null, route }) as any,
+      );
+    mockEnsureConfiguredAcpRouteReady.mockReset().mockResolvedValue({ ok: true });
+    mockResolveBoundConversation.mockReset().mockReturnValue(null);
+    mockTouchBinding.mockReset();
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:group:oc-tfu-group:topic:msg-root",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+    });
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          routing: {
+            resolveAgentRoute:
+              mockResolveAgentRoute as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+          },
+          session: {
+            readSessionUpdatedAt:
+              mockReadSessionUpdatedAt as unknown as PluginRuntime["channel"]["session"]["readSessionUpdatedAt"],
+            resolveStorePath:
+              mockResolveStorePath as unknown as PluginRuntime["channel"]["session"]["resolveStorePath"],
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn(
+              () => ({}),
+            ) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+            formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+            finalizeInboundContext:
+              mockFinalizeInboundContext as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+            dispatchReplyFromConfig: mockDispatchReplyFromConfig,
+            withReplyDispatcher:
+              mockWithReplyDispatcher as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
+          },
+          commands: {
+            shouldComputeCommandAuthorized: vi.fn(() => false),
+            resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+          },
+          media: {
+            saveMediaBuffer:
+              vi.fn() as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
+          },
+          pairing: {
+            readAllowFromStore: vi.fn().mockResolvedValue([]),
+            upsertPairingRequest: vi.fn(),
+            buildPairingReply: vi.fn(),
+          },
+        },
+      }),
+    );
+  });
+
+  /** Build a group message event with unique IDs per test. */
+  function groupEvent(overrides: {
+    mentionBot?: boolean;
+    rootId?: string;
+    messageId?: string;
+    text?: string;
+  }): FeishuMessageEvent {
+    const mentions = overrides.mentionBot
+      ? [{ key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" }]
+      : undefined;
+    return {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: overrides.messageId ?? `msg-tfu-${testId}`,
+        chat_id: "oc-tfu-group",
+        chat_type: "group",
+        message_type: "text",
+        root_id: overrides.rootId,
+        content: JSON.stringify({ text: overrides.text ?? "hello" }),
+        mentions,
+      },
+    };
+  }
+
+  /** Build a config with group_topic scope. */
+  function topicCfg(threadFollowUp?: string): ClawdbotConfig {
+    return {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groupSessionScope: "group_topic",
+          groupAllowFrom: ["oc-tfu-group"],
+          ...(threadFollowUp != null ? { threadFollowUp } : {}),
+        },
+      },
+    } as ClawdbotConfig;
+  }
+
+  /** Dispatch with botOpenId so @mention detection works. */
+  async function dispatch(cfg: ClawdbotConfig, event: FeishuMessageEvent) {
+    const runtime = createRuntimeEnv();
+    await handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "ou-bot",
+      runtime,
+    });
+    return runtime;
+  }
+
+  it("dispatches top-level @mention in group_topic mode", async () => {
+    await dispatch(topicCfg(), groupEvent({ mentionBot: true, messageId: `msg-root-${testId}` }));
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops top-level message without @mention in group_topic mode", async () => {
+    await dispatch(topicCfg(), groupEvent({ mentionBot: false }));
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("dispatches thread reply in active bot topic (threadFollowUp=active)", async () => {
+    const rootId = `msg-root-active-${testId}`;
+    // Step 1: bot is @mentioned — marks the topic as active
+    await dispatch(topicCfg(), groupEvent({ mentionBot: true, messageId: rootId }));
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    vi.clearAllMocks();
+
+    // Step 2: follow-up reply in the same topic without @mention
+    await dispatch(
+      topicCfg(),
+      groupEvent({ mentionBot: false, rootId, messageId: `msg-followup-${testId}` }),
+    );
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops thread reply in unrelated human topic (threadFollowUp=active)", async () => {
+    // No prior @mention for this topic — bot was never invited
+    await dispatch(
+      topicCfg(),
+      groupEvent({
+        mentionBot: false,
+        rootId: `msg-human-${testId}`,
+        messageId: `msg-reply-${testId}`,
+      }),
+    );
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("dispatches any thread reply when threadFollowUp=topic", async () => {
+    // Even without a prior @mention, "topic" mode allows all thread replies
+    await dispatch(
+      topicCfg("topic"),
+      groupEvent({ mentionBot: false, rootId: `msg-any-${testId}` }),
+    );
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops thread reply without @mention when threadFollowUp=off", async () => {
+    const rootId = `msg-root-off-${testId}`;
+    // Even after a prior @mention, "off" mode still requires mention
+    await dispatch(topicCfg("off"), groupEvent({ mentionBot: true, messageId: rootId }));
+    vi.clearAllMocks();
+
+    await dispatch(topicCfg("off"), groupEvent({ mentionBot: false, rootId }));
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("drops thread reply without @mention in group-scoped session", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groupSessionScope: "group",
+          groupAllowFrom: ["oc-tfu-group"],
+          threadFollowUp: "active",
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatch(cfg, groupEvent({ mentionBot: false, rootId: `msg-group-${testId}` }));
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -42,6 +42,36 @@ import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from ".
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
+// --- Active bot topic tracking (#40475) ---
+// Tracks group topics where the bot was @-mentioned, so that subsequent thread
+// replies can skip the mention check without responding in unrelated threads.
+// Keyed by "chatId:topicId", value is the last-activity epoch-ms timestamp.
+const activeBotTopicTimestamps = new Map<string, number>();
+const ACTIVE_TOPIC_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function isActiveBotTopic(chatId: string, topicId: string): boolean {
+  const key = `${chatId}:${topicId}`;
+  const ts = activeBotTopicTimestamps.get(key);
+  if (ts == null) return false;
+  if (Date.now() - ts > ACTIVE_TOPIC_TTL_MS) {
+    activeBotTopicTimestamps.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function markActiveBotTopic(chatId: string, topicId: string): void {
+  const key = `${chatId}:${topicId}`;
+  activeBotTopicTimestamps.set(key, Date.now());
+  // Lazy eviction when the map grows large
+  if (activeBotTopicTimestamps.size > 500) {
+    const cutoff = Date.now() - ACTIVE_TOPIC_TTL_MS;
+    for (const [k, v] of activeBotTopicTimestamps) {
+      if (v < cutoff) activeBotTopicTimestamps.delete(k);
+    }
+  }
+}
+
 // --- Permission error extraction ---
 // Extract permission grant URL from Feishu API error response.
 type PermissionError = {
@@ -1087,7 +1117,47 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
-    if (requireMention && !ctx.mentionedBot) {
+    // --- Thread follow-up mention bypass (#40475) ---
+    //
+    // In topic-scoped sessions (group_topic / group_topic_sender) a user
+    // @-mentions the bot once to start a conversation; the bot replies inside a
+    // thread.  Requiring @-mention for every subsequent reply makes topic
+    // sessions unusable.
+    //
+    // threadFollowUp controls this behavior:
+    //   "off"    — always require @-mention, even in threads (legacy)
+    //   "topic"  — skip @-mention for all thread replies in topic-scoped sessions
+    //   "active" — skip @-mention only in topics the bot was previously
+    //              @-mentioned in (prevents responding to unrelated human
+    //              threads) [default]
+    //
+    // Group-scoped sessions (groupSessionScope="group") are never affected
+    // regardless of this setting — threads there may be entirely unrelated to
+    // the bot.
+    const threadFollowUp: string =
+      groupConfig?.threadFollowUp ?? feishuCfg?.threadFollowUp ?? "active";
+    const isTopicScoped =
+      groupSession?.groupSessionScope === "group_topic" ||
+      groupSession?.groupSessionScope === "group_topic_sender";
+    const topicId = ctx.rootId || ctx.messageId;
+
+    // Record active topics when the bot is explicitly @-mentioned so that the
+    // "active" mode can recognise follow-ups later.
+    if (isTopicScoped && ctx.mentionedBot) {
+      markActiveBotTopic(ctx.chatId, topicId);
+    }
+
+    let skipMentionForThread = false;
+    if (isTopicScoped && ctx.rootId && !ctx.mentionedBot) {
+      if (threadFollowUp === "topic") {
+        skipMentionForThread = true;
+      } else if (threadFollowUp === "active") {
+        skipMentionForThread = isActiveBotTopic(ctx.chatId, ctx.rootId);
+      }
+      // threadFollowUp === "off" → skipMentionForThread stays false
+    }
+
+    if (requireMention && !ctx.mentionedBot && !skipMentionForThread) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,
       // the mentioned handler's broadcast dispatch writes the turn directly into all
@@ -1107,6 +1177,16 @@ export async function handleFeishuMessage(params: {
         });
       }
       return;
+    }
+
+    // Refresh the active topic timestamp on successful follow-ups so that
+    // long-running conversations stay alive.
+    if (skipMentionForThread) {
+      markActiveBotTopic(ctx.chatId, ctx.rootId!);
+      log(
+        `feishu[${account.accountId}]: thread follow-up in group ${ctx.chatId} ` +
+          `(threadFollowUp=${threadFollowUp}, rootId=${ctx.rootId})`,
+      );
     }
   } else {
   }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -45,12 +45,18 @@ import type { DynamicAgentCreationConfig } from "./types.js";
 // --- Active bot topic tracking (#40475) ---
 // Tracks group topics where the bot was @-mentioned, so that subsequent thread
 // replies can skip the mention check without responding in unrelated threads.
-// Keyed by "chatId:topicId", value is the last-activity epoch-ms timestamp.
+// Keyed by "accountId:chatId:topicId" (scoped per account so multi-account
+// setups do not leak activation across bots), value is last-activity epoch-ms.
 const activeBotTopicTimestamps = new Map<string, number>();
 const ACTIVE_TOPIC_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_ACTIVE_TOPICS = 500;
 
-function isActiveBotTopic(chatId: string, topicId: string): boolean {
-  const key = `${chatId}:${topicId}`;
+function buildTopicKey(accountId: string, chatId: string, topicId: string): string {
+  return `${accountId}:${chatId}:${topicId}`;
+}
+
+function isActiveBotTopic(accountId: string, chatId: string, topicId: string): boolean {
+  const key = buildTopicKey(accountId, chatId, topicId);
   const ts = activeBotTopicTimestamps.get(key);
   if (ts == null) return false;
   if (Date.now() - ts > ACTIVE_TOPIC_TTL_MS) {
@@ -60,14 +66,23 @@ function isActiveBotTopic(chatId: string, topicId: string): boolean {
   return true;
 }
 
-function markActiveBotTopic(chatId: string, topicId: string): void {
-  const key = `${chatId}:${topicId}`;
+function markActiveBotTopic(accountId: string, chatId: string, topicId: string): void {
+  const key = buildTopicKey(accountId, chatId, topicId);
   activeBotTopicTimestamps.set(key, Date.now());
-  // Lazy eviction when the map grows large
-  if (activeBotTopicTimestamps.size > 500) {
+  // Evict when the map exceeds the cap.
+  if (activeBotTopicTimestamps.size > MAX_ACTIVE_TOPICS) {
+    // First pass: remove expired entries.
     const cutoff = Date.now() - ACTIVE_TOPIC_TTL_MS;
     for (const [k, v] of activeBotTopicTimestamps) {
       if (v < cutoff) activeBotTopicTimestamps.delete(k);
+    }
+    // Second pass: if still over limit, evict oldest entries.
+    if (activeBotTopicTimestamps.size > MAX_ACTIVE_TOPICS) {
+      const sorted = [...activeBotTopicTimestamps.entries()].sort((a, b) => a[1] - b[1]);
+      const excess = activeBotTopicTimestamps.size - MAX_ACTIVE_TOPICS;
+      for (let i = 0; i < excess; i++) {
+        activeBotTopicTimestamps.delete(sorted[i][0]);
+      }
     }
   }
 }
@@ -1125,7 +1140,7 @@ export async function handleFeishuMessage(params: {
     // sessions unusable.
     //
     // threadFollowUp controls this behavior:
-    //   "off"    — always require @-mention, even in threads (legacy)
+    //   "off"    — always require @-mention, even in threads (pre-feature behaviour)
     //   "topic"  — skip @-mention for all thread replies in topic-scoped sessions
     //   "active" — skip @-mention only in topics the bot was previously
     //              @-mentioned in (prevents responding to unrelated human
@@ -1139,20 +1154,23 @@ export async function handleFeishuMessage(params: {
     const isTopicScoped =
       groupSession?.groupSessionScope === "group_topic" ||
       groupSession?.groupSessionScope === "group_topic_sender";
-    const topicId = ctx.rootId || ctx.messageId;
+    // Use rootId when available, fall back to threadId for topic continuity
+    // (some Feishu deliveries only carry thread_id without root_id).
+    const threadAnchorId = ctx.rootId || ctx.threadId;
+    const topicId = threadAnchorId || ctx.messageId;
 
     // Record active topics when the bot is explicitly @-mentioned so that the
     // "active" mode can recognise follow-ups later.
     if (isTopicScoped && ctx.mentionedBot) {
-      markActiveBotTopic(ctx.chatId, topicId);
+      markActiveBotTopic(account.accountId, ctx.chatId, topicId);
     }
 
     let skipMentionForThread = false;
-    if (isTopicScoped && ctx.rootId && !ctx.mentionedBot) {
+    if (isTopicScoped && threadAnchorId && !ctx.mentionedBot) {
       if (threadFollowUp === "topic") {
         skipMentionForThread = true;
       } else if (threadFollowUp === "active") {
-        skipMentionForThread = isActiveBotTopic(ctx.chatId, ctx.rootId);
+        skipMentionForThread = isActiveBotTopic(account.accountId, ctx.chatId, threadAnchorId);
       }
       // threadFollowUp === "off" → skipMentionForThread stays false
     }
@@ -1182,10 +1200,10 @@ export async function handleFeishuMessage(params: {
     // Refresh the active topic timestamp on successful follow-ups so that
     // long-running conversations stay alive.
     if (skipMentionForThread) {
-      markActiveBotTopic(ctx.chatId, ctx.rootId!);
+      markActiveBotTopic(account.accountId, ctx.chatId, threadAnchorId!);
       log(
         `feishu[${account.accountId}]: thread follow-up in group ${ctx.chatId} ` +
-          `(threadFollowUp=${threadFollowUp}, rootId=${ctx.rootId})`,
+          `(threadFollowUp=${threadFollowUp}, rootId=${ctx.rootId}, threadId=${ctx.threadId})`,
       );
     }
   } else {
@@ -1717,7 +1735,9 @@ export async function handleFeishuMessage(params: {
         ((cfg as Record<string, unknown>).broadcast as Record<string, unknown> | undefined)
           ?.strategy || "parallel";
       const activeAgentId =
-        ctx.mentionedBot || !requireMention ? normalizeAgentId(route.agentId) : null;
+        ctx.mentionedBot || !requireMention || skipMentionForThread
+          ? normalizeAgentId(route.agentId)
+          : null;
       const agentIds = (cfg.agents?.list ?? []).map((a: { id: string }) => normalizeAgentId(a.id));
       const hasKnownAgents = agentIds.length > 0;
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -138,9 +138,27 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+/**
+ * Thread follow-up mention policy for group chats (#40475).
+ *
+ * Controls whether the bot responds to thread replies without an explicit
+ * @-mention.  Only effective when `groupSessionScope` is `"group_topic"` or
+ * `"group_topic_sender"` — group-scoped sessions are never affected.
+ *
+ * - "off"     — always require @-mention, even inside threads (legacy default)
+ * - "topic"   — skip @-mention for all thread replies in topic-scoped sessions
+ * - "active"  — skip @-mention only in topics where the bot was previously
+ *               @-mentioned (prevents the bot from responding in unrelated
+ *               human threads) [recommended]
+ *
+ * Default: "active"
+ */
+const ThreadFollowUpSchema = z.enum(["off", "topic", "active"]).optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    threadFollowUp: ThreadFollowUpSchema,
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -164,6 +182,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  threadFollowUp: ThreadFollowUpSchema,
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -145,7 +145,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
  * @-mention.  Only effective when `groupSessionScope` is `"group_topic"` or
  * `"group_topic_sender"` — group-scoped sessions are never affected.
  *
- * - "off"     — always require @-mention, even inside threads (legacy default)
+ * - "off"     — always require @-mention, even inside threads (pre-feature behaviour)
  * - "topic"   — skip @-mention for all thread replies in topic-scoped sessions
  * - "active"  — skip @-mention only in topics where the bot was previously
  *               @-mentioned (prevents the bot from responding in unrelated


### PR DESCRIPTION
## Summary

- **Problem**: When `groupSessionScope` is `group_topic` or `group_topic_sender`, users must @-mention the bot for *every* reply inside a thread — making topic-scoped sessions effectively unusable for multi-turn conversations.
- **Why it matters**: This is the most requested Feishu feature gap (see #40475, #42191, #35478). Users expect that @-mentioning the bot once to start a topic is sufficient, with follow-ups flowing naturally inside the thread.
- **What changed**: Added a new `threadFollowUp` config option (`"off"` / `"topic"` / `"active"`) that controls whether thread replies bypass the @-mention check. The default `"active"` mode only allows follow-ups in topics where the bot was previously @-mentioned, preventing the bot from responding in unrelated human threads.
- **What did NOT change**: Group-scoped sessions (`groupSessionScope="group"`) are never affected. The `requireMention` behaviour for top-level messages is unchanged. No existing configuration is broken.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra

## Scope

- [x] Integrations (channel plugins)

## Linked Issue / PR

Closes #40475
Related: #42191, #35478

## User-visible / Behavior Changes

New config option `channels.feishu.threadFollowUp` (also available per-group in `channels.feishu.groups.<id>.threadFollowUp`):

| Value | Behaviour |
|-------|-----------|
| `"off"` | Always require @-mention in threads (legacy behaviour, backward-compatible) |
| `"topic"` | Skip @-mention for all thread replies in topic-scoped sessions |
| `"active"` (default) | Skip @-mention only in topics where the bot was previously @-mentioned |

Example config:
```jsonc
{
  "channels": {
    "feishu": {
      "groupSessionScope": "group_topic",
      "replyInThread": "enabled",
      "threadFollowUp": "active"   // default — can be omitted
    }
  }
}
```

## Security Impact

1. Does this change handle user-controlled input? **No** — `threadFollowUp` is a server-side config value, not user input.
2. Does this change affect authentication or authorization? **No** — the existing `requireMention` + `groupPolicy` + `allowFrom` checks remain intact for top-level messages.
3. Does this change expose new endpoints or APIs? **No**
4. Does this change modify file system or process operations? **No**
5. Could this change leak sensitive information? **No**

## Repro + Verification

**Environment**: macOS, OpenClaw 2026.3.8, Feishu WebSocket mode

**Steps to reproduce (before fix)**:
1. Set `groupSessionScope: "group_topic"`, `replyInThread: "enabled"`, `requireMention: true`
2. @-mention the bot in a group → bot replies in a thread
3. Reply inside the thread without @-mention → **bot ignores the message**

**Expected**: Bot responds to the thread follow-up
**Actual (before)**: Message silently dropped at the mention gate

**After fix**: Thread follow-up is dispatched. Log shows:
```
feishu[default]: thread follow-up in group oc_xxx (threadFollowUp=active, rootId=om_xxx)
```

## Evidence

7 new vitest tests covering all scenarios:

| Test | Asserts |
|------|---------|
| `dispatches top-level @mention in group_topic mode` | @mention always works |
| `drops top-level message without @mention` | Main-timeline noise filtered |
| `dispatches thread reply in active bot topic (active)` | Core fix — follow-up works |
| `drops thread reply in unrelated human topic (active)` | Prevents bot intrusion |
| `dispatches any thread reply (topic mode)` | Broader "topic" mode |
| `drops thread reply when threadFollowUp=off` | Opt-out works |
| `drops thread reply in group-scoped session` | Non-topic sessions unaffected |

## Human Verification

- Tested with a live Feishu group (3 users + bot) in WebSocket mode
- Verified the three modes (`off`, `topic`, `active`) produce correct dispatch/drop behaviour
- Confirmed group-scoped sessions are completely unaffected
- Confirmed the active-topic map correctly tracks @-mentioned topics and ignores unrelated human threads

## Compatibility / Migration

Fully backward-compatible. The default `"active"` mode only activates when `groupSessionScope` is topic-based, which users have explicitly opted into. Existing configurations with `groupSessionScope="group"` (the default) see zero behaviour change.

## Failure Recovery

The in-memory active-topic map is lost on gateway restart. After restart, the first message in each topic requires a fresh @-mention to re-activate — this is the conservative, safe default. No persistent state is added.

## Risks and Mitigations

| Risk | Mitigation |
|------|------------|
| Bot responds in unrelated threads | "active" mode (default) only allows topics the bot was @-mentioned in |
| Memory growth from active-topic map | TTL-based eviction (24h) + lazy cleanup when map exceeds 500 entries |
| Breaking existing setups | Default only affects topic-scoped sessions; group-scoped sessions are never touched |

---

> **AI-assisted contribution**: Problem discovery, solution design (three-mode `threadFollowUp`, active-topic tracking), and edge-case analysis originated from [@JianyuLin1999](https://github.com/JianyuLin1999)'s production Feishu + OpenClaw deployment. Claude assisted with implementation. All changes verified live by the author.
