### PR TITLE
tests(channels): fix slack, whatsapp, line, and browser CI regressions

### DIFF
--- a/extensions/discord/src/monitor.test.ts
+++ b/extensions/discord/src/monitor.test.ts
@@ -892,13 +892,25 @@ const { enqueueSystemEventSpy, resolveAgentRouteMock } = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("../../../src/infra/system-events.js", () => ({
-  enqueueSystemEvent: enqueueSystemEventSpy,
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/infra-runtime")>(
+    "openclaw/plugin-sdk/infra-runtime",
+  );
+  return {
+    ...actual,
+    enqueueSystemEvent: enqueueSystemEventSpy,
+  };
+});
 
-vi.mock("../../../src/routing/resolve-route.js", () => ({
-  resolveAgentRoute: resolveAgentRouteMock,
-}));
+vi.mock("openclaw/plugin-sdk/routing", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/routing")>(
+    "openclaw/plugin-sdk/routing",
+  );
+  return {
+    ...actual,
+    resolveAgentRoute: resolveAgentRouteMock,
+  };
+});
 
 function makeReactionEvent(overrides?: {
   guildId?: string;

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -76,7 +76,7 @@ vi.mock("../send.shared.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../../src/gateway/client.js", () => ({
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
   GatewayClient: class {
     private params: Record<string, unknown>;
     constructor(params: Record<string, unknown>) {
@@ -94,10 +94,63 @@ vi.mock("../../../../src/gateway/client.js", () => ({
       return gatewayClientRequests();
     }
   },
-}));
-
-vi.mock("../../../../src/gateway/connection-auth.js", () => ({
-  resolveGatewayConnectionAuth: mockResolveGatewayConnectionAuth,
+  createOperatorApprovalsGatewayClient: async (params: {
+    config?: {
+      gateway?: {
+        mode?: string;
+        bind?: string;
+      };
+    };
+    gatewayUrl?: string;
+    clientDisplayName: string;
+    onEvent: (evt: unknown) => void;
+    onHelloOk?: () => void;
+    onConnectError?: (err: Error) => void;
+    onClose?: (code: number, reason: string) => void;
+  }) => {
+    const url =
+      params.gatewayUrl ??
+      process.env.OPENCLAW_GATEWAY_URL ??
+      (params.config?.gateway?.mode === "local" && params.config?.gateway?.bind === "loopback"
+        ? "ws://127.0.0.1:18789"
+        : "ws://localhost:18789");
+    const urlOverrideSource = params.gatewayUrl
+      ? "cli"
+      : process.env.OPENCLAW_GATEWAY_URL
+        ? "env"
+        : undefined;
+    const auth = await mockResolveGatewayConnectionAuth({
+      config: params.config,
+      env: process.env,
+      urlOverride: urlOverrideSource ? url : undefined,
+      urlOverrideSource,
+    });
+    return new (class {
+      start() {
+        gatewayClientParams.push({
+          url,
+          token: auth.token,
+          password: auth.password,
+          clientDisplayName: params.clientDisplayName,
+          scopes: ["operator.approvals"],
+        });
+        mockGatewayClientCtor({
+          url,
+          token: auth.token,
+          password: auth.password,
+          clientDisplayName: params.clientDisplayName,
+          scopes: ["operator.approvals"],
+        });
+        gatewayClientStarts();
+      }
+      stop() {
+        gatewayClientStops();
+      }
+      async request() {
+        return gatewayClientRequests();
+      }
+    })();
+  },
 }));
 
 vi.mock("../../../../src/logger.js", () => ({

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -1,5 +1,5 @@
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../../../src/runtime.js";
 
 const sendMessageIMessageMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ messageId: "imsg-1" }),
@@ -14,36 +14,28 @@ vi.mock("../send.js", () => ({
     sendMessageIMessageMock(to, message, opts),
 }));
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
+vi.mock("../../../../src/auto-reply/chunk.js", () => ({
   chunkTextWithMode: (text: string) => chunkTextWithModeMock(text),
   resolveChunkMode: () => resolveChunkModeMock(),
 }));
 
-vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+vi.mock("../../../../src/config/config.js", () => ({
   loadConfig: () => ({}),
+}));
+
+vi.mock("../../../../src/config/markdown-tables.js", () => ({
   resolveMarkdownTableMode: () => resolveMarkdownTableModeMock(),
 }));
 
-vi.mock("openclaw/plugin-sdk/text-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-runtime")>(
-    "openclaw/plugin-sdk/text-runtime",
-  );
-  return {
-    ...actual,
-    convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
-  };
-});
+vi.mock("../../../../src/markdown/tables.js", () => ({
+  convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
+}));
 
-let deliverReplies: typeof import("./deliver.js").deliverReplies;
+import { deliverReplies } from "./deliver.js";
 
 describe("deliverReplies", () => {
   const runtime = { log: vi.fn(), error: vi.fn() } as unknown as RuntimeEnv;
   const client = {} as Awaited<ReturnType<typeof import("../client.js").createIMessageRpcClient>>;
-
-  beforeAll(async () => {
-    vi.resetModules();
-    ({ deliverReplies } = await import("./deliver.js"));
-  });
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -1,5 +1,5 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageIMessageMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ messageId: "imsg-1" }),
@@ -40,11 +40,14 @@ describe("deliverReplies", () => {
   const runtime = { log: vi.fn(), error: vi.fn() } as unknown as RuntimeEnv;
   const client = {} as Awaited<ReturnType<typeof import("../client.js").createIMessageRpcClient>>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
+    ({ deliverReplies } = await import("./deliver.js"));
+  });
+
+  beforeEach(() => {
     vi.clearAllMocks();
     chunkTextWithModeMock.mockImplementation((text: string) => [text]);
-    ({ deliverReplies } = await import("./deliver.js"));
   });
 
   it("propagates payload replyToId through all text chunks", async () => {

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -1,5 +1,5 @@
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeEnv } from "../../../../src/runtime.js";
 
 const sendMessageIMessageMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ messageId: "imsg-1" }),
@@ -14,32 +14,37 @@ vi.mock("../send.js", () => ({
     sendMessageIMessageMock(to, message, opts),
 }));
 
-vi.mock("../../../../src/auto-reply/chunk.js", () => ({
+vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   chunkTextWithMode: (text: string) => chunkTextWithModeMock(text),
   resolveChunkMode: () => resolveChunkModeMock(),
 }));
 
-vi.mock("../../../../src/config/config.js", () => ({
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
   loadConfig: () => ({}),
-}));
-
-vi.mock("../../../../src/config/markdown-tables.js", () => ({
   resolveMarkdownTableMode: () => resolveMarkdownTableModeMock(),
 }));
 
-vi.mock("../../../../src/markdown/tables.js", () => ({
-  convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
-}));
+vi.mock("openclaw/plugin-sdk/text-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-runtime")>(
+    "openclaw/plugin-sdk/text-runtime",
+  );
+  return {
+    ...actual,
+    convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
+  };
+});
 
-import { deliverReplies } from "./deliver.js";
+let deliverReplies: typeof import("./deliver.js").deliverReplies;
 
 describe("deliverReplies", () => {
   const runtime = { log: vi.fn(), error: vi.fn() } as unknown as RuntimeEnv;
   const client = {} as Awaited<ReturnType<typeof import("../client.js").createIMessageRpcClient>>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
     chunkTextWithModeMock.mockImplementation((text: string) => [text]);
+    ({ deliverReplies } = await import("./deliver.js"));
   });
 
   it("propagates payload replyToId through all text chunks", async () => {

--- a/extensions/imessage/src/probe.test.ts
+++ b/extensions/imessage/src/probe.test.ts
@@ -1,13 +1,13 @@
-import * as execRuntime from "openclaw/plugin-sdk/process-runtime";
-import * as setupSdk from "openclaw/plugin-sdk/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as onboardHelpers from "../../../src/commands/onboard-helpers.js";
+import * as execModule from "../../../src/process/exec.js";
 import * as clientModule from "./client.js";
 import { probeIMessage } from "./probe.js";
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  vi.spyOn(setupSdk, "detectBinary").mockResolvedValue(true);
-  vi.spyOn(execRuntime, "runCommandWithTimeout").mockResolvedValue({
+  vi.spyOn(onboardHelpers, "detectBinary").mockResolvedValue(true);
+  vi.spyOn(execModule, "runCommandWithTimeout").mockResolvedValue({
     stdout: "",
     stderr: 'unknown command "rpc" for "imsg"',
     code: 1,

--- a/extensions/imessage/src/probe.test.ts
+++ b/extensions/imessage/src/probe.test.ts
@@ -1,13 +1,13 @@
+import * as execRuntime from "openclaw/plugin-sdk/process-runtime";
+import * as setupSdk from "openclaw/plugin-sdk/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as onboardHelpers from "../../../src/commands/onboard-helpers.js";
-import * as execModule from "../../../src/process/exec.js";
 import * as clientModule from "./client.js";
 import { probeIMessage } from "./probe.js";
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  vi.spyOn(onboardHelpers, "detectBinary").mockResolvedValue(true);
-  vi.spyOn(execModule, "runCommandWithTimeout").mockResolvedValue({
+  vi.spyOn(setupSdk, "detectBinary").mockResolvedValue(true);
+  vi.spyOn(execRuntime, "runCommandWithTimeout").mockResolvedValue({
     stdout: "",
     stderr: 'unknown command "rpc" for "imsg"',
     code: 1,

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -1,30 +1,21 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchWithTimeoutMock = vi.fn();
 const resolveFetchMock = vi.fn();
 
-vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/infra-runtime")>(
-    "openclaw/plugin-sdk/infra-runtime",
-  );
-  return {
-    ...actual,
-    resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
-    generateSecureUuid: () => "test-id",
-  };
-});
+vi.mock("../../../src/infra/fetch.js", () => ({
+  resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
+}));
 
-vi.mock("openclaw/plugin-sdk/text-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-runtime")>(
-    "openclaw/plugin-sdk/text-runtime",
-  );
-  return {
-    ...actual,
-    fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
-  };
-});
+vi.mock("../../../src/infra/secure-random.js", () => ({
+  generateSecureUuid: () => "test-id",
+}));
 
-let signalRpcRequest: typeof import("./client.js").signalRpcRequest;
+vi.mock("../../../src/utils/fetch-timeout.js", () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+}));
+
+import { signalRpcRequest } from "./client.js";
 
 function rpcResponse(body: unknown, status = 200): Response {
   if (typeof body === "string") {
@@ -34,11 +25,6 @@ function rpcResponse(body: unknown, status = 200): Response {
 }
 
 describe("signalRpcRequest", () => {
-  beforeAll(async () => {
-    vi.resetModules();
-    ({ signalRpcRequest } = await import("./client.js"));
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     resolveFetchMock.mockReturnValue(vi.fn());

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -3,19 +3,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const fetchWithTimeoutMock = vi.fn();
 const resolveFetchMock = vi.fn();
 
-vi.mock("../../../src/infra/fetch.js", () => ({
-  resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/infra-runtime")>(
+    "openclaw/plugin-sdk/infra-runtime",
+  );
+  return {
+    ...actual,
+    resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
+    generateSecureUuid: () => "test-id",
+  };
+});
 
-vi.mock("../../../src/infra/secure-random.js", () => ({
-  generateSecureUuid: () => "test-id",
-}));
+vi.mock("openclaw/plugin-sdk/text-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/text-runtime")>(
+    "openclaw/plugin-sdk/text-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+  };
+});
 
-vi.mock("../../../src/utils/fetch-timeout.js", () => ({
-  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
-}));
-
-import { signalRpcRequest } from "./client.js";
+let signalRpcRequest: typeof import("./client.js").signalRpcRequest;
 
 function rpcResponse(body: unknown, status = 200): Response {
   if (typeof body === "string") {
@@ -25,9 +34,11 @@ function rpcResponse(body: unknown, status = 200): Response {
 }
 
 describe("signalRpcRequest", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
     resolveFetchMock.mockReturnValue(vi.fn());
+    ({ signalRpcRequest } = await import("./client.js"));
   });
 
   it("returns parsed RPC result", async () => {

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchWithTimeoutMock = vi.fn();
 const resolveFetchMock = vi.fn();
@@ -34,11 +34,14 @@ function rpcResponse(body: unknown, status = 200): Response {
 }
 
 describe("signalRpcRequest", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
+    ({ signalRpcRequest } = await import("./client.js"));
+  });
+
+  beforeEach(() => {
     vi.clearAllMocks();
     resolveFetchMock.mockReturnValue(vi.fn());
-    ({ signalRpcRequest } = await import("./client.js"));
   });
 
   it("returns parsed RPC result", async () => {

--- a/extensions/signal/src/send-reactions.test.ts
+++ b/extensions/signal/src/send-reactions.test.ts
@@ -1,11 +1,10 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { removeReactionSignal, sendReactionSignal } from "./send-reactions.js";
 
 const rpcMock = vi.fn();
 
-vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-runtime")>(
-    "openclaw/plugin-sdk/config-runtime",
-  );
+vi.mock("../../../src/config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
   return {
     ...actual,
     loadConfig: () => ({}),
@@ -26,15 +25,7 @@ vi.mock("./client.js", () => ({
   signalRpcRequest: (...args: unknown[]) => rpcMock(...args),
 }));
 
-let sendReactionSignal: typeof import("./send-reactions.js").sendReactionSignal;
-let removeReactionSignal: typeof import("./send-reactions.js").removeReactionSignal;
-
 describe("sendReactionSignal", () => {
-  beforeAll(async () => {
-    vi.resetModules();
-    ({ sendReactionSignal, removeReactionSignal } = await import("./send-reactions.js"));
-  });
-
   beforeEach(() => {
     rpcMock.mockClear().mockResolvedValue({ timestamp: 123 });
   });

--- a/extensions/signal/src/send-reactions.test.ts
+++ b/extensions/signal/src/send-reactions.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { removeReactionSignal, sendReactionSignal } from "./send-reactions.js";
 
 const rpcMock = vi.fn();
 
-vi.mock("../../../src/config/config.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
+vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-runtime")>(
+    "openclaw/plugin-sdk/config-runtime",
+  );
   return {
     ...actual,
     loadConfig: () => ({}),
@@ -25,9 +26,14 @@ vi.mock("./client.js", () => ({
   signalRpcRequest: (...args: unknown[]) => rpcMock(...args),
 }));
 
+let sendReactionSignal: typeof import("./send-reactions.js").sendReactionSignal;
+let removeReactionSignal: typeof import("./send-reactions.js").removeReactionSignal;
+
 describe("sendReactionSignal", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     rpcMock.mockClear().mockResolvedValue({ timestamp: 123 });
+    ({ sendReactionSignal, removeReactionSignal } = await import("./send-reactions.js"));
   });
 
   it("uses recipients array and targetAuthor for uuid dms", async () => {

--- a/extensions/signal/src/send-reactions.test.ts
+++ b/extensions/signal/src/send-reactions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const rpcMock = vi.fn();
 
@@ -30,10 +30,13 @@ let sendReactionSignal: typeof import("./send-reactions.js").sendReactionSignal;
 let removeReactionSignal: typeof import("./send-reactions.js").removeReactionSignal;
 
 describe("sendReactionSignal", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
-    rpcMock.mockClear().mockResolvedValue({ timestamp: 123 });
     ({ sendReactionSignal, removeReactionSignal } = await import("./send-reactions.js"));
+  });
+
+  beforeEach(() => {
+    rpcMock.mockClear().mockResolvedValue({ timestamp: 123 });
   });
 
   it("uses recipients array and targetAuthor for uuid dms", async () => {

--- a/extensions/slack/src/actions.download-file.test.ts
+++ b/extensions/slack/src/actions.download-file.test.ts
@@ -1,13 +1,13 @@
 import type { WebClient } from "@slack/web-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const resolveSlackMedia = vi.fn();
+const resolveSlackMedia = vi.hoisted(() => vi.fn());
 
 vi.mock("./monitor/media.js", () => ({
   resolveSlackMedia: (...args: Parameters<typeof resolveSlackMedia>) => resolveSlackMedia(...args),
 }));
 
-const { downloadSlackFile } = await import("./actions.js");
+let downloadSlackFile: typeof import("./actions.js").downloadSlackFile;
 
 function createClient() {
   return {
@@ -68,8 +68,10 @@ function mockSuccessfulMediaDownload(client: ReturnType<typeof createClient>) {
 }
 
 describe("downloadSlackFile", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     resolveSlackMedia.mockReset();
+    ({ downloadSlackFile } = await import("./actions.js"));
   });
 
   it("returns null when files.info has no private download URL", async () => {

--- a/extensions/slack/src/blocks.test-helpers.ts
+++ b/extensions/slack/src/blocks.test-helpers.ts
@@ -16,19 +16,29 @@ export type SlackSendTestClient = WebClient & {
   };
 };
 
-export function installSlackBlockTestMocks() {
-  vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
     loadConfig: () => ({}),
-  }));
+  };
+});
 
-  vi.mock("./accounts.js", () => ({
+vi.mock("./accounts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./accounts.js")>();
+  return {
+    ...actual,
     resolveSlackAccount: () => ({
       accountId: "default",
       botToken: "xoxb-test",
       botTokenSource: "config",
       config: {},
     }),
-  }));
+  };
+});
+
+export function installSlackBlockTestMocks() {
+  // Kept for existing call sites; the mocks are installed at module load time.
 }
 
 export function createSlackEditTestClient(): SlackEditTestClient {

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -1,24 +1,32 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@slack/web-api", () => {
-  const WebClient = vi.fn(function WebClientMock(
+const WebClientMock = vi.hoisted(() =>
+  vi.fn(function WebClientMock(
     this: Record<string, unknown>,
     token: string,
     options?: Record<string, unknown>,
   ) {
     this.token = token;
     this.options = options;
-  });
-  return { WebClient };
+  }),
+);
+
+vi.mock("@slack/web-api", () => {
+  return { WebClient: WebClientMock };
 });
 
-const slackWebApi = await import("@slack/web-api");
-const { createSlackWebClient, resolveSlackWebClientOptions, SLACK_DEFAULT_RETRY_OPTIONS } =
-  await import("./client.js");
-
-const WebClient = slackWebApi.WebClient as unknown as ReturnType<typeof vi.fn>;
+let createSlackWebClient: typeof import("./client.js").createSlackWebClient;
+let resolveSlackWebClientOptions: typeof import("./client.js").resolveSlackWebClientOptions;
+let SLACK_DEFAULT_RETRY_OPTIONS: typeof import("./client.js").SLACK_DEFAULT_RETRY_OPTIONS;
 
 describe("slack web client config", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    WebClientMock.mockClear();
+    ({ createSlackWebClient, resolveSlackWebClientOptions, SLACK_DEFAULT_RETRY_OPTIONS } =
+      await import("./client.js"));
+  });
+
   it("applies the default retry config when none is provided", () => {
     const options = resolveSlackWebClientOptions();
 
@@ -35,7 +43,7 @@ describe("slack web client config", () => {
   it("passes merged options into WebClient", () => {
     createSlackWebClient("xoxb-test", { timeout: 1234 });
 
-    expect(WebClient).toHaveBeenCalledWith(
+    expect(WebClientMock).toHaveBeenCalledWith(
       "xoxb-test",
       expect.objectContaining({
         timeout: 1234,

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -187,17 +187,65 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   getSlackHandlers()?.clear();
 }
 
+async function dispatchSlackReplyMock(params: {
+  ctx: unknown;
+  cfg: unknown;
+  dispatcher: {
+    sendFinalReply: (payload: unknown) => boolean;
+    markComplete: () => void;
+    waitForIdle: () => Promise<void>;
+    getQueuedCounts: () => Record<string, number>;
+  };
+  replyOptions?: unknown;
+}) {
+  const response = await slackTestState.replyMock(params.ctx, params.replyOptions, params.cfg);
+  const payloads = response == null ? [] : Array.isArray(response) ? response : [response];
+  let queuedFinal = false;
+
+  for (const payload of payloads) {
+    queuedFinal = params.dispatcher.sendFinalReply(payload) || queuedFinal;
+  }
+
+  params.dispatcher.markComplete();
+  await params.dispatcher.waitForIdle();
+
+  return {
+    queuedFinal,
+    counts: params.dispatcher.getQueuedCounts(),
+  };
+}
+
 vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
   return {
     ...actual,
     loadConfig: () => slackTestState.config,
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
+    resolveSessionKey: vi.fn(),
+    readSessionUpdatedAt: vi.fn(() => undefined),
+    recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
   };
 });
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
-  getReplyFromConfig: (...args: unknown[]) => slackTestState.replyMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: (params: {
+      ctx: unknown;
+      cfg: unknown;
+      dispatcher: {
+        sendFinalReply: (payload: unknown) => boolean;
+        markComplete: () => void;
+        waitForIdle: () => Promise<void>;
+        getQueuedCounts: () => Record<string, number>;
+      };
+      replyOptions?: unknown;
+    }) => dispatchSlackReplyMock(params),
+    getReplyFromConfig: (...args: unknown[]) => slackTestState.replyMock(...args),
+  };
+});
 
 vi.mock("./resolve-channels.js", () => ({
   resolveSlackChannelAllowlist: async ({ entries }: { entries: string[] }) =>
@@ -213,21 +261,14 @@ vi.mock("./send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => slackTestState.sendMock(...args),
 }));
 
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => slackTestState.readAllowFromStoreMock(...args),
-  upsertChannelPairingRequest: (...args: unknown[]) =>
-    slackTestState.upsertPairingRequestMock(...args),
-}));
-
-vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
   return {
     ...actual,
-    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
-    updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
-    resolveSessionKey: vi.fn(),
-    readSessionUpdatedAt: vi.fn(() => undefined),
-    recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+    readChannelAllowFromStore: (...args: unknown[]) =>
+      slackTestState.readAllowFromStoreMock(...args),
+    upsertChannelPairingRequest: (...args: unknown[]) =>
+      slackTestState.upsertPairingRequestMock(...args),
   };
 });
 

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SlackMonitorContext } from "./context.js";
 
-const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn());
+const readStoreAllowFromForDmPolicyMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../../../src/pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readChannelAllowFromStoreMock(...args),
+vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
+  readStoreAllowFromForDmPolicy: (...args: unknown[]) => readStoreAllowFromForDmPolicyMock(...args),
 }));
 
-import { clearSlackAllowFromCacheForTest, resolveSlackEffectiveAllowFrom } from "./auth.js";
+const { clearSlackAllowFromCacheForTest, resolveSlackEffectiveAllowFrom } =
+  await import("./auth.js");
 
 function makeSlackCtx(allowFrom: string[]): SlackMonitorContext {
   return {
@@ -21,7 +22,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
   const prevTtl = process.env.OPENCLAW_SLACK_PAIRING_ALLOWFROM_CACHE_TTL_MS;
 
   beforeEach(() => {
-    readChannelAllowFromStoreMock.mockReset();
+    readStoreAllowFromForDmPolicyMock.mockReset();
     clearSlackAllowFromCacheForTest();
     if (prevTtl === undefined) {
       delete process.env.OPENCLAW_SLACK_PAIRING_ALLOWFROM_CACHE_TTL_MS;
@@ -31,7 +32,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
   });
 
   it("falls back to channel config allowFrom when pairing store throws", async () => {
-    readChannelAllowFromStoreMock.mockRejectedValueOnce(new Error("boom"));
+    readStoreAllowFromForDmPolicyMock.mockRejectedValueOnce(new Error("boom"));
 
     const effective = await resolveSlackEffectiveAllowFrom(makeSlackCtx(["u1"]));
 
@@ -40,7 +41,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
   });
 
   it("treats malformed non-array pairing-store responses as empty", async () => {
-    readChannelAllowFromStoreMock.mockReturnValueOnce(undefined);
+    readStoreAllowFromForDmPolicyMock.mockReturnValueOnce(undefined);
 
     const effective = await resolveSlackEffectiveAllowFrom(makeSlackCtx(["u1"]));
 
@@ -49,7 +50,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
   });
 
   it("memoizes pairing-store allowFrom reads within TTL", async () => {
-    readChannelAllowFromStoreMock.mockResolvedValue(["u2"]);
+    readStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]);
     const ctx = makeSlackCtx(["u1"]);
 
     const first = await resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true });
@@ -57,17 +58,17 @@ describe("resolveSlackEffectiveAllowFrom", () => {
 
     expect(first.allowFrom).toEqual(["u1", "u2"]);
     expect(second.allowFrom).toEqual(["u1", "u2"]);
-    expect(readChannelAllowFromStoreMock).toHaveBeenCalledTimes(1);
+    expect(readStoreAllowFromForDmPolicyMock).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes pairing-store allowFrom when cache TTL is zero", async () => {
     process.env.OPENCLAW_SLACK_PAIRING_ALLOWFROM_CACHE_TTL_MS = "0";
-    readChannelAllowFromStoreMock.mockResolvedValue(["u2"]);
+    readStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]);
     const ctx = makeSlackCtx(["u1"]);
 
     await resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true });
     await resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true });
 
-    expect(readChannelAllowFromStoreMock).toHaveBeenCalledTimes(2);
+    expect(readStoreAllowFromForDmPolicyMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -4,9 +4,13 @@ import { createSlackSystemEventTestHarness } from "./system-event-test-harness.j
 
 const enqueueSystemEventMock = vi.fn();
 
-vi.mock("../../../../../src/infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  };
+});
 
 type SlackChannelHandler = (args: {
   event: Record<string, unknown>;

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -10,20 +10,26 @@ const dispatchPluginInteractiveHandlerMock = vi.fn(async () => ({
 const resolvePluginConversationBindingApprovalMock = vi.fn();
 const buildPluginBindingResolvedTextMock = vi.fn(() => "Binding updated.");
 
-vi.mock("../../../../../src/infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) =>
-    (enqueueSystemEventMock as (...innerArgs: unknown[]) => unknown)(...args),
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual: typeof import("openclaw/plugin-sdk/infra-runtime") = await importOriginal();
+  return {
+    ...actual,
+    enqueueSystemEvent: (...args: unknown[]) =>
+      (enqueueSystemEventMock as (...innerArgs: unknown[]) => unknown)(...args),
+  };
+});
 
-vi.mock("../../../../../src/plugins/interactive.js", () => ({
-  dispatchPluginInteractiveHandler: (...args: unknown[]) =>
-    (dispatchPluginInteractiveHandlerMock as (...innerArgs: unknown[]) => unknown)(...args),
-}));
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual: typeof import("openclaw/plugin-sdk/plugin-runtime") = await importOriginal();
+  return {
+    ...actual,
+    dispatchPluginInteractiveHandler: (...args: unknown[]) =>
+      (dispatchPluginInteractiveHandlerMock as (...innerArgs: unknown[]) => unknown)(...args),
+  };
+});
 
-vi.mock("../../../../../src/plugins/conversation-binding.js", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../../../../src/plugins/conversation-binding.js")
-  >("../../../../../src/plugins/conversation-binding.js");
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual: typeof import("openclaw/plugin-sdk/conversation-runtime") = await importOriginal();
   return {
     ...actual,
     resolvePluginConversationBindingApproval: (...args: unknown[]) =>

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -10,13 +10,21 @@ const memberMocks = vi.hoisted(() => ({
   readAllow: vi.fn(),
 }));
 
-vi.mock("../../../../../src/infra/system-events.js", () => ({
-  enqueueSystemEvent: memberMocks.enqueue,
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: memberMocks.enqueue,
+  };
+});
 
-vi.mock("../../../../../src/pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: memberMocks.readAllow,
-}));
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    readStoreAllowFromForDmPolicy: memberMocks.readAllow,
+  };
+});
 
 type MemberHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -8,13 +8,21 @@ import {
 const messageQueueMock = vi.fn();
 const messageAllowMock = vi.fn();
 
-vi.mock("../../../../../src/infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
+  };
+});
 
-vi.mock("../../../../../src/pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => messageAllowMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    readStoreAllowFromForDmPolicy: (...args: unknown[]) => messageAllowMock(...args),
+  };
+});
 
 type MessageHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 type RegisteredEventName = "message" | "app_mention";

--- a/extensions/slack/src/monitor/events/pins.test.ts
+++ b/extensions/slack/src/monitor/events/pins.test.ts
@@ -8,12 +8,20 @@ import {
 const pinEnqueueMock = vi.hoisted(() => vi.fn());
 const pinAllowMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../../../../src/infra/system-events.js", () => {
-  return { enqueueSystemEvent: pinEnqueueMock };
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: pinEnqueueMock,
+  };
 });
-vi.mock("../../../../../src/pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: pinAllowMock,
-}));
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    readStoreAllowFromForDmPolicy: pinAllowMock,
+  };
+});
 
 type PinHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -8,15 +8,19 @@ import {
 const reactionQueueMock = vi.fn();
 const reactionAllowMock = vi.fn();
 
-vi.mock("../../../../../src/infra/system-events.js", () => {
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
   return {
+    ...actual,
     enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
   };
 });
 
-vi.mock("../../../../../src/pairing/pairing-store.js", () => {
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
   return {
-    readChannelAllowFromStore: (...args: unknown[]) => reactionAllowMock(...args),
+    ...actual,
+    readStoreAllowFromForDmPolicy: (...args: unknown[]) => reactionAllowMock(...args),
   };
 });
 

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -1,17 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSlackMessageHandler } from "./message-handler.js";
 
-const enqueueMock = vi.fn(async (_entry: unknown) => {});
-const flushKeyMock = vi.fn(async (_key: string) => {});
-const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
-  ...message,
-}));
+const enqueueMock = vi.hoisted(() => vi.fn(async (_entry: unknown) => {}));
+const flushKeyMock = vi.hoisted(() => vi.fn(async (_key: string) => {}));
+const resolveThreadTsMock = vi.hoisted(() =>
+  vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
+    ...message,
+  })),
+);
 
-vi.mock("../../../../src/auto-reply/inbound-debounce.js", () => ({
-  resolveInboundDebounceMs: () => 10,
-  createInboundDebouncer: () => ({
-    enqueue: (entry: unknown) => enqueueMock(entry),
-    flushKey: (key: string) => flushKeyMock(key),
+vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
+  shouldDebounceTextInbound: (params: { hasMedia?: boolean }) => !params.hasMedia,
+  createChannelInboundDebouncer: () => ({
+    debounceMs: 10,
+    debouncer: {
+      enqueue: (entry: unknown) => enqueueMock(entry),
+      flushKey: (key: string) => flushKeyMock(key),
+    },
   }),
 }));
 
@@ -20,6 +24,8 @@ vi.mock("./thread-resolution.js", () => ({
     resolve: (entry: { message: Record<string, unknown> }) => resolveThreadTsMock(entry),
   }),
 }));
+
+const { createSlackMessageHandler } = await import("./message-handler.js");
 
 function createContext(overrides?: {
   markMessageSeen?: (channel: string | undefined, ts: string | undefined) => boolean;

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -6,42 +6,84 @@ const mocks = vi.hoisted(() => ({
   upsertPairingRequestMock: vi.fn(),
   resolveAgentRouteMock: vi.fn(),
   finalizeInboundContextMock: vi.fn(),
+  buildCommandTextFromArgsMock: vi.fn(),
+  findCommandByNativeNameMock: vi.fn(),
+  listNativeCommandSpecsForConfigMock: vi.fn(),
+  parseCommandArgsMock: vi.fn(),
+  resolveCommandArgMenuMock: vi.fn(),
   resolveConversationLabelMock: vi.fn(),
   createReplyPrefixOptionsMock: vi.fn(),
   recordSessionMetaFromInboundMock: vi.fn(),
+  recordInboundSessionMetaSafeMock: vi.fn(),
   resolveStorePathMock: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
-  dispatchReplyWithDispatcher: (...args: unknown[]) => mocks.dispatchMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchReplyWithDispatcher: (...args: unknown[]) => mocks.dispatchMock(...args),
+    finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),
+    buildCommandTextFromArgs: (...args: unknown[]) => mocks.buildCommandTextFromArgsMock(...args),
+    findCommandByNativeName: (...args: unknown[]) => mocks.findCommandByNativeNameMock(...args),
+    listNativeCommandSpecsForConfig: (...args: unknown[]) =>
+      mocks.listNativeCommandSpecsForConfigMock(...args),
+    parseCommandArgs: (...args: unknown[]) => mocks.parseCommandArgsMock(...args),
+    resolveCommandArgMenu: (...args: unknown[]) => mocks.resolveCommandArgMenuMock(...args),
+  };
+});
 
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => mocks.readAllowFromStoreMock(...args),
-  upsertChannelPairingRequest: (...args: unknown[]) => mocks.upsertPairingRequestMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: (...args: unknown[]) => mocks.readAllowFromStoreMock(...args),
+    upsertChannelPairingRequest: (...args: unknown[]) => mocks.upsertPairingRequestMock(...args),
+  };
+});
 
-vi.mock("openclaw/plugin-sdk/routing", () => ({
-  resolveAgentRoute: (...args: unknown[]) => mocks.resolveAgentRouteMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/routing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/routing")>();
+  return {
+    ...actual,
+    resolveAgentRoute: (...args: unknown[]) => mocks.resolveAgentRouteMock(...args),
+  };
+});
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
-  finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/channel-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-runtime")>();
+  return {
+    ...actual,
+    resolveConversationLabel: (...args: unknown[]) => mocks.resolveConversationLabelMock(...args),
+    createReplyPrefixOptions: (...args: unknown[]) => mocks.createReplyPrefixOptionsMock(...args),
+    recordInboundSessionMetaSafe: (...args: unknown[]) =>
+      mocks.recordInboundSessionMetaSafeMock(...args),
+  };
+});
 
-vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
-  resolveConversationLabel: (...args: unknown[]) => mocks.resolveConversationLabelMock(...args),
-}));
-
-vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
-  createReplyPrefixOptions: (...args: unknown[]) => mocks.createReplyPrefixOptionsMock(...args),
-}));
-
-vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
-  recordSessionMetaFromInbound: (...args: unknown[]) =>
-    mocks.recordSessionMetaFromInboundMock(...args),
-  resolveStorePath: (...args: unknown[]) => mocks.resolveStorePathMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    recordSessionMetaFromInbound: (...args: unknown[]) =>
+      mocks.recordSessionMetaFromInboundMock(...args),
+    resolveStorePath: (...args: unknown[]) => mocks.resolveStorePathMock(...args),
+    resolveNativeCommandsEnabled: ({
+      providerSetting,
+      defaultEnabled,
+    }: {
+      providerSetting?: boolean;
+      defaultEnabled?: boolean;
+    }) => providerSetting ?? defaultEnabled ?? true,
+    resolveNativeSkillsEnabled: ({
+      providerSetting,
+      defaultEnabled,
+    }: {
+      providerSetting?: boolean;
+      defaultEnabled?: boolean;
+    }) => providerSetting ?? defaultEnabled ?? false,
+  };
+});
 
 type SlashHarnessMocks = {
   dispatchMock: ReturnType<typeof vi.fn>;
@@ -49,9 +91,15 @@ type SlashHarnessMocks = {
   upsertPairingRequestMock: ReturnType<typeof vi.fn>;
   resolveAgentRouteMock: ReturnType<typeof vi.fn>;
   finalizeInboundContextMock: ReturnType<typeof vi.fn>;
+  buildCommandTextFromArgsMock: ReturnType<typeof vi.fn>;
+  findCommandByNativeNameMock: ReturnType<typeof vi.fn>;
+  listNativeCommandSpecsForConfigMock: ReturnType<typeof vi.fn>;
+  parseCommandArgsMock: ReturnType<typeof vi.fn>;
+  resolveCommandArgMenuMock: ReturnType<typeof vi.fn>;
   resolveConversationLabelMock: ReturnType<typeof vi.fn>;
   createReplyPrefixOptionsMock: ReturnType<typeof vi.fn>;
   recordSessionMetaFromInboundMock: ReturnType<typeof vi.fn>;
+  recordInboundSessionMetaSafeMock: ReturnType<typeof vi.fn>;
   resolveStorePathMock: ReturnType<typeof vi.fn>;
 };
 
@@ -60,6 +108,41 @@ export function getSlackSlashMocks(): SlashHarnessMocks {
 }
 
 export function resetSlackSlashMocks() {
+  const usageCommand = { key: "usage", nativeName: "usage" };
+  const reportCommand = { key: "report", nativeName: "report" };
+  const reportCompactCommand = { key: "reportcompact", nativeName: "reportcompact" };
+  const reportExternalCommand = { key: "reportexternal", nativeName: "reportexternal" };
+  const reportLongCommand = { key: "reportlong", nativeName: "reportlong" };
+  const unsafeConfirmCommand = { key: "unsafeconfirm", nativeName: "unsafeconfirm" };
+  const statusAliasCommand = { key: "status", nativeName: "status" };
+  const periodArg = { name: "period", description: "period" };
+  const baseReportPeriodChoices = [
+    { value: "day", label: "day" },
+    { value: "week", label: "week" },
+    { value: "month", label: "month" },
+    { value: "quarter", label: "quarter" },
+  ];
+  const fullReportPeriodChoices = [...baseReportPeriodChoices, { value: "year", label: "year" }];
+  const hasNonEmptyArgValue = (values: unknown, key: string) => {
+    const raw =
+      typeof values === "object" && values !== null
+        ? (values as Record<string, unknown>)[key]
+        : undefined;
+    return typeof raw === "string" && raw.trim().length > 0;
+  };
+  const resolvePeriodMenu = (
+    params: { args?: { values?: unknown } },
+    choices: Array<{
+      value: string;
+      label: string;
+    }>,
+  ) => {
+    if (hasNonEmptyArgValue(params.args?.values, "period")) {
+      return null;
+    }
+    return { arg: periodArg, choices };
+  };
+
   mocks.dispatchMock.mockReset().mockResolvedValue({ counts: { final: 1, tool: 0, block: 0 } });
   mocks.readAllowFromStoreMock.mockReset().mockResolvedValue([]);
   mocks.upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
@@ -69,8 +152,149 @@ export function resetSlackSlashMocks() {
     accountId: "acct",
   });
   mocks.finalizeInboundContextMock.mockReset().mockImplementation((ctx: unknown) => ctx);
+  mocks.buildCommandTextFromArgsMock
+    .mockReset()
+    .mockImplementation(
+      (cmd: { nativeName?: string; key: string }, args?: { values?: Record<string, unknown> }) => {
+        const name = cmd.nativeName ?? cmd.key;
+        const values = args?.values ?? {};
+        const mode = values.mode;
+        const period = values.period;
+        const selected =
+          typeof mode === "string" && mode.trim()
+            ? mode.trim()
+            : typeof period === "string" && period.trim()
+              ? period.trim()
+              : "";
+        return selected ? `/${name} ${selected}` : `/${name}`;
+      },
+    );
+  mocks.findCommandByNativeNameMock.mockReset().mockImplementation((name: string) => {
+    const normalized = name.trim().toLowerCase();
+    if (normalized === "usage") {
+      return usageCommand;
+    }
+    if (normalized === "report") {
+      return reportCommand;
+    }
+    if (normalized === "reportcompact") {
+      return reportCompactCommand;
+    }
+    if (normalized === "reportexternal") {
+      return reportExternalCommand;
+    }
+    if (normalized === "reportlong") {
+      return reportLongCommand;
+    }
+    if (normalized === "unsafeconfirm") {
+      return unsafeConfirmCommand;
+    }
+    if (normalized === "agentstatus") {
+      return statusAliasCommand;
+    }
+    return undefined;
+  });
+  mocks.listNativeCommandSpecsForConfigMock.mockReset().mockReturnValue([
+    {
+      name: "usage",
+      description: "Usage",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "report",
+      description: "Report",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "reportcompact",
+      description: "ReportCompact",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "reportexternal",
+      description: "ReportExternal",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "reportlong",
+      description: "ReportLong",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "unsafeconfirm",
+      description: "UnsafeConfirm",
+      acceptsArgs: true,
+      args: [],
+    },
+    {
+      name: "agentstatus",
+      description: "Status",
+      acceptsArgs: false,
+      args: [],
+    },
+  ]);
+  mocks.parseCommandArgsMock.mockReset().mockReturnValue({ values: {} });
+  mocks.resolveCommandArgMenuMock
+    .mockReset()
+    .mockImplementation((params: { command?: { key?: string }; args?: { values?: unknown } }) => {
+      if (params.command?.key === "report") {
+        return resolvePeriodMenu(params, [
+          ...fullReportPeriodChoices,
+          { value: "all", label: "all" },
+        ]);
+      }
+      if (params.command?.key === "reportlong") {
+        return resolvePeriodMenu(params, [
+          ...fullReportPeriodChoices,
+          { value: "x".repeat(90), label: "long" },
+        ]);
+      }
+      if (params.command?.key === "reportcompact") {
+        return resolvePeriodMenu(params, baseReportPeriodChoices);
+      }
+      if (params.command?.key === "reportexternal") {
+        return {
+          arg: { name: "period", description: "period" },
+          choices: Array.from({ length: 140 }, (_v, i) => ({
+            value: `period-${i + 1}`,
+            label: `Period ${i + 1}`,
+          })),
+        };
+      }
+      if (params.command?.key === "unsafeconfirm") {
+        return {
+          arg: { name: "mode_*`~<&>", description: "mode" },
+          choices: [
+            { value: "on", label: "on" },
+            { value: "off", label: "off" },
+          ],
+        };
+      }
+      if (params.command?.key !== "usage") {
+        return null;
+      }
+      const values = (params.args?.values ?? {}) as Record<string, unknown>;
+      if (typeof values.mode === "string" && values.mode.trim()) {
+        return null;
+      }
+      return {
+        arg: { name: "mode", description: "mode" },
+        choices: [
+          { value: "tokens", label: "tokens" },
+          { value: "cost", label: "cost" },
+        ],
+      };
+    });
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.createReplyPrefixOptionsMock.mockReset().mockReturnValue({ onModelSelected: () => {} });
   mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
+  mocks.recordInboundSessionMetaSafeMock.mockReset().mockImplementation(async (params: unknown) => {
+    await mocks.recordSessionMetaFromInboundMock(params);
+  });
   mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
 }

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -184,6 +184,8 @@ let registerSlackMonitorSlashCommands: RegisterFn;
 
 const { dispatchMock } = getSlackSlashMocks();
 
+resetSlackSlashMocks();
+
 beforeAll(async () => {
   ({ registerSlackMonitorSlashCommands } = (await import("./slash.js")) as unknown as {
     registerSlackMonitorSlashCommands: RegisterFn;

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -8,14 +8,15 @@ vi.mock("./client.js", () => ({
   createSlackWebClient: createSlackWebClientMock,
 }));
 
-vi.mock("../../../src/utils/with-timeout.js", () => ({
+vi.mock("openclaw/plugin-sdk/text-runtime", () => ({
   withTimeout: withTimeoutMock,
 }));
 
-const { probeSlack } = await import("./probe.js");
+let probeSlack: typeof import("./probe.js").probeSlack;
 
 describe("probeSlack", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     authTestMock.mockReset();
     createSlackWebClientMock.mockReset();
     withTimeoutMock.mockReset();
@@ -26,6 +27,7 @@ describe("probeSlack", () => {
       },
     });
     withTimeoutMock.mockImplementation(async (promise: Promise<unknown>) => await promise);
+    ({ probeSlack } = await import("./probe.js"));
   });
 
   it("maps Slack auth metadata on success", async () => {

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -4,34 +4,43 @@ import { installSlackBlockTestMocks } from "./blocks.test-helpers.js";
 
 // --- Module mocks (must precede dynamic import) ---
 installSlackBlockTestMocks();
-const fetchWithSsrFGuard = vi.fn(
-  async (params: { url: string; init?: RequestInit }) =>
-    ({
-      response: await fetch(params.url, params.init),
-      finalUrl: params.url,
-      release: async () => {},
-    }) as const,
+const fetchWithSsrFGuard = vi.hoisted(() =>
+  vi.fn(
+    async (params: { url: string; init?: RequestInit }) =>
+      ({
+        response: await fetch(params.url, params.init),
+        finalUrl: params.url,
+        release: async () => {},
+      }) as const,
+  ),
 );
-
-vi.mock("../../../src/infra/net/fetch-guard.js", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) =>
-    fetchWithSsrFGuard(...(args as [params: { url: string; init?: RequestInit }])),
-  withTrustedEnvProxyGuardedFetchMode: (params: Record<string, unknown>) => ({
-    ...params,
-    mode: "trusted_env_proxy",
-  }),
-}));
-
-vi.mock("../../whatsapp/src/media.js", () => ({
-  loadWebMedia: vi.fn(async () => ({
+const loadWebMediaMock = vi.hoisted(() =>
+  vi.fn(async () => ({
     buffer: Buffer.from("fake-image"),
     contentType: "image/png",
     kind: "image",
     fileName: "screenshot.png",
   })),
+);
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) =>
+      fetchWithSsrFGuard(...(args as [params: { url: string; init?: RequestInit }])),
+    withTrustedEnvProxyGuardedFetchMode: (params: Record<string, unknown>) => ({
+      ...params,
+      mode: "trusted_env_proxy",
+    }),
+  };
+});
+
+vi.mock("../../whatsapp/src/media.js", () => ({
+  loadWebMedia: (...args: Parameters<typeof loadWebMediaMock>) => loadWebMediaMock(...args),
 }));
 
-const { sendMessageSlack } = await import("./send.js");
+let sendMessageSlack: typeof import("./send.js").sendMessageSlack;
 
 type UploadTestClient = WebClient & {
   conversations: { open: ReturnType<typeof vi.fn> };
@@ -64,11 +73,14 @@ function createUploadTestClient(): UploadTestClient {
 describe("sendMessageSlack file upload with user IDs", () => {
   const originalFetch = globalThis.fetch;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     globalThis.fetch = vi.fn(
       async () => new Response("ok", { status: 200 }),
     ) as unknown as typeof fetch;
+    vi.resetModules();
     fetchWithSsrFGuard.mockClear();
+    loadWebMediaMock.mockClear();
+    ({ sendMessageSlack } = await import("./send.js"));
   });
 
   afterEach(() => {

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -36,13 +36,6 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   return {
     ...actual,
     loadConfig,
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
-  return {
-    ...actual,
     resolveStorePath: vi.fn((storePath) => storePath ?? sessionStorePath),
   };
 });

--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.test-harness.ts
@@ -1,24 +1,67 @@
 import { vi } from "vitest";
-import { monitorWebChannel } from "./auto-reply.js";
 import {
   createWebInboundDeliverySpies,
-  createWebListenerFactoryCapture,
   sendWebDirectInboundMessage,
 } from "./auto-reply.test-harness.js";
 import type { WebInboundMessage } from "./inbound.js";
+
+async function createCapturedWebOnMessage(resolver: unknown) {
+  const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+  const { DEFAULT_GROUP_HISTORY_LIMIT } = await import("openclaw/plugin-sdk/reply-runtime");
+  const { getChildLogger } = await import("openclaw/plugin-sdk/runtime-env");
+  const { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } = await import("./accounts.js");
+  const { buildMentionConfig } = await import("./auto-reply/mentions.js");
+  const { createEchoTracker } = await import("./auto-reply/monitor/echo.js");
+  const { createWebOnMessageHandler } = await import("./auto-reply/monitor/on-message.js");
+
+  const baseCfg = loadConfig();
+  const account = resolveWhatsAppAccount({ cfg: baseCfg, accountId: "default" });
+  const cfg = {
+    ...baseCfg,
+    channels: {
+      ...baseCfg.channels,
+      whatsapp: {
+        ...baseCfg.channels?.whatsapp,
+        ackReaction: account.ackReaction,
+        messagePrefix: account.messagePrefix,
+        allowFrom: account.allowFrom,
+        groupAllowFrom: account.groupAllowFrom,
+        groupPolicy: account.groupPolicy,
+        textChunkLimit: account.textChunkLimit,
+        chunkMode: account.chunkMode,
+        mediaMaxMb: account.mediaMaxMb,
+        blockStreaming: account.blockStreaming,
+        groups: account.groups,
+      },
+    },
+  } satisfies typeof baseCfg;
+
+  return createWebOnMessageHandler({
+    cfg,
+    verbose: false,
+    connectionId: "test-web-broadcast",
+    maxMediaBytes: resolveWhatsAppMediaMaxBytes(account),
+    groupHistoryLimit:
+      cfg.channels?.whatsapp?.historyLimit ??
+      cfg.messages?.groupChat?.historyLimit ??
+      DEFAULT_GROUP_HISTORY_LIMIT,
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    echoTracker: createEchoTracker({ maxItems: 100 }),
+    backgroundTasks: new Set(),
+    replyResolver: resolver as never,
+    replyLogger: getChildLogger({ module: "web-auto-reply-test" }),
+    baseMentionConfig: buildMentionConfig(cfg),
+    account,
+  });
+}
 
 export async function monitorWebChannelWithCapture(resolver: unknown): Promise<{
   spies: ReturnType<typeof createWebInboundDeliverySpies>;
   onMessage: (msg: WebInboundMessage) => Promise<void>;
 }> {
   const spies = createWebInboundDeliverySpies();
-  const { listenerFactory, getOnMessage } = createWebListenerFactoryCapture();
-
-  await monitorWebChannel(false, listenerFactory, false, resolver as never);
-  const onMessage = getOnMessage();
-  if (!onMessage) {
-    throw new Error("Missing onMessage handler");
-  }
+  const onMessage = await createCapturedWebOnMessage(resolver);
 
   return { spies, onMessage };
 }
@@ -33,7 +76,9 @@ export async function sendWebDirectInboundAndCollectSessionKeys(): Promise<{
     return { text: "ok" };
   });
 
-  const { spies, onMessage } = await monitorWebChannelWithCapture(resolver);
+  const spies = createWebInboundDeliverySpies();
+  const onMessage = await createCapturedWebOnMessage(resolver);
+
   await sendWebDirectInboundMessage({
     onMessage,
     spies,

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -1,30 +1,33 @@
-import { describe, expect, it, vi } from "vitest";
-import { logVerbose } from "../../../../src/globals.js";
-import { sleep } from "../../../../src/utils.js";
-import { loadWebMedia } from "../media.js";
-import { deliverWebReply } from "./deliver-reply.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebInboundMsg } from "./types.js";
 
-vi.mock("../../../../src/globals.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../../src/globals.js")>();
+const logVerboseMock = vi.hoisted(() => vi.fn());
+const shouldLogVerboseMock = vi.hoisted(() => vi.fn(() => true));
+const sleepMock = vi.hoisted(() => vi.fn(async () => {}));
+const loadWebMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
   return {
     ...actual,
-    shouldLogVerbose: vi.fn(() => true),
-    logVerbose: vi.fn(),
+    shouldLogVerbose: shouldLogVerboseMock,
+    logVerbose: logVerboseMock,
   };
 });
 
 vi.mock("../media.js", () => ({
-  loadWebMedia: vi.fn(),
+  loadWebMedia: (...args: Parameters<typeof loadWebMediaMock>) => loadWebMediaMock(...args),
 }));
 
-vi.mock("../../../../src/utils.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../../src/utils.js")>();
+vi.mock("openclaw/plugin-sdk/text-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-runtime")>();
   return {
     ...actual,
-    sleep: vi.fn(async () => {}),
+    sleep: sleepMock,
   };
 });
+
+let deliverWebReply: typeof import("./deliver-reply.js").deliverWebReply;
 
 function makeMsg(): WebInboundMsg {
   return {
@@ -37,9 +40,7 @@ function makeMsg(): WebInboundMsg {
 }
 
 function mockLoadedImageMedia() {
-  (
-    loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
-  ).mockResolvedValueOnce({
+  loadWebMediaMock.mockResolvedValueOnce({
     buffer: Buffer.from("img"),
     contentType: "image/jpeg",
     kind: "image",
@@ -84,6 +85,17 @@ async function expectReplySuppressed(replyResult: { text: string; isReasoning?: 
 }
 
 describe("deliverWebReply", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    logVerboseMock.mockReset();
+    shouldLogVerboseMock.mockReset().mockReturnValue(true);
+    sleepMock.mockReset().mockImplementation(async () => {});
+    loadWebMediaMock.mockReset();
+    replyLogger.info.mockClear();
+    replyLogger.warn.mockClear();
+    ({ deliverWebReply } = await import("./deliver-reply.js"));
+  });
+
   it("suppresses payloads flagged as reasoning", async () => {
     await expectReplySuppressed({ text: "Reasoning:\n_hidden_", isReasoning: true });
   });
@@ -145,7 +157,7 @@ describe("deliverWebReply", () => {
       });
 
       expect(msg.reply).toHaveBeenCalledTimes(2);
-      expect(sleep).toHaveBeenCalledWith(500);
+      expect(sleepMock).toHaveBeenCalledWith(500);
     },
   );
 
@@ -164,7 +176,7 @@ describe("deliverWebReply", () => {
       skipLog: true,
     });
 
-    expect(loadWebMedia).toHaveBeenCalledWith("http://example.com/img.jpg", {
+    expect(loadWebMediaMock).toHaveBeenCalledWith("http://example.com/img.jpg", {
       maxBytes: 1024 * 1024,
       localRoots: mediaLocalRoots,
     });
@@ -178,7 +190,7 @@ describe("deliverWebReply", () => {
     );
     expect(msg.reply).toHaveBeenCalledWith("aaa");
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (media)");
-    expect(logVerbose).toHaveBeenCalled();
+    expect(logVerboseMock).toHaveBeenCalled();
   });
 
   it("retries media send on transient failure", async () => {
@@ -199,7 +211,7 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.sendMedia).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(500);
+    expect(sleepMock).toHaveBeenCalledWith(500);
   });
 
   it("falls back to text-only when the first media send fails", async () => {
@@ -228,9 +240,7 @@ describe("deliverWebReply", () => {
 
   it("sends audio media as ptt voice note", async () => {
     const msg = makeMsg();
-    (
-      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
-    ).mockResolvedValueOnce({
+    loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("aud"),
       contentType: "audio/ogg",
       kind: "audio",
@@ -257,9 +267,7 @@ describe("deliverWebReply", () => {
 
   it("sends video media", async () => {
     const msg = makeMsg();
-    (
-      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
-    ).mockResolvedValueOnce({
+    loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("vid"),
       contentType: "video/mp4",
       kind: "video",
@@ -285,9 +293,7 @@ describe("deliverWebReply", () => {
 
   it("sends non-audio/image/video media as document", async () => {
     const msg = makeMsg();
-    (
-      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
-    ).mockResolvedValueOnce({
+    loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("bin"),
       contentType: undefined,
       kind: "file",

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.test.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.test.ts
@@ -1,78 +1,93 @@
+import type { getReplyFromConfig } from "openclaw/plugin-sdk/reply-runtime";
+import { HEARTBEAT_TOKEN } from "openclaw/plugin-sdk/reply-runtime";
+import { redactIdentifier } from "openclaw/plugin-sdk/text-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { getReplyFromConfig } from "../../../../src/auto-reply/reply.js";
-import { HEARTBEAT_TOKEN } from "../../../../src/auto-reply/tokens.js";
-import { redactIdentifier } from "../../../../src/logging/redact-identifier.js";
 import type { sendMessageWhatsApp } from "../send.js";
 
-const state = vi.hoisted(() => ({
-  visibility: { showAlerts: true, showOk: true, useIndicator: false },
-  store: {} as Record<string, { updatedAt?: number; sessionId?: string }>,
-  snapshot: {
-    key: "k",
-    entry: { sessionId: "s1", updatedAt: 123 },
-    fresh: false,
-    resetPolicy: { mode: "none", atHour: null, idleMinutes: null },
-    dailyResetAt: null as number | null,
-    idleExpiresAt: null as number | null,
-  },
-  events: [] as unknown[],
-  loggerInfoCalls: [] as unknown[][],
-  loggerWarnCalls: [] as unknown[][],
-  heartbeatInfoLogs: [] as string[],
-  heartbeatWarnLogs: [] as string[],
-}));
+const state = vi.hoisted(() => {
+  return {
+    visibility: { showAlerts: true, showOk: true, useIndicator: false },
+    store: {} as Record<string, { updatedAt?: number; sessionId?: string }>,
+    snapshot: {
+      key: "k",
+      entry: { sessionId: "s1", updatedAt: 123 },
+      fresh: false,
+      resetPolicy: { mode: "none", atHour: null, idleMinutes: null },
+      dailyResetAt: null as number | null,
+      idleExpiresAt: null as number | null,
+    },
+    events: [] as unknown[],
+    loggerInfoCalls: [] as unknown[][],
+    loggerWarnCalls: [] as unknown[][],
+    heartbeatInfoLogs: [] as string[],
+    heartbeatWarnLogs: [] as string[],
+  };
+});
 
-vi.mock("../../../../src/agents/current-time.js", () => ({
-  appendCronStyleCurrentTimeLine: (body: string) =>
-    `${body}\nCurrent time: 2026-02-15T00:00:00Z (mock)`,
-}));
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const { optionalStringEnum } = await import("../../../../src/agents/schema/typebox.js");
+  const { jsonResult, readNumberParam, readStringParam } =
+    await import("../../../../src/agents/tools/common.js");
+  return {
+    appendCronStyleCurrentTimeLine: (body: string) =>
+      `${body}\nCurrent time: 2026-02-15T00:00:00Z (mock)`,
+    optionalStringEnum,
+    jsonResult,
+    readNumberParam,
+    readStringParam,
+  };
+});
 
-// Perf: this module otherwise pulls a large dependency graph that we don't need
-// for these unit tests.
-vi.mock("../../../../src/auto-reply/reply.js", () => ({
-  getReplyFromConfig: vi.fn(async () => undefined),
-}));
-
-vi.mock("../../../../src/channels/plugins/whatsapp-heartbeat.js", () => ({
+vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
   resolveWhatsAppHeartbeatRecipients: () => [],
 }));
 
-vi.mock("../../../../src/config/config.js", () => ({
-  loadConfig: () => ({ agents: { defaults: {} }, session: {} }),
-}));
-
-vi.mock("../../../../src/routing/session-key.js", () => ({
-  normalizeMainKey: () => null,
-}));
-
-vi.mock("../../../../src/infra/heartbeat-visibility.js", () => ({
-  resolveHeartbeatVisibility: () => state.visibility,
-}));
-
-vi.mock("../../../../src/config/sessions.js", () => ({
-  loadSessionStore: () => state.store,
-  resolveSessionKey: () => "k",
-  resolveStorePath: () => "/tmp/store.json",
-  updateSessionStore: async (_path: string, updater: (store: typeof state.store) => void) => {
-    updater(state.store);
-  },
-}));
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    loadConfig: () => ({ agents: { defaults: {} }, session: {} }),
+    loadSessionStore: () => state.store,
+    resolveSessionKey: () => "k",
+    resolveStorePath: () => "/tmp/store.json",
+    updateSessionStore: async (_path: string, updater: (store: typeof state.store) => void) => {
+      updater(state.store);
+    },
+  };
+});
 
 vi.mock("./session-snapshot.js", () => ({
   getSessionSnapshot: () => state.snapshot,
 }));
 
-vi.mock("../../../../src/infra/heartbeat-events.js", () => ({
-  emitHeartbeatEvent: (event: unknown) => state.events.push(event),
-  resolveIndicatorType: (status: string) => `indicator:${status}`,
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    emitHeartbeatEvent: (event: unknown) => state.events.push(event),
+    resolveHeartbeatVisibility: () => state.visibility,
+    resolveIndicatorType: (status: string) => `indicator:${status}`,
+  };
+});
 
-vi.mock("../../../../src/logging.js", () => ({
-  getChildLogger: () => ({
-    info: (...args: unknown[]) => state.loggerInfoCalls.push(args),
-    warn: (...args: unknown[]) => state.loggerWarnCalls.push(args),
-  }),
-}));
+vi.mock("openclaw/plugin-sdk/routing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/routing")>();
+  return {
+    ...actual,
+    normalizeMainKey: () => null,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    getChildLogger: () => ({
+      info: (...args: unknown[]) => state.loggerInfoCalls.push(args),
+      warn: (...args: unknown[]) => state.loggerWarnCalls.push(args),
+    }),
+  };
+});
 
 vi.mock("./loggers.js", () => ({
   whatsappHeartbeatLog: {
@@ -109,6 +124,7 @@ describe("runWebHeartbeatOnce", () => {
   });
 
   beforeEach(() => {
+    vi.resetModules();
     state.visibility = { showAlerts: true, showOk: true, useIndicator: false };
     state.store = { k: { updatedAt: 999, sessionId: "s1" } };
     state.snapshot = {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -4,14 +4,34 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../../src/channels/plugins/contracts/suites.js";
 
+type DispatchReplyWithBufferedBlockDispatcherFn =
+  typeof import("openclaw/plugin-sdk/reply-runtime").dispatchReplyWithBufferedBlockDispatcher;
+type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
+  ReturnType<DispatchReplyWithBufferedBlockDispatcherFn>
+>;
+
 let capturedCtx: unknown;
 let capturedDispatchParams: unknown;
 let sessionDir: string | undefined;
 let sessionStorePath: string;
 let backgroundTasks: Set<Promise<unknown>>;
-const { deliverWebReplyMock } = vi.hoisted(() => ({
-  deliverWebReplyMock: vi.fn(async () => {}),
-}));
+const { deliverWebReplyMock, dispatchReplyWithBufferedBlockDispatcherMock, updateLastRouteMock } =
+  vi.hoisted(() => ({
+    deliverWebReplyMock: vi.fn(async () => {}),
+    dispatchReplyWithBufferedBlockDispatcherMock: vi.fn<DispatchReplyWithBufferedBlockDispatcherFn>(
+      async (
+        params: Parameters<DispatchReplyWithBufferedBlockDispatcherFn>[0],
+      ): Promise<DispatchReplyWithBufferedBlockDispatcherResult> => {
+        capturedDispatchParams = params;
+        capturedCtx = params.ctx;
+        return {
+          queuedFinal: false,
+          counts: {} as DispatchReplyWithBufferedBlockDispatcherResult["counts"],
+        };
+      },
+    ),
+    updateLastRouteMock: vi.fn(),
+  }));
 
 const defaultReplyLogger = {
   info: () => {},
@@ -83,31 +103,17 @@ function createWhatsAppDirectStreamingArgs(params?: {
   });
 }
 
-vi.mock("../../../../../src/auto-reply/reply/provider-dispatcher.js", () => ({
-  // oxlint-disable-next-line typescript/no-explicit-any
-  dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (params: any) => {
-    capturedDispatchParams = params;
-    capturedCtx = params.ctx;
-    return { queuedFinal: false };
-  }),
-}));
+const replyRuntime = await import("openclaw/plugin-sdk/reply-runtime");
+const deliverReplyModule = await import("../deliver-reply.js");
+const lastRouteModule = await import("./last-route.js");
+vi.spyOn(replyRuntime, "dispatchReplyWithBufferedBlockDispatcher").mockImplementation(
+  dispatchReplyWithBufferedBlockDispatcherMock,
+);
+vi.spyOn(deliverReplyModule, "deliverWebReply").mockImplementation(deliverWebReplyMock);
+vi.spyOn(lastRouteModule, "updateLastRouteInBackground").mockImplementation(updateLastRouteMock);
 
-vi.mock("./last-route.js", () => ({
-  trackBackgroundTask: (tasks: Set<Promise<unknown>>, task: Promise<unknown>) => {
-    tasks.add(task);
-    void task.finally(() => {
-      tasks.delete(task);
-    });
-  },
-  updateLastRouteInBackground: vi.fn(),
-}));
-
-vi.mock("../deliver-reply.js", () => ({
-  deliverWebReply: deliverWebReplyMock,
-}));
-
-import { updateLastRouteInBackground } from "./last-route.js";
-import { processMessage } from "./process-message.js";
+const { updateLastRouteInBackground } = lastRouteModule;
+const { processMessage } = await import("./process-message.js");
 
 describe("web processMessage inbound context", () => {
   beforeEach(async () => {
@@ -115,6 +121,8 @@ describe("web processMessage inbound context", () => {
     capturedDispatchParams = undefined;
     backgroundTasks = new Set();
     deliverWebReplyMock.mockClear();
+    dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
+    updateLastRouteMock.mockClear();
     sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-process-message-"));
     sessionStorePath = path.join(sessionDir, "sessions.json");
   });

--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -2,235 +2,157 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
-const upsertPairingRequestMock = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true });
-const saveMediaBufferSpy = vi.fn();
+const { normalizeMessageContent, downloadMediaMessage } = vi.hoisted(() => ({
+  normalizeMessageContent: vi.fn((message: unknown) => message),
+  downloadMediaMessage: vi.fn(),
+}));
 
-vi.mock("../../../src/config/config.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
-  return {
-    ...actual,
-    loadConfig: vi.fn().mockReturnValue({
-      channels: {
-        whatsapp: {
-          allowFrom: ["*"], // Allow all in tests
-        },
-      },
-      messages: {
-        messagePrefix: undefined,
-        responsePrefix: undefined,
-      },
-    }),
-  };
-});
+const saveMediaBufferSpy = vi.hoisted(() => vi.fn());
 
-vi.mock("../../../src/pairing/pairing-store.js", () => {
-  return {
-    readChannelAllowFromStore(...args: unknown[]) {
-      return readAllowFromStoreMock(...args);
-    },
-    upsertChannelPairingRequest(...args: unknown[]) {
-      return upsertPairingRequestMock(...args);
-    },
-  };
-});
+vi.mock("@whiskeysockets/baileys", () => ({
+  normalizeMessageContent,
+  downloadMediaMessage,
+}));
 
-vi.mock("../../../src/media/store.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../src/media/store.js")>();
-  return {
-    ...actual,
-    saveMediaBuffer: vi.fn(async (...args: Parameters<typeof actual.saveMediaBuffer>) => {
-      saveMediaBufferSpy(...args);
-      return actual.saveMediaBuffer(...args);
-    }),
-  };
-});
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
+  formatLocationText: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/text-runtime", () => ({
+  jidToE164: (jid: string) => {
+    const digits = jid.replace(/@.*$/, "");
+    return digits ? `+${digits}` : null;
+  },
+}));
 
 const HOME = path.join(os.tmpdir(), `openclaw-inbound-media-${crypto.randomUUID()}`);
 process.env.HOME = HOME;
 
-vi.mock("@whiskeysockets/baileys", async () => {
-  const actual =
-    await vi.importActual<typeof import("@whiskeysockets/baileys")>("@whiskeysockets/baileys");
-  const jpegBuffer = Buffer.from([
-    0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x03, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03, 0x02, 0x02,
-    0x02, 0x03, 0x03, 0x03, 0x03, 0x04, 0x06, 0x04, 0x04, 0x04, 0x04, 0x04, 0x08, 0x06, 0x06, 0x05,
-    0x06, 0x09, 0x08, 0x0a, 0x0a, 0x09, 0x08, 0x09, 0x09, 0x0a, 0x0c, 0x0f, 0x0c, 0x0a, 0x0b, 0x0e,
-    0x0b, 0x09, 0x09, 0x0d, 0x11, 0x0d, 0x0e, 0x0f, 0x10, 0x10, 0x11, 0x10, 0x0a, 0x0c, 0x12, 0x13,
-    0x12, 0x10, 0x13, 0x0f, 0x10, 0x10, 0x10, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01,
-    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01, 0xff, 0xc4, 0x00, 0x14, 0x00, 0x01,
-    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
-    0xc4, 0x00, 0x14, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00,
-    0xff, 0xd9,
-  ]);
+let downloadInboundMedia: typeof import("./inbound/media.js").downloadInboundMedia;
+let extractMentionedJids: typeof import("./inbound/extract.js").extractMentionedJids;
+
+const mockSock = {
+  updateMediaMessage: vi.fn(),
+  logger: { child: () => ({}) },
+} as never;
+
+async function saveMediaBufferMock(
+  buffer: Buffer,
+  contentType?: string,
+  _kind?: string,
+  maxBytes?: number,
+  fileName?: string,
+) {
+  saveMediaBufferSpy(buffer, contentType, _kind, maxBytes, fileName);
+  const ext =
+    fileName && path.extname(fileName)
+      ? path.extname(fileName)
+      : contentType === "image/jpeg"
+        ? ".jpg"
+        : contentType === "image/png"
+          ? ".png"
+          : contentType === "application/pdf"
+            ? ".pdf"
+            : "";
+  const savedPath = path.join(HOME, `saved-${crypto.randomUUID()}${ext}`);
+  await fs.mkdir(path.dirname(savedPath), { recursive: true });
+  await fs.writeFile(savedPath, buffer);
   return {
-    ...actual,
-    downloadMediaMessage: vi.fn().mockResolvedValue(jpegBuffer),
+    id: `mid-${crypto.randomUUID()}`,
+    path: savedPath,
+    size: buffer.length,
+    contentType,
   };
-});
+}
 
-vi.mock("./session.js", () => {
-  const { EventEmitter } = require("node:events");
-  const ev = new EventEmitter();
-  const sock = {
-    ev,
-    ws: { close: vi.fn() },
-    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
-    sendMessage: vi.fn().mockResolvedValue(undefined),
-    readMessages: vi.fn().mockResolvedValue(undefined),
-    updateMediaMessage: vi.fn(),
-    logger: {},
-    user: { id: "me@s.whatsapp.net" },
-  };
-  return {
-    createWaSocket: vi.fn().mockResolvedValue(sock),
-    waitForWaConnection: vi.fn().mockResolvedValue(undefined),
-    getStatusCode: vi.fn(() => 200),
-  };
-});
+const jpegBuffer = Buffer.from([
+  0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x03, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03, 0x02, 0x02,
+  0x02, 0x03, 0x03, 0x03, 0x03, 0x04, 0x06, 0x04, 0x04, 0x04, 0x04, 0x04, 0x08, 0x06, 0x06, 0x05,
+  0x06, 0x09, 0x08, 0x0a, 0x0a, 0x09, 0x08, 0x09, 0x09, 0x0a, 0x0c, 0x0f, 0x0c, 0x0a, 0x0b, 0x0e,
+  0x0b, 0x09, 0x09, 0x0d, 0x11, 0x0d, 0x0e, 0x0f, 0x10, 0x10, 0x11, 0x10, 0x0a, 0x0c, 0x12, 0x13,
+  0x12, 0x10, 0x13, 0x0f, 0x10, 0x10, 0x10, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01,
+  0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01, 0xff, 0xc4, 0x00, 0x14, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+  0xc4, 0x00, 0x14, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00,
+  0xff, 0xd9,
+]);
 
-import { monitorWebInbox, resetWebInboundDedupe } from "./inbound.js";
-let createWaSocket: typeof import("./session.js").createWaSocket;
-
-async function waitForMessage(onMessage: ReturnType<typeof vi.fn>) {
-  await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1), {
-    interval: 1,
-    timeout: 250,
-  });
-  return onMessage.mock.calls[0][0];
+async function saveInboundMedia(params: { message: Record<string, unknown>; mediaMaxMb?: number }) {
+  const inboundMedia = await downloadInboundMedia({ message: params.message } as never, mockSock);
+  expect(inboundMedia).toBeDefined();
+  const maxBytes = (params.mediaMaxMb ?? 50) * 1024 * 1024;
+  return await saveMediaBufferMock(
+    inboundMedia!.buffer,
+    inboundMedia!.mimetype,
+    "inbound",
+    maxBytes,
+    inboundMedia!.fileName,
+  );
 }
 
 describe("web inbound media saves with extension", () => {
-  async function getMockSocket() {
-    return (await createWaSocket(false, false)) as unknown as {
-      ev: import("node:events").EventEmitter;
-    };
-  }
-
-  beforeEach(() => {
-    saveMediaBufferSpy.mockClear();
-    resetWebInboundDedupe();
-  });
-
   beforeAll(async () => {
-    ({ createWaSocket } = await import("./session.js"));
     await fs.rm(HOME, { recursive: true, force: true });
   });
 
-  afterAll(async () => {
-    await fs.rm(HOME, { recursive: true, force: true });
+  beforeEach(async () => {
+    vi.resetModules();
+    saveMediaBufferSpy.mockClear();
+    normalizeMessageContent.mockImplementation((message: unknown) => message);
+    downloadMediaMessage.mockReset().mockResolvedValue(jpegBuffer);
+    ({ downloadInboundMedia } = await import("./inbound/media.js"));
+    ({ extractMentionedJids } = await import("./inbound/extract.js"));
   });
 
   it("stores image extension, extracts caption mentions, and keeps document filename", async () => {
-    const onMessage = vi.fn();
-    const listener = await monitorWebInbox({
-      verbose: false,
-      onMessage,
-      accountId: "default",
-      authDir: path.join(HOME, "wa-auth"),
-    });
-    const realSock = await getMockSocket();
-
-    realSock.ev.emit("messages.upsert", {
-      type: "notify",
-      messages: [
-        {
-          key: { id: "img1", fromMe: false, remoteJid: "111@s.whatsapp.net" },
-          message: { imageMessage: { mimetype: "image/jpeg" } },
-          messageTimestamp: 1_700_000_001,
-        },
-      ],
+    const savedImage = await saveInboundMedia({
+      message: { imageMessage: { mimetype: "image/jpeg" } },
     });
 
-    const first = await waitForMessage(onMessage);
-    const mediaPath = first.mediaPath;
-    expect(mediaPath).toBeDefined();
-    expect(path.extname(mediaPath as string)).toBe(".jpg");
-    const stat = await fs.stat(mediaPath as string);
+    expect(path.extname(savedImage.path)).toBe(".jpg");
+    const stat = await fs.stat(savedImage.path);
     expect(stat.size).toBeGreaterThan(0);
 
-    onMessage.mockClear();
-    realSock.ev.emit("messages.upsert", {
-      type: "notify",
-      messages: [
-        {
-          key: {
-            id: "img2",
-            fromMe: false,
-            remoteJid: "123@g.us",
-            participant: "999@s.whatsapp.net",
-          },
-          message: {
-            messageContextInfo: {},
-            imageMessage: {
-              caption: "@bot",
-              contextInfo: { mentionedJid: ["999@s.whatsapp.net"] },
-              mimetype: "image/jpeg",
-            },
-          },
-          messageTimestamp: 1_700_000_002,
+    expect(
+      extractMentionedJids({
+        imageMessage: {
+          caption: "@bot",
+          contextInfo: { mentionedJid: ["999@s.whatsapp.net"] },
+          mimetype: "image/jpeg",
         },
-      ],
-    });
+      } as never),
+    ).toEqual(["999@s.whatsapp.net"]);
 
-    const second = await waitForMessage(onMessage);
-    expect(second.chatType).toBe("group");
-    expect(second.mentionedJids).toEqual(["999@s.whatsapp.net"]);
-
-    onMessage.mockClear();
-    const fileName = "invoice.pdf";
-    realSock.ev.emit("messages.upsert", {
-      type: "notify",
-      messages: [
-        {
-          key: { id: "doc1", fromMe: false, remoteJid: "333@s.whatsapp.net" },
-          message: { documentMessage: { mimetype: "application/pdf", fileName } },
-          messageTimestamp: 1_700_000_004,
+    const documentMedia = await downloadInboundMedia(
+      {
+        message: {
+          documentMessage: {
+            mimetype: "application/pdf",
+            fileName: "invoice.pdf",
+          },
         },
-      ],
-    });
-
-    const third = await waitForMessage(onMessage);
-    expect(third.mediaFileName).toBe(fileName);
+      } as never,
+      mockSock,
+    );
+    expect(documentMedia?.fileName).toBe("invoice.pdf");
     expect(saveMediaBufferSpy).toHaveBeenCalled();
-    const lastCall = saveMediaBufferSpy.mock.calls.at(-1);
-    expect(lastCall?.[4]).toBe(fileName);
-
-    await listener.close();
   });
 
   it("passes mediaMaxMb to saveMediaBuffer", async () => {
-    const onMessage = vi.fn();
-    const listener = await monitorWebInbox({
-      verbose: false,
-      onMessage,
+    await saveInboundMedia({
+      message: { imageMessage: { mimetype: "image/jpeg" } },
       mediaMaxMb: 1,
-      accountId: "default",
-      authDir: path.join(HOME, "wa-auth"),
     });
-    const realSock = await getMockSocket();
 
-    const upsert = {
-      type: "notify",
-      messages: [
-        {
-          key: { id: "img3", fromMe: false, remoteJid: "222@s.whatsapp.net" },
-          message: { imageMessage: { mimetype: "image/jpeg" } },
-          messageTimestamp: 1_700_000_003,
-        },
-      ],
-    };
-
-    realSock.ev.emit("messages.upsert", upsert);
-
-    await waitForMessage(onMessage);
     expect(saveMediaBufferSpy).toHaveBeenCalled();
     const lastCall = saveMediaBufferSpy.mock.calls.at(-1);
     expect(lastCall?.[3]).toBe(1 * 1024 * 1024);
-
-    await listener.close();
   });
 });

--- a/extensions/whatsapp/src/inbound/access-control.test-harness.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test-harness.ts
@@ -41,7 +41,27 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
-  upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    readStoreAllowFromForDmPolicy: (params: {
+      provider: "whatsapp";
+      accountId: string;
+      dmPolicy?: string | null;
+    }) =>
+      actual.readStoreAllowFromForDmPolicy({
+        ...params,
+        readStore: async (provider, accountId): Promise<string[]> =>
+          (await readAllowFromStoreMock(provider, accountId)) as string[],
+      }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
+  };
+});

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   readAllowFromStoreMock,
   sendMessageMock,
@@ -9,7 +9,7 @@ import {
 
 setupAccessControlTestHarness();
 
-const { checkInboundAccessControl } = await import("./access-control.js");
+let checkInboundAccessControl: typeof import("./access-control.js").checkInboundAccessControl;
 
 async function checkUnauthorizedWorkDmSender() {
   return checkInboundAccessControl({
@@ -32,6 +32,11 @@ function expectSilentlyBlocked(result: { allowed: boolean }) {
 }
 
 describe("checkInboundAccessControl pairing grace", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ checkInboundAccessControl } = await import("./access-control.js"));
+  });
+
   async function runPairingGraceCase(messageTimestampMs: number) {
     const connectedAtMs = 1_000_000;
     return await checkInboundAccessControl({

--- a/extensions/whatsapp/src/inbound/media.node.test.ts
+++ b/extensions/whatsapp/src/inbound/media.node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { normalizeMessageContent, downloadMediaMessage } = vi.hoisted(() => ({
   normalizeMessageContent: vi.fn((msg: unknown) => msg),
@@ -10,7 +10,7 @@ vi.mock("@whiskeysockets/baileys", () => ({
   downloadMediaMessage,
 }));
 
-import { downloadInboundMedia } from "./media.js";
+let downloadInboundMedia: typeof import("./media.js").downloadInboundMedia;
 
 const mockSock = {
   updateMediaMessage: vi.fn(),
@@ -24,6 +24,13 @@ async function expectMimetype(message: Record<string, unknown>, expected: string
 }
 
 describe("downloadInboundMedia", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    normalizeMessageContent.mockClear();
+    downloadMediaMessage.mockClear().mockResolvedValue(Buffer.from("fake-media-data"));
+    ({ downloadInboundMedia } = await import("./media.js"));
+  });
+
   it("returns undefined for messages without media", async () => {
     const msg = { message: { conversation: "hello" } } as never;
     const result = await downloadInboundMedia(msg, mockSock);

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -1,22 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const recordChannelActivity = vi.fn();
-vi.mock("../../../../src/infra/channel-activity.js", () => ({
+const recordChannelActivity = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
   recordChannelActivity: (...args: unknown[]) => recordChannelActivity(...args),
 }));
 
-import { createWebSendApi } from "./send-api.js";
+let createWebSendApi: typeof import("./send-api.js").createWebSendApi;
 
 describe("createWebSendApi", () => {
   const sendMessage = vi.fn(async () => ({ key: { id: "msg-1" } }));
   const sendPresenceUpdate = vi.fn(async () => {});
-  const api = createWebSendApi({
-    sock: { sendMessage, sendPresenceUpdate },
-    defaultAccountId: "main",
-  });
+  let api: ReturnType<typeof createWebSendApi>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+    ({ createWebSendApi } = await import("./send-api.js"));
+    api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+    });
   });
 
   it("uses sendOptions fileName for outbound documents", async () => {

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -3,13 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { DisconnectReason } from "@whiskeysockets/baileys";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loginWeb } from "./login.js";
-import {
-  createWaSocket,
-  formatError,
-  waitForCredsSaveQueueWithTimeout,
-  waitForWaConnection,
-} from "./session.js";
 
 const rmMock = vi.spyOn(fs, "rm");
 
@@ -19,18 +12,22 @@ function resolveTestAuthDir() {
 
 const authDir = resolveTestAuthDir();
 
-vi.mock("../../../src/config/config.js", () => ({
-  loadConfig: () =>
-    ({
-      channels: {
-        whatsapp: {
-          accounts: {
-            default: { enabled: true, authDir: resolveTestAuthDir() },
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    loadConfig: () =>
+      ({
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: { enabled: true, authDir: resolveTestAuthDir() },
+            },
           },
         },
-      },
-    }) as never,
-}));
+      }) as never,
+  };
+});
 
 vi.mock("./session.js", () => {
   const authDir = resolveTestAuthDir();
@@ -64,10 +61,15 @@ vi.mock("./session.js", () => {
   };
 });
 
-const createWaSocketMock = vi.mocked(createWaSocket);
-const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
-const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
-const formatErrorMock = vi.mocked(formatError);
+let loginWeb: typeof import("./login.js").loginWeb;
+let createWaSocketMock: ReturnType<typeof vi.mocked<typeof import("./session.js").createWaSocket>>;
+let waitForWaConnectionMock: ReturnType<
+  typeof vi.mocked<typeof import("./session.js").waitForWaConnection>
+>;
+let waitForCredsSaveQueueWithTimeoutMock: ReturnType<
+  typeof vi.mocked<typeof import("./session.js").waitForCredsSaveQueueWithTimeout>
+>;
+let formatErrorMock: ReturnType<typeof vi.mocked<typeof import("./session.js").formatError>>;
 
 async function flushTasks() {
   await Promise.resolve();
@@ -75,10 +77,19 @@ async function flushTasks() {
 }
 
 describe("loginWeb coverage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
+    vi.resetModules();
     vi.clearAllMocks();
     rmMock.mockClear();
+    ({ loginWeb } = await import("./login.js"));
+    const sessionModule = await import("./session.js");
+    createWaSocketMock = vi.mocked(sessionModule.createWaSocket);
+    waitForWaConnectionMock = vi.mocked(sessionModule.waitForWaConnection);
+    waitForCredsSaveQueueWithTimeoutMock = vi.mocked(
+      sessionModule.waitForCredsSaveQueueWithTimeout,
+    );
+    formatErrorMock = vi.mocked(sessionModule.formatError);
   });
   afterEach(() => {
     vi.useRealTimers();

--- a/extensions/whatsapp/src/login.test.ts
+++ b/extensions/whatsapp/src/login.test.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
 import { renderQrPngBase64 } from "./qr-image.js";
 
 vi.mock("./session.js", () => {
@@ -19,15 +18,20 @@ vi.mock("./session.js", () => {
   };
 });
 
-import { loginWeb } from "./login.js";
-import type { waitForWaConnection } from "./session.js";
-
-const { createWaSocket } = await import("./session.js");
+let loginWeb: typeof import("./login.js").loginWeb;
+let createWaSocket: typeof import("./session.js").createWaSocket;
+let resetLogger: typeof import("../../../src/logging.js").resetLogger;
+let setLoggerOverride: typeof import("../../../src/logging.js").setLoggerOverride;
+type WaitForWaConnection = typeof import("./session.js").waitForWaConnection;
 
 describe("web login", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
+    vi.resetModules();
     vi.clearAllMocks();
+    ({ loginWeb } = await import("./login.js"));
+    ({ createWaSocket } = await import("./session.js"));
+    ({ resetLogger, setLoggerOverride } = await import("../../../src/logging.js"));
   });
 
   afterEach(() => {
@@ -41,7 +45,7 @@ describe("web login", () => {
       createWaSocket as unknown as () => Promise<{ ws: { close: () => void } }>
     )();
     const close = vi.spyOn(sock.ws, "close");
-    const waiter: typeof waitForWaConnection = vi.fn().mockResolvedValue(undefined);
+    const waiter: WaitForWaConnection = vi.fn().mockResolvedValue(undefined);
     await loginWeb(false, waiter);
     expect(close).not.toHaveBeenCalled();
 

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -2,31 +2,32 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import sharp from "sharp";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../../../src/config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../../../src/infra/tmp-openclaw-dir.js";
 import { optimizeImageToPng } from "../../../src/media/image-ops.js";
 import { mockPinnedHostnameResolution } from "../../../src/test-helpers/ssrf.js";
 import { captureEnv } from "../../../test/helpers/extensions/env.js";
 import { sendVoiceMessageDiscord } from "../../discord/src/send.js";
-import {
-  LocalMediaAccessError,
-  loadWebMedia,
-  loadWebMediaRaw,
-  optimizeImageToJpeg,
-} from "./media.js";
 
-const convertHeicToJpegMock = vi.fn();
+const state = vi.hoisted(() => ({
+  convertHeicToJpegMock: vi.fn(),
+}));
 
-vi.mock("../../../src/media/image-ops.js", async () => {
-  const actual = await vi.importActual<typeof import("../../../src/media/image-ops.js")>(
-    "../../../src/media/image-ops.js",
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
+    "openclaw/plugin-sdk/media-runtime",
   );
   return {
     ...actual,
-    convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
+    convertHeicToJpeg: (...args: unknown[]) => state.convertHeicToJpegMock(...args),
   };
 });
+
+let LocalMediaAccessError: typeof import("./media.js").LocalMediaAccessError;
+let loadWebMedia: typeof import("./media.js").loadWebMedia;
+let loadWebMediaRaw: typeof import("./media.js").loadWebMediaRaw;
+let optimizeImageToJpeg: typeof import("./media.js").optimizeImageToJpeg;
 
 let fixtureRoot = "";
 let fixtureFileCount = 0;
@@ -49,6 +50,11 @@ async function writeTempFile(buffer: Buffer, ext: string): Promise<string> {
   return file;
 }
 
+async function loadMediaModule(): Promise<void> {
+  ({ LocalMediaAccessError, loadWebMedia, loadWebMediaRaw, optimizeImageToJpeg } =
+    await import("./media.js"));
+}
+
 function buildDeterministicBytes(length: number): Buffer {
   const buffer = Buffer.allocUnsafe(length);
   let seed = 0x12345678;
@@ -68,6 +74,7 @@ function cloneStatWithDev<T extends { dev: number | bigint }>(stat: T, dev: numb
 }
 
 beforeAll(async () => {
+  await loadMediaModule();
   fixtureRoot = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-test-"),
   );
@@ -122,8 +129,10 @@ afterAll(async () => {
   await fs.rm(fixtureRoot, { recursive: true, force: true });
 });
 
-afterEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
+  vi.resetModules();
+  await loadMediaModule();
 });
 
 describe("web media loading", () => {
@@ -193,11 +202,11 @@ describe("web media loading", () => {
   });
 
   it("normalizes HEIC local files to JPEG output", async () => {
-    convertHeicToJpegMock.mockResolvedValueOnce(tinyPngBuffer);
+    state.convertHeicToJpegMock.mockResolvedValueOnce(tinyPngBuffer);
 
     const result = await loadWebMedia(fakeHeicFile, 1024 * 1024);
 
-    expect(convertHeicToJpegMock).toHaveBeenCalledTimes(1);
+    expect(state.convertHeicToJpegMock).toHaveBeenCalledTimes(1);
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
     expect(result.fileName).toBe(path.basename(fakeHeicFile, ".heic") + ".jpg");

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -1,6 +1,5 @@
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
-import { monitorWebInbox } from "./inbound.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   expectPairingPromptSent,
@@ -10,6 +9,8 @@ import {
   mockLoadConfig,
   upsertPairingRequestMock,
 } from "./monitor-inbox.test-harness.js";
+
+let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
 
 const nowSeconds = (offsetMs = 0) => Math.floor((Date.now() + offsetMs) / 1000);
 const DEFAULT_MESSAGES_CFG = {
@@ -93,6 +94,10 @@ async function expectOutboundDmSkipsPairing(params: {
 
 describe("web monitor inbox", () => {
   installWebMonitorInboxUnitTestHooks();
+
+  beforeEach(async () => {
+    ({ monitorWebInbox } = await import("./inbound.js"));
+  });
 
   it("allows messages from senders in allowFrom list", async () => {
     mockLoadConfig.mockReturnValue(createAllowListConfig(["+111", "+999"]));

--- a/extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts
@@ -1,6 +1,5 @@
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
-import { monitorWebInbox } from "./inbound.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   getAuthDir,
@@ -8,9 +7,17 @@ import {
   installWebMonitorInboxUnitTestHooks,
 } from "./monitor-inbox.test-harness.js";
 
+let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
+
 describe("append upsert handling (#20952)", () => {
   installWebMonitorInboxUnitTestHooks();
-  type InboxOnMessage = NonNullable<Parameters<typeof monitorWebInbox>[0]["onMessage"]>;
+  type InboxOnMessage = NonNullable<
+    Parameters<typeof import("./inbound.js").monitorWebInbox>[0]["onMessage"]
+  >;
+
+  beforeEach(async () => {
+    ({ monitorWebInbox } = await import("./inbound.js"));
+  });
 
   async function tick() {
     await new Promise((resolve) => setImmediate(resolve));

--- a/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
@@ -1,6 +1,5 @@
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
-import { monitorWebInbox } from "./inbound.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   expectPairingPromptSent,
@@ -9,6 +8,8 @@ import {
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
 } from "./monitor-inbox.test-harness.js";
+
+let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
 
 const nowSeconds = (offsetMs = 0) => Math.floor((Date.now() + offsetMs) / 1000);
 const DEFAULT_MESSAGES_CFG = {
@@ -82,6 +83,10 @@ async function startWebInboxMonitor(params: {
 
 describe("web monitor inbox", () => {
   installWebMonitorInboxUnitTestHooks();
+
+  beforeEach(async () => {
+    ({ monitorWebInbox } = await import("./inbound.js"));
+  });
 
   it("blocks messages from unauthorized senders not in allowFrom", async () => {
     // Test for auto-recovery fix: early allowFrom filtering prevents Bad MAC errors

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -3,9 +3,7 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
-import { setLoggerOverride } from "../../../src/logging.js";
-import { monitorWebInbox } from "./inbound.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   getAuthDir,
@@ -14,8 +12,16 @@ import {
   mockLoadConfig,
 } from "./monitor-inbox.test-harness.js";
 
+let setLoggerOverride: typeof import("../../../src/logging.js").setLoggerOverride;
+let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
+
 describe("web monitor inbox", () => {
   installWebMonitorInboxUnitTestHooks();
+
+  beforeEach(async () => {
+    ({ setLoggerOverride } = await import("../../../src/logging.js"));
+    ({ monitorWebInbox } = await import("./inbound.js"));
+  });
 
   async function openMonitor(onMessage = vi.fn()) {
     return await monitorWebInbox({

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -1,8 +1,7 @@
 import fsSync from "node:fs";
 import path from "node:path";
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
-import { monitorWebInbox } from "./inbound.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   getAuthDir,
@@ -10,9 +9,17 @@ import {
   installWebMonitorInboxUnitTestHooks,
 } from "./monitor-inbox.test-harness.js";
 
+let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
+
 describe("web monitor inbox", () => {
   installWebMonitorInboxUnitTestHooks();
-  type InboxOnMessage = NonNullable<Parameters<typeof monitorWebInbox>[0]["onMessage"]>;
+  type InboxOnMessage = NonNullable<
+    Parameters<typeof import("./inbound.js").monitorWebInbox>[0]["onMessage"]
+  >;
+
+  beforeEach(async () => {
+    ({ monitorWebInbox } = await import("./inbound.js"));
+  });
 
   async function tick() {
     await new Promise((resolve) => setImmediate(resolve));

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -70,15 +70,6 @@ function createMockSock(): MockSock {
   };
 }
 
-function getPairingStoreMocks() {
-  const readChannelAllowFromStore = (...args: unknown[]) => readAllowFromStoreMock(...args);
-  const upsertChannelPairingRequest = (...args: unknown[]) => upsertPairingRequestMock(...args);
-  return {
-    readChannelAllowFromStore,
-    upsertChannelPairingRequest,
-  };
-}
-
 const sock: MockSock = createMockSock();
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
@@ -102,7 +93,31 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => getPairingStoreMocks());
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    readStoreAllowFromForDmPolicy: (params: {
+      provider: "whatsapp";
+      accountId: string;
+      dmPolicy?: string | null;
+    }) =>
+      actual.readStoreAllowFromForDmPolicy({
+        ...params,
+        readStore: async (provider, accountId): Promise<string[]> =>
+          (await readAllowFromStoreMock(provider, accountId)) as string[],
+      }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+    upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
+  };
+});
 
 vi.mock("./session.js", () => ({
   createWaSocket: vi.fn().mockResolvedValue(sock),
@@ -137,14 +152,17 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
   const createAuthDir = opts?.authDir ?? true;
 
   beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+    sock.ev.removeAllListeners();
+    sock.signalRepository.lidMapping.getPNForLID.mockResolvedValue(null);
     mockLoadConfig.mockReturnValue(DEFAULT_WEB_INBOX_CONFIG);
     readAllowFromStoreMock.mockResolvedValue([]);
     upsertPairingRequestMock.mockResolvedValue({
       code: "PAIRCODE",
       created: true,
     });
-    const { resetWebInboundDedupe } = await import("./inbound.js");
+    const { resetWebInboundDedupe } = await import("./inbound/dedupe.js");
     resetWebInboundDedupe();
     if (createAuthDir) {
       authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -4,16 +4,22 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
-import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
 import { redactIdentifier } from "../../../src/logging/redact-identifier.js";
-import { setActiveWebListener } from "./active-listener.js";
 
-const loadWebMediaMock = vi.fn();
-vi.mock("./media.js", () => ({
-  loadWebMedia: (...args: unknown[]) => loadWebMediaMock(...args),
+const state = vi.hoisted(() => ({
+  loadWebMediaMock: vi.fn(),
 }));
 
-import { sendMessageWhatsApp, sendPollWhatsApp, sendReactionWhatsApp } from "./send.js";
+vi.mock("./media.js", () => ({
+  loadWebMedia: (...args: unknown[]) => state.loadWebMediaMock(...args),
+}));
+
+let sendMessageWhatsApp: typeof import("./send.js").sendMessageWhatsApp;
+let sendPollWhatsApp: typeof import("./send.js").sendPollWhatsApp;
+let sendReactionWhatsApp: typeof import("./send.js").sendReactionWhatsApp;
+let setActiveWebListener: typeof import("./active-listener.js").setActiveWebListener;
+let resetLogger: typeof import("../../../src/logging.js").resetLogger;
+let setLoggerOverride: typeof import("../../../src/logging.js").setLoggerOverride;
 
 describe("web outbound", () => {
   const sendComposingTo = vi.fn(async () => {});
@@ -21,8 +27,12 @@ describe("web outbound", () => {
   const sendPoll = vi.fn(async () => ({ messageId: "poll123" }));
   const sendReaction = vi.fn(async () => {});
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+    ({ sendMessageWhatsApp, sendPollWhatsApp, sendReactionWhatsApp } = await import("./send.js"));
+    ({ setActiveWebListener } = await import("./active-listener.js"));
+    ({ resetLogger, setLoggerOverride } = await import("../../../src/logging.js"));
     setActiveWebListener({
       sendComposingTo,
       sendMessage,
@@ -53,7 +63,7 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "hello", undefined, undefined);
 
     const buf = Buffer.from("img");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "image/jpeg",
       kind: "image",
@@ -91,7 +101,7 @@ describe("web outbound", () => {
 
   it("maps audio to PTT with opus mime when ogg", async () => {
     const buf = Buffer.from("audio");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "audio/ogg",
       kind: "audio",
@@ -110,7 +120,7 @@ describe("web outbound", () => {
 
   it("maps video with caption", async () => {
     const buf = Buffer.from("video");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "video/mp4",
       kind: "video",
@@ -124,7 +134,7 @@ describe("web outbound", () => {
 
   it("marks gif playback for video when requested", async () => {
     const buf = Buffer.from("gifvid");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "video/mp4",
       kind: "video",
@@ -141,7 +151,7 @@ describe("web outbound", () => {
 
   it("maps image with caption", async () => {
     const buf = Buffer.from("img");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "image/jpeg",
       kind: "image",
@@ -155,7 +165,7 @@ describe("web outbound", () => {
 
   it("maps other kinds to document with filename", async () => {
     const buf = Buffer.from("pdf");
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
       contentType: "application/pdf",
       kind: "document",
@@ -177,7 +187,7 @@ describe("web outbound", () => {
       sendPoll,
       sendReaction,
     });
-    loadWebMediaMock.mockResolvedValueOnce({
+    state.loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("img"),
       contentType: "image/jpeg",
       kind: "image",
@@ -204,7 +214,7 @@ describe("web outbound", () => {
       mediaLocalRoots: ["/tmp/workspace"],
     });
 
-    expect(loadWebMediaMock).toHaveBeenCalledWith("/tmp/pic.jpg", {
+    expect(state.loadWebMediaMock).toHaveBeenCalledWith("/tmp/pic.jpg", {
       maxBytes: 100 * 1024 * 1024,
       localRoots: ["/tmp/workspace"],
     });

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -2,18 +2,24 @@ import { EventEmitter } from "node:events";
 import fsSync from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
-import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
 
-const { createWaSocket, formatError, logWebSelfId, waitForWaConnection } =
-  await import("./session.js");
-const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
+let resetLogger: typeof import("../../../src/logging.js").resetLogger;
+let setLoggerOverride: typeof import("../../../src/logging.js").setLoggerOverride;
+let baileys: typeof import("./test-helpers.js").baileys;
+let getLastSocket: typeof import("./test-helpers.js").getLastSocket;
+let resetBaileysMocks: typeof import("./test-helpers.js").resetBaileysMocks;
+let resetLoadConfigMock: typeof import("./test-helpers.js").resetLoadConfigMock;
+let createWaSocket: typeof import("./session.js").createWaSocket;
+let formatError: typeof import("./session.js").formatError;
+let logWebSelfId: typeof import("./session.js").logWebSelfId;
+let waitForWaConnection: typeof import("./session.js").waitForWaConnection;
 
 async function flushCredsUpdate() {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 async function emitCredsUpdateAndReadSaveCreds() {
+  const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
   const sock = getLastSocket();
   const saveCreds = (await useMultiFileAuthStateMock.mock.results[0]?.value)?.saveCreds;
   sock.ev.emit("creds.update", {});
@@ -55,10 +61,16 @@ function mockCredsJsonSpies(readContents: string) {
 }
 
 describe("web session", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+    ({ resetLogger, setLoggerOverride } = await import("../../../src/logging.js"));
+    ({ baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } =
+      await import("./test-helpers.js"));
     resetBaileysMocks();
     resetLoadConfigMock();
+    ({ createWaSocket, formatError, logWebSelfId, waitForWaConnection } =
+      await import("./session.js"));
   });
 
   afterEach(() => {
@@ -78,6 +90,7 @@ describe("web session", () => {
     expect(passedLogger?.level).toBe("silent");
     expect(typeof passedLogger?.trace).toBe("function");
     const sock = getLastSocket();
+    const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
     const saveCreds = (await useMultiFileAuthStateMock.mock.results[0]?.value)?.saveCreds;
     // trigger creds.update listener
     sock.ev.emit("creds.update", {});
@@ -179,6 +192,7 @@ describe("web session", () => {
       await gate;
       inFlight -= 1;
     });
+    const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
     useMultiFileAuthStateMock.mockResolvedValueOnce({
       state: { creds: {} as never, keys: {} as never },
       saveCreds,
@@ -226,6 +240,7 @@ describe("web session", () => {
       await gateB;
       inFlightB -= 1;
     });
+    const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
     useMultiFileAuthStateMock
       .mockResolvedValueOnce({
         state: { creds: {} as never, keys: {} as never },

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -3,7 +3,6 @@ import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../../src/chan
 import { DEFAULT_ACCOUNT_ID } from "../../../src/routing/session-key.js";
 import type { RuntimeEnv } from "../../../src/runtime.js";
 import type { WizardPrompter } from "../../../src/wizard/prompts.js";
-import { whatsappPlugin } from "./channel.js";
 
 const loginWebMock = vi.hoisted(() => vi.fn(async () => {}));
 const pathExistsMock = vi.hoisted(() => vi.fn(async () => false));
@@ -15,13 +14,14 @@ const resolveWhatsAppAuthDirMock = vi.hoisted(() =>
   })),
 );
 
-vi.mock("../../../src/channel-web.js", () => ({
+vi.mock("./login.js", () => ({
   loginWeb: loginWebMock,
 }));
 
-vi.mock("../../../src/utils.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../../../src/utils.js")>("../../../src/utils.js");
+vi.mock("openclaw/plugin-sdk/setup", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/setup")>(
+    "openclaw/plugin-sdk/setup",
+  );
   return {
     ...actual,
     pathExists: pathExistsMock,
@@ -83,10 +83,7 @@ function createRuntime(): RuntimeEnv {
   } as unknown as RuntimeEnv;
 }
 
-const whatsappConfigureAdapter = buildChannelSetupWizardAdapterFromSetupWizard({
-  plugin: whatsappPlugin,
-  wizard: whatsappPlugin.setupWizard!,
-});
+let whatsappConfigureAdapter: ReturnType<typeof buildChannelSetupWizardAdapterFromSetupWizard>;
 
 async function runConfigureWithHarness(params: {
   harness: ReturnType<typeof createPrompterHarness>;
@@ -129,8 +126,14 @@ async function runSeparatePhoneFlow(params: { selectValues: string[]; textValues
 }
 
 describe("whatsapp setup wizard", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+    const { whatsappPlugin } = await import("./channel.js");
+    whatsappConfigureAdapter = buildChannelSetupWizardAdapterFromSetupWizard({
+      plugin: whatsappPlugin,
+      wizard: whatsappPlugin.setupWizard!,
+    });
     pathExistsMock.mockResolvedValue(false);
     listWhatsAppAccountIdsMock.mockReturnValue([]);
     resolveDefaultWhatsAppAccountIdMock.mockReturnValue(DEFAULT_ACCOUNT_ID);

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveBrowserConfig } from "./config.js";
-import { createBrowserProfilesService } from "./profiles-service.js";
 import type { BrowserRouteContext, BrowserServerState } from "./server-context.js";
+
+vi.resetModules();
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
@@ -25,6 +25,8 @@ vi.mock("./chrome.js", () => ({
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveOpenClawUserDataDir } from "./chrome.js";
 import { movePathToTrash } from "./trash.js";
+const { resolveBrowserConfig } = await import("./config.js");
+const { createBrowserProfilesService } = await import("./profiles-service.js");
 
 function createCtx(resolved: BrowserServerState["resolved"]) {
   const state: BrowserServerState = {

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -1,10 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveBrowserConfig, resolveProfile } from "./config.js";
-import {
-  refreshResolvedBrowserConfigFromDisk,
-  resolveBrowserProfileWithHotReload,
-} from "./resolved-config-refresh.js";
 import type { BrowserServerState } from "./server-context.types.js";
+
+vi.resetModules();
 
 let cfgProfiles: Record<string, { cdpPort?: number; cdpUrl?: string; color?: string }> = {};
 
@@ -40,6 +37,10 @@ vi.mock("../config/config.js", () => ({
   },
   writeConfigFile: vi.fn(async () => {}),
 }));
+
+const { resolveBrowserConfig, resolveProfile } = await import("./config.js");
+const { refreshResolvedBrowserConfigFromDisk, resolveBrowserProfileWithHotReload } =
+  await import("./resolved-config-refresh.js");
 
 describe("server-context hot-reload profiles", () => {
   let loadConfig: typeof import("../config/config.js").loadConfig;

--- a/src/browser/server-lifecycle.test.ts
+++ b/src/browser/server-lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.resetModules();
+
 const { stopOpenClawChromeMock } = vi.hoisted(() => ({
   stopOpenClawChromeMock: vi.fn(async () => {}),
 }));
@@ -18,7 +20,8 @@ vi.mock("./server-context.js", () => ({
   listKnownProfileNames: listKnownProfileNamesMock,
 }));
 
-import { ensureExtensionRelayForProfiles, stopKnownBrowserProfiles } from "./server-lifecycle.js";
+const { ensureExtensionRelayForProfiles, stopKnownBrowserProfiles } =
+  await import("./server-lifecycle.js");
 
 describe("ensureExtensionRelayForProfiles", () => {
   it("is a no-op after removing the Chrome extension relay path", async () => {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -2,6 +2,8 @@ import type { MessageEvent, PostbackEvent } from "@line/bot-sdk";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LineAccountConfig } from "./types.js";
 
+vi.resetModules();
+
 // Avoid pulling in globals/pairing/media dependencies; this suite only asserts
 // allowlist/groupPolicy gating and message-context wiring.
 vi.mock("../globals.js", () => ({

--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -5,7 +5,9 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const getMessageContentMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@line/bot-sdk", () => ({
+vi.resetModules();
+
+vi.doMock("@line/bot-sdk", () => ({
   messagingApi: {
     MessagingApiBlobClient: class {
       getMessageContent(messageId: string) {
@@ -15,11 +17,11 @@ vi.mock("@line/bot-sdk", () => ({
   },
 }));
 
-vi.mock("../globals.js", () => ({
+vi.doMock("../globals.js", () => ({
   logVerbose: () => {},
 }));
 
-import { downloadLineMedia } from "./download.js";
+const { downloadLineMedia } = await import("./download.js");
 
 async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
   for (const part of parts) {

--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 
+vi.resetModules();
+
 const { createLineBotMock, registerPluginHttpRouteMock, unregisterHttpMock } = vi.hoisted(() => ({
   createLineBotMock: vi.fn(() => ({
     account: { accountId: "default" },

--- a/src/line/probe.test.ts
+++ b/src/line/probe.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
   const getBotInfoMock = vi.fn();
   const MessagingApiClientMock = vi.fn(function () {
@@ -7,11 +7,13 @@ const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
   return { getBotInfoMock, MessagingApiClientMock };
 });
 
-vi.mock("@line/bot-sdk", () => ({
+vi.resetModules();
+
+vi.doMock("@line/bot-sdk", () => ({
   messagingApi: { MessagingApiClient: MessagingApiClientMock },
 }));
 
-let probeLineBot: typeof import("./probe.js").probeLineBot;
+const { probeLineBot } = await import("./probe.js");
 
 afterEach(() => {
   vi.useRealTimers();
@@ -19,10 +21,6 @@ afterEach(() => {
 });
 
 describe("probeLineBot", () => {
-  beforeAll(async () => {
-    ({ probeLineBot } = await import("./probe.js"));
-  });
-
   it("returns timeout when bot info stalls", async () => {
     vi.useFakeTimers();
     getBotInfoMock.mockImplementation(() => new Promise(() => {}));

--- a/src/line/send.test.ts
+++ b/src/line/send.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   pushMessageMock,
@@ -43,37 +43,35 @@ const {
   };
 });
 
-vi.mock("@line/bot-sdk", () => ({
+vi.resetModules();
+
+vi.doMock("@line/bot-sdk", () => ({
   messagingApi: { MessagingApiClient: MessagingApiClientMock },
 }));
 
-vi.mock("../config/config.js", () => ({
+vi.doMock("../config/config.js", () => ({
   loadConfig: loadConfigMock,
 }));
 
-vi.mock("./accounts.js", () => ({
+vi.doMock("./accounts.js", () => ({
   resolveLineAccount: resolveLineAccountMock,
 }));
 
-vi.mock("./channel-access-token.js", () => ({
+vi.doMock("./channel-access-token.js", () => ({
   resolveLineChannelAccessToken: resolveLineChannelAccessTokenMock,
 }));
 
-vi.mock("../infra/channel-activity.js", () => ({
+vi.doMock("../infra/channel-activity.js", () => ({
   recordChannelActivity: recordChannelActivityMock,
 }));
 
-vi.mock("../globals.js", () => ({
+vi.doMock("../globals.js", () => ({
   logVerbose: logVerboseMock,
 }));
 
-let sendModule: typeof import("./send.js");
+const sendModule = await import("./send.js");
 
 describe("LINE send helpers", () => {
-  beforeAll(async () => {
-    sendModule = await import("./send.js");
-  });
-
   beforeEach(() => {
     pushMessageMock.mockReset();
     replyMessageMock.mockReset();


### PR DESCRIPTION
## Summary
- realign Slack runtime-seam mocks so download, client, probe, upload, auth, and message-handler tests hit the current plugin-sdk boundaries
- reload WhatsApp runtime seams for inbound context, auto-reply delivery, heartbeat, access control, inbound media, and send-api tests
- reload WhatsApp outbound media seams so send/media tests mock the live media runtime imports again
- reload WhatsApp login and session seams so login coverage and Baileys-backed session tests rebind to the current config and session modules
- realign the WhatsApp setup wizard test to mock `./login.js` and `openclaw/plugin-sdk/setup`, which are the seams `setup-surface.ts` now uses
- reload WhatsApp monitor-inbox tests after setup so config, security, conversation, and session seams are rebound before each file under the new lazy runtime boundaries
- realign the WhatsApp broadcast-groups harness to build the current on-message pipeline directly, so broadcast routing and group-history assertions no longer depend on monitor startup side effects
- rewrite WhatsApp inbound media coverage as a focused inbound-media extraction and save unit so extension/filename and `mediaMaxMb` behavior stay covered without the stale inbox monitor harness
- reload LINE modules after test setup preloads them so SDK, send, lifecycle, and webhook-handler mocks apply again
- reload browser profile lifecycle and hot-reload tests after setup so config/chrome mocks are honored

## Verification
- `pnpm test -- extensions/slack/src/send.upload.test.ts extensions/slack/src/actions.download-file.test.ts extensions/slack/src/client.test.ts extensions/slack/src/probe.test.ts extensions/slack/src/monitor/auth.test.ts extensions/slack/src/monitor/message-handler.test.ts`
- `pnpm test:extension slack`
- `pnpm test -- extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts extensions/whatsapp/src/auto-reply/heartbeat-runner.test.ts extensions/whatsapp/src/inbound/access-control.test.ts extensions/whatsapp/src/inbound/media.node.test.ts extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/media.test.ts extensions/whatsapp/src/login.test.ts extensions/whatsapp/src/login.coverage.test.ts extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/setup-surface.test.ts`
- `pnpm test -- extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts extensions/whatsapp/src/monitor-inbox.append-upsert.test.ts extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts extensions/whatsapp/src/inbound.media.test.ts`
- `pnpm test:extension whatsapp`
- `pnpm test -- src/utils.test.ts src/plugins/loader.test.ts test/git-hooks-pre-commit.test.ts`
- `pnpm check`

## Scope
- test-only CI fixes for `pnpm test:channels`
- no intended runtime behavior changes
