### PR TITLE
fix(security): use constant-time comparison for TLS fingerprint verification

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { rawDataToString } from "../infra/ws.js";
 import { logDebug, logError } from "../logger.js";
+import { safeEqualSecret } from "../security/secret-equal.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -201,7 +202,7 @@ export class GatewayClient {
         if (!fingerprint) {
           return new Error("gateway tls fingerprint unavailable");
         }
-        if (fingerprint !== expected) {
+        if (!safeEqualSecret(fingerprint, expected)) {
           return new Error("gateway tls fingerprint mismatch");
         }
         return undefined;
@@ -677,7 +678,7 @@ export class GatewayClient {
     if (!fingerprint) {
       return new Error("gateway tls fingerprint unavailable");
     }
-    if (fingerprint !== expected) {
+    if (!safeEqualSecret(fingerprint, expected)) {
       return new Error("gateway tls fingerprint mismatch");
     }
     return null;


### PR DESCRIPTION
## Summary

TLS certificate fingerprint verification in `src/gateway/client.ts` uses `!==` (standard JavaScript string equality), which is vulnerable to **timing side-channel attacks** (CWE-208).

An attacker on the network path can measure response time differences to iteratively guess the correct fingerprint byte-by-byte, potentially bypassing TLS pinning for MITM attacks on gateway connections.

## Root cause

Two locations perform fingerprint comparison with `!==`:

| Location | Context |
|----------|---------|
| Line 205 | WebSocket `checkServerIdentity` callback |
| Line 681 | HTTP `validateTlsFingerprint` method |

## Fix

Replace both with `safeEqualSecret()` from `src/security/secret-equal.ts`, which uses `SHA-256` hashing + `crypto.timingSafeEqual` for constant-time comparison.

This is the **same function already used** for pairing token verification elsewhere in the codebase — just missed for TLS fingerprints.

```diff
- if (fingerprint !== expected) {
+ if (!safeEqualSecret(fingerprint, expected)) {
```

## Why safeEqualSecret and not raw timingSafeEqual

`timingSafeEqual` requires both buffers to have equal length, which would leak the length of the expected fingerprint. `safeEqualSecret` avoids this by hashing both values with SHA-256 first (producing fixed 32-byte digests), then comparing the digests in constant time.

## Test plan

- [x] `pnpm tsgo` — compiles cleanly
- [x] `pnpm check` — lint/format passes
- [x] Existing `safeEqualSecret` tests in `src/security/audit-extra.sync.test.ts` cover equal, unequal, different-length, and undefined inputs
- [x] No remaining `fingerprint !== expected` patterns in codebase