### PR TITLE
[AI] fix(logging): use POSIX path join for browser-safe DEFAULT_LOG_FILE on Windows

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -31,12 +31,22 @@ function canUseNodeFs(): boolean {
   }
 }
 
-function resolveDefaultLogDir(): string {
-  return canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : POSIX_OPENCLAW_TMP_DIR;
+function resolveDefaultLogPaths(): { dir: string; file: string } {
+  // In browser-safe environments (no node:fs), use POSIX paths directly so that
+  // path.join does not convert forward slashes to backslashes on Windows.
+  if (!canUseNodeFs()) {
+    return {
+      dir: POSIX_OPENCLAW_TMP_DIR,
+      file: `${POSIX_OPENCLAW_TMP_DIR}/openclaw.log`,
+    };
+  }
+  const dir = resolvePreferredOpenClawTmpDir();
+  return { dir, file: path.join(dir, "openclaw.log") };
 }
 
-export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
-export const DEFAULT_LOG_FILE = path.join(DEFAULT_LOG_DIR, "openclaw.log"); // legacy single-file path
+const { dir: _defaultLogDir, file: _defaultLogFile } = resolveDefaultLogPaths();
+export const DEFAULT_LOG_DIR = _defaultLogDir;
+export const DEFAULT_LOG_FILE = _defaultLogFile; // legacy single-file path
 
 const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -348,6 +348,10 @@ function formatLocalDate(date: Date): string {
 }
 
 function defaultRollingPathForToday(): string {
+  // DEFAULT_LOG_DIR is always a Node-resolved path here: resolveSettings()
+  // gates on canUseNodeFs() and returns early for browser-safe environments,
+  // so this function is only ever reached when node:fs is available and
+  // path.join uses OS-native separators intentionally.
   const today = formatLocalDate(new Date());
   return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }


### PR DESCRIPTION
## Summary

`DEFAULT_LOG_FILE` was computed using `path.join(DEFAULT_LOG_DIR, "openclaw.log")`. On Windows, `path.join` converts forward slashes to backslashes, so when `canUseNodeFs()` is false (browser-safe import path), the value became `\tmp\openclaw\openclaw.log` instead of `/tmp/openclaw/openclaw.log`.

The browser-safe path is built from the hardcoded POSIX constant `POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw"` and must stay POSIX-style on all platforms.

**Root cause**: `path.join("/tmp/openclaw", "openclaw.log")` on Windows returns `\tmp\openclaw\openclaw.log`

**Fix**: Refactor `resolveDefaultLogDir` into `resolveDefaultLogPaths` which computes both `dir` and `file` in one pass. The POSIX/browser-safe branch uses template-literal concatenation; the Node.js branch continues to use `path.join` (correct for native OS paths).

## Failing tests fixed

`src/logging/logger.browser-import.test.ts` — two tests were failing on Windows CI:

- `does not resolve the preferred temp dir at import time when node fs is unavailable` (expected `/tmp/openclaw/openclaw.log`, received `\tmp\openclaw\openclaw.log`)
- `disables file logging when imported in a browser-like environment` (same path mismatch in `getResolvedLoggerSettings().file`)

## Test plan

- [x] `pnpm test -- src/logging/logger.browser-import.test.ts` — 2/2 pass locally
- [x] `pnpm check` — format and lint pass (0 warnings, 0 errors on changed file)
- [x] Windows CI shard passes `logger.browser-import.test.ts` (shard 5 ✓)

---

> [!NOTE]
> AI-assisted: code written/reviewed with Claude Sonnet 4.6

**AI Checklist:**
- [x] I have reviewed the AI-generated changes and verified they are correct
- [x] The changes solve the described problem without unintended side effects
- [x] Tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)