### PR TITLE
docs(provider): point claude-max-api-proxy to maintained fork

### DIFF
--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -156,8 +156,8 @@ The proxy:
 ## Links
 
 - **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/atalovesyou/claude-max-api-proxy](https://github.com/atalovesyou/claude-max-api-proxy)
-- **Issues:** [https://github.com/atalovesyou/claude-max-api-proxy/issues](https://github.com/atalovesyou/claude-max-api-proxy/issues)
+- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 

--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -43,8 +43,9 @@ The proxy:
   <Step title="Install the proxy">
     Requires Node.js 20+ and Claude Code CLI.
 
-    The published npm package still uses the original package name; source and
-    issue tracking now live in the maintained `wende` fork linked below.
+    The published npm package still uses the original package name. The `wende`
+    fork linked below is a maintained community source reference, not a package
+    ownership transfer.
 
     ```bash
     npm install -g claude-max-api-proxy
@@ -159,8 +160,7 @@ The proxy:
 ## Links
 
 - **npm package:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **Maintained source fork:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
-- **Issues for the maintained fork:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
+- **Maintained community source fork:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
 
 ## Notes
 

--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -43,6 +43,9 @@ The proxy:
   <Step title="Install the proxy">
     Requires Node.js 20+ and Claude Code CLI.
 
+    The published npm package still uses the original package name; source and
+    issue tracking now live in the maintained `wende` fork linked below.
+
     ```bash
     npm install -g claude-max-api-proxy
 
@@ -155,9 +158,9 @@ The proxy:
 
 ## Links
 
-- **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
-- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
+- **npm package:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
+- **Maintained source fork:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues for the maintained fork:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- clarify that the npm package remains `claude-max-api-proxy`
- point the source and issue tracker docs links at the maintained `wende/claude-max-api-proxy` fork
- keep the change limited to the English source-of-truth docs page

## Testing
- `pnpm docs:check-mdx docs/providers/claude-max-api-proxy.md`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed**: The English source-of-truth docs for `claude-max-api-proxy` now distinguish the npm package from the maintained GitHub source fork and issue tracker.
- **Real environment tested**: Local OpenClaw docs checkout on Linux at head `cf7eeae8d9`, Node `v22.22.0`, pnpm `10.33.2`.
- **Exact steps or command run after this patch**:

```bash
pnpm docs:check-mdx docs/providers/claude-max-api-proxy.md
git diff --check
```

- **Evidence after fix**:

```text
pnpm docs:check-mdx docs/providers/claude-max-api-proxy.md
passed

git diff --check
exit status: 0
```

- **Observed result after fix**: The docs page renders/checks as MDX and the provenance wording now avoids implying that the npm package itself moved to the maintained fork.
- **What was not tested**: I did not run the full docs site locally. Generated locale sync can remain a post-merge maintainer step.

Fixes #20260
