### PR TITLE
feat: add minimal lifecycle hooks for agent dispatch, handoff, and memory retrieval

### DIFF
--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -6,6 +6,7 @@ import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { emitLifecycleHook } from "../lifecycle-hooks.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -338,6 +339,16 @@ export function startAcpSpawnParentStreamRelay(params: {
       } else {
         emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
       }
+      
+      // Emit lifecycle hook: agent:handoff (producer -> consumer)
+      emitLifecycleHook("agent:handoff", {
+        sessionKey: params.parentSessionKey,
+        producerAgent: params.agentId,
+        consumerAgent: "parent-session", // Parent session receives the output
+        payload: { childSessionKey: params.childSessionKey, runId: params.runId },
+        handoffMetadata: { completed: true, durationMs },
+      });
+      
       dispose();
       return;
     }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -695,6 +695,17 @@ export async function spawnAcpDirect(
       emitStartNotice: false,
     });
   }
+
+  // Emit lifecycle hook: agent:dispatch - fires BEFORE the actual dispatch attempt
+  emitLifecycleHook("agent:dispatch", {
+    sessionKey,
+    taskId: undefined, // Will be populated after successful dispatch
+    agentId: targetAgentId,
+    contextKeys: parentSessionKey ? [parentSessionKey] : undefined,
+    runtime: runtimeMode,
+    mode: spawnMode,
+  });
+
   try {
     const response = await callGateway<{ runId?: string }>({
       method: "agent",

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -28,6 +28,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import { callGateway } from "../gateway/call.js";
+import { emitLifecycleHook } from "../lifecycle-hooks.js";
 import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 import {
@@ -742,6 +743,17 @@ export async function spawnAcpDirect(
       });
     }
     parentRelay?.notifyStarted();
+    
+    // Emit lifecycle hook: agent:dispatch
+    emitLifecycleHook("agent:dispatch", {
+      sessionKey,
+      taskId: childRunId,
+      agentId: targetAgentId,
+      contextKeys: parentSessionKey ? [parentSessionKey] : undefined,
+      runtime: runtimeMode,
+      mode: spawnMode,
+    });
+    
     return {
       status: "accepted",
       childSessionKey: sessionKey,
@@ -751,6 +763,16 @@ export async function spawnAcpDirect(
       note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
     };
   }
+
+  // Emit lifecycle hook: agent:dispatch
+  emitLifecycleHook("agent:dispatch", {
+    sessionKey,
+    taskId: childRunId,
+    agentId: targetAgentId,
+    contextKeys: parentSessionKey ? [parentSessionKey] : undefined,
+    runtime: runtimeMode,
+    mode: spawnMode,
+  });
 
   return {
     status: "accepted",

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -755,16 +755,6 @@ export async function spawnAcpDirect(
     }
     parentRelay?.notifyStarted();
     
-    // Emit lifecycle hook: agent:dispatch
-    emitLifecycleHook("agent:dispatch", {
-      sessionKey,
-      taskId: childRunId,
-      agentId: targetAgentId,
-      contextKeys: parentSessionKey ? [parentSessionKey] : undefined,
-      runtime: runtimeMode,
-      mode: spawnMode,
-    });
-    
     return {
       status: "accepted",
       childSessionKey: sessionKey,
@@ -774,16 +764,6 @@ export async function spawnAcpDirect(
       note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
     };
   }
-
-  // Emit lifecycle hook: agent:dispatch
-  emitLifecycleHook("agent:dispatch", {
-    sessionKey,
-    taskId: childRunId,
-    agentId: targetAgentId,
-    contextKeys: parentSessionKey ? [parentSessionKey] : undefined,
-    runtime: runtimeMode,
-    mode: spawnMode,
-  });
 
   return {
     status: "accepted",

--- a/src/lifecycle-hooks.ts
+++ b/src/lifecycle-hooks.ts
@@ -46,7 +46,7 @@ export type MemoryRetrieveContext = {
   agentId?: string;
   query: string;
   results: Array<{
-    content: string;
+    snippet: string;
     score: number;
     source?: string;
     path?: string;
@@ -139,8 +139,15 @@ export async function emitLifecycleHook<T extends LifecycleHookName>(
   for (const entry of handlers) {
     try {
       const result = entry.handler(context);
-      if (entry.options?.async && result instanceof Promise) {
-        await result;
+      if (result instanceof Promise) {
+        if (entry.options?.async) {
+          await result;
+        } else {
+          // Swallow promise rejections for non-async handlers - don't break execution
+          result.catch((err) => {
+            log.error(`Hook handler error for ${hook}:`, err);
+          });
+        }
       }
     } catch (err) {
       log.error(`Hook handler error for ${hook}:`, err);

--- a/src/lifecycle-hooks.ts
+++ b/src/lifecycle-hooks.ts
@@ -1,0 +1,171 @@
+/**
+ * Lifecycle Hooks System
+ * 
+ * Provides minimal hooks at key points in the gateway execution path:
+ * - agent:dispatch - fires before agent spawn/dispatch
+ * - agent:handoff - fires after producer output, before consumer input
+ * - memory:retrieve - fires after memory fetch, before results returned
+ * 
+ * These hooks are optional, additive, and non-breaking.
+ */
+
+import { createSubsystemLogger } from "./logging/subsystem.js";
+
+const log = createSubsystemLogger("lifecycle-hooks");
+
+// Hook types
+export const LIFECYCLE_HOOKS = [
+  "agent:dispatch",
+  "agent:handoff",
+  "memory:retrieve",
+] as const;
+
+export type LifecycleHookName = (typeof LIFECYCLE_HOOKS)[number];
+
+// Context types for each hook
+export type AgentDispatchContext = {
+  sessionKey: string;
+  taskId?: string;
+  agentId: string;
+  contextKeys?: string[];
+  runtime?: string;
+  mode?: string;
+};
+
+export type AgentHandoffContext = {
+  sessionKey: string;
+  taskId?: string;
+  producerAgent: string;
+  consumerAgent: string;
+  payload: unknown;
+  handoffMetadata?: Record<string, unknown>;
+};
+
+export type MemoryRetrieveContext = {
+  sessionKey?: string;
+  agentId?: string;
+  query: string;
+  results: Array<{
+    content: string;
+    score: number;
+    source?: string;
+    path?: string;
+  }>;
+};
+
+// Union type for context
+export type LifecycleHookContext = 
+  | { type: "agent:dispatch"; context: AgentDispatchContext }
+  | { type: "agent:handoff"; context: AgentHandoffContext }
+  | { type: "memory:retrieve"; context: MemoryRetrieveContext };
+
+// Handler type
+export type LifecycleHookHandler<T extends LifecycleHookName> = (
+  context: T extends "agent:dispatch" ? AgentDispatchContext
+    : T extends "agent:handoff" ? AgentHandoffContext
+    : T extends "memory:retrieve" ? MemoryRetrieveContext
+    : never
+) => void | Promise<void>;
+
+// Internal registry
+type HookEntry = {
+  handler: LifecycleHookHandler<any>;
+  options?: {
+    async?: boolean;
+  };
+};
+
+const hookRegistry = new Map<LifecycleHookName, Set<HookEntry>>();
+
+// Initialize registries
+for (const hookName of LIFECYCLE_HOOKS) {
+  hookRegistry.set(hookName, new Set());
+}
+
+/**
+ * Register a handler for a lifecycle hook
+ */
+export function registerLifecycleHook<T extends LifecycleHookName>(
+  hook: T,
+  handler: LifecycleHookHandler<T>,
+  options?: { async?: boolean }
+): void {
+  const handlers = hookRegistry.get(hook);
+  if (!handlers) {
+    log.warn(`Unknown hook: ${hook}`);
+    return;
+  }
+  handlers.add({ handler, options });
+  log.info(`Registered handler for hook: ${hook}`);
+}
+
+/**
+ * Unregister a handler
+ */
+export function unregisterLifecycleHook<T extends LifecycleHookName>(
+  hook: T,
+  handler: LifecycleHookHandler<T>
+): void {
+  const handlers = hookRegistry.get(hook);
+  if (!handlers) return;
+  
+  for (const entry of handlers) {
+    if (entry.handler === handler) {
+      handlers.delete(entry);
+      log.info(`Unregistered handler for hook: ${hook}`);
+      return;
+    }
+  }
+}
+
+/**
+ * Emit a lifecycle hook
+ * Handlers are called synchronously by default for minimal performance impact
+ */
+export async function emitLifecycleHook<T extends LifecycleHookName>(
+  hook: T,
+  context: T extends "agent:dispatch" ? AgentDispatchContext
+    : T extends "agent:handoff" ? AgentHandoffContext
+    : T extends "memory:retrieve" ? MemoryRetrieveContext
+    : never
+): Promise<void> {
+  const handlers = hookRegistry.get(hook);
+  if (!handlers || handlers.size === 0) {
+    return; // No handlers registered, no-op
+  }
+  
+  log.debug(`Emitting hook: ${hook}`, { contextKeys: 'contextKeys' in context ? context.contextKeys : undefined });
+  
+  for (const entry of handlers) {
+    try {
+      const result = entry.handler(context);
+      if (entry.options?.async && result instanceof Promise) {
+        await result;
+      }
+    } catch (err) {
+      log.error(`Hook handler error for ${hook}:`, err);
+      // Hook errors should not break execution
+    }
+  }
+}
+
+/**
+ * Check if any handlers are registered for a hook
+ */
+export function hasLifecycleHookListeners(hook: LifecycleHookName): boolean {
+  const handlers = hookRegistry.get(hook);
+  return handlers ? handlers.size > 0 : false;
+}
+
+/**
+ * Get list of registered hooks (for debugging)
+ */
+export function getRegisteredHooks(): LifecycleHookName[] {
+  const registered: LifecycleHookName[] = [];
+  for (const [hook, handlers] of hookRegistry) {
+    if (handlers.size > 0) {
+      registered.push(hook);
+    }
+  }
+  return registered;
+}

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -54,6 +54,7 @@ export async function getMemorySearchManager(params: {
         const wrapper = new FallbackMemoryManager(
           {
             primary,
+            agentId: params.agentId,
             fallbackFactory: async () => {
               const { MemoryIndexManager } = await loadManagerRuntime();
               return await MemoryIndexManager.get(params);
@@ -79,7 +80,17 @@ export async function getMemorySearchManager(params: {
   try {
     const { MemoryIndexManager } = await loadManagerRuntime();
     const manager = await MemoryIndexManager.get(params);
-    return { manager };
+    
+    // Wrap builtin manager to emit memory:retrieve hook
+    const wrapper = new FallbackMemoryManager(
+      {
+        primary: manager,
+        agentId: params.agentId,
+        fallbackFactory: async () => null,
+      },
+      undefined,
+    );
+    return { manager: wrapper };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { manager: null, error: message };
@@ -107,14 +118,18 @@ class FallbackMemoryManager implements MemorySearchManager {
   private primaryFailed = false;
   private lastError?: string;
   private cacheEvicted = false;
+  private readonly agentId: string;
 
   constructor(
     private readonly deps: {
       primary: MemorySearchManager;
+      agentId: string;
       fallbackFactory: () => Promise<MemorySearchManager | null>;
     },
     private readonly onClose?: () => void,
-  ) {}
+  ) {
+    this.agentId = deps.agentId;
+  }
 
   async search(
     query: string,

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -151,7 +151,7 @@ class FallbackMemoryManager implements MemorySearchManager {
       sessionKey: opts?.sessionKey,
       agentId: this.deps.agentId,
       query,
-      results: Array.isArray(results) ? results : [results],
+      results: Array.isArray(results) ? results.map(r => ({ snippet: r.snippet, score: r.score, source: r.source, path: r.path })) : [{ snippet: results.snippet, score: results.score, source: results.source, path: results.path }],
     });
     
     return results;

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { emitLifecycleHook } from "../lifecycle-hooks.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
 import type {
@@ -119,9 +120,11 @@ class FallbackMemoryManager implements MemorySearchManager {
     query: string,
     opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
   ) {
+    let results: any;
+    
     if (!this.primaryFailed) {
       try {
-        return await this.deps.primary.search(query, opts);
+        results = await this.deps.primary.search(query, opts);
       } catch (err) {
         this.primaryFailed = true;
         this.lastError = err instanceof Error ? err.message : String(err);
@@ -131,11 +134,27 @@ class FallbackMemoryManager implements MemorySearchManager {
         this.evictCacheEntry();
       }
     }
-    const fallback = await this.ensureFallback();
-    if (fallback) {
-      return await fallback.search(query, opts);
+    
+    if (!results) {
+      const fallback = await this.ensureFallback();
+      if (fallback) {
+        results = await fallback.search(query, opts);
+      }
     }
-    throw new Error(this.lastError ?? "memory search unavailable");
+    
+    if (!results) {
+      throw new Error(this.lastError ?? "memory search unavailable");
+    }
+    
+    // Emit lifecycle hook: memory:retrieve
+    emitLifecycleHook("memory:retrieve", {
+      sessionKey: opts?.sessionKey,
+      agentId: this.deps.agentId,
+      query,
+      results: Array.isArray(results) ? results : [results],
+    });
+    
+    return results;
   }
 
   async readFile(params: { relPath: string; from?: number; lines?: number }) {


### PR DESCRIPTION
## Summary

Implements feature request #48661 — adds three minimal lifecycle hooks at key points in the gateway execution path:

### Hooks Added

1. **agent:dispatch** — Fires before agent spawn/dispatch
   - Context: sessionKey, taskId, agentId, contextKeys, runtime, mode
   - Use case: Decision journaling, dispatch instrumentation

2. **agent:handoff** — Fires after producer output, before consumer receives
   - Context: sessionKey, producerAgent, consumerAgent, payload, handoffMetadata
   - Use case: Output contract validation, handoff checks

3. **memory:retrieve** — Fires after memory search, before results returned
   - Context: sessionKey, agentId, query, results
   - Use case: Scoring, filtering, reordering retrieved memories

### Implementation

- New file: src/lifecycle-hooks.ts — hook registration and emission system
- Modified: src/agents/acp-spawn.ts — emits agent:dispatch before spawn
- Modified: src/agents/acp-spawn-parent-stream.ts — emits agent:handoff on completion
- Modified: src/memory/search-manager.ts — emits memory:retrieve after search

### Design

- Optional: Handlers are registered dynamically, no handlers required
- Additive: No breaking changes to existing behavior
- Non-blocking: Hook errors do not break core execution
- Minimal surface: Three hooks at high-leverage points only

### Usage

import { registerLifecycleHook } from './lifecycle-hooks.js';

registerLifecycleHook('agent:dispatch', (ctx) => {
  console.log(Dispatching agent ${ctx.agentId});
});

registerLifecycleHook('memory:retrieve', (ctx) => {
  console.log(Memory search returned ${ctx.results.length} results);
});

---

Related: #48661
