### PR TITLE
fix(acp): keep stdout JSON clean

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -23,6 +23,8 @@ const mockState = {
   })),
 };
 
+const routeLogsToStderr = vi.fn();
+
 class MockGatewayClient {
   private callbacks: GatewayClientCallbacks;
 
@@ -83,6 +85,14 @@ vi.mock("../gateway/call.js", () => ({
     };
   },
 }));
+
+vi.mock("../logging.js", async () => {
+  const actual = await vi.importActual<typeof import("../logging.js")>("../logging.js");
+  return {
+    ...actual,
+    routeLogsToStderr: () => routeLogsToStderr(),
+  };
+});
 
 vi.mock("../gateway/connection-auth.js", () => ({
   resolveGatewayConnectionAuth: (params: unknown) => mockState.resolveGatewayConnectionAuth(params),
@@ -155,10 +165,27 @@ describe("serveAcpGateway startup", () => {
     mockState.agentSideConnectionCtor.mockReset();
     mockState.agentStart.mockReset();
     mockState.resolveGatewayConnectionAuth.mockReset();
+    routeLogsToStderr.mockReset();
     mockState.resolveGatewayConnectionAuth.mockResolvedValue({
       token: undefined,
       password: undefined,
     });
+  });
+
+  it("routes console logs to stderr for stdout-safe ACP JSON transport", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await Promise.resolve();
+
+      expect(routeLogsToStderr).toHaveBeenCalledTimes(1);
+
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+    } finally {
+      onceSpy.mockRestore();
+    }
   });
 
   it("waits for gateway hello before creating AgentSideConnection", async () => {

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -11,8 +11,11 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-cha
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { normalizeAcpProvenanceMode, type AcpServerOptions } from "./types.js";
+import { routeLogsToStderr } from "../logging.js";
 
 export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void> {
+  // Route logs to stderr so JSON-RPC on stdout remains parseable.
+  routeLogsToStderr();
   const cfg = loadConfig();
   const connection = buildGatewayConnectionDetails({
     config: cfg,

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -7,11 +7,11 @@ import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { GatewayClient } from "../gateway/client.js";
 import { resolveGatewayConnectionAuth } from "../gateway/connection-auth.js";
 import { isMainModule } from "../infra/is-main.js";
+import { routeLogsToStderr } from "../logging.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { normalizeAcpProvenanceMode, type AcpServerOptions } from "./types.js";
-import { routeLogsToStderr } from "../logging.js";
 
 export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void> {
   // Route logs to stderr so JSON-RPC on stdout remains parseable.

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -71,6 +71,9 @@ vi.mock("./program/command-registry.js", () => ({
 vi.mock("./program/register.subclis.js", () => ({
   registerSubCliByName: registerSubCliByNameMock,
   loadValidatedConfigForPluginRegistration: loadValidatedConfigForPluginRegistrationMock,
+}));
+
+vi.mock("../plugins/cli.js", () => ({
   registerPluginCliCommands: registerPluginCliCommandsMock,
 }));
 
@@ -153,5 +156,15 @@ describe("runCli exit behavior", () => {
 
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
     expect(registerCoreCliByNameMock).toHaveBeenCalled();
+  });
+
+  it("routes ACP stdout logging even when acp includes option values", async () => {
+    registerSubCliByNameMock.mockImplementation(() => {});
+
+    loadValidatedConfigForPluginRegistrationMock.mockResolvedValue({});
+
+    await runCli(["node", "openclaw", "acp", "--url", "wss://example.local"]);
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -158,6 +158,18 @@ describe("runCli exit behavior", () => {
     expect(registerCoreCliByNameMock).toHaveBeenCalled();
   });
 
+  it("does not route ACP logs to stderr for interactive client mode", async () => {
+    await runCli(["node", "openclaw", "acp", "client"]);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("does not route ACP logs to stderr for interactive client mode options", async () => {
+    await runCli(["node", "openclaw", "acp", "client", "--cwd", "/tmp"]);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
   it("routes ACP stdout logging even when acp includes option values", async () => {
     registerSubCliByNameMock.mockImplementation(() => {});
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -164,22 +164,22 @@ describe("runCli exit behavior", () => {
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
-  it("does not route ACP logs to stderr for interactive client mode options", async () => {
+  it("routes ACP logs to stderr for interactive client mode with options", async () => {
     await runCli(["node", "openclaw", "acp", "client", "--cwd", "/tmp"]);
 
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
-  it("does not route ACP logs to stderr when acp option-value resembles a subcommand", async () => {
+  it("routes ACP logs to stderr for acp option-value session", async () => {
     await runCli(["node", "openclaw", "acp", "--session", "client"]);
 
-    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not route ACP logs to stderr for acp session-label option values that look like 'client'", async () => {
+  it("routes ACP logs to stderr for acp session-label option value", async () => {
     await runCli(["node", "openclaw", "acp", "--session-label", "client"]);
 
-    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
   });
 
   it("routes ACP stdout logging even when acp includes option values", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -170,6 +170,18 @@ describe("runCli exit behavior", () => {
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
+  it("does not route ACP logs to stderr when acp option-value resembles a subcommand", async () => {
+    await runCli(["node", "openclaw", "acp", "--session", "client"]);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("does not route ACP logs to stderr for acp session-label option values that look like 'client'", async () => {
+    await runCli(["node", "openclaw", "acp", "--session-label", "client"]);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
   it("routes ACP stdout logging even when acp includes option values", async () => {
     registerSubCliByNameMock.mockImplementation(() => {});
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -9,6 +9,15 @@ const assertRuntimeMock = vi.hoisted(() => vi.fn());
 const closeAllMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const outputRootHelpMock = vi.hoisted(() => vi.fn());
 const buildProgramMock = vi.hoisted(() => vi.fn());
+const enableConsoleCaptureMock = vi.hoisted(() => vi.fn());
+const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
+const parseAsyncMock = vi.hoisted(() => vi.fn(async () => {}));
+const getProgramContextMock = vi.hoisted(() => vi.fn());
+const registerCoreCliByNameMock = vi.hoisted(() => vi.fn());
+const registerSubCliByNameMock = vi.hoisted(() => vi.fn());
+const registerPluginCliCommandsMock = vi.hoisted(() => vi.fn());
+const loadValidatedConfigForPluginRegistrationMock = vi.hoisted(() => vi.fn());
+const installUnhandledRejectionHandlerMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
@@ -42,11 +51,42 @@ vi.mock("./program.js", () => ({
   buildProgram: buildProgramMock,
 }));
 
+vi.mock("../infra/unhandled-rejections.js", () => ({
+  installUnhandledRejectionHandler: installUnhandledRejectionHandlerMock,
+}));
+
+vi.mock("../logging.js", () => ({
+  enableConsoleCapture: enableConsoleCaptureMock,
+  routeLogsToStderr: routeLogsToStderrMock,
+}));
+
+vi.mock("./program/program-context.js", () => ({
+  getProgramContext: getProgramContextMock,
+}));
+
+vi.mock("./program/command-registry.js", () => ({
+  registerCoreCliByName: registerCoreCliByNameMock,
+}));
+
+vi.mock("./program/register.subclis.js", () => ({
+  registerSubCliByName: registerSubCliByNameMock,
+  loadValidatedConfigForPluginRegistration: loadValidatedConfigForPluginRegistrationMock,
+  registerPluginCliCommands: registerPluginCliCommandsMock,
+}));
+
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    getProgramContextMock.mockReturnValue({});
+    buildProgramMock.mockReturnValue({
+      commands: [],
+      parseAsync: parseAsyncMock,
+    });
+    loadValidatedConfigForPluginRegistrationMock.mockResolvedValue(undefined);
+    parseAsyncMock.mockClear();
   });
 
   it("does not force process.exit after successful routed command", async () => {
@@ -76,5 +116,42 @@ describe("runCli exit behavior", () => {
     expect(closeAllMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+
+  it("routes ACP stdout logging to stderr before command registration", async () => {
+    const callOrder: string[] = [];
+
+    routeLogsToStderrMock.mockImplementation(() => {
+      callOrder.push("route");
+    });
+    registerCoreCliByNameMock.mockImplementation(() => {
+      callOrder.push("core");
+    });
+    registerSubCliByNameMock.mockImplementation(() => {
+      callOrder.push("sub");
+    });
+    registerPluginCliCommandsMock.mockImplementation(() => {
+      callOrder.push("plugin");
+    });
+
+    loadValidatedConfigForPluginRegistrationMock.mockResolvedValue({});
+
+    await runCli(["node", "openclaw", "acp"]);
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
+    expect(callOrder[0]).toBe("route");
+    expect(callOrder).toContain("core");
+    expect(callOrder).toContain("sub");
+    expect(callOrder.indexOf("core")).toBeGreaterThan(callOrder.indexOf("route"));
+    expect(callOrder.indexOf("sub")).toBeGreaterThan(callOrder.indexOf("route"));
+    expect(registerPluginCliCommandsMock).toHaveBeenCalledTimes(1);
+    expect(callOrder.indexOf("plugin")).toBeGreaterThan(callOrder.indexOf("route"));
+  });
+
+  it("does not force ACP log redirection for non-acp commands", async () => {
+    await runCli(["node", "openclaw", "status"]);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+    expect(registerCoreCliByNameMock).toHaveBeenCalled();
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -8,6 +8,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture, routeLogsToStderr } from "../logging.js";
 import {
   getCommandPathWithRootOptions,
+  getCommandPositionalsWithRootOptions,
   hasHelpOrVersion,
   isRootHelpInvocation,
 } from "./argv.js";
@@ -127,14 +128,34 @@ export async function runCli(argv: string[] = process.argv) {
 
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
 
-    // Determine primary command first, so ACP protocol-safe routing happens before registration side-effects.
-    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
+    // Determine primary command first, so ACP protocol-safe routing happens before
+    // registration side-effects.
+    const [routePathPrimary] = getCommandPathWithRootOptions(parseArgv, 2);
     const primary = routePathPrimary ?? null;
+
+    const acpCommandArgs =
+      primary === "acp"
+        ? getCommandPositionalsWithRootOptions(parseArgv, {
+          commandPath: ["acp"],
+          booleanFlags: ["--require-existing", "--reset-session", "--no-prefix-cwd", "--verbose", "-v"],
+          valueFlags: [
+            "--url",
+            "--token",
+            "--token-file",
+            "--password",
+            "--password-file",
+            "--session",
+            "--session-label",
+            "--provenance",
+          ],
+        })
+        : null;
+    const isAcpClient = acpCommandArgs?.[0] === "client";
 
     // Route logs to stderr for ACP bridge mode before registration side-effects,
     // so stdout remains clean for protocol clients when running `openclaw acp`
     // (including `--url`, `--token`, etc. variants).
-    if (routePathPrimary === "acp" && routePathSecondary !== "client") {
+    if (routePathPrimary === "acp" && !isAcpClient) {
       routeLogsToStderr();
     }
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -8,7 +8,6 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture, routeLogsToStderr } from "../logging.js";
 import {
   getCommandPathWithRootOptions,
-  getPrimaryCommand,
   hasHelpOrVersion,
   isRootHelpInvocation,
 } from "./argv.js";
@@ -129,11 +128,13 @@ export async function runCli(argv: string[] = process.argv) {
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
 
     // Determine primary command first, so ACP protocol-safe routing happens before registration side-effects.
-    const primary = getPrimaryCommand(parseArgv);
+    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
+    const primary = routePathPrimary ?? null;
 
-    // Route logs to stderr for ACP mode before registration side-effects,
-    // so stdout remains clean for protocol clients even when acp has option args.
-    if (primary === "acp") {
+    // Route logs to stderr for ACP bridge mode before registration side-effects,
+    // so stdout remains clean for protocol clients when running `openclaw acp`
+    // (including `--url`, `--token`, etc. variants).
+    if (routePathPrimary === "acp" && routePathSecondary !== "client") {
       routeLogsToStderr();
     }
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -5,7 +5,7 @@ import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
-import { enableConsoleCapture } from "../logging.js";
+import { enableConsoleCapture, routeLogsToStderr } from "../logging.js";
 import {
   getCommandPathWithRootOptions,
   getPrimaryCommand,
@@ -139,6 +139,13 @@ export async function runCli(argv: string[] = process.argv) {
       }
       const { registerSubCliByName } = await import("./program/register.subclis.js");
       await registerSubCliByName(program, primary);
+    }
+
+    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
+
+    // Route logs to stderr for ACP gateway mode so protocol JSON on stdout is never polluted.
+    if (routePathPrimary === "acp" && routePathSecondary === undefined) {
+      routeLogsToStderr();
     }
 
     const hasBuiltinPrimary =

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -127,6 +127,14 @@ export async function runCli(argv: string[] = process.argv) {
     });
 
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+
+    // Route logs to stderr for ACP gateway mode as soon as we know the target
+    // command, to keep stdout protocol-safe during command registration.
+    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
+    if (routePathPrimary === "acp" && routePathSecondary === undefined) {
+      routeLogsToStderr();
+    }
+
     // Register the primary command (builtin or subcli) so help and command parsing
     // are correct even with lazy command registration.
     const primary = getPrimaryCommand(parseArgv);
@@ -139,13 +147,6 @@ export async function runCli(argv: string[] = process.argv) {
       }
       const { registerSubCliByName } = await import("./program/register.subclis.js");
       await registerSubCliByName(program, primary);
-    }
-
-    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
-
-    // Route logs to stderr for ACP gateway mode so protocol JSON on stdout is never polluted.
-    if (routePathPrimary === "acp" && routePathSecondary === undefined) {
-      routeLogsToStderr();
     }
 
     const hasBuiltinPrimary =

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -136,19 +136,29 @@ export async function runCli(argv: string[] = process.argv) {
     const acpCommandArgs =
       primary === "acp"
         ? getCommandPositionalsWithRootOptions(parseArgv, {
-          commandPath: ["acp"],
-          booleanFlags: ["--require-existing", "--reset-session", "--no-prefix-cwd", "--verbose", "-v"],
-          valueFlags: [
-            "--url",
-            "--token",
-            "--token-file",
-            "--password",
-            "--password-file",
-            "--session",
-            "--session-label",
-            "--provenance",
-          ],
-        })
+            commandPath: ["acp"],
+            booleanFlags: [
+              "--require-existing",
+              "--reset-session",
+              "--no-prefix-cwd",
+              "--verbose",
+              "-v",
+              "--server-verbose",
+            ],
+            valueFlags: [
+              "--url",
+              "--token",
+              "--token-file",
+              "--password",
+              "--password-file",
+              "--session",
+              "--session-label",
+              "--provenance",
+              "--cwd",
+              "--server",
+              "--server-args",
+            ],
+          })
         : null;
     const isAcpClient = acpCommandArgs?.[0] === "client";
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -128,16 +128,17 @@ export async function runCli(argv: string[] = process.argv) {
 
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
 
-    // Route logs to stderr for ACP gateway mode as soon as we know the target
-    // command, to keep stdout protocol-safe during command registration.
-    const [routePathPrimary, routePathSecondary] = getCommandPathWithRootOptions(parseArgv, 2);
-    if (routePathPrimary === "acp" && routePathSecondary === undefined) {
+    // Determine primary command first, so ACP protocol-safe routing happens before registration side-effects.
+    const primary = getPrimaryCommand(parseArgv);
+
+    // Route logs to stderr for ACP mode before registration side-effects,
+    // so stdout remains clean for protocol clients even when acp has option args.
+    if (primary === "acp") {
       routeLogsToStderr();
     }
 
     // Register the primary command (builtin or subcli) so help and command parsing
     // are correct even with lazy command registration.
-    const primary = getPrimaryCommand(parseArgv);
     if (primary) {
       const { getProgramContext } = await import("./program/program-context.js");
       const ctx = getProgramContext(program);


### PR DESCRIPTION
## Why

When running the ACP bridge, `openclaw acp` currently uses the shared CLI console capture path without forcing logs to stderr. Any logging output on stdout can corrupt the NDJSON protocol stream and break clients expecting pure JSON.

## What changed

- Route console logging to stderr at the start of `serveAcpGateway`.
- Route logging to stderr for ACP gateway CLI mode in `run-main` before plugin command registration, so startup logs (including plugin diagnostics) stay off stdout.
- Added a startup test in `src/acp/server.startup.test.ts` asserting `routeLogsToStderr` is invoked by `serveAcpGateway`.

## Verification

- Added unit test coverage for startup log routing in `src/acp/server.startup.test.ts`.
- Runtime behavior validated by static/logical audit; environment currently lacks full local test tooling for `vitest`.
