### PR TITLE
feat(signal): reliable reply context, reaction wake, and quoted replies (v2)

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -35,6 +35,9 @@ import { getSignalRuntime } from "./runtime.js";
 import { signalSetupAdapter } from "./setup-core.js";
 import { createSignalPluginBase, signalConfigAccessors, signalSetupWizard } from "./shared.js";
 
+/** Default text chunk size for Signal outbound messages (chars). */
+const SIGNAL_TEXT_CHUNK_LIMIT = 4000;
+
 const signalMessageActions: ChannelMessageActionAdapter = {
   listActions: (ctx) => getSignalRuntime().channel.signal.messageActions?.listActions?.(ctx) ?? [],
   supportsAction: (ctx) =>
@@ -67,6 +70,30 @@ function resolveSignalSendContext(params: {
   return { send, maxBytes };
 }
 
+function resolveSignalQuoteParams(
+  to: string,
+  replyToId: string | null | undefined,
+  accountPhone: string | undefined,
+): { quoteTimestamp?: number; quoteAuthor?: string } {
+  if (!replyToId) {
+    return {};
+  }
+  const quoteTimestamp = Number(replyToId);
+  if (!Number.isFinite(quoteTimestamp) || quoteTimestamp <= 0) {
+    return {};
+  }
+  const normalizedTo = to.replace(/^signal:/i, "").trim();
+  const isGroup = normalizedTo.toLowerCase().startsWith("group:");
+  if (isGroup) {
+    return {};
+  }
+  const quoteAuthor = normalizedTo || accountPhone;
+  if (!quoteAuthor) {
+    return {};
+  }
+  return { quoteTimestamp, quoteAuthor };
+}
+
 async function sendSignalOutbound(params: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
   to: string;
@@ -74,15 +101,23 @@ async function sendSignalOutbound(params: {
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   accountId?: string;
+  replyToId?: string | null;
   deps?: { [channelId: string]: unknown };
 }) {
   const { send, maxBytes } = resolveSignalSendContext(params);
+  const accountInfo = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId });
+  const quoteParams = resolveSignalQuoteParams(
+    params.to,
+    params.replyToId,
+    accountInfo.config.account ?? undefined,
+  );
   return await send(params.to, params.text, {
     cfg: params.cfg,
     ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
     ...(params.mediaLocalRoots?.length ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
     maxBytes,
     accountId: params.accountId ?? undefined,
+    ...quoteParams,
   });
 }
 
@@ -350,7 +385,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     deliveryMode: "direct",
     chunker: (text, limit) => getSignalRuntime().channel.text.chunkText(text, limit),
     chunkerMode: "text",
-    textChunkLimit: 4000,
+    textChunkLimit: SIGNAL_TEXT_CHUNK_LIMIT,
     sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
       await sendFormattedSignalText({
         cfg,
@@ -380,17 +415,66 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         deps,
         abortSignal,
       }),
-    sendText: async ({ cfg, to, text, accountId, deps }) => {
+    sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
+      const urls: string[] = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (!text && urls.length === 0) {
+        return { channel: "signal", messageId: "" };
+      }
+      if (urls.length > 0) {
+        let lastResult: { channel: string; messageId: string } | undefined;
+        for (let i = 0; i < urls.length; i++) {
+          const mediaUrl = urls[i];
+          if (!mediaUrl) continue;
+          const result = await sendSignalOutbound({
+            cfg: ctx.cfg,
+            to: ctx.to,
+            text: i === 0 ? text : "",
+            mediaUrl,
+            mediaLocalRoots: ctx.mediaLocalRoots,
+            accountId: ctx.accountId ?? undefined,
+            replyToId: i === 0 ? (ctx.replyToId ?? undefined) : undefined,
+            deps: ctx.deps,
+          });
+          lastResult = { channel: "signal", ...result };
+        }
+        return lastResult ?? { channel: "signal", messageId: "" };
+      }
+      // Text-only: chunk and send; only first chunk carries the quote.
+      const limit = SIGNAL_TEXT_CHUNK_LIMIT;
+      const chunks = getSignalRuntime().channel.text.chunkText(text, limit);
+      let lastResult: { channel: string; messageId: string } | undefined;
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        if (!chunk) continue;
+        const result = await sendSignalOutbound({
+          cfg: ctx.cfg,
+          to: ctx.to,
+          text: chunk,
+          accountId: ctx.accountId ?? undefined,
+          replyToId: i === 0 ? (ctx.replyToId ?? undefined) : undefined,
+          deps: ctx.deps,
+        });
+        lastResult = { channel: "signal", ...result };
+      }
+      return lastResult ?? { channel: "signal", messageId: "" };
+    },
+    sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       const result = await sendSignalOutbound({
         cfg,
         to,
         text,
         accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
         deps,
       });
       return { channel: "signal", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
       const result = await sendSignalOutbound({
         cfg,
         to,
@@ -398,6 +482,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         mediaUrl,
         mediaLocalRoots,
         accountId: accountId ?? undefined,
+        replyToId: replyToId ?? undefined,
         deps,
       });
       return { channel: "signal", ...result };

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -209,6 +209,7 @@ async function sendFormattedSignalText(ctx: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
   to: string;
   text: string;
+  replyToId?: string | null;
   accountId?: string | null;
   deps?: { [channelId: string]: unknown };
   abortSignal?: AbortSignal;
@@ -234,7 +235,9 @@ async function sendFormattedSignalText(ctx: {
     chunks = [{ text: ctx.text, styles: [] }];
   }
   const results = [];
-  for (const chunk of chunks) {
+  for (let i = 0; i < chunks.length; i += 1) {
+    const chunk = chunks[i];
+    if (!chunk) continue;
     ctx.abortSignal?.throwIfAborted();
     const result = await send(ctx.to, chunk.text, {
       cfg: ctx.cfg,
@@ -242,6 +245,7 @@ async function sendFormattedSignalText(ctx: {
       accountId: ctx.accountId ?? undefined,
       textMode: "plain",
       textStyles: chunk.styles,
+      replyToId: i === 0 ? (ctx.replyToId ?? undefined) : undefined,
     });
     results.push({ channel: "signal" as const, ...result });
   }
@@ -254,6 +258,7 @@ async function sendFormattedSignalMedia(ctx: {
   text: string;
   mediaUrl: string;
   mediaLocalRoots?: readonly string[];
+  replyToId?: string | null;
   accountId?: string | null;
   deps?: { [channelId: string]: unknown };
   abortSignal?: AbortSignal;
@@ -283,6 +288,7 @@ async function sendFormattedSignalMedia(ctx: {
     accountId: ctx.accountId ?? undefined,
     textMode: "plain",
     textStyles: formatted.styles,
+    replyToId: ctx.replyToId ?? undefined,
   });
   return { channel: "signal" as const, ...result };
 }
@@ -363,11 +369,12 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     chunker: (text, limit) => getSignalRuntime().channel.text.chunkText(text, limit),
     chunkerMode: "text",
     textChunkLimit: SIGNAL_TEXT_CHUNK_LIMIT,
-    sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
+    sendFormattedText: async ({ cfg, to, text, replyToId, accountId, deps, abortSignal }) =>
       await sendFormattedSignalText({
         cfg,
         to,
         text,
+        replyToId,
         accountId,
         deps,
         abortSignal,
@@ -378,6 +385,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
       text,
       mediaUrl,
       mediaLocalRoots,
+      replyToId,
       accountId,
       deps,
       abortSignal,
@@ -388,6 +396,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         text,
         mediaUrl,
         mediaLocalRoots,
+        replyToId,
         accountId,
         deps,
         abortSignal,

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -23,6 +23,7 @@ import {
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/signal";
 import { resolveSignalAccount, type ResolvedSignalAccount } from "./accounts.js";
+import { resolveSignalQuoteParams } from "./send.js";
 import { markdownToSignalTextChunks } from "./format.js";
 import {
   looksLikeUuid,
@@ -70,29 +71,6 @@ function resolveSignalSendContext(params: {
   return { send, maxBytes };
 }
 
-function resolveSignalQuoteParams(
-  to: string,
-  replyToId: string | null | undefined,
-  accountPhone: string | undefined,
-): { quoteTimestamp?: number; quoteAuthor?: string } {
-  if (!replyToId) {
-    return {};
-  }
-  const quoteTimestamp = Number(replyToId);
-  if (!Number.isFinite(quoteTimestamp) || quoteTimestamp <= 0) {
-    return {};
-  }
-  const normalizedTo = to.replace(/^signal:/i, "").trim();
-  const isGroup = normalizedTo.toLowerCase().startsWith("group:");
-  if (isGroup) {
-    return {};
-  }
-  const quoteAuthor = normalizedTo || accountPhone;
-  if (!quoteAuthor) {
-    return {};
-  }
-  return { quoteTimestamp, quoteAuthor };
-}
 
 async function sendSignalOutbound(params: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
@@ -106,11 +84,10 @@ async function sendSignalOutbound(params: {
 }) {
   const { send, maxBytes } = resolveSignalSendContext(params);
   const accountInfo = resolveSignalAccount({ cfg: params.cfg, accountId: params.accountId });
-  const quoteParams = resolveSignalQuoteParams(
-    params.to,
-    params.replyToId,
-    accountInfo.config.account ?? undefined,
-  );
+  const quoteParams = resolveSignalQuoteParams({
+    to: params.to,
+    replyToId: params.replyToId ?? undefined,
+  });
   return await send(params.to, params.text, {
     cfg: params.cfg,
     ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -298,30 +298,35 @@ async function deliverReplies(params: {
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
+    const replyTo = payload.replyToId ?? undefined;
     if (!text && mediaList.length === 0) {
       continue;
     }
     if (mediaList.length === 0) {
+      let firstChunk = true;
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
         await sendMessageSignal(target, chunk, {
           baseUrl,
           account,
           maxBytes,
           accountId,
+          replyToId: firstChunk ? replyTo : undefined,
         });
+        firstChunk = false;
       }
     } else {
       let first = true;
       for (const url of mediaList) {
         const caption = first ? text : "";
-        first = false;
         await sendMessageSignal(target, caption, {
           baseUrl,
           account,
           mediaUrl: url,
           maxBytes,
           accountId,
+          replyToId: first ? replyTo : undefined,
         });
+        first = false;
       }
     }
     runtime.log?.(`delivered reply to ${target}`);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -13,6 +13,7 @@ import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
 import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/config-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+import { requestHeartbeatNow } from "openclaw/plugin-sdk/infra-runtime";
 import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { hasControlCommand } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
@@ -113,6 +114,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
+    replyToBody?: string;
+    replyToSender?: string;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -213,6 +217,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
@@ -459,6 +466,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       .filter(Boolean)
       .join(":");
     enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+    requestHeartbeatNow({ coalesceMs: 500, sessionKey: route.sessionKey });
     return true;
   }
 
@@ -778,6 +786,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const senderName = envelope.sourceName ?? senderDisplay;
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+    const quoteId = dataMessage.quote?.id;
+    const quoteAuthor =
+      dataMessage.quote?.author?.trim() ||
+      dataMessage.quote?.authorNumber?.trim() ||
+      undefined;
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,
@@ -796,6 +809,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId: typeof quoteId === "number" ? String(quoteId) : undefined,
+      replyToBody: quoteText || undefined,
+      replyToSender: quoteAuthor,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -37,7 +37,12 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | null;
+    text?: string | null;
+    author?: string | null;
+    authorNumber?: string | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 

--- a/extensions/signal/src/outbound-adapter.ts
+++ b/extensions/signal/src/outbound-adapter.ts
@@ -91,7 +91,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "signal", ...result };
   },
-  sendText: async ({ cfg, to, text, accountId, deps }) => {
+  sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
     const send = resolveSignalSender(deps);
     const maxBytes = resolveSignalMaxBytes({
       cfg,
@@ -101,10 +101,11 @@ export const signalOutbound: ChannelOutboundAdapter = {
       cfg,
       maxBytes,
       accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
     });
     return { channel: "signal", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
     const send = resolveSignalSender(deps);
     const maxBytes = resolveSignalMaxBytes({
       cfg,
@@ -115,6 +116,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       maxBytes,
       accountId: accountId ?? undefined,
+      replyToId: replyToId ?? undefined,
       mediaLocalRoots,
     });
     return { channel: "signal", ...result };

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -18,6 +18,16 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  /**
+   * Message ID (timestamp string) to quote/reply-to. When provided and quoteTimestamp
+   * is not set, this is parsed as the quote timestamp and `to` is used as quote-author
+   * (best-effort; works for DM inbound replies, skipped for groups).
+   */
+  replyToId?: string;
+  /** Timestamp of the message being quoted (from replyToId). Takes precedence over replyToId. */
+  quoteTimestamp?: number;
+  /** Author of the quoted message (UUID for inbound, phone number for outbound). */
+  quoteAuthor?: string;
 };
 
 export type SignalSendResult = {
@@ -169,6 +179,35 @@ export async function sendMessageSignal(
   }
   if (attachments && attachments.length > 0) {
     params.attachments = attachments;
+  }
+  // Resolve quote params: prefer explicit quoteTimestamp/quoteAuthor, fall back to replyToId.
+  let resolvedQuoteTimestamp = opts.quoteTimestamp;
+  let resolvedQuoteAuthor = opts.quoteAuthor?.trim();
+  if (
+    (typeof resolvedQuoteTimestamp !== "number" || !resolvedQuoteAuthor) &&
+    opts.replyToId?.trim()
+  ) {
+    const parsedTs = Number(opts.replyToId.trim());
+    if (Number.isFinite(parsedTs) && parsedTs > 0) {
+      // Best-effort: use `to` as quote-author for DM cases; skip for groups.
+      const normalizedTo = to.replace(/^signal:/i, "").trim();
+      const isGroup = normalizedTo.toLowerCase().startsWith("group:");
+      if (!isGroup) {
+        if (typeof resolvedQuoteTimestamp !== "number") {
+          resolvedQuoteTimestamp = parsedTs;
+        }
+        resolvedQuoteAuthor = resolvedQuoteAuthor || normalizedTo;
+      }
+    }
+  }
+  if (
+    typeof resolvedQuoteTimestamp === "number" &&
+    Number.isFinite(resolvedQuoteTimestamp) &&
+    resolvedQuoteTimestamp > 0 &&
+    resolvedQuoteAuthor
+  ) {
+    params["quote-timestamp"] = resolvedQuoteTimestamp;
+    params["quote-author"] = resolvedQuoteAuthor;
   }
 
   const targetParams = buildTargetParams(target, {

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -44,6 +44,59 @@ type SignalTarget =
   | { type: "group"; groupId: string }
   | { type: "username"; username: string };
 
+function normalizeSignalQuoteAuthorFromTarget(rawTo: string): string | undefined {
+  let value = rawTo.trim();
+  if (!value) {
+    return undefined;
+  }
+  if (/^signal:/i.test(value)) {
+    value = value.replace(/^signal:/i, "").trim();
+  }
+  if (!value) {
+    return undefined;
+  }
+  const lower = value.toLowerCase();
+  if (lower.startsWith("group:")) {
+    return undefined;
+  }
+  if (lower.startsWith("username:")) {
+    value = value.slice("username:".length).trim();
+  } else if (lower.startsWith("u:")) {
+    value = value.slice("u:".length).trim();
+  }
+  return value || undefined;
+}
+
+export function resolveSignalQuoteParams(input: {
+  to: string;
+  replyToId?: string;
+  quoteTimestamp?: number;
+  quoteAuthor?: string;
+}): { quoteTimestamp?: number; quoteAuthor?: string } {
+  let quoteTimestamp = input.quoteTimestamp;
+  let quoteAuthor = input.quoteAuthor?.trim();
+
+  if ((typeof quoteTimestamp !== "number" || !quoteAuthor) && input.replyToId?.trim()) {
+    const parsedTs = Number(input.replyToId.trim());
+    if (Number.isFinite(parsedTs) && parsedTs > 0) {
+      if (typeof quoteTimestamp !== "number") {
+        quoteTimestamp = parsedTs;
+      }
+      quoteAuthor = quoteAuthor || normalizeSignalQuoteAuthorFromTarget(input.to);
+    }
+  }
+
+  if (
+    typeof quoteTimestamp === "number" &&
+    Number.isFinite(quoteTimestamp) &&
+    quoteTimestamp > 0 &&
+    quoteAuthor
+  ) {
+    return { quoteTimestamp, quoteAuthor };
+  }
+  return {};
+}
+
 function parseTarget(raw: string): SignalTarget {
   let value = raw.trim();
   if (!value) {
@@ -180,34 +233,15 @@ export async function sendMessageSignal(
   if (attachments && attachments.length > 0) {
     params.attachments = attachments;
   }
-  // Resolve quote params: prefer explicit quoteTimestamp/quoteAuthor, fall back to replyToId.
-  let resolvedQuoteTimestamp = opts.quoteTimestamp;
-  let resolvedQuoteAuthor = opts.quoteAuthor?.trim();
-  if (
-    (typeof resolvedQuoteTimestamp !== "number" || !resolvedQuoteAuthor) &&
-    opts.replyToId?.trim()
-  ) {
-    const parsedTs = Number(opts.replyToId.trim());
-    if (Number.isFinite(parsedTs) && parsedTs > 0) {
-      // Best-effort: use `to` as quote-author for DM cases; skip for groups.
-      const normalizedTo = to.replace(/^signal:/i, "").trim();
-      const isGroup = normalizedTo.toLowerCase().startsWith("group:");
-      if (!isGroup) {
-        if (typeof resolvedQuoteTimestamp !== "number") {
-          resolvedQuoteTimestamp = parsedTs;
-        }
-        resolvedQuoteAuthor = resolvedQuoteAuthor || normalizedTo;
-      }
-    }
-  }
-  if (
-    typeof resolvedQuoteTimestamp === "number" &&
-    Number.isFinite(resolvedQuoteTimestamp) &&
-    resolvedQuoteTimestamp > 0 &&
-    resolvedQuoteAuthor
-  ) {
-    params["quote-timestamp"] = resolvedQuoteTimestamp;
-    params["quote-author"] = resolvedQuoteAuthor;
+  const resolvedQuote = resolveSignalQuoteParams({
+    to,
+    replyToId: opts.replyToId,
+    quoteTimestamp: opts.quoteTimestamp,
+    quoteAuthor: opts.quoteAuthor,
+  });
+  if (typeof resolvedQuote.quoteTimestamp === "number" && resolvedQuote.quoteAuthor) {
+    params["quote-timestamp"] = resolvedQuote.quoteTimestamp;
+    params["quote-author"] = resolvedQuote.quoteAuthor;
   }
 
   const targetParams = buildTargetParams(target, {

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -17,6 +17,7 @@ export * from "../infra/format-time/format-duration.ts";
 export * from "../infra/fs-safe.ts";
 export * from "../infra/heartbeat-events.ts";
 export * from "../infra/heartbeat-visibility.ts";
+export { requestHeartbeatNow } from "../infra/heartbeat-wake.ts";
 export * from "../infra/home-dir.js";
 export * from "../infra/http-body.js";
 export * from "../infra/json-files.js";


### PR DESCRIPTION
Supersedes #47368.

Includes:
- inbound Signal quote context (ReplyToId/ReplyToBody/ReplyToSender)
- immediate wake on reactions
- outbound quoted replies with quote-timestamp/quote-author
- first-chunk-only quote behavior for chunked messages