### PR TITLE
fix(web-fetch): allow RFC 2544 trusted benchmark endpoints

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -130,6 +130,19 @@ describe("web_fetch SSRF protection", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("allows RFC 2544 benchmark-range fake IPs for trusted web fetches", async () => {
+    lookupMock.mockResolvedValue([{ address: "198.18.0.42", family: 4 }]);
+
+    setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = await createWebFetchToolForTest();
+
+    const result = await tool?.execute?.("call", { url: "https://example.com" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "raw",
+    });
+  });
+
   it("allows public hosts", async () => {
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -7,6 +7,7 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 export const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
+  allowRfc2544BenchmarkRange: true,
 };
 
 type WebToolGuardedFetchOptions = Omit<GuardedFetchOptions, "proxy"> & {


### PR DESCRIPTION
## Summary

- Problem: `web_fetch` used the trusted web-tools SSRF policy, but that policy only allowed private-network endpoints and forgot the RFC 2544 benchmark range (`198.18.0.0/15`) that some hosted fake-IP setups use.
- Why it matters: `web_search` already allowed that range for trusted providers, but `web_fetch` still failed on the same infrastructure with `remote IP 198.18.x.x is blocked`.
- What changed: extended `WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY` to also allow the RFC 2544 benchmark range, and added focused regression coverage for a trusted `web_fetch` call resolving to `198.18.0.42`.
- What did NOT change (scope boundary): no changes to default SSRF blocking for untrusted fetches, no broader allowlist expansion beyond the existing trusted web-tools policy.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48961

## User-visible / Behavior Changes

Trusted `web_fetch` requests now accept RFC 2544 benchmark-range fake IPs (for example `198.18.x.x`) the same way trusted `web_search` requests already do.

## Test plan

- `corepack pnpm exec vitest run src/agents/tools/web-fetch.ssrf.test.ts`
- `corepack pnpm exec oxfmt --check src/agents/tools/web-guarded-fetch.ts src/agents/tools/web-fetch.ssrf.test.ts`
- `corepack pnpm exec oxlint src/agents/tools/web-guarded-fetch.ts src/agents/tools/web-fetch.ssrf.test.ts`
