### PR TITLE
fix(agents): prefer agent model for subagent spawns

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -14,6 +14,7 @@ import {
   resolveConfiguredModelRef,
   resolveThinkingDefault,
   resolveModelRefFromString,
+  resolveSubagentConfiguredModelSelection,
 } from "./model-selection.js";
 
 const EXPLICIT_ALLOWLIST_CONFIG = {
@@ -824,5 +825,23 @@ describe("normalizeModelSelection", () => {
     expect(normalizeModelSelection(undefined)).toBeUndefined();
     expect(normalizeModelSelection(null)).toBeUndefined();
     expect(normalizeModelSelection(42)).toBeUndefined();
+  });
+});
+
+describe("resolveSubagentConfiguredModelSelection", () => {
+  it("prefers the target agent primary model over the global subagent default", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          subagents: { model: "minimax/MiniMax-M2.5" },
+          model: { primary: "openai/gpt-5.4" },
+        },
+        list: [{ id: "research", model: { primary: "opencode/claude" } }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
+      "opencode/claude",
+    );
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -381,8 +381,8 @@ export function resolveSubagentConfiguredModelSelection(params: {
   const agentConfig = resolveAgentConfig(params.cfg, params.agentId);
   return (
     normalizeModelSelection(agentConfig?.subagents?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
-    normalizeModelSelection(agentConfig?.model)
+    normalizeModelSelection(agentConfig?.model) ??
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model)
   );
 }
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -230,6 +230,24 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     });
   });
 
+  it("sessions_spawn prefers target agent primary model over global subagent default", async () => {
+    await expectSpawnUsesConfiguredModel({
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: {
+          defaults: {
+            subagents: { model: "minimax/MiniMax-M2.5" },
+            model: { primary: "openai/gpt-5.4" },
+          },
+          list: [{ id: "research", model: { primary: "opencode/claude" } }],
+        },
+      },
+      runId: "run-agent-primary-over-subagent-default",
+      callId: "call-agent-primary-over-subagent-default",
+      expectedModel: "opencode/claude",
+    });
+  });
+
   it("sessions_spawn prefers target agent primary model over global default", async () => {
     await expectSpawnUsesConfiguredModel({
       config: {


### PR DESCRIPTION
Summary
- prefer the target agent's configured primary model before the global `agents.defaults.subagents.model` fallback when resolving subagent spawn models
- add regression coverage for the precedence bug at the model-selection layer and the sessions_spawn path

Change Type
- bug fix
- tests

Scope
- src/agents/model-selection.ts
- src/agents/model-selection.test.ts
- src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts

User-visible / Behavior Changes
- subagent spawns now honor `agents.list[id].model.primary` before falling back to `agents.defaults.subagents.model`
- per-agent `subagents.model` still keeps highest precedence

Test plan
- `pnpm -C /tmp/openclaw-issue-49074 exec vitest run src/agents/model-selection.test.ts -t "prefers the target agent primary model over the global subagent default"`
- attempted `pnpm -C /tmp/openclaw-issue-49074 exec vitest run src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts` (currently fails in local test env before assertions due `GatewayClientRequestError: unauthorized: gateway token missing`, unrelated to this patch)

Closes #49074
