### PR TITLE
fix: clear stale inputTokens after compaction to fix context UI

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -286,12 +286,15 @@ export async function incrementCompactionCount(params: {
   if (tokensAfter != null && tokensAfter > 0) {
     updates.totalTokens = tokensAfter;
     updates.totalTokensFresh = true;
-    // Clear input/output breakdown since we only have the total estimate after compaction
-    updates.inputTokens = undefined;
-    updates.outputTokens = undefined;
-    updates.cacheRead = undefined;
-    updates.cacheWrite = undefined;
   }
+  // Always clear per-call token breakdown after compaction — the previous
+  // inputTokens value reflects the last pre-compaction API call and is stale.
+  // Without this, the Control UI can show "100% context used" even though the
+  // actual post-compaction context is much smaller (see #49076).
+  updates.inputTokens = undefined;
+  updates.outputTokens = undefined;
+  updates.cacheRead = undefined;
+  updates.cacheWrite = undefined;
   sessionStore[sessionKey] = {
     ...entry,
     ...updates,


### PR DESCRIPTION
## Summary

Fixes #49076 — the Control UI showed "100% context used" when actual usage was ~39% after compaction.

## Root Cause

After compaction, `inputTokens` (from the last pre-compaction API call) was only cleared when `tokensAfter` was available. Without it, the stale `inputTokens` value persisted, and the UI calculated `used / limit` using the old pre-compaction count.

**Before fix:**
- Pre-compaction API call uses 292k input tokens → `inputTokens = 292k`
- Compaction runs without `tokensAfter` → `inputTokens` stays 292k
- UI shows `292k / 272k` = 107% → capped to "100% context used"
- But actual context is 105k post-compaction

## Fix

Always clear per-call token breakdown (`inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`) after compaction, regardless of whether `tokensAfter` is provided. The `totalTokens` update still only happens when `tokensAfter` is available.

## Changes

- `src/auto-reply/reply/session-updates.ts`: Move token metric clearing outside the `tokensAfter` conditional block in `incrementCompactionCount()`