### PR TITLE
tests(contracts): fix provider catalog runtime wiring

### DIFF
--- a/src/plugins/contracts/catalog.contract.test.ts
+++ b/src/plugins/contracts/catalog.contract.test.ts
@@ -5,36 +5,57 @@ import {
   expectCodexMissingAuthHint,
 } from "../provider-runtime.test-support.js";
 import {
-  providerContractPluginIds,
+  resolveProviderContractPluginIdsForProvider,
   resolveProviderContractProvidersForPluginIds,
   uniqueProviderContractProviders,
 } from "./registry.js";
 
-const resolvePluginProvidersMock = vi.fn();
-const resolveOwningPluginIdsForProviderMock = vi.fn();
-const resolveNonBundledProviderPluginIdsMock = vi.fn();
+type ResolvePluginProviders = typeof import("../providers.js").resolvePluginProviders;
+type ResolveOwningPluginIdsForProvider =
+  typeof import("../providers.js").resolveOwningPluginIdsForProvider;
+type ResolveNonBundledProviderPluginIds =
+  typeof import("../providers.js").resolveNonBundledProviderPluginIds;
+
+const resolvePluginProvidersMock = vi.hoisted(() =>
+  vi.fn<ResolvePluginProviders>((_) => uniqueProviderContractProviders),
+);
+const resolveOwningPluginIdsForProviderMock = vi.hoisted(() =>
+  vi.fn<ResolveOwningPluginIdsForProvider>((params) =>
+    resolveProviderContractPluginIdsForProvider(params.provider),
+  ),
+);
+const resolveNonBundledProviderPluginIdsMock = vi.hoisted(() =>
+  vi.fn<ResolveNonBundledProviderPluginIds>((_) => [] as string[]),
+);
 
 vi.mock("../providers.js", () => ({
-  resolvePluginProviders: (...args: unknown[]) => resolvePluginProvidersMock(...args),
-  resolveOwningPluginIdsForProvider: (...args: unknown[]) =>
-    resolveOwningPluginIdsForProviderMock(...args),
-  resolveNonBundledProviderPluginIds: (...args: unknown[]) =>
-    resolveNonBundledProviderPluginIdsMock(...args),
+  resolvePluginProviders: (params: unknown) => resolvePluginProvidersMock(params as never),
+  resolveOwningPluginIdsForProvider: (params: unknown) =>
+    resolveOwningPluginIdsForProviderMock(params as never),
+  resolveNonBundledProviderPluginIds: (params: unknown) =>
+    resolveNonBundledProviderPluginIdsMock(params as never),
 }));
 
-const {
-  augmentModelCatalogWithProviderPlugins,
-  buildProviderMissingAuthMessageWithPlugin,
-  resetProviderRuntimeHookCacheForTest,
-  resolveProviderBuiltInModelSuppression,
-} = await import("../provider-runtime.js");
+let augmentModelCatalogWithProviderPlugins: typeof import("../provider-runtime.js").augmentModelCatalogWithProviderPlugins;
+let buildProviderMissingAuthMessageWithPlugin: typeof import("../provider-runtime.js").buildProviderMissingAuthMessageWithPlugin;
+let resetProviderRuntimeHookCacheForTest: typeof import("../provider-runtime.js").resetProviderRuntimeHookCacheForTest;
+let resolveProviderBuiltInModelSuppression: typeof import("../provider-runtime.js").resolveProviderBuiltInModelSuppression;
 
 describe("provider catalog contract", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({
+      augmentModelCatalogWithProviderPlugins,
+      buildProviderMissingAuthMessageWithPlugin,
+      resetProviderRuntimeHookCacheForTest,
+      resolveProviderBuiltInModelSuppression,
+    } = await import("../provider-runtime.js"));
     resetProviderRuntimeHookCacheForTest();
 
     resolveOwningPluginIdsForProviderMock.mockReset();
-    resolveOwningPluginIdsForProviderMock.mockReturnValue(providerContractPluginIds);
+    resolveOwningPluginIdsForProviderMock.mockImplementation((params) =>
+      resolveProviderContractPluginIdsForProvider(params.provider),
+    );
 
     resolveNonBundledProviderPluginIdsMock.mockReset();
     resolveNonBundledProviderPluginIdsMock.mockReturnValue([]);

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -177,6 +177,19 @@ export function requireProviderContractProvider(providerId: string): ProviderPlu
   return provider;
 }
 
+export function resolveProviderContractPluginIdsForProvider(
+  providerId: string,
+): string[] | undefined {
+  const pluginIds = [
+    ...new Set(
+      providerContractRegistry
+        .filter((entry) => entry.provider.id === providerId)
+        .map((entry) => entry.pluginId),
+    ),
+  ];
+  return pluginIds.length > 0 ? pluginIds : undefined;
+}
+
 export function resolveProviderContractProvidersForPluginIds(
   pluginIds: readonly string[],
 ): ProviderPlugin[] {


### PR DESCRIPTION
## Summary
- fix the provider catalog contract to mirror real provider ownership instead of treating every bundled plugin as an owner
- hoist the `../providers.js` mocks so the catalog contract stays stable inside the full `src/plugins/contracts` suite
- re-import `provider-runtime.js` per test to avoid stale hook-module state across contract files

## Provenance
- this contract drift came from earlier catalog-contract refactors, especially `750ce393bc` (`Plugins: stabilize global catalog contracts`), `0a93e22b37` (`Plugins: fix catalog contract mocks`), `6c866b8543` (`Tests: centralize contract coverage follow-ups`), and the later assertion-sharing refactor in `5747700b3c` (`refactor(provider-tests): share codex catalog assertions`)
- the runtime behavior was still correct; the failure was in the contract test harness, which mocked provider ownership too broadly and relied on non-hoisted module mocks plus a one-time top-level import of `provider-runtime.js`
- that made the file pass in isolation but fail under the full `src/plugins/contracts` suite when runtime/mock state leaked across files

## Testing
- pnpm test -- src/plugins/contracts/catalog.contract.test.ts
- pnpm test -- src/plugins/contracts
- pnpm test:contracts
- pnpm check
