### PR TITLE
feat(whatsapp): extract GIF/media metadata from externalAdReply

### DIFF
--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -193,6 +193,115 @@ describe("web inbound helpers", () => {
     ).toBe("<media:audio>");
   });
 
+  it("returns <media:gif> for video messages with gifPlayback", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: { gifPlayback: true },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe("<media:gif>");
+  });
+
+  it("returns <media:gif> with metadata from externalAdReply", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          gifPlayback: true,
+          contextInfo: {
+            externalAdReply: {
+              title: "This Is Fine",
+              sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
+            },
+          },
+        },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe('<media:gif title="This Is Fine" source="https://giphy.com/gifs/this-is-fine-3o7TK">');
+  });
+
+  it("returns <media:video> for video messages without gifPlayback", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {},
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe("<media:video>");
+  });
+
+  it("returns <media:video> with metadata when gifPlayback is absent", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          contextInfo: {
+            externalAdReply: {
+              title: "Funny Clip",
+              sourceUrl: "https://example.com/video",
+              body: "A funny video clip",
+            },
+          },
+        },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe(
+      '<media:video title="Funny Clip" source="https://example.com/video" description="A funny video clip">',
+    );
+  });
+
+  it("returns <media:image> with metadata from externalAdReply", () => {
+    expect(
+      extractMediaPlaceholder({
+        imageMessage: {
+          contextInfo: {
+            externalAdReply: {
+              title: "Shared Link Preview",
+              sourceUrl: "https://example.com/article",
+            },
+          },
+        },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe('<media:image title="Shared Link Preview" source="https://example.com/article">');
+  });
+
+  it("returns plain <media:image> when imageMessage has no externalAdReply", () => {
+    expect(
+      extractMediaPlaceholder({
+        imageMessage: { caption: "just a photo" },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe("<media:image>");
+  });
+
+  it("returns <media:image> with description from externalAdReply body", () => {
+    expect(
+      extractMediaPlaceholder({
+        imageMessage: {
+          contextInfo: {
+            externalAdReply: {
+              title: "Article Title",
+              sourceUrl: "https://example.com/article",
+              body: "An article description",
+            },
+          },
+        },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe(
+      '<media:image title="Article Title" source="https://example.com/article" description="An article description">',
+    );
+  });
+
+  it("escapes double quotes and angle brackets in adReply attributes", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          gifPlayback: true,
+          contextInfo: {
+            externalAdReply: {
+              title: 'Say "Hello" To My Little Friend',
+              sourceUrl: "https://example.com/gif?a=1&b=>2",
+            },
+          },
+        },
+      } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
+    ).toBe(
+      '<media:gif title="Say &quot;Hello&quot; To My Little Friend" source="https://example.com/gif?a=1&b=&gt;2">',
+    );
+  });
+
   it("extracts WhatsApp location messages", () => {
     const location = extractLocationData({
       locationMessage: {

--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -284,7 +284,7 @@ describe("web inbound helpers", () => {
     );
   });
 
-  it("escapes double quotes and angle brackets in adReply attributes", () => {
+  it('escapes special characters (&, ", <, >) in adReply attributes', () => {
     expect(
       extractMediaPlaceholder({
         videoMessage: {

--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -298,7 +298,7 @@ describe("web inbound helpers", () => {
         },
       } as unknown as import("@whiskeysockets/baileys").proto.IMessage),
     ).toBe(
-      '<media:gif title="Say &quot;Hello&quot; To My Little Friend" source="https://example.com/gif?a=1&b=&gt;2">',
+      '<media:gif title="Say &quot;Hello&quot; To My Little Friend" source="https://example.com/gif?a=1&amp;b=&gt;2">',
     );
   });
 

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -122,7 +122,11 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
 }
 
 function escapeAttr(value: string): string {
-  return value.replace(/"/g, "&quot;").replace(/>/g, "&gt;");
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function extractMediaPlaceholder(

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -121,6 +121,10 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
   return undefined;
 }
 
+function escapeAttr(value: string): string {
+  return value.replace(/"/g, "&quot;").replace(/>/g, "&gt;");
+}
+
 export function extractMediaPlaceholder(
   rawMessage: proto.IMessage | undefined,
 ): string | undefined {
@@ -129,10 +133,23 @@ export function extractMediaPlaceholder(
     return undefined;
   }
   if (message.imageMessage) {
+    const adReply = message.imageMessage.contextInfo?.externalAdReply;
+    const parts: string[] = [];
+    if (adReply?.title) parts.push(`title="${escapeAttr(adReply.title)}"`);
+    if (adReply?.sourceUrl) parts.push(`source="${escapeAttr(adReply.sourceUrl)}"`);
+    if (adReply?.body) parts.push(`description="${escapeAttr(adReply.body)}"`);
+    if (parts.length > 0) return `<media:image ${parts.join(" ")}>`;
     return "<media:image>";
   }
   if (message.videoMessage) {
-    return "<media:video>";
+    const isGif = message.videoMessage.gifPlayback;
+    const adReply = message.videoMessage.contextInfo?.externalAdReply;
+    const parts: string[] = [];
+    if (adReply?.title) parts.push(`title="${escapeAttr(adReply.title)}"`);
+    if (adReply?.sourceUrl) parts.push(`source="${escapeAttr(adReply.sourceUrl)}"`);
+    if (adReply?.body) parts.push(`description="${escapeAttr(adReply.body)}"`);
+    const attrs = parts.length > 0 ? ` ${parts.join(" ")}` : "";
+    return isGif ? `<media:gif${attrs}>` : `<media:video${attrs}>`;
   }
   if (message.audioMessage) {
     return "<media:audio>";


### PR DESCRIPTION
## Summary

- Distinguish GIFs from regular videos using `videoMessage.gifPlayback` (`<media:gif>` vs `<media:video>`)
- Extract `title`, `sourceUrl`, and `body` from `contextInfo.externalAdReply` on video and image messages
- Add `escapeAttr` helper to sanitize `"` and `>` in attribute values
- Enables the bot to understand GIF content from Giphy/Tenor URLs without requiring ffmpeg or video processing

Before: `<media:video>`
After: `<media:gif title="This Is Fine" source="https://giphy.com/gifs/this-is-fine-3o7TK...">`

## Test plan

- [x] 8 new test cases covering GIF/video/image with/without metadata, plus escaping edge cases
- [x] All 22 tests pass (`npx vitest run extensions/whatsapp/src/inbound.test.ts --config vitest.channels.config.ts`)
- [ ] Manual test: send a GIF from WhatsApp's GIF picker and verify the bot sees metadata

Closes #49099