### PR TITLE
fix: skip consecutiveErrors increment for connectivity errors in cron

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -148,6 +148,20 @@ function isTransientCronError(error: string | undefined, retryOn?: CronRetryOn[]
   return keys.some((k) => TRANSIENT_PATTERNS[k]?.test(error));
 }
 
+/**
+ * Detect connectivity/network errors that typically occur during host
+ * sleep/hibernate or temporary network loss.  These should not inflate
+ * consecutiveErrors because they are environmental, not application failures.
+ */
+function isConnectivityError(error: string | undefined): boolean {
+  if (!error || typeof error !== "string") {
+    return false;
+  }
+  return (
+    TRANSIENT_PATTERNS.network.test(error) || TRANSIENT_PATTERNS.timeout.test(error)
+  );
+}
+
 function resolveRetryConfig(cronConfig?: CronConfig) {
   const retry = cronConfig?.retry;
   return {
@@ -335,8 +349,14 @@ export function applyJobResult(
   job.updatedAtMs = result.endedAt;
 
   // Track consecutive errors for backoff / auto-disable.
+  // Connectivity errors (network/timeout) during host sleep/hibernate are
+  // environmental, not application failures — skip the counter so agents
+  // don't treat them as real breakage (#49124).
   if (result.status === "error") {
-    job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
+    const connectivity = isConnectivityError(result.error);
+    if (!connectivity) {
+      job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
+    }
     const alertConfig = resolveFailureAlert(state, job);
     if (alertConfig && job.state.consecutiveErrors >= alertConfig.after) {
       const isBestEffort =


### PR DESCRIPTION
## Summary

Fixes #49124 — cron job `consecutiveErrors` no longer inflates during host sleep or temporary connectivity loss.

## Problem

When a host sleeps or loses connectivity, cron delivery fails with network/timeout errors. Every failed attempt increments `consecutiveErrors`, so agents reviewing `openclaw cron status` see "10 consecutive errors" and spend tokens investigating non-existent bugs.

## Fix

Reuse the existing `TRANSIENT_PATTERNS.network` and `TRANSIENT_PATTERNS.timeout` regexes to detect connectivity errors. When an error matches, the `consecutiveErrors` counter is NOT incremented. The error is still recorded in `lastError` for diagnostics.

This means:
- **Connectivity errors** (ECONNRESET, ECONNREFUSED, timeout, etc.) → counter stays stable
- **Application errors** (400, 500, config issues) → counter increments normally
- **Success** → counter resets to 0 (unchanged)

## Changes

- `src/cron/service/timer.ts`: Added `isConnectivityError()` helper and guarded `consecutiveErrors` increment