### PR TITLE
docs(pairing): document first-run device approval for gateway clients

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -84,6 +84,17 @@ openclaw devices approve <requestId>
 openclaw devices reject <requestId>
 ```
 
+Third-party Gateway WS clients use the same device-pairing flow. For example,
+Paperclip's `openclaw_gateway` adapter may fail the first run with
+`openclaw_gateway_pairing_required` until you approve the pending device
+request. After the first failed connection, approve the latest request and
+retry:
+
+```bash
+openclaw devices approve --latest
+openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>
+```
+
 ### Node pairing state storage
 
 Stored under `~/.openclaw/devices/`:

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -91,8 +91,8 @@ request. After the first failed connection, approve the latest request and
 retry:
 
 ```bash
-openclaw devices approve --latest
-openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>
+openclaw devices approve --latest                                                         # local gateway
+openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>  # remote gateway
 ```
 
 ### Node pairing state storage

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -55,8 +55,8 @@ Common first-run recovery for headless or third-party Gateway WS clients (for
 example Paperclip's `openclaw_gateway` adapter):
 
 ```
-openclaw devices approve --latest
-openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>
+openclaw devices approve --latest                                                         # local gateway
+openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>  # remote gateway
 ```
 
 If a client does not persist its device identity, it may create a new pending

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -51,6 +51,17 @@ openclaw devices approve <requestId>
 openclaw devices approve --latest
 ```
 
+Common first-run recovery for headless or third-party Gateway WS clients (for
+example Paperclip's `openclaw_gateway` adapter):
+
+```
+openclaw devices approve --latest
+openclaw devices approve --latest --url ws://gateway-host:18789 --token <gateway-token>
+```
+
+If a client does not persist its device identity, it may create a new pending
+request after restart and require approval again.
+
 ### `openclaw devices reject <requestId>`
 
 Reject a pending device pairing request.


### PR DESCRIPTION
## Summary
- document that third-party Gateway WS clients use the same device-pairing flow as nodes
- call out Paperclip's openclaw_gateway adapter as a concrete first-run pairing required example
- add openclaw devices approve --latest recovery examples for both local and remote gateways

## Testing
- git diff --check

Fixes #48566