### PR TITLE
feat(tui): inline image rendering via pi-tui Image component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/appearance: unify theme border radii across Claw, Knot, and Dash, and add a Roundness slider to the Appearance settings so users can adjust corner radius from sharp to fully rounded. Thanks @BunsDev.
 - Control UI/chat: add an expand-to-canvas button on assistant chat bubbles and in-app session navigation from Sessions and Cron views. Thanks @BunsDev.
 - Plugins/context engines: expose `delegateCompactionToRuntime(...)` on the public plugin SDK, refactor the legacy engine to use the shared helper, and clarify `ownsCompaction` delegation semantics for non-owning engines. (#49061) Thanks @jalehman.
+- TUI/inline images: render images inline when tools emit `MEDIA:` paths, using Kitty and iTerm2 graphics protocols with automatic text fallback on unsupported terminals. (#49022) Thanks @ademczuk.
 
 ### Fixes
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -12,6 +12,9 @@ export class ChatLog extends Container {
   private streamingRuns = new Map<string, AssistantMessageComponent>();
   private btwMessage: BtwInlineMessage | null = null;
   private toolsExpanded = false;
+  // Shared across all tool components to dedup images rendered by different
+  // tool calls (e.g. skill exec + follow-up media delivery for the same file).
+  readonly renderedImagePaths = new Set<string>();
 
   constructor(maxComponents = 180) {
     super();
@@ -55,6 +58,7 @@ export class ChatLog extends Container {
     this.toolById.clear();
     this.streamingRuns.clear();
     this.btwMessage = null;
+    this.renderedImagePaths.clear();
   }
 
   addSystem(text: string) {
@@ -147,7 +151,7 @@ export class ChatLog extends Container {
       existing.setArgs(args);
       return existing;
     }
-    const component = new ToolExecutionComponent(toolName, args);
+    const component = new ToolExecutionComponent(toolName, args, this.renderedImagePaths);
     component.setExpanded(this.toolsExpanded);
     this.toolById.set(toolCallId, component);
     this.append(component);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -14,7 +14,7 @@ export class ChatLog extends Container {
   private toolsExpanded = false;
   // Shared across all tool components to dedup images rendered by different
   // tool calls (e.g. skill exec + follow-up media delivery for the same file).
-  readonly renderedImagePaths = new Set<string>();
+  readonly renderedImages = new Set<string>();
 
   constructor(maxComponents = 180) {
     super();
@@ -58,7 +58,7 @@ export class ChatLog extends Container {
     this.toolById.clear();
     this.streamingRuns.clear();
     this.btwMessage = null;
-    this.renderedImagePaths.clear();
+    this.renderedImages.clear();
   }
 
   addSystem(text: string) {
@@ -151,7 +151,7 @@ export class ChatLog extends Container {
       existing.setArgs(args);
       return existing;
     }
-    const component = new ToolExecutionComponent(toolName, args, this.renderedImagePaths);
+    const component = new ToolExecutionComponent(toolName, args, this.renderedImages);
     component.setExpanded(this.toolsExpanded);
     this.toolById.set(toolCallId, component);
     this.append(component);

--- a/src/tui/components/inline-image.test.ts
+++ b/src/tui/components/inline-image.test.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MIME_BY_EXT,
+  _resetCapabilityCache,
+  canRenderInlineImages,
+  createInlineImage,
+  isSupportedImageExt,
+  readMediaImageAsBase64,
+} from "./inline-image.js";
+
+// Minimal valid 1x1 PNG (67 bytes)
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+const TINY_PNG_BUF = Buffer.from(TINY_PNG_B64, "base64");
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `inline-image-test-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  _resetCapabilityCache();
+});
+
+describe("canRenderInlineImages", () => {
+  it("returns a boolean", () => {
+    // In test environment, terminal typically has no image support
+    expect(typeof canRenderInlineImages()).toBe("boolean");
+  });
+
+  it("caches the result across calls", () => {
+    const first = canRenderInlineImages();
+    const second = canRenderInlineImages();
+    expect(first).toBe(second);
+  });
+});
+
+describe("readMediaImageAsBase64", () => {
+  it("reads a valid PNG file", () => {
+    const filePath = join(testDir, "test.png");
+    writeFileSync(filePath, TINY_PNG_BUF);
+    const result = readMediaImageAsBase64(filePath);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/png");
+    expect(result!.data).toBe(TINY_PNG_B64);
+  });
+
+  it("reads a valid JPEG file", () => {
+    const filePath = join(testDir, "test.jpg");
+    writeFileSync(filePath, TINY_PNG_BUF); // contents don't matter for MIME check
+    const result = readMediaImageAsBase64(filePath);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/jpeg");
+  });
+
+  it("reads a .webp file", () => {
+    const filePath = join(testDir, "test.webp");
+    writeFileSync(filePath, TINY_PNG_BUF);
+    const result = readMediaImageAsBase64(filePath);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/webp");
+  });
+
+  it("returns null for non-existent file", () => {
+    expect(readMediaImageAsBase64(join(testDir, "nope.png"))).toBeNull();
+  });
+
+  it("returns null for non-image extension", () => {
+    const filePath = join(testDir, "data.json");
+    writeFileSync(filePath, "{}");
+    expect(readMediaImageAsBase64(filePath)).toBeNull();
+  });
+
+  it("returns null for .txt extension", () => {
+    const filePath = join(testDir, "notes.txt");
+    writeFileSync(filePath, "hello");
+    expect(readMediaImageAsBase64(filePath)).toBeNull();
+  });
+
+  it("returns null for relative path", () => {
+    const filePath = join(testDir, "test.png");
+    writeFileSync(filePath, TINY_PNG_BUF);
+    expect(readMediaImageAsBase64("./test.png")).toBeNull();
+  });
+
+  it("normalizes paths with .. segments before reading", () => {
+    // Path with .. segments should be normalized and succeed if the
+    // resolved file is a valid image. This is a local TUI reading local
+    // files, so normalization is sufficient defense-in-depth.
+    const subdir = join(testDir, "subdir");
+    mkdirSync(subdir, { recursive: true });
+    writeFileSync(join(testDir, "test.png"), TINY_PNG_BUF);
+    const traversalPath = `${subdir}/../test.png`;
+    const result = readMediaImageAsBase64(traversalPath);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/png");
+  });
+
+  it("returns null for empty string", () => {
+    expect(readMediaImageAsBase64("")).toBeNull();
+  });
+
+  it("returns null for path with null byte", () => {
+    expect(readMediaImageAsBase64("/tmp/evil\0.png")).toBeNull();
+  });
+
+  it("returns null for empty file", () => {
+    const filePath = join(testDir, "empty.png");
+    writeFileSync(filePath, "");
+    expect(readMediaImageAsBase64(filePath)).toBeNull();
+  });
+
+  it("returns null for oversized file", () => {
+    const filePath = join(testDir, "big.png");
+    // Write a file just over 6MB
+    writeFileSync(filePath, Buffer.alloc(6 * 1024 * 1024 + 1));
+    expect(readMediaImageAsBase64(filePath)).toBeNull();
+  });
+
+  it("returns null for symlinks", () => {
+    const realPath = join(testDir, "real.png");
+    const linkPath = join(testDir, "link.png");
+    writeFileSync(realPath, TINY_PNG_BUF);
+    try {
+      symlinkSync(realPath, linkPath);
+    } catch {
+      // Symlinks may require elevated privileges on Windows, skip
+      return;
+    }
+    expect(readMediaImageAsBase64(linkPath)).toBeNull();
+  });
+
+  it("returns null for directory path", () => {
+    const dirPath = join(testDir, "subdir.png");
+    mkdirSync(dirPath, { recursive: true });
+    expect(readMediaImageAsBase64(dirPath)).toBeNull();
+  });
+});
+
+describe("createInlineImage", () => {
+  it("returns an Image component", () => {
+    const image = createInlineImage(TINY_PNG_B64, "image/png");
+    expect(image).toBeDefined();
+    expect(typeof image.render).toBe("function");
+  });
+
+  it("accepts optional filename", () => {
+    const image = createInlineImage(TINY_PNG_B64, "image/png", {
+      filename: "chart.png",
+    });
+    expect(image).toBeDefined();
+  });
+
+  it("accepts custom maxWidthCells", () => {
+    const image = createInlineImage(TINY_PNG_B64, "image/png", {
+      maxWidthCells: 40,
+    });
+    expect(image).toBeDefined();
+  });
+});
+
+describe("MIME_BY_EXT", () => {
+  it("maps all standard image extensions", () => {
+    expect(MIME_BY_EXT[".png"]).toBe("image/png");
+    expect(MIME_BY_EXT[".jpg"]).toBe("image/jpeg");
+    expect(MIME_BY_EXT[".jpeg"]).toBe("image/jpeg");
+    expect(MIME_BY_EXT[".gif"]).toBe("image/gif");
+    expect(MIME_BY_EXT[".webp"]).toBe("image/webp");
+  });
+
+  it("does not include non-image types", () => {
+    expect(MIME_BY_EXT[".txt"]).toBeUndefined();
+    expect(MIME_BY_EXT[".json"]).toBeUndefined();
+    expect(MIME_BY_EXT[".pdf"]).toBeUndefined();
+  });
+});
+
+describe("isSupportedImageExt", () => {
+  it("accepts supported extensions", () => {
+    expect(isSupportedImageExt(".png")).toBe(true);
+    expect(isSupportedImageExt(".jpg")).toBe(true);
+    expect(isSupportedImageExt(".jpeg")).toBe(true);
+    expect(isSupportedImageExt(".gif")).toBe(true);
+    expect(isSupportedImageExt(".webp")).toBe(true);
+  });
+
+  it("rejects unsupported extensions", () => {
+    expect(isSupportedImageExt(".txt")).toBe(false);
+    expect(isSupportedImageExt(".pdf")).toBe(false);
+    expect(isSupportedImageExt(".svg")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSupportedImageExt(".PNG")).toBe(true);
+    expect(isSupportedImageExt(".Jpg")).toBe(true);
+  });
+});

--- a/src/tui/components/inline-image.ts
+++ b/src/tui/components/inline-image.ts
@@ -1,0 +1,107 @@
+// Inline image rendering utilities for the TUI.
+// Reads local MEDIA: image files and creates pi-tui Image components
+// when the terminal supports Kitty or iTerm2 graphics protocols.
+
+import { lstatSync, readFileSync } from "node:fs";
+import { extname, isAbsolute, normalize } from "node:path";
+import { Image, getCapabilities, getImageDimensions, type ImageTheme } from "@mariozechner/pi-tui";
+import { MAX_IMAGE_BYTES } from "../../media/constants.js";
+import { theme } from "../theme/theme.js";
+
+export const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+const IMAGE_EXTS = new Set(Object.keys(MIME_BY_EXT));
+
+const imageTheme: ImageTheme = {
+  fallbackColor: (str: string) => theme.dim(str),
+};
+
+let _cachedCapable: boolean | undefined;
+
+/** Whether the current terminal supports inline image rendering. */
+export function canRenderInlineImages(): boolean {
+  if (_cachedCapable === undefined) {
+    _cachedCapable = getCapabilities().images !== null;
+  }
+  return _cachedCapable;
+}
+
+/**
+ * Read a local image file and return its base64 data + MIME type.
+ * Returns null on any validation failure (wrong extension, too large,
+ * symlink, relative path, traversal, etc). Never throws.
+ */
+export function readMediaImageAsBase64(
+  filePath: string,
+): { data: string; mimeType: string } | null {
+  try {
+    if (!filePath || !isAbsolute(filePath)) {
+      return null;
+    }
+    if (filePath.includes("\0")) {
+      return null;
+    }
+    // Normalize to resolve any .. segments and inconsistent separators
+    // before extension/stat checks. This is a local TUI reading local files
+    // (no remote clients), so normalization is sufficient defense-in-depth.
+    const cleaned = normalize(filePath);
+
+    const ext = extname(cleaned).toLowerCase();
+    const mimeType = MIME_BY_EXT[ext];
+    if (!mimeType) {
+      return null;
+    }
+
+    const stat = lstatSync(cleaned);
+    if (!stat.isFile()) {
+      return null; // rejects symlinks, directories, etc.
+    }
+    if (stat.size <= 0 || stat.size > MAX_IMAGE_BYTES) {
+      return null;
+    }
+
+    const buf = readFileSync(cleaned);
+    if (buf.length > MAX_IMAGE_BYTES) {
+      return null; // TOCTOU guard
+    }
+
+    return { data: buf.toString("base64"), mimeType };
+  } catch {
+    return null;
+  }
+}
+
+/** Create a pi-tui Image component for inline rendering. */
+export function createInlineImage(
+  base64Data: string,
+  mimeType: string,
+  opts?: { maxWidthCells?: number; filename?: string },
+): Image {
+  const dims = getImageDimensions(base64Data, mimeType) ?? undefined;
+  return new Image(
+    base64Data,
+    mimeType,
+    imageTheme,
+    {
+      maxWidthCells: opts?.maxWidthCells ?? 60,
+      filename: opts?.filename,
+    },
+    dims,
+  );
+}
+
+/** Check whether a file extension is a supported image type. */
+export function isSupportedImageExt(ext: string): boolean {
+  return IMAGE_EXTS.has(ext.toLowerCase());
+}
+
+/** Reset the cached capability flag (for testing). */
+export function _resetCapabilityCache(): void {
+  _cachedCapable = undefined;
+}

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolExecutionComponent } from "./tool-execution.js";
+
+// Minimal valid 1x1 PNG
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+const TINY_PNG_BUF = Buffer.from(TINY_PNG_B64, "base64");
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `tool-exec-test-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+// Mock canRenderInlineImages to control image rendering in tests
+vi.mock("./inline-image.js", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    canRenderInlineImages: vi.fn(() => false),
+  };
+});
+
+describe("ToolExecutionComponent", () => {
+  it("renders tool name and args on construction", () => {
+    const component = new ToolExecutionComponent("read_file", { path: "/tmp/test.txt" });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toBeTruthy();
+  });
+
+  it("shows running state for partial results", () => {
+    const component = new ToolExecutionComponent("bash", { command: "ls" });
+    component.setPartialResult({
+      content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
+    });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("running");
+  });
+
+  it("shows final result text", () => {
+    const component = new ToolExecutionComponent("bash", { command: "echo hello" });
+    component.setResult({
+      content: [{ type: "text", text: "hello" }],
+    });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("hello");
+    expect(rendered).not.toContain("running");
+  });
+
+  it("shows image placeholder when terminal does not support images", () => {
+    const component = new ToolExecutionComponent("image_generate", { prompt: "sunset" });
+    component.setResult({
+      content: [
+        { type: "text", text: "Generated 1 image." },
+        { type: "image", mimeType: "image/png", bytes: 1024, omitted: true },
+      ],
+    });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("[image/png 1kb (omitted)]");
+  });
+
+  it("preserves MEDIA: paths in text when terminal does not support images", () => {
+    const imgPath = join(testDir, "chart.png");
+    writeFileSync(imgPath, TINY_PNG_BUF);
+    const component = new ToolExecutionComponent("image_generate", { prompt: "chart" });
+    component.setResult({
+      content: [{ type: "text", text: `Generated 1 image.\nMEDIA:${imgPath}` }],
+    });
+    const rendered = component.render(80).join("\n");
+    // On non-image terminals, MEDIA: lines remain visible as text
+    expect(rendered).toContain("Generated 1 image");
+  });
+
+  it("handles setResult after setPartialResult", () => {
+    const component = new ToolExecutionComponent("bash", { command: "long" });
+    component.setPartialResult({ content: [{ type: "text", text: "partial..." }] });
+    component.setResult({ content: [{ type: "text", text: "done" }] });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("done");
+    expect(rendered).not.toContain("running");
+  });
+
+  it("handles setPartialResult after setResult (clears stale state)", () => {
+    const component = new ToolExecutionComponent("bash", { command: "retry" });
+    component.setResult({ content: [{ type: "text", text: "result1" }] });
+    // Partial after final simulates a retry/new streaming run
+    component.setPartialResult({ content: [{ type: "text", text: "streaming..." }] });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("running");
+    expect(rendered).toContain("streaming");
+  });
+
+  it("handles double setResult (replaces previous)", () => {
+    const component = new ToolExecutionComponent("bash", { command: "retry" });
+    component.setResult({ content: [{ type: "text", text: "first" }] });
+    component.setResult({ content: [{ type: "text", text: "second" }] });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("second");
+  });
+
+  it("handles setResult with undefined", () => {
+    const component = new ToolExecutionComponent("bash", { command: "test" });
+    component.setResult(undefined);
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toBeTruthy();
+  });
+
+  it("handles empty content array", () => {
+    const component = new ToolExecutionComponent("bash", { command: "test" });
+    component.setResult({ content: [] });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toBeTruthy();
+  });
+
+  it("truncates long output when not expanded", () => {
+    const longText = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const component = new ToolExecutionComponent("bash", { command: "test" });
+    component.setResult({ content: [{ type: "text", text: longText }] });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("line 0");
+    expect(rendered).toContain("…");
+  });
+
+  it("shows full output when expanded", () => {
+    const longText = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const component = new ToolExecutionComponent("bash", { command: "test" });
+    component.setResult({ content: [{ type: "text", text: longText }] });
+    component.setExpanded(true);
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("line 19");
+  });
+
+  it("shows error styling for error results", () => {
+    const component = new ToolExecutionComponent("bash", { command: "fail" });
+    component.setResult({ content: [{ type: "text", text: "command failed" }] }, { isError: true });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("command failed");
+  });
+
+  it("updates args without affecting result", () => {
+    const component = new ToolExecutionComponent("bash", { command: "old" });
+    component.setResult({ content: [{ type: "text", text: "output" }] });
+    component.setArgs({ command: "new" });
+    const rendered = component.render(80).join("\n");
+    expect(rendered).toContain("output");
+  });
+});

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -13,6 +13,7 @@ import {
 type ToolResultContent = {
   type?: string;
   text?: string;
+  data?: string; // base64 image data (when upstream doesn't strip it)
   mimeType?: string;
   bytes?: number;
   omitted?: boolean;
@@ -44,10 +45,14 @@ function formatArgs(toolName: string, args: unknown): string {
 }
 
 /**
- * Process tool result content blocks in a single pass:
- * - Extract MEDIA: paths from text blocks and load images from disk
- * - Build both raw text and media-stripped text simultaneously
- * Avoids calling splitMediaFromOutput twice per block.
+ * Process tool result content blocks in a single sequential pass.
+ *
+ * Tools emit images as [TEXT with MEDIA:path, IMAGE with base64] pairs.
+ * When a MEDIA text block is rendered from file, `lastMediaRenderedFromFile`
+ * is set so the immediately following IMAGE block (base64 duplicate) is
+ * skipped. Orphan IMAGE blocks (no preceding MEDIA) render from base64.
+ * This dedup approach comes from the old PR #36740 and avoids index-space
+ * mismatches when MEDIA paths and image blocks are interleaved.
  */
 function processResult(
   result?: ToolResult,
@@ -62,9 +67,11 @@ function processResult(
   const seenPaths = new Set<string>();
   const rawLines: string[] = [];
   const strippedLines: string[] = [];
+  let lastMediaRenderedFromFile = false;
 
   for (const entry of result.content) {
     if (entry.type === "text" && entry.text) {
+      lastMediaRenderedFromFile = false;
       rawLines.push(sanitizeRenderableText(entry.text));
 
       if (canRender) {
@@ -85,17 +92,31 @@ function processResult(
                 component: createInlineImage(loaded.data, loaded.mimeType, { filename }),
                 filename,
               });
+              lastMediaRenderedFromFile = true;
             }
           }
         }
       }
     } else if (entry.type === "image") {
-      if (!canRender) {
+      if (canRender) {
+        if (lastMediaRenderedFromFile) {
+          // Already rendered from file; skip the base64 duplicate.
+          lastMediaRenderedFromFile = false;
+          continue;
+        }
+        // Orphan image block (no preceding MEDIA) - render from base64 if available
+        if (entry.data && entry.mimeType && !entry.omitted) {
+          images.push({
+            component: createInlineImage(entry.data, entry.mimeType),
+          });
+        }
+      } else {
         const mime = entry.mimeType ?? "image";
         const size = entry.bytes ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
         const omitted = entry.omitted ? " (omitted)" : "";
         rawLines.push(`[${mime}${size}${omitted}]`);
       }
+      lastMediaRenderedFromFile = false;
     }
   }
 
@@ -158,7 +179,8 @@ export class ToolExecutionComponent extends Container {
     this.isError = Boolean(opts?.isError);
 
     // All I/O happens here, NOT in refresh(). Single-pass processes text and
-    // images together to avoid calling splitMediaFromOutput twice per block.
+    // images together, with sequential dedup: when a MEDIA text block is
+    // rendered from file, the next image block (base64 duplicate) is skipped.
     this.detachImages();
     const processed = processResult(result, canRenderInlineImages());
     this.cachedImages = processed.images;

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -54,10 +54,17 @@ function formatArgs(toolName: string, args: unknown): string {
  * This dedup approach comes from the old PR #36740 and avoids index-space
  * mismatches when MEDIA paths and image blocks are interleaved.
  */
+// Short fingerprint of base64 data for cross-tool dedup. Covers the image
+// header + enough pixel data to distinguish different images while staying
+// cheap to compute. Two tool calls with the same file produce identical data.
+function imageFingerprint(data: string): string {
+  return data.slice(0, 128);
+}
+
 function processResult(
   result?: ToolResult,
   canRender?: boolean,
-  globalSeenPaths?: Set<string>,
+  globalRendered?: Set<string>,
 ): { images: CachedImage[]; text: string; textStripped: string } {
   const empty = { images: [], text: "", textStripped: "" };
   if (!result?.content) {
@@ -82,13 +89,18 @@ function processResult(
         }
         if (mediaUrls) {
           for (const mediaPath of mediaUrls) {
-            if (seenPaths.has(mediaPath) || globalSeenPaths?.has(mediaPath)) {
+            if (seenPaths.has(mediaPath) || globalRendered?.has(mediaPath)) {
               continue;
             }
             seenPaths.add(mediaPath);
-            globalSeenPaths?.add(mediaPath);
+            globalRendered?.add(mediaPath);
             const loaded = readMediaImageAsBase64(mediaPath);
             if (loaded) {
+              const fp = imageFingerprint(loaded.data);
+              if (globalRendered?.has(fp)) {
+                continue;
+              }
+              globalRendered?.add(fp);
               const filename = mediaPath.split(/[/\\]/).pop();
               images.push({
                 component: createInlineImage(loaded.data, loaded.mimeType, { filename }),
@@ -108,9 +120,13 @@ function processResult(
         }
         // Orphan image block (no preceding MEDIA) - render from base64 if available
         if (entry.data && entry.mimeType && !entry.omitted) {
-          images.push({
-            component: createInlineImage(entry.data, entry.mimeType),
-          });
+          const fp = imageFingerprint(entry.data);
+          if (!globalRendered?.has(fp)) {
+            globalRendered?.add(fp);
+            images.push({
+              component: createInlineImage(entry.data, entry.mimeType),
+            });
+          }
         }
       } else {
         const mime = entry.mimeType ?? "image";
@@ -146,13 +162,13 @@ export class ToolExecutionComponent extends Container {
   private cachedText = "";
   private cachedTextStripped = "";
   private imagesAttached = false;
-  private globalSeenPaths?: Set<string>;
+  private globalRendered?: Set<string>;
 
-  constructor(toolName: string, args: unknown, globalSeenPaths?: Set<string>) {
+  constructor(toolName: string, args: unknown, globalRendered?: Set<string>) {
     super();
     this.toolName = toolName;
     this.args = args;
-    this.globalSeenPaths = globalSeenPaths;
+    this.globalRendered = globalRendered;
     this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
     this.header = new Text("", 0, 0);
     this.argsLine = new Text("", 0, 0);
@@ -186,7 +202,7 @@ export class ToolExecutionComponent extends Container {
     // images together, with sequential dedup: when a MEDIA text block is
     // rendered from file, the next image block (base64 duplicate) is skipped.
     this.detachImages();
-    const processed = processResult(result, canRenderInlineImages(), this.globalSeenPaths);
+    const processed = processResult(result, canRenderInlineImages(), this.globalRendered);
     this.cachedImages = processed.images;
     this.cachedText = processed.text;
     this.cachedTextStripped = processed.textStripped;

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -57,6 +57,7 @@ function formatArgs(toolName: string, args: unknown): string {
 function processResult(
   result?: ToolResult,
   canRender?: boolean,
+  globalSeenPaths?: Set<string>,
 ): { images: CachedImage[]; text: string; textStripped: string } {
   const empty = { images: [], text: "", textStripped: "" };
   if (!result?.content) {
@@ -81,10 +82,11 @@ function processResult(
         }
         if (mediaUrls) {
           for (const mediaPath of mediaUrls) {
-            if (seenPaths.has(mediaPath)) {
+            if (seenPaths.has(mediaPath) || globalSeenPaths?.has(mediaPath)) {
               continue;
             }
             seenPaths.add(mediaPath);
+            globalSeenPaths?.add(mediaPath);
             const loaded = readMediaImageAsBase64(mediaPath);
             if (loaded) {
               const filename = mediaPath.split(/[/\\]/).pop();
@@ -144,11 +146,13 @@ export class ToolExecutionComponent extends Container {
   private cachedText = "";
   private cachedTextStripped = "";
   private imagesAttached = false;
+  private globalSeenPaths?: Set<string>;
 
-  constructor(toolName: string, args: unknown) {
+  constructor(toolName: string, args: unknown, globalSeenPaths?: Set<string>) {
     super();
     this.toolName = toolName;
     this.args = args;
+    this.globalSeenPaths = globalSeenPaths;
     this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
     this.header = new Text("", 0, 0);
     this.argsLine = new Text("", 0, 0);
@@ -182,7 +186,7 @@ export class ToolExecutionComponent extends Container {
     // images together, with sequential dedup: when a MEDIA text block is
     // rendered from file, the next image block (base64 duplicate) is skipped.
     this.detachImages();
-    const processed = processResult(result, canRenderInlineImages());
+    const processed = processResult(result, canRenderInlineImages(), this.globalSeenPaths);
     this.cachedImages = processed.images;
     this.cachedText = processed.text;
     this.cachedTextStripped = processed.textStripped;

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,7 +1,14 @@
 import { Box, Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
+import type { Image } from "@mariozechner/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
+import { splitMediaFromOutput } from "../../media/parse.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
+import {
+  canRenderInlineImages,
+  createInlineImage,
+  readMediaImageAsBase64,
+} from "./inline-image.js";
 
 type ToolResultContent = {
   type?: string;
@@ -15,6 +22,8 @@ type ToolResult = {
   content?: ToolResultContent[];
   details?: Record<string, unknown>;
 };
+
+type CachedImage = { component: Image; filename?: string };
 
 const PREVIEW_LINES = 12;
 
@@ -34,22 +43,66 @@ function formatArgs(toolName: string, args: unknown): string {
   }
 }
 
-function extractText(result?: ToolResult): string {
+/**
+ * Process tool result content blocks in a single pass:
+ * - Extract MEDIA: paths from text blocks and load images from disk
+ * - Build both raw text and media-stripped text simultaneously
+ * Avoids calling splitMediaFromOutput twice per block.
+ */
+function processResult(
+  result?: ToolResult,
+  canRender?: boolean,
+): { images: CachedImage[]; text: string; textStripped: string } {
+  const empty = { images: [], text: "", textStripped: "" };
   if (!result?.content) {
-    return "";
+    return empty;
   }
-  const lines: string[] = [];
+
+  const images: CachedImage[] = [];
+  const seenPaths = new Set<string>();
+  const rawLines: string[] = [];
+  const strippedLines: string[] = [];
+
   for (const entry of result.content) {
     if (entry.type === "text" && entry.text) {
-      lines.push(sanitizeRenderableText(entry.text));
+      rawLines.push(sanitizeRenderableText(entry.text));
+
+      if (canRender) {
+        const { text, mediaUrls } = splitMediaFromOutput(entry.text);
+        if (text) {
+          strippedLines.push(sanitizeRenderableText(text));
+        }
+        if (mediaUrls) {
+          for (const mediaPath of mediaUrls) {
+            if (seenPaths.has(mediaPath)) {
+              continue;
+            }
+            seenPaths.add(mediaPath);
+            const loaded = readMediaImageAsBase64(mediaPath);
+            if (loaded) {
+              const filename = mediaPath.split(/[/\\]/).pop();
+              images.push({
+                component: createInlineImage(loaded.data, loaded.mimeType, { filename }),
+                filename,
+              });
+            }
+          }
+        }
+      }
     } else if (entry.type === "image") {
-      const mime = entry.mimeType ?? "image";
-      const size = entry.bytes ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
-      const omitted = entry.omitted ? " (omitted)" : "";
-      lines.push(`[${mime}${size}${omitted}]`);
+      if (!canRender) {
+        const mime = entry.mimeType ?? "image";
+        const size = entry.bytes ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
+        const omitted = entry.omitted ? " (omitted)" : "";
+        rawLines.push(`[${mime}${size}${omitted}]`);
+      }
     }
   }
-  return lines.join("\n").trim();
+
+  const text = rawLines.join("\n").trim();
+  const hasImages = images.length > 0;
+  const textStripped = hasImages ? strippedLines.join("\n").trim() : text;
+  return { images, text, textStripped };
 }
 
 export class ToolExecutionComponent extends Container {
@@ -63,6 +116,13 @@ export class ToolExecutionComponent extends Container {
   private expanded = false;
   private isError = false;
   private isPartial = true;
+
+  // Cached image data - loaded once in setResult(), reused across refreshes.
+  // This avoids synchronous file I/O in the render path.
+  private cachedImages: CachedImage[] = [];
+  private cachedText = "";
+  private cachedTextStripped = "";
+  private imagesAttached = false;
 
   constructor(toolName: string, args: unknown) {
     super();
@@ -96,13 +156,49 @@ export class ToolExecutionComponent extends Container {
     this.result = result;
     this.isPartial = false;
     this.isError = Boolean(opts?.isError);
+
+    // All I/O happens here, NOT in refresh(). Single-pass processes text and
+    // images together to avoid calling splitMediaFromOutput twice per block.
+    this.detachImages();
+    const processed = processResult(result, canRenderInlineImages());
+    this.cachedImages = processed.images;
+    this.cachedText = processed.text;
+    this.cachedTextStripped = processed.textStripped;
+
     this.refresh();
   }
 
   setPartialResult(result: ToolResult | undefined) {
     this.result = result;
     this.isPartial = true;
+    // Clear any cached images from a prior setResult() to prevent stale state
+    this.detachImages();
+    this.cachedImages = [];
+    this.cachedText = processResult(result, false).text;
+    this.cachedTextStripped = this.cachedText;
     this.refresh();
+  }
+
+  /** Remove image components from the box without destroying cached data. */
+  private detachImages() {
+    if (!this.imagesAttached) {
+      return;
+    }
+    for (const img of this.cachedImages) {
+      this.box.removeChild(img.component);
+    }
+    this.imagesAttached = false;
+  }
+
+  /** Attach cached image components to the box. */
+  private attachImages() {
+    if (this.imagesAttached || this.cachedImages.length === 0) {
+      return;
+    }
+    for (const img of this.cachedImages) {
+      this.box.addChild(img.component);
+    }
+    this.imagesAttached = true;
   }
 
   private refresh() {
@@ -123,8 +219,12 @@ export class ToolExecutionComponent extends Container {
     const argLine = formatArgs(this.toolName, this.args);
     this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
 
-    const raw = extractText(this.result);
+    // Use pre-cached text (with or without MEDIA: lines stripped).
+    // refresh() does zero I/O - all data was loaded in setResult().
+    const renderImages = !this.isPartial && this.cachedImages.length > 0;
+    const raw = renderImages ? this.cachedTextStripped : this.cachedText;
     const text = raw || (this.isPartial ? "…" : "");
+
     if (!this.expanded && text) {
       const lines = text.split("\n");
       const preview =
@@ -132,6 +232,13 @@ export class ToolExecutionComponent extends Container {
       this.output.setText(preview);
     } else {
       this.output.setText(text);
+    }
+
+    // Attach/detach stable Image components - no recreation, no I/O
+    if (renderImages) {
+      this.attachImages();
+    } else {
+      this.detachImages();
     }
   }
 }


### PR DESCRIPTION
## Summary

- Problem: When tools generate images (charts, diagrams, AI art via `image_generate`), the TUI shows `[image/png 800kb]` text placeholders. Users can't see images without switching to another app.
- Why it matters: Breaks the flow during iterative visual work. The `image_generate` tool landed recently (`3a456678ee`, `21c2ba480a`) but there's no rendering surface for it in the TUI.
- What changed: TUI tool result boxes now render images inline on terminals that support Kitty or iTerm2 graphics protocols, using pi-tui's built-in `Image` component. All file I/O happens once in `setResult()` and is cached - `refresh()` does zero I/O.
- What did NOT change (scope boundary): Gateway, WebUI, verbose filter, image tools, parse.ts, media store. Only TUI rendering is touched. Non-image-capable terminals keep the existing text fallback with zero behavior change.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #23764, #36641, #36740 (prior attempts - 1700+ lines / 26 files, all closed)
- Depends on `3a456678ee` feat(image-generation): add image_generate tool
- Depends on `21c2ba480a` Image generation: native provider migration (#49551)

## User-visible / Behavior Changes

On terminals with Kitty or iTerm2 graphics support (Kitty, WezTerm, iTerm2): tool results containing `MEDIA:` image paths now render the image inline inside the tool result box. `MEDIA:` path text is stripped when the image renders visually.

On all other terminals (VS Code, Windows Terminal, Apple Terminal): no change. Existing `[image/png 800kb]` text placeholders are preserved.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No - reads local files that tools already wrote to disk. Validated with: absolute path check, `lstatSync` symlink rejection, image extension whitelist, 6MB size bound with TOCTOU guard, `path.normalize` before all checks.

## Repro + Verification

### Environment

- OS: Windows 11 / macOS / Linux
- Runtime/container: Node 22+
- Model/provider: Any provider with `image_generate` configured (Google, OpenAI, fal, xAI)
- Integration/channel (if any): TUI only
- Relevant config (redacted): `agents.defaults.imageGenerationModel` set (or auto-inferred since `0aff1c7630`)

### Steps

1. Open the TUI in a Kitty/WezTerm/iTerm2 terminal
2. Ask the agent to generate an image: "Generate an image of a sunset over mountains"
3. Wait for the `image_generate` tool to complete

### Expected

- Image renders inline inside the tool result box
- `MEDIA:` path text is not visible (replaced by the visual image)
- Expanding/collapsing the tool result attaches/detaches the image without delay

### Actual

- Before this PR: `[image/png]` text placeholder shown, no visual rendering

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

63 tests pass across 5 test files (24 inline-image security/capability tests + 14 tool-execution lifecycle tests + 25 existing TUI component tests). `pnpm check` passes all 15 linters.

## Human Verification (required)

- Verified scenarios: Built worktree with `image_generate` on upstream/main, ran `pnpm check` (all pass), ran `vitest run src/tui/components/` (63/63 pass), verified `canRenderInlineImages()` detects WezTerm Kitty protocol support.
- Edge cases checked: symlink rejection, oversized files (>6MB), non-image extensions, null bytes in paths, relative paths, empty files, `..` traversal normalization, `setPartialResult` after `setResult` (stale cache clearing), double `setResult` (replacement).
- What you did **not** verify: Live end-to-end TUI rendering with actual image generation (waiting for stable main CI to do a full manual test).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot comments received yet (draft PR).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit touching `src/tui/components/tool-execution.ts`. The `canRenderInlineImages()` gate means non-image terminals are never affected.
- Files/config to restore: `src/tui/components/tool-execution.ts` (restore to upstream version). Delete `src/tui/components/inline-image.ts` and test files.
- Known bad symptoms reviewers should watch for: Garbled escape sequences in tool output on terminals that falsely report Kitty/iTerm2 support. TUI freezing after tool result (would indicate sync I/O leaked into render path - but this is architecturally prevented by the setResult/refresh split).

## Risks and Mitigations

- Risk: pi-tui `getCapabilities()` falsely detects image support on a terminal that doesn't actually render Kitty/iTerm2 protocol, producing garbled escape sequences.
  - Mitigation: This is a pi-tui detection issue, not specific to this PR. The `Image` component already has a text fallback path. Any detection bug would affect all pi-tui image users, not just this feature.
- Risk: Large images (up to 6MB base64 = ~8MB string) cached per tool result. With many image-producing tool results visible, memory usage grows.
  - Mitigation: ChatLog prunes oldest components at 180 entries. Cached images are GC'd when their ToolExecutionComponent is removed. In practice, most sessions have fewer than 5 image-producing tool results visible at once.
