### PR TITLE
fix(security): block JVM, Python, and .NET env injection vectors in host exec sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD Windows: fail closed when `qmd.cmd` or `mcporter.cmd` wrappers cannot be resolved to a direct entrypoint, so memory search no longer falls back to shell execution on Windows.
 - macOS/remote gateway: stop PortGuardian from killing Docker Desktop and other external listeners on the gateway port in remote mode, so containerized and tunneled gateway setups no longer lose their port-forward owner on app startup. (#6755) Thanks @teslamint.
 - Feishu/streaming recovery: clear stale `streamingStartPromise` when card creation fails (HTTP 400) so subsequent messages can retry streaming instead of silently dropping all future replies. Fixes #43322.
+- Exec/env sandbox: block JVM agent injection (`JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`), Python breakpoint hijack (`PYTHONBREAKPOINT`), and .NET startup hooks (`DOTNET_STARTUP_HOOKS`) from the host exec environment. (#49025)
 
 ## 2026.3.8
 

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -23,7 +23,12 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "PYTHONBREAKPOINT",
+        "DOTNET_STARTUP_HOOKS"
     ]
 
     static let blockedOverrideKeys: Set<String> = [

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -17,7 +17,12 @@
     "PS4",
     "GCONV_PATH",
     "IFS",
-    "SSLKEYLOGFILE"
+    "SSLKEYLOGFILE",
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "PYTHONBREAKPOINT",
+    "DOTNET_STARTUP_HOOKS"
   ],
   "blockedOverrideKeys": [
     "HOME",

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -48,6 +48,12 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("DYLD_INSERT_LIBRARIES")).toBe(true);
     expect(isDangerousHostEnvVarName("ld_preload")).toBe(true);
     expect(isDangerousHostEnvVarName("BASH_FUNC_echo%%")).toBe(true);
+    expect(isDangerousHostEnvVarName("JAVA_TOOL_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("_JAVA_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("JDK_JAVA_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("java_tool_options")).toBe(true);
+    expect(isDangerousHostEnvVarName("PYTHONBREAKPOINT")).toBe(true);
+    expect(isDangerousHostEnvVarName("DOTNET_STARTUP_HOOKS")).toBe(true);
     expect(isDangerousHostEnvVarName("PATH")).toBe(false);
     expect(isDangerousHostEnvVarName("FOO")).toBe(false);
   });

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -49,11 +49,15 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("ld_preload")).toBe(true);
     expect(isDangerousHostEnvVarName("BASH_FUNC_echo%%")).toBe(true);
     expect(isDangerousHostEnvVarName("JAVA_TOOL_OPTIONS")).toBe(true);
-    expect(isDangerousHostEnvVarName("_JAVA_OPTIONS")).toBe(true);
-    expect(isDangerousHostEnvVarName("JDK_JAVA_OPTIONS")).toBe(true);
     expect(isDangerousHostEnvVarName("java_tool_options")).toBe(true);
+    expect(isDangerousHostEnvVarName("_JAVA_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("_java_options")).toBe(true);
+    expect(isDangerousHostEnvVarName("JDK_JAVA_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("jdk_java_options")).toBe(true);
     expect(isDangerousHostEnvVarName("PYTHONBREAKPOINT")).toBe(true);
+    expect(isDangerousHostEnvVarName("pythonbreakpoint")).toBe(true);
     expect(isDangerousHostEnvVarName("DOTNET_STARTUP_HOOKS")).toBe(true);
+    expect(isDangerousHostEnvVarName("dotnet_startup_hooks")).toBe(true);
     expect(isDangerousHostEnvVarName("PATH")).toBe(false);
     expect(isDangerousHostEnvVarName("FOO")).toBe(false);
   });


### PR DESCRIPTION
Closes #22681

`JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, and `JDK_JAVA_OPTIONS` let an attacker inject `-javaagent` into any JVM process spawned by an agent. `PYTHONBREAKPOINT` can redirect Python's `breakpoint()` to an arbitrary callable like `os.system`. `DOTNET_STARTUP_HOOKS` loads arbitrary assemblies into .NET hosts before `Main()` runs. None of these have legitimate use inside the exec sandbox.

This adds all five vars to `blockedKeys` in `host-env-security-policy.json` and regenerates the Swift policy file. Strictly additive - no existing entries removed or moved.

### Changes

- `src/infra/host-env-security-policy.json`: add `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `PYTHONBREAKPOINT`, `DOTNET_STARTUP_HOOKS` to `blockedKeys`
- `apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift`: regenerated via `scripts/generate-host-env-security-policy-swift.mjs`
- `src/infra/host-env-security.test.ts`: assertions for all new entries including case-insensitive match

### Why these specific vars?

| Variable | Attack vector | Runtime |
|---|---|---|
| `JAVA_TOOL_OPTIONS` | Inject `-javaagent:/path/evil.jar` on any JVM startup (JVMTI standard) | JVM |
| `_JAVA_OPTIONS` | Same injection path, non-standard but supported by HotSpot/OpenJDK | JVM |
| `JDK_JAVA_OPTIONS` | Java 9+ standardized replacement | JVM |
| `PYTHONBREAKPOINT` | Redirects `breakpoint()` to arbitrary callable (e.g. `os.system`) | Python 3.7+ |
| `DOTNET_STARTUP_HOOKS` | Loads arbitrary assemblies and runs `StartupHook.Initialize()` before `Main()` | .NET Core 3.0+ |

### Not included (already covered or not dangerous)

- `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT` caught by existing `LD_` prefix block
- `DYLD_INSERT_LIBRARIES` caught by `DYLD_` prefix block
- `PYTHONPATH` and `PYTHONHOME` already in `blockedKeys`
- `PYTHONEXECUTABLE` excluded after verification - it only affects `sys.argv[0]` reporting on macOS, no execution control

### Prior art

#45174 by @BenediktSchackenberg covers some of the same JVM vars but bundles them with unrelated changes to `blockedOverrideKeys` (removes GIT_SSH, OPENSSL_CONF, HISTFILE, etc.). This PR is a focused subset that avoids those scope issues.

### Test plan

- [x] `pnpm test -- src/infra/host-env-security.test.ts` passes (11 tests)
- [x] `pnpm test -- src/agents/bash-tools.exec-runtime.test` passes (3 tests)
- [x] `pnpm check` clean
- [ ] CI green
