### PR TITLE
fix(security): reject private/internal hosts in cron webhook URLs

### DIFF
--- a/src/cron/webhook-url.test.ts
+++ b/src/cron/webhook-url.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHttpWebhookUrl } from "./webhook-url.js";
+
+describe("normalizeHttpWebhookUrl", () => {
+  it("accepts valid https URLs", () => {
+    expect(normalizeHttpWebhookUrl("https://example.com/webhook")).toBe(
+      "https://example.com/webhook",
+    );
+  });
+
+  it("accepts valid http URLs", () => {
+    expect(normalizeHttpWebhookUrl("http://hooks.example.com/cron")).toBe(
+      "http://hooks.example.com/cron",
+    );
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeHttpWebhookUrl("  https://example.com/hook  ")).toBe(
+      "https://example.com/hook",
+    );
+  });
+
+  it("rejects non-string input", () => {
+    expect(normalizeHttpWebhookUrl(42)).toBeNull();
+    expect(normalizeHttpWebhookUrl(null)).toBeNull();
+    expect(normalizeHttpWebhookUrl(undefined)).toBeNull();
+    expect(normalizeHttpWebhookUrl({})).toBeNull();
+  });
+
+  it("rejects empty strings", () => {
+    expect(normalizeHttpWebhookUrl("")).toBeNull();
+    expect(normalizeHttpWebhookUrl("   ")).toBeNull();
+  });
+
+  it("rejects non-http(s) protocols", () => {
+    expect(normalizeHttpWebhookUrl("ftp://example.com/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("file:///etc/passwd")).toBeNull();
+    expect(normalizeHttpWebhookUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(normalizeHttpWebhookUrl("not-a-url")).toBeNull();
+    expect(normalizeHttpWebhookUrl("://missing-scheme")).toBeNull();
+  });
+
+  // SSRF guard: private/internal addresses
+  it("rejects localhost", () => {
+    expect(normalizeHttpWebhookUrl("http://localhost/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://localhost:8080/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("https://localhost/hook")).toBeNull();
+  });
+
+  it("rejects loopback IPv4", () => {
+    expect(normalizeHttpWebhookUrl("http://127.0.0.1/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://127.0.0.1:3000/hook")).toBeNull();
+  });
+
+  it("rejects loopback IPv6", () => {
+    expect(normalizeHttpWebhookUrl("http://[::1]/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://[::1]:8080/hook")).toBeNull();
+  });
+
+  it("rejects private RFC 1918 ranges", () => {
+    expect(normalizeHttpWebhookUrl("http://10.0.0.1/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://172.16.0.1/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://192.168.1.1/hook")).toBeNull();
+  });
+
+  it("rejects link-local addresses", () => {
+    expect(normalizeHttpWebhookUrl("http://169.254.169.254/latest/meta-data/")).toBeNull();
+  });
+
+  it("rejects cloud metadata endpoints", () => {
+    expect(
+      normalizeHttpWebhookUrl("http://metadata.google.internal/computeMetadata/v1/"),
+    ).toBeNull();
+  });
+
+  it("rejects .local and .internal hostnames", () => {
+    expect(normalizeHttpWebhookUrl("http://myservice.local/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://secret.internal/hook")).toBeNull();
+  });
+
+  it("allows public IPs", () => {
+    expect(normalizeHttpWebhookUrl("https://8.8.8.8/hook")).toBe("https://8.8.8.8/hook");
+  });
+});

--- a/src/cron/webhook-url.test.ts
+++ b/src/cron/webhook-url.test.ts
@@ -81,6 +81,15 @@ describe("normalizeHttpWebhookUrl", () => {
     expect(normalizeHttpWebhookUrl("http://secret.internal/hook")).toBeNull();
   });
 
+  it("rejects 0.0.0.0", () => {
+    expect(normalizeHttpWebhookUrl("http://0.0.0.0/hook")).toBeNull();
+  });
+
+  it("rejects IPv4-mapped IPv6 loopback", () => {
+    expect(normalizeHttpWebhookUrl("http://[::ffff:127.0.0.1]/hook")).toBeNull();
+    expect(normalizeHttpWebhookUrl("http://[::ffff:7f00:1]/hook")).toBeNull();
+  });
+
   it("allows public IPs", () => {
     expect(normalizeHttpWebhookUrl("https://8.8.8.8/hook")).toBe("https://8.8.8.8/hook");
   });

--- a/src/cron/webhook-url.ts
+++ b/src/cron/webhook-url.ts
@@ -1,7 +1,18 @@
+import { isBlockedHostnameOrIp } from "../infra/net/ssrf.js";
+
 function isAllowedWebhookProtocol(protocol: string) {
   return protocol === "http:" || protocol === "https:";
 }
 
+/**
+ * Validate and normalize a webhook URL.
+ *
+ * Rejects non-http(s) protocols and hostnames that resolve to private,
+ * loopback, link-local, or other special-use addresses (SSRF guard).
+ * This is an early, static check on the literal hostname/IP before any
+ * DNS resolution; the runtime fetch layer should still perform its own
+ * DNS-pinned SSRF validation.
+ */
 export function normalizeHttpWebhookUrl(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
@@ -13,6 +24,11 @@ export function normalizeHttpWebhookUrl(value: unknown): string | null {
   try {
     const parsed = new URL(trimmed);
     if (!isAllowedWebhookProtocol(parsed.protocol)) {
+      return null;
+    }
+    // Block URLs targeting private/internal/special-use addresses.
+    // parsed.hostname strips brackets from IPv6 literals automatically.
+    if (isBlockedHostnameOrIp(parsed.hostname)) {
       return null;
     }
     return trimmed;


### PR DESCRIPTION
## Problem

`normalizeHttpWebhookUrl` only validated that webhook URLs used http(s) protocol, but did not check whether the hostname pointed to private, loopback, link-local, or other special-use addresses. A cron job configured with `delivery.mode="webhook"` could target:

- `localhost` / `127.0.0.1` / `[::1]`
- RFC 1918 private ranges (`10.x`, `172.16.x`, `192.168.x`)
- Cloud metadata endpoints (`169.254.169.254`, `metadata.google.internal`)
- `.local` / `.internal` hostnames

While the runtime fetch layer performs DNS-pinned SSRF validation, rejecting these at URL creation time prevents dangerous URLs from being persisted in cron job configs in the first place.

## Fix

Import and apply the existing `isBlockedHostnameOrIp` guard from the SSRF module (`src/infra/net/ssrf.ts`) inside `normalizeHttpWebhookUrl`. This provides defense-in-depth: blocked URLs are rejected early during cron job creation/patching, before any network request is attempted.

## Testing

- Added `src/cron/webhook-url.test.ts` with 15 test cases covering protocol validation, SSRF hostname/IP rejection, and public URL acceptance
- Verified existing `service.jobs.test.ts` (35 tests) and `normalize.test.ts` (30 tests) continue to pass
- [x] AI-assisted, fully tested
- [x] Understand what the code does