### PR TITLE
fix(ui): Stop button shows Send during tool execution

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -801,7 +801,7 @@ function renderSlashMenu(
 
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
-  const isBusy = props.sending || props.stream !== null;
+  const isBusy = props.sending || props.stream !== null || props.canAbort;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";


### PR DESCRIPTION
## Problem

In the Control UI, the Stop button incorrectly shows "Send" during tool execution (when `canAbort` is true but no text stream is active).

**Issue:**
- Stop button only showed "Stop" when AI was outputting text (`props.stream !== null`)
- During tool execution without text output, `isBusy` was false, causing "Send" to display
- Users couldn't visually tell if a task was running during tool calls

## Fix

Added `props.canAbort` to the `isBusy` condition in `ui/src/ui/views/chat.ts`:

```diff
- const isBusy = props.sending || props.stream !== null;
+ const isBusy = props.sending || props.stream !== null || props.canAbort;

Testing
✅ Stop button correctly displays during tool execution
✅ Stop button can interrupt running tasks
✅ Button returns to "Send" after task completion