### PR TITLE
fix(skills): add detailed loading diagnostics for silent failures

### DIFF
--- a/src/agents/skills/workspace.test.ts
+++ b/src/agents/skills/workspace.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { loadWorkspaceSkillEntries } from "./workspace.js";
+
+const tempDirs = createTrackedTempDirs();
+
+describe("loadWorkspaceSkillEntries", () => {
+  let workspaceDir: string;
+  let skillsDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await tempDirs.make("openclaw-workspace-");
+    skillsDir = path.join(workspaceDir, "skills");
+    await fs.mkdir(skillsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await tempDirs.cleanup();
+  });
+
+  it("warns when SKILL.md exists but no skills are loaded due to parse failure", async () => {
+    const skillName = "parse-failure-test";
+    const skillDir = path.join(skillsDir, skillName);
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // Create a malformed SKILL.md that will fail to parse
+    const malformedSkillMd = `
+# Invalid SKILL.md
+
+This is missing the required frontmatter sections.
+
+No ## Description or ## Usage sections here.
+`;
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), malformedSkillMd, "utf-8");
+
+    // Mock logger to capture warnings
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const entries = loadWorkspaceSkillEntries(workspaceDir);
+
+      // The skill should not be in the loaded entries
+      const hasParseFailureSkill = entries.some((e) => e.skill.name === skillName);
+      expect(hasParseFailureSkill).toBe(false);
+
+      // The warning should have been logged
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Failed to parse SKILL.md - file exists but no skills loaded",
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not warn when SKILL.md does not exist", async () => {
+    const skillName = "no-skill-md";
+    const skillDir = path.join(skillsDir, skillName);
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // Create some other files but no SKILL.md
+    await fs.writeFile(path.join(skillDir, "README.md"), "Just a readme", "utf-8");
+
+    // Mock logger to ensure no warnings are logged
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const entries = loadWorkspaceSkillEntries(workspaceDir);
+
+      // The skill should not be in the loaded entries
+      const hasNoSkillMdSkill = entries.some((e) => e.skill.name === skillName);
+      expect(hasNoSkillMdSkill).toBe(false);
+
+      // No parse failure warning should have been logged for this directory
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Failed to parse SKILL.md - file exists but no skills loaded",
+          skill: skillName,
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("tracks parse failures in summary", async () => {
+    const skillName = "parse-failure-tracked";
+    const skillDir = path.join(skillsDir, skillName);
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // Create a malformed SKILL.md
+    const malformedSkillMd = `
+# Malformed Skill
+`;
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), malformedSkillMd, "utf-8");
+
+    // Mock logger to capture info logs
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      loadWorkspaceSkillEntries(workspaceDir);
+
+      // Check that the summary log includes parseFailures
+      const summaryCalls = infoSpy.mock.calls.filter(
+        (call) => call[0]?.message === "Skills loading completed",
+      );
+
+      expect(summaryCalls.length).toBeGreaterThan(0);
+      expect(summaryCalls[0][0]).toMatchObject({
+        parseFailures: expect.any(Number),
+      });
+
+      // parseFailures should be at least 1
+      expect(summaryCalls[0][0].parseFailures).toBeGreaterThanOrEqual(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -313,6 +313,11 @@ function loadSkillEntries(
       candidatePath: baseDir,
     });
     if (!baseDirRealPath) {
+      skillsLogger.debug("Skills directory not accessible or does not exist", {
+        dir: params.dir,
+        source: params.source,
+        reason: "path resolution failed",
+      });
       return [];
     }
 
@@ -418,14 +423,25 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
-      loadedSkills.push(
-        ...filterLoadedSkillsInsideRoot({
-          skills: unwrapLoadedSkills(loaded),
+      const unwrapped = unwrapLoadedSkills(loaded);
+      const filtered = filterLoadedSkillsInsideRoot({
+        skills: unwrapped,
+        source: params.source,
+        rootDir,
+        rootRealPath: baseDirRealPath,
+      });
+
+      // Log parsing failures
+      if (unwrapped.length === 0 && fs.existsSync(skillMd)) {
+        skillsLogger.warn("Failed to parse SKILL.md - file exists but no skills loaded", {
+          skill: name,
+          filePath: skillMd,
           source: params.source,
-          rootDir,
-          rootRealPath: baseDirRealPath,
-        }),
-      );
+          hint: "Check SKILL.md format - must use markdown with ## Description, ## Usage sections",
+        });
+      }
+
+      loadedSkills.push(...filtered);
 
       if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
         break;
@@ -433,11 +449,27 @@ function loadSkillEntries(
     }
 
     if (loadedSkills.length > limits.maxSkillsLoadedPerSource) {
-      return loadedSkills
+      const truncated = loadedSkills
         .slice()
         .sort((a, b) => a.name.localeCompare(b.name))
         .slice(0, limits.maxSkillsLoadedPerSource);
+      skillsLogger.info("Skills discovery completed (truncated to limit)", {
+        dir: params.dir,
+        source: params.source,
+        totalCandidates: childDirs.length,
+        loaded: truncated.length,
+        skipped: childDirs.length - truncated.length,
+      });
+      return truncated;
     }
+
+    skillsLogger.info("Skills discovery completed", {
+      dir: params.dir,
+      source: params.source,
+      totalCandidates: childDirs.length,
+      loaded: loadedSkills.length,
+      skipped: childDirs.length - loadedSkills.length,
+    });
 
     return loadedSkills;
   };
@@ -513,8 +545,12 @@ function loadSkillEntries(
     try {
       const raw = fs.readFileSync(skill.filePath, "utf-8");
       frontmatter = parseFrontmatter(raw);
-    } catch {
-      // ignore malformed skills
+    } catch (error) {
+      skillsLogger.error("Failed to load skill frontmatter", {
+        skill: skill.name,
+        filePath: skill.filePath,
+        error: String(error),
+      });
     }
     return {
       skill,
@@ -523,6 +559,31 @@ function loadSkillEntries(
       invocation: resolveSkillInvocationPolicy(frontmatter),
     };
   });
+
+  // Log overall skills loading summary
+  const sources = {
+    bundled: bundledSkills.length,
+    extra: extraSkills.length,
+    managed: managedSkills.length,
+    personalAgents: personalAgentsSkills.length,
+    projectAgents: projectAgentsSkills.length,
+    workspace: workspaceSkills.length,
+  };
+  skillsLogger.info("Skills loading completed", {
+    workspaceDir,
+    totalSkills: skillEntries.length,
+    sources,
+    uniqueSkills: merged.size,
+    duplicatesRemoved:
+      sources.bundled +
+      sources.extra +
+      sources.managed +
+      sources.personalAgents +
+      sources.projectAgents +
+      sources.workspace -
+      merged.size,
+  });
+
   return skillEntries;
 }
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -299,7 +299,10 @@ function loadSkillEntries(
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config);
 
-  const loadSkills = (params: { dir: string; source: string }): Skill[] => {
+  const loadSkills = (params: {
+    dir: string;
+    source: string;
+  }): { skills: Skill[]; parseFailures: number } => {
     const rootDir = path.resolve(params.dir);
     const rootRealPath = tryRealpath(rootDir) ?? rootDir;
     const resolved = resolveNestedSkillsRoot(params.dir, {
@@ -318,7 +321,7 @@ function loadSkillEntries(
         source: params.source,
         reason: "path resolution failed",
       });
-      return [];
+      return { skills: [], parseFailures: 0 };
     }
 
     // If the root itself is a skill directory, just load it directly (but enforce size cap).
@@ -331,7 +334,7 @@ function loadSkillEntries(
         candidatePath: rootSkillMd,
       });
       if (!rootSkillRealPath) {
-        return [];
+        return { skills: [], parseFailures: 0 };
       }
       try {
         const size = fs.statSync(rootSkillRealPath).size;
@@ -342,19 +345,20 @@ function loadSkillEntries(
             size,
             maxSkillFileBytes: limits.maxSkillFileBytes,
           });
-          return [];
+          return { skills: [], parseFailures: 0 };
         }
       } catch {
-        return [];
+        return { skills: [], parseFailures: 0 };
       }
 
       const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
-      return filterLoadedSkillsInsideRoot({
+      const skills = filterLoadedSkillsInsideRoot({
         skills: unwrapLoadedSkills(loaded),
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
       });
+      return { skills, parseFailures: skills.length === 0 ? 1 : 0 };
     }
 
     const childDirs = listChildDirectories(baseDir);
@@ -381,6 +385,7 @@ function loadSkillEntries(
     }
 
     const loadedSkills: Skill[] = [];
+    let parseFailures = 0;
 
     // Only consider immediate subfolders that look like skills (have SKILL.md) and are under size cap.
     for (const name of limitedChildren) {
@@ -432,13 +437,14 @@ function loadSkillEntries(
       });
 
       // Log parsing failures
-      if (unwrapped.length === 0 && fs.existsSync(skillMd)) {
+      if (unwrapped.length === 0) {
         skillsLogger.warn("Failed to parse SKILL.md - file exists but no skills loaded", {
           skill: name,
           filePath: skillMd,
           source: params.source,
           hint: "Check SKILL.md format - must use markdown with ## Description, ## Usage sections",
         });
+        parseFailures += 1;
       }
 
       loadedSkills.push(...filtered);
@@ -453,17 +459,17 @@ function loadSkillEntries(
         .slice()
         .sort((a, b) => a.name.localeCompare(b.name))
         .slice(0, limits.maxSkillsLoadedPerSource);
-      skillsLogger.info("Skills discovery completed (truncated to limit)", {
+      skillsLogger.debug("Skills discovery completed (truncated to limit)", {
         dir: params.dir,
         source: params.source,
         totalCandidates: childDirs.length,
         loaded: truncated.length,
         skipped: childDirs.length - truncated.length,
       });
-      return truncated;
+      return { skills: truncated, parseFailures };
     }
 
-    skillsLogger.info("Skills discovery completed", {
+    skillsLogger.debug("Skills discovery completed", {
       dir: params.dir,
       source: params.source,
       totalCandidates: childDirs.length,
@@ -471,7 +477,7 @@ function loadSkillEntries(
       skipped: childDirs.length - loadedSkills.length,
     });
 
-    return loadedSkills;
+    return { skills: loadedSkills, parseFailures };
   };
 
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
@@ -487,37 +493,42 @@ function loadSkillEntries(
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
 
-  const bundledSkills = bundledSkillsDir
+  const bundledSkillsResult = bundledSkillsDir
     ? loadSkills({
         dir: bundledSkillsDir,
         source: "openclaw-bundled",
       })
-    : [];
-  const extraSkills = mergedExtraDirs.flatMap((dir) => {
+    : { skills: [], parseFailures: 0 };
+  const extraSkillsResult = mergedExtraDirs.flatMap((dir) => {
     const resolved = resolveUserPath(dir);
     return loadSkills({
       dir: resolved,
       source: "openclaw-extra",
     });
   });
-  const managedSkills = loadSkills({
+  const managedSkillsResult = loadSkills({
     dir: managedSkillsDir,
     source: "openclaw-managed",
   });
-  const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
-  const personalAgentsSkills = loadSkills({
-    dir: personalAgentsSkillsDir,
+  const personalAgentsSkillsResult = loadSkills({
+    dir: path.resolve(os.homedir(), ".agents", "skills"),
     source: "agents-skills-personal",
   });
-  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
-  const projectAgentsSkills = loadSkills({
-    dir: projectAgentsSkillsDir,
+  const projectAgentsSkillsResult = loadSkills({
+    dir: path.resolve(workspaceDir, ".agents", "skills"),
     source: "agents-skills-project",
   });
-  const workspaceSkills = loadSkills({
+  const workspaceSkillsResult = loadSkills({
     dir: workspaceSkillsDir,
     source: "openclaw-workspace",
   });
+
+  const bundledSkills = bundledSkillsResult.skills;
+  const extraSkills = extraSkillsResult.flatMap((r) => r.skills);
+  const managedSkills = managedSkillsResult.skills;
+  const personalAgentsSkills = personalAgentsSkillsResult.skills;
+  const projectAgentsSkills = projectAgentsSkillsResult.skills;
+  const workspaceSkills = workspaceSkillsResult.skills;
 
   const merged = new Map<string, Skill>();
   // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace
@@ -546,7 +557,7 @@ function loadSkillEntries(
       const raw = fs.readFileSync(skill.filePath, "utf-8");
       frontmatter = parseFrontmatter(raw);
     } catch (error) {
-      skillsLogger.error("Failed to load skill frontmatter", {
+      skillsLogger.warn("Failed to load skill frontmatter", {
         skill: skill.name,
         filePath: skill.filePath,
         error: String(error),
@@ -569,19 +580,25 @@ function loadSkillEntries(
     projectAgents: projectAgentsSkills.length,
     workspace: workspaceSkills.length,
   };
+  const sourceValues = Object.values(sources);
+  const totalSkillsLoaded = sourceValues.reduce((sum, count) => sum + count, 0);
+  const duplicatesRemoved = totalSkillsLoaded - merged.size;
+
+  const parseFailures =
+    bundledSkillsResult.parseFailures +
+    extraSkillsResult.reduce((sum, r) => sum + r.parseFailures, 0) +
+    managedSkillsResult.parseFailures +
+    personalAgentsSkillsResult.parseFailures +
+    projectAgentsSkillsResult.parseFailures +
+    workspaceSkillsResult.parseFailures;
+
   skillsLogger.info("Skills loading completed", {
     workspaceDir,
     totalSkills: skillEntries.length,
     sources,
     uniqueSkills: merged.size,
-    duplicatesRemoved:
-      sources.bundled +
-      sources.extra +
-      sources.managed +
-      sources.personalAgents +
-      sources.projectAgents +
-      sources.workspace -
-      merged.size,
+    duplicatesRemoved,
+    parseFailures,
   });
 
   return skillEntries;


### PR DESCRIPTION
# Summary

Addresses #48932 by adding detailed diagnostics for silent skill loading failures.

## Changes

### 1. Path Resolution Failures
- Log when skills directory is not accessible or does not exist
- Include dir, source, and reason

### 2. SKILL.md Parsing Failures
- Log when SKILL.md exists but no skills are loaded
- Include skill name, file path, source, and format hint
- Hint: "Check SKILL.md format - must use markdown with ## Description, ## Usage sections"

### 3. Frontmatter Parsing Errors
- Log when skill frontmatter fails to parse
- Include skill name, file path, and error message

### 4. Skills Discovery Completion
- Log when discovery completes for each source
- Include total candidates, loaded count, and skipped count

### 5. Overall Loading Summary
- Log total skills loaded from all sources
- Include breakdown by source (bundled, extra, managed, personal, project, workspace)
- Include unique skills count and duplicates removed

## Example Logs

```
INFO [skills] Skills discovery completed {
  dir: "/root/.openclaw/skills",
  source: "openclaw-bundled",
  totalCandidates: 52,
  loaded: 14,
  skipped: 38
}

WARN [skills] Failed to parse SKILL.md - file exists but no skills loaded {
  skill: "my-skill",
  filePath: "/root/.openclaw/skills/my-skill/SKILL.md",
  source: "openclaw-workspace",
  hint: "Check SKILL.md format - must use markdown with ## Description, ## Usage sections"
}

INFO [skills] Skills loading completed {
  workspaceDir: "/root/.openclaw/workspaces/kev",
  totalSkills: 20,
  sources: {
    bundled: 14,
    extra: 0,
    managed: 0,
    personalAgents: 2,
    projectAgents: 1,
    workspace: 3
  },
  uniqueSkills: 18,
  duplicatesRemoved: 2
}
```

## Next Steps

- [ ] Add Doctor diagnostics to show file-system vs registry drift
- [ ] Add startup log with scan summary

## Testing

- [x] Build passes
- [ ] Unit tests pass (2 unrelated failures in plugin-skills.test.ts)

---

Fixes #48932

Co-Authored-By: Kev <kev@openclaw.ai>