### PR TITLE
fix(acpx): read ACPX_PINNED_VERSION from package.json instead of hard…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACPX/runtime: derive the bundled ACPX expected version from the extension package metadata instead of hardcoding a separate literal, so plugin-local ACPX installs stop drifting out of health-check parity after version bumps. (#49089) Thanks @jiejiesks and @vincentkoc.
 - Gateway/auth: make local-direct `trusted-proxy` fallback require the configured shared token instead of silently authenticating same-host callers, while keeping same-host reverse proxy identity-header flows on the normal trusted-proxy path. Thanks @zhangning-agent and @vincentkoc.
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
 - LINE/ACP: add current-conversation binding and inbound binding-routing parity so `/acp spawn ... --thread here`, configured ACP bindings, and active conversation-bound ACP sessions work on LINE like the other conversation channels.

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -11,7 +11,6 @@ export type AcpxPermissionMode = (typeof ACPX_PERMISSION_MODES)[number];
 export const ACPX_NON_INTERACTIVE_POLICIES = ["deny", "fail"] as const;
 export type AcpxNonInteractivePermissionPolicy = (typeof ACPX_NON_INTERACTIVE_POLICIES)[number];
 
-export const ACPX_PINNED_VERSION = "0.3.1";
 export const ACPX_VERSION_ANY = "any";
 const ACPX_BIN_NAME = process.platform === "win32" ? "acpx.cmd" : "acpx";
 
@@ -58,6 +57,8 @@ export function resolveAcpxPluginRoot(moduleUrl: string = import.meta.url): stri
 }
 
 export const ACPX_PLUGIN_ROOT = resolveAcpxPluginRoot();
+const pluginPkg = JSON.parse(fs.readFileSync(path.join(ACPX_PLUGIN_ROOT, "package.json"), "utf8"));
+export const ACPX_PINNED_VERSION: string = pluginPkg.dependencies.acpx;
 export const ACPX_BUNDLED_BIN = path.join(ACPX_PLUGIN_ROOT, "node_modules", ".bin", ACPX_BIN_NAME);
 export function buildAcpxLocalInstallCommand(version: string = ACPX_PINNED_VERSION): string {
   return `npm install --omit=dev --no-save --package-lock=false acpx@${version}`;

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -58,7 +58,13 @@ export function resolveAcpxPluginRoot(moduleUrl: string = import.meta.url): stri
 
 export const ACPX_PLUGIN_ROOT = resolveAcpxPluginRoot();
 const pluginPkg = JSON.parse(fs.readFileSync(path.join(ACPX_PLUGIN_ROOT, "package.json"), "utf8"));
-export const ACPX_PINNED_VERSION: string = pluginPkg.dependencies.acpx;
+const acpxVersion: unknown = pluginPkg?.dependencies?.acpx;
+if (typeof acpxVersion !== "string" || acpxVersion.trim() === "") {
+  throw new Error(
+    `Could not read acpx version from ${path.join(ACPX_PLUGIN_ROOT, "package.json")} — expected a non-empty string at dependencies.acpx`
+  );
+}
+export const ACPX_PINNED_VERSION: string = acpxVersion.replace(/^[^0-9]*/, "");
 export const ACPX_BUNDLED_BIN = path.join(ACPX_PLUGIN_ROOT, "node_modules", ".bin", ACPX_BIN_NAME);
 export function buildAcpxLocalInstallCommand(version: string = ACPX_PINNED_VERSION): string {
   return `npm install --omit=dev --no-save --package-lock=false acpx@${version}`;


### PR DESCRIPTION
…coding

The hardcoded ACPX_PINNED_VERSION ("0.1.16") falls out of sync with the bundled acpx version in package.json every release, causing ACP runtime to be marked unavailable due to version mismatch (see #43997).

## Summary

- Problem: `ACPX_PINNED_VERSION` is hardcoded to `"0.1.16"` while `package.json` declares a different acpx version, causing version mismatch on every release
- Why it matters: The mismatch causes ACP runtime to be marked unavailable, breaking ACP agent functionality
- What changed: Read `ACPX_PINNED_VERSION` dynamically from the plugin's own `package.json` instead of hardcoding
- What did NOT change (scope boundary): Version check logic itself is untouched; only the source of the expected version string changed

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #43997

## User-visible / Behavior Changes

ACP runtime will no longer fail to start due to pinned version mismatch after upgrades.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Install OpenClaw v2026.3.11 (`npm install -g openclaw@2026.3.11`)
2. Install bundled acpx in plugin directory (`cd extensions/acpx && npm install`)
3. Run `openclaw agent --agent main --message 'Please use sessions_spawn to start a claude code ACP session'`

### Expected

- ACP session spawns successfully via bundled acpx

### Actual

- Agent reports: "The ACP runtime is not configured on this system. ACP backend: Not configured"
- Root cause: bundled acpx version (0.2.0) does not match `ACPX_PINNED_VERSION` ("0.1.16") in `config.ts`, causing version check failure and ACP runtime marked as unavailable

## Human Verification (required)

- Verified scenarios: On v2026.3.11, after installing bundled acpx (`cd extensions/acpx && npm install`), confirmed agent reports "ACP runtime is not configured" due to version mismatch (bundled 0.2.0 vs pinned 0.1.16). Also confirmed the same hardcoded mismatch exists on v2026.3.8 (pinned 0.1.16 vs declared 0.1.15) and v2026.3.13 (pinned 0.1.16 vs declared 0.3.0).
- Edge cases checked: `fs.readFileSync` will throw if `package.json` is missing, which is correct — a missing `package.json` is an abnormal state that should not be silently ignored
- What you did **not** verify: Did not run the full OpenClaw test suite

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit and re-hardcode `ACPX_PINNED_VERSION`
- Files/config to restore: `extensions/acpx/src/config.ts`
- Known bad symptoms reviewers should watch for: Plugin startup crash if `package.json` is missing or `dependencies.acpx` is undefined

## Risks and Mitigations

- Risk: `package.json` missing `dependencies.acpx` field
  - Mitigation: This field is required for npm to install the bundled acpx; if it's missing, the plugin is already broken regardless of this change