### PR TITLE
docs(zh-CN): sync feishu doc with EN — add missing send types, threads, and runtime actions

### DIFF
--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -725,4 +725,28 @@ openclaw pairing list feishu
 - ✅ 图片
 - ✅ 文件
 - ✅ 音频
-- ⚠️ 富文本（部分支持）
+- ✅ 视频/媒体
+- ✅ 互动卡片
+- ⚠️ 富文本（post 格式和卡片，不涵盖飞书所有编辑能力）
+
+### 话题与回复
+
+- ✅ 内联回复
+- ✅ 话题回复（飞书 `reply_in_thread` 支持的场景）
+- ✅ 回复话题消息时，媒体回复会自动归入对应话题
+
+## 运行时支持的操作
+
+飞书当前支持以下运行时操作：
+
+- `send`
+- `read`
+- `edit`
+- `thread-reply`
+- `pin`
+- `list-pins`
+- `unpin`
+- `member-info`
+- `channel-info`
+- `channel-list`
+- `react` 和 `reactions`（需在配置中启用 reactions）


### PR DESCRIPTION
## Summary

- **Problem:** zh-CN Feishu channel doc is out of sync with the English version — missing send types, threads section, and runtime action surface section
- **Why it matters:** Chinese users reading the localized docs get incomplete information about supported features
- **What changed:** Added missing content to `docs/zh-CN/channels/feishu.md` to match `docs/channels/feishu.md`
- **What did NOT change:** No code changes, no English doc changes

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: zh-CN doc drift from EN source

## User-visible / Behavior Changes

None (docs only)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Relevant config: N/A (docs change)

### Steps

1. Compare `docs/channels/feishu.md` with `docs/zh-CN/channels/feishu.md`
2. Note missing sections in zh-CN version

### Expected

Both docs should cover the same sections

### Actual

zh-CN was missing: video/media + interactive cards in Send, Threads and replies section, Runtime action surface section

## Evidence

- [x] Diff shows content matches EN source

## Human Verification (required)

- Verified scenarios: Compared section headers and content between EN and zh-CN docs line by line
- Edge cases checked: Chinese translations reviewed by native speaker for natural phrasing
- What you did **not** verify: No automated i18n tooling check

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single file
- Known bad symptoms: N/A (docs only)

## Risks and Mitigations

None