### PR TITLE
tests: fix extension CI seams for googlechat, google, and feishu

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -77,12 +77,9 @@ vi.mock("./client.js", () => ({
   createFeishuClient: mockCreateFeishuClient,
 }));
 
-vi.mock("../../../src/acp/persistent-bindings.route.js", () => ({
+vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
   resolveConfiguredAcpRoute: (params: unknown) => mockResolveConfiguredAcpRoute(params),
   ensureConfiguredAcpRouteReady: (params: unknown) => mockEnsureConfiguredAcpRouteReady(params),
-}));
-
-vi.mock("../../../src/infra/outbound/session-binding-service.js", () => ({
   getSessionBindingService: () => ({
     resolveByConversation: mockResolveBoundConversation,
     touch: mockTouchBinding,

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FeishuConfig, ResolvedFeishuAccount } from "./types.js";
 
+const clientCtorMock = vi.hoisted(() => vi.fn());
 const wsClientCtorMock = vi.hoisted(() =>
   vi.fn(function wsClientCtor() {
     return { connected: true };
@@ -22,22 +23,6 @@ const mockBaseHttpInstance = vi.hoisted(() => ({
   head: vi.fn().mockResolvedValue({}),
   options: vi.fn().mockResolvedValue({}),
 }));
-
-vi.mock("@larksuiteoapi/node-sdk", () => ({
-  AppType: { SelfBuild: "self" },
-  Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
-  LoggerLevel: { info: "info" },
-  Client: vi.fn(),
-  WSClient: wsClientCtorMock,
-  EventDispatcher: vi.fn(),
-  defaultHttpInstance: mockBaseHttpInstance,
-}));
-
-vi.mock("https-proxy-agent", () => ({
-  HttpsProxyAgent: httpsProxyAgentCtorMock,
-}));
-
-import { Client as LarkClient } from "@larksuiteoapi/node-sdk";
 import {
   createFeishuClient,
   createFeishuWSClient,
@@ -45,6 +30,7 @@ import {
   FEISHU_HTTP_TIMEOUT_MS,
   FEISHU_HTTP_TIMEOUT_MAX_MS,
   FEISHU_HTTP_TIMEOUT_ENV_VAR,
+  setFeishuClientRuntimeForTest,
 } from "./client.js";
 
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
@@ -78,6 +64,21 @@ beforeEach(() => {
     delete process.env[key];
   }
   vi.clearAllMocks();
+  setFeishuClientRuntimeForTest({
+    sdk: {
+      AppType: { SelfBuild: "self" } as never,
+      Domain: {
+        Feishu: "https://open.feishu.cn",
+        Lark: "https://open.larksuite.com",
+      } as never,
+      LoggerLevel: { info: "info" } as never,
+      Client: clientCtorMock as never,
+      WSClient: wsClientCtorMock as never,
+      EventDispatcher: vi.fn() as never,
+      defaultHttpInstance: mockBaseHttpInstance as never,
+    },
+    HttpsProxyAgent: httpsProxyAgentCtorMock as never,
+  });
 });
 
 afterEach(() => {
@@ -94,6 +95,7 @@ afterEach(() => {
   } else {
     process.env[FEISHU_HTTP_TIMEOUT_ENV_VAR] = priorFeishuTimeoutEnv;
   }
+  setFeishuClientRuntimeForTest();
 });
 
 describe("createFeishuClient HTTP timeout", () => {
@@ -102,7 +104,7 @@ describe("createFeishuClient HTTP timeout", () => {
   });
 
   const getLastClientHttpInstance = () => {
-    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = clientCtorMock.mock.calls;
     const lastCall = calls[calls.length - 1]?.[0] as
       | { httpInstance?: { get: (...args: unknown[]) => Promise<unknown> } }
       | undefined;
@@ -122,7 +124,7 @@ describe("createFeishuClient HTTP timeout", () => {
   it("passes a custom httpInstance with default timeout to Lark.Client", () => {
     createFeishuClient({ appId: "app_1", appSecret: "secret_1", accountId: "timeout-test" }); // pragma: allowlist secret
 
-    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = clientCtorMock.mock.calls;
     const lastCall = calls[calls.length - 1][0] as { httpInstance?: unknown };
     expect(lastCall.httpInstance).toBeDefined();
   });
@@ -130,7 +132,7 @@ describe("createFeishuClient HTTP timeout", () => {
   it("injects default timeout into HTTP request options", async () => {
     createFeishuClient({ appId: "app_2", appSecret: "secret_2", accountId: "timeout-inject" }); // pragma: allowlist secret
 
-    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = clientCtorMock.mock.calls;
     const lastCall = calls[calls.length - 1][0] as {
       httpInstance: { post: (...args: unknown[]) => Promise<unknown> };
     };
@@ -152,7 +154,7 @@ describe("createFeishuClient HTTP timeout", () => {
   it("allows explicit timeout override per-request", async () => {
     createFeishuClient({ appId: "app_3", appSecret: "secret_3", accountId: "timeout-override" }); // pragma: allowlist secret
 
-    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = clientCtorMock.mock.calls;
     const lastCall = calls[calls.length - 1][0] as {
       httpInstance: { get: (...args: unknown[]) => Promise<unknown> };
     };
@@ -241,7 +243,7 @@ describe("createFeishuClient HTTP timeout", () => {
       config: { httpTimeoutMs: 45_000 },
     });
 
-    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = clientCtorMock.mock.calls;
     expect(calls.length).toBe(2);
 
     const lastCall = calls[calls.length - 1][0] as {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,6 +2,30 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuConfig, FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
+type FeishuClientSdk = Pick<
+  typeof Lark,
+  | "AppType"
+  | "Client"
+  | "defaultHttpInstance"
+  | "Domain"
+  | "EventDispatcher"
+  | "LoggerLevel"
+  | "WSClient"
+>;
+
+const defaultFeishuClientSdk: FeishuClientSdk = {
+  AppType: Lark.AppType,
+  Client: Lark.Client,
+  defaultHttpInstance: Lark.defaultHttpInstance,
+  Domain: Lark.Domain,
+  EventDispatcher: Lark.EventDispatcher,
+  LoggerLevel: Lark.LoggerLevel,
+  WSClient: Lark.WSClient,
+};
+
+let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
+let httpsProxyAgentCtor: typeof HttpsProxyAgent = HttpsProxyAgent;
+
 /** Default HTTP timeout for Feishu API requests (30 seconds). */
 export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
 export const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;
@@ -14,7 +38,7 @@ function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
     process.env.http_proxy ||
     process.env.HTTP_PROXY;
   if (!proxyUrl) return undefined;
-  return new HttpsProxyAgent(proxyUrl);
+  return new httpsProxyAgentCtor(proxyUrl);
 }
 
 // Multi-account client cache
@@ -28,10 +52,10 @@ const clientCache = new Map<
 
 function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
   if (domain === "lark") {
-    return Lark.Domain.Lark;
+    return feishuClientSdk.Domain.Lark;
   }
   if (domain === "feishu" || !domain) {
-    return Lark.Domain.Feishu;
+    return feishuClientSdk.Domain.Feishu;
   }
   return domain.replace(/\/+$/, ""); // Custom URL for private deployment
 }
@@ -42,7 +66,8 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
  * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks).
  */
 function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
-  const base: Lark.HttpInstance = Lark.defaultHttpInstance as unknown as Lark.HttpInstance;
+  const base: Lark.HttpInstance =
+    feishuClientSdk.defaultHttpInstance as unknown as Lark.HttpInstance;
 
   function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
     return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
@@ -129,10 +154,10 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
   }
 
   // Create new client with timeout-aware HTTP instance
-  const client = new Lark.Client({
+  const client = new feishuClientSdk.Client({
     appId,
     appSecret,
-    appType: Lark.AppType.SelfBuild,
+    appType: feishuClientSdk.AppType.SelfBuild,
     domain: resolveDomain(domain),
     httpInstance: createTimeoutHttpInstance(defaultHttpTimeoutMs),
   });
@@ -158,11 +183,11 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
   }
 
   const agent = getWsProxyAgent();
-  return new Lark.WSClient({
+  return new feishuClientSdk.WSClient({
     appId,
     appSecret,
     domain: resolveDomain(domain),
-    loggerLevel: Lark.LoggerLevel.info,
+    loggerLevel: feishuClientSdk.LoggerLevel.info,
     ...(agent ? { agent } : {}),
   });
 }
@@ -171,7 +196,7 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
  * Create an event dispatcher for an account.
  */
 export function createEventDispatcher(account: ResolvedFeishuAccount): Lark.EventDispatcher {
-  return new Lark.EventDispatcher({
+  return new feishuClientSdk.EventDispatcher({
     encryptKey: account.encryptKey,
     verificationToken: account.verificationToken,
   });
@@ -193,4 +218,14 @@ export function clearClientCache(accountId?: string): void {
   } else {
     clientCache.clear();
   }
+}
+
+export function setFeishuClientRuntimeForTest(overrides?: {
+  sdk?: Partial<FeishuClientSdk>;
+  HttpsProxyAgent?: typeof HttpsProxyAgent;
+}): void {
+  feishuClientSdk = overrides?.sdk
+    ? { ...defaultFeishuClientSdk, ...overrides.sdk }
+    : defaultFeishuClientSdk;
+  httpsProxyAgentCtor = overrides?.HttpsProxyAgent ?? HttpsProxyAgent;
 }

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const createFeishuClientMock = vi.hoisted(() => vi.fn());
-
-vi.mock("./client.js", () => ({
-  createFeishuClient: createFeishuClientMock,
+const clientCtorMock = vi.hoisted(() => vi.fn());
+const mockBaseHttpInstance = vi.hoisted(() => ({
+  request: vi.fn().mockResolvedValue({}),
+  get: vi.fn().mockResolvedValue({}),
+  post: vi.fn().mockResolvedValue({}),
+  put: vi.fn().mockResolvedValue({}),
+  patch: vi.fn().mockResolvedValue({}),
+  delete: vi.fn().mockResolvedValue({}),
+  head: vi.fn().mockResolvedValue({}),
+  options: vi.fn().mockResolvedValue({}),
 }));
 
+import { clearClientCache, setFeishuClientRuntimeForTest } from "./client.js";
 import { FEISHU_PROBE_REQUEST_TIMEOUT_MS, probeFeishu, clearProbeCache } from "./probe.js";
 
 const DEFAULT_CREDS = { appId: "cli_123", appSecret: "secret" } as const; // pragma: allowlist secret
@@ -28,9 +35,15 @@ function makeRequestFn(response: Record<string, unknown>) {
   return vi.fn().mockResolvedValue(response);
 }
 
+function installClientCtor(requestFn: unknown) {
+  clientCtorMock.mockImplementation(function MockFeishuClient(this: { request: unknown }) {
+    this.request = requestFn;
+  } as never);
+}
+
 function setupClient(response: Record<string, unknown>) {
   const requestFn = makeRequestFn(response);
-  createFeishuClientMock.mockReturnValue({ request: requestFn });
+  installClientCtor(requestFn);
   return requestFn;
 }
 
@@ -60,7 +73,7 @@ async function expectErrorResultCached(params: {
   expectedError: string;
   ttlMs: number;
 }) {
-  createFeishuClientMock.mockReturnValue({ request: params.requestFn });
+  installClientCtor(params.requestFn);
 
   const first = await probeFeishu(DEFAULT_CREDS);
   const second = await probeFeishu(DEFAULT_CREDS);
@@ -95,11 +108,25 @@ async function readSequentialDefaultProbePair() {
 describe("probeFeishu", () => {
   beforeEach(() => {
     clearProbeCache();
-    vi.restoreAllMocks();
+    clearClientCache();
+    vi.clearAllMocks();
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        AppType: { SelfBuild: "self" } as never,
+        Domain: {
+          Feishu: "https://open.feishu.cn",
+          Lark: "https://open.larksuite.com",
+        } as never,
+        Client: clientCtorMock as never,
+        defaultHttpInstance: mockBaseHttpInstance as never,
+      },
+    });
   });
 
   afterEach(() => {
     clearProbeCache();
+    clearClientCache();
+    setFeishuClientRuntimeForTest();
   });
 
   it("returns error when credentials are missing", async () => {
@@ -141,7 +168,7 @@ describe("probeFeishu", () => {
   it("returns timeout error when request exceeds timeout", async () => {
     await withFakeTimers(async () => {
       const requestFn = vi.fn().mockImplementation(() => new Promise(() => {}));
-      createFeishuClientMock.mockReturnValue({ request: requestFn });
+      installClientCtor(requestFn);
 
       const promise = probeFeishu(DEFAULT_CREDS, { timeoutMs: 1_000 });
       await vi.advanceTimersByTimeAsync(1_000);
@@ -152,7 +179,6 @@ describe("probeFeishu", () => {
   });
 
   it("returns aborted when abort signal is already aborted", async () => {
-    createFeishuClientMock.mockClear();
     const abortController = new AbortController();
     abortController.abort();
 
@@ -162,7 +188,7 @@ describe("probeFeishu", () => {
     );
 
     expect(result).toMatchObject({ ok: false, error: "probe aborted" });
-    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(clientCtorMock).not.toHaveBeenCalled();
   });
   it("returns cached result on subsequent calls within TTL", async () => {
     const requestFn = setupSuccessClient();

--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -1,6 +1,26 @@
 import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import { delimiter, dirname, join } from "node:path";
 import { CLIENT_ID_KEYS, CLIENT_SECRET_KEYS } from "./oauth.shared.js";
+
+type CredentialFs = {
+  existsSync: (path: Parameters<typeof existsSync>[0]) => ReturnType<typeof existsSync>;
+  readFileSync: (path: Parameters<typeof readFileSync>[0], encoding: "utf8") => string;
+  realpathSync: (path: Parameters<typeof realpathSync>[0]) => string;
+  readdirSync: (
+    path: Parameters<typeof readdirSync>[0],
+    options: { withFileTypes: true },
+  ) => Dirent[];
+};
+
+const defaultFs: CredentialFs = {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+};
+
+let credentialFs: CredentialFs = defaultFs;
 
 function resolveEnv(keys: string[]): string | undefined {
   for (const key of keys) {
@@ -18,6 +38,10 @@ export function clearCredentialsCache(): void {
   cachedGeminiCliCredentials = null;
 }
 
+export function setOAuthCredentialsFsForTest(overrides?: Partial<CredentialFs>): void {
+  credentialFs = overrides ? { ...defaultFs, ...overrides } : defaultFs;
+}
+
 export function extractGeminiCliCredentials(): { clientId: string; clientSecret: string } | null {
   if (cachedGeminiCliCredentials) {
     return cachedGeminiCliCredentials;
@@ -29,7 +53,7 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
       return null;
     }
 
-    const resolvedPath = realpathSync(geminiPath);
+    const resolvedPath = credentialFs.realpathSync(geminiPath);
     const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     let content: string | null = null;
@@ -55,10 +79,9 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
           "oauth2.js",
         ),
       ];
-
       for (const path of searchPaths) {
-        if (existsSync(path)) {
-          content = readFileSync(path, "utf8");
+        if (credentialFs.existsSync(path)) {
+          content = credentialFs.readFileSync(path, "utf8");
           break;
         }
       }
@@ -67,7 +90,7 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
       }
       const found = findFile(geminiCliDir, "oauth2.js", 10);
       if (found) {
-        content = readFileSync(found, "utf8");
+        content = credentialFs.readFileSync(found, "utf8");
         break;
       }
     }
@@ -116,7 +139,7 @@ function findInPath(name: string): string | null {
   for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     for (const ext of exts) {
       const path = join(dir, name + ext);
-      if (existsSync(path)) {
+      if (credentialFs.existsSync(path)) {
         return path;
       }
     }
@@ -129,7 +152,7 @@ function findFile(dir: string, name: string, depth: number): string | null {
     return null;
   }
   try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    for (const entry of credentialFs.readdirSync(dir, { withFileTypes: true })) {
       const path = join(dir, entry.name);
       if (entry.isFile() && entry.name === name) {
         return path;

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -21,22 +21,10 @@ vi.mock("../../src/infra/net/fetch-guard.js", () => ({
   },
 }));
 
-// Mock fs module before importing the module under test
 const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockRealpathSync = vi.fn();
 const mockReaddirSync = vi.fn();
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    existsSync: (...args: Parameters<typeof actual.existsSync>) => mockExistsSync(...args),
-    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => mockReadFileSync(...args),
-    realpathSync: (...args: Parameters<typeof actual.realpathSync>) => mockRealpathSync(...args),
-    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => mockReaddirSync(...args),
-  };
-});
 
 describe("extractGeminiCliCredentials", () => {
   const normalizePath = (value: string) =>
@@ -50,6 +38,20 @@ describe("extractGeminiCliCredentials", () => {
   `;
 
   let originalPath: string | undefined;
+
+  async function loadCredentialsModule() {
+    return await import("./oauth.credentials.js");
+  }
+
+  async function installMockFs() {
+    const { setOAuthCredentialsFsForTest } = await loadCredentialsModule();
+    setOAuthCredentialsFsForTest({
+      existsSync: (...args) => mockExistsSync(...args),
+      readFileSync: (...args) => mockReadFileSync(...args),
+      realpathSync: (...args) => mockRealpathSync(...args),
+      readdirSync: (...args) => mockReaddirSync(...args),
+    });
+  }
 
   function makeFakeLayout() {
     const binDir = join(rootDir, "fake", "bin");
@@ -157,17 +159,20 @@ describe("extractGeminiCliCredentials", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     originalPath = process.env.PATH;
+    await installMockFs();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.env.PATH = originalPath;
+    const { setOAuthCredentialsFsForTest } = await loadCredentialsModule();
+    setOAuthCredentialsFsForTest();
   });
 
   it("returns null when gemini binary is not in PATH", async () => {
     process.env.PATH = "/nonexistent";
     mockExistsSync.mockReturnValue(false);
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
   });
@@ -175,7 +180,7 @@ describe("extractGeminiCliCredentials", () => {
   it("extracts credentials from oauth2.js in known path", async () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
     const result = extractGeminiCliCredentials();
 
@@ -185,7 +190,7 @@ describe("extractGeminiCliCredentials", () => {
   it("extracts credentials when PATH entry is an npm global shim", async () => {
     installNpmShimLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
     const result = extractGeminiCliCredentials();
 
@@ -195,7 +200,7 @@ describe("extractGeminiCliCredentials", () => {
   it("returns null when oauth2.js cannot be found", async () => {
     installGeminiLayout({ oauth2Exists: false, readdir: [] });
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
   });
@@ -203,7 +208,7 @@ describe("extractGeminiCliCredentials", () => {
   it("returns null when oauth2.js lacks credentials", async () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: "// no credentials here" });
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
   });
@@ -211,7 +216,7 @@ describe("extractGeminiCliCredentials", () => {
   it("caches credentials after first extraction", async () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await loadCredentialsModule();
     clearCredentialsCache();
 
     // First call

--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -4,10 +4,14 @@ import { describe, expect, it, vi } from "vitest";
 const uploadGoogleChatAttachmentMock = vi.hoisted(() => vi.fn());
 const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./api.js", () => ({
-  sendGoogleChatMessage: sendGoogleChatMessageMock,
-  uploadGoogleChatAttachment: uploadGoogleChatAttachmentMock,
-}));
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    sendGoogleChatMessage: sendGoogleChatMessageMock,
+    uploadGoogleChatAttachment: uploadGoogleChatAttachmentMock,
+  };
+});
 
 import { googlechatPlugin } from "./channel.js";
 import { setGoogleChatRuntime } from "./runtime.js";


### PR DESCRIPTION
## Summary

- Problem: `pnpm test:extensions` on `main` had three separate extension test failure clusters in Google Chat, Google OAuth, and Feishu.
- Why it matters: main CI was red for extension-only test breakage, and several failures were caused by stale or brittle test seams after recent runtime/module refactors.
- What changed:
  - Google Chat outbound tests now partially mock `./api.js` so lazy runtime imports still see real untouched exports.
  - Google OAuth credential extraction tests now use an explicit filesystem test seam instead of brittle `node:fs` package mocking after the OAuth module split.
  - Feishu ACP-routing tests now mock `openclaw/plugin-sdk/conversation-runtime`, which is the seam `bot.ts` actually imports.
  - Feishu client/probe tests now inject SDK and proxy behavior through a dedicated runtime seam in `client.ts` instead of depending on package-level mocking of `@larksuiteoapi/node-sdk`.
  - Follow-up typing/format fixes keep the new seams green under `pnpm check`.
- What did NOT change (scope boundary): no user-facing product behavior, network behavior, or extension runtime logic changed beyond adding test seams whose default behavior remains the real implementation.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 via repo test wrapper
- Model/provider: N/A
- Integration/channel (if any): Google Chat, Google OAuth, Feishu
- Relevant config (redacted): test fixtures only

### Steps

1. Run `pnpm test:extensions` on `main`.
2. Observe failures in:
   - `extensions/googlechat/src/channel.outbound.test.ts`
   - `extensions/google/oauth.test.ts`
   - `extensions/feishu/src/client.test.ts`
   - `extensions/feishu/src/probe.test.ts`
   - `extensions/feishu/src/bot.test.ts`
3. Apply this branch and rerun the extension suite.

### Expected

- Extension tests pass without relying on stale import seams or brittle built-in/package mocks.

### Actual

- Local `pnpm test:extensions` is fully green.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- extensions/googlechat/src/channel.outbound.test.ts extensions/googlechat/src/resolve-target.test.ts`
  - `pnpm test -- extensions/google/oauth.test.ts`
  - `pnpm test -- extensions/feishu/src/bot.test.ts`
  - `pnpm test -- extensions/feishu/src/client.test.ts extensions/feishu/src/probe.test.ts extensions/feishu/src/bot.test.ts`
  - `pnpm test:extensions`
  - `pnpm check`
- Edge cases checked:
  - Google Chat lazy runtime still resolves real `probeGoogleChat` while outbound send/upload stay mocked.
  - Google OAuth extraction tests cover both direct install and npm shim layouts through the injected fs seam.
  - Feishu client/probe tests no longer depend on external package mocks intercepting SDK constructors.
- What you did **not** verify:
  - I did not address the separate contracts/check lanes that can still fail independently of extension tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `d1a8c3ecfe`, `b61a048009`, `58eab237d9`, `e1107912e1`, and `8789aee17e`.
- Files/config to restore:
  - `extensions/googlechat/src/channel.outbound.test.ts`
  - `extensions/google/oauth.credentials.ts`
  - `extensions/google/oauth.test.ts`
  - `extensions/feishu/src/bot.test.ts`
  - `extensions/feishu/src/client.ts`
  - `extensions/feishu/src/client.test.ts`
  - `extensions/feishu/src/probe.test.ts`
- Known bad symptoms reviewers should watch for:
  - extension tests reverting to package-level mock breakage after future import-path or runtime-boundary refactors
  - accidental production use of the new test seam exports instead of the default runtime path

## Risks and Mitigations

- Risk: the new exported test seams in `extensions/google/oauth.credentials.ts` and `extensions/feishu/src/client.ts` slightly widen internal surface area.
- Mitigation: both seams default to the existing real implementations and are only referenced from tests in this branch.

- Risk: future refactors could move import seams again and stale tests may drift.
- Mitigation: this PR updates tests to mock the actual current seams and removes reliance on the most brittle package-level mocks.
