### PR TITLE
fix(telegram): add block streaming coalesce defaults to prevent message splitting

### DIFF
--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -95,6 +95,9 @@ export function createTelegramPluginBase(params: {
       nativeCommands: true,
       blockStreaming: true,
     },
+    streaming: {
+      blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+    },
     reload: { configPrefixes: ["channels.telegram"] },
     configSchema: buildChannelConfigSchema(TelegramConfigSchema),
     config: {

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -77,7 +77,7 @@ export function createTelegramPluginBase(params: {
   setup: NonNullable<ChannelPlugin<ResolvedTelegramAccount>["setup"]>;
 }): Pick<
   ChannelPlugin<ResolvedTelegramAccount>,
-  "id" | "meta" | "setupWizard" | "capabilities" | "reload" | "configSchema" | "config" | "setup"
+  "id" | "meta" | "setupWizard" | "capabilities" | "reload" | "configSchema" | "config" | "setup" | "streaming"
 > {
   return {
     id: TELEGRAM_CHANNEL,


### PR DESCRIPTION
## Summary

- Telegram was the only channel plugin missing `blockStreamingCoalesceDefaults` in its streaming config
- Every other block-streaming channel (Slack, Discord, Mattermost, Google Chat, Signal) sets `{ minChars: 1500, idleMs: 1000 }` so the block reply coalescer buffers small streamed fragments before flushing them as separate messages
- Without these defaults, Telegram fell back to the global minimum (800 chars / 1 s idle), causing short streamed paragraphs to be sent as individual messages instead of being merged into a single message

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

Fixes #47454

## User-visible / Behavior Changes

Multi-line Telegram responses are now properly coalesced into fewer messages during block streaming, matching the behavior of other channels.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Test plan

- [x] Existing `chunk.test.ts` (31 tests), `deliver.test.ts` (43 tests), `draft-chunking.test.ts` (3 tests), and `block-streaming.test.ts` (3 tests) all pass
- [ ] Manual verification: send a multi-line response to a Telegram bot — should arrive as a single message instead of being split per paragraph