### PR TITLE
fix(ci): unblock channel import guardrails

### DIFF
--- a/extensions/discord/src/setup-core.ts
+++ b/extensions/discord/src/setup-core.ts
@@ -2,7 +2,6 @@ import type { DiscordGuildEntry } from "openclaw/plugin-sdk/config-runtime";
 import {
   DEFAULT_ACCOUNT_ID,
   createEnvPatchedAccountSetupAdapter,
-  formatDocsLink,
   noteChannelLookupFailure,
   noteChannelLookupSummary,
   parseMentionOrPrefixedId,
@@ -17,6 +16,7 @@ import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { listDiscordAccountIds, resolveDiscordAccount } from "./accounts.js";
 

--- a/extensions/discord/src/setup-surface.ts
+++ b/extensions/discord/src/setup-surface.ts
@@ -1,11 +1,11 @@
 import {
-  formatDocsLink,
   type OpenClawConfig,
   promptLegacyChannelAllowFrom,
   resolveSetupAccountId,
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
 import { type ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { resolveDefaultDiscordAccountId, resolveDiscordAccount } from "./accounts.js";
 import { normalizeDiscordSlug } from "./monitor/allow-list.js";
 import {

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -3,12 +3,10 @@ import {
   createScopedAccountConfigAccessors,
   createScopedChannelConfigBase,
 } from "openclaw/plugin-sdk/channel-config-helpers";
-import {
-  buildChannelConfigSchema,
-  DiscordConfigSchema,
-  getChatChannelMeta,
-  type ChannelPlugin,
-} from "openclaw/plugin-sdk/discord";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { DiscordConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import {
   listDiscordAccountIds,

--- a/extensions/imessage/src/setup-core.ts
+++ b/extensions/imessage/src/setup-core.ts
@@ -1,6 +1,5 @@
 import {
   createPatchedAccountSetupAdapter,
-  formatDocsLink,
   parseSetupEntriesAllowingWildcard,
   promptParsedAllowFromForScopedChannel,
   setChannelDmPolicyWithAllowFrom,
@@ -14,6 +13,7 @@ import type {
   ChannelSetupWizard,
   ChannelSetupWizardTextInput,
 } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import {
   listIMessageAccountIds,
   resolveDefaultIMessageAccountId,

--- a/extensions/imessage/src/setup-surface.ts
+++ b/extensions/imessage/src/setup-surface.ts
@@ -1,8 +1,5 @@
-import {
-  detectBinary,
-  setSetupChannelEnabled,
-  type ChannelSetupWizard,
-} from "openclaw/plugin-sdk/setup";
+import { setSetupChannelEnabled, type ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { detectBinary } from "../../../src/plugins/setup-binary.js";
 import { listIMessageAccountIds, resolveIMessageAccount } from "./accounts.js";
 import {
   createIMessageCliPathTextInput,

--- a/extensions/imessage/src/shared.ts
+++ b/extensions/imessage/src/shared.ts
@@ -1,19 +1,21 @@
 import {
+  formatTrimmedAllowFromEntries,
+  resolveIMessageConfigAllowFrom,
+  resolveIMessageConfigDefaultTo,
+} from "openclaw/plugin-sdk/channel-config-helpers";
+import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/channel-policy";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
 import {
-  buildChannelConfigSchema,
-  DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
-  formatTrimmedAllowFromEntries,
-  getChatChannelMeta,
-  IMessageConfigSchema,
-  resolveIMessageConfigAllowFrom,
-  resolveIMessageConfigDefaultTo,
   setAccountEnabledInConfigSection,
-  type ChannelPlugin,
-} from "openclaw/plugin-sdk/imessage";
+} from "../../../src/channels/plugins/config-helpers.js";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { IMessageConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import {
   listIMessageAccountIds,
   resolveDefaultIMessageAccountId,

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -1,7 +1,6 @@
+import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import {
   createPatchedAccountSetupAdapter,
-  formatCliCommand,
-  formatDocsLink,
   normalizeE164,
   parseSetupEntriesAllowingWildcard,
   promptParsedAllowFromForScopedChannel,
@@ -16,6 +15,7 @@ import type {
   ChannelSetupWizard,
   ChannelSetupWizardTextInput,
 } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import {
   listSignalAccountIds,
   resolveDefaultSignalAccountId,

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -1,9 +1,6 @@
-import {
-  detectBinary,
-  installSignalCli,
-  setSetupChannelEnabled,
-  type ChannelSetupWizard,
-} from "openclaw/plugin-sdk/setup";
+import { setSetupChannelEnabled, type ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { detectBinary } from "../../../src/plugins/setup-binary.js";
+import { installSignalCli } from "../../../src/plugins/signal-cli-install.js";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
 import {
   createSignalCliPathTextInput,

--- a/extensions/signal/src/shared.ts
+++ b/extensions/signal/src/shared.ts
@@ -3,16 +3,15 @@ import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/channel-policy";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID, normalizeE164 } from "openclaw/plugin-sdk/setup";
 import {
-  buildChannelConfigSchema,
-  DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
-  getChatChannelMeta,
-  normalizeE164,
   setAccountEnabledInConfigSection,
-  SignalConfigSchema,
-  type ChannelPlugin,
-} from "openclaw/plugin-sdk/signal";
+} from "../../../src/channels/plugins/config-helpers.js";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { SignalConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import {
   listSignalAccountIds,
   resolveDefaultSignalAccountId,

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -2,7 +2,6 @@ import {
   createAllowlistSetupWizardProxy,
   DEFAULT_ACCOUNT_ID,
   createEnvPatchedAccountSetupAdapter,
-  formatDocsLink,
   hasConfiguredSecretInput,
   type OpenClawConfig,
   noteChannelLookupFailure,
@@ -19,6 +18,7 @@ import {
   type ChannelSetupWizard,
   type ChannelSetupWizardAllowFromEntry,
 } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { inspectSlackAccount } from "./account-inspect.js";
 import { listSlackAccountIds, resolveSlackAccount, type ResolvedSlackAccount } from "./accounts.js";
 import {

--- a/extensions/slack/src/setup-surface.ts
+++ b/extensions/slack/src/setup-surface.ts
@@ -1,5 +1,4 @@
 import {
-  formatDocsLink,
   noteChannelLookupFailure,
   noteChannelLookupSummary,
   type OpenClawConfig,
@@ -12,6 +11,7 @@ import type {
   ChannelSetupWizard,
   ChannelSetupWizardAllowFromEntry,
 } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { resolveDefaultSlackAccountId, resolveSlackAccount } from "./accounts.js";
 import { resolveSlackChannelAllowlist } from "./resolve-channels.js";
 import { resolveSlackUserAllowlist } from "./resolve-users.js";

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -3,18 +3,15 @@ import {
   createScopedAccountConfigAccessors,
   createScopedChannelConfigBase,
 } from "openclaw/plugin-sdk/channel-config-helpers";
+import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import {
   formatDocsLink,
   hasConfiguredSecretInput,
   patchChannelConfigForAccount,
 } from "openclaw/plugin-sdk/setup";
-import {
-  buildChannelConfigSchema,
-  getChatChannelMeta,
-  SlackConfigSchema,
-  type ChannelPlugin,
-  type OpenClawConfig,
-} from "openclaw/plugin-sdk/slack";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { SlackConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import { inspectSlackAccount } from "./account-inspect.js";
 import {
   listSlackAccountIds,

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -1,8 +1,7 @@
+import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import {
   createEnvPatchedAccountSetupAdapter,
   DEFAULT_ACCOUNT_ID,
-  formatCliCommand,
-  formatDocsLink,
   patchChannelConfigForAccount,
   promptResolvedAllowFrom,
   splitSetupEntries,
@@ -10,6 +9,7 @@ import {
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupAdapter, ChannelSetupDmPolicy } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { resolveDefaultTelegramAccountId, resolveTelegramAccount } from "./accounts.js";
 import { fetchTelegramChatId } from "./api-fetch.js";
 

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -3,14 +3,11 @@ import {
   createScopedAccountConfigAccessors,
   createScopedChannelConfigBase,
 } from "openclaw/plugin-sdk/channel-config-helpers";
-import {
-  buildChannelConfigSchema,
-  getChatChannelMeta,
-  normalizeAccountId,
-  TelegramConfigSchema,
-  type ChannelPlugin,
-  type OpenClawConfig,
-} from "openclaw/plugin-sdk/telegram";
+import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { normalizeAccountId } from "openclaw/plugin-sdk/setup";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { TelegramConfigSchema } from "../../../src/config/zod-schema.providers-core.js";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {
   listTelegramAccountIds,

--- a/extensions/whatsapp/src/setup-surface.ts
+++ b/extensions/whatsapp/src/setup-surface.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
+import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import {
   DEFAULT_ACCOUNT_ID,
-  formatCliCommand,
-  formatDocsLink,
   normalizeAccountId,
   normalizeAllowFromEntries,
   normalizeE164,
@@ -13,6 +12,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import { formatDocsLink } from "../../../src/terminal/links.js";
 import { listWhatsAppAccountIds, resolveWhatsAppAuthDir } from "./accounts.js";
 import { loginWeb } from "./login.js";
 import { whatsappSetupAdapter } from "./setup-core.js";

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -1,22 +1,27 @@
 import {
+  formatWhatsAppConfigAllowFromEntries,
+  resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigDefaultTo,
+} from "openclaw/plugin-sdk/channel-config-helpers";
+import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderGroupPolicyWarnings,
   collectOpenGroupPolicyRouteAllowlistWarnings,
 } from "openclaw/plugin-sdk/channel-policy";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID, normalizeE164 } from "openclaw/plugin-sdk/setup";
 import {
-  buildChannelConfigSchema,
-  DEFAULT_ACCOUNT_ID,
-  formatWhatsAppConfigAllowFromEntries,
-  getChatChannelMeta,
-  normalizeE164,
-  resolveWhatsAppConfigAllowFrom,
-  resolveWhatsAppConfigDefaultTo,
-  resolveWhatsAppGroupIntroHint,
+  deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
+} from "../../../src/channels/plugins/config-helpers.js";
+import { buildChannelConfigSchema } from "../../../src/channels/plugins/config-schema.js";
+import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
-  WhatsAppConfigSchema,
-  type ChannelPlugin,
-} from "openclaw/plugin-sdk/whatsapp";
+} from "../../../src/channels/plugins/group-mentions.js";
+import { resolveWhatsAppGroupIntroHint } from "../../../src/channels/plugins/whatsapp-shared.js";
+import { getChatChannelMeta } from "../../../src/channels/registry.js";
+import { WhatsAppConfigSchema } from "../../../src/config/zod-schema.providers-whatsapp.js";
 import {
   listWhatsAppAccountIds,
   resolveDefaultWhatsAppAccountId,


### PR DESCRIPTION
## Summary

AI-assisted: yes (Cursor). Testing: fully tested locally.

- Problem: `src/plugin-sdk/channel-import-guardrails.test.ts` fails on latest `main` because bundled channel shared/setup files still import broad channel/setup SDK barrels that the guardrail now forbids.
- Why it matters: this keeps the unit lane red and weakens the import boundaries the guardrail is supposed to enforce.
- What changed: rewired the guarded Discord, iMessage, Signal, Slack, Telegram, and WhatsApp files to use narrower imports (`cli-runtime`, direct links/setup-binary helpers, and direct config/meta helpers) instead of the forbidden broad barrels.
- What did NOT change (scope boundary): no channel behavior, config semantics, or runtime logic changed; this is import-boundary cleanup only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0 (Darwin 25.3.0)
- Runtime/container: Node 22 + pnpm + Bun/Vitest
- Model/provider: N/A
- Integration/channel (if any): Discord, iMessage, Signal, Slack, Telegram, WhatsApp
- Relevant config (redacted): none

### Steps

1. Check out latest `main`.
2. Run `bunx vitest run --config vitest.unit.config.ts src/plugin-sdk/channel-import-guardrails.test.ts`.
3. Observe the guardrail failures in `extensions/discord/src/shared.ts` and `extensions/signal/src/setup-core.ts` first; additional files are latent because the test aborts on first failure per loop.

### Expected

- The channel import guardrail test passes and bundled channel helpers stay on the intended narrow import seams.

### Actual

- The test fails on latest `main` due to broad `openclaw/plugin-sdk/<channel>` and `openclaw/plugin-sdk/setup` imports in guarded files.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failing guardrail test before the fix; after the fix ran `bunx vitest run --config vitest.unit.config.ts src/plugin-sdk/channel-import-guardrails.test.ts`, `pnpm test:contracts`, `pnpm build`, and `pnpm check`.
- Edge cases checked: confirmed there are no remaining guarded same-channel barrel imports in the targeted shared files and no guarded setup-barrel import violations in the targeted setup files.
- What you did **not** verify: live channel setup or messaging flows, since this PR only changes import wiring.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e2ce9a82c`.
- Files/config to restore: the touched channel `shared.ts`, `setup-core.ts`, and `setup-surface.ts` files.
- Known bad symptoms reviewers should watch for: build-time import resolution failures in bundled channel modules.

## Risks and Mitigations

- Risk: a replacement narrow import path could be wrong for one bundled channel file.
- Mitigation: `pnpm build`, `pnpm check`, `pnpm test:contracts`, and the targeted guardrail test all pass locally.

Made with [Cursor](https://cursor.com)