### PR TITLE
fix(whatsapp): guard missing direct peer ids

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/peer.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/peer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { WebInboundMsg } from "../types.js";
+import { resolvePeerId } from "./peer.js";
+
+function makeMessage(overrides: Record<string, unknown> = {}): WebInboundMsg {
+  return {
+    chatType: "direct",
+    conversationId: "+15551234567",
+    from: "+15551234567",
+    to: "+15550000000",
+    accountId: "default",
+    body: "hi",
+    chatId: "chat-1",
+    sendComposing: async () => {},
+    reply: async () => {},
+    sendMedia: async () => {},
+    ...overrides,
+  } as unknown as WebInboundMsg;
+}
+
+describe("resolvePeerId", () => {
+  it("falls back to conversationId when from is missing on direct messages", () => {
+    expect(
+      resolvePeerId(
+        makeMessage({
+          conversationId: "+15557654321",
+          from: undefined,
+        }),
+      ),
+    ).toBe("+15557654321");
+  });
+
+  it("returns unknown when direct messages have no sender identifiers", () => {
+    expect(
+      resolvePeerId(
+        makeMessage({
+          conversationId: undefined,
+          from: undefined,
+          senderE164: undefined,
+        }),
+      ),
+    ).toBe("unknown");
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/peer.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/peer.ts
@@ -3,13 +3,17 @@ import type { WebInboundMsg } from "../types.js";
 
 export function resolvePeerId(msg: WebInboundMsg) {
   if (msg.chatType === "group") {
-    return msg.conversationId ?? msg.from;
+    return msg.conversationId ?? msg.from ?? "unknown";
   }
   if (msg.senderE164) {
     return normalizeE164(msg.senderE164) ?? msg.senderE164;
   }
-  if (msg.from.includes("@")) {
-    return jidToE164(msg.from) ?? msg.from;
+  const directPeerSource = msg.from ?? msg.conversationId;
+  if (!directPeerSource) {
+    return "unknown";
   }
-  return normalizeE164(msg.from) ?? msg.from;
+  if (directPeerSource.includes("@")) {
+    return jidToE164(directPeerSource) ?? directPeerSource;
+  }
+  return normalizeE164(directPeerSource) ?? directPeerSource;
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -59,8 +59,9 @@ async function resolveWhatsAppCommandAuthorized(params: {
   }
 
   const isGroup = params.msg.chatType === "group";
+  const directPeerSource = params.msg.from ?? params.msg.conversationId ?? "";
   const senderE164 = normalizeE164(
-    isGroup ? (params.msg.senderE164 ?? "") : (params.msg.senderE164 ?? params.msg.from ?? ""),
+    isGroup ? (params.msg.senderE164 ?? "") : (params.msg.senderE164 ?? directPeerSource),
   );
   if (!senderE164) {
     return false;
@@ -151,7 +152,9 @@ export async function processMessage(params: {
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
 }) {
-  const conversationId = params.msg.conversationId ?? params.msg.from;
+  const conversationId = params.msg.conversationId ?? params.msg.from ?? "unknown";
+  const directPeerSource = params.msg.from ?? params.msg.conversationId;
+  const directFrom = directPeerSource ?? "unknown";
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
     agentId: params.route.agentId,
@@ -223,7 +226,7 @@ export async function processMessage(params: {
     {
       connectionId: params.connectionId,
       correlationId,
-      from: params.msg.chatType === "group" ? conversationId : params.msg.from,
+      from: params.msg.chatType === "group" ? conversationId : directFrom,
       to: params.msg.to,
       body: elide(combinedBody, 240),
       mediaType: params.msg.mediaType ?? null,
@@ -232,7 +235,7 @@ export async function processMessage(params: {
     "inbound web message",
   );
 
-  const fromDisplay = params.msg.chatType === "group" ? conversationId : params.msg.from;
+  const fromDisplay = params.msg.chatType === "group" ? conversationId : directFrom;
   const kindLabel = params.msg.mediaType ? `, ${params.msg.mediaType}` : "";
   whatsappInboundLog.info(
     `Inbound message ${fromDisplay} -> ${params.msg.to} (${params.msg.chatType}${kindLabel}, ${combinedBody.length} chars)`,
@@ -247,11 +250,14 @@ export async function processMessage(params: {
           if (params.msg.senderE164) {
             return normalizeE164(params.msg.senderE164);
           }
-          // In direct chats, `msg.from` is already the canonical conversation id.
-          if (params.msg.from.includes("@")) {
-            return jidToE164(params.msg.from);
+          if (!directPeerSource) {
+            return "unknown";
           }
-          return normalizeE164(params.msg.from);
+          // In direct chats, `msg.from` is already the canonical conversation id.
+          if (directPeerSource.includes("@")) {
+            return jidToE164(directPeerSource);
+          }
+          return normalizeE164(directPeerSource);
         })()
       : undefined;
 
@@ -278,7 +284,8 @@ export async function processMessage(params: {
   const isSelfChat =
     params.msg.chatType !== "group" &&
     Boolean(params.msg.selfE164) &&
-    normalizeE164(params.msg.from) === normalizeE164(params.msg.selfE164 ?? "");
+    Boolean(directPeerSource) &&
+    normalizeE164(directPeerSource) === normalizeE164(params.msg.selfE164 ?? "");
   const responsePrefix =
     prefixOptions.responsePrefix ??
     (configuredResponsePrefix === undefined && isSelfChat
@@ -302,7 +309,7 @@ export async function processMessage(params: {
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,
-    From: params.msg.from,
+    From: directFrom,
     To: params.msg.to,
     SessionKey: params.route.sessionKey,
     AccountId: params.route.accountId,
@@ -314,7 +321,7 @@ export async function processMessage(params: {
     MediaUrl: params.msg.mediaUrl,
     MediaType: params.msg.mediaType,
     ChatType: params.msg.chatType,
-    ConversationLabel: params.msg.chatType === "group" ? conversationId : params.msg.from,
+    ConversationLabel: params.msg.chatType === "group" ? conversationId : directFrom,
     GroupSubject: params.msg.groupSubject,
     GroupMembers: formatGroupMembers({
       participants: params.msg.groupParticipants,
@@ -330,7 +337,7 @@ export async function processMessage(params: {
     Provider: "whatsapp",
     Surface: "whatsapp",
     OriginatingChannel: "whatsapp",
-    OriginatingTo: params.msg.from,
+    OriginatingTo: directFrom,
   });
 
   // Only update main session's lastRoute when DM actually IS the main session.


### PR DESCRIPTION
## Summary
- guard WhatsApp direct-message peer resolution when inbound events arrive without `from`
- fall back to `conversationId` and finally `unknown` instead of crashing on `.includes()`
- harden the downstream direct-message monitor path so the same malformed event does not trip later null-sensitive access

## Testing
- pnpm -C "/root/pr/openclaw" exec tsx <<TS
  import { resolvePeerId } from ./extensions/whatsapp/src/auto-reply/monitor/peer.ts;
  // verified conversationId and unknown fallbacks for missing `from`
  TS
- pnpm -C "/root/pr/openclaw" exec tsc -p tsconfig.json --noEmit --pretty false
  - result: existing unrelated repo errors remain on `origin/main`, but no errors from the touched WhatsApp files

Closes #49094