### PR TITLE
fix(onboard): keep Azure custom providers on Azure Responses API

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -201,7 +201,7 @@ describe("promptCustomApiConfig", () => {
     });
     const fetchMock = stubFetchSequence([{ ok: true }]);
 
-    await runPromptCustomApi(prompter);
+    const result = await runPromptCustomApi(prompter);
 
     const firstCall = fetchMock.mock.calls[0];
     const firstUrl = firstCall?.[0];
@@ -225,6 +225,10 @@ describe("promptCustomApiConfig", () => {
     });
     expect(parsedBody).not.toHaveProperty("model");
     expect(parsedBody).not.toHaveProperty("max_tokens");
+    const configuredProvider = Object.values(result.config.models?.providers ?? {})[0] as
+      | { api?: string }
+      | undefined;
+    expect(configuredProvider?.api).toBe("azure-openai-responses");
   });
 
   it("uses expanded max_tokens for anthropic verification probes", async () => {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -473,8 +473,12 @@ async function applyCustomApiRetryChoice(params: {
 
 function resolveProviderApi(
   compatibility: CustomApiCompatibility,
-): "openai-completions" | "anthropic-messages" {
-  return compatibility === "anthropic" ? "anthropic-messages" : "openai-completions";
+  baseUrl: string,
+): "openai-completions" | "azure-openai-responses" | "anthropic-messages" {
+  if (compatibility === "anthropic") {
+    return "anthropic-messages";
+  }
+  return isAzureUrl(baseUrl) ? "azure-openai-responses" : "openai-completions";
 }
 
 function parseCustomApiCompatibility(raw?: string): CustomApiCompatibility {
@@ -631,7 +635,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
         [providerId]: {
           ...existingProviderRest,
           baseUrl: resolvedBaseUrl,
-          api: resolveProviderApi(params.compatibility),
+          api: resolveProviderApi(params.compatibility, baseUrl),
           ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
           models: mergedModels.length > 0 ? mergedModels : [nextModel],
         },

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -3,6 +3,7 @@ import type { SecretInput } from "./types.secrets.js";
 export const MODEL_APIS = [
   "openai-completions",
   "openai-responses",
+  "azure-openai-responses",
   "openai-codex-responses",
   "anthropic-messages",
   "google-generative-ai",


### PR DESCRIPTION
## Summary
- store Azure OpenAI compatible custom providers as `azure-openai-responses` instead of `openai-completions`
- preserve the existing Azure URL transformation while selecting the provider API from the original endpoint host
- add a regression assertion covering Azure custom provider onboarding output

## Testing
- pnpm -C "/root/pr/openclaw" exec vitest run "src/commands/onboard-custom.test.ts"

Closes #48939