### PR TITLE
CI: rename startup-memory to build-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,8 +304,8 @@ jobs:
       - name: Enforce safe external URL opening policy
         run: pnpm lint:ui:no-raw-window-open
 
-  startup-memory:
-    name: "startup-memory"
+  build-smoke:
+    name: "build-smoke"
     needs: [docs-scope, changed-scope]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the CI smoke lane is still named `startup-memory`, which no longer matches its broader role.
- Why it matters: the current name is misleading when discussing or extending post-build smoke coverage.
- What changed: renamed the workflow job key and displayed check name from `startup-memory` to `build-smoke` in `.github/workflows/ci.yml`.
- What did NOT change (scope boundary): this PR does not add or modify smoke behavior, test scripts, build outputs, or any runtime logic.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48710

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local git worktree
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions workflow config
- Relevant config (redacted): none

### Steps

1. Check `.github/workflows/ci.yml` on `main` and locate the `startup-memory` job.
2. Apply the rename so the job key and surfaced name are both `build-smoke`.
3. Confirm the diff is limited to that rename.

### Expected

- The workflow exposes the lane as `build-smoke` and no other behavior changes are introduced.

### Actual

- The rename is isolated to `.github/workflows/ci.yml`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the workflow diff and confirmed only the job key/name rename is present.
- Edge cases checked: confirmed no additional scripts, steps, or unrelated files changed on this branch.
- What you did **not** verify: I did not validate branch-protection status-check configuration; maintainers will need to coordinate that separately if `startup-memory` is currently required.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Yes
- If yes, exact upgrade steps: update any required-status-check or automation references from `startup-memory` to `build-smoke` before relying on the renamed check.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the old check name.
- Files/config to restore: `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for: branch protection or automation waiting on `startup-memory` after the rename lands.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: required status checks or automations may still reference `startup-memory`.
  - Mitigation: coordinate status-check and automation updates at the same time as merge, or defer merge until those references are updated.