### PR TITLE
fix(session-status): infer provider for bare model overrides

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -52,6 +52,12 @@ vi.mock("../agents/model-catalog.js", () => ({
       name: "Sonnet",
       contextWindow: 200000,
     },
+    {
+      provider: "deepseek",
+      id: "deepseek-chat",
+      name: "DeepSeek Chat",
+      contextWindow: 64000,
+    },
   ],
 }));
 
@@ -236,5 +242,46 @@ describe("session_status tool", () => {
     expect(saved.providerOverride).toBeUndefined();
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();
+  });
+
+  it("infers provider for bare model names when switching away from the current provider", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.3-codex",
+      },
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.3-codex" },
+            models: {
+              "openai-codex/gpt-5.3-codex": {},
+              "deepseek/deepseek-chat": {},
+            },
+          },
+        },
+      } as unknown as import("../config/config.js").OpenClawConfig,
+    }).find((candidate) => candidate.name === "session_status");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing session_status tool");
+    }
+
+    await tool.execute("call4", { model: "deepseek-chat" });
+    expect(updateSessionStoreMock).toHaveBeenCalled();
+    const [, savedStore] = updateSessionStoreMock.mock.calls.at(-1) as [
+      string,
+      Record<string, unknown>,
+    ];
+    const saved = savedStore.main as Record<string, unknown>;
+    expect(saved.providerOverride).toBe("deepseek");
+    expect(saved.modelOverride).toBe("deepseek-chat");
   });
 });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -26,9 +26,11 @@ import { resolveAgentDir } from "../agent-scope.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { resolveModelAuthLabel } from "../model-auth-label.js";
 import { loadModelCatalog } from "../model-catalog.js";
+import { splitTrailingAuthProfile } from "../model-ref-profile.js";
 import {
   buildAllowedModelSet,
   buildModelAliasIndex,
+  inferUniqueProviderFromConfiguredModels,
   modelKey,
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
@@ -150,9 +152,18 @@ async function resolveModelOverride(params: {
     defaultModel: currentModel,
   });
 
+  const rawModel = splitTrailingAuthProfile(raw).model?.trim() ?? "";
+  const inferredProvider =
+    rawModel && !rawModel.includes("/") && !aliasIndex.byAlias.has(rawModel.toLowerCase())
+      ? inferUniqueProviderFromConfiguredModels({
+          cfg: params.cfg,
+          model: rawModel,
+        })
+      : undefined;
+
   const resolved = resolveModelRefFromString({
     raw,
-    defaultProvider: currentProvider,
+    defaultProvider: inferredProvider ?? currentProvider,
     aliasIndex,
   });
   if (!resolved) {


### PR DESCRIPTION
## Summary

Fix model switching when the current session is on one provider (for example `openai-codex`) and the user selects a bare model name that belongs to a different provider (for example `deepseek-chat`).

Before this change, the `session_status` model override path used the current provider as the default provider for bare model names, so `deepseek-chat` could be incorrectly resolved as `openai-codex/deepseek-chat`, which then failed allowlist validation.

## Root cause

In `src/agents/tools/session-status-tool.ts`, `resolveModelOverride()` called `resolveModelRefFromString()` with `defaultProvider: currentProvider`.

That works for same-provider shorthand, but it breaks when:

- the current session provider is `openai-codex`
- the configured allowlist also includes `deepseek/deepseek-chat`
- the user switches using the bare model name `deepseek-chat`

The bare model was resolved against the wrong provider and rejected as:

`model not allowed: openai-codex/deepseek-chat`

## Fix

- extract the raw model portion with `splitTrailingAuthProfile()`
- when the selection is a bare model name (not alias, not `provider/model`), try `inferUniqueProviderFromConfiguredModels()` against the configured allowlist
- use the inferred provider when available, otherwise fall back to the current provider

This preserves existing same-provider shorthand behavior while allowing cross-provider switches when the target model can be uniquely inferred from config.

## Tests

Added a regression test covering:

- current override: `openai-codex/gpt-5.3-codex`
- allowlisted target: `deepseek/deepseek-chat`
- user input: `deepseek-chat`
- expected stored override: `deepseek/deepseek-chat`

Ran:

- `corepack pnpm exec vitest src/agents/openclaw-tools.session-status.test.ts`
- `corepack pnpm exec vitest src/agents/model-selection.test.ts`

## Notes

This bug is especially visible for auth-backed `openai-codex` setups, because users often switch away from Codex to other configured providers using short model names in the model picker / session override flow.
