### PR TITLE
CI: guard gateway watch against duplicate runtime regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,34 @@ jobs:
       - name: Check CLI startup memory
         run: pnpm test:startup:memory
 
+  gateway-watch-regression:
+    name: "gateway-watch-regression"
+    needs: [docs-scope, changed-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Run gateway watch regression harness
+        run: pnpm test:gateway:watch-regression
+
+      - name: Upload gateway watch regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gateway-watch-regression
+          path: .local/gateway-watch-regression/
+          retention-days: 7
+
   # Validate docs (format, lint, broken links) only when docs files changed.
   check-docs:
     needs: [docs-scope]

--- a/package.json
+++ b/package.json
@@ -553,6 +553,7 @@
     "test:fast": "vitest run --config vitest.unit.config.ts",
     "test:force": "node --import tsx scripts/test-force.ts",
     "test:gateway": "vitest run --config vitest.gateway.config.ts --pool=forks",
+    "test:gateway:watch-regression": "node scripts/check-gateway-watch-regression.mjs",
     "test:install:e2e": "bash scripts/test-install-sh-e2e-docker.sh",
     "test:install:e2e:anthropic": "OPENCLAW_E2E_MODELS=anthropic CLAWDBOT_E2E_MODELS=anthropic bash scripts/test-install-sh-e2e-docker.sh",
     "test:install:e2e:openai": "OPENCLAW_E2E_MODELS=openai CLAWDBOT_E2E_MODELS=openai bash scripts/test-install-sh-e2e-docker.sh",

--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -215,12 +215,16 @@ async function runTimedWatch(options, outputDir) {
   const stderrPath = path.join(outputDir, "watch.stderr.log");
   const startedAt = Date.now();
   let startupReadyMs = null;
-  const child = spawn("pnpm", ["gateway:watch"], {
-    cwd: process.cwd(),
-    env: process.env,
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: true,
-  });
+  const child = spawn(
+    process.execPath,
+    ["scripts/watch-node.mjs", "gateway", "--force", "--allow-unconfigured"],
+    {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    },
+  );
   const watchPid = child.pid;
   if (typeof watchPid !== "number") {
     throw new Error("Failed to spawn pnpm gateway:watch");

--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -1,0 +1,487 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const DEFAULTS = {
+  outputDir: path.join(process.cwd(), ".local", "gateway-watch-regression"),
+  windowMs: 8_000,
+  sigkillGraceMs: 3_000,
+  cpuWarnMs: 500,
+  cpuFailMs: 8_000,
+  distRuntimeFileGrowthMax: 200,
+  distRuntimeByteGrowthMax: 2 * 1024 * 1024,
+  keepLogs: true,
+  skipBuild: false,
+};
+
+function parseArgs(argv) {
+  const options = { ...DEFAULTS };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    const readValue = () => {
+      if (!next) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      i += 1;
+      return next;
+    };
+    switch (arg) {
+      case "--output-dir":
+        options.outputDir = path.resolve(readValue());
+        break;
+      case "--window-ms":
+        options.windowMs = Number(readValue());
+        break;
+      case "--sigkill-grace-ms":
+        options.sigkillGraceMs = Number(readValue());
+        break;
+      case "--cpu-warn-ms":
+        options.cpuWarnMs = Number(readValue());
+        break;
+      case "--cpu-fail-ms":
+        options.cpuFailMs = Number(readValue());
+        break;
+      case "--dist-runtime-file-growth-max":
+        options.distRuntimeFileGrowthMax = Number(readValue());
+        break;
+      case "--dist-runtime-byte-growth-max":
+        options.distRuntimeByteGrowthMax = Number(readValue());
+        break;
+      case "--skip-build":
+        options.skipBuild = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function normalizePath(filePath) {
+  return filePath.replaceAll("\\", "/");
+}
+
+function listTreeEntries(rootName) {
+  const rootPath = path.join(process.cwd(), rootName);
+  if (!fs.existsSync(rootPath)) {
+    return [`${rootName} (missing)`];
+  }
+
+  const entries = [rootName];
+  const queue = [rootPath];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    const dirents = fs.readdirSync(current, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const fullPath = path.join(current, dirent.name);
+      const relativePath = normalizePath(path.relative(process.cwd(), fullPath));
+      entries.push(relativePath);
+      if (dirent.isDirectory()) {
+        queue.push(fullPath);
+      }
+    }
+  }
+  return entries.toSorted((a, b) => a.localeCompare(b));
+}
+
+function humanBytes(bytes) {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}K`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}G`;
+}
+
+function snapshotTree(rootName) {
+  const rootPath = path.join(process.cwd(), rootName);
+  const stats = {
+    exists: fs.existsSync(rootPath),
+    files: 0,
+    directories: 0,
+    symlinks: 0,
+    entries: 0,
+    apparentBytes: 0,
+  };
+
+  if (!stats.exists) {
+    return stats;
+  }
+
+  const queue = [rootPath];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    const currentStats = fs.lstatSync(current);
+    stats.entries += 1;
+    if (currentStats.isDirectory()) {
+      stats.directories += 1;
+      for (const dirent of fs.readdirSync(current, { withFileTypes: true })) {
+        queue.push(path.join(current, dirent.name));
+      }
+      continue;
+    }
+    if (currentStats.isSymbolicLink()) {
+      stats.symlinks += 1;
+      continue;
+    }
+    if (currentStats.isFile()) {
+      stats.files += 1;
+      stats.apparentBytes += currentStats.size;
+    }
+  }
+
+  return stats;
+}
+
+function writeSnapshot(snapshotDir) {
+  ensureDir(snapshotDir);
+  const pathEntries = [...listTreeEntries("dist"), ...listTreeEntries("dist-runtime")];
+  fs.writeFileSync(path.join(snapshotDir, "paths.txt"), `${pathEntries.join("\n")}\n`, "utf8");
+
+  const dist = snapshotTree("dist");
+  const distRuntime = snapshotTree("dist-runtime");
+  const snapshot = {
+    generatedAt: new Date().toISOString(),
+    dist,
+    distRuntime,
+  };
+  fs.writeFileSync(
+    path.join(snapshotDir, "snapshot.json"),
+    `${JSON.stringify(snapshot, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(snapshotDir, "stats.txt"),
+    [
+      `generated_at: ${snapshot.generatedAt}`,
+      "",
+      "[dist]",
+      `files: ${dist.files}`,
+      `directories: ${dist.directories}`,
+      `symlinks: ${dist.symlinks}`,
+      `entries: ${dist.entries}`,
+      `apparent_bytes: ${dist.apparentBytes}`,
+      `apparent_human: ${humanBytes(dist.apparentBytes)}`,
+      "",
+      "[dist-runtime]",
+      `files: ${distRuntime.files}`,
+      `directories: ${distRuntime.directories}`,
+      `symlinks: ${distRuntime.symlinks}`,
+      `entries: ${distRuntime.entries}`,
+      `apparent_bytes: ${distRuntime.apparentBytes}`,
+      `apparent_human: ${humanBytes(distRuntime.apparentBytes)}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return snapshot;
+}
+
+function runCheckedCommand(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (typeof result.status === "number" && result.status === 0) {
+    return;
+  }
+  throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? "unknown"}`);
+}
+
+function buildTimeCommandArgs(pidFilePath) {
+  const wrapperSource = [
+    "const fs = require('node:fs');",
+    "const { spawn } = require('node:child_process');",
+    "const child = spawn('pnpm', ['gateway:watch'], {",
+    "  cwd: process.cwd(),",
+    "  env: process.env,",
+    "  stdio: 'inherit',",
+    "  detached: true,",
+    "});",
+    "fs.writeFileSync(process.env.OPENCLAW_WATCH_CHILD_PID_FILE, `${child.pid}\\n`, 'utf8');",
+    "child.on('exit', (code, signal) => {",
+    "  if (typeof code === 'number') process.exit(code);",
+    "  process.exit(signal ? 128 : 0);",
+    "});",
+  ].join(" ");
+  if (process.platform === "darwin") {
+    return {
+      command: "/usr/bin/time",
+      args: ["-lp", process.execPath, "-e", wrapperSource],
+      extraEnv: { OPENCLAW_WATCH_CHILD_PID_FILE: pidFilePath },
+    };
+  }
+  return {
+    command: "/usr/bin/time",
+    args: ["-f", "__TIMING__ user=%U sys=%S elapsed=%e", process.execPath, "-e", wrapperSource],
+    extraEnv: { OPENCLAW_WATCH_CHILD_PID_FILE: pidFilePath },
+  };
+}
+
+function parseTiming(stderrText) {
+  if (process.platform === "darwin") {
+    const user = Number(stderrText.match(/^user\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    const sys = Number(stderrText.match(/^sys\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    const elapsed = Number(stderrText.match(/^real\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    return {
+      userSeconds: user,
+      sysSeconds: sys,
+      elapsedSeconds: elapsed,
+    };
+  }
+
+  const match = stderrText.match(/__TIMING__ user=([0-9.]+) sys=([0-9.]+) elapsed=([0-9.]+)/);
+  return {
+    userSeconds: Number(match?.[1] ?? "NaN"),
+    sysSeconds: Number(match?.[2] ?? "NaN"),
+    elapsedSeconds: Number(match?.[3] ?? "NaN"),
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runTimedWatch(options, outputDir) {
+  const pidFilePath = path.join(outputDir, "watch.child.pid");
+  const { command: timeCommand, args: timeArgs, extraEnv } = buildTimeCommandArgs(pidFilePath);
+  const stdoutPath = path.join(outputDir, "watch.stdout.log");
+  const stderrPath = path.join(outputDir, "watch.stderr.log");
+  const child = spawn(timeCommand, timeArgs, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...extraEnv },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+
+  const exitPromise = new Promise((resolve) => {
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+
+  let watchChildPid = null;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (fs.existsSync(pidFilePath)) {
+      watchChildPid = Number(fs.readFileSync(pidFilePath, "utf8").trim());
+      break;
+    }
+    await sleep(100);
+  }
+
+  await sleep(options.windowMs);
+  if (watchChildPid) {
+    try {
+      process.kill(-watchChildPid, "SIGTERM");
+    } catch {
+      // ignore
+    }
+  }
+
+  const gracefulExit = await Promise.race([
+    exitPromise,
+    sleep(options.sigkillGraceMs).then(() => null),
+  ]);
+
+  if (gracefulExit === null) {
+    if (watchChildPid) {
+      try {
+        process.kill(-watchChildPid, "SIGKILL");
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  const exit = (await exitPromise) ?? { code: null, signal: null };
+  fs.writeFileSync(stdoutPath, stdout, "utf8");
+  fs.writeFileSync(stderrPath, stderr, "utf8");
+
+  return {
+    exit,
+    timing: parseTiming(stderr),
+    stdoutPath,
+    stderrPath,
+  };
+}
+
+function isDirtyWatchTree() {
+  const result = spawnSync(
+    "git",
+    [
+      "status",
+      "--porcelain",
+      "--untracked-files=normal",
+      "--",
+      "src",
+      "extensions",
+      "package.json",
+      "tsconfig.json",
+      "tsdown.config.ts",
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  if (result.status !== 0) {
+    return null;
+  }
+  return (result.stdout ?? "").trim().length > 0;
+}
+
+function parsePathFile(filePath) {
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+}
+
+function writeDiffArtifacts(outputDir, preDir, postDir) {
+  const diffDir = path.join(outputDir, "diff");
+  ensureDir(diffDir);
+  const prePaths = parsePathFile(path.join(preDir, "paths.txt"));
+  const postPaths = parsePathFile(path.join(postDir, "paths.txt"));
+  const preSet = new Set(prePaths);
+  const postSet = new Set(postPaths);
+  const added = postPaths.filter((entry) => !preSet.has(entry));
+  const removed = prePaths.filter((entry) => !postSet.has(entry));
+
+  fs.writeFileSync(path.join(diffDir, "added-paths.txt"), `${added.join("\n")}\n`, "utf8");
+  fs.writeFileSync(path.join(diffDir, "removed-paths.txt"), `${removed.join("\n")}\n`, "utf8");
+  return { added, removed };
+}
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+}
+
+function warn(message) {
+  console.warn(`WARN: ${message}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  ensureDir(options.outputDir);
+  if (!options.skipBuild) {
+    runCheckedCommand("pnpm", ["build"]);
+  }
+
+  const preDir = path.join(options.outputDir, "pre");
+  const pre = writeSnapshot(preDir);
+
+  const watchDir = path.join(options.outputDir, "watch");
+  ensureDir(watchDir);
+  const dirtyWatchTree = isDirtyWatchTree();
+  const watchResult = await runTimedWatch(options, watchDir);
+
+  const postDir = path.join(options.outputDir, "post");
+  const post = writeSnapshot(postDir);
+  const diff = writeDiffArtifacts(options.outputDir, preDir, postDir);
+
+  const distRuntimeFileGrowth = post.distRuntime.files - pre.distRuntime.files;
+  const distRuntimeByteGrowth = post.distRuntime.apparentBytes - pre.distRuntime.apparentBytes;
+  const distRuntimeAddedPaths = diff.added.filter((entry) =>
+    entry.startsWith("dist-runtime/"),
+  ).length;
+  const cpuMs = Math.round((watchResult.timing.userSeconds + watchResult.timing.sysSeconds) * 1000);
+  const watchTriggeredBuild =
+    fs
+      .readFileSync(watchResult.stderrPath, "utf8")
+      .includes("Building TypeScript (dist is stale).") ||
+    fs
+      .readFileSync(watchResult.stdoutPath, "utf8")
+      .includes("Building TypeScript (dist is stale).");
+
+  const summary = {
+    windowMs: options.windowMs,
+    dirtyWatchTree,
+    watchTriggeredBuild,
+    cpuMs,
+    cpuWarnMs: options.cpuWarnMs,
+    cpuFailMs: options.cpuFailMs,
+    distRuntimeFileGrowth,
+    distRuntimeFileGrowthMax: options.distRuntimeFileGrowthMax,
+    distRuntimeByteGrowth,
+    distRuntimeByteGrowthMax: options.distRuntimeByteGrowthMax,
+    distRuntimeAddedPaths,
+    addedPaths: diff.added.length,
+    removedPaths: diff.removed.length,
+    watchExit: watchResult.exit,
+    timing: watchResult.timing,
+  };
+  fs.writeFileSync(
+    path.join(options.outputDir, "summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  const failures = [];
+  const skipCpuGate = dirtyWatchTree === true && watchTriggeredBuild;
+  if (distRuntimeFileGrowth > options.distRuntimeFileGrowthMax) {
+    failures.push(
+      `dist-runtime file growth ${distRuntimeFileGrowth} exceeded max ${options.distRuntimeFileGrowthMax}`,
+    );
+  }
+  if (distRuntimeByteGrowth > options.distRuntimeByteGrowthMax) {
+    failures.push(
+      `dist-runtime apparent byte growth ${distRuntimeByteGrowth} exceeded max ${options.distRuntimeByteGrowthMax}`,
+    );
+  }
+  if (skipCpuGate) {
+    warn(
+      "Skipping CPU threshold gate because the watched tree is dirty and gateway:watch rebuilt dist.",
+    );
+  } else {
+    if (!Number.isFinite(cpuMs)) {
+      failures.push("failed to parse CPU timing from gateway:watch run");
+    }
+    if (cpuMs > options.cpuFailMs) {
+      failures.push(
+        `gateway:watch used ${cpuMs}ms CPU in ${options.windowMs}ms window (max ${options.cpuFailMs}ms)`,
+      );
+    }
+    if (cpuMs > options.cpuWarnMs) {
+      warn(`gateway:watch used ${cpuMs}ms CPU, above warn threshold ${options.cpuWarnMs}ms`);
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const message of failures) {
+      fail(message);
+    }
+    fail(
+      "Possible duplicate dist-runtime graph regression: this can reintroduce split runtime personalities where plugins and core observe different global state, including Telegram missing /voice, /phone, or /pair.",
+    );
+    process.exit(1);
+  }
+}
+
+await main();

--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -2,15 +2,16 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
 const DEFAULTS = {
   outputDir: path.join(process.cwd(), ".local", "gateway-watch-regression"),
-  windowMs: 8_000,
+  windowMs: 10_000,
   sigkillGraceMs: 10_000,
-  startupReadyWarnMs: 5_000,
-  startupReadyFailMs: 8_000,
+  cpuWarnMs: 1_000,
+  cpuFailMs: 8_000,
   distRuntimeFileGrowthMax: 200,
   distRuntimeByteGrowthMax: 2 * 1024 * 1024,
   keepLogs: true,
@@ -39,11 +40,11 @@ function parseArgs(argv) {
       case "--sigkill-grace-ms":
         options.sigkillGraceMs = Number(readValue());
         break;
-      case "--startup-ready-warn-ms":
-        options.startupReadyWarnMs = Number(readValue());
+      case "--cpu-warn-ms":
+        options.cpuWarnMs = Number(readValue());
         break;
-      case "--startup-ready-fail-ms":
-        options.startupReadyFailMs = Number(readValue());
+      case "--cpu-fail-ms":
+        options.cpuFailMs = Number(readValue());
         break;
       case "--dist-runtime-file-growth-max":
         options.distRuntimeFileGrowthMax = Number(readValue());
@@ -210,34 +211,79 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function buildTimedWatchCommand(pidFilePath, timeFilePath, isolatedHomeDir) {
+  const shellSource = [
+    'echo "$$" > "$OPENCLAW_WATCH_PID_FILE"',
+    "exec node scripts/watch-node.mjs gateway --force --allow-unconfigured",
+  ].join("\n");
+  const env = {
+    OPENCLAW_WATCH_PID_FILE: pidFilePath,
+    HOME: isolatedHomeDir,
+    OPENCLAW_HOME: isolatedHomeDir,
+  };
+
+  if (process.platform === "darwin") {
+    return {
+      command: "/usr/bin/time",
+      args: ["-lp", "-o", timeFilePath, "/bin/sh", "-lc", shellSource],
+      env,
+    };
+  }
+
+  return {
+    command: "/usr/bin/time",
+    args: [
+      "-f",
+      "__TIMING__ user=%U sys=%S elapsed=%e",
+      "-o",
+      timeFilePath,
+      "/bin/sh",
+      "-lc",
+      shellSource,
+    ],
+    env,
+  };
+}
+
+function parseTimingFile(timeFilePath) {
+  const text = fs.readFileSync(timeFilePath, "utf8");
+  if (process.platform === "darwin") {
+    const user = Number(text.match(/^user\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    const sys = Number(text.match(/^sys\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    const elapsed = Number(text.match(/^real\s+([0-9.]+)/m)?.[1] ?? "NaN");
+    return {
+      userSeconds: user,
+      sysSeconds: sys,
+      elapsedSeconds: elapsed,
+    };
+  }
+
+  const match = text.match(/__TIMING__ user=([0-9.]+) sys=([0-9.]+) elapsed=([0-9.]+)/);
+  return {
+    userSeconds: Number(match?.[1] ?? "NaN"),
+    sysSeconds: Number(match?.[2] ?? "NaN"),
+    elapsedSeconds: Number(match?.[3] ?? "NaN"),
+  };
+}
+
 async function runTimedWatch(options, outputDir) {
+  const pidFilePath = path.join(outputDir, "watch.pid");
+  const timeFilePath = path.join(outputDir, "watch.time.log");
+  const isolatedHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-watch-"));
+  fs.writeFileSync(path.join(outputDir, "watch.home.txt"), `${isolatedHomeDir}\n`, "utf8");
   const stdoutPath = path.join(outputDir, "watch.stdout.log");
   const stderrPath = path.join(outputDir, "watch.stderr.log");
-  const startedAt = Date.now();
-  let startupReadyMs = null;
-  const child = spawn(
-    process.execPath,
-    ["scripts/watch-node.mjs", "gateway", "--force", "--allow-unconfigured"],
-    {
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
-    },
-  );
-  const watchPid = child.pid;
-  if (typeof watchPid !== "number") {
-    throw new Error("Failed to spawn pnpm gateway:watch");
-  }
+  const { command, args, env } = buildTimedWatchCommand(pidFilePath, timeFilePath, isolatedHomeDir);
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 
   let stdout = "";
   let stderr = "";
   child.stdout?.on("data", (chunk) => {
-    const chunkText = String(chunk);
-    stdout += chunkText;
-    if (startupReadyMs === null && chunkText.includes("[gateway] listening on ws://")) {
-      startupReadyMs = Date.now() - startedAt;
-    }
+    stdout += String(chunk);
   });
   child.stderr?.on("data", (chunk) => {
     stderr += String(chunk);
@@ -247,12 +293,23 @@ async function runTimedWatch(options, outputDir) {
     child.on("exit", (code, signal) => resolve({ code, signal }));
   });
 
+  let watchPid = null;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (fs.existsSync(pidFilePath)) {
+      watchPid = Number(fs.readFileSync(pidFilePath, "utf8").trim());
+      break;
+    }
+    await sleep(100);
+  }
+
   await sleep(options.windowMs);
 
-  try {
-    process.kill(-watchPid, "SIGTERM");
-  } catch {
-    // ignore
+  if (watchPid) {
+    try {
+      process.kill(watchPid, "SIGTERM");
+    } catch {
+      // ignore
+    }
   }
 
   const gracefulExit = await Promise.race([
@@ -261,22 +318,28 @@ async function runTimedWatch(options, outputDir) {
   ]);
 
   if (gracefulExit === null) {
-    try {
-      process.kill(-watchPid, "SIGKILL");
-    } catch {
-      // ignore
+    if (watchPid) {
+      try {
+        process.kill(watchPid, "SIGKILL");
+      } catch {
+        // ignore
+      }
     }
   }
 
   const exit = (await exitPromise) ?? { code: null, signal: null };
   fs.writeFileSync(stdoutPath, stdout, "utf8");
   fs.writeFileSync(stderrPath, stderr, "utf8");
+  const timing = fs.existsSync(timeFilePath)
+    ? parseTimingFile(timeFilePath)
+    : { userSeconds: Number.NaN, sysSeconds: Number.NaN, elapsedSeconds: Number.NaN };
 
   return {
     exit,
-    startupReadyMs,
+    timing,
     stdoutPath,
     stderrPath,
+    timeFilePath,
   };
 }
 
@@ -330,7 +393,7 @@ async function main() {
   const distRuntimeAddedPaths = diff.added.filter((entry) =>
     entry.startsWith("dist-runtime/"),
   ).length;
-  const startupReadyMs = watchResult.startupReadyMs;
+  const cpuMs = Math.round((watchResult.timing.userSeconds + watchResult.timing.sysSeconds) * 1000);
   const watchTriggeredBuild =
     fs
       .readFileSync(watchResult.stderrPath, "utf8")
@@ -342,9 +405,9 @@ async function main() {
   const summary = {
     windowMs: options.windowMs,
     watchTriggeredBuild,
-    startupReadyMs,
-    startupReadyWarnMs: options.startupReadyWarnMs,
-    startupReadyFailMs: options.startupReadyFailMs,
+    cpuMs,
+    cpuWarnMs: options.cpuWarnMs,
+    cpuFailMs: options.cpuFailMs,
     distRuntimeFileGrowth,
     distRuntimeFileGrowthMax: options.distRuntimeFileGrowthMax,
     distRuntimeByteGrowth,
@@ -353,6 +416,7 @@ async function main() {
     addedPaths: diff.added.length,
     removedPaths: diff.removed.length,
     watchExit: watchResult.exit,
+    timing: watchResult.timing,
   };
   fs.writeFileSync(
     path.join(options.outputDir, "summary.json"),
@@ -372,17 +436,15 @@ async function main() {
       `dist-runtime apparent byte growth ${distRuntimeByteGrowth} exceeded max ${options.distRuntimeByteGrowthMax}`,
     );
   }
-  if (!Number.isFinite(startupReadyMs)) {
+  if (!Number.isFinite(cpuMs)) {
+    failures.push("failed to parse CPU timing from the bounded gateway:watch run");
+  } else if (cpuMs > options.cpuFailMs) {
     failures.push(
-      "gateway:watch never reached the gateway listening state in the measurement window",
+      `LOUD ALARM: gateway:watch used ${cpuMs}ms CPU in ${options.windowMs}ms window, above loud-alarm threshold ${options.cpuFailMs}ms`,
     );
-  } else if (startupReadyMs > options.startupReadyFailMs) {
+  } else if (cpuMs > options.cpuWarnMs) {
     failures.push(
-      `LOUD ALARM: gateway:watch took ${startupReadyMs}ms to reach the listening state after pnpm build, above loud-alarm threshold ${options.startupReadyFailMs}ms`,
-    );
-  } else if (startupReadyMs > options.startupReadyWarnMs) {
-    failures.push(
-      `gateway:watch took ${startupReadyMs}ms to reach the listening state after pnpm build, above target ${options.startupReadyWarnMs}ms`,
+      `gateway:watch used ${cpuMs}ms CPU in ${options.windowMs}ms window, above target ${options.cpuWarnMs}ms`,
     );
   }
 

--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -8,9 +8,9 @@ import process from "node:process";
 const DEFAULTS = {
   outputDir: path.join(process.cwd(), ".local", "gateway-watch-regression"),
   windowMs: 8_000,
-  sigkillGraceMs: 3_000,
-  cpuWarnMs: 500,
-  cpuFailMs: 8_000,
+  sigkillGraceMs: 10_000,
+  startupReadyWarnMs: 5_000,
+  startupReadyFailMs: 8_000,
   distRuntimeFileGrowthMax: 200,
   distRuntimeByteGrowthMax: 2 * 1024 * 1024,
   keepLogs: true,
@@ -39,11 +39,11 @@ function parseArgs(argv) {
       case "--sigkill-grace-ms":
         options.sigkillGraceMs = Number(readValue());
         break;
-      case "--cpu-warn-ms":
-        options.cpuWarnMs = Number(readValue());
+      case "--startup-ready-warn-ms":
+        options.startupReadyWarnMs = Number(readValue());
         break;
-      case "--cpu-fail-ms":
-        options.cpuFailMs = Number(readValue());
+      case "--startup-ready-fail-ms":
+        options.startupReadyFailMs = Number(readValue());
         break;
       case "--dist-runtime-file-growth-max":
         options.distRuntimeFileGrowthMax = Number(readValue());
@@ -206,75 +206,34 @@ function runCheckedCommand(command, args) {
   throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? "unknown"}`);
 }
 
-function buildTimeCommandArgs(pidFilePath) {
-  const wrapperSource = [
-    "const fs = require('node:fs');",
-    "const { spawn } = require('node:child_process');",
-    "const child = spawn('pnpm', ['gateway:watch'], {",
-    "  cwd: process.cwd(),",
-    "  env: process.env,",
-    "  stdio: 'inherit',",
-    "  detached: true,",
-    "});",
-    "fs.writeFileSync(process.env.OPENCLAW_WATCH_CHILD_PID_FILE, `${child.pid}\\n`, 'utf8');",
-    "child.on('exit', (code, signal) => {",
-    "  if (typeof code === 'number') process.exit(code);",
-    "  process.exit(signal ? 128 : 0);",
-    "});",
-  ].join(" ");
-  if (process.platform === "darwin") {
-    return {
-      command: "/usr/bin/time",
-      args: ["-lp", process.execPath, "-e", wrapperSource],
-      extraEnv: { OPENCLAW_WATCH_CHILD_PID_FILE: pidFilePath },
-    };
-  }
-  return {
-    command: "/usr/bin/time",
-    args: ["-f", "__TIMING__ user=%U sys=%S elapsed=%e", process.execPath, "-e", wrapperSource],
-    extraEnv: { OPENCLAW_WATCH_CHILD_PID_FILE: pidFilePath },
-  };
-}
-
-function parseTiming(stderrText) {
-  if (process.platform === "darwin") {
-    const user = Number(stderrText.match(/^user\s+([0-9.]+)/m)?.[1] ?? "NaN");
-    const sys = Number(stderrText.match(/^sys\s+([0-9.]+)/m)?.[1] ?? "NaN");
-    const elapsed = Number(stderrText.match(/^real\s+([0-9.]+)/m)?.[1] ?? "NaN");
-    return {
-      userSeconds: user,
-      sysSeconds: sys,
-      elapsedSeconds: elapsed,
-    };
-  }
-
-  const match = stderrText.match(/__TIMING__ user=([0-9.]+) sys=([0-9.]+) elapsed=([0-9.]+)/);
-  return {
-    userSeconds: Number(match?.[1] ?? "NaN"),
-    sysSeconds: Number(match?.[2] ?? "NaN"),
-    elapsedSeconds: Number(match?.[3] ?? "NaN"),
-  };
-}
-
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function runTimedWatch(options, outputDir) {
-  const pidFilePath = path.join(outputDir, "watch.child.pid");
-  const { command: timeCommand, args: timeArgs, extraEnv } = buildTimeCommandArgs(pidFilePath);
   const stdoutPath = path.join(outputDir, "watch.stdout.log");
   const stderrPath = path.join(outputDir, "watch.stderr.log");
-  const child = spawn(timeCommand, timeArgs, {
+  const startedAt = Date.now();
+  let startupReadyMs = null;
+  const child = spawn("pnpm", ["gateway:watch"], {
     cwd: process.cwd(),
-    env: { ...process.env, ...extraEnv },
+    env: process.env,
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
   });
+  const watchPid = child.pid;
+  if (typeof watchPid !== "number") {
+    throw new Error("Failed to spawn pnpm gateway:watch");
+  }
 
   let stdout = "";
   let stderr = "";
   child.stdout?.on("data", (chunk) => {
-    stdout += String(chunk);
+    const chunkText = String(chunk);
+    stdout += chunkText;
+    if (startupReadyMs === null && chunkText.includes("[gateway] listening on ws://")) {
+      startupReadyMs = Date.now() - startedAt;
+    }
   });
   child.stderr?.on("data", (chunk) => {
     stderr += String(chunk);
@@ -284,22 +243,12 @@ async function runTimedWatch(options, outputDir) {
     child.on("exit", (code, signal) => resolve({ code, signal }));
   });
 
-  let watchChildPid = null;
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    if (fs.existsSync(pidFilePath)) {
-      watchChildPid = Number(fs.readFileSync(pidFilePath, "utf8").trim());
-      break;
-    }
-    await sleep(100);
-  }
-
   await sleep(options.windowMs);
-  if (watchChildPid) {
-    try {
-      process.kill(-watchChildPid, "SIGTERM");
-    } catch {
-      // ignore
-    }
+
+  try {
+    process.kill(-watchPid, "SIGTERM");
+  } catch {
+    // ignore
   }
 
   const gracefulExit = await Promise.race([
@@ -308,12 +257,10 @@ async function runTimedWatch(options, outputDir) {
   ]);
 
   if (gracefulExit === null) {
-    if (watchChildPid) {
-      try {
-        process.kill(-watchChildPid, "SIGKILL");
-      } catch {
-        // ignore
-      }
+    try {
+      process.kill(-watchPid, "SIGKILL");
+    } catch {
+      // ignore
     }
   }
 
@@ -323,36 +270,10 @@ async function runTimedWatch(options, outputDir) {
 
   return {
     exit,
-    timing: parseTiming(stderr),
+    startupReadyMs,
     stdoutPath,
     stderrPath,
   };
-}
-
-function isDirtyWatchTree() {
-  const result = spawnSync(
-    "git",
-    [
-      "status",
-      "--porcelain",
-      "--untracked-files=normal",
-      "--",
-      "src",
-      "extensions",
-      "package.json",
-      "tsconfig.json",
-      "tsdown.config.ts",
-    ],
-    {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    },
-  );
-  if (result.status !== 0) {
-    return null;
-  }
-  return (result.stdout ?? "").trim().length > 0;
 }
 
 function parsePathFile(filePath) {
@@ -382,10 +303,6 @@ function fail(message) {
   console.error(`FAIL: ${message}`);
 }
 
-function warn(message) {
-  console.warn(`WARN: ${message}`);
-}
-
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   ensureDir(options.outputDir);
@@ -398,7 +315,6 @@ async function main() {
 
   const watchDir = path.join(options.outputDir, "watch");
   ensureDir(watchDir);
-  const dirtyWatchTree = isDirtyWatchTree();
   const watchResult = await runTimedWatch(options, watchDir);
 
   const postDir = path.join(options.outputDir, "post");
@@ -410,7 +326,7 @@ async function main() {
   const distRuntimeAddedPaths = diff.added.filter((entry) =>
     entry.startsWith("dist-runtime/"),
   ).length;
-  const cpuMs = Math.round((watchResult.timing.userSeconds + watchResult.timing.sysSeconds) * 1000);
+  const startupReadyMs = watchResult.startupReadyMs;
   const watchTriggeredBuild =
     fs
       .readFileSync(watchResult.stderrPath, "utf8")
@@ -421,11 +337,10 @@ async function main() {
 
   const summary = {
     windowMs: options.windowMs,
-    dirtyWatchTree,
     watchTriggeredBuild,
-    cpuMs,
-    cpuWarnMs: options.cpuWarnMs,
-    cpuFailMs: options.cpuFailMs,
+    startupReadyMs,
+    startupReadyWarnMs: options.startupReadyWarnMs,
+    startupReadyFailMs: options.startupReadyFailMs,
     distRuntimeFileGrowth,
     distRuntimeFileGrowthMax: options.distRuntimeFileGrowthMax,
     distRuntimeByteGrowth,
@@ -434,7 +349,6 @@ async function main() {
     addedPaths: diff.added.length,
     removedPaths: diff.removed.length,
     watchExit: watchResult.exit,
-    timing: watchResult.timing,
   };
   fs.writeFileSync(
     path.join(options.outputDir, "summary.json"),
@@ -444,7 +358,6 @@ async function main() {
   console.log(JSON.stringify(summary, null, 2));
 
   const failures = [];
-  const skipCpuGate = dirtyWatchTree === true && watchTriggeredBuild;
   if (distRuntimeFileGrowth > options.distRuntimeFileGrowthMax) {
     failures.push(
       `dist-runtime file growth ${distRuntimeFileGrowth} exceeded max ${options.distRuntimeFileGrowthMax}`,
@@ -455,22 +368,18 @@ async function main() {
       `dist-runtime apparent byte growth ${distRuntimeByteGrowth} exceeded max ${options.distRuntimeByteGrowthMax}`,
     );
   }
-  if (skipCpuGate) {
-    warn(
-      "Skipping CPU threshold gate because the watched tree is dirty and gateway:watch rebuilt dist.",
+  if (!Number.isFinite(startupReadyMs)) {
+    failures.push(
+      "gateway:watch never reached the gateway listening state in the measurement window",
     );
-  } else {
-    if (!Number.isFinite(cpuMs)) {
-      failures.push("failed to parse CPU timing from gateway:watch run");
-    }
-    if (cpuMs > options.cpuFailMs) {
-      failures.push(
-        `gateway:watch used ${cpuMs}ms CPU in ${options.windowMs}ms window (max ${options.cpuFailMs}ms)`,
-      );
-    }
-    if (cpuMs > options.cpuWarnMs) {
-      warn(`gateway:watch used ${cpuMs}ms CPU, above warn threshold ${options.cpuWarnMs}ms`);
-    }
+  } else if (startupReadyMs > options.startupReadyFailMs) {
+    failures.push(
+      `LOUD ALARM: gateway:watch took ${startupReadyMs}ms to reach the listening state after pnpm build, above loud-alarm threshold ${options.startupReadyFailMs}ms`,
+    );
+  } else if (startupReadyMs > options.startupReadyWarnMs) {
+    failures.push(
+      `gateway:watch took ${startupReadyMs}ms to reach the listening state after pnpm build, above target ${options.startupReadyWarnMs}ms`,
+    );
   }
 
   if (failures.length > 0) {
@@ -482,6 +391,8 @@ async function main() {
     );
     process.exit(1);
   }
+
+  process.exit(0);
 }
 
 await main();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: after `pnpm build`, a later `pnpm gateway:watch` regression can repopulate `dist-runtime/` with a second runtime graph, which is the same class of failure that previously gave OpenClaw split runtime personalities between core and plugins.
- Why it matters: when that happens, plugins can observe different global state than core, which can surface as Telegram missing plugin-registered slash commands like `/voice`, `/phone`, and `/pair`, and it also damages local developer startup time.
- What changed: add a dedicated `scripts/check-gateway-watch-regression.mjs` harness plus a CI job that runs `pnpm build`, snapshots `dist/` and `dist-runtime/`, runs a bounded `pnpm gateway:watch`, and fails if `dist-runtime/` grows unexpectedly or if gateway startup takes too long after build.
- What did NOT change (scope boundary): this does not change plugin loading, bundling behavior, or runtime staging itself; it only adds regression detection and CI coverage around the existing fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48595

## User-visible / Behavior Changes

- `pnpm test:gateway:watch-regression` is available locally and in CI.
- PRs and `main` now fail if `pnpm gateway:watch` after `pnpm build` starts recreating a large `dist-runtime/` tree or regresses badly on startup readiness.
- The guard explicitly calls out the split-runtime failure mode that can lead to Telegram missing plugin slash commands such as `/voice`, `/phone`, and `/pair`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): gateway startup with bundled + configured local channels
- Relevant config (redacted): existing local gateway config with Telegram enabled

### Steps

1. Run `pnpm build`.
2. Run `pnpm test:gateway:watch-regression`.
3. Inspect `.local/gateway-watch-regression/summary.json` and the saved snapshots/diffs.

### Expected

- `dist-runtime/` should not explode into a mirrored second JS graph after `pnpm gateway:watch`.
- Gateway should reach the listening state quickly after `pnpm build`.

### Actual

- Cold run after `pnpm build`: `startupReadyMs=4075`, `distRuntimeFileGrowth=0`, `distRuntimeByteGrowth=0`, `distRuntimeAddedPaths=0`.
- Follow-up run with `--skip-build`: `startupReadyMs=2636`, `distRuntimeFileGrowth=0`, `distRuntimeByteGrowth=0`, `addedPaths=0`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm check`; ran `pnpm test:gateway:watch-regression`; ran `node scripts/check-gateway-watch-regression.mjs --skip-build`.
- Edge cases checked: validated both a cold run after `pnpm build` and a follow-up run without rebuild; confirmed `dist-runtime` growth stayed at zero in both cases.
- What you did **not** verify: Linux CI timing variance; a synthetic reintroduction of the old duplicate-runtime bug to watch the check fail in CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or skip the `gateway-watch-regression` CI job while investigating the guard itself.
- Files/config to restore: `.github/workflows/ci.yml`, `package.json`, `scripts/check-gateway-watch-regression.mjs`
- Known bad symptoms reviewers should watch for: false positives from the readiness threshold, or unexpected `dist-runtime` growth in the saved artifact snapshots.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: startup-readiness timing could be noisy on slower CI hosts.
  - Mitigation: use a generous `5000ms` warning threshold and `8000ms` loud-alarm threshold, and save artifacts for inspection on every run.
- Risk: the structural guard could miss a new duplication shape that keeps file counts flat but still changes runtime identity.
  - Mitigation: the check stores path snapshots, byte counts, and startup logs so regressions can be expanded if a new pattern appears.
