### PR TITLE
feat(webchat): implement cursor-based pagination for chat history

### DIFF
--- a/dist-runtime/extensions/acpx/index.js
+++ b/dist-runtime/extensions/acpx/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/acpx/index.js";
+import * as module from "../../../dist/extensions/acpx/index.js";
+export default module.default;

--- a/dist-runtime/extensions/acpx/openclaw.plugin.json
+++ b/dist-runtime/extensions/acpx/openclaw.plugin.json
@@ -1,0 +1,109 @@
+{
+  "id": "acpx",
+  "name": "ACPX Runtime",
+  "description": "ACP runtime backend powered by acpx with configurable command path and version policy.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "command": {
+        "type": "string"
+      },
+      "expectedVersion": {
+        "type": "string"
+      },
+      "cwd": {
+        "type": "string"
+      },
+      "permissionMode": {
+        "type": "string",
+        "enum": ["approve-all", "approve-reads", "deny-all"]
+      },
+      "nonInteractivePermissions": {
+        "type": "string",
+        "enum": ["deny", "fail"]
+      },
+      "strictWindowsCmdWrapper": {
+        "type": "boolean"
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 0.001
+      },
+      "queueOwnerTtlSeconds": {
+        "type": "number",
+        "minimum": 0
+      },
+      "mcpServers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command to run the MCP server"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Arguments to pass to the command"
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Environment variables for the MCP server"
+            }
+          },
+          "required": ["command"]
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "command": {
+      "label": "acpx Command",
+      "help": "Optional path/command override for acpx (for example /home/user/repos/acpx/dist/cli.js). Leave unset to use plugin-local bundled acpx."
+    },
+    "expectedVersion": {
+      "label": "Expected acpx Version",
+      "help": "Exact version to enforce (for example 0.1.16) or \"any\" to skip strict version matching."
+    },
+    "cwd": {
+      "label": "Default Working Directory",
+      "help": "Default cwd for ACP session operations when not set per session."
+    },
+    "permissionMode": {
+      "label": "Permission Mode",
+      "help": "Default acpx permission policy for runtime prompts."
+    },
+    "nonInteractivePermissions": {
+      "label": "Non-Interactive Permission Policy",
+      "help": "acpx policy when interactive permission prompts are unavailable."
+    },
+    "strictWindowsCmdWrapper": {
+      "label": "Strict Windows cmd Wrapper",
+      "help": "Enabled by default. On Windows, reject unresolved .cmd/.bat wrappers instead of shell fallback. Disable only for compatibility with non-standard wrappers.",
+      "advanced": true
+    },
+    "timeoutSeconds": {
+      "label": "Prompt Timeout Seconds",
+      "help": "Optional acpx timeout for each runtime turn.",
+      "advanced": true
+    },
+    "queueOwnerTtlSeconds": {
+      "label": "Queue Owner TTL Seconds",
+      "help": "Idle queue-owner TTL for acpx prompt turns. Keep this short in OpenClaw to avoid delayed completion after each turn.",
+      "advanced": true
+    },
+    "mcpServers": {
+      "label": "MCP Servers",
+      "help": "Named MCP server definitions to inject into ACPX-backed session bootstrap. Each entry needs a command and can include args and env.",
+      "advanced": true
+    }
+  }
+}

--- a/dist-runtime/extensions/acpx/package.json
+++ b/dist-runtime/extensions/acpx/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/acpx",
+  "version": "2026.3.14",
+  "description": "OpenClaw ACP runtime backend via acpx",
+  "type": "module",
+  "dependencies": {
+    "acpx": "0.3.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/acpx/skills/acp-router/SKILL.md
+++ b/dist-runtime/extensions/acpx/skills/acp-router/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/acpx/skills/acp-router/SKILL.md

--- a/dist-runtime/extensions/amazon-bedrock/index.js
+++ b/dist-runtime/extensions/amazon-bedrock/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/amazon-bedrock/index.js";
+import * as module from "../../../dist/extensions/amazon-bedrock/index.js";
+export default module.default;

--- a/dist-runtime/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/dist-runtime/extensions/amazon-bedrock/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "amazon-bedrock",
+  "providers": ["amazon-bedrock"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/amazon-bedrock/package.json
+++ b/dist-runtime/extensions/amazon-bedrock/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/amazon-bedrock-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Amazon Bedrock provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/anthropic/index.js
+++ b/dist-runtime/extensions/anthropic/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/anthropic/index.js";
+import * as module from "../../../dist/extensions/anthropic/index.js";
+export default module.default;

--- a/dist-runtime/extensions/anthropic/openclaw.plugin.json
+++ b/dist-runtime/extensions/anthropic/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "anthropic",
+  "providers": ["anthropic"],
+  "providerAuthEnvVars": {
+    "anthropic": ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "anthropic",
+      "method": "setup-token",
+      "choiceId": "token",
+      "choiceLabel": "Anthropic token (paste setup-token)",
+      "choiceHint": "Run `claude setup-token` elsewhere, then paste the token here",
+      "groupId": "anthropic",
+      "groupLabel": "Anthropic",
+      "groupHint": "setup-token + API key"
+    },
+    {
+      "provider": "anthropic",
+      "method": "api-key",
+      "choiceId": "apiKey",
+      "choiceLabel": "Anthropic API key",
+      "groupId": "anthropic",
+      "groupLabel": "Anthropic",
+      "groupHint": "setup-token + API key",
+      "optionKey": "anthropicApiKey",
+      "cliFlag": "--anthropic-api-key",
+      "cliOption": "--anthropic-api-key <key>",
+      "cliDescription": "Anthropic API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/anthropic/package.json
+++ b/dist-runtime/extensions/anthropic/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/anthropic-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Anthropic provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/bluebubbles/index.js
+++ b/dist-runtime/extensions/bluebubbles/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/bluebubbles/index.js";
+import * as module from "../../../dist/extensions/bluebubbles/index.js";
+export default module.default;

--- a/dist-runtime/extensions/bluebubbles/openclaw.plugin.json
+++ b/dist-runtime/extensions/bluebubbles/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "bluebubbles",
+  "channels": ["bluebubbles"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/bluebubbles/package.json
+++ b/dist-runtime/extensions/bluebubbles/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/bluebubbles",
+  "version": "2026.3.14",
+  "description": "OpenClaw BlueBubbles channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "bluebubbles",
+      "label": "BlueBubbles",
+      "selectionLabel": "BlueBubbles (macOS app)",
+      "detailLabel": "BlueBubbles",
+      "docsPath": "/channels/bluebubbles",
+      "docsLabel": "bluebubbles",
+      "blurb": "iMessage via the BlueBubbles mac app + REST API.",
+      "aliases": [
+        "bb"
+      ],
+      "preferOver": [
+        "imessage"
+      ],
+      "systemImage": "bubble.left.and.text.bubble.right",
+      "order": 75
+    },
+    "install": {
+      "npmSpec": "@openclaw/bluebubbles",
+      "localPath": "extensions/bluebubbles",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/bluebubbles/setup-entry.js
+++ b/dist-runtime/extensions/bluebubbles/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/bluebubbles/setup-entry.js";
+import * as module from "../../../dist/extensions/bluebubbles/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/brave/index.js
+++ b/dist-runtime/extensions/brave/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/brave/index.js";
+import * as module from "../../../dist/extensions/brave/index.js";
+export default module.default;

--- a/dist-runtime/extensions/brave/openclaw.plugin.json
+++ b/dist-runtime/extensions/brave/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "brave",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/brave/package.json
+++ b/dist-runtime/extensions/brave/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/brave-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Brave plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/byteplus/index.js
+++ b/dist-runtime/extensions/byteplus/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/byteplus/index.js";
+import * as module from "../../../dist/extensions/byteplus/index.js";
+export default module.default;

--- a/dist-runtime/extensions/byteplus/openclaw.plugin.json
+++ b/dist-runtime/extensions/byteplus/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "byteplus",
+  "providers": ["byteplus", "byteplus-plan"],
+  "providerAuthEnvVars": {
+    "byteplus": ["BYTEPLUS_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "byteplus",
+      "method": "api-key",
+      "choiceId": "byteplus-api-key",
+      "choiceLabel": "BytePlus API key",
+      "groupId": "byteplus",
+      "groupLabel": "BytePlus",
+      "groupHint": "API key",
+      "optionKey": "byteplusApiKey",
+      "cliFlag": "--byteplus-api-key",
+      "cliOption": "--byteplus-api-key <key>",
+      "cliDescription": "BytePlus API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/byteplus/package.json
+++ b/dist-runtime/extensions/byteplus/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/byteplus-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw BytePlus provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/cloudflare-ai-gateway/index.js
+++ b/dist-runtime/extensions/cloudflare-ai-gateway/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/cloudflare-ai-gateway/index.js";
+import * as module from "../../../dist/extensions/cloudflare-ai-gateway/index.js";
+export default module.default;

--- a/dist-runtime/extensions/cloudflare-ai-gateway/openclaw.plugin.json
+++ b/dist-runtime/extensions/cloudflare-ai-gateway/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "cloudflare-ai-gateway",
+  "providers": ["cloudflare-ai-gateway"],
+  "providerAuthEnvVars": {
+    "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "cloudflare-ai-gateway",
+      "method": "api-key",
+      "choiceId": "cloudflare-ai-gateway-api-key",
+      "choiceLabel": "Cloudflare AI Gateway",
+      "choiceHint": "Account ID + Gateway ID + API key",
+      "groupId": "cloudflare-ai-gateway",
+      "groupLabel": "Cloudflare AI Gateway",
+      "groupHint": "Account ID + Gateway ID + API key",
+      "optionKey": "cloudflareAiGatewayApiKey",
+      "cliFlag": "--cloudflare-ai-gateway-api-key",
+      "cliOption": "--cloudflare-ai-gateway-api-key <key>",
+      "cliDescription": "Cloudflare AI Gateway API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/cloudflare-ai-gateway/package.json
+++ b/dist-runtime/extensions/cloudflare-ai-gateway/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/cloudflare-ai-gateway-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Cloudflare AI Gateway provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/copilot-proxy/index.js
+++ b/dist-runtime/extensions/copilot-proxy/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/copilot-proxy/index.js";
+import * as module from "../../../dist/extensions/copilot-proxy/index.js";
+export default module.default;

--- a/dist-runtime/extensions/copilot-proxy/openclaw.plugin.json
+++ b/dist-runtime/extensions/copilot-proxy/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "copilot-proxy",
+  "providers": ["copilot-proxy"],
+  "providerAuthChoices": [
+    {
+      "provider": "copilot-proxy",
+      "method": "local",
+      "choiceId": "copilot-proxy",
+      "choiceLabel": "Copilot Proxy",
+      "choiceHint": "Configure base URL + model ids",
+      "groupId": "copilot",
+      "groupLabel": "Copilot",
+      "groupHint": "GitHub + local proxy"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/copilot-proxy/package.json
+++ b/dist-runtime/extensions/copilot-proxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/copilot-proxy",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Copilot Proxy provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/device-pair/index.js
+++ b/dist-runtime/extensions/device-pair/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/device-pair/index.js";
+import * as module from "../../../dist/extensions/device-pair/index.js";
+export default module.default;

--- a/dist-runtime/extensions/device-pair/openclaw.plugin.json
+++ b/dist-runtime/extensions/device-pair/openclaw.plugin.json
@@ -1,0 +1,20 @@
+{
+  "id": "device-pair",
+  "name": "Device Pairing",
+  "description": "Generate setup codes and approve device pairing requests.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "publicUrl": {
+        "type": "string"
+      }
+    }
+  },
+  "uiHints": {
+    "publicUrl": {
+      "label": "Gateway URL",
+      "help": "Public WebSocket URL used for /pair setup codes (ws/wss or http/https)."
+    }
+  }
+}

--- a/dist-runtime/extensions/diagnostics-otel/index.js
+++ b/dist-runtime/extensions/diagnostics-otel/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/diagnostics-otel/index.js";
+import * as module from "../../../dist/extensions/diagnostics-otel/index.js";
+export default module.default;

--- a/dist-runtime/extensions/diagnostics-otel/openclaw.plugin.json
+++ b/dist-runtime/extensions/diagnostics-otel/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "diagnostics-otel",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/diagnostics-otel/package.json
+++ b/dist-runtime/extensions/diagnostics-otel/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openclaw/diagnostics-otel",
+  "version": "2026.3.14",
+  "description": "OpenClaw diagnostics OpenTelemetry exporter",
+  "type": "module",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.213.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.213.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.213.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.213.0",
+    "@opentelemetry/resources": "^2.6.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
+    "@opentelemetry/sdk-metrics": "^2.6.0",
+    "@opentelemetry/sdk-node": "^0.213.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/diffs/index.js
+++ b/dist-runtime/extensions/diffs/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/diffs/index.js";
+import * as module from "../../../dist/extensions/diffs/index.js";
+export default module.default;

--- a/dist-runtime/extensions/diffs/openclaw.plugin.json
+++ b/dist-runtime/extensions/diffs/openclaw.plugin.json
@@ -1,0 +1,182 @@
+{
+  "id": "diffs",
+  "name": "Diffs",
+  "description": "Read-only diff viewer and file renderer for agents.",
+  "skills": ["./skills"],
+  "uiHints": {
+    "defaults.fontFamily": {
+      "label": "Default Font",
+      "help": "Preferred font family name for diff content and headers."
+    },
+    "defaults.fontSize": {
+      "label": "Default Font Size",
+      "help": "Base diff font size in pixels."
+    },
+    "defaults.lineSpacing": {
+      "label": "Default Line Spacing",
+      "help": "Line-height multiplier applied to diff rows."
+    },
+    "defaults.layout": {
+      "label": "Default Layout",
+      "help": "Initial diff layout shown in the viewer."
+    },
+    "defaults.showLineNumbers": {
+      "label": "Show Line Numbers",
+      "help": "Show line numbers by default."
+    },
+    "defaults.diffIndicators": {
+      "label": "Diff Indicator Style",
+      "help": "Choose added/removed indicators style."
+    },
+    "defaults.wordWrap": {
+      "label": "Default Word Wrap",
+      "help": "Wrap long lines by default."
+    },
+    "defaults.background": {
+      "label": "Default Background Highlights",
+      "help": "Show added/removed background highlights by default."
+    },
+    "defaults.theme": {
+      "label": "Default Theme",
+      "help": "Initial viewer theme."
+    },
+    "defaults.fileFormat": {
+      "label": "Default File Format",
+      "help": "Rendered file format for file mode (PNG or PDF)."
+    },
+    "defaults.fileQuality": {
+      "label": "Default File Quality",
+      "help": "Quality preset for PNG/PDF rendering."
+    },
+    "defaults.fileScale": {
+      "label": "Default File Scale",
+      "help": "Device scale factor used while rendering file artifacts."
+    },
+    "defaults.fileMaxWidth": {
+      "label": "Default File Max Width",
+      "help": "Maximum file render width in CSS pixels."
+    },
+    "defaults.mode": {
+      "label": "Default Output Mode",
+      "help": "Tool default when mode is omitted. Use view for canvas/gateway viewer, file for PNG/PDF, or both."
+    },
+    "security.allowRemoteViewer": {
+      "label": "Allow Remote Viewer",
+      "help": "Allow non-loopback access to diff viewer URLs when the token path is known."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaults": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fontFamily": {
+            "type": "string",
+            "default": "Fira Code"
+          },
+          "fontSize": {
+            "type": "number",
+            "minimum": 10,
+            "maximum": 24,
+            "default": 15
+          },
+          "lineSpacing": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 3,
+            "default": 1.6
+          },
+          "layout": {
+            "type": "string",
+            "enum": ["unified", "split"],
+            "default": "unified"
+          },
+          "showLineNumbers": {
+            "type": "boolean",
+            "default": true
+          },
+          "diffIndicators": {
+            "type": "string",
+            "enum": ["bars", "classic", "none"],
+            "default": "bars"
+          },
+          "wordWrap": {
+            "type": "boolean",
+            "default": true
+          },
+          "background": {
+            "type": "boolean",
+            "default": true
+          },
+          "theme": {
+            "type": "string",
+            "enum": ["light", "dark"],
+            "default": "dark"
+          },
+          "fileFormat": {
+            "type": "string",
+            "enum": ["png", "pdf"],
+            "default": "png"
+          },
+          "format": {
+            "type": "string",
+            "enum": ["png", "pdf"]
+          },
+          "fileQuality": {
+            "type": "string",
+            "enum": ["standard", "hq", "print"],
+            "default": "standard"
+          },
+          "fileScale": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 4,
+            "default": 2
+          },
+          "fileMaxWidth": {
+            "type": "number",
+            "minimum": 640,
+            "maximum": 2400,
+            "default": 960
+          },
+          "imageFormat": {
+            "type": "string",
+            "enum": ["png", "pdf"]
+          },
+          "imageQuality": {
+            "type": "string",
+            "enum": ["standard", "hq", "print"]
+          },
+          "imageScale": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 4
+          },
+          "imageMaxWidth": {
+            "type": "number",
+            "minimum": 640,
+            "maximum": 2400
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["view", "image", "file", "both"],
+            "default": "both"
+          }
+        }
+      },
+      "security": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowRemoteViewer": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist-runtime/extensions/diffs/package.json
+++ b/dist-runtime/extensions/diffs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openclaw/diffs",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw diff viewer plugin",
+  "type": "module",
+  "scripts": {
+    "build:viewer": "bun build src/viewer-client.ts --target browser --format esm --minify --outfile assets/viewer-runtime.js"
+  },
+  "dependencies": {
+    "@pierre/diffs": "1.1.0",
+    "@sinclair/typebox": "0.34.48",
+    "playwright-core": "1.58.2"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/diffs/skills/diffs/SKILL.md
+++ b/dist-runtime/extensions/diffs/skills/diffs/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/diffs/skills/diffs/SKILL.md

--- a/dist-runtime/extensions/discord/index.js
+++ b/dist-runtime/extensions/discord/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/discord/index.js";
+import * as module from "../../../dist/extensions/discord/index.js";
+export default module.default;

--- a/dist-runtime/extensions/discord/openclaw.plugin.json
+++ b/dist-runtime/extensions/discord/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "discord",
+  "channels": ["discord"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/discord/package.json
+++ b/dist-runtime/extensions/discord/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/discord",
+  "version": "2026.3.14",
+  "description": "OpenClaw Discord channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/discord/setup-entry.js
+++ b/dist-runtime/extensions/discord/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/discord/setup-entry.js";
+import * as module from "../../../dist/extensions/discord/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/elevenlabs/index.js
+++ b/dist-runtime/extensions/elevenlabs/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/elevenlabs/index.js";
+import * as module from "../../../dist/extensions/elevenlabs/index.js";
+export default module.default;

--- a/dist-runtime/extensions/elevenlabs/openclaw.plugin.json
+++ b/dist-runtime/extensions/elevenlabs/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "elevenlabs",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/elevenlabs/package.json
+++ b/dist-runtime/extensions/elevenlabs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/elevenlabs-speech",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw ElevenLabs speech plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/feishu/index.js
+++ b/dist-runtime/extensions/feishu/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/feishu/index.js";
+import * as module from "../../../dist/extensions/feishu/index.js";
+export default module.default;

--- a/dist-runtime/extensions/feishu/openclaw.plugin.json
+++ b/dist-runtime/extensions/feishu/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "feishu",
+  "channels": ["feishu"],
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/feishu/package.json
+++ b/dist-runtime/extensions/feishu/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@openclaw/feishu",
+  "version": "2026.3.14",
+  "description": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
+  "type": "module",
+  "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@sinclair/typebox": "0.34.48",
+    "https-proxy-agent": "^8.0.0",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "feishu",
+      "label": "Feishu",
+      "selectionLabel": "Feishu/Lark (飞书)",
+      "docsPath": "/channels/feishu",
+      "docsLabel": "feishu",
+      "blurb": "飞书/Lark enterprise messaging with doc/wiki/drive tools.",
+      "aliases": [
+        "lark"
+      ],
+      "order": 35,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/feishu",
+      "localPath": "extensions/feishu",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/feishu/setup-entry.js
+++ b/dist-runtime/extensions/feishu/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/feishu/setup-entry.js";
+import * as module from "../../../dist/extensions/feishu/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/dist-runtime/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/feishu/skills/feishu-doc/SKILL.md

--- a/dist-runtime/extensions/feishu/skills/feishu-doc/references/block-types.md
+++ b/dist-runtime/extensions/feishu/skills/feishu-doc/references/block-types.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/feishu/skills/feishu-doc/references/block-types.md

--- a/dist-runtime/extensions/feishu/skills/feishu-drive/SKILL.md
+++ b/dist-runtime/extensions/feishu/skills/feishu-drive/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/feishu/skills/feishu-drive/SKILL.md

--- a/dist-runtime/extensions/feishu/skills/feishu-perm/SKILL.md
+++ b/dist-runtime/extensions/feishu/skills/feishu-perm/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/feishu/skills/feishu-perm/SKILL.md

--- a/dist-runtime/extensions/feishu/skills/feishu-wiki/SKILL.md
+++ b/dist-runtime/extensions/feishu/skills/feishu-wiki/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/feishu/skills/feishu-wiki/SKILL.md

--- a/dist-runtime/extensions/firecrawl/index.js
+++ b/dist-runtime/extensions/firecrawl/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/firecrawl/index.js";
+import * as module from "../../../dist/extensions/firecrawl/index.js";
+export default module.default;

--- a/dist-runtime/extensions/firecrawl/openclaw.plugin.json
+++ b/dist-runtime/extensions/firecrawl/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "firecrawl",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/firecrawl/package.json
+++ b/dist-runtime/extensions/firecrawl/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/firecrawl-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Firecrawl plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/github-copilot/index.js
+++ b/dist-runtime/extensions/github-copilot/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/github-copilot/index.js";
+import * as module from "../../../dist/extensions/github-copilot/index.js";
+export default module.default;

--- a/dist-runtime/extensions/github-copilot/openclaw.plugin.json
+++ b/dist-runtime/extensions/github-copilot/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "github-copilot",
+  "providers": ["github-copilot"],
+  "providerAuthEnvVars": {
+    "github-copilot": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "github-copilot",
+      "method": "device",
+      "choiceId": "github-copilot",
+      "choiceLabel": "GitHub Copilot",
+      "choiceHint": "Device login with your GitHub account",
+      "groupId": "copilot",
+      "groupLabel": "Copilot",
+      "groupHint": "GitHub + local proxy"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/github-copilot/package.json
+++ b/dist-runtime/extensions/github-copilot/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/github-copilot-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw GitHub Copilot provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/google/index.js
+++ b/dist-runtime/extensions/google/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/google/index.js";
+import * as module from "../../../dist/extensions/google/index.js";
+export default module.default;

--- a/dist-runtime/extensions/google/openclaw.plugin.json
+++ b/dist-runtime/extensions/google/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "google",
+  "providers": ["google", "google-gemini-cli"],
+  "providerAuthEnvVars": {
+    "google": ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "google",
+      "method": "api-key",
+      "choiceId": "gemini-api-key",
+      "choiceLabel": "Google Gemini API key",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth",
+      "optionKey": "geminiApiKey",
+      "cliFlag": "--gemini-api-key",
+      "cliOption": "--gemini-api-key <key>",
+      "cliDescription": "Gemini API key"
+    },
+    {
+      "provider": "google-gemini-cli",
+      "method": "oauth",
+      "choiceId": "google-gemini-cli",
+      "choiceLabel": "Gemini CLI OAuth",
+      "choiceHint": "Google OAuth with project-aware token payload",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/google/package.json
+++ b/dist-runtime/extensions/google/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/google-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Google plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/googlechat/index.js
+++ b/dist-runtime/extensions/googlechat/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/googlechat/index.js";
+import * as module from "../../../dist/extensions/googlechat/index.js";
+export default module.default;

--- a/dist-runtime/extensions/googlechat/openclaw.plugin.json
+++ b/dist-runtime/extensions/googlechat/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "googlechat",
+  "channels": ["googlechat"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/googlechat/package.json
+++ b/dist-runtime/extensions/googlechat/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@openclaw/googlechat",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Google Chat channel plugin",
+  "type": "module",
+  "dependencies": {
+    "google-auth-library": "^10.6.1"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.11"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "googlechat",
+      "label": "Google Chat",
+      "selectionLabel": "Google Chat (Chat API)",
+      "detailLabel": "Google Chat",
+      "docsPath": "/channels/googlechat",
+      "docsLabel": "googlechat",
+      "blurb": "Google Workspace Chat app via HTTP webhooks.",
+      "aliases": [
+        "gchat",
+        "google-chat"
+      ],
+      "order": 55
+    },
+    "install": {
+      "npmSpec": "@openclaw/googlechat",
+      "localPath": "extensions/googlechat",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "google-auth-library"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/googlechat/setup-entry.js
+++ b/dist-runtime/extensions/googlechat/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/googlechat/setup-entry.js";
+import * as module from "../../../dist/extensions/googlechat/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/huggingface/index.js
+++ b/dist-runtime/extensions/huggingface/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/huggingface/index.js";
+import * as module from "../../../dist/extensions/huggingface/index.js";
+export default module.default;

--- a/dist-runtime/extensions/huggingface/openclaw.plugin.json
+++ b/dist-runtime/extensions/huggingface/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "huggingface",
+  "providers": ["huggingface"],
+  "providerAuthEnvVars": {
+    "huggingface": ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "huggingface",
+      "method": "api-key",
+      "choiceId": "huggingface-api-key",
+      "choiceLabel": "Hugging Face API key",
+      "choiceHint": "Inference API (HF token)",
+      "groupId": "huggingface",
+      "groupLabel": "Hugging Face",
+      "groupHint": "Inference API (HF token)",
+      "optionKey": "huggingfaceApiKey",
+      "cliFlag": "--huggingface-api-key",
+      "cliOption": "--huggingface-api-key <key>",
+      "cliDescription": "Hugging Face API key (HF token)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/huggingface/package.json
+++ b/dist-runtime/extensions/huggingface/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/huggingface-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Hugging Face provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/imessage/index.js
+++ b/dist-runtime/extensions/imessage/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/imessage/index.js";
+import * as module from "../../../dist/extensions/imessage/index.js";
+export default module.default;

--- a/dist-runtime/extensions/imessage/openclaw.plugin.json
+++ b/dist-runtime/extensions/imessage/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "imessage",
+  "channels": ["imessage"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/imessage/package.json
+++ b/dist-runtime/extensions/imessage/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openclaw/imessage",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw iMessage channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/imessage/setup-entry.js
+++ b/dist-runtime/extensions/imessage/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/imessage/setup-entry.js";
+import * as module from "../../../dist/extensions/imessage/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/irc/index.js
+++ b/dist-runtime/extensions/irc/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/irc/index.js";
+import * as module from "../../../dist/extensions/irc/index.js";
+export default module.default;

--- a/dist-runtime/extensions/irc/openclaw.plugin.json
+++ b/dist-runtime/extensions/irc/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "irc",
+  "channels": ["irc"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/irc/package.json
+++ b/dist-runtime/extensions/irc/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/irc",
+  "version": "2026.3.14",
+  "description": "OpenClaw IRC channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/irc/setup-entry.js
+++ b/dist-runtime/extensions/irc/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/irc/setup-entry.js";
+import * as module from "../../../dist/extensions/irc/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/kilocode/index.js
+++ b/dist-runtime/extensions/kilocode/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/kilocode/index.js";
+import * as module from "../../../dist/extensions/kilocode/index.js";
+export default module.default;

--- a/dist-runtime/extensions/kilocode/openclaw.plugin.json
+++ b/dist-runtime/extensions/kilocode/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "kilocode",
+  "providers": ["kilocode"],
+  "providerAuthEnvVars": {
+    "kilocode": ["KILOCODE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "kilocode",
+      "method": "api-key",
+      "choiceId": "kilocode-api-key",
+      "choiceLabel": "Kilo Gateway API key",
+      "choiceHint": "API key (OpenRouter-compatible)",
+      "groupId": "kilocode",
+      "groupLabel": "Kilo Gateway",
+      "groupHint": "API key (OpenRouter-compatible)",
+      "optionKey": "kilocodeApiKey",
+      "cliFlag": "--kilocode-api-key",
+      "cliOption": "--kilocode-api-key <key>",
+      "cliDescription": "Kilo Gateway API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/kilocode/package.json
+++ b/dist-runtime/extensions/kilocode/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/kilocode-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Kilo Gateway provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/kimi-coding/index.js
+++ b/dist-runtime/extensions/kimi-coding/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/kimi-coding/index.js";
+import * as module from "../../../dist/extensions/kimi-coding/index.js";
+export default module.default;

--- a/dist-runtime/extensions/kimi-coding/openclaw.plugin.json
+++ b/dist-runtime/extensions/kimi-coding/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "kimi",
+  "providers": ["kimi", "kimi-coding"],
+  "providerAuthEnvVars": {
+    "kimi": ["KIMI_API_KEY", "KIMICODE_API_KEY"],
+    "kimi-coding": ["KIMI_API_KEY", "KIMICODE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "kimi",
+      "method": "api-key",
+      "choiceId": "kimi-code-api-key",
+      "choiceLabel": "Kimi Code API key",
+      "groupId": "kimi-code",
+      "groupLabel": "Kimi Code",
+      "groupHint": "Dedicated coding endpoint",
+      "optionKey": "kimiCodeApiKey",
+      "cliFlag": "--kimi-code-api-key",
+      "cliOption": "--kimi-code-api-key <key>",
+      "cliDescription": "Kimi Code API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/kimi-coding/package.json
+++ b/dist-runtime/extensions/kimi-coding/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/kimi-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Kimi provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/line/index.js
+++ b/dist-runtime/extensions/line/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/line/index.js";
+import * as module from "../../../dist/extensions/line/index.js";
+export default module.default;

--- a/dist-runtime/extensions/line/openclaw.plugin.json
+++ b/dist-runtime/extensions/line/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "line",
+  "channels": ["line"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/line/package.json
+++ b/dist-runtime/extensions/line/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openclaw/line",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw LINE channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "line",
+      "label": "LINE",
+      "selectionLabel": "LINE (Messaging API)",
+      "docsPath": "/channels/line",
+      "docsLabel": "line",
+      "blurb": "LINE Messaging API bot for Japan/Taiwan/Thailand markets.",
+      "order": 75,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/line",
+      "localPath": "extensions/line",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/line/setup-entry.js
+++ b/dist-runtime/extensions/line/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/line/setup-entry.js";
+import * as module from "../../../dist/extensions/line/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/llm-task/index.js
+++ b/dist-runtime/extensions/llm-task/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/llm-task/index.js";
+import * as module from "../../../dist/extensions/llm-task/index.js";
+export default module.default;

--- a/dist-runtime/extensions/llm-task/openclaw.plugin.json
+++ b/dist-runtime/extensions/llm-task/openclaw.plugin.json
@@ -1,0 +1,33 @@
+{
+  "id": "llm-task",
+  "name": "LLM Task",
+  "description": "Generic JSON-only LLM tool for structured tasks callable from workflows.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultProvider": {
+        "type": "string"
+      },
+      "defaultModel": {
+        "type": "string"
+      },
+      "defaultAuthProfileId": {
+        "type": "string"
+      },
+      "allowedModels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Allowlist of provider/model keys like openai-codex/gpt-5.2."
+      },
+      "maxTokens": {
+        "type": "number"
+      },
+      "timeoutMs": {
+        "type": "number"
+      }
+    }
+  }
+}

--- a/dist-runtime/extensions/llm-task/package.json
+++ b/dist-runtime/extensions/llm-task/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/llm-task",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw JSON-only LLM task plugin",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "ajv": "^8.18.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/lobster/index.js
+++ b/dist-runtime/extensions/lobster/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/lobster/index.js";
+import * as module from "../../../dist/extensions/lobster/index.js";
+export default module.default;

--- a/dist-runtime/extensions/lobster/openclaw.plugin.json
+++ b/dist-runtime/extensions/lobster/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "lobster",
+  "name": "Lobster",
+  "description": "Typed workflow tool with resumable approvals.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/lobster/package.json
+++ b/dist-runtime/extensions/lobster/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/lobster",
+  "version": "2026.3.14",
+  "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/matrix/index.js
+++ b/dist-runtime/extensions/matrix/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/matrix/index.js";
+import * as module from "../../../dist/extensions/matrix/index.js";
+export default module.default;

--- a/dist-runtime/extensions/matrix/openclaw.plugin.json
+++ b/dist-runtime/extensions/matrix/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "matrix",
+  "channels": ["matrix"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/matrix/package.json
+++ b/dist-runtime/extensions/matrix/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@openclaw/matrix",
+  "version": "2026.3.14",
+  "description": "OpenClaw Matrix channel plugin",
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-agent-core": "0.58.0",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
+    "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
+    "markdown-it": "14.1.1",
+    "music-metadata": "^11.12.3",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "matrix",
+      "label": "Matrix",
+      "selectionLabel": "Matrix (plugin)",
+      "docsPath": "/channels/matrix",
+      "docsLabel": "matrix",
+      "blurb": "open protocol; install the plugin to enable.",
+      "order": 70,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/matrix",
+      "localPath": "extensions/matrix",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@matrix-org/matrix-sdk-crypto-nodejs",
+        "@vector-im/matrix-bot-sdk",
+        "music-metadata"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/matrix/setup-entry.js
+++ b/dist-runtime/extensions/matrix/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/matrix/setup-entry.js";
+import * as module from "../../../dist/extensions/matrix/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/mattermost/index.js
+++ b/dist-runtime/extensions/mattermost/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/mattermost/index.js";
+import * as module from "../../../dist/extensions/mattermost/index.js";
+export default module.default;

--- a/dist-runtime/extensions/mattermost/openclaw.plugin.json
+++ b/dist-runtime/extensions/mattermost/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "mattermost",
+  "channels": ["mattermost"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/mattermost/package.json
+++ b/dist-runtime/extensions/mattermost/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openclaw/mattermost",
+  "version": "2026.3.14",
+  "description": "OpenClaw Mattermost channel plugin",
+  "type": "module",
+  "dependencies": {
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "mattermost",
+      "label": "Mattermost",
+      "selectionLabel": "Mattermost (plugin)",
+      "docsPath": "/channels/mattermost",
+      "docsLabel": "mattermost",
+      "blurb": "self-hosted Slack-style chat; install the plugin to enable.",
+      "order": 65
+    },
+    "install": {
+      "npmSpec": "@openclaw/mattermost",
+      "localPath": "extensions/mattermost",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/mattermost/setup-entry.js
+++ b/dist-runtime/extensions/mattermost/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/mattermost/setup-entry.js";
+import * as module from "../../../dist/extensions/mattermost/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/memory-core/index.js
+++ b/dist-runtime/extensions/memory-core/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/memory-core/index.js";
+import * as module from "../../../dist/extensions/memory-core/index.js";
+export default module.default;

--- a/dist-runtime/extensions/memory-core/openclaw.plugin.json
+++ b/dist-runtime/extensions/memory-core/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "memory-core",
+  "kind": "memory",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/memory-core/package.json
+++ b/dist-runtime/extensions/memory-core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openclaw/memory-core",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw core memory search plugin",
+  "type": "module",
+  "peerDependencies": {
+    "openclaw": ">=2026.3.11"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/memory-lancedb/index.js
+++ b/dist-runtime/extensions/memory-lancedb/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/memory-lancedb/index.js";
+import * as module from "../../../dist/extensions/memory-lancedb/index.js";
+export default module.default;

--- a/dist-runtime/extensions/memory-lancedb/openclaw.plugin.json
+++ b/dist-runtime/extensions/memory-lancedb/openclaw.plugin.json
@@ -1,0 +1,88 @@
+{
+  "id": "memory-lancedb",
+  "kind": "memory",
+  "uiHints": {
+    "embedding.apiKey": {
+      "label": "OpenAI API Key",
+      "sensitive": true,
+      "placeholder": "sk-proj-...",
+      "help": "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})"
+    },
+    "embedding.model": {
+      "label": "Embedding Model",
+      "placeholder": "text-embedding-3-small",
+      "help": "OpenAI embedding model to use"
+    },
+    "embedding.baseUrl": {
+      "label": "Base URL",
+      "placeholder": "https://api.openai.com/v1",
+      "help": "Base URL for compatible providers (e.g. http://localhost:11434/v1)",
+      "advanced": true
+    },
+    "embedding.dimensions": {
+      "label": "Dimensions",
+      "placeholder": "1536",
+      "help": "Vector dimensions for custom models (required for non-standard models)",
+      "advanced": true
+    },
+    "dbPath": {
+      "label": "Database Path",
+      "placeholder": "~/.openclaw/memory/lancedb",
+      "advanced": true
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Automatically capture important information from conversations"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Automatically inject relevant memories into context"
+    },
+    "captureMaxChars": {
+      "label": "Capture Max Chars",
+      "help": "Maximum message length eligible for auto-capture",
+      "advanced": true,
+      "placeholder": "500"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "embedding": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "baseUrl": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "number"
+          }
+        },
+        "required": ["apiKey"]
+      },
+      "dbPath": {
+        "type": "string"
+      },
+      "autoCapture": {
+        "type": "boolean"
+      },
+      "autoRecall": {
+        "type": "boolean"
+      },
+      "captureMaxChars": {
+        "type": "number",
+        "minimum": 100,
+        "maximum": 10000
+      }
+    },
+    "required": ["embedding"]
+  }
+}

--- a/dist-runtime/extensions/memory-lancedb/package.json
+++ b/dist-runtime/extensions/memory-lancedb/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/memory-lancedb",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture",
+  "type": "module",
+  "dependencies": {
+    "@lancedb/lancedb": "^0.26.2",
+    "@sinclair/typebox": "0.34.48",
+    "openai": "^6.29.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/microsoft/index.js
+++ b/dist-runtime/extensions/microsoft/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/microsoft/index.js";
+import * as module from "../../../dist/extensions/microsoft/index.js";
+export default module.default;

--- a/dist-runtime/extensions/microsoft/openclaw.plugin.json
+++ b/dist-runtime/extensions/microsoft/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "microsoft",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/microsoft/package.json
+++ b/dist-runtime/extensions/microsoft/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/microsoft-speech",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Microsoft speech plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/minimax/index.js
+++ b/dist-runtime/extensions/minimax/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/minimax/index.js";
+import * as module from "../../../dist/extensions/minimax/index.js";
+export default module.default;

--- a/dist-runtime/extensions/minimax/openclaw.plugin.json
+++ b/dist-runtime/extensions/minimax/openclaw.plugin.json
@@ -1,0 +1,63 @@
+{
+  "id": "minimax",
+  "providers": ["minimax", "minimax-portal"],
+  "providerAuthEnvVars": {
+    "minimax": ["MINIMAX_API_KEY"],
+    "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "minimax-portal",
+      "method": "oauth",
+      "choiceId": "minimax-global-oauth",
+      "choiceLabel": "MiniMax OAuth (Global)",
+      "choiceHint": "Global endpoint - api.minimax.io",
+      "groupId": "minimax",
+      "groupLabel": "MiniMax",
+      "groupHint": "M2.5 (recommended)"
+    },
+    {
+      "provider": "minimax",
+      "method": "api-global",
+      "choiceId": "minimax-global-api",
+      "choiceLabel": "MiniMax API key (Global)",
+      "choiceHint": "Global endpoint - api.minimax.io",
+      "groupId": "minimax",
+      "groupLabel": "MiniMax",
+      "groupHint": "M2.5 (recommended)",
+      "optionKey": "minimaxApiKey",
+      "cliFlag": "--minimax-api-key",
+      "cliOption": "--minimax-api-key <key>",
+      "cliDescription": "MiniMax API key"
+    },
+    {
+      "provider": "minimax-portal",
+      "method": "oauth-cn",
+      "choiceId": "minimax-cn-oauth",
+      "choiceLabel": "MiniMax OAuth (CN)",
+      "choiceHint": "CN endpoint - api.minimaxi.com",
+      "groupId": "minimax",
+      "groupLabel": "MiniMax",
+      "groupHint": "M2.5 (recommended)"
+    },
+    {
+      "provider": "minimax",
+      "method": "api-cn",
+      "choiceId": "minimax-cn-api",
+      "choiceLabel": "MiniMax API key (CN)",
+      "choiceHint": "CN endpoint - api.minimaxi.com",
+      "groupId": "minimax",
+      "groupLabel": "MiniMax",
+      "groupHint": "M2.5 (recommended)",
+      "optionKey": "minimaxApiKey",
+      "cliFlag": "--minimax-api-key",
+      "cliOption": "--minimax-api-key <key>",
+      "cliDescription": "MiniMax API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/minimax/package.json
+++ b/dist-runtime/extensions/minimax/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/minimax-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw MiniMax provider and OAuth plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/mistral/index.js
+++ b/dist-runtime/extensions/mistral/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/mistral/index.js";
+import * as module from "../../../dist/extensions/mistral/index.js";
+export default module.default;

--- a/dist-runtime/extensions/mistral/openclaw.plugin.json
+++ b/dist-runtime/extensions/mistral/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "mistral",
+  "providers": ["mistral"],
+  "providerAuthEnvVars": {
+    "mistral": ["MISTRAL_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "mistral",
+      "method": "api-key",
+      "choiceId": "mistral-api-key",
+      "choiceLabel": "Mistral API key",
+      "groupId": "mistral",
+      "groupLabel": "Mistral AI",
+      "groupHint": "API key",
+      "optionKey": "mistralApiKey",
+      "cliFlag": "--mistral-api-key",
+      "cliOption": "--mistral-api-key <key>",
+      "cliDescription": "Mistral API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/mistral/package.json
+++ b/dist-runtime/extensions/mistral/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/mistral-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Mistral provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/modelstudio/index.js
+++ b/dist-runtime/extensions/modelstudio/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/modelstudio/index.js";
+import * as module from "../../../dist/extensions/modelstudio/index.js";
+export default module.default;

--- a/dist-runtime/extensions/modelstudio/openclaw.plugin.json
+++ b/dist-runtime/extensions/modelstudio/openclaw.plugin.json
@@ -1,0 +1,42 @@
+{
+  "id": "modelstudio",
+  "providers": ["modelstudio"],
+  "providerAuthEnvVars": {
+    "modelstudio": ["MODELSTUDIO_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "modelstudio",
+      "method": "api-key-cn",
+      "choiceId": "modelstudio-api-key-cn",
+      "choiceLabel": "Coding Plan API Key for China (subscription)",
+      "choiceHint": "Endpoint: coding.dashscope.aliyuncs.com",
+      "groupId": "modelstudio",
+      "groupLabel": "Alibaba Cloud Model Studio",
+      "groupHint": "Coding Plan API key (CN / Global)",
+      "optionKey": "modelstudioApiKeyCn",
+      "cliFlag": "--modelstudio-api-key-cn",
+      "cliOption": "--modelstudio-api-key-cn <key>",
+      "cliDescription": "Alibaba Cloud Model Studio Coding Plan API key (China)"
+    },
+    {
+      "provider": "modelstudio",
+      "method": "api-key",
+      "choiceId": "modelstudio-api-key",
+      "choiceLabel": "Coding Plan API Key for Global/Intl (subscription)",
+      "choiceHint": "Endpoint: coding-intl.dashscope.aliyuncs.com",
+      "groupId": "modelstudio",
+      "groupLabel": "Alibaba Cloud Model Studio",
+      "groupHint": "Coding Plan API key (CN / Global)",
+      "optionKey": "modelstudioApiKey",
+      "cliFlag": "--modelstudio-api-key",
+      "cliOption": "--modelstudio-api-key <key>",
+      "cliDescription": "Alibaba Cloud Model Studio Coding Plan API key (Global/Intl)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/modelstudio/package.json
+++ b/dist-runtime/extensions/modelstudio/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/modelstudio-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Model Studio provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/moonshot/index.js
+++ b/dist-runtime/extensions/moonshot/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/moonshot/index.js";
+import * as module from "../../../dist/extensions/moonshot/index.js";
+export default module.default;

--- a/dist-runtime/extensions/moonshot/openclaw.plugin.json
+++ b/dist-runtime/extensions/moonshot/openclaw.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "moonshot",
+  "providers": ["moonshot"],
+  "providerAuthEnvVars": {
+    "moonshot": ["MOONSHOT_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "moonshot",
+      "method": "api-key",
+      "choiceId": "moonshot-api-key",
+      "choiceLabel": "Moonshot API key (.ai)",
+      "groupId": "moonshot",
+      "groupLabel": "Moonshot AI (Kimi K2.5)",
+      "groupHint": "Kimi K2.5",
+      "optionKey": "moonshotApiKey",
+      "cliFlag": "--moonshot-api-key",
+      "cliOption": "--moonshot-api-key <key>",
+      "cliDescription": "Moonshot API key"
+    },
+    {
+      "provider": "moonshot",
+      "method": "api-key-cn",
+      "choiceId": "moonshot-api-key-cn",
+      "choiceLabel": "Moonshot API key (.cn)",
+      "groupId": "moonshot",
+      "groupLabel": "Moonshot AI (Kimi K2.5)",
+      "groupHint": "Kimi K2.5",
+      "optionKey": "moonshotApiKey",
+      "cliFlag": "--moonshot-api-key",
+      "cliOption": "--moonshot-api-key <key>",
+      "cliDescription": "Moonshot API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/moonshot/package.json
+++ b/dist-runtime/extensions/moonshot/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/moonshot-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Moonshot provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/msteams/index.js
+++ b/dist-runtime/extensions/msteams/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/msteams/index.js";
+import * as module from "../../../dist/extensions/msteams/index.js";
+export default module.default;

--- a/dist-runtime/extensions/msteams/openclaw.plugin.json
+++ b/dist-runtime/extensions/msteams/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "msteams",
+  "channels": ["msteams"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/msteams/package.json
+++ b/dist-runtime/extensions/msteams/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@openclaw/msteams",
+  "version": "2026.3.14",
+  "description": "OpenClaw Microsoft Teams channel plugin",
+  "type": "module",
+  "dependencies": {
+    "@microsoft/agents-hosting": "^1.3.1",
+    "express": "^5.2.1"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "msteams",
+      "label": "Microsoft Teams",
+      "selectionLabel": "Microsoft Teams (Bot Framework)",
+      "docsPath": "/channels/msteams",
+      "docsLabel": "msteams",
+      "blurb": "Bot Framework; enterprise support.",
+      "aliases": [
+        "teams"
+      ],
+      "order": 60
+    },
+    "install": {
+      "npmSpec": "@openclaw/msteams",
+      "localPath": "extensions/msteams",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@microsoft/agents-hosting"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/msteams/setup-entry.js
+++ b/dist-runtime/extensions/msteams/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/msteams/setup-entry.js";
+import * as module from "../../../dist/extensions/msteams/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/nextcloud-talk/index.js
+++ b/dist-runtime/extensions/nextcloud-talk/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/nextcloud-talk/index.js";
+import * as module from "../../../dist/extensions/nextcloud-talk/index.js";
+export default module.default;

--- a/dist-runtime/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/dist-runtime/extensions/nextcloud-talk/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "nextcloud-talk",
+  "channels": ["nextcloud-talk"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/nextcloud-talk/package.json
+++ b/dist-runtime/extensions/nextcloud-talk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@openclaw/nextcloud-talk",
+  "version": "2026.3.14",
+  "description": "OpenClaw Nextcloud Talk channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "nextcloud-talk",
+      "label": "Nextcloud Talk",
+      "selectionLabel": "Nextcloud Talk (self-hosted)",
+      "docsPath": "/channels/nextcloud-talk",
+      "docsLabel": "nextcloud-talk",
+      "blurb": "Self-hosted chat via Nextcloud Talk webhook bots.",
+      "aliases": [
+        "nc-talk",
+        "nc"
+      ],
+      "order": 65,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/nextcloud-talk",
+      "localPath": "extensions/nextcloud-talk",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/nextcloud-talk/setup-entry.js
+++ b/dist-runtime/extensions/nextcloud-talk/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/nextcloud-talk/setup-entry.js";
+import * as module from "../../../dist/extensions/nextcloud-talk/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/nostr/index.js
+++ b/dist-runtime/extensions/nostr/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/nostr/index.js";
+import * as module from "../../../dist/extensions/nostr/index.js";
+export default module.default;

--- a/dist-runtime/extensions/nostr/openclaw.plugin.json
+++ b/dist-runtime/extensions/nostr/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "nostr",
+  "channels": ["nostr"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/nostr/package.json
+++ b/dist-runtime/extensions/nostr/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@openclaw/nostr",
+  "version": "2026.3.14",
+  "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
+  "type": "module",
+  "dependencies": {
+    "nostr-tools": "^2.23.3",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "nostr",
+      "label": "Nostr",
+      "selectionLabel": "Nostr (NIP-04 DMs)",
+      "docsPath": "/channels/nostr",
+      "docsLabel": "nostr",
+      "blurb": "Decentralized protocol; encrypted DMs via NIP-04.",
+      "order": 55,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/nostr",
+      "localPath": "extensions/nostr",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "nostr-tools"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/nostr/setup-entry.js
+++ b/dist-runtime/extensions/nostr/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/nostr/setup-entry.js";
+import * as module from "../../../dist/extensions/nostr/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/nvidia/index.js
+++ b/dist-runtime/extensions/nvidia/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/nvidia/index.js";
+import * as module from "../../../dist/extensions/nvidia/index.js";
+export default module.default;

--- a/dist-runtime/extensions/nvidia/openclaw.plugin.json
+++ b/dist-runtime/extensions/nvidia/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "nvidia",
+  "providers": ["nvidia"],
+  "providerAuthEnvVars": {
+    "nvidia": ["NVIDIA_API_KEY"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/nvidia/package.json
+++ b/dist-runtime/extensions/nvidia/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/nvidia-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw NVIDIA provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/ollama/index.js
+++ b/dist-runtime/extensions/ollama/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/ollama/index.js";
+import * as module from "../../../dist/extensions/ollama/index.js";
+export default module.default;

--- a/dist-runtime/extensions/ollama/openclaw.plugin.json
+++ b/dist-runtime/extensions/ollama/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "ollama",
+  "providers": ["ollama"],
+  "providerAuthEnvVars": {
+    "ollama": ["OLLAMA_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "ollama",
+      "method": "local",
+      "choiceId": "ollama",
+      "choiceLabel": "Ollama",
+      "choiceHint": "Cloud and local open models",
+      "groupId": "ollama",
+      "groupLabel": "Ollama",
+      "groupHint": "Cloud and local open models"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/ollama/package.json
+++ b/dist-runtime/extensions/ollama/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/ollama-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Ollama provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/open-prose/index.js
+++ b/dist-runtime/extensions/open-prose/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/open-prose/index.js";
+import * as module from "../../../dist/extensions/open-prose/index.js";
+export default module.default;

--- a/dist-runtime/extensions/open-prose/openclaw.plugin.json
+++ b/dist-runtime/extensions/open-prose/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "open-prose",
+  "name": "OpenProse",
+  "description": "OpenProse VM skill pack with a /prose slash command.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/open-prose/package.json
+++ b/dist-runtime/extensions/open-prose/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/open-prose",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/open-prose/skills/prose/LICENSE
+++ b/dist-runtime/extensions/open-prose/skills/prose/LICENSE
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/LICENSE

--- a/dist-runtime/extensions/open-prose/skills/prose/SKILL.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/SKILL.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alt-borges.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alt-borges.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/alt-borges.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/arabian-nights.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/arabian-nights.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/arabian-nights.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/borges.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/borges.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/borges.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/folk.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/folk.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/folk.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/homer.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/homer.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/homer.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/kafka.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/kafka.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/kafka.md

--- a/dist-runtime/extensions/open-prose/skills/prose/alts/shared-appendix.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/alts/shared-appendix.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/alts/shared-appendix.md

--- a/dist-runtime/extensions/open-prose/skills/prose/compiler.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/compiler.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/compiler.md

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/01-hello-world.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/01-hello-world.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/01-hello-world.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/02-research-and-summarize.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/02-research-and-summarize.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/02-research-and-summarize.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/03-code-review.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/03-code-review.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/03-code-review.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/04-write-and-refine.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/04-write-and-refine.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/04-write-and-refine.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/05-debug-issue.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/05-debug-issue.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/05-debug-issue.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/06-explain-codebase.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/06-explain-codebase.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/06-explain-codebase.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/07-refactor.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/07-refactor.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/07-refactor.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/08-blog-post.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/08-blog-post.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/08-blog-post.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/09-research-with-agents.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/09-research-with-agents.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/09-research-with-agents.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/10-code-review-agents.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/10-code-review-agents.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/10-code-review-agents.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/11-skills-and-imports.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/11-skills-and-imports.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/11-skills-and-imports.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/12-secure-agent-permissions.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/12-secure-agent-permissions.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/12-secure-agent-permissions.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/13-variables-and-context.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/13-variables-and-context.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/13-variables-and-context.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/14-composition-blocks.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/14-composition-blocks.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/14-composition-blocks.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/15-inline-sequences.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/15-inline-sequences.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/15-inline-sequences.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/16-parallel-reviews.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/16-parallel-reviews.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/16-parallel-reviews.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/17-parallel-research.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/17-parallel-research.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/17-parallel-research.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/18-mixed-parallel-sequential.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/18-mixed-parallel-sequential.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/18-mixed-parallel-sequential.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/19-advanced-parallel.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/19-advanced-parallel.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/19-advanced-parallel.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/20-fixed-loops.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/20-fixed-loops.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/20-fixed-loops.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/21-pipeline-operations.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/21-pipeline-operations.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/21-pipeline-operations.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/22-error-handling.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/22-error-handling.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/22-error-handling.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/23-retry-with-backoff.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/23-retry-with-backoff.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/23-retry-with-backoff.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/24-choice-blocks.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/24-choice-blocks.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/24-choice-blocks.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/25-conditionals.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/25-conditionals.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/25-conditionals.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/26-parameterized-blocks.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/26-parameterized-blocks.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/26-parameterized-blocks.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/27-string-interpolation.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/27-string-interpolation.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/27-string-interpolation.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/28-automated-pr-review.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/28-automated-pr-review.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/28-automated-pr-review.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/28-gas-town.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/28-gas-town.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/28-gas-town.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/29-captains-chair.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/29-captains-chair.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/29-captains-chair.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/30-captains-chair-simple.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/30-captains-chair-simple.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/30-captains-chair-simple.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/31-captains-chair-with-memory.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/31-captains-chair-with-memory.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/31-captains-chair-with-memory.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/33-pr-review-autofix.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/33-pr-review-autofix.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/33-pr-review-autofix.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/34-content-pipeline.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/34-content-pipeline.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/34-content-pipeline.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/35-feature-factory.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/35-feature-factory.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/35-feature-factory.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/36-bug-hunter.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/36-bug-hunter.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/36-bug-hunter.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/37-the-forge.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/37-the-forge.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/37-the-forge.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/38-skill-scan.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/38-skill-scan.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/38-skill-scan.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/39-architect-by-simulation.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/39-architect-by-simulation.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/39-architect-by-simulation.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/40-rlm-self-refine.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/40-rlm-self-refine.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/40-rlm-self-refine.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/41-rlm-divide-conquer.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/41-rlm-divide-conquer.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/41-rlm-divide-conquer.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/42-rlm-filter-recurse.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/42-rlm-filter-recurse.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/42-rlm-filter-recurse.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/43-rlm-pairwise.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/43-rlm-pairwise.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/43-rlm-pairwise.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/44-run-endpoint-ux-test.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/44-run-endpoint-ux-test.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/44-run-endpoint-ux-test.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/45-plugin-release.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/45-plugin-release.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/45-plugin-release.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/45-run-endpoint-ux-test-with-remediation.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/45-run-endpoint-ux-test-with-remediation.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/45-run-endpoint-ux-test-with-remediation.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/46-workflow-crystallizer.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/46-workflow-crystallizer.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/46-workflow-crystallizer.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/47-language-self-improvement.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/47-language-self-improvement.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/47-language-self-improvement.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/48-habit-miner.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/48-habit-miner.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/48-habit-miner.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/49-prose-run-retrospective.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/49-prose-run-retrospective.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/49-prose-run-retrospective.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/README.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/README.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/examples/README.md

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/README.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/README.md
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/open-prose/skills/prose/examples/roadmap/README.md

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/iterative-refinement.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/iterative-refinement.prose
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/open-prose/skills/prose/examples/roadmap/iterative-refinement.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/parallel-review.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/parallel-review.prose
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/open-prose/skills/prose/examples/roadmap/parallel-review.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/simple-pipeline.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/simple-pipeline.prose
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/open-prose/skills/prose/examples/roadmap/simple-pipeline.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/syntax/open-prose-syntax.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/examples/roadmap/syntax/open-prose-syntax.prose
@@ -1,0 +1,1 @@
+../../../../../../../../dist/extensions/open-prose/skills/prose/examples/roadmap/syntax/open-prose-syntax.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/guidance/antipatterns.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/guidance/antipatterns.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/guidance/antipatterns.md

--- a/dist-runtime/extensions/open-prose/skills/prose/guidance/patterns.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/guidance/patterns.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/guidance/patterns.md

--- a/dist-runtime/extensions/open-prose/skills/prose/guidance/system-prompt.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/guidance/system-prompt.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/guidance/system-prompt.md

--- a/dist-runtime/extensions/open-prose/skills/prose/help.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/help.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/help.md

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/README.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/README.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/README.md

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/calibrator.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/calibrator.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/calibrator.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/cost-analyzer.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/cost-analyzer.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/cost-analyzer.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/error-forensics.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/error-forensics.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/error-forensics.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/inspector.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/inspector.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/inspector.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/profiler.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/profiler.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/profiler.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/program-improver.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/program-improver.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/program-improver.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/project-memory.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/project-memory.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/project-memory.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/user-memory.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/user-memory.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/user-memory.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/lib/vm-improver.prose
+++ b/dist-runtime/extensions/open-prose/skills/prose/lib/vm-improver.prose
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/lib/vm-improver.prose

--- a/dist-runtime/extensions/open-prose/skills/prose/primitives/session.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/primitives/session.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/primitives/session.md

--- a/dist-runtime/extensions/open-prose/skills/prose/prose.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/prose.md
@@ -1,0 +1,1 @@
+../../../../../dist/extensions/open-prose/skills/prose/prose.md

--- a/dist-runtime/extensions/open-prose/skills/prose/state/filesystem.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/state/filesystem.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/state/filesystem.md

--- a/dist-runtime/extensions/open-prose/skills/prose/state/in-context.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/state/in-context.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/state/in-context.md

--- a/dist-runtime/extensions/open-prose/skills/prose/state/postgres.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/state/postgres.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/state/postgres.md

--- a/dist-runtime/extensions/open-prose/skills/prose/state/sqlite.md
+++ b/dist-runtime/extensions/open-prose/skills/prose/state/sqlite.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/open-prose/skills/prose/state/sqlite.md

--- a/dist-runtime/extensions/openai/index.js
+++ b/dist-runtime/extensions/openai/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/openai/index.js";
+import * as module from "../../../dist/extensions/openai/index.js";
+export default module.default;

--- a/dist-runtime/extensions/openai/openclaw.plugin.json
+++ b/dist-runtime/extensions/openai/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "openai",
+  "providers": ["openai", "openai-codex"],
+  "providerAuthEnvVars": {
+    "openai": ["OPENAI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "openai-codex",
+      "method": "oauth",
+      "choiceId": "openai-codex",
+      "choiceLabel": "OpenAI Codex (ChatGPT OAuth)",
+      "choiceHint": "Browser sign-in",
+      "groupId": "openai",
+      "groupLabel": "OpenAI",
+      "groupHint": "Codex OAuth + API key"
+    },
+    {
+      "provider": "openai",
+      "method": "api-key",
+      "choiceId": "openai-api-key",
+      "choiceLabel": "OpenAI API key",
+      "groupId": "openai",
+      "groupLabel": "OpenAI",
+      "groupHint": "Codex OAuth + API key",
+      "optionKey": "openaiApiKey",
+      "cliFlag": "--openai-api-key",
+      "cliOption": "--openai-api-key <key>",
+      "cliDescription": "OpenAI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/openai/package.json
+++ b/dist-runtime/extensions/openai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/openai-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw OpenAI provider plugins",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/opencode-go/index.js
+++ b/dist-runtime/extensions/opencode-go/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/opencode-go/index.js";
+import * as module from "../../../dist/extensions/opencode-go/index.js";
+export default module.default;

--- a/dist-runtime/extensions/opencode-go/openclaw.plugin.json
+++ b/dist-runtime/extensions/opencode-go/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "opencode-go",
+  "providers": ["opencode-go"],
+  "providerAuthEnvVars": {
+    "opencode-go": ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "opencode-go",
+      "method": "api-key",
+      "choiceId": "opencode-go",
+      "choiceLabel": "OpenCode Go catalog",
+      "groupId": "opencode",
+      "groupLabel": "OpenCode",
+      "groupHint": "Shared API key for Zen + Go catalogs",
+      "optionKey": "opencodeGoApiKey",
+      "cliFlag": "--opencode-go-api-key",
+      "cliOption": "--opencode-go-api-key <key>",
+      "cliDescription": "OpenCode API key (Go catalog)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/opencode-go/package.json
+++ b/dist-runtime/extensions/opencode-go/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/opencode-go-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw OpenCode Go provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/opencode/index.js
+++ b/dist-runtime/extensions/opencode/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/opencode/index.js";
+import * as module from "../../../dist/extensions/opencode/index.js";
+export default module.default;

--- a/dist-runtime/extensions/opencode/openclaw.plugin.json
+++ b/dist-runtime/extensions/opencode/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "opencode",
+  "providers": ["opencode"],
+  "providerAuthEnvVars": {
+    "opencode": ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "opencode",
+      "method": "api-key",
+      "choiceId": "opencode-zen",
+      "choiceLabel": "OpenCode Zen catalog",
+      "groupId": "opencode",
+      "groupLabel": "OpenCode",
+      "groupHint": "Shared API key for Zen + Go catalogs",
+      "optionKey": "opencodeZenApiKey",
+      "cliFlag": "--opencode-zen-api-key",
+      "cliOption": "--opencode-zen-api-key <key>",
+      "cliDescription": "OpenCode API key (Zen catalog)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/opencode/package.json
+++ b/dist-runtime/extensions/opencode/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/opencode-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw OpenCode Zen provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/openrouter/index.js
+++ b/dist-runtime/extensions/openrouter/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/openrouter/index.js";
+import * as module from "../../../dist/extensions/openrouter/index.js";
+export default module.default;

--- a/dist-runtime/extensions/openrouter/openclaw.plugin.json
+++ b/dist-runtime/extensions/openrouter/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "openrouter",
+  "providers": ["openrouter"],
+  "providerAuthEnvVars": {
+    "openrouter": ["OPENROUTER_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "openrouter",
+      "method": "api-key",
+      "choiceId": "openrouter-api-key",
+      "choiceLabel": "OpenRouter API key",
+      "groupId": "openrouter",
+      "groupLabel": "OpenRouter",
+      "groupHint": "API key",
+      "optionKey": "openrouterApiKey",
+      "cliFlag": "--openrouter-api-key",
+      "cliOption": "--openrouter-api-key <key>",
+      "cliDescription": "OpenRouter API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/openrouter/package.json
+++ b/dist-runtime/extensions/openrouter/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/openrouter-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw OpenRouter provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/openshell/index.js
+++ b/dist-runtime/extensions/openshell/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/openshell/index.js";
+import * as module from "../../../dist/extensions/openshell/index.js";
+export default module.default;

--- a/dist-runtime/extensions/openshell/openclaw.plugin.json
+++ b/dist-runtime/extensions/openshell/openclaw.plugin.json
@@ -1,0 +1,99 @@
+{
+  "id": "openshell",
+  "name": "OpenShell Sandbox",
+  "description": "Sandbox backend powered by OpenShell with mirrored local workspaces and SSH-based command execution.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "command": {
+        "type": "string"
+      },
+      "gateway": {
+        "type": "string"
+      },
+      "gatewayEndpoint": {
+        "type": "string"
+      },
+      "from": {
+        "type": "string"
+      },
+      "policy": {
+        "type": "string"
+      },
+      "providers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "gpu": {
+        "type": "boolean"
+      },
+      "autoProviders": {
+        "type": "boolean"
+      },
+      "remoteWorkspaceDir": {
+        "type": "string"
+      },
+      "remoteAgentWorkspaceDir": {
+        "type": "string"
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 1
+      }
+    }
+  },
+  "uiHints": {
+    "command": {
+      "label": "OpenShell Command",
+      "help": "Path or command name for the openshell CLI."
+    },
+    "gateway": {
+      "label": "Gateway Name",
+      "help": "Optional OpenShell gateway name passed as --gateway."
+    },
+    "gatewayEndpoint": {
+      "label": "Gateway Endpoint",
+      "help": "Optional OpenShell gateway endpoint passed as --gateway-endpoint."
+    },
+    "from": {
+      "label": "Sandbox Source",
+      "help": "OpenShell sandbox source for first-time create. Defaults to openclaw."
+    },
+    "policy": {
+      "label": "Policy File",
+      "help": "Optional path to a custom OpenShell sandbox policy YAML."
+    },
+    "providers": {
+      "label": "Providers",
+      "help": "Provider names to attach when a sandbox is created."
+    },
+    "gpu": {
+      "label": "GPU",
+      "help": "Request GPU resources when creating the sandbox.",
+      "advanced": true
+    },
+    "autoProviders": {
+      "label": "Auto-create Providers",
+      "help": "When enabled, pass --auto-providers during sandbox create.",
+      "advanced": true
+    },
+    "remoteWorkspaceDir": {
+      "label": "Remote Workspace Dir",
+      "help": "Primary writable workspace inside the OpenShell sandbox.",
+      "advanced": true
+    },
+    "remoteAgentWorkspaceDir": {
+      "label": "Remote Agent Dir",
+      "help": "Mirror path for the real agent workspace when workspaceAccess is read-only.",
+      "advanced": true
+    },
+    "timeoutSeconds": {
+      "label": "Command Timeout Seconds",
+      "help": "Timeout for openshell CLI operations such as create/upload/download.",
+      "advanced": true
+    }
+  }
+}

--- a/dist-runtime/extensions/openshell/package.json
+++ b/dist-runtime/extensions/openshell/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/openshell-sandbox",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw OpenShell sandbox backend",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/perplexity/index.js
+++ b/dist-runtime/extensions/perplexity/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/perplexity/index.js";
+import * as module from "../../../dist/extensions/perplexity/index.js";
+export default module.default;

--- a/dist-runtime/extensions/perplexity/openclaw.plugin.json
+++ b/dist-runtime/extensions/perplexity/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "perplexity",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/perplexity/package.json
+++ b/dist-runtime/extensions/perplexity/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/perplexity-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Perplexity plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/phone-control/index.js
+++ b/dist-runtime/extensions/phone-control/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/phone-control/index.js";
+import * as module from "../../../dist/extensions/phone-control/index.js";
+export default module.default;

--- a/dist-runtime/extensions/phone-control/openclaw.plugin.json
+++ b/dist-runtime/extensions/phone-control/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "phone-control",
+  "name": "Phone Control",
+  "description": "Arm/disarm high-risk phone node commands (camera/screen/writes) with an optional auto-expiry.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/qianfan/index.js
+++ b/dist-runtime/extensions/qianfan/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/qianfan/index.js";
+import * as module from "../../../dist/extensions/qianfan/index.js";
+export default module.default;

--- a/dist-runtime/extensions/qianfan/openclaw.plugin.json
+++ b/dist-runtime/extensions/qianfan/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "qianfan",
+  "providers": ["qianfan"],
+  "providerAuthEnvVars": {
+    "qianfan": ["QIANFAN_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "qianfan",
+      "method": "api-key",
+      "choiceId": "qianfan-api-key",
+      "choiceLabel": "Qianfan API key",
+      "groupId": "qianfan",
+      "groupLabel": "Qianfan",
+      "groupHint": "API key",
+      "optionKey": "qianfanApiKey",
+      "cliFlag": "--qianfan-api-key",
+      "cliOption": "--qianfan-api-key <key>",
+      "cliDescription": "QIANFAN API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/qianfan/package.json
+++ b/dist-runtime/extensions/qianfan/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/qianfan-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Qianfan provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/qwen-portal-auth/index.js
+++ b/dist-runtime/extensions/qwen-portal-auth/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/qwen-portal-auth/index.js";
+import * as module from "../../../dist/extensions/qwen-portal-auth/index.js";
+export default module.default;

--- a/dist-runtime/extensions/qwen-portal-auth/openclaw.plugin.json
+++ b/dist-runtime/extensions/qwen-portal-auth/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "qwen-portal-auth",
+  "providers": ["qwen-portal"],
+  "providerAuthEnvVars": {
+    "qwen-portal": ["QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "qwen-portal",
+      "method": "device",
+      "choiceId": "qwen-portal",
+      "choiceLabel": "Qwen OAuth",
+      "choiceHint": "Device code login",
+      "groupId": "qwen",
+      "groupLabel": "Qwen",
+      "groupHint": "OAuth"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/sglang/index.js
+++ b/dist-runtime/extensions/sglang/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/sglang/index.js";
+import * as module from "../../../dist/extensions/sglang/index.js";
+export default module.default;

--- a/dist-runtime/extensions/sglang/openclaw.plugin.json
+++ b/dist-runtime/extensions/sglang/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "sglang",
+  "providers": ["sglang"],
+  "providerAuthEnvVars": {
+    "sglang": ["SGLANG_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "sglang",
+      "method": "custom",
+      "choiceId": "sglang",
+      "choiceLabel": "SGLang",
+      "choiceHint": "Fast self-hosted OpenAI-compatible server",
+      "groupId": "sglang",
+      "groupLabel": "SGLang",
+      "groupHint": "Fast self-hosted server"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/sglang/package.json
+++ b/dist-runtime/extensions/sglang/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/sglang-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw SGLang provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/signal/index.js
+++ b/dist-runtime/extensions/signal/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/signal/index.js";
+import * as module from "../../../dist/extensions/signal/index.js";
+export default module.default;

--- a/dist-runtime/extensions/signal/openclaw.plugin.json
+++ b/dist-runtime/extensions/signal/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "signal",
+  "channels": ["signal"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/signal/package.json
+++ b/dist-runtime/extensions/signal/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openclaw/signal",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Signal channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/signal/setup-entry.js
+++ b/dist-runtime/extensions/signal/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/signal/setup-entry.js";
+import * as module from "../../../dist/extensions/signal/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/slack/index.js
+++ b/dist-runtime/extensions/slack/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/slack/index.js";
+import * as module from "../../../dist/extensions/slack/index.js";
+export default module.default;

--- a/dist-runtime/extensions/slack/openclaw.plugin.json
+++ b/dist-runtime/extensions/slack/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "slack",
+  "channels": ["slack"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/slack/package.json
+++ b/dist-runtime/extensions/slack/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openclaw/slack",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Slack channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/slack/setup-entry.js
+++ b/dist-runtime/extensions/slack/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/slack/setup-entry.js";
+import * as module from "../../../dist/extensions/slack/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/synology-chat/index.js
+++ b/dist-runtime/extensions/synology-chat/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/synology-chat/index.js";
+import * as module from "../../../dist/extensions/synology-chat/index.js";
+export default module.default;

--- a/dist-runtime/extensions/synology-chat/openclaw.plugin.json
+++ b/dist-runtime/extensions/synology-chat/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "synology-chat",
+  "channels": ["synology-chat"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/synology-chat/package.json
+++ b/dist-runtime/extensions/synology-chat/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openclaw/synology-chat",
+  "version": "2026.3.14",
+  "description": "Synology Chat channel plugin for OpenClaw",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "synology-chat",
+      "label": "Synology Chat",
+      "selectionLabel": "Synology Chat (Webhook)",
+      "docsPath": "/channels/synology-chat",
+      "docsLabel": "synology-chat",
+      "blurb": "Connect your Synology NAS Chat to OpenClaw with full agent capabilities.",
+      "order": 90
+    },
+    "install": {
+      "npmSpec": "@openclaw/synology-chat",
+      "localPath": "extensions/synology-chat",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/synology-chat/setup-entry.js
+++ b/dist-runtime/extensions/synology-chat/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/synology-chat/setup-entry.js";
+import * as module from "../../../dist/extensions/synology-chat/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/synthetic/index.js
+++ b/dist-runtime/extensions/synthetic/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/synthetic/index.js";
+import * as module from "../../../dist/extensions/synthetic/index.js";
+export default module.default;

--- a/dist-runtime/extensions/synthetic/openclaw.plugin.json
+++ b/dist-runtime/extensions/synthetic/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "synthetic",
+  "providers": ["synthetic"],
+  "providerAuthEnvVars": {
+    "synthetic": ["SYNTHETIC_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "synthetic",
+      "method": "api-key",
+      "choiceId": "synthetic-api-key",
+      "choiceLabel": "Synthetic API key",
+      "groupId": "synthetic",
+      "groupLabel": "Synthetic",
+      "groupHint": "Anthropic-compatible (multi-model)",
+      "optionKey": "syntheticApiKey",
+      "cliFlag": "--synthetic-api-key",
+      "cliOption": "--synthetic-api-key <key>",
+      "cliDescription": "Synthetic API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/synthetic/package.json
+++ b/dist-runtime/extensions/synthetic/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/synthetic-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Synthetic provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/talk-voice/index.js
+++ b/dist-runtime/extensions/talk-voice/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/talk-voice/index.js";
+import * as module from "../../../dist/extensions/talk-voice/index.js";
+export default module.default;

--- a/dist-runtime/extensions/talk-voice/openclaw.plugin.json
+++ b/dist-runtime/extensions/talk-voice/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "talk-voice",
+  "name": "Talk Voice",
+  "description": "Manage Talk voice selection (list/set).",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/telegram/index.js
+++ b/dist-runtime/extensions/telegram/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/telegram/index.js";
+import * as module from "../../../dist/extensions/telegram/index.js";
+export default module.default;

--- a/dist-runtime/extensions/telegram/openclaw.plugin.json
+++ b/dist-runtime/extensions/telegram/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "telegram",
+  "channels": ["telegram"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/telegram/package.json
+++ b/dist-runtime/extensions/telegram/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openclaw/telegram",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Telegram channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/telegram/setup-entry.js
+++ b/dist-runtime/extensions/telegram/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/telegram/setup-entry.js";
+import * as module from "../../../dist/extensions/telegram/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/thread-ownership/index.js
+++ b/dist-runtime/extensions/thread-ownership/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/thread-ownership/index.js";
+import * as module from "../../../dist/extensions/thread-ownership/index.js";
+export default module.default;

--- a/dist-runtime/extensions/thread-ownership/openclaw.plugin.json
+++ b/dist-runtime/extensions/thread-ownership/openclaw.plugin.json
@@ -1,0 +1,30 @@
+{
+  "id": "thread-ownership",
+  "name": "Thread Ownership",
+  "description": "Prevents multiple agents from responding in the same Slack thread. Uses HTTP calls to the slack-forwarder ownership API.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "forwarderUrl": {
+        "type": "string"
+      },
+      "abTestChannels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "forwarderUrl": {
+      "label": "Forwarder URL",
+      "help": "Base URL of the slack-forwarder ownership API (default: http://slack-forwarder:8750)"
+    },
+    "abTestChannels": {
+      "label": "A/B Test Channels",
+      "help": "Slack channel IDs where thread ownership is enforced"
+    }
+  }
+}

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/README.md
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/README.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/README.md

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/SKILL.md
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/SKILL.md

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/package.json
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@tloncorp/tlon-skill",
+  "version": "0.2.2",
+  "description": "Tlon/Urbit skill for OpenClaw agents",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill.git"
+  },
+  "bin": {
+    "tlon": "./bin/tlon.js"
+  },
+  "files": [
+    "bin/",
+    "scripts/postinstall.js",
+    "SKILL.md",
+    "references/"
+  ],
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "build:all": "node scripts/build-all.js",
+    "dev:link": "bun run build:all && cp \"npm/$(node -e 'console.log(process.platform + \"-\" + process.arch)')/tlon\" bin/",
+    "postinstall": "node scripts/postinstall.js",
+    "test": "bun test",
+    "version": "node scripts/bump-version.js"
+  },
+  "devDependencies": {
+    "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#c5eb1720d94435b62503605acb294ef42a5440b3",
+    "@types/node": "^22.0.0",
+    "@urbit/aura": "^3.0.0",
+    "typescript": "^5.9.3"
+  },
+  "optionalDependencies": {
+    "@tloncorp/tlon-skill-darwin-arm64": "0.2.2",
+    "@tloncorp/tlon-skill-darwin-x64": "0.2.2",
+    "@tloncorp/tlon-skill-linux-arm64": "0.2.2",
+    "@tloncorp/tlon-skill-linux-x64": "0.2.2"
+  }
+}

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/auto-react.hoon
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/auto-react.hoon
@@ -1,0 +1,1 @@
+../../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/auto-react.hoon

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/delete-old-posts.hoon
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/delete-old-posts.hoon
@@ -1,0 +1,1 @@
+../../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/delete-old-posts.hoon

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/word-filter.hoon
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/word-filter.hoon
@@ -1,0 +1,1 @@
+../../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks-examples/word-filter.hoon

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks.md
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks.md
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/hooks.md

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/urbit-api.md
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/urbit-api.md
@@ -1,0 +1,1 @@
+../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/references/urbit-api.md

--- a/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/scripts/postinstall.js
+++ b/dist-runtime/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/scripts/postinstall.js
@@ -1,0 +1,3 @@
+export * from "../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/scripts/postinstall.js";
+import * as module from "../../../../../../../dist/extensions/tlon/bundled-skills/@tloncorp/tlon-skill/scripts/postinstall.js";
+export default module.default;

--- a/dist-runtime/extensions/tlon/index.js
+++ b/dist-runtime/extensions/tlon/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/tlon/index.js";
+import * as module from "../../../dist/extensions/tlon/index.js";
+export default module.default;

--- a/dist-runtime/extensions/tlon/openclaw.plugin.json
+++ b/dist-runtime/extensions/tlon/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "tlon",
+  "channels": ["tlon"],
+  "skills": ["./bundled-skills/@tloncorp/tlon-skill"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/tlon/package.json
+++ b/dist-runtime/extensions/tlon/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@openclaw/tlon",
+  "version": "2026.3.14",
+  "description": "OpenClaw Tlon/Urbit channel plugin",
+  "type": "module",
+  "dependencies": {
+    "@tloncorp/api": "github:tloncorp/api-beta#7eede1c1a756977b09f96aa14a92e2b06318ae87",
+    "@tloncorp/tlon-skill": "0.2.2",
+    "@urbit/aura": "^3.0.0",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "tlon",
+      "label": "Tlon",
+      "selectionLabel": "Tlon (Urbit)",
+      "docsPath": "/channels/tlon",
+      "docsLabel": "tlon",
+      "blurb": "decentralized messaging on Urbit; install the plugin to enable.",
+      "order": 90,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/tlon",
+      "localPath": "extensions/tlon",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@tloncorp/api",
+        "@tloncorp/tlon-skill",
+        "@urbit/aura"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/tlon/setup-entry.js
+++ b/dist-runtime/extensions/tlon/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/tlon/setup-entry.js";
+import * as module from "../../../dist/extensions/tlon/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/together/index.js
+++ b/dist-runtime/extensions/together/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/together/index.js";
+import * as module from "../../../dist/extensions/together/index.js";
+export default module.default;

--- a/dist-runtime/extensions/together/openclaw.plugin.json
+++ b/dist-runtime/extensions/together/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "together",
+  "providers": ["together"],
+  "providerAuthEnvVars": {
+    "together": ["TOGETHER_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "together",
+      "method": "api-key",
+      "choiceId": "together-api-key",
+      "choiceLabel": "Together AI API key",
+      "groupId": "together",
+      "groupLabel": "Together AI",
+      "groupHint": "API key",
+      "optionKey": "togetherApiKey",
+      "cliFlag": "--together-api-key",
+      "cliOption": "--together-api-key <key>",
+      "cliDescription": "Together AI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/together/package.json
+++ b/dist-runtime/extensions/together/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/together-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Together provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/twitch/index.js
+++ b/dist-runtime/extensions/twitch/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/twitch/index.js";
+import * as module from "../../../dist/extensions/twitch/index.js";
+export default module.default;

--- a/dist-runtime/extensions/twitch/openclaw.plugin.json
+++ b/dist-runtime/extensions/twitch/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "twitch",
+  "channels": ["twitch"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/twitch/package.json
+++ b/dist-runtime/extensions/twitch/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/twitch",
+  "version": "2026.3.14",
+  "description": "OpenClaw Twitch channel plugin",
+  "type": "module",
+  "dependencies": {
+    "@twurple/api": "^8.0.3",
+    "@twurple/auth": "^8.0.3",
+    "@twurple/chat": "^8.0.3",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/venice/index.js
+++ b/dist-runtime/extensions/venice/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/venice/index.js";
+import * as module from "../../../dist/extensions/venice/index.js";
+export default module.default;

--- a/dist-runtime/extensions/venice/openclaw.plugin.json
+++ b/dist-runtime/extensions/venice/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "venice",
+  "providers": ["venice"],
+  "providerAuthEnvVars": {
+    "venice": ["VENICE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "venice",
+      "method": "api-key",
+      "choiceId": "venice-api-key",
+      "choiceLabel": "Venice AI API key",
+      "groupId": "venice",
+      "groupLabel": "Venice AI",
+      "groupHint": "Privacy-focused (uncensored models)",
+      "optionKey": "veniceApiKey",
+      "cliFlag": "--venice-api-key",
+      "cliOption": "--venice-api-key <key>",
+      "cliDescription": "Venice API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/venice/package.json
+++ b/dist-runtime/extensions/venice/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/venice-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Venice provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/vercel-ai-gateway/index.js
+++ b/dist-runtime/extensions/vercel-ai-gateway/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/vercel-ai-gateway/index.js";
+import * as module from "../../../dist/extensions/vercel-ai-gateway/index.js";
+export default module.default;

--- a/dist-runtime/extensions/vercel-ai-gateway/openclaw.plugin.json
+++ b/dist-runtime/extensions/vercel-ai-gateway/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "vercel-ai-gateway",
+  "providers": ["vercel-ai-gateway"],
+  "providerAuthEnvVars": {
+    "vercel-ai-gateway": ["AI_GATEWAY_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "vercel-ai-gateway",
+      "method": "api-key",
+      "choiceId": "ai-gateway-api-key",
+      "choiceLabel": "Vercel AI Gateway API key",
+      "groupId": "ai-gateway",
+      "groupLabel": "Vercel AI Gateway",
+      "groupHint": "API key",
+      "optionKey": "aiGatewayApiKey",
+      "cliFlag": "--ai-gateway-api-key",
+      "cliOption": "--ai-gateway-api-key <key>",
+      "cliDescription": "Vercel AI Gateway API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/vercel-ai-gateway/package.json
+++ b/dist-runtime/extensions/vercel-ai-gateway/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/vercel-ai-gateway-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Vercel AI Gateway provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/vllm/index.js
+++ b/dist-runtime/extensions/vllm/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/vllm/index.js";
+import * as module from "../../../dist/extensions/vllm/index.js";
+export default module.default;

--- a/dist-runtime/extensions/vllm/openclaw.plugin.json
+++ b/dist-runtime/extensions/vllm/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "vllm",
+  "providers": ["vllm"],
+  "providerAuthEnvVars": {
+    "vllm": ["VLLM_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "vllm",
+      "method": "custom",
+      "choiceId": "vllm",
+      "choiceLabel": "vLLM",
+      "choiceHint": "Local/self-hosted OpenAI-compatible server",
+      "groupId": "vllm",
+      "groupLabel": "vLLM",
+      "groupHint": "Local/self-hosted OpenAI-compatible"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/vllm/package.json
+++ b/dist-runtime/extensions/vllm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/vllm-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw vLLM provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/voice-call/index.js
+++ b/dist-runtime/extensions/voice-call/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/voice-call/index.js";
+import * as module from "../../../dist/extensions/voice-call/index.js";
+export default module.default;

--- a/dist-runtime/extensions/voice-call/openclaw.plugin.json
+++ b/dist-runtime/extensions/voice-call/openclaw.plugin.json
@@ -1,0 +1,610 @@
+{
+  "id": "voice-call",
+  "uiHints": {
+    "provider": {
+      "label": "Provider",
+      "help": "Use twilio, telnyx, or mock for dev/no-network."
+    },
+    "fromNumber": {
+      "label": "From Number",
+      "placeholder": "+15550001234"
+    },
+    "toNumber": {
+      "label": "Default To Number",
+      "placeholder": "+15550001234"
+    },
+    "inboundPolicy": {
+      "label": "Inbound Policy"
+    },
+    "allowFrom": {
+      "label": "Inbound Allowlist"
+    },
+    "inboundGreeting": {
+      "label": "Inbound Greeting",
+      "advanced": true
+    },
+    "telnyx.apiKey": {
+      "label": "Telnyx API Key",
+      "sensitive": true
+    },
+    "telnyx.connectionId": {
+      "label": "Telnyx Connection ID"
+    },
+    "telnyx.publicKey": {
+      "label": "Telnyx Public Key",
+      "sensitive": true
+    },
+    "twilio.accountSid": {
+      "label": "Twilio Account SID"
+    },
+    "twilio.authToken": {
+      "label": "Twilio Auth Token",
+      "sensitive": true
+    },
+    "outbound.defaultMode": {
+      "label": "Default Call Mode"
+    },
+    "outbound.notifyHangupDelaySec": {
+      "label": "Notify Hangup Delay (sec)",
+      "advanced": true
+    },
+    "serve.port": {
+      "label": "Webhook Port"
+    },
+    "serve.bind": {
+      "label": "Webhook Bind"
+    },
+    "serve.path": {
+      "label": "Webhook Path"
+    },
+    "tailscale.mode": {
+      "label": "Tailscale Mode",
+      "advanced": true
+    },
+    "tailscale.path": {
+      "label": "Tailscale Path",
+      "advanced": true
+    },
+    "tunnel.provider": {
+      "label": "Tunnel Provider",
+      "advanced": true
+    },
+    "tunnel.ngrokAuthToken": {
+      "label": "ngrok Auth Token",
+      "sensitive": true,
+      "advanced": true
+    },
+    "tunnel.ngrokDomain": {
+      "label": "ngrok Domain",
+      "advanced": true
+    },
+    "tunnel.allowNgrokFreeTierLoopbackBypass": {
+      "label": "Allow ngrok Free Tier (Loopback Bypass)",
+      "advanced": true
+    },
+    "streaming.enabled": {
+      "label": "Enable Streaming",
+      "advanced": true
+    },
+    "streaming.openaiApiKey": {
+      "label": "OpenAI Realtime API Key",
+      "sensitive": true,
+      "advanced": true
+    },
+    "streaming.sttModel": {
+      "label": "Realtime STT Model",
+      "advanced": true
+    },
+    "streaming.streamPath": {
+      "label": "Media Stream Path",
+      "advanced": true
+    },
+    "tts.provider": {
+      "label": "TTS Provider Override",
+      "help": "Deep-merges with messages.tts (Microsoft is ignored for calls).",
+      "advanced": true
+    },
+    "tts.openai.model": {
+      "label": "OpenAI TTS Model",
+      "advanced": true
+    },
+    "tts.openai.voice": {
+      "label": "OpenAI TTS Voice",
+      "advanced": true
+    },
+    "tts.openai.apiKey": {
+      "label": "OpenAI API Key",
+      "sensitive": true,
+      "advanced": true
+    },
+    "tts.elevenlabs.modelId": {
+      "label": "ElevenLabs Model ID",
+      "advanced": true
+    },
+    "tts.elevenlabs.voiceId": {
+      "label": "ElevenLabs Voice ID",
+      "advanced": true
+    },
+    "tts.elevenlabs.apiKey": {
+      "label": "ElevenLabs API Key",
+      "sensitive": true,
+      "advanced": true
+    },
+    "tts.elevenlabs.baseUrl": {
+      "label": "ElevenLabs Base URL",
+      "advanced": true
+    },
+    "publicUrl": {
+      "label": "Public Webhook URL",
+      "advanced": true
+    },
+    "skipSignatureVerification": {
+      "label": "Skip Signature Verification",
+      "advanced": true
+    },
+    "store": {
+      "label": "Call Log Store Path",
+      "advanced": true
+    },
+    "responseModel": {
+      "label": "Response Model",
+      "advanced": true
+    },
+    "responseSystemPrompt": {
+      "label": "Response System Prompt",
+      "advanced": true
+    },
+    "responseTimeoutMs": {
+      "label": "Response Timeout (ms)",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "provider": {
+        "type": "string",
+        "enum": ["telnyx", "twilio", "plivo", "mock"]
+      },
+      "telnyx": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": "string"
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string"
+          }
+        }
+      },
+      "twilio": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "accountSid": {
+            "type": "string"
+          },
+          "authToken": {
+            "type": "string"
+          }
+        }
+      },
+      "plivo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "authId": {
+            "type": "string"
+          },
+          "authToken": {
+            "type": "string"
+          }
+        }
+      },
+      "fromNumber": {
+        "type": "string",
+        "pattern": "^\\+[1-9]\\d{1,14}$"
+      },
+      "toNumber": {
+        "type": "string",
+        "pattern": "^\\+[1-9]\\d{1,14}$"
+      },
+      "inboundPolicy": {
+        "type": "string",
+        "enum": ["disabled", "allowlist", "pairing", "open"]
+      },
+      "allowFrom": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^\\+[1-9]\\d{1,14}$"
+        }
+      },
+      "inboundGreeting": {
+        "type": "string"
+      },
+      "outbound": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "defaultMode": {
+            "type": "string",
+            "enum": ["notify", "conversation"]
+          },
+          "notifyHangupDelaySec": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "maxDurationSeconds": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "silenceTimeoutMs": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "transcriptTimeoutMs": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "ringTimeoutMs": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "maxConcurrentCalls": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "serve": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "port": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "bind": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        }
+      },
+      "tailscale": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["off", "serve", "funnel"]
+          },
+          "path": {
+            "type": "string"
+          }
+        }
+      },
+      "tunnel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["none", "ngrok", "tailscale-serve", "tailscale-funnel"]
+          },
+          "ngrokAuthToken": {
+            "type": "string"
+          },
+          "ngrokDomain": {
+            "type": "string"
+          },
+          "allowNgrokFreeTierLoopbackBypass": {
+            "type": "boolean"
+          }
+        }
+      },
+      "webhookSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowedHosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "trustForwardingHeaders": {
+            "type": "boolean"
+          },
+          "trustedProxyIPs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "streaming": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "sttProvider": {
+            "type": "string",
+            "enum": ["openai-realtime"]
+          },
+          "openaiApiKey": {
+            "type": "string"
+          },
+          "sttModel": {
+            "type": "string"
+          },
+          "silenceDurationMs": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "vadThreshold": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "streamPath": {
+            "type": "string"
+          },
+          "preStartTimeoutMs": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnections": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnectionsPerIp": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxConnections": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "publicUrl": {
+        "type": "string"
+      },
+      "skipSignatureVerification": {
+        "type": "boolean"
+      },
+      "stt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["openai"]
+          },
+          "model": {
+            "type": "string"
+          }
+        }
+      },
+      "tts": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "auto": {
+            "type": "string",
+            "enum": ["off", "always", "inbound", "tagged"]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["final", "all"]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "summaryModel": {
+            "type": "string"
+          },
+          "modelOverrides": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "allowText": {
+                "type": "boolean"
+              },
+              "allowProvider": {
+                "type": "boolean"
+              },
+              "allowVoice": {
+                "type": "boolean"
+              },
+              "allowModelId": {
+                "type": "boolean"
+              },
+              "allowVoiceSettings": {
+                "type": "boolean"
+              },
+              "allowNormalization": {
+                "type": "boolean"
+              },
+              "allowSeed": {
+                "type": "boolean"
+              }
+            }
+          },
+          "elevenlabs": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "apiKey": {
+                "type": "string"
+              },
+              "baseUrl": {
+                "type": "string"
+              },
+              "voiceId": {
+                "type": "string"
+              },
+              "modelId": {
+                "type": "string"
+              },
+              "seed": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4294967295
+              },
+              "applyTextNormalization": {
+                "type": "string",
+                "enum": ["auto", "on", "off"]
+              },
+              "languageCode": {
+                "type": "string"
+              },
+              "voiceSettings": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "stability": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "similarityBoost": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "style": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "useSpeakerBoost": {
+                    "type": "boolean"
+                  },
+                  "speed": {
+                    "type": "number",
+                    "minimum": 0.5,
+                    "maximum": 2
+                  }
+                }
+              }
+            }
+          },
+          "openai": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "apiKey": {
+                "type": "string"
+              },
+              "baseUrl": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "voice": {
+                "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4
+              },
+              "instructions": {
+                "type": "string"
+              }
+            }
+          },
+          "edge": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "string"
+              },
+              "lang": {
+                "type": "string"
+              },
+              "outputFormat": {
+                "type": "string"
+              },
+              "pitch": {
+                "type": "string"
+              },
+              "rate": {
+                "type": "string"
+              },
+              "volume": {
+                "type": "string"
+              },
+              "saveSubtitles": {
+                "type": "boolean"
+              },
+              "proxy": {
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 120000
+              }
+            }
+          },
+          "prefsPath": {
+            "type": "string"
+          },
+          "maxTextLength": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 120000
+          }
+        }
+      },
+      "store": {
+        "type": "string"
+      },
+      "responseModel": {
+        "type": "string"
+      },
+      "responseSystemPrompt": {
+        "type": "string"
+      },
+      "responseTimeoutMs": {
+        "type": "integer",
+        "minimum": 1
+      }
+    }
+  }
+}

--- a/dist-runtime/extensions/voice-call/package.json
+++ b/dist-runtime/extensions/voice-call/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/voice-call",
+  "version": "2026.3.14",
+  "description": "OpenClaw voice-call plugin",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "commander": "^14.0.3",
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/volcengine/index.js
+++ b/dist-runtime/extensions/volcengine/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/volcengine/index.js";
+import * as module from "../../../dist/extensions/volcengine/index.js";
+export default module.default;

--- a/dist-runtime/extensions/volcengine/openclaw.plugin.json
+++ b/dist-runtime/extensions/volcengine/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "volcengine",
+  "providers": ["volcengine", "volcengine-plan"],
+  "providerAuthEnvVars": {
+    "volcengine": ["VOLCANO_ENGINE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "volcengine",
+      "method": "api-key",
+      "choiceId": "volcengine-api-key",
+      "choiceLabel": "Volcano Engine API key",
+      "groupId": "volcengine",
+      "groupLabel": "Volcano Engine",
+      "groupHint": "API key",
+      "optionKey": "volcengineApiKey",
+      "cliFlag": "--volcengine-api-key",
+      "cliOption": "--volcengine-api-key <key>",
+      "cliDescription": "Volcano Engine API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/volcengine/package.json
+++ b/dist-runtime/extensions/volcengine/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/volcengine-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Volcengine provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/whatsapp/index.js
+++ b/dist-runtime/extensions/whatsapp/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/whatsapp/index.js";
+import * as module from "../../../dist/extensions/whatsapp/index.js";
+export default module.default;

--- a/dist-runtime/extensions/whatsapp/openclaw.plugin.json
+++ b/dist-runtime/extensions/whatsapp/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "whatsapp",
+  "channels": ["whatsapp"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/whatsapp/package.json
+++ b/dist-runtime/extensions/whatsapp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openclaw/whatsapp",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw WhatsApp channel plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js"
+  }
+}

--- a/dist-runtime/extensions/whatsapp/setup-entry.js
+++ b/dist-runtime/extensions/whatsapp/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/whatsapp/setup-entry.js";
+import * as module from "../../../dist/extensions/whatsapp/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/xai/index.js
+++ b/dist-runtime/extensions/xai/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/xai/index.js";
+import * as module from "../../../dist/extensions/xai/index.js";
+export default module.default;

--- a/dist-runtime/extensions/xai/openclaw.plugin.json
+++ b/dist-runtime/extensions/xai/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "xai",
+  "providers": ["xai"],
+  "providerAuthEnvVars": {
+    "xai": ["XAI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "xai",
+      "method": "api-key",
+      "choiceId": "xai-api-key",
+      "choiceLabel": "xAI API key",
+      "groupId": "xai",
+      "groupLabel": "xAI (Grok)",
+      "groupHint": "API key",
+      "optionKey": "xaiApiKey",
+      "cliFlag": "--xai-api-key",
+      "cliOption": "--xai-api-key <key>",
+      "cliDescription": "xAI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/xai/package.json
+++ b/dist-runtime/extensions/xai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/xai-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw xAI plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/xiaomi/index.js
+++ b/dist-runtime/extensions/xiaomi/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/xiaomi/index.js";
+import * as module from "../../../dist/extensions/xiaomi/index.js";
+export default module.default;

--- a/dist-runtime/extensions/xiaomi/openclaw.plugin.json
+++ b/dist-runtime/extensions/xiaomi/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "xiaomi",
+  "providers": ["xiaomi"],
+  "providerAuthEnvVars": {
+    "xiaomi": ["XIAOMI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "xiaomi",
+      "method": "api-key",
+      "choiceId": "xiaomi-api-key",
+      "choiceLabel": "Xiaomi API key",
+      "groupId": "xiaomi",
+      "groupLabel": "Xiaomi",
+      "groupHint": "API key",
+      "optionKey": "xiaomiApiKey",
+      "cliFlag": "--xiaomi-api-key",
+      "cliOption": "--xiaomi-api-key <key>",
+      "cliDescription": "Xiaomi API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/xiaomi/package.json
+++ b/dist-runtime/extensions/xiaomi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/xiaomi-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Xiaomi provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/zai/index.js
+++ b/dist-runtime/extensions/zai/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/zai/index.js";
+import * as module from "../../../dist/extensions/zai/index.js";
+export default module.default;

--- a/dist-runtime/extensions/zai/openclaw.plugin.json
+++ b/dist-runtime/extensions/zai/openclaw.plugin.json
@@ -1,0 +1,83 @@
+{
+  "id": "zai",
+  "providers": ["zai"],
+  "providerAuthEnvVars": {
+    "zai": ["ZAI_API_KEY", "Z_AI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "zai",
+      "method": "api-key",
+      "choiceId": "zai-api-key",
+      "choiceLabel": "Z.AI API key",
+      "groupId": "zai",
+      "groupLabel": "Z.AI",
+      "groupHint": "GLM Coding Plan / Global / CN",
+      "optionKey": "zaiApiKey",
+      "cliFlag": "--zai-api-key",
+      "cliOption": "--zai-api-key <key>",
+      "cliDescription": "Z.AI API key"
+    },
+    {
+      "provider": "zai",
+      "method": "coding-global",
+      "choiceId": "zai-coding-global",
+      "choiceLabel": "Coding-Plan-Global",
+      "choiceHint": "GLM Coding Plan Global (api.z.ai)",
+      "groupId": "zai",
+      "groupLabel": "Z.AI",
+      "groupHint": "GLM Coding Plan / Global / CN",
+      "optionKey": "zaiApiKey",
+      "cliFlag": "--zai-api-key",
+      "cliOption": "--zai-api-key <key>",
+      "cliDescription": "Z.AI API key"
+    },
+    {
+      "provider": "zai",
+      "method": "coding-cn",
+      "choiceId": "zai-coding-cn",
+      "choiceLabel": "Coding-Plan-CN",
+      "choiceHint": "GLM Coding Plan CN (open.bigmodel.cn)",
+      "groupId": "zai",
+      "groupLabel": "Z.AI",
+      "groupHint": "GLM Coding Plan / Global / CN",
+      "optionKey": "zaiApiKey",
+      "cliFlag": "--zai-api-key",
+      "cliOption": "--zai-api-key <key>",
+      "cliDescription": "Z.AI API key"
+    },
+    {
+      "provider": "zai",
+      "method": "global",
+      "choiceId": "zai-global",
+      "choiceLabel": "Global",
+      "choiceHint": "Z.AI Global (api.z.ai)",
+      "groupId": "zai",
+      "groupLabel": "Z.AI",
+      "groupHint": "GLM Coding Plan / Global / CN",
+      "optionKey": "zaiApiKey",
+      "cliFlag": "--zai-api-key",
+      "cliOption": "--zai-api-key <key>",
+      "cliDescription": "Z.AI API key"
+    },
+    {
+      "provider": "zai",
+      "method": "cn",
+      "choiceId": "zai-cn",
+      "choiceLabel": "CN",
+      "choiceHint": "Z.AI CN (open.bigmodel.cn)",
+      "groupId": "zai",
+      "groupLabel": "Z.AI",
+      "groupHint": "GLM Coding Plan / Global / CN",
+      "optionKey": "zaiApiKey",
+      "cliFlag": "--zai-api-key",
+      "cliOption": "--zai-api-key <key>",
+      "cliDescription": "Z.AI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/zai/package.json
+++ b/dist-runtime/extensions/zai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/zai-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Z.AI provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/dist-runtime/extensions/zalo/index.js
+++ b/dist-runtime/extensions/zalo/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/zalo/index.js";
+import * as module from "../../../dist/extensions/zalo/index.js";
+export default module.default;

--- a/dist-runtime/extensions/zalo/openclaw.plugin.json
+++ b/dist-runtime/extensions/zalo/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "zalo",
+  "channels": ["zalo"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/zalo/package.json
+++ b/dist-runtime/extensions/zalo/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@openclaw/zalo",
+  "version": "2026.3.14",
+  "description": "OpenClaw Zalo channel plugin",
+  "type": "module",
+  "dependencies": {
+    "undici": "7.24.1",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "zalo",
+      "label": "Zalo",
+      "selectionLabel": "Zalo (Bot API)",
+      "docsPath": "/channels/zalo",
+      "docsLabel": "zalo",
+      "blurb": "Vietnam-focused messaging platform with Bot API.",
+      "aliases": [
+        "zl"
+      ],
+      "order": 80,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/zalo",
+      "localPath": "extensions/zalo",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/dist-runtime/extensions/zalo/setup-entry.js
+++ b/dist-runtime/extensions/zalo/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/zalo/setup-entry.js";
+import * as module from "../../../dist/extensions/zalo/setup-entry.js";
+export default module.default;

--- a/dist-runtime/extensions/zalouser/index.js
+++ b/dist-runtime/extensions/zalouser/index.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/zalouser/index.js";
+import * as module from "../../../dist/extensions/zalouser/index.js";
+export default module.default;

--- a/dist-runtime/extensions/zalouser/openclaw.plugin.json
+++ b/dist-runtime/extensions/zalouser/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "zalouser",
+  "channels": ["zalouser"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/dist-runtime/extensions/zalouser/package.json
+++ b/dist-runtime/extensions/zalouser/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@openclaw/zalouser",
+  "version": "2026.3.14",
+  "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "zca-js": "2.1.1",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "zalouser",
+      "label": "Zalo Personal",
+      "selectionLabel": "Zalo (Personal Account)",
+      "docsPath": "/channels/zalouser",
+      "docsLabel": "zalouser",
+      "blurb": "Zalo personal account via QR code login.",
+      "aliases": [
+        "zlu"
+      ],
+      "order": 85,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/zalouser",
+      "localPath": "extensions/zalouser",
+      "defaultChoice": "npm"
+    },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "zca-js"
+      ]
+    }
+  }
+}

--- a/dist-runtime/extensions/zalouser/setup-entry.js
+++ b/dist-runtime/extensions/zalouser/setup-entry.js
@@ -1,0 +1,3 @@
+export * from "../../../dist/extensions/zalouser/setup-entry.js";
+import * as module from "../../../dist/extensions/zalouser/setup-entry.js";
+export default module.default;

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -27,6 +27,7 @@ export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    before: Type.Optional(Type.String()), // cursor for pagination
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -932,14 +932,27 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
+    // chat.history pagination
+    const { sessionKey, limit, before } = params as {
       sessionKey: string;
       limit?: number;
+      before?: string;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
-    const rawMessages =
+    let rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+
+    // Pagination: filter messages before the cursor
+    if (before) {
+      const beforeTs = parseInt(before, 10);
+      if (!isNaN(beforeTs)) {
+        rawMessages = rawMessages.filter((msg: { timestamp?: number }) => {
+          const ts = (msg as { timestamp?: number }).timestamp;
+          return ts && ts < beforeTs;
+        });
+      }
+    }
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
@@ -975,6 +988,12 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+
+    // Generate cursor and hasMore for pagination
+    const hasMore = rawMessages.length > sliced.length;
+    const oldestMessage = sliced.length > 0 ? (sliced[0] as { timestamp?: number }) : null;
+    const cursor = oldestMessage?.timestamp ? String(oldestMessage.timestamp) : null;
+
     respond(true, {
       sessionKey,
       sessionId,
@@ -982,6 +1001,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,
+      cursor,
+      hasMore,
     });
   },
   "chat.abort": ({ params, respond, context, client }) => {

--- a/src/gateway/server-methods/chat.ts.bak
+++ b/src/gateway/server-methods/chat.ts.bak
@@ -1,0 +1,1523 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveThinkingDefault } from "../../agents/model-selection.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
+import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
+import { resolveSessionFilePath } from "../../config/sessions.js";
+import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
+import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import {
+  stripInlineDirectiveTagsForDisplay,
+  stripInlineDirectiveTagsFromMessageForDisplay,
+} from "../../utils/directive-tags.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isGatewayCliClient,
+  isWebchatClient,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
+import {
+  abortChatRunById,
+  type ChatAbortControllerEntry,
+  type ChatAbortOps,
+  isChatStopCommandText,
+  resolveChatRunExpiresAtMs,
+} from "../chat-abort.js";
+import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
+import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import { ADMIN_SCOPE } from "../method-scopes.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  hasGatewayClientCap,
+} from "../protocol/client-info.js";
+import {
+  ErrorCodes,
+  errorShape,
+  formatValidationErrors,
+  validateChatAbortParams,
+  validateChatHistoryParams,
+  validateChatInjectParams,
+  validateChatSendParams,
+} from "../protocol/index.js";
+import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../protocol/schema/primitives.js";
+import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
+import {
+  capArrayByJsonBytes,
+  loadSessionEntry,
+  readSessionMessages,
+  resolveSessionModelRef,
+} from "../session-utils.js";
+import { formatForLog } from "../ws-log.js";
+import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
+import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
+import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+  GatewayRequestHandlers,
+} from "./types.js";
+
+type TranscriptAppendResult = {
+  ok: boolean;
+  messageId?: string;
+  message?: Record<string, unknown>;
+  error?: string;
+};
+
+type AbortOrigin = "rpc" | "stop-command";
+
+type AbortedPartialSnapshot = {
+  runId: string;
+  sessionId: string;
+  text: string;
+  abortOrigin: AbortOrigin;
+};
+
+type ChatAbortRequester = {
+  connId?: string;
+  deviceId?: string;
+  isAdmin: boolean;
+};
+
+const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
+const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
+const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+let chatHistoryPlaceholderEmitCount = 0;
+const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
+  "main",
+  "direct",
+  "dm",
+  "group",
+  "channel",
+  "cron",
+  "run",
+  "subagent",
+  "acp",
+  "thread",
+  "topic",
+]);
+const CHANNEL_SCOPED_SESSION_SHAPES = new Set(["direct", "dm", "group", "channel"]);
+
+type ChatSendDeliveryEntry = {
+  deliveryContext?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
+  lastChannel?: string;
+  lastTo?: string;
+  lastAccountId?: string;
+  lastThreadId?: string | number;
+};
+
+type ChatSendOriginatingRoute = {
+  originatingChannel: string;
+  originatingTo?: string;
+  accountId?: string;
+  messageThreadId?: string | number;
+  explicitDeliverRoute: boolean;
+};
+
+function resolveChatSendOriginatingRoute(params: {
+  client?: { mode?: string | null; id?: string | null } | null;
+  deliver?: boolean;
+  entry?: ChatSendDeliveryEntry;
+  hasConnectedClient?: boolean;
+  mainKey?: string;
+  sessionKey: string;
+}): ChatSendOriginatingRoute {
+  const shouldDeliverExternally = params.deliver === true;
+  if (!shouldDeliverExternally) {
+    return {
+      originatingChannel: INTERNAL_MESSAGE_CHANNEL,
+      explicitDeliverRoute: false,
+    };
+  }
+
+  const routeChannelCandidate = normalizeMessageChannel(
+    params.entry?.deliveryContext?.channel ?? params.entry?.lastChannel,
+  );
+  const routeToCandidate = params.entry?.deliveryContext?.to ?? params.entry?.lastTo;
+  const routeAccountIdCandidate =
+    params.entry?.deliveryContext?.accountId ?? params.entry?.lastAccountId ?? undefined;
+  const routeThreadIdCandidate =
+    params.entry?.deliveryContext?.threadId ?? params.entry?.lastThreadId;
+  if (params.sessionKey.length > CHAT_SEND_SESSION_KEY_MAX_LENGTH) {
+    return {
+      originatingChannel: INTERNAL_MESSAGE_CHANNEL,
+      explicitDeliverRoute: false,
+    };
+  }
+
+  const parsedSessionKey = parseAgentSessionKey(params.sessionKey);
+  const sessionScopeParts = (parsedSessionKey?.rest ?? params.sessionKey)
+    .split(":", 3)
+    .filter(Boolean);
+  const sessionScopeHead = sessionScopeParts[0];
+  const sessionChannelHint = normalizeMessageChannel(sessionScopeHead);
+  const normalizedSessionScopeHead = (sessionScopeHead ?? "").trim().toLowerCase();
+  const sessionPeerShapeCandidates = [sessionScopeParts[1], sessionScopeParts[2]]
+    .map((part) => (part ?? "").trim().toLowerCase())
+    .filter(Boolean);
+  const isChannelAgnosticSessionScope = CHANNEL_AGNOSTIC_SESSION_SCOPES.has(
+    normalizedSessionScopeHead,
+  );
+  const isChannelScopedSession = sessionPeerShapeCandidates.some((part) =>
+    CHANNEL_SCOPED_SESSION_SHAPES.has(part),
+  );
+  const hasLegacyChannelPeerShape =
+    !isChannelScopedSession &&
+    typeof sessionScopeParts[1] === "string" &&
+    sessionChannelHint === routeChannelCandidate;
+  const isFromWebchatClient = isWebchatClient(params.client);
+  const isFromGatewayCliClient = isGatewayCliClient(params.client);
+  const hasClientMetadata =
+    (typeof params.client?.mode === "string" && params.client.mode.trim().length > 0) ||
+    (typeof params.client?.id === "string" && params.client.id.trim().length > 0);
+  const configuredMainKey = (params.mainKey ?? "main").trim().toLowerCase();
+  const isConfiguredMainSessionScope =
+    normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
+  const canInheritConfiguredMainRoute =
+    isConfiguredMainSessionScope &&
+    params.hasConnectedClient &&
+    (isFromGatewayCliClient || !hasClientMetadata);
+
+  // Webchat clients never inherit external delivery routes. Configured-main
+  // sessions are stricter than channel-scoped sessions: only CLI callers, or
+  // legacy callers with no client metadata, may inherit the last external route.
+  const canInheritDeliverableRoute = Boolean(
+    !isFromWebchatClient &&
+    sessionChannelHint &&
+    sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
+    ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
+      canInheritConfiguredMainRoute),
+  );
+  const hasDeliverableRoute =
+    canInheritDeliverableRoute &&
+    routeChannelCandidate &&
+    routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
+    typeof routeToCandidate === "string" &&
+    routeToCandidate.trim().length > 0;
+
+  if (!hasDeliverableRoute) {
+    return {
+      originatingChannel: INTERNAL_MESSAGE_CHANNEL,
+      explicitDeliverRoute: false,
+    };
+  }
+
+  return {
+    originatingChannel: routeChannelCandidate,
+    originatingTo: routeToCandidate,
+    accountId: routeAccountIdCandidate,
+    messageThreadId: routeThreadIdCandidate,
+    explicitDeliverRoute: true,
+  };
+}
+
+function stripDisallowedChatControlChars(message: string): string {
+  let output = "";
+  for (const char of message) {
+    const code = char.charCodeAt(0);
+    if (code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127)) {
+      output += char;
+    }
+  }
+  return output;
+}
+
+export function sanitizeChatSendMessageInput(
+  message: string,
+): { ok: true; message: string } | { ok: false; error: string } {
+  const normalized = message.normalize("NFC");
+  if (normalized.includes("\u0000")) {
+    return { ok: false, error: "message must not contain null bytes" };
+  }
+  return { ok: true, message: stripDisallowedChatControlChars(normalized) };
+}
+
+function normalizeOptionalChatSystemReceipt(
+  value: unknown,
+): { ok: true; receipt?: string } | { ok: false; error: string } {
+  if (value == null) {
+    return { ok: true };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, error: "systemProvenanceReceipt must be a string" };
+  }
+  const sanitized = sanitizeChatSendMessageInput(value);
+  if (!sanitized.ok) {
+    return sanitized;
+  }
+  const receipt = sanitized.message.trim();
+  return { ok: true, receipt: receipt || undefined };
+}
+
+function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): boolean {
+  const info = client?.connect?.client;
+  return (
+    info?.id === GATEWAY_CLIENT_NAMES.CLI &&
+    info?.mode === GATEWAY_CLIENT_MODES.CLI &&
+    info?.displayName === "ACP" &&
+    info?.version === "acp"
+  );
+}
+
+function truncateChatHistoryText(text: string): { text: string; truncated: boolean } {
+  if (text.length <= CHAT_HISTORY_TEXT_MAX_CHARS) {
+    return { text, truncated: false };
+  }
+  return {
+    text: `${text.slice(0, CHAT_HISTORY_TEXT_MAX_CHARS)}\n...(truncated)...`,
+    truncated: true,
+  };
+}
+
+function sanitizeChatHistoryContentBlock(block: unknown): { block: unknown; changed: boolean } {
+  if (!block || typeof block !== "object") {
+    return { block, changed: false };
+  }
+  const entry = { ...(block as Record<string, unknown>) };
+  let changed = false;
+  if (typeof entry.text === "string") {
+    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const res = truncateChatHistoryText(stripped.text);
+    entry.text = res.text;
+    changed ||= stripped.changed || res.truncated;
+  }
+  if (typeof entry.partialJson === "string") {
+    const res = truncateChatHistoryText(entry.partialJson);
+    entry.partialJson = res.text;
+    changed ||= res.truncated;
+  }
+  if (typeof entry.arguments === "string") {
+    const res = truncateChatHistoryText(entry.arguments);
+    entry.arguments = res.text;
+    changed ||= res.truncated;
+  }
+  if (typeof entry.thinking === "string") {
+    const res = truncateChatHistoryText(entry.thinking);
+    entry.thinking = res.text;
+    changed ||= res.truncated;
+  }
+  if ("thinkingSignature" in entry) {
+    delete entry.thinkingSignature;
+    changed = true;
+  }
+  const type = typeof entry.type === "string" ? entry.type : "";
+  if (type === "image" && typeof entry.data === "string") {
+    const bytes = Buffer.byteLength(entry.data, "utf8");
+    delete entry.data;
+    entry.omitted = true;
+    entry.bytes = bytes;
+    changed = true;
+  }
+  return { block: changed ? entry : block, changed };
+}
+
+/**
+ * Validate that a value is a finite number, returning undefined otherwise.
+ */
+function toFiniteNumber(x: unknown): number | undefined {
+  return typeof x === "number" && Number.isFinite(x) ? x : undefined;
+}
+
+/**
+ * Sanitize usage metadata to ensure only finite numeric fields are included.
+ * Prevents UI crashes from malformed transcript JSON.
+ */
+function sanitizeUsage(raw: unknown): Record<string, number> | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const u = raw as Record<string, unknown>;
+  const out: Record<string, number> = {};
+
+  // Whitelist known usage fields and validate they're finite numbers
+  const knownFields = [
+    "input",
+    "output",
+    "totalTokens",
+    "inputTokens",
+    "outputTokens",
+    "cacheRead",
+    "cacheWrite",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+  ];
+
+  for (const k of knownFields) {
+    const n = toFiniteNumber(u[k]);
+    if (n !== undefined) {
+      out[k] = n;
+    }
+  }
+
+  // Preserve nested usage.cost when present
+  if ("cost" in u && u.cost != null && typeof u.cost === "object") {
+    const sanitizedCost = sanitizeCost(u.cost);
+    if (sanitizedCost) {
+      (out as Record<string, unknown>).cost = sanitizedCost;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Sanitize cost metadata to ensure only finite numeric fields are included.
+ * Prevents UI crashes from calling .toFixed() on non-numbers.
+ */
+function sanitizeCost(raw: unknown): { total?: number } | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const c = raw as Record<string, unknown>;
+  const total = toFiniteNumber(c.total);
+  return total !== undefined ? { total } : undefined;
+}
+
+function sanitizeChatHistoryMessage(message: unknown): { message: unknown; changed: boolean } {
+  if (!message || typeof message !== "object") {
+    return { message, changed: false };
+  }
+  const entry = { ...(message as Record<string, unknown>) };
+  let changed = false;
+
+  if ("details" in entry) {
+    delete entry.details;
+    changed = true;
+  }
+
+  // Keep usage/cost so the chat UI can render per-message token and cost badges.
+  // Only retain usage/cost on assistant messages and validate numeric fields to prevent UI crashes.
+  if (entry.role !== "assistant") {
+    if ("usage" in entry) {
+      delete entry.usage;
+      changed = true;
+    }
+    if ("cost" in entry) {
+      delete entry.cost;
+      changed = true;
+    }
+  } else {
+    // Validate and sanitize usage/cost for assistant messages
+    if ("usage" in entry) {
+      const sanitized = sanitizeUsage(entry.usage);
+      if (sanitized) {
+        entry.usage = sanitized;
+      } else {
+        delete entry.usage;
+      }
+      changed = true;
+    }
+    if ("cost" in entry) {
+      const sanitized = sanitizeCost(entry.cost);
+      if (sanitized) {
+        entry.cost = sanitized;
+      } else {
+        delete entry.cost;
+      }
+      changed = true;
+    }
+  }
+
+  if (typeof entry.content === "string") {
+    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const res = truncateChatHistoryText(stripped.text);
+    entry.content = res.text;
+    changed ||= stripped.changed || res.truncated;
+  } else if (Array.isArray(entry.content)) {
+    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block));
+    if (updated.some((item) => item.changed)) {
+      entry.content = updated.map((item) => item.block);
+      changed = true;
+    }
+  }
+
+  if (typeof entry.text === "string") {
+    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const res = truncateChatHistoryText(stripped.text);
+    entry.text = res.text;
+    changed ||= stripped.changed || res.truncated;
+  }
+
+  return { message: changed ? entry : message, changed };
+}
+
+/**
+ * Extract the visible text from an assistant history message for silent-token checks.
+ * Returns `undefined` for non-assistant messages or messages with no extractable text.
+ * When `entry.text` is present it takes precedence over `entry.content` to avoid
+ * dropping messages that carry real text alongside a stale `content: "NO_REPLY"`.
+ */
+function extractAssistantTextForSilentCheck(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const entry = message as Record<string, unknown>;
+  if (entry.role !== "assistant") {
+    return undefined;
+  }
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  if (!Array.isArray(entry.content) || entry.content.length === 0) {
+    return undefined;
+  }
+
+  const texts: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      return undefined;
+    }
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type !== "text" || typeof typed.text !== "string") {
+      return undefined;
+    }
+    texts.push(typed.text);
+  }
+  return texts.length > 0 ? texts.join("\n") : undefined;
+}
+
+function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  let changed = false;
+  const next: unknown[] = [];
+  for (const message of messages) {
+    const res = sanitizeChatHistoryMessage(message);
+    changed ||= res.changed;
+    // Drop assistant messages whose entire visible text is the silent reply token.
+    const text = extractAssistantTextForSilentCheck(res.message);
+    if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+      changed = true;
+      continue;
+    }
+    next.push(res.message);
+  }
+  return changed ? next : messages;
+}
+
+function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unknown> {
+  const role =
+    message &&
+    typeof message === "object" &&
+    typeof (message as { role?: unknown }).role === "string"
+      ? (message as { role: string }).role
+      : "assistant";
+  const timestamp =
+    message &&
+    typeof message === "object" &&
+    typeof (message as { timestamp?: unknown }).timestamp === "number"
+      ? (message as { timestamp: number }).timestamp
+      : Date.now();
+  return {
+    role,
+    timestamp,
+    content: [{ type: "text", text: CHAT_HISTORY_OVERSIZED_PLACEHOLDER }],
+    __openclaw: { truncated: true, reason: "oversized" },
+  };
+}
+
+function replaceOversizedChatHistoryMessages(params: {
+  messages: unknown[];
+  maxSingleMessageBytes: number;
+}): { messages: unknown[]; replacedCount: number } {
+  const { messages, maxSingleMessageBytes } = params;
+  if (messages.length === 0) {
+    return { messages, replacedCount: 0 };
+  }
+  let replacedCount = 0;
+  const next = messages.map((message) => {
+    if (jsonUtf8Bytes(message) <= maxSingleMessageBytes) {
+      return message;
+    }
+    replacedCount += 1;
+    return buildOversizedHistoryPlaceholder(message);
+  });
+  return { messages: replacedCount > 0 ? next : messages, replacedCount };
+}
+
+function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
+  messages: unknown[];
+  placeholderCount: number;
+} {
+  const { messages, maxBytes } = params;
+  if (messages.length === 0) {
+    return { messages, placeholderCount: 0 };
+  }
+  if (jsonUtf8Bytes(messages) <= maxBytes) {
+    return { messages, placeholderCount: 0 };
+  }
+  const last = messages.at(-1);
+  if (last && jsonUtf8Bytes([last]) <= maxBytes) {
+    return { messages: [last], placeholderCount: 0 };
+  }
+  const placeholder = buildOversizedHistoryPlaceholder(last);
+  if (jsonUtf8Bytes([placeholder]) <= maxBytes) {
+    return { messages: [placeholder], placeholderCount: 1 };
+  }
+  return { messages: [], placeholderCount: 0 };
+}
+
+function resolveTranscriptPath(params: {
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+}): string | null {
+  const { sessionId, storePath, sessionFile, agentId } = params;
+  if (!storePath && !sessionFile) {
+    return null;
+  }
+  try {
+    const sessionsDir = storePath ? path.dirname(storePath) : undefined;
+    return resolveSessionFilePath(
+      sessionId,
+      sessionFile ? { sessionFile } : undefined,
+      sessionsDir || agentId ? { sessionsDir, agentId } : undefined,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function ensureTranscriptFile(params: { transcriptPath: string; sessionId: string }): {
+  ok: boolean;
+  error?: string;
+} {
+  if (fs.existsSync(params.transcriptPath)) {
+    return { ok: true };
+  }
+  try {
+    fs.mkdirSync(path.dirname(params.transcriptPath), { recursive: true });
+    const header = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: params.sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function transcriptHasIdempotencyKey(transcriptPath: string, idempotencyKey: string): boolean {
+  try {
+    const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      const parsed = JSON.parse(line) as { message?: { idempotencyKey?: unknown } };
+      if (parsed?.message?.idempotencyKey === idempotencyKey) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function appendAssistantTranscriptMessage(params: {
+  message: string;
+  label?: string;
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+  createIfMissing?: boolean;
+  idempotencyKey?: string;
+  abortMeta?: {
+    aborted: true;
+    origin: AbortOrigin;
+    runId: string;
+  };
+}): TranscriptAppendResult {
+  const transcriptPath = resolveTranscriptPath({
+    sessionId: params.sessionId,
+    storePath: params.storePath,
+    sessionFile: params.sessionFile,
+    agentId: params.agentId,
+  });
+  if (!transcriptPath) {
+    return { ok: false, error: "transcript path not resolved" };
+  }
+
+  if (!fs.existsSync(transcriptPath)) {
+    if (!params.createIfMissing) {
+      return { ok: false, error: "transcript file not found" };
+    }
+    const ensured = ensureTranscriptFile({
+      transcriptPath,
+      sessionId: params.sessionId,
+    });
+    if (!ensured.ok) {
+      return { ok: false, error: ensured.error ?? "failed to create transcript file" };
+    }
+  }
+
+  if (params.idempotencyKey && transcriptHasIdempotencyKey(transcriptPath, params.idempotencyKey)) {
+    return { ok: true };
+  }
+
+  return appendInjectedAssistantMessageToTranscript({
+    transcriptPath,
+    message: params.message,
+    label: params.label,
+    idempotencyKey: params.idempotencyKey,
+    abortMeta: params.abortMeta,
+  });
+}
+
+function collectSessionAbortPartials(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  chatRunBuffers: Map<string, string>;
+  runIds: ReadonlySet<string>;
+  abortOrigin: AbortOrigin;
+}): AbortedPartialSnapshot[] {
+  const out: AbortedPartialSnapshot[] = [];
+  for (const [runId, active] of params.chatAbortControllers) {
+    if (!params.runIds.has(runId)) {
+      continue;
+    }
+    const text = params.chatRunBuffers.get(runId);
+    if (!text || !text.trim()) {
+      continue;
+    }
+    out.push({
+      runId,
+      sessionId: active.sessionId,
+      text,
+      abortOrigin: params.abortOrigin,
+    });
+  }
+  return out;
+}
+
+function persistAbortedPartials(params: {
+  context: Pick<GatewayRequestContext, "logGateway">;
+  sessionKey: string;
+  snapshots: AbortedPartialSnapshot[];
+}) {
+  if (params.snapshots.length === 0) {
+    return;
+  }
+  const { storePath, entry } = loadSessionEntry(params.sessionKey);
+  for (const snapshot of params.snapshots) {
+    const sessionId = entry?.sessionId ?? snapshot.sessionId ?? snapshot.runId;
+    const appended = appendAssistantTranscriptMessage({
+      message: snapshot.text,
+      sessionId,
+      storePath,
+      sessionFile: entry?.sessionFile,
+      createIfMissing: true,
+      idempotencyKey: `${snapshot.runId}:assistant`,
+      abortMeta: {
+        aborted: true,
+        origin: snapshot.abortOrigin,
+        runId: snapshot.runId,
+      },
+    });
+    if (!appended.ok) {
+      params.context.logGateway.warn(
+        `chat.abort transcript append failed: ${appended.error ?? "unknown error"}`,
+      );
+    }
+  }
+}
+
+function createChatAbortOps(context: GatewayRequestContext): ChatAbortOps {
+  return {
+    chatAbortControllers: context.chatAbortControllers,
+    chatRunBuffers: context.chatRunBuffers,
+    chatDeltaSentAt: context.chatDeltaSentAt,
+    chatAbortedRuns: context.chatAbortedRuns,
+    removeChatRun: context.removeChatRun,
+    agentRunSeq: context.agentRunSeq,
+    broadcast: context.broadcast,
+    nodeSendToSession: context.nodeSendToSession,
+  };
+}
+
+function normalizeOptionalText(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function resolveChatAbortRequester(
+  client: GatewayRequestHandlerOptions["client"],
+): ChatAbortRequester {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  return {
+    connId: normalizeOptionalText(client?.connId),
+    deviceId: normalizeOptionalText(client?.connect?.device?.id),
+    isAdmin: scopes.includes(ADMIN_SCOPE),
+  };
+}
+
+function canRequesterAbortChatRun(
+  entry: ChatAbortControllerEntry,
+  requester: ChatAbortRequester,
+): boolean {
+  if (requester.isAdmin) {
+    return true;
+  }
+  const ownerDeviceId = normalizeOptionalText(entry.ownerDeviceId);
+  const ownerConnId = normalizeOptionalText(entry.ownerConnId);
+  if (!ownerDeviceId && !ownerConnId) {
+    return true;
+  }
+  if (ownerDeviceId && requester.deviceId && ownerDeviceId === requester.deviceId) {
+    return true;
+  }
+  if (ownerConnId && requester.connId && ownerConnId === requester.connId) {
+    return true;
+  }
+  return false;
+}
+
+function resolveAuthorizedRunIdsForSession(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  sessionKey: string;
+  requester: ChatAbortRequester;
+}) {
+  const authorizedRunIds: string[] = [];
+  let matchedSessionRuns = 0;
+  for (const [runId, active] of params.chatAbortControllers) {
+    if (active.sessionKey !== params.sessionKey) {
+      continue;
+    }
+    matchedSessionRuns += 1;
+    if (canRequesterAbortChatRun(active, params.requester)) {
+      authorizedRunIds.push(runId);
+    }
+  }
+  return {
+    matchedSessionRuns,
+    authorizedRunIds,
+  };
+}
+
+function abortChatRunsForSessionKeyWithPartials(params: {
+  context: GatewayRequestContext;
+  ops: ChatAbortOps;
+  sessionKey: string;
+  abortOrigin: AbortOrigin;
+  stopReason?: string;
+  requester: ChatAbortRequester;
+}) {
+  const { matchedSessionRuns, authorizedRunIds } = resolveAuthorizedRunIdsForSession({
+    chatAbortControllers: params.context.chatAbortControllers,
+    sessionKey: params.sessionKey,
+    requester: params.requester,
+  });
+  if (authorizedRunIds.length === 0) {
+    return {
+      aborted: false,
+      runIds: [],
+      unauthorized: matchedSessionRuns > 0,
+    };
+  }
+  const authorizedRunIdSet = new Set(authorizedRunIds);
+  const snapshots = collectSessionAbortPartials({
+    chatAbortControllers: params.context.chatAbortControllers,
+    chatRunBuffers: params.context.chatRunBuffers,
+    runIds: authorizedRunIdSet,
+    abortOrigin: params.abortOrigin,
+  });
+  const runIds: string[] = [];
+  for (const runId of authorizedRunIds) {
+    const res = abortChatRunById(params.ops, {
+      runId,
+      sessionKey: params.sessionKey,
+      stopReason: params.stopReason,
+    });
+    if (res.aborted) {
+      runIds.push(runId);
+    }
+  }
+  const res = { aborted: runIds.length > 0, runIds, unauthorized: false };
+  if (res.aborted) {
+    persistAbortedPartials({
+      context: params.context,
+      sessionKey: params.sessionKey,
+      snapshots,
+    });
+  }
+  return res;
+}
+
+function nextChatSeq(context: { agentRunSeq: Map<string, number> }, runId: string) {
+  const next = (context.agentRunSeq.get(runId) ?? 0) + 1;
+  context.agentRunSeq.set(runId, next);
+  return next;
+}
+
+function broadcastChatFinal(params: {
+  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
+  runId: string;
+  sessionKey: string;
+  message?: Record<string, unknown>;
+}) {
+  const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
+  const strippedEnvelopeMessage = stripEnvelopeFromMessage(params.message) as
+    | Record<string, unknown>
+    | undefined;
+  const payload = {
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    seq,
+    state: "final" as const,
+    message: stripInlineDirectiveTagsFromMessageForDisplay(strippedEnvelopeMessage),
+  };
+  params.context.broadcast("chat", payload);
+  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
+  params.context.agentRunSeq.delete(params.runId);
+}
+
+function broadcastChatError(params: {
+  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
+  runId: string;
+  sessionKey: string;
+  errorMessage?: string;
+}) {
+  const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
+  const payload = {
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    seq,
+    state: "error" as const,
+    errorMessage: params.errorMessage,
+  };
+  params.context.broadcast("chat", payload);
+  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
+  params.context.agentRunSeq.delete(params.runId);
+}
+
+export const chatHandlers: GatewayRequestHandlers = {
+  "chat.history": async ({ params, respond, context }) => {
+    if (!validateChatHistoryParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid chat.history params: ${formatValidationErrors(validateChatHistoryParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const { sessionKey, limit, before } = params as {
+      sessionKey: string;
+      limit?: number;
+      before?: string;
+    };
+    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+    const sessionId = entry?.sessionId;
+    let rawMessages =
+      sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+
+    // Pagination: filter messages before the cursor
+    if (before) {
+      const beforeTs = parseInt(before, 10);
+      if (!isNaN(beforeTs)) {
+        rawMessages = rawMessages.filter((msg: { timestamp?: number }) => {
+          const ts = (msg as { timestamp?: number }).timestamp;
+          return ts && ts < beforeTs;
+        });
+      }
+    }
+    const hardMax = 1000;
+    const defaultLimit = 200;
+    const requested = typeof limit === "number" ? limit : defaultLimit;
+    const max = Math.min(hardMax, requested);
+    const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+    const sanitized = stripEnvelopeFromMessages(sliced);
+    const normalized = sanitizeChatHistoryMessages(sanitized);
+    const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
+    const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
+    const replaced = replaceOversizedChatHistoryMessages({
+      messages: normalized,
+      maxSingleMessageBytes: perMessageHardCap,
+    });
+    const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
+    const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+    const placeholderCount = replaced.replacedCount + bounded.placeholderCount;
+    if (placeholderCount > 0) {
+      chatHistoryPlaceholderEmitCount += placeholderCount;
+      context.logGateway.debug(
+        `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
+      );
+    }
+    let thinkingLevel = entry?.thinkingLevel;
+    if (!thinkingLevel) {
+      const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const { provider, model } = resolveSessionModelRef(cfg, entry, sessionAgentId);
+      const catalog = await context.loadGatewayModelCatalog();
+      thinkingLevel = resolveThinkingDefault({
+        cfg,
+        provider,
+        model,
+        catalog,
+      });
+    }
+    const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+
+    // Generate cursor and hasMore for pagination
+    const hasMore = rawMessages.length > sliced.length;
+    const oldestMessage = sliced.length > 0 ? (sliced[0] as { timestamp?: number }) : null;
+    const cursor = oldestMessage?.timestamp ? String(oldestMessage.timestamp) : null;
+
+    respond(true, {
+      sessionKey,
+      sessionId,
+      messages: bounded.messages,
+      thinkingLevel,
+      fastMode: entry?.fastMode,
+      verboseLevel,
+      cursor,
+      hasMore,
+    });
+  },
+  "chat.abort": ({ params, respond, context, client }) => {
+    if (!validateChatAbortParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid chat.abort params: ${formatValidationErrors(validateChatAbortParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const { sessionKey: rawSessionKey, runId } = params as {
+      sessionKey: string;
+      runId?: string;
+    };
+
+    const ops = createChatAbortOps(context);
+    const requester = resolveChatAbortRequester(client);
+
+    if (!runId) {
+      const res = abortChatRunsForSessionKeyWithPartials({
+        context,
+        ops,
+        sessionKey: rawSessionKey,
+        abortOrigin: "rpc",
+        stopReason: "rpc",
+        requester,
+      });
+      if (res.unauthorized) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+        return;
+      }
+      respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
+      return;
+    }
+
+    const active = context.chatAbortControllers.get(runId);
+    if (!active) {
+      respond(true, { ok: true, aborted: false, runIds: [] });
+      return;
+    }
+    if (active.sessionKey !== rawSessionKey) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match sessionKey"),
+      );
+      return;
+    }
+    if (!canRequesterAbortChatRun(active, requester)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+      return;
+    }
+
+    const partialText = context.chatRunBuffers.get(runId);
+    const res = abortChatRunById(ops, {
+      runId,
+      sessionKey: rawSessionKey,
+      stopReason: "rpc",
+    });
+    if (res.aborted && partialText && partialText.trim()) {
+      persistAbortedPartials({
+        context,
+        sessionKey: rawSessionKey,
+        snapshots: [
+          {
+            runId,
+            sessionId: active.sessionId,
+            text: partialText,
+            abortOrigin: "rpc",
+          },
+        ],
+      });
+    }
+    respond(true, {
+      ok: true,
+      aborted: res.aborted,
+      runIds: res.aborted ? [runId] : [],
+    });
+  },
+  "chat.send": async ({ params, respond, context, client }) => {
+    if (!validateChatSendParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid chat.send params: ${formatValidationErrors(validateChatSendParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as {
+      sessionKey: string;
+      message: string;
+      thinking?: string;
+      deliver?: boolean;
+      attachments?: Array<{
+        type?: string;
+        mimeType?: string;
+        fileName?: string;
+        content?: unknown;
+      }>;
+      timeoutMs?: number;
+      systemInputProvenance?: InputProvenance;
+      systemProvenanceReceipt?: string;
+      idempotencyKey: string;
+    };
+    if ((p.systemInputProvenance || p.systemProvenanceReceipt) && !isAcpBridgeClient(client)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "system provenance fields are reserved for the ACP bridge",
+        ),
+      );
+      return;
+    }
+    const sanitizedMessageResult = sanitizeChatSendMessageInput(p.message);
+    if (!sanitizedMessageResult.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, sanitizedMessageResult.error),
+      );
+      return;
+    }
+    const systemReceiptResult = normalizeOptionalChatSystemReceipt(p.systemProvenanceReceipt);
+    if (!systemReceiptResult.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, systemReceiptResult.error));
+      return;
+    }
+    const inboundMessage = sanitizedMessageResult.message;
+    const systemInputProvenance = normalizeInputProvenance(p.systemInputProvenance);
+    const systemProvenanceReceipt = systemReceiptResult.receipt;
+    const stopCommand = isChatStopCommandText(inboundMessage);
+    const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(p.attachments);
+    const rawMessage = inboundMessage.trim();
+    if (!rawMessage && normalizedAttachments.length === 0) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "message or attachment required"),
+      );
+      return;
+    }
+    let parsedMessage = inboundMessage;
+    let parsedImages: ChatImageContent[] = [];
+    if (normalizedAttachments.length > 0) {
+      try {
+        const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
+          maxBytes: 5_000_000,
+          log: context.logGateway,
+        });
+        parsedMessage = parsed.message;
+        parsedImages = parsed.images;
+      } catch (err) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+        return;
+      }
+    }
+    const rawSessionKey = p.sessionKey;
+    const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+    const timeoutMs = resolveAgentTimeoutMs({
+      cfg,
+      overrideMs: p.timeoutMs,
+    });
+    const now = Date.now();
+    const clientRunId = p.idempotencyKey;
+
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry,
+      sessionKey,
+      channel: entry?.channel,
+      chatType: entry?.chatType,
+    });
+    if (sendPolicy === "deny") {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+      );
+      return;
+    }
+
+    if (stopCommand) {
+      const res = abortChatRunsForSessionKeyWithPartials({
+        context,
+        ops: createChatAbortOps(context),
+        sessionKey: rawSessionKey,
+        abortOrigin: "stop-command",
+        stopReason: "stop",
+        requester: resolveChatAbortRequester(client),
+      });
+      if (res.unauthorized) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+        return;
+      }
+      respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
+      return;
+    }
+
+    const cached = context.dedupe.get(`chat:${clientRunId}`);
+    if (cached) {
+      respond(cached.ok, cached.payload, cached.error, {
+        cached: true,
+      });
+      return;
+    }
+
+    const activeExisting = context.chatAbortControllers.get(clientRunId);
+    if (activeExisting) {
+      respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
+        cached: true,
+        runId: clientRunId,
+      });
+      return;
+    }
+
+    try {
+      const abortController = new AbortController();
+      context.chatAbortControllers.set(clientRunId, {
+        controller: abortController,
+        sessionId: entry?.sessionId ?? clientRunId,
+        sessionKey: rawSessionKey,
+        startedAtMs: now,
+        expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
+        ownerConnId: normalizeOptionalText(client?.connId),
+        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+      });
+      const ackPayload = {
+        runId: clientRunId,
+        status: "started" as const,
+      };
+      respond(true, ackPayload, undefined, { runId: clientRunId });
+
+      const trimmedMessage = parsedMessage.trim();
+      const injectThinking = Boolean(
+        p.thinking && trimmedMessage && !trimmedMessage.startsWith("/"),
+      );
+      const commandBody = injectThinking ? `/think ${p.thinking} ${parsedMessage}` : parsedMessage;
+      const messageForAgent = systemProvenanceReceipt
+        ? [systemProvenanceReceipt, parsedMessage].filter(Boolean).join("\n\n")
+        : parsedMessage;
+      const clientInfo = client?.connect?.client;
+      const {
+        originatingChannel,
+        originatingTo,
+        accountId,
+        messageThreadId,
+        explicitDeliverRoute,
+      } = resolveChatSendOriginatingRoute({
+        client: clientInfo,
+        deliver: p.deliver,
+        entry,
+        hasConnectedClient: client?.connect !== undefined,
+        mainKey: cfg.session?.mainKey,
+        sessionKey,
+      });
+      // Inject timestamp so agents know the current date/time.
+      // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
+      // See: https://github.com/moltbot/moltbot/issues/3658
+      const stampedMessage = injectTimestamp(messageForAgent, timestampOptsFromConfig(cfg));
+
+      const ctx: MsgContext = {
+        Body: messageForAgent,
+        BodyForAgent: stampedMessage,
+        BodyForCommands: commandBody,
+        RawBody: parsedMessage,
+        CommandBody: commandBody,
+        InputProvenance: systemInputProvenance,
+        SessionKey: sessionKey,
+        Provider: INTERNAL_MESSAGE_CHANNEL,
+        Surface: INTERNAL_MESSAGE_CHANNEL,
+        OriginatingChannel: originatingChannel,
+        OriginatingTo: originatingTo,
+        ExplicitDeliverRoute: explicitDeliverRoute,
+        AccountId: accountId,
+        MessageThreadId: messageThreadId,
+        ChatType: "direct",
+        CommandAuthorized: true,
+        MessageSid: clientRunId,
+        SenderId: clientInfo?.id,
+        SenderName: clientInfo?.displayName,
+        SenderUsername: clientInfo?.displayName,
+        GatewayClientScopes: client?.connect?.scopes,
+      };
+
+      const agentId = resolveSessionAgentId({
+        sessionKey,
+        config: cfg,
+      });
+      const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+        cfg,
+        agentId,
+        channel: INTERNAL_MESSAGE_CHANNEL,
+      });
+      const finalReplyParts: string[] = [];
+      const dispatcher = createReplyDispatcher({
+        ...prefixOptions,
+        onError: (err) => {
+          context.logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
+        },
+        deliver: async (payload, info) => {
+          if (info.kind !== "final") {
+            return;
+          }
+          const text = payload.text?.trim() ?? "";
+          if (!text) {
+            return;
+          }
+          finalReplyParts.push(text);
+        },
+      });
+
+      let agentRunStarted = false;
+      void dispatchInboundMessage({
+        ctx,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          runId: clientRunId,
+          abortSignal: abortController.signal,
+          images: parsedImages.length > 0 ? parsedImages : undefined,
+          onAgentRunStart: (runId) => {
+            agentRunStarted = true;
+            const connId = typeof client?.connId === "string" ? client.connId : undefined;
+            const wantsToolEvents = hasGatewayClientCap(
+              client?.connect?.caps,
+              GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
+            );
+            if (connId && wantsToolEvents) {
+              context.registerToolEventRecipient(runId, connId);
+              // Register for any other active runs *in the same session* so
+              // late-joining clients (e.g. page refresh mid-response) receive
+              // in-progress tool events without leaking cross-session data.
+              for (const [activeRunId, active] of context.chatAbortControllers) {
+                if (activeRunId !== runId && active.sessionKey === p.sessionKey) {
+                  context.registerToolEventRecipient(activeRunId, connId);
+                }
+              }
+            }
+          },
+          onModelSelected,
+        },
+      })
+        .then(() => {
+          if (!agentRunStarted) {
+            const combinedReply = finalReplyParts
+              .map((part) => part.trim())
+              .filter(Boolean)
+              .join("\n\n")
+              .trim();
+            let message: Record<string, unknown> | undefined;
+            if (combinedReply) {
+              const { storePath: latestStorePath, entry: latestEntry } =
+                loadSessionEntry(sessionKey);
+              const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
+              const appended = appendAssistantTranscriptMessage({
+                message: combinedReply,
+                sessionId,
+                storePath: latestStorePath,
+                sessionFile: latestEntry?.sessionFile,
+                agentId,
+                createIfMissing: true,
+              });
+              if (appended.ok) {
+                message = appended.message;
+              } else {
+                context.logGateway.warn(
+                  `webchat transcript append failed: ${appended.error ?? "unknown error"}`,
+                );
+                const now = Date.now();
+                message = {
+                  role: "assistant",
+                  content: [{ type: "text", text: combinedReply }],
+                  timestamp: now,
+                  // Keep this compatible with Pi stopReason enums even though this message isn't
+                  // persisted to the transcript due to the append failure.
+                  stopReason: "stop",
+                  usage: { input: 0, output: 0, totalTokens: 0 },
+                };
+              }
+            }
+            broadcastChatFinal({
+              context,
+              runId: clientRunId,
+              sessionKey: rawSessionKey,
+              message,
+            });
+          }
+          setGatewayDedupeEntry({
+            dedupe: context.dedupe,
+            key: `chat:${clientRunId}`,
+            entry: {
+              ts: Date.now(),
+              ok: true,
+              payload: { runId: clientRunId, status: "ok" as const },
+            },
+          });
+        })
+        .catch((err) => {
+          const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
+          setGatewayDedupeEntry({
+            dedupe: context.dedupe,
+            key: `chat:${clientRunId}`,
+            entry: {
+              ts: Date.now(),
+              ok: false,
+              payload: {
+                runId: clientRunId,
+                status: "error" as const,
+                summary: String(err),
+              },
+              error,
+            },
+          });
+          broadcastChatError({
+            context,
+            runId: clientRunId,
+            sessionKey: rawSessionKey,
+            errorMessage: String(err),
+          });
+        })
+        .finally(() => {
+          context.chatAbortControllers.delete(clientRunId);
+        });
+    } catch (err) {
+      const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
+      const payload = {
+        runId: clientRunId,
+        status: "error" as const,
+        summary: String(err),
+      };
+      setGatewayDedupeEntry({
+        dedupe: context.dedupe,
+        key: `chat:${clientRunId}`,
+        entry: {
+          ts: Date.now(),
+          ok: false,
+          payload,
+          error,
+        },
+      });
+      respond(false, payload, error, {
+        runId: clientRunId,
+        error: formatForLog(err),
+      });
+    }
+  },
+  "chat.inject": async ({ params, respond, context }) => {
+    if (!validateChatInjectParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid chat.inject params: ${formatValidationErrors(validateChatInjectParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as {
+      sessionKey: string;
+      message: string;
+      label?: string;
+    };
+
+    // Load session to find transcript file
+    const rawSessionKey = p.sessionKey;
+    const { cfg, storePath, entry } = loadSessionEntry(rawSessionKey);
+    const sessionId = entry?.sessionId;
+    if (!sessionId || !storePath) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "session not found"));
+      return;
+    }
+
+    const appended = appendAssistantTranscriptMessage({
+      message: p.message,
+      label: p.label,
+      sessionId,
+      storePath,
+      sessionFile: entry?.sessionFile,
+      agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
+      createIfMissing: true,
+    });
+    if (!appended.ok || !appended.messageId || !appended.message) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `failed to write transcript: ${appended.error ?? "unknown error"}`,
+        ),
+      );
+      return;
+    }
+
+    // Broadcast to webchat for immediate UI update
+    const chatPayload = {
+      runId: `inject-${appended.messageId}`,
+      sessionKey: rawSessionKey,
+      seq: 0,
+      state: "final" as const,
+      message: stripInlineDirectiveTagsFromMessageForDisplay(
+        stripEnvelopeFromMessage(appended.message) as Record<string, unknown>,
+      ),
+    };
+    context.broadcast("chat", chatPayload);
+    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
+
+    respond(true, { ok: true, messageId: appended.messageId });
+  },
+};

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -135,6 +135,36 @@
   border-color: var(--accent);
 }
 
+/* Load more history button */
+.chat-load-more {
+  display: flex;
+  justify-content: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.chat-load-more__btn {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.chat-load-more__btn:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.chat-load-more__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .chat-new-messages svg {
   width: 16px;
   height: 16px;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1437,6 +1437,12 @@ export function renderApp(state: AppViewState) {
                 onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
                 onCloseSidebar: () => state.handleCloseSidebar(),
                 onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                // Pagination props
+                historyCursor: state.chatHistoryCursor,
+                historyHasMore: state.chatHistoryHasMore,
+                onLoadMoreHistory: () => {
+                  void loadChatHistory(state, state.chatHistoryCursor ?? undefined);
+                },
                 assistantName: state.assistantName,
                 assistantAvatar: state.assistantAvatar,
                 basePath: state.basePath ?? "",

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -164,6 +164,8 @@ export class OpenClawApp extends LitElement {
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatManualRefreshInFlight = false;
+  @state() chatHistoryCursor: string | null = null;
+  @state() chatHistoryHasMore = false;
   @state() navDrawerOpen = false;
 
   onSlashAction?: (action: string) => void;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -42,6 +42,8 @@ export type ChatState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
+  chatHistoryCursor: string | null;
+  chatHistoryHasMore: boolean;
 };
 
 export type ChatEventPayload = {
@@ -64,23 +66,43 @@ function maybeResetToolStream(state: ChatState) {
   }
 }
 
-export async function loadChatHistory(state: ChatState) {
+export async function loadChatHistory(state: ChatState, before?: string) {
+  // Load earlier messages (pagination)
   if (!state.client || !state.connected) {
     return;
   }
   state.chatLoading = true;
   state.lastError = null;
   try {
-    const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-      "chat.history",
-      {
-        sessionKey: state.sessionKey,
-        limit: 200,
-      },
-    );
+    const res = await state.client.request<{
+      messages?: Array<unknown>;
+      thinkingLevel?: string;
+      cursor?: string;
+      hasMore?: boolean;
+    }>("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 200,
+      before,
+    });
+    // API response handled
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    const filtered = messages.filter((message) => !isAssistantSilentReply(message));
+    // Filtered messages handled
+
+    if (before) {
+      // Prepend older messages when loading more
+      state.chatMessages = [...filtered, ...state.chatMessages];
+      // Prepend handled
+    } else {
+      // Initial load
+      state.chatMessages = filtered;
+    }
+
     state.chatThinkingLevel = res.thinkingLevel ?? null;
+    state.chatHistoryCursor = res.cursor ?? null;
+    state.chatHistoryHasMore = res.hasMore ?? false;
+    // State updated
+
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);
@@ -90,6 +112,13 @@ export async function loadChatHistory(state: ChatState) {
     state.lastError = String(err);
   } finally {
     state.chatLoading = false;
+  }
+}
+
+export async function loadMoreChatHistory(state: ChatState) {
+  // Load more history called
+  if (state.chatHistoryCursor) {
+    await loadChatHistory(state, state.chatHistoryCursor);
   }
 }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -108,6 +108,10 @@ export type ChatProps = {
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
   basePath?: string;
+  // Pagination
+  historyCursor?: string | null;
+  historyHasMore?: boolean;
+  onLoadMoreHistory?: () => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -892,6 +896,21 @@ export function renderChat(props: ChatProps) {
             `
           : nothing
       }
+      ${
+        props.historyHasMore && !props.loading
+          ? html`
+              <div class="chat-load-more">
+                <button
+                  class="chat-load-more__btn"
+                  @click=${props.onLoadMoreHistory}
+                  ?disabled=${props.loading}
+                >
+                  Load earlier messages
+                </button>
+              </div>
+            `
+          : nothing
+      }
       ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
       ${
         isEmpty && vs.searchOpen
@@ -1326,7 +1345,7 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
+const CHAT_HISTORY_RENDER_LIMIT = 2000;
 
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];


### PR DESCRIPTION

## Summary

Implement cursor-based pagination for WebChat history to address issue #48514: WebChat UI freezes with accumulated session history.

## Changes

### Backend
- `src/gateway/protocol/schema/logs-chat.ts`: Add `before?: string` parameter to ChatHistoryParamsSchema
- `src/gateway/server-methods/chat.ts`: 
  - Handle `before` cursor parameter to filter messages
  - Return `cursor` (oldest message timestamp) and `hasMore` boolean

### Frontend
- `ui/src/ui/app.ts`: Add `chatHistoryCursor` and `chatHistoryHasMore` state
- `ui/src/ui/app-render.ts`: Pass pagination props to chat component
- `ui/src/ui/controllers/chat.ts`: 
  - Modify `loadChatHistory(state, before?)` to support pagination
  - Prepend older messages when loading more
- `ui/src/ui/views/chat.ts`: Add "Load earlier messages" button
- `ui/src/styles/chat/layout.css`: Add button styles
- Increase `CHAT_HISTORY_RENDER_LIMIT` from 200 to 2000

## Features
- Manual "Load earlier messages" button (not auto-load)
- Shows "Showing last N messages (X hidden)" indicator
- Cursor-based pagination using timestamps
- Loads 200 messages per page
- Backward compatible with existing API

## Test Results
✅ Successfully loaded 1202 messages
✅ `hasMore: false` when no more messages
✅ Button shows/hides based on `hasMore`

Closes #48514
