### PR TITLE
Discord: resolve /think autocomplete from session model

### DIFF
--- a/extensions/discord/src/monitor/native-command-route.ts
+++ b/extensions/discord/src/monitor/native-command-route.ts
@@ -1,0 +1,89 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  ensureConfiguredBindingRouteReady,
+  resolveConfiguredBindingRoute,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import {
+  resolveDiscordBoundConversationRoute,
+  resolveDiscordEffectiveRoute,
+} from "./route-resolution.js";
+import type { ThreadBindingRecord } from "./thread-bindings.js";
+
+type ResolvedConfiguredBindingRoute = ReturnType<typeof resolveConfiguredBindingRoute>;
+type ConfiguredBindingResolution = NonNullable<
+  NonNullable<ResolvedConfiguredBindingRoute>["bindingResolution"]
+>;
+
+export type DiscordNativeInteractionRouteState = {
+  route: ResolvedAgentRoute;
+  effectiveRoute: ResolvedAgentRoute;
+  boundSessionKey?: string;
+  configuredRoute: ResolvedConfiguredBindingRoute | null;
+  configuredBinding: ConfiguredBindingResolution | null;
+  bindingReadiness: Awaited<ReturnType<typeof ensureConfiguredBindingRouteReady>> | null;
+};
+
+export async function resolveDiscordNativeInteractionRouteState(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  guildId?: string;
+  memberRoleIds?: string[];
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+  directUserId?: string;
+  conversationId: string;
+  parentConversationId?: string;
+  threadBinding?: ThreadBindingRecord;
+  enforceConfiguredBindingReadiness?: boolean;
+}): Promise<DiscordNativeInteractionRouteState> {
+  const route = resolveDiscordBoundConversationRoute({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    guildId: params.guildId,
+    memberRoleIds: params.memberRoleIds,
+    isDirectMessage: params.isDirectMessage,
+    isGroupDm: params.isGroupDm,
+    directUserId: params.directUserId,
+    conversationId: params.conversationId,
+    parentConversationId: params.parentConversationId,
+  });
+  const configuredRoute =
+    params.threadBinding == null
+      ? resolveConfiguredBindingRoute({
+          cfg: params.cfg,
+          route,
+          conversation: {
+            channel: "discord",
+            accountId: params.accountId,
+            conversationId: params.conversationId,
+            parentConversationId: params.parentConversationId,
+          },
+        })
+      : null;
+  const configuredBinding = configuredRoute?.bindingResolution ?? null;
+  const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
+  const boundSessionKey =
+    params.threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
+  const effectiveRoute = resolveDiscordEffectiveRoute({
+    route,
+    boundSessionKey,
+    configuredRoute,
+    matchedBy: configuredBinding ? "binding.channel" : undefined,
+  });
+  const bindingReadiness =
+    params.enforceConfiguredBindingReadiness && configuredBinding
+      ? await ensureConfiguredBindingRouteReady({
+          cfg: params.cfg,
+          bindingResolution: configuredBinding,
+        })
+      : null;
+  return {
+    route,
+    effectiveRoute,
+    boundSessionKey,
+    configuredRoute,
+    configuredBinding,
+    bindingReadiness,
+  };
+}

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -5,12 +5,14 @@ import {
   Row,
   StringSelectMenu,
   TextDisplay,
+  type AutocompleteInteraction,
   type ButtonInteraction,
   type CommandInteraction,
   type ComponentData,
   type StringSelectMenuInteraction,
 } from "@buape/carbon";
 import { ButtonStyle } from "discord-api-types/v10";
+import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -218,7 +220,11 @@ function buildDiscordModelPickerNoticePayload(message: string): { components: Co
 }
 
 async function resolveDiscordModelPickerRoute(params: {
-  interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
+  interaction:
+    | CommandInteraction
+    | ButtonInteraction
+    | StringSelectMenuInteraction
+    | AutocompleteInteraction;
   cfg: ReturnType<typeof loadConfig>;
   accountId: string;
   threadBindings: ThreadBindingManager;
@@ -267,6 +273,48 @@ async function resolveDiscordModelPickerRoute(params: {
     parentConversationId: threadParentId,
     boundSessionKey: threadBinding?.targetSessionKey,
   });
+}
+
+export async function resolveDiscordNativeChoiceContext(params: {
+  interaction: AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  accountId: string;
+  threadBindings: ThreadBindingManager;
+}): Promise<{ provider?: string; model?: string } | null> {
+  try {
+    const route = await resolveDiscordModelPickerRoute({
+      interaction: params.interaction,
+      cfg: params.cfg,
+      accountId: params.accountId,
+      threadBindings: params.threadBindings,
+    });
+    const fallback = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId: route.agentId,
+    });
+    const storePath = resolveStorePath(params.cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    const sessionStore = loadSessionStore(storePath);
+    const sessionEntry = sessionStore[route.sessionKey];
+    const override = resolveStoredModelOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey: route.sessionKey,
+    });
+    if (!override?.model) {
+      return {
+        provider: fallback.provider,
+        model: fallback.model,
+      };
+    }
+    return {
+      provider: override.provider || fallback.provider,
+      model: override.model,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function resolveDiscordModelPickerCurrentModel(params: {

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -17,6 +17,7 @@ import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
   listChatCommands,
+  resolveCommandAuthorizedFromAuthorizers,
   resolveCommandArgChoices,
   resolveStoredModelOverride,
   serializeCommandArgs,
@@ -26,12 +27,25 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  isDangerousNameMatchingEnabled,
+  resolveOpenProviderRuntimeGroupPolicy,
+} from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
-import { normalizeDiscordSlug } from "./allow-list.js";
+import {
+  isDiscordGroupAllowedByPolicy,
+  normalizeDiscordAllowList,
+  normalizeDiscordSlug,
+  resolveDiscordChannelConfigWithFallback,
+  resolveDiscordAllowListMatch,
+  resolveDiscordGuildEntry,
+  resolveDiscordMemberAccessState,
+  resolveDiscordOwnerAccess,
+} from "./allow-list.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import {
   readDiscordModelPickerRecentModels,
@@ -52,10 +66,21 @@ import {
   resolveDiscordBoundConversationRoute,
   resolveDiscordEffectiveRoute,
 } from "./route-resolution.js";
+import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
+type DiscordModelPickerRouteContext = {
+  route: ResolvedAgentRoute;
+  sender: ReturnType<typeof resolveDiscordSenderIdentity>;
+  guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
+  channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback> | null;
+  memberRoleIds: string[];
+  allowNameMatching: boolean;
+  rawChannelId: string;
+  isThreadChannel: boolean;
+};
 
 const DISCORD_COMMAND_ARG_CUSTOM_ID_KEY = "cmdarg";
 
@@ -233,6 +258,19 @@ async function resolveDiscordModelPickerRoute(params: {
   accountId: string;
   threadBindings: ThreadBindingManager;
 }) {
+  return (await resolveDiscordModelPickerRouteContext(params)).route;
+}
+
+async function resolveDiscordModelPickerRouteContext(params: {
+  interaction:
+    | CommandInteraction
+    | ButtonInteraction
+    | StringSelectMenuInteraction
+    | AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  accountId: string;
+  threadBindings: ThreadBindingManager;
+}): Promise<DiscordModelPickerRouteContext> {
   const { interaction, cfg, accountId } = params;
   const channel = interaction.channel;
   const channelType = channel?.type;
@@ -246,7 +284,14 @@ async function resolveDiscordModelPickerRoute(params: {
   const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
     ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
     : [];
+  const sender = resolveDiscordSenderIdentity({
+    author: interaction.user,
+    pluralkitInfo: null,
+  });
+  const allowNameMatching = isDangerousNameMatchingEnabled(cfg.channels?.discord ?? {});
   let threadParentId: string | undefined;
+  let threadParentName: string | undefined;
+  let threadParentSlug = "";
   if (interaction.guild && channel && isThreadChannel && rawChannelId) {
     const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
     const parentInfo = await resolveDiscordThreadParentInfo({
@@ -260,8 +305,30 @@ async function resolveDiscordModelPickerRoute(params: {
       channelInfo,
     });
     threadParentId = parentInfo.id;
+    threadParentName = parentInfo.name;
+    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
   }
 
+  const guildInfo = resolveDiscordGuildEntry({
+    guild: interaction.guild ?? undefined,
+    guildId: interaction.guild?.id ?? undefined,
+    guildEntries: cfg.channels?.discord?.guilds,
+  });
+  const channelName =
+    channel && "name" in channel ? (channel.name as string | undefined) : undefined;
+  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+  const channelConfig = interaction.guild
+    ? resolveDiscordChannelConfigWithFallback({
+        guildInfo,
+        channelId: rawChannelId,
+        channelName,
+        channelSlug,
+        parentId: threadParentId,
+        parentName: threadParentName,
+        parentSlug: threadParentSlug,
+        scope: isThreadChannel ? "thread" : "channel",
+      })
+    : null;
   const route = resolveDiscordBoundConversationRoute({
     cfg,
     accountId,
@@ -292,27 +359,170 @@ async function resolveDiscordModelPickerRoute(params: {
   const configuredBinding = configuredRoute?.bindingResolution ?? null;
   const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
   const boundSessionKey = threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
-  return resolveDiscordEffectiveRoute({
-    route,
-    boundSessionKey,
-    configuredRoute,
-    matchedBy: configuredBinding ? "binding.channel" : undefined,
+  return {
+    route: resolveDiscordEffectiveRoute({
+      route,
+      boundSessionKey,
+      configuredRoute,
+      matchedBy: configuredBinding ? "binding.channel" : undefined,
+    }),
+    sender,
+    guildInfo,
+    channelConfig,
+    memberRoleIds,
+    allowNameMatching,
+    rawChannelId,
+    isThreadChannel,
+  };
+}
+
+function resolveDiscordNativeAutocompleteAllowlistAccess(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  sender: { id: string; name?: string; tag?: string };
+  chatType: "direct" | "group" | "thread" | "channel";
+  conversationId?: string;
+}) {
+  const commandsAllowFrom = params.cfg.commands?.allowFrom;
+  if (!commandsAllowFrom || typeof commandsAllowFrom !== "object") {
+    return { configured: false, allowed: false } as const;
+  }
+  const rawAllowList = Array.isArray(commandsAllowFrom.discord)
+    ? commandsAllowFrom.discord
+    : commandsAllowFrom["*"];
+  if (!Array.isArray(rawAllowList)) {
+    return { configured: false, allowed: false } as const;
+  }
+  const allowList = normalizeDiscordAllowList(rawAllowList.map(String), [
+    "discord:",
+    "user:",
+    "pk:",
+  ]);
+  if (!allowList) {
+    return { configured: true, allowed: false } as const;
+  }
+  const match = resolveDiscordAllowListMatch({
+    allowList,
+    candidate: params.sender,
+    allowNameMatching: false,
+  });
+  return { configured: true, allowed: match.allowed } as const;
+}
+
+async function resolveDiscordNativeChoiceContextAuthorized(params: {
+  interaction: AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+  routeContext: DiscordModelPickerRouteContext;
+}): Promise<boolean> {
+  const { interaction, cfg, discordConfig, accountId, routeContext } = params;
+  if (!interaction.guild) {
+    return true;
+  }
+  if (routeContext.channelConfig?.enabled === false) {
+    return false;
+  }
+  if (routeContext.channelConfig?.allowed === false) {
+    return false;
+  }
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  if (useAccessGroups) {
+    const channelAllowlistConfigured =
+      Boolean(routeContext.guildInfo?.channels) &&
+      Object.keys(routeContext.guildInfo?.channels ?? {}).length > 0;
+    const channelAllowed = routeContext.channelConfig?.allowed !== false;
+    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.discord !== undefined,
+      groupPolicy: discordConfig?.groupPolicy,
+      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+    });
+    const allowByPolicy = isDiscordGroupAllowedByPolicy({
+      groupPolicy,
+      guildAllowlisted: Boolean(routeContext.guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    });
+    if (!allowByPolicy) {
+      return false;
+    }
+  }
+  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
+    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    sender: {
+      id: routeContext.sender.id,
+      name: routeContext.sender.name,
+      tag: routeContext.sender.tag,
+    },
+    allowNameMatching: routeContext.allowNameMatching,
+  });
+  const commandsAllowFromAccess = resolveDiscordNativeAutocompleteAllowlistAccess({
+    cfg,
+    accountId,
+    sender: {
+      id: routeContext.sender.id,
+      name: routeContext.sender.name,
+      tag: routeContext.sender.tag,
+    },
+    chatType: routeContext.isThreadChannel ? "thread" : "channel",
+    conversationId: routeContext.rawChannelId || undefined,
+  });
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig: routeContext.channelConfig,
+    guildInfo: routeContext.guildInfo,
+    memberRoleIds: routeContext.memberRoleIds,
+    sender: routeContext.sender,
+    allowNameMatching: routeContext.allowNameMatching,
+  });
+  const authorizers = useAccessGroups
+    ? [
+        {
+          configured: commandsAllowFromAccess.configured,
+          allowed: commandsAllowFromAccess.allowed,
+        },
+        { configured: ownerAllowList != null, allowed: ownerOk },
+        { configured: hasAccessRestrictions, allowed: memberAllowed },
+      ]
+    : [
+        {
+          configured: commandsAllowFromAccess.configured,
+          allowed: commandsAllowFromAccess.allowed,
+        },
+        { configured: hasAccessRestrictions, allowed: memberAllowed },
+      ];
+  return resolveCommandAuthorizedFromAuthorizers({
+    useAccessGroups,
+    authorizers,
+    modeWhenAccessGroupsOff: "configured",
   });
 }
 
 export async function resolveDiscordNativeChoiceContext(params: {
   interaction: AutocompleteInteraction;
   cfg: ReturnType<typeof loadConfig>;
+  discordConfig?: DiscordConfig;
   accountId: string;
   threadBindings: ThreadBindingManager;
 }): Promise<{ provider?: string; model?: string } | null> {
   try {
-    const route = await resolveDiscordModelPickerRoute({
+    const routeContext = await resolveDiscordModelPickerRouteContext({
       interaction: params.interaction,
       cfg: params.cfg,
       accountId: params.accountId,
       threadBindings: params.threadBindings,
     });
+    const discordConfig = params.discordConfig ?? params.cfg.channels?.discord ?? {};
+    const authorized = await resolveDiscordNativeChoiceContextAuthorized({
+      interaction: params.interaction,
+      cfg: params.cfg,
+      discordConfig,
+      accountId: params.accountId,
+      routeContext,
+    });
+    if (!authorized) {
+      return null;
+    }
+    const route = routeContext.route;
     const fallback = resolveDefaultModelForAgent({
       cfg: params.cfg,
       agentId: route.agentId,

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -13,7 +13,6 @@ import {
 } from "@buape/carbon";
 import { ButtonStyle } from "discord-api-types/v10";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
-import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -28,6 +27,7 @@ import {
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
+import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -13,6 +13,7 @@ import {
 } from "@buape/carbon";
 import { ButtonStyle } from "discord-api-types/v10";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -47,7 +48,10 @@ import {
   toDiscordModelPickerMessagePayload,
   type DiscordModelPickerCommandContext,
 } from "./model-picker.js";
-import { resolveDiscordBoundConversationRoute } from "./route-resolution.js";
+import {
+  resolveDiscordBoundConversationRoute,
+  resolveDiscordEffectiveRoute,
+} from "./route-resolution.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -258,10 +262,7 @@ async function resolveDiscordModelPickerRoute(params: {
     threadParentId = parentInfo.id;
   }
 
-  const threadBinding = isThreadChannel
-    ? params.threadBindings.getByThreadId(rawChannelId)
-    : undefined;
-  return resolveDiscordBoundConversationRoute({
+  const route = resolveDiscordBoundConversationRoute({
     cfg,
     accountId,
     guildId: interaction.guild?.id ?? undefined,
@@ -271,7 +272,31 @@ async function resolveDiscordModelPickerRoute(params: {
     directUserId: interaction.user?.id ?? rawChannelId,
     conversationId: rawChannelId,
     parentConversationId: threadParentId,
-    boundSessionKey: threadBinding?.targetSessionKey,
+  });
+  const threadBinding = isThreadChannel
+    ? params.threadBindings.getByThreadId(rawChannelId)
+    : undefined;
+  const configuredRoute =
+    threadBinding == null
+      ? resolveConfiguredBindingRoute({
+          cfg,
+          route,
+          conversation: {
+            channel: "discord",
+            accountId,
+            conversationId: rawChannelId,
+            parentConversationId: threadParentId,
+          },
+        })
+      : null;
+  const configuredBinding = configuredRoute?.bindingResolution ?? null;
+  const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
+  const boundSessionKey = threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
+  return resolveDiscordEffectiveRoute({
+    route,
+    boundSessionKey,
+    configuredRoute,
+    matchedBy: configuredBinding ? "binding.channel" : undefined,
   });
 }
 

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -17,7 +17,6 @@ import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
   listChatCommands,
-  resolveCommandAuthorizedFromAuthorizers,
   resolveCommandArgChoices,
   resolveStoredModelOverride,
   serializeCommandArgs,
@@ -27,24 +26,15 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import {
-  isDangerousNameMatchingEnabled,
-  resolveOpenProviderRuntimeGroupPolicy,
-} from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
 import {
-  isDiscordGroupAllowedByPolicy,
-  normalizeDiscordAllowList,
   normalizeDiscordSlug,
   resolveDiscordChannelConfigWithFallback,
-  resolveDiscordAllowListMatch,
   resolveDiscordGuildEntry,
-  resolveDiscordMemberAccessState,
-  resolveDiscordOwnerAccess,
 } from "./allow-list.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import {
@@ -66,21 +56,10 @@ import {
   resolveDiscordBoundConversationRoute,
   resolveDiscordEffectiveRoute,
 } from "./route-resolution.js";
-import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
-type DiscordModelPickerRouteContext = {
-  route: ResolvedAgentRoute;
-  sender: ReturnType<typeof resolveDiscordSenderIdentity>;
-  guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
-  channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback> | null;
-  memberRoleIds: string[];
-  allowNameMatching: boolean;
-  rawChannelId: string;
-  isThreadChannel: boolean;
-};
 
 const DISCORD_COMMAND_ARG_CUSTOM_ID_KEY = "cmdarg";
 
@@ -258,19 +237,6 @@ async function resolveDiscordModelPickerRoute(params: {
   accountId: string;
   threadBindings: ThreadBindingManager;
 }) {
-  return (await resolveDiscordModelPickerRouteContext(params)).route;
-}
-
-async function resolveDiscordModelPickerRouteContext(params: {
-  interaction:
-    | CommandInteraction
-    | ButtonInteraction
-    | StringSelectMenuInteraction
-    | AutocompleteInteraction;
-  cfg: ReturnType<typeof loadConfig>;
-  accountId: string;
-  threadBindings: ThreadBindingManager;
-}): Promise<DiscordModelPickerRouteContext> {
   const { interaction, cfg, accountId } = params;
   const channel = interaction.channel;
   const channelType = channel?.type;
@@ -284,11 +250,6 @@ async function resolveDiscordModelPickerRouteContext(params: {
   const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
     ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
     : [];
-  const sender = resolveDiscordSenderIdentity({
-    author: interaction.user,
-    pluralkitInfo: null,
-  });
-  const allowNameMatching = isDangerousNameMatchingEnabled(cfg.channels?.discord ?? {});
   let threadParentId: string | undefined;
   let threadParentName: string | undefined;
   let threadParentSlug = "";
@@ -309,26 +270,6 @@ async function resolveDiscordModelPickerRouteContext(params: {
     threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
   }
 
-  const guildInfo = resolveDiscordGuildEntry({
-    guild: interaction.guild ?? undefined,
-    guildId: interaction.guild?.id ?? undefined,
-    guildEntries: cfg.channels?.discord?.guilds,
-  });
-  const channelName =
-    channel && "name" in channel ? (channel.name as string | undefined) : undefined;
-  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
-  const channelConfig = interaction.guild
-    ? resolveDiscordChannelConfigWithFallback({
-        guildInfo,
-        channelId: rawChannelId,
-        channelName,
-        channelSlug,
-        parentId: threadParentId,
-        parentName: threadParentName,
-        parentSlug: threadParentSlug,
-        scope: isThreadChannel ? "thread" : "channel",
-      })
-    : null;
   const route = resolveDiscordBoundConversationRoute({
     cfg,
     accountId,
@@ -359,170 +300,27 @@ async function resolveDiscordModelPickerRouteContext(params: {
   const configuredBinding = configuredRoute?.bindingResolution ?? null;
   const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
   const boundSessionKey = threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
-  return {
-    route: resolveDiscordEffectiveRoute({
-      route,
-      boundSessionKey,
-      configuredRoute,
-      matchedBy: configuredBinding ? "binding.channel" : undefined,
-    }),
-    sender,
-    guildInfo,
-    channelConfig,
-    memberRoleIds,
-    allowNameMatching,
-    rawChannelId,
-    isThreadChannel,
-  };
-}
-
-function resolveDiscordNativeAutocompleteAllowlistAccess(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  sender: { id: string; name?: string; tag?: string };
-  chatType: "direct" | "group" | "thread" | "channel";
-  conversationId?: string;
-}) {
-  const commandsAllowFrom = params.cfg.commands?.allowFrom;
-  if (!commandsAllowFrom || typeof commandsAllowFrom !== "object") {
-    return { configured: false, allowed: false } as const;
-  }
-  const rawAllowList = Array.isArray(commandsAllowFrom.discord)
-    ? commandsAllowFrom.discord
-    : commandsAllowFrom["*"];
-  if (!Array.isArray(rawAllowList)) {
-    return { configured: false, allowed: false } as const;
-  }
-  const allowList = normalizeDiscordAllowList(rawAllowList.map(String), [
-    "discord:",
-    "user:",
-    "pk:",
-  ]);
-  if (!allowList) {
-    return { configured: true, allowed: false } as const;
-  }
-  const match = resolveDiscordAllowListMatch({
-    allowList,
-    candidate: params.sender,
-    allowNameMatching: false,
-  });
-  return { configured: true, allowed: match.allowed } as const;
-}
-
-async function resolveDiscordNativeChoiceContextAuthorized(params: {
-  interaction: AutocompleteInteraction;
-  cfg: ReturnType<typeof loadConfig>;
-  discordConfig: DiscordConfig;
-  accountId: string;
-  routeContext: DiscordModelPickerRouteContext;
-}): Promise<boolean> {
-  const { interaction, cfg, discordConfig, accountId, routeContext } = params;
-  if (!interaction.guild) {
-    return true;
-  }
-  if (routeContext.channelConfig?.enabled === false) {
-    return false;
-  }
-  if (routeContext.channelConfig?.allowed === false) {
-    return false;
-  }
-  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-  if (useAccessGroups) {
-    const channelAllowlistConfigured =
-      Boolean(routeContext.guildInfo?.channels) &&
-      Object.keys(routeContext.guildInfo?.channels ?? {}).length > 0;
-    const channelAllowed = routeContext.channelConfig?.allowed !== false;
-    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
-      providerConfigPresent: cfg.channels?.discord !== undefined,
-      groupPolicy: discordConfig?.groupPolicy,
-      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
-    });
-    const allowByPolicy = isDiscordGroupAllowedByPolicy({
-      groupPolicy,
-      guildAllowlisted: Boolean(routeContext.guildInfo),
-      channelAllowlistConfigured,
-      channelAllowed,
-    });
-    if (!allowByPolicy) {
-      return false;
-    }
-  }
-  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
-    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
-    sender: {
-      id: routeContext.sender.id,
-      name: routeContext.sender.name,
-      tag: routeContext.sender.tag,
-    },
-    allowNameMatching: routeContext.allowNameMatching,
-  });
-  const commandsAllowFromAccess = resolveDiscordNativeAutocompleteAllowlistAccess({
-    cfg,
-    accountId,
-    sender: {
-      id: routeContext.sender.id,
-      name: routeContext.sender.name,
-      tag: routeContext.sender.tag,
-    },
-    chatType: routeContext.isThreadChannel ? "thread" : "channel",
-    conversationId: routeContext.rawChannelId || undefined,
-  });
-  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-    channelConfig: routeContext.channelConfig,
-    guildInfo: routeContext.guildInfo,
-    memberRoleIds: routeContext.memberRoleIds,
-    sender: routeContext.sender,
-    allowNameMatching: routeContext.allowNameMatching,
-  });
-  const authorizers = useAccessGroups
-    ? [
-        {
-          configured: commandsAllowFromAccess.configured,
-          allowed: commandsAllowFromAccess.allowed,
-        },
-        { configured: ownerAllowList != null, allowed: ownerOk },
-        { configured: hasAccessRestrictions, allowed: memberAllowed },
-      ]
-    : [
-        {
-          configured: commandsAllowFromAccess.configured,
-          allowed: commandsAllowFromAccess.allowed,
-        },
-        { configured: hasAccessRestrictions, allowed: memberAllowed },
-      ];
-  return resolveCommandAuthorizedFromAuthorizers({
-    useAccessGroups,
-    authorizers,
-    modeWhenAccessGroupsOff: "configured",
+  return resolveDiscordEffectiveRoute({
+    route,
+    boundSessionKey,
+    configuredRoute,
+    matchedBy: configuredBinding ? "binding.channel" : undefined,
   });
 }
 
 export async function resolveDiscordNativeChoiceContext(params: {
   interaction: AutocompleteInteraction;
   cfg: ReturnType<typeof loadConfig>;
-  discordConfig?: DiscordConfig;
   accountId: string;
   threadBindings: ThreadBindingManager;
 }): Promise<{ provider?: string; model?: string } | null> {
   try {
-    const routeContext = await resolveDiscordModelPickerRouteContext({
+    const route = await resolveDiscordModelPickerRoute({
       interaction: params.interaction,
       cfg: params.cfg,
       accountId: params.accountId,
       threadBindings: params.threadBindings,
     });
-    const discordConfig = params.discordConfig ?? params.cfg.channels?.discord ?? {};
-    const authorized = await resolveDiscordNativeChoiceContextAuthorized({
-      interaction: params.interaction,
-      cfg: params.cfg,
-      discordConfig,
-      accountId: params.accountId,
-      routeContext,
-    });
-    if (!authorized) {
-      return null;
-    }
-    const route = routeContext.route;
     const fallback = resolveDefaultModelForAgent({
       cfg: params.cfg,
       agentId: route.agentId,

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -288,7 +288,7 @@ async function resolveDiscordModelPickerRoute(params: {
   threadBindings: ThreadBindingManager;
 }) {
   const resolved = await resolveDiscordModelPickerRouteState(params);
-  return resolved.route;
+  return resolved.effectiveRoute;
 }
 
 export async function resolveDiscordNativeChoiceContext(params: {

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -27,15 +27,10 @@ import {
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
-import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
-import {
-  normalizeDiscordSlug,
-  resolveDiscordChannelConfigWithFallback,
-  resolveDiscordGuildEntry,
-} from "./allow-list.js";
+import { resolveDiscordChannelConfigWithFallback, resolveDiscordGuildEntry } from "./allow-list.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import {
   readDiscordModelPickerRecentModels,
@@ -52,10 +47,7 @@ import {
   toDiscordModelPickerMessagePayload,
   type DiscordModelPickerCommandContext,
 } from "./model-picker.js";
-import {
-  resolveDiscordBoundConversationRoute,
-  resolveDiscordEffectiveRoute,
-} from "./route-resolution.js";
+import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -227,7 +219,7 @@ function buildDiscordModelPickerNoticePayload(message: string): { components: Co
   };
 }
 
-async function resolveDiscordModelPickerRoute(params: {
+async function resolveDiscordModelPickerRouteState(params: {
   interaction:
     | CommandInteraction
     | ButtonInteraction
@@ -236,6 +228,7 @@ async function resolveDiscordModelPickerRoute(params: {
   cfg: ReturnType<typeof loadConfig>;
   accountId: string;
   threadBindings: ThreadBindingManager;
+  enforceConfiguredBindingReadiness?: boolean;
 }) {
   const { interaction, cfg, accountId } = params;
   const channel = interaction.channel;
@@ -251,8 +244,6 @@ async function resolveDiscordModelPickerRoute(params: {
     ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
     : [];
   let threadParentId: string | undefined;
-  let threadParentName: string | undefined;
-  let threadParentSlug = "";
   if (interaction.guild && channel && isThreadChannel && rawChannelId) {
     const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
     const parentInfo = await resolveDiscordThreadParentInfo({
@@ -266,11 +257,12 @@ async function resolveDiscordModelPickerRoute(params: {
       channelInfo,
     });
     threadParentId = parentInfo.id;
-    threadParentName = parentInfo.name;
-    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
   }
 
-  const route = resolveDiscordBoundConversationRoute({
+  const threadBinding = isThreadChannel
+    ? params.threadBindings.getByThreadId(rawChannelId)
+    : undefined;
+  return await resolveDiscordNativeInteractionRouteState({
     cfg,
     accountId,
     guildId: interaction.guild?.id ?? undefined,
@@ -280,32 +272,23 @@ async function resolveDiscordModelPickerRoute(params: {
     directUserId: interaction.user?.id ?? rawChannelId,
     conversationId: rawChannelId,
     parentConversationId: threadParentId,
+    threadBinding,
+    enforceConfiguredBindingReadiness: params.enforceConfiguredBindingReadiness,
   });
-  const threadBinding = isThreadChannel
-    ? params.threadBindings.getByThreadId(rawChannelId)
-    : undefined;
-  const configuredRoute =
-    threadBinding == null
-      ? resolveConfiguredBindingRoute({
-          cfg,
-          route,
-          conversation: {
-            channel: "discord",
-            accountId,
-            conversationId: rawChannelId,
-            parentConversationId: threadParentId,
-          },
-        })
-      : null;
-  const configuredBinding = configuredRoute?.bindingResolution ?? null;
-  const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
-  const boundSessionKey = threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
-  return resolveDiscordEffectiveRoute({
-    route,
-    boundSessionKey,
-    configuredRoute,
-    matchedBy: configuredBinding ? "binding.channel" : undefined,
-  });
+}
+
+async function resolveDiscordModelPickerRoute(params: {
+  interaction:
+    | CommandInteraction
+    | ButtonInteraction
+    | StringSelectMenuInteraction
+    | AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  accountId: string;
+  threadBindings: ThreadBindingManager;
+}) {
+  const resolved = await resolveDiscordModelPickerRouteState(params);
+  return resolved.route;
 }
 
 export async function resolveDiscordNativeChoiceContext(params: {
@@ -315,12 +298,17 @@ export async function resolveDiscordNativeChoiceContext(params: {
   threadBindings: ThreadBindingManager;
 }): Promise<{ provider?: string; model?: string } | null> {
   try {
-    const route = await resolveDiscordModelPickerRoute({
+    const resolved = await resolveDiscordModelPickerRouteState({
       interaction: params.interaction,
       cfg: params.cfg,
       accountId: params.accountId,
       threadBindings: params.threadBindings,
+      enforceConfiguredBindingReadiness: true,
     });
+    if (resolved.bindingReadiness && !resolved.bindingReadiness.ok) {
+      return null;
+    }
+    const route = resolved.effectiveRoute;
     const fallback = resolveDefaultModelForAgent({
       cfg: params.cfg,
       agentId: route.agentId,

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -1,12 +1,8 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../../../src/auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../../../src/auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../../../src/config/config.js";
-import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store.js";
 import type { DiscordAccountConfig } from "../../../../src/config/types.discord.js";
 import * as pluginCommandsModule from "../../../../src/plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
@@ -14,13 +10,7 @@ import {
   createMockCommandInteraction,
   type MockCommandInteraction,
 } from "./native-command.test-helpers.js";
-import { resolveDiscordBoundConversationRoute } from "./route-resolution.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
-
-const STORE_PATH = path.join(
-  os.tmpdir(),
-  `openclaw-discord-native-command-allowfrom-${process.pid}.json`,
-);
 
 function createInteraction(params?: { userId?: string }): MockCommandInteraction {
   return createMockCommandInteraction({
@@ -120,10 +110,6 @@ function expectUnauthorizedReply(interaction: MockCommandInteraction) {
 describe("Discord native slash commands with commands.allowFrom", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    clearSessionStoreCacheForTest();
-    try {
-      fs.unlinkSync(STORE_PATH);
-    } catch {}
   });
 
   it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {
@@ -179,93 +165,6 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     });
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectUnauthorizedReply(interaction);
-  });
-
-  it("does not expose session-derived /think choices to unauthorized guild users", async () => {
-    const cfg = createConfig();
-    cfg.agents = {
-      defaults: {
-        model: {
-          primary: "anthropic/claude-sonnet-4.5",
-        },
-      },
-    };
-    cfg.session = { store: STORE_PATH };
-    const route = resolveDiscordBoundConversationRoute({
-      cfg,
-      accountId: "default",
-      guildId: "345678901234567890",
-      memberRoleIds: [],
-      isDirectMessage: false,
-      isGroupDm: false,
-      directUserId: "999999999999999999",
-      conversationId: "234567890123456789",
-    });
-    fs.writeFileSync(
-      STORE_PATH,
-      JSON.stringify({
-        [route.sessionKey]: {
-          updatedAt: Date.now(),
-          providerOverride: "openai-codex",
-          modelOverride: "gpt-5.4",
-        },
-      }),
-      "utf8",
-    );
-
-    const command = createDiscordNativeCommand({
-      command: {
-        name: "think",
-        description: "Set thinking level.",
-        acceptsArgs: true,
-      },
-      cfg,
-      discordConfig: cfg.channels?.discord ?? {},
-      accountId: "default",
-      sessionPrefix: "discord:slash",
-      ephemeralDefault: true,
-      threadBindings: createNoopThreadBindingManager("default"),
-    });
-    const levelOption = command.options?.find((entry) => entry.name === "level") as
-      | {
-          autocomplete?: (interaction: {
-            options: { getFocused: () => { value: string } };
-            respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
-            rawData: { member: { roles: string[] } };
-            channel: { id: string; type: ChannelType };
-            user: { id: string; username: string; globalName: string };
-            guild: { id: string; name: string };
-            client: object;
-          }) => Promise<void>;
-        }
-      | undefined;
-    expect(typeof levelOption?.autocomplete).toBe("function");
-    if (typeof levelOption?.autocomplete !== "function") {
-      return;
-    }
-
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await levelOption.autocomplete({
-      options: {
-        getFocused: () => ({ value: "xh" }),
-      },
-      respond,
-      rawData: {
-        member: { roles: [] },
-      },
-      channel: { id: "234567890123456789", type: ChannelType.GuildText },
-      user: {
-        id: "999999999999999999",
-        username: "discord-user",
-        globalName: "Discord User",
-      },
-      guild: { id: "345678901234567890", name: "Test Guild" },
-      client: {},
-    });
-
-    const choices = respond.mock.calls[0]?.[0] ?? [];
-    const values = choices.map((choice: { value: string }) => choice.value);
-    expect(values).not.toContain("xhigh");
   });
 
   it("uses the root discord maxLinesPerMessage when runtime discordConfig omits it", async () => {

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../../../src/auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../../../src/auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../../../src/config/config.js";
+import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store.js";
 import type { DiscordAccountConfig } from "../../../../src/config/types.discord.js";
 import * as pluginCommandsModule from "../../../../src/plugins/commands.js";
 import { createDiscordNativeCommand } from "./native-command.js";
@@ -10,7 +14,13 @@ import {
   createMockCommandInteraction,
   type MockCommandInteraction,
 } from "./native-command.test-helpers.js";
+import { resolveDiscordBoundConversationRoute } from "./route-resolution.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+const STORE_PATH = path.join(
+  os.tmpdir(),
+  `openclaw-discord-native-command-allowfrom-${process.pid}.json`,
+);
 
 function createInteraction(params?: { userId?: string }): MockCommandInteraction {
   return createMockCommandInteraction({
@@ -110,6 +120,10 @@ function expectUnauthorizedReply(interaction: MockCommandInteraction) {
 describe("Discord native slash commands with commands.allowFrom", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    clearSessionStoreCacheForTest();
+    try {
+      fs.unlinkSync(STORE_PATH);
+    } catch {}
   });
 
   it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {
@@ -165,6 +179,93 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     });
     expect(dispatchSpy).not.toHaveBeenCalled();
     expectUnauthorizedReply(interaction);
+  });
+
+  it("does not expose session-derived /think choices to unauthorized guild users", async () => {
+    const cfg = createConfig();
+    cfg.agents = {
+      defaults: {
+        model: {
+          primary: "anthropic/claude-sonnet-4.5",
+        },
+      },
+    };
+    cfg.session = { store: STORE_PATH };
+    const route = resolveDiscordBoundConversationRoute({
+      cfg,
+      accountId: "default",
+      guildId: "345678901234567890",
+      memberRoleIds: [],
+      isDirectMessage: false,
+      isGroupDm: false,
+      directUserId: "999999999999999999",
+      conversationId: "234567890123456789",
+    });
+    fs.writeFileSync(
+      STORE_PATH,
+      JSON.stringify({
+        [route.sessionKey]: {
+          updatedAt: Date.now(),
+          providerOverride: "openai-codex",
+          modelOverride: "gpt-5.4",
+        },
+      }),
+      "utf8",
+    );
+
+    const command = createDiscordNativeCommand({
+      command: {
+        name: "think",
+        description: "Set thinking level.",
+        acceptsArgs: true,
+      },
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const levelOption = command.options?.find((entry) => entry.name === "level") as
+      | {
+          autocomplete?: (interaction: {
+            options: { getFocused: () => { value: string } };
+            respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
+            rawData: { member: { roles: string[] } };
+            channel: { id: string; type: ChannelType };
+            user: { id: string; username: string; globalName: string };
+            guild: { id: string; name: string };
+            client: object;
+          }) => Promise<void>;
+        }
+      | undefined;
+    expect(typeof levelOption?.autocomplete).toBe("function");
+    if (typeof levelOption?.autocomplete !== "function") {
+      return;
+    }
+
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await levelOption.autocomplete({
+      options: {
+        getFocused: () => ({ value: "xh" }),
+      },
+      respond,
+      rawData: {
+        member: { roles: [] },
+      },
+      channel: { id: "234567890123456789", type: ChannelType.GuildText },
+      user: {
+        id: "999999999999999999",
+        username: "discord-user",
+        globalName: "Discord User",
+      },
+      guild: { id: "345678901234567890", name: "Test Guild" },
+      client: {},
+    });
+
+    const choices = respond.mock.calls[0]?.[0] ?? [];
+    const values = choices.map((choice: { value: string }) => choice.value);
+    expect(values).not.toContain("xhigh");
   });
 
   it("uses the root discord maxLinesPerMessage when runtime discordConfig omits it", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -13,6 +13,7 @@ import * as timeoutModule from "../../../../src/utils/with-timeout.js";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
+import { replyWithDiscordModelPickerProviders } from "./native-command-ui.js";
 import {
   createDiscordModelPickerFallbackButton,
   createDiscordModelPickerFallbackSelect,
@@ -29,8 +30,8 @@ type PickerSelectData = Parameters<PickerSelect["run"]>[1];
 
 type MockInteraction = {
   user: { id: string; username: string; globalName: string };
-  channel: { type: ChannelType; id: string };
-  guild: null;
+  channel: { type: ChannelType; id: string; name?: string; parentId?: string };
+  guild: { id: string } | null;
   rawData: { id: string; member: { roles: string[] } };
   values?: string[];
   reply: ReturnType<typeof vi.fn>;
@@ -458,5 +459,39 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+  });
+
+  it("loads model picker data from the effective bound route", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const loadSpy = vi
+      .spyOn(modelPickerModule, "loadDiscordModelPickerData")
+      .mockResolvedValue(createDefaultModelPickerData());
+    const interaction = createInteraction({ userId: "owner" });
+    interaction.guild = { id: "guild-1" };
+    interaction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+      name: "bound-thread",
+      parentId: "parent-1",
+    };
+
+    await replyWithDiscordModelPickerProviders({
+      interaction: interaction as never,
+      cfg: context.cfg,
+      command: "model",
+      userId: "owner",
+      accountId: context.accountId,
+      threadBindings: context.threadBindings,
+      preferFollowUp: false,
+      safeInteractionCall: async (_label, fn) => await fn(),
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(context.cfg, "worker");
   });
 });

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -1,3 +1,4 @@
+import { ChannelType } from "discord-api-types/v10";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, loadConfig } from "../../../../src/config/config.js";
 let listNativeCommandSpecs: typeof import("../../../../src/auto-reply/commands-registry.js").listNativeCommandSpecs;
@@ -6,6 +7,10 @@ let createNoopThreadBindingManager: typeof import("./thread-bindings.js").create
 
 function createNativeCommand(
   name: string,
+  opts?: {
+    cfg?: ReturnType<typeof loadConfig>;
+    discordConfig?: NonNullable<OpenClawConfig["channels"]>["discord"];
+  },
 ): ReturnType<typeof import("./native-command.js").createDiscordNativeCommand> {
   const command = listNativeCommandSpecs({ provider: "discord" }).find(
     (entry) => entry.name === name,
@@ -13,8 +18,10 @@ function createNativeCommand(
   if (!command) {
     throw new Error(`missing native command: ${name}`);
   }
-  const cfg = {} as ReturnType<typeof loadConfig>;
-  const discordConfig = {} as NonNullable<OpenClawConfig["channels"]>["discord"];
+  const cfg = (opts?.cfg ?? {}) as ReturnType<typeof loadConfig>;
+  const discordConfig = (opts?.discordConfig ?? {}) as NonNullable<
+    OpenClawConfig["channels"]
+  >["discord"];
   return createDiscordNativeCommand({
     command,
     cfg,
@@ -81,10 +88,22 @@ describe("createDiscordNativeCommand option wiring", () => {
 
     expect(readChoices(action)).toBeUndefined();
     await autocomplete({
+      user: {
+        id: "owner",
+        username: "tester",
+        globalName: "Tester",
+      },
+      channel: {
+        type: ChannelType.DM,
+        id: "dm-1",
+      },
+      guild: undefined,
+      rawData: {},
       options: {
         getFocused: () => ({ value: "st" }),
       },
       respond,
+      client: {},
     } as never);
     expect(respond).toHaveBeenCalledWith([
       { name: "steer", value: "steer" },
@@ -104,5 +123,49 @@ describe("createDiscordNativeCommand option wiring", () => {
         expect.objectContaining({ name: expect.any(String), value: expect.any(String) }),
       ]),
     );
+  });
+
+  it("returns no autocomplete choices for unauthorized users", async () => {
+    const command = createNativeCommand("think", {
+      cfg: {
+        commands: {
+          allowFrom: {
+            discord: ["user:allowed-user"],
+          },
+        },
+      } as ReturnType<typeof loadConfig>,
+    });
+    const level = requireOption(command, "level");
+    const autocomplete = readAutocomplete(level);
+    if (typeof autocomplete !== "function") {
+      throw new Error("think level option did not wire autocomplete");
+    }
+    const respond = vi.fn(async (_choices: unknown[]) => undefined);
+
+    await autocomplete({
+      user: {
+        id: "blocked-user",
+        username: "blocked",
+        globalName: "Blocked",
+      },
+      channel: {
+        type: ChannelType.GuildText,
+        id: "channel-1",
+        name: "general",
+      },
+      guild: {
+        id: "guild-1",
+      },
+      rawData: {
+        member: { roles: [] },
+      },
+      options: {
+        getFocused: () => ({ value: "xh" }),
+      },
+      respond,
+      client: {},
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith([]);
   });
 });

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -1,0 +1,109 @@
+import { ChannelType, type AutocompleteInteraction } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listNativeCommandSpecs } from "../../../../src/auto-reply/commands-registry.js";
+import type { OpenClawConfig, loadConfig } from "../../../../src/config/config.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveBoundConversationRoute: vi.fn(),
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
+
+vi.mock("./route-resolution.js", () => ({
+  resolveDiscordBoundConversationRoute: mocks.resolveBoundConversationRoute,
+  resolveDiscordEffectiveRoute: vi.fn(),
+}));
+
+vi.mock("../../../../src/config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../src/config/sessions.js")>();
+  return {
+    ...actual,
+    loadSessionStore: mocks.loadSessionStore,
+    resolveStorePath: mocks.resolveStorePath,
+  };
+});
+
+describe("discord native /think autocomplete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveBoundConversationRoute.mockResolvedValue({
+      agentId: "main",
+      sessionKey: "discord:session:1",
+    });
+    mocks.resolveStorePath.mockReturnValue("/tmp/openclaw-sessions.mock.json");
+    mocks.loadSessionStore.mockReturnValue({
+      "discord:session:1": {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+      },
+    });
+  });
+
+  it("uses bound session model override for /think choices", async () => {
+    const spec = listNativeCommandSpecs({ provider: "discord" }).find(
+      (entry) => entry.name === "think",
+    );
+    expect(spec).toBeTruthy();
+    if (!spec) {
+      return;
+    }
+
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4.5",
+          },
+        },
+      },
+    } as ReturnType<typeof loadConfig>;
+    const discordConfig = {} as NonNullable<OpenClawConfig["channels"]>["discord"];
+    const command = createDiscordNativeCommand({
+      command: spec,
+      cfg,
+      discordConfig,
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+
+    const levelOption = command.options?.find((entry) => entry.name === "level") as
+      | {
+          autocomplete?: (
+            interaction: AutocompleteInteraction & {
+              respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
+            },
+          ) => Promise<void>;
+        }
+      | undefined;
+    expect(typeof levelOption?.autocomplete).toBe("function");
+    if (typeof levelOption?.autocomplete !== "function") {
+      return;
+    }
+
+    const respond = vi.fn(async (_choices: Array<{ name: string; value: string }>) => {});
+    const interaction = {
+      options: {
+        getFocused: () => ({ value: "xh" }),
+      },
+      respond,
+      rawData: {},
+      channel: { id: "D1", type: ChannelType.DM },
+      user: { id: "U1" },
+      guild: undefined,
+      client: {},
+    } as unknown as AutocompleteInteraction & {
+      respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
+    };
+
+    await levelOption.autocomplete(interaction);
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const choices = respond.mock.calls[0]?.[0] ?? [];
+    const values = choices.map((choice) => choice.value);
+    expect(values).toContain("xhigh");
+  });
+});

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -1,58 +1,48 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { ChannelType, type AutocompleteInteraction } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listNativeCommandSpecs } from "../../../../src/auto-reply/commands-registry.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findCommandByNativeName,
+  resolveCommandArgChoices,
+} from "../../../../src/auto-reply/commands-registry.js";
 import type { OpenClawConfig, loadConfig } from "../../../../src/config/config.js";
-import { createDiscordNativeCommand } from "./native-command.js";
+import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store.js";
+import { resolveDiscordNativeChoiceContext } from "./native-command-ui.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
-const mocks = vi.hoisted(() => ({
-  resolveBoundConversationRoute: vi.fn(),
-  resolveEffectiveRoute: vi.fn((params: { route: { agentId: string; sessionKey: string } }) => {
-    return params.route;
-  }),
-  loadSessionStore: vi.fn(),
-  resolveStorePath: vi.fn(),
-}));
-
-vi.mock("./route-resolution.js", () => ({
-  resolveDiscordBoundConversationRoute: mocks.resolveBoundConversationRoute,
-  resolveDiscordEffectiveRoute: mocks.resolveEffectiveRoute,
-}));
-
-vi.mock("../../../../src/config/sessions.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../../src/config/sessions.js")>();
-  return {
-    ...actual,
-    loadSessionStore: mocks.loadSessionStore,
-    resolveStorePath: mocks.resolveStorePath,
-  };
-});
+const STORE_PATH = path.join(
+  os.tmpdir(),
+  `openclaw-discord-think-autocomplete-${process.pid}.json`,
+);
+const SESSION_KEY = "agent:main:main";
 
 describe("discord native /think autocomplete", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.resolveBoundConversationRoute.mockReturnValue({
-      agentId: "main",
-      sessionKey: "discord:session:1",
-    });
-    mocks.resolveStorePath.mockReturnValue("/tmp/openclaw-sessions.mock.json");
-    mocks.loadSessionStore.mockReturnValue({
-      "discord:session:1": {
-        providerOverride: "openai-codex",
-        modelOverride: "gpt-5.4",
-      },
-    });
+    clearSessionStoreCacheForTest();
+    fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
+    fs.writeFileSync(
+      STORE_PATH,
+      JSON.stringify({
+        [SESSION_KEY]: {
+          updatedAt: Date.now(),
+          providerOverride: "openai-codex",
+          modelOverride: "gpt-5.4",
+        },
+      }),
+      "utf8",
+    );
   });
 
-  it("uses bound session model override for /think choices", async () => {
-    const spec = listNativeCommandSpecs({ provider: "discord" }).find(
-      (entry) => entry.name === "think",
-    );
-    expect(spec).toBeTruthy();
-    if (!spec) {
-      return;
-    }
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    try {
+      fs.unlinkSync(STORE_PATH);
+    } catch {}
+  });
 
+  it("uses the session override context for /think choices", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -61,38 +51,15 @@ describe("discord native /think autocomplete", () => {
           },
         },
       },
+      session: {
+        store: STORE_PATH,
+      },
     } as ReturnType<typeof loadConfig>;
-    const discordConfig = {} as NonNullable<OpenClawConfig["channels"]>["discord"];
-    const command = createDiscordNativeCommand({
-      command: spec,
-      cfg,
-      discordConfig,
-      accountId: "default",
-      sessionPrefix: "discord:slash",
-      ephemeralDefault: true,
-      threadBindings: createNoopThreadBindingManager("default"),
-    });
-
-    const levelOption = command.options?.find((entry) => entry.name === "level") as
-      | {
-          autocomplete?: (
-            interaction: AutocompleteInteraction & {
-              respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
-            },
-          ) => Promise<void>;
-        }
-      | undefined;
-    expect(typeof levelOption?.autocomplete).toBe("function");
-    if (typeof levelOption?.autocomplete !== "function") {
-      return;
-    }
-
-    const respond = vi.fn(async (_choices: Array<{ name: string; value: string }>) => {});
     const interaction = {
       options: {
         getFocused: () => ({ value: "xh" }),
       },
-      respond,
+      respond: async (_choices: Array<{ name: string; value: string }>) => {},
       rawData: {},
       channel: { id: "D1", type: ChannelType.DM },
       user: { id: "U1" },
@@ -102,13 +69,33 @@ describe("discord native /think autocomplete", () => {
       respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
     };
 
-    await levelOption.autocomplete(interaction);
+    const command = findCommandByNativeName("think", "discord");
+    expect(command).toBeTruthy();
+    const levelArg = command?.args?.find((entry) => entry.name === "level");
+    expect(levelArg).toBeTruthy();
+    if (!command || !levelArg) {
+      return;
+    }
 
-    expect(respond).toHaveBeenCalledTimes(1);
-    const choices = respond.mock.calls[0]?.[0] ?? [];
+    const context = await resolveDiscordNativeChoiceContext({
+      interaction,
+      cfg,
+      accountId: "default",
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    expect(context).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    });
+
+    const choices = resolveCommandArgChoices({
+      command,
+      arg: levelArg,
+      cfg,
+      provider: context?.provider,
+      model: context?.model,
+    });
     const values = choices.map((choice) => choice.value);
     expect(values).toContain("xhigh");
-    expect(mocks.loadSessionStore).toHaveBeenCalledWith("/tmp/openclaw-sessions.mock.json");
-    expect(mocks.loadSessionStore.mock.calls[0]?.[1]).toBeUndefined();
   });
 });

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -7,13 +7,16 @@ import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
 const mocks = vi.hoisted(() => ({
   resolveBoundConversationRoute: vi.fn(),
+  resolveEffectiveRoute: vi.fn((params: { route: { agentId: string; sessionKey: string } }) => {
+    return params.route;
+  }),
   loadSessionStore: vi.fn(),
   resolveStorePath: vi.fn(),
 }));
 
 vi.mock("./route-resolution.js", () => ({
   resolveDiscordBoundConversationRoute: mocks.resolveBoundConversationRoute,
-  resolveDiscordEffectiveRoute: vi.fn(),
+  resolveDiscordEffectiveRoute: mocks.resolveEffectiveRoute,
 }));
 
 vi.mock("../../../../src/config/sessions.js", async (importOriginal) => {
@@ -28,7 +31,7 @@ vi.mock("../../../../src/config/sessions.js", async (importOriginal) => {
 describe("discord native /think autocomplete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveBoundConversationRoute.mockResolvedValue({
+    mocks.resolveBoundConversationRoute.mockReturnValue({
       agentId: "main",
       sessionKey: "discord:session:1",
     });

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -2,15 +2,50 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ChannelType, type AutocompleteInteraction } from "@buape/carbon";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   findCommandByNativeName,
   resolveCommandArgChoices,
 } from "../../../../src/auto-reply/commands-registry.js";
 import type { OpenClawConfig, loadConfig } from "../../../../src/config/config.js";
 import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store.js";
+import { createConfiguredBindingConversationRuntimeModuleMock } from "../../../../test/helpers/extensions/configured-binding-runtime.js";
 import { resolveDiscordNativeChoiceContext } from "./native-command-ui.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() =>
+  vi.fn<() => Promise<{ ok: boolean; error?: string }>>(async () => ({ ok: true })),
+);
+const resolveConfiguredBindingRouteMock = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      bindingResolution: {
+        record: {
+          conversation: {
+            channel: string;
+            accountId: string;
+            conversationId: string;
+          };
+        };
+      };
+      boundSessionKey: string;
+      route: {
+        agentId: string;
+        sessionKey: string;
+      };
+    } | null
+  >(() => null),
+);
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  return await createConfiguredBindingConversationRuntimeModuleMock(
+    {
+      ensureConfiguredBindingRouteReadyMock,
+      resolveConfiguredBindingRouteMock,
+    },
+    importOriginal,
+  );
+});
 
 const STORE_PATH = path.join(
   os.tmpdir(),
@@ -21,6 +56,10 @@ const SESSION_KEY = "agent:main:main";
 describe("discord native /think autocomplete", () => {
   beforeEach(() => {
     clearSessionStoreCacheForTest();
+    ensureConfiguredBindingRouteReadyMock.mockReset();
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValue({ ok: true });
+    resolveConfiguredBindingRouteMock.mockReset();
+    resolveConfiguredBindingRouteMock.mockReturnValue(null);
     fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
     fs.writeFileSync(
       STORE_PATH,
@@ -42,8 +81,8 @@ describe("discord native /think autocomplete", () => {
     } catch {}
   });
 
-  it("uses the session override context for /think choices", async () => {
-    const cfg = {
+  function createConfig() {
+    return {
       agents: {
         defaults: {
           model: {
@@ -55,6 +94,10 @@ describe("discord native /think autocomplete", () => {
         store: STORE_PATH,
       },
     } as ReturnType<typeof loadConfig>;
+  }
+
+  it("uses the session override context for /think choices", async () => {
+    const cfg = createConfig();
     const interaction = {
       options: {
         getFocused: () => ({ value: "xh" }),
@@ -97,5 +140,71 @@ describe("discord native /think autocomplete", () => {
     });
     const values = choices.map((choice) => choice.value);
     expect(values).toContain("xhigh");
+  });
+
+  it("falls back when a configured binding is unavailable", async () => {
+    const cfg = createConfig();
+    resolveConfiguredBindingRouteMock.mockReturnValue({
+      bindingResolution: {
+        record: {
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "C1",
+          },
+        },
+      },
+      boundSessionKey: SESSION_KEY,
+      route: {
+        agentId: "main",
+        sessionKey: SESSION_KEY,
+      },
+    });
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValue({
+      ok: false,
+      error: "acpx exited",
+    });
+    const interaction = {
+      options: {
+        getFocused: () => ({ value: "xh" }),
+      },
+      respond: async (_choices: Array<{ name: string; value: string }>) => {},
+      rawData: {
+        member: { roles: [] },
+      },
+      channel: { id: "C1", type: ChannelType.GuildText },
+      user: { id: "U1" },
+      guild: { id: "G1" },
+      client: {},
+    } as unknown as AutocompleteInteraction & {
+      respond: (choices: Array<{ name: string; value: string }>) => Promise<void>;
+    };
+
+    const context = await resolveDiscordNativeChoiceContext({
+      interaction,
+      cfg,
+      accountId: "default",
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+
+    expect(context).toBeNull();
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledTimes(1);
+
+    const command = findCommandByNativeName("think", "discord");
+    const levelArg = command?.args?.find((entry) => entry.name === "level");
+    expect(command).toBeTruthy();
+    expect(levelArg).toBeTruthy();
+    if (!command || !levelArg) {
+      return;
+    }
+    const choices = resolveCommandArgChoices({
+      command,
+      arg: levelArg,
+      cfg,
+      provider: context?.provider,
+      model: context?.model,
+    });
+    const values = choices.map((choice) => choice.value);
+    expect(values).not.toContain("xhigh");
   });
 });

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -105,5 +105,7 @@ describe("discord native /think autocomplete", () => {
     const choices = respond.mock.calls[0]?.[0] ?? [];
     const values = choices.map((choice) => choice.value);
     expect(values).toContain("xhigh");
+    expect(mocks.loadSessionStore).toHaveBeenCalledWith("/tmp/openclaw-sessions.mock.json");
+    expect(mocks.loadSessionStore.mock.calls[0]?.[1]).toBeUndefined();
   });
 });

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -73,6 +73,7 @@ import {
   createDiscordModelPickerFallbackButton as createDiscordModelPickerFallbackButtonUi,
   createDiscordModelPickerFallbackSelect as createDiscordModelPickerFallbackSelectUi,
   replyWithDiscordModelPickerProviders,
+  resolveDiscordNativeChoiceContext,
   shouldOpenDiscordModelPickerFromCommand,
   type DiscordCommandArgContext,
   type DiscordModelPickerContext,
@@ -124,8 +125,11 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
 function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
   cfg: ReturnType<typeof loadConfig>;
+  resolveChoiceContext?: (
+    interaction: AutocompleteInteraction,
+  ) => Promise<{ provider?: string; model?: string } | null>;
 }): CommandOptions | undefined {
-  const { command, cfg } = params;
+  const { command, cfg, resolveChoiceContext } = params;
   const args = command.args;
   if (!args || args.length === 0) {
     return undefined;
@@ -158,7 +162,17 @@ function buildDiscordCommandOptions(params: {
           const focused = interaction.options.getFocused();
           const focusValue =
             typeof focused?.value === "string" ? focused.value.trim().toLowerCase() : "";
-          const choices = resolveCommandArgChoices({ command, arg, cfg });
+          const context =
+            typeof arg.choices === "function" && resolveChoiceContext
+              ? await resolveChoiceContext(interaction)
+              : null;
+          const choices = resolveCommandArgChoices({
+            command,
+            arg,
+            cfg,
+            provider: context?.provider,
+            model: context?.model,
+          });
           const filtered = focusValue
             ? choices.filter((choice) => choice.label.toLowerCase().includes(focusValue))
             : choices;
@@ -297,6 +311,13 @@ export function createDiscordNativeCommand(params: {
   const commandOptions = buildDiscordCommandOptions({
     command: commandDefinition,
     cfg,
+    resolveChoiceContext: async (interaction) =>
+      resolveDiscordNativeChoiceContext({
+        interaction,
+        cfg,
+        accountId,
+        threadBindings,
+      }),
   });
   const options = commandOptions
     ? (commandOptions satisfies CommandOptions)

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -88,39 +88,6 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
-type DiscordNativeInteraction =
-  | CommandInteraction
-  | ButtonInteraction
-  | StringSelectMenuInteraction
-  | AutocompleteInteraction;
-type DiscordNativeAccessDenial =
-  | "channel_disabled"
-  | "channel_not_allowed"
-  | "dm_disabled"
-  | "dm_policy"
-  | "group_dm_disabled"
-  | "unauthorized";
-type DiscordNativeAccessState = {
-  user: NonNullable<DiscordNativeInteraction["user"]>;
-  sender: ReturnType<typeof resolveDiscordSenderIdentity>;
-  channel: DiscordNativeInteraction["channel"];
-  channelName?: string;
-  channelSlug: string;
-  rawChannelId: string;
-  memberRoleIds: string[];
-  allowNameMatching: boolean;
-  guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
-  threadParentId?: string;
-  threadParentName?: string;
-  threadParentSlug: string;
-  channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback> | null;
-  isDirectMessage: boolean;
-  isGroupDm: boolean;
-  isThreadChannel: boolean;
-  commandAuthorized: boolean;
-  denial?: DiscordNativeAccessDenial;
-  dmAccess?: Awaited<ReturnType<typeof resolveDiscordDmCommandAccess>>;
-};
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
   cfg: OpenClawConfig;
@@ -153,232 +120,6 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
     allowNameMatching: false,
   });
   return { configured: true, allowed: match.allowed } as const;
-}
-
-async function resolveDiscordNativeAutocompleteAuthorized(params: {
-  interaction: AutocompleteInteraction;
-  cfg: ReturnType<typeof loadConfig>;
-  discordConfig: DiscordConfig;
-  accountId: string;
-}): Promise<boolean> {
-  const access = await resolveDiscordNativeInteractionAccessState(params);
-  return access?.commandAuthorized ?? false;
-}
-
-async function resolveDiscordNativeInteractionAccessState(params: {
-  interaction: DiscordNativeInteraction;
-  cfg: ReturnType<typeof loadConfig>;
-  discordConfig: DiscordConfig;
-  accountId: string;
-}): Promise<DiscordNativeAccessState | null> {
-  const { interaction, cfg, discordConfig, accountId } = params;
-  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-  const user = interaction.user;
-  if (!user) {
-    return null;
-  }
-  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
-  const channel = interaction.channel;
-  const channelType = channel?.type;
-  const isDirectMessage = channelType === ChannelType.DM;
-  const isGroupDm = channelType === ChannelType.GroupDM;
-  const isThreadChannel =
-    channelType === ChannelType.PublicThread ||
-    channelType === ChannelType.PrivateThread ||
-    channelType === ChannelType.AnnouncementThread;
-  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
-  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
-  const rawChannelId = channel?.id ?? "";
-  const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
-    ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
-    : [];
-  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
-  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
-    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
-    sender: {
-      id: sender.id,
-      name: sender.name,
-      tag: sender.tag,
-    },
-    allowNameMatching,
-  });
-  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
-    cfg,
-    accountId,
-    sender: {
-      id: sender.id,
-      name: sender.name,
-      tag: sender.tag,
-    },
-    chatType: isDirectMessage
-      ? "direct"
-      : isThreadChannel
-        ? "thread"
-        : interaction.guild
-          ? "channel"
-          : "group",
-    conversationId: rawChannelId || undefined,
-  });
-  const guildInfo = resolveDiscordGuildEntry({
-    guild: interaction.guild ?? undefined,
-    guildId: interaction.guild?.id ?? undefined,
-    guildEntries: discordConfig?.guilds,
-  });
-  let threadParentId: string | undefined;
-  let threadParentName: string | undefined;
-  let threadParentSlug = "";
-  if (interaction.guild && channel && isThreadChannel && rawChannelId) {
-    const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
-    const parentInfo = await resolveDiscordThreadParentInfo({
-      client: interaction.client,
-      threadChannel: {
-        id: rawChannelId,
-        name: channelName,
-        parentId: "parentId" in channel ? (channel.parentId ?? undefined) : undefined,
-        parent: undefined,
-      },
-      channelInfo,
-    });
-    threadParentId = parentInfo.id;
-    threadParentName = parentInfo.name;
-    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
-  }
-  const channelConfig = interaction.guild
-    ? resolveDiscordChannelConfigWithFallback({
-        guildInfo,
-        channelId: rawChannelId,
-        channelName,
-        channelSlug,
-        parentId: threadParentId,
-        parentName: threadParentName,
-        parentSlug: threadParentSlug,
-        scope: isThreadChannel ? "thread" : "channel",
-      })
-    : null;
-  const baseState = {
-    user,
-    sender,
-    channel,
-    channelName,
-    channelSlug,
-    rawChannelId,
-    memberRoleIds,
-    allowNameMatching,
-    guildInfo,
-    threadParentId,
-    threadParentName,
-    threadParentSlug,
-    channelConfig,
-    isDirectMessage,
-    isGroupDm,
-    isThreadChannel,
-  } satisfies Omit<DiscordNativeAccessState, "commandAuthorized" | "denial" | "dmAccess">;
-  if (channelConfig?.enabled === false) {
-    return {
-      ...baseState,
-      commandAuthorized: false,
-      denial: "channel_disabled",
-    };
-  }
-  if (interaction.guild && channelConfig?.allowed === false) {
-    return {
-      ...baseState,
-      commandAuthorized: false,
-      denial: "channel_not_allowed",
-    };
-  }
-  if (useAccessGroups && interaction.guild) {
-    const channelAllowlistConfigured =
-      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
-    const channelAllowed = channelConfig?.allowed !== false;
-    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
-      providerConfigPresent: cfg.channels?.discord !== undefined,
-      groupPolicy: discordConfig?.groupPolicy,
-      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
-    });
-    const allowByPolicy = isDiscordGroupAllowedByPolicy({
-      groupPolicy,
-      guildAllowlisted: Boolean(guildInfo),
-      channelAllowlistConfigured,
-      channelAllowed,
-    });
-    if (!allowByPolicy) {
-      return {
-        ...baseState,
-        commandAuthorized: false,
-        denial: "channel_not_allowed",
-      };
-    }
-  }
-  const dmEnabled = discordConfig?.dm?.enabled ?? true;
-  const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
-  if (isDirectMessage) {
-    if (!dmEnabled || dmPolicy === "disabled") {
-      return {
-        ...baseState,
-        commandAuthorized: false,
-        denial: "dm_disabled",
-      };
-    }
-    const dmAccess = await resolveDiscordDmCommandAccess({
-      accountId,
-      dmPolicy,
-      configuredAllowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
-      sender: {
-        id: sender.id,
-        name: sender.name,
-        tag: sender.tag,
-      },
-      allowNameMatching,
-      useAccessGroups,
-    });
-    return {
-      ...baseState,
-      commandAuthorized: dmAccess.decision === "allow" && dmAccess.commandAuthorized,
-      ...(dmAccess.decision !== "allow" ? { denial: "dm_policy" as const } : {}),
-      dmAccess,
-    };
-  }
-  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
-    return {
-      ...baseState,
-      commandAuthorized: false,
-      denial: "group_dm_disabled",
-    };
-  }
-  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-    channelConfig,
-    guildInfo,
-    memberRoleIds,
-    sender,
-    allowNameMatching,
-  });
-  const authorizers = useAccessGroups
-    ? [
-        {
-          configured: commandsAllowFromAccess.configured,
-          allowed: commandsAllowFromAccess.allowed,
-        },
-        { configured: ownerAllowList != null, allowed: ownerOk },
-        { configured: hasAccessRestrictions, allowed: memberAllowed },
-      ]
-    : [
-        {
-          configured: commandsAllowFromAccess.configured,
-          allowed: commandsAllowFromAccess.allowed,
-        },
-        { configured: hasAccessRestrictions, allowed: memberAllowed },
-      ];
-  const commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
-    useAccessGroups,
-    authorizers,
-    modeWhenAccessGroupsOff: "configured",
-  });
-  return {
-    ...baseState,
-    commandAuthorized,
-    ...(!commandAuthorized ? { denial: "unauthorized" as const } : {}),
-  };
 }
 
 function buildDiscordCommandOptions(params: {
@@ -570,23 +311,14 @@ export function createDiscordNativeCommand(params: {
   const commandOptions = buildDiscordCommandOptions({
     command: commandDefinition,
     cfg,
-    resolveChoiceContext: async (interaction) => {
-      const authorized = await resolveDiscordNativeAutocompleteAuthorized({
+    resolveChoiceContext: async (interaction) =>
+      resolveDiscordNativeChoiceContext({
         interaction,
         cfg,
         discordConfig,
         accountId,
-      });
-      if (!authorized) {
-        return null;
-      }
-      return resolveDiscordNativeChoiceContext({
-        interaction,
-        cfg,
-        accountId,
         threadBindings,
-      });
-    },
+      }),
   });
   const options = commandOptions
     ? (commandOptions satisfies CommandOptions)
@@ -677,76 +409,202 @@ async function dispatchDiscordCommandInteraction(params: {
     });
   };
 
-  const access = await resolveDiscordNativeInteractionAccessState({
-    interaction,
-    cfg,
-    discordConfig,
-    accountId,
-  });
-  if (!access) {
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const user = interaction.user;
+  if (!user) {
     return;
   }
-  const {
-    user,
-    sender,
-    channel,
-    channelName,
-    channelSlug,
-    rawChannelId,
-    memberRoleIds,
+  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
+  const channel = interaction.channel;
+  const channelType = channel?.type;
+  const isDirectMessage = channelType === ChannelType.DM;
+  const isGroupDm = channelType === ChannelType.GroupDM;
+  const isThreadChannel =
+    channelType === ChannelType.PublicThread ||
+    channelType === ChannelType.PrivateThread ||
+    channelType === ChannelType.AnnouncementThread;
+  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
+  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+  const rawChannelId = channel?.id ?? "";
+  const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
+    ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
+    : [];
+  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
+  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
+    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
     allowNameMatching,
-    guildInfo,
-    threadParentId,
-    threadParentName,
-    threadParentSlug,
-    channelConfig,
-    isDirectMessage,
-    isGroupDm,
-    isThreadChannel,
-    commandAuthorized,
-  } = access;
-  switch (access.denial) {
-    case "channel_disabled":
-      await respond("This channel is disabled.");
-      return;
-    case "channel_not_allowed":
+  });
+  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
+    cfg,
+    accountId,
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    chatType: isDirectMessage
+      ? "direct"
+      : isThreadChannel
+        ? "thread"
+        : interaction.guild
+          ? "channel"
+          : "group",
+    conversationId: rawChannelId || undefined,
+  });
+  const guildInfo = resolveDiscordGuildEntry({
+    guild: interaction.guild ?? undefined,
+    guildId: interaction.guild?.id ?? undefined,
+    guildEntries: discordConfig?.guilds,
+  });
+  let threadParentId: string | undefined;
+  let threadParentName: string | undefined;
+  let threadParentSlug = "";
+  if (interaction.guild && channel && isThreadChannel && rawChannelId) {
+    // Threads inherit parent channel config unless explicitly overridden.
+    const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
+    const parentInfo = await resolveDiscordThreadParentInfo({
+      client: interaction.client,
+      threadChannel: {
+        id: rawChannelId,
+        name: channelName,
+        parentId: "parentId" in channel ? (channel.parentId ?? undefined) : undefined,
+        parent: undefined,
+      },
+      channelInfo,
+    });
+    threadParentId = parentInfo.id;
+    threadParentName = parentInfo.name;
+    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+  }
+  const channelConfig = interaction.guild
+    ? resolveDiscordChannelConfigWithFallback({
+        guildInfo,
+        channelId: rawChannelId,
+        channelName,
+        channelSlug,
+        parentId: threadParentId,
+        parentName: threadParentName,
+        parentSlug: threadParentSlug,
+        scope: isThreadChannel ? "thread" : "channel",
+      })
+    : null;
+  if (channelConfig?.enabled === false) {
+    await respond("This channel is disabled.");
+    return;
+  }
+  if (interaction.guild && channelConfig?.allowed === false) {
+    await respond("This channel is not allowed.");
+    return;
+  }
+  if (useAccessGroups && interaction.guild) {
+    const channelAllowlistConfigured =
+      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+    const channelAllowed = channelConfig?.allowed !== false;
+    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.discord !== undefined,
+      groupPolicy: discordConfig?.groupPolicy,
+      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+    });
+    const allowByPolicy = isDiscordGroupAllowedByPolicy({
+      groupPolicy,
+      guildAllowlisted: Boolean(guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    });
+    if (!allowByPolicy) {
       await respond("This channel is not allowed.");
       return;
-    case "dm_disabled":
+    }
+  }
+  const dmEnabled = discordConfig?.dm?.enabled ?? true;
+  const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
+  let commandAuthorized = true;
+  if (isDirectMessage) {
+    if (!dmEnabled || dmPolicy === "disabled") {
       await respond("Discord DMs are disabled.");
       return;
-    case "group_dm_disabled":
-      await respond("Discord group DMs are disabled.");
+    }
+    const dmAccess = await resolveDiscordDmCommandAccess({
+      accountId,
+      dmPolicy,
+      configuredAllowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+      sender: {
+        id: sender.id,
+        name: sender.name,
+        tag: sender.tag,
+      },
+      allowNameMatching,
+      useAccessGroups,
+    });
+    commandAuthorized = dmAccess.commandAuthorized;
+    if (dmAccess.decision !== "allow") {
+      await handleDiscordDmCommandDecision({
+        dmAccess,
+        accountId,
+        sender: {
+          id: user.id,
+          tag: sender.tag,
+          name: sender.name,
+        },
+        onPairingCreated: async (code) => {
+          await respond(
+            buildPairingReply({
+              channel: "discord",
+              idLine: `Your Discord user id: ${user.id}`,
+              code,
+            }),
+            { ephemeral: true },
+          );
+        },
+        onUnauthorized: async () => {
+          await respond("You are not authorized to use this command.", { ephemeral: true });
+        },
+      });
       return;
-    case "dm_policy":
-      if (access.dmAccess) {
-        await handleDiscordDmCommandDecision({
-          dmAccess: access.dmAccess,
-          accountId,
-          sender: {
-            id: user.id,
-            tag: sender.tag,
-            name: sender.name,
+    }
+  }
+  if (!isDirectMessage) {
+    const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+      channelConfig,
+      guildInfo,
+      memberRoleIds,
+      sender,
+      allowNameMatching,
+    });
+    const authorizers = useAccessGroups
+      ? [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
           },
-          onPairingCreated: async (code) => {
-            await respond(
-              buildPairingReply({
-                channel: "discord",
-                idLine: `Your Discord user id: ${user.id}`,
-                code,
-              }),
-              { ephemeral: true },
-            );
+          { configured: ownerAllowList != null, allowed: ownerOk },
+          { configured: hasAccessRestrictions, allowed: memberAllowed },
+        ]
+      : [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
           },
-          onUnauthorized: async () => {
-            await respond("You are not authorized to use this command.", { ephemeral: true });
-          },
-        });
-      }
-      return;
-    case "unauthorized":
+          { configured: hasAccessRestrictions, allowed: memberAllowed },
+        ];
+    commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
+      useAccessGroups,
+      authorizers,
+      modeWhenAccessGroupsOff: "configured",
+    });
+    if (!commandAuthorized) {
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return;
+    }
+  }
+  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
+    await respond("Discord group DMs are disabled.");
+    return;
   }
 
   const menu = resolveCommandArgMenu({

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -88,6 +88,39 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+type DiscordNativeInteraction =
+  | CommandInteraction
+  | ButtonInteraction
+  | StringSelectMenuInteraction
+  | AutocompleteInteraction;
+type DiscordNativeAccessDenial =
+  | "channel_disabled"
+  | "channel_not_allowed"
+  | "dm_disabled"
+  | "dm_policy"
+  | "group_dm_disabled"
+  | "unauthorized";
+type DiscordNativeAccessState = {
+  user: NonNullable<DiscordNativeInteraction["user"]>;
+  sender: ReturnType<typeof resolveDiscordSenderIdentity>;
+  channel: DiscordNativeInteraction["channel"];
+  channelName?: string;
+  channelSlug: string;
+  rawChannelId: string;
+  memberRoleIds: string[];
+  allowNameMatching: boolean;
+  guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
+  threadParentId?: string;
+  threadParentName?: string;
+  threadParentSlug: string;
+  channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback> | null;
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+  isThreadChannel: boolean;
+  commandAuthorized: boolean;
+  denial?: DiscordNativeAccessDenial;
+  dmAccess?: Awaited<ReturnType<typeof resolveDiscordDmCommandAccess>>;
+};
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
   cfg: OpenClawConfig;
@@ -128,11 +161,21 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
   discordConfig: DiscordConfig;
   accountId: string;
 }): Promise<boolean> {
+  const access = await resolveDiscordNativeInteractionAccessState(params);
+  return access?.commandAuthorized ?? false;
+}
+
+async function resolveDiscordNativeInteractionAccessState(params: {
+  interaction: DiscordNativeInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+}): Promise<DiscordNativeAccessState | null> {
   const { interaction, cfg, discordConfig, accountId } = params;
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const user = interaction.user;
   if (!user) {
-    return false;
+    return null;
   }
   const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
   const channel = interaction.channel;
@@ -212,11 +255,37 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
         scope: isThreadChannel ? "thread" : "channel",
       })
     : null;
+  const baseState = {
+    user,
+    sender,
+    channel,
+    channelName,
+    channelSlug,
+    rawChannelId,
+    memberRoleIds,
+    allowNameMatching,
+    guildInfo,
+    threadParentId,
+    threadParentName,
+    threadParentSlug,
+    channelConfig,
+    isDirectMessage,
+    isGroupDm,
+    isThreadChannel,
+  } satisfies Omit<DiscordNativeAccessState, "commandAuthorized" | "denial" | "dmAccess">;
   if (channelConfig?.enabled === false) {
-    return false;
+    return {
+      ...baseState,
+      commandAuthorized: false,
+      denial: "channel_disabled",
+    };
   }
   if (interaction.guild && channelConfig?.allowed === false) {
-    return false;
+    return {
+      ...baseState,
+      commandAuthorized: false,
+      denial: "channel_not_allowed",
+    };
   }
   if (useAccessGroups && interaction.guild) {
     const channelAllowlistConfigured =
@@ -234,14 +303,22 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
       channelAllowed,
     });
     if (!allowByPolicy) {
-      return false;
+      return {
+        ...baseState,
+        commandAuthorized: false,
+        denial: "channel_not_allowed",
+      };
     }
   }
   const dmEnabled = discordConfig?.dm?.enabled ?? true;
   const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
   if (isDirectMessage) {
     if (!dmEnabled || dmPolicy === "disabled") {
-      return false;
+      return {
+        ...baseState,
+        commandAuthorized: false,
+        denial: "dm_disabled",
+      };
     }
     const dmAccess = await resolveDiscordDmCommandAccess({
       accountId,
@@ -255,10 +332,19 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
       allowNameMatching,
       useAccessGroups,
     });
-    return dmAccess.decision === "allow";
+    return {
+      ...baseState,
+      commandAuthorized: dmAccess.decision === "allow" && dmAccess.commandAuthorized,
+      ...(dmAccess.decision !== "allow" ? { denial: "dm_policy" as const } : {}),
+      dmAccess,
+    };
   }
   if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
-    return false;
+    return {
+      ...baseState,
+      commandAuthorized: false,
+      denial: "group_dm_disabled",
+    };
   }
   const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
     channelConfig,
@@ -283,11 +369,16 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
         },
         { configured: hasAccessRestrictions, allowed: memberAllowed },
       ];
-  return resolveCommandAuthorizedFromAuthorizers({
+  const commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
     authorizers,
     modeWhenAccessGroupsOff: "configured",
   });
+  return {
+    ...baseState,
+    commandAuthorized,
+    ...(!commandAuthorized ? { denial: "unauthorized" as const } : {}),
+  };
 }
 
 function buildDiscordCommandOptions(params: {
@@ -586,202 +677,76 @@ async function dispatchDiscordCommandInteraction(params: {
     });
   };
 
-  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-  const user = interaction.user;
-  if (!user) {
-    return;
-  }
-  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
-  const channel = interaction.channel;
-  const channelType = channel?.type;
-  const isDirectMessage = channelType === ChannelType.DM;
-  const isGroupDm = channelType === ChannelType.GroupDM;
-  const isThreadChannel =
-    channelType === ChannelType.PublicThread ||
-    channelType === ChannelType.PrivateThread ||
-    channelType === ChannelType.AnnouncementThread;
-  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
-  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
-  const rawChannelId = channel?.id ?? "";
-  const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
-    ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
-    : [];
-  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
-  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
-    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
-    sender: {
-      id: sender.id,
-      name: sender.name,
-      tag: sender.tag,
-    },
-    allowNameMatching,
-  });
-  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
+  const access = await resolveDiscordNativeInteractionAccessState({
+    interaction,
     cfg,
+    discordConfig,
     accountId,
-    sender: {
-      id: sender.id,
-      name: sender.name,
-      tag: sender.tag,
-    },
-    chatType: isDirectMessage
-      ? "direct"
-      : isThreadChannel
-        ? "thread"
-        : interaction.guild
-          ? "channel"
-          : "group",
-    conversationId: rawChannelId || undefined,
   });
-  const guildInfo = resolveDiscordGuildEntry({
-    guild: interaction.guild ?? undefined,
-    guildId: interaction.guild?.id ?? undefined,
-    guildEntries: discordConfig?.guilds,
-  });
-  let threadParentId: string | undefined;
-  let threadParentName: string | undefined;
-  let threadParentSlug = "";
-  if (interaction.guild && channel && isThreadChannel && rawChannelId) {
-    // Threads inherit parent channel config unless explicitly overridden.
-    const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
-    const parentInfo = await resolveDiscordThreadParentInfo({
-      client: interaction.client,
-      threadChannel: {
-        id: rawChannelId,
-        name: channelName,
-        parentId: "parentId" in channel ? (channel.parentId ?? undefined) : undefined,
-        parent: undefined,
-      },
-      channelInfo,
-    });
-    threadParentId = parentInfo.id;
-    threadParentName = parentInfo.name;
-    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
-  }
-  const channelConfig = interaction.guild
-    ? resolveDiscordChannelConfigWithFallback({
-        guildInfo,
-        channelId: rawChannelId,
-        channelName,
-        channelSlug,
-        parentId: threadParentId,
-        parentName: threadParentName,
-        parentSlug: threadParentSlug,
-        scope: isThreadChannel ? "thread" : "channel",
-      })
-    : null;
-  if (channelConfig?.enabled === false) {
-    await respond("This channel is disabled.");
+  if (!access) {
     return;
   }
-  if (interaction.guild && channelConfig?.allowed === false) {
-    await respond("This channel is not allowed.");
-    return;
-  }
-  if (useAccessGroups && interaction.guild) {
-    const channelAllowlistConfigured =
-      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
-    const channelAllowed = channelConfig?.allowed !== false;
-    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
-      providerConfigPresent: cfg.channels?.discord !== undefined,
-      groupPolicy: discordConfig?.groupPolicy,
-      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
-    });
-    const allowByPolicy = isDiscordGroupAllowedByPolicy({
-      groupPolicy,
-      guildAllowlisted: Boolean(guildInfo),
-      channelAllowlistConfigured,
-      channelAllowed,
-    });
-    if (!allowByPolicy) {
+  const {
+    user,
+    sender,
+    channel,
+    channelName,
+    channelSlug,
+    rawChannelId,
+    memberRoleIds,
+    allowNameMatching,
+    guildInfo,
+    threadParentId,
+    threadParentName,
+    threadParentSlug,
+    channelConfig,
+    isDirectMessage,
+    isGroupDm,
+    isThreadChannel,
+    commandAuthorized,
+  } = access;
+  switch (access.denial) {
+    case "channel_disabled":
+      await respond("This channel is disabled.");
+      return;
+    case "channel_not_allowed":
       await respond("This channel is not allowed.");
       return;
-    }
-  }
-  const dmEnabled = discordConfig?.dm?.enabled ?? true;
-  const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
-  let commandAuthorized = true;
-  if (isDirectMessage) {
-    if (!dmEnabled || dmPolicy === "disabled") {
+    case "dm_disabled":
       await respond("Discord DMs are disabled.");
       return;
-    }
-    const dmAccess = await resolveDiscordDmCommandAccess({
-      accountId,
-      dmPolicy,
-      configuredAllowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
-      sender: {
-        id: sender.id,
-        name: sender.name,
-        tag: sender.tag,
-      },
-      allowNameMatching,
-      useAccessGroups,
-    });
-    commandAuthorized = dmAccess.commandAuthorized;
-    if (dmAccess.decision !== "allow") {
-      await handleDiscordDmCommandDecision({
-        dmAccess,
-        accountId,
-        sender: {
-          id: user.id,
-          tag: sender.tag,
-          name: sender.name,
-        },
-        onPairingCreated: async (code) => {
-          await respond(
-            buildPairingReply({
-              channel: "discord",
-              idLine: `Your Discord user id: ${user.id}`,
-              code,
-            }),
-            { ephemeral: true },
-          );
-        },
-        onUnauthorized: async () => {
-          await respond("You are not authorized to use this command.", { ephemeral: true });
-        },
-      });
+    case "group_dm_disabled":
+      await respond("Discord group DMs are disabled.");
       return;
-    }
-  }
-  if (!isDirectMessage) {
-    const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-      channelConfig,
-      guildInfo,
-      memberRoleIds,
-      sender,
-      allowNameMatching,
-    });
-    const authorizers = useAccessGroups
-      ? [
-          {
-            configured: commandsAllowFromAccess.configured,
-            allowed: commandsAllowFromAccess.allowed,
+    case "dm_policy":
+      if (access.dmAccess) {
+        await handleDiscordDmCommandDecision({
+          dmAccess: access.dmAccess,
+          accountId,
+          sender: {
+            id: user.id,
+            tag: sender.tag,
+            name: sender.name,
           },
-          { configured: ownerAllowList != null, allowed: ownerOk },
-          { configured: hasAccessRestrictions, allowed: memberAllowed },
-        ]
-      : [
-          {
-            configured: commandsAllowFromAccess.configured,
-            allowed: commandsAllowFromAccess.allowed,
+          onPairingCreated: async (code) => {
+            await respond(
+              buildPairingReply({
+                channel: "discord",
+                idLine: `Your Discord user id: ${user.id}`,
+                code,
+              }),
+              { ephemeral: true },
+            );
           },
-          { configured: hasAccessRestrictions, allowed: memberAllowed },
-        ];
-    commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
-      useAccessGroups,
-      authorizers,
-      modeWhenAccessGroupsOff: "configured",
-    });
-    if (!commandAuthorized) {
+          onUnauthorized: async () => {
+            await respond("You are not authorized to use this command.", { ephemeral: true });
+          },
+        });
+      }
+      return;
+    case "unauthorized":
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return;
-    }
-  }
-  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
-    await respond("Discord group DMs are disabled.");
-    return;
   }
 
   const menu = resolveCommandArgMenu({

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -34,10 +34,6 @@ import {
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/config-runtime";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
-import {
-  ensureConfiguredBindingRouteReady,
-  resolveConfiguredBindingRoute,
-} from "openclaw/plugin-sdk/conversation-runtime";
 import { buildPairingReply } from "openclaw/plugin-sdk/conversation-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { executePluginCommand, matchPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
@@ -67,6 +63,7 @@ import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import { buildDiscordNativeCommandContext } from "./native-command-context.js";
+import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 import {
   buildDiscordCommandArgMenu,
   createDiscordCommandArgFallbackButton as createDiscordCommandArgFallbackButtonUi,
@@ -78,10 +75,6 @@ import {
   type DiscordCommandArgContext,
   type DiscordModelPickerContext,
 } from "./native-command-ui.js";
-import {
-  resolveDiscordBoundConversationRoute,
-  resolveDiscordEffectiveRoute,
-} from "./route-resolution.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
@@ -125,11 +118,12 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
 function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
   cfg: ReturnType<typeof loadConfig>;
+  authorizeChoiceContext?: (interaction: AutocompleteInteraction) => Promise<boolean>;
   resolveChoiceContext?: (
     interaction: AutocompleteInteraction,
   ) => Promise<{ provider?: string; model?: string } | null>;
 }): CommandOptions | undefined {
-  const { command, cfg, resolveChoiceContext } = params;
+  const { command, cfg, authorizeChoiceContext, resolveChoiceContext } = params;
   const args = command.args;
   if (!args || args.length === 0) {
     return undefined;
@@ -159,6 +153,15 @@ function buildDiscordCommandOptions(params: {
         (typeof arg.choices === "function" || resolvedChoices.length > 25));
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
+          if (
+            typeof arg.choices === "function" &&
+            resolveChoiceContext &&
+            authorizeChoiceContext &&
+            !(await authorizeChoiceContext(interaction))
+          ) {
+            await interaction.respond([]);
+            return;
+          }
           const focused = interaction.options.getFocused();
           const focusValue =
             typeof focused?.value === "string" ? focused.value.trim().toLowerCase() : "";
@@ -201,6 +204,179 @@ function buildDiscordCommandOptions(params: {
 function shouldBypassConfiguredAcpEnsure(commandName: string): boolean {
   const normalized = commandName.trim().toLowerCase();
   return normalized === "acp" || normalized === "new" || normalized === "reset";
+}
+
+async function resolveDiscordNativeAutocompleteAuthorized(params: {
+  interaction: AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+}): Promise<boolean> {
+  const { interaction, cfg, discordConfig, accountId } = params;
+  const user = interaction.user;
+  if (!user) {
+    return false;
+  }
+  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
+  const channel = interaction.channel;
+  const channelType = channel?.type;
+  const isDirectMessage = channelType === ChannelType.DM;
+  const isGroupDm = channelType === ChannelType.GroupDM;
+  const isThreadChannel =
+    channelType === ChannelType.PublicThread ||
+    channelType === ChannelType.PrivateThread ||
+    channelType === ChannelType.AnnouncementThread;
+  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
+  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+  const rawChannelId = channel?.id ?? "";
+  const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
+    ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
+    : [];
+  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
+    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    allowNameMatching,
+  });
+  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
+    cfg,
+    accountId,
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    chatType: isDirectMessage
+      ? "direct"
+      : isThreadChannel
+        ? "thread"
+        : interaction.guild
+          ? "channel"
+          : "group",
+    conversationId: rawChannelId || undefined,
+  });
+  const guildInfo = resolveDiscordGuildEntry({
+    guild: interaction.guild ?? undefined,
+    guildId: interaction.guild?.id ?? undefined,
+    guildEntries: discordConfig?.guilds,
+  });
+  let threadParentId: string | undefined;
+  let threadParentName: string | undefined;
+  let threadParentSlug = "";
+  if (interaction.guild && channel && isThreadChannel && rawChannelId) {
+    const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
+    const parentInfo = await resolveDiscordThreadParentInfo({
+      client: interaction.client,
+      threadChannel: {
+        id: rawChannelId,
+        name: channelName,
+        parentId: "parentId" in channel ? (channel.parentId ?? undefined) : undefined,
+        parent: undefined,
+      },
+      channelInfo,
+    });
+    threadParentId = parentInfo.id;
+    threadParentName = parentInfo.name;
+    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+  }
+  const channelConfig = interaction.guild
+    ? resolveDiscordChannelConfigWithFallback({
+        guildInfo,
+        channelId: rawChannelId,
+        channelName,
+        channelSlug,
+        parentId: threadParentId,
+        parentName: threadParentName,
+        parentSlug: threadParentSlug,
+        scope: isThreadChannel ? "thread" : "channel",
+      })
+    : null;
+  if (channelConfig?.enabled === false) {
+    return false;
+  }
+  if (interaction.guild && channelConfig?.allowed === false) {
+    return false;
+  }
+  if (useAccessGroups && interaction.guild) {
+    const channelAllowlistConfigured =
+      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+    const channelAllowed = channelConfig?.allowed !== false;
+    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.discord !== undefined,
+      groupPolicy: discordConfig?.groupPolicy,
+      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+    });
+    const allowByPolicy = isDiscordGroupAllowedByPolicy({
+      groupPolicy,
+      guildAllowlisted: Boolean(guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    });
+    if (!allowByPolicy) {
+      return false;
+    }
+  }
+  const dmEnabled = discordConfig?.dm?.enabled ?? true;
+  const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
+  if (isDirectMessage) {
+    if (!dmEnabled || dmPolicy === "disabled") {
+      return false;
+    }
+    const dmAccess = await resolveDiscordDmCommandAccess({
+      accountId,
+      dmPolicy,
+      configuredAllowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+      sender: {
+        id: sender.id,
+        name: sender.name,
+        tag: sender.tag,
+      },
+      allowNameMatching,
+      useAccessGroups,
+    });
+    if (dmAccess.decision !== "allow") {
+      return false;
+    }
+  }
+  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
+    return false;
+  }
+  if (!isDirectMessage) {
+    const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+      channelConfig,
+      guildInfo,
+      memberRoleIds,
+      sender,
+      allowNameMatching,
+    });
+    const authorizers = useAccessGroups
+      ? [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
+          },
+          { configured: ownerAllowList != null, allowed: ownerOk },
+          { configured: hasAccessRestrictions, allowed: memberAllowed },
+        ]
+      : [
+          {
+            configured: commandsAllowFromAccess.configured,
+            allowed: commandsAllowFromAccess.allowed,
+          },
+          { configured: hasAccessRestrictions, allowed: memberAllowed },
+        ];
+    return resolveCommandAuthorizedFromAuthorizers({
+      useAccessGroups,
+      authorizers,
+      modeWhenAccessGroupsOff: "configured",
+    });
+  }
+  return true;
 }
 
 function readDiscordCommandArgs(
@@ -311,6 +487,13 @@ export function createDiscordNativeCommand(params: {
   const commandOptions = buildDiscordCommandOptions({
     command: commandDefinition,
     cfg,
+    authorizeChoiceContext: async (interaction) =>
+      await resolveDiscordNativeAutocompleteAuthorized({
+        interaction,
+        cfg,
+        discordConfig,
+        accountId,
+      }),
     resolveChoiceContext: async (interaction) =>
       resolveDiscordNativeChoiceContext({
         interaction,
@@ -707,7 +890,9 @@ async function dispatchDiscordCommandInteraction(params: {
   const isGuild = Boolean(interaction.guild);
   const channelId = rawChannelId || "unknown";
   const interactionId = interaction.rawData.id;
-  const route = resolveDiscordBoundConversationRoute({
+  const threadBinding = isThreadChannel ? threadBindings.getByThreadId(rawChannelId) : undefined;
+  const commandName = command.nativeName ?? command.key;
+  const routeState = await resolveDiscordNativeInteractionRouteState({
     cfg,
     accountId,
     guildId: interaction.guild?.id ?? undefined,
@@ -717,46 +902,21 @@ async function dispatchDiscordCommandInteraction(params: {
     directUserId: user.id,
     conversationId: channelId,
     parentConversationId: threadParentId,
-    // Configured ACP routes apply after raw route resolution, so do not pass
-    // bound/configured overrides here.
+    threadBinding,
+    enforceConfiguredBindingReadiness: !shouldBypassConfiguredAcpEnsure(commandName),
   });
-  const threadBinding = isThreadChannel ? threadBindings.getByThreadId(rawChannelId) : undefined;
-  const configuredRoute =
-    threadBinding == null
-      ? resolveConfiguredBindingRoute({
-          cfg,
-          route,
-          conversation: {
-            channel: "discord",
-            accountId,
-            conversationId: channelId,
-            parentConversationId: threadParentId,
-          },
-        })
-      : null;
-  const configuredBinding = configuredRoute?.bindingResolution ?? null;
-  const commandName = command.nativeName ?? command.key;
-  if (configuredBinding && !shouldBypassConfiguredAcpEnsure(commandName)) {
-    const ensured = await ensureConfiguredBindingRouteReady({
-      cfg,
-      bindingResolution: configuredBinding,
-    });
-    if (!ensured.ok) {
+  if (routeState.bindingReadiness && !routeState.bindingReadiness.ok) {
+    const configuredBinding = routeState.configuredBinding;
+    if (configuredBinding) {
       logVerbose(
-        `discord native command: configured ACP binding unavailable for channel ${configuredBinding.record.conversation.conversationId}: ${ensured.error}`,
+        `discord native command: configured ACP binding unavailable for channel ${configuredBinding.record.conversation.conversationId}: ${routeState.bindingReadiness.error}`,
       );
       await respond("Configured ACP binding is unavailable right now. Please try again.");
       return;
     }
   }
-  const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
-  const boundSessionKey = threadBinding?.targetSessionKey?.trim() || configuredBoundSessionKey;
-  const effectiveRoute = resolveDiscordEffectiveRoute({
-    route,
-    boundSessionKey,
-    configuredRoute,
-    matchedBy: configuredBinding ? "binding.channel" : undefined,
-  });
+  const boundSessionKey = routeState.boundSessionKey;
+  const effectiveRoute = routeState.effectiveRoute;
   const { sessionKey, commandTargetSessionKey } = resolveNativeCommandSessionTargets({
     agentId: effectiveRoute.agentId,
     sessionPrefix,

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -315,7 +315,6 @@ export function createDiscordNativeCommand(params: {
       resolveDiscordNativeChoiceContext({
         interaction,
         cfg,
-        discordConfig,
         accountId,
         threadBindings,
       }),

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -122,6 +122,174 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
   return { configured: true, allowed: match.allowed } as const;
 }
 
+async function resolveDiscordNativeAutocompleteAuthorized(params: {
+  interaction: AutocompleteInteraction;
+  cfg: ReturnType<typeof loadConfig>;
+  discordConfig: DiscordConfig;
+  accountId: string;
+}): Promise<boolean> {
+  const { interaction, cfg, discordConfig, accountId } = params;
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const user = interaction.user;
+  if (!user) {
+    return false;
+  }
+  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
+  const channel = interaction.channel;
+  const channelType = channel?.type;
+  const isDirectMessage = channelType === ChannelType.DM;
+  const isGroupDm = channelType === ChannelType.GroupDM;
+  const isThreadChannel =
+    channelType === ChannelType.PublicThread ||
+    channelType === ChannelType.PrivateThread ||
+    channelType === ChannelType.AnnouncementThread;
+  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
+  const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+  const rawChannelId = channel?.id ?? "";
+  const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
+    ? interaction.rawData.member.roles.map((roleId: string) => String(roleId))
+    : [];
+  const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
+  const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
+    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    allowNameMatching,
+  });
+  const commandsAllowFromAccess = resolveDiscordNativeCommandAllowlistAccess({
+    cfg,
+    accountId,
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    chatType: isDirectMessage
+      ? "direct"
+      : isThreadChannel
+        ? "thread"
+        : interaction.guild
+          ? "channel"
+          : "group",
+    conversationId: rawChannelId || undefined,
+  });
+  const guildInfo = resolveDiscordGuildEntry({
+    guild: interaction.guild ?? undefined,
+    guildId: interaction.guild?.id ?? undefined,
+    guildEntries: discordConfig?.guilds,
+  });
+  let threadParentId: string | undefined;
+  let threadParentName: string | undefined;
+  let threadParentSlug = "";
+  if (interaction.guild && channel && isThreadChannel && rawChannelId) {
+    const channelInfo = await resolveDiscordChannelInfo(interaction.client, rawChannelId);
+    const parentInfo = await resolveDiscordThreadParentInfo({
+      client: interaction.client,
+      threadChannel: {
+        id: rawChannelId,
+        name: channelName,
+        parentId: "parentId" in channel ? (channel.parentId ?? undefined) : undefined,
+        parent: undefined,
+      },
+      channelInfo,
+    });
+    threadParentId = parentInfo.id;
+    threadParentName = parentInfo.name;
+    threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+  }
+  const channelConfig = interaction.guild
+    ? resolveDiscordChannelConfigWithFallback({
+        guildInfo,
+        channelId: rawChannelId,
+        channelName,
+        channelSlug,
+        parentId: threadParentId,
+        parentName: threadParentName,
+        parentSlug: threadParentSlug,
+        scope: isThreadChannel ? "thread" : "channel",
+      })
+    : null;
+  if (channelConfig?.enabled === false) {
+    return false;
+  }
+  if (interaction.guild && channelConfig?.allowed === false) {
+    return false;
+  }
+  if (useAccessGroups && interaction.guild) {
+    const channelAllowlistConfigured =
+      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+    const channelAllowed = channelConfig?.allowed !== false;
+    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.discord !== undefined,
+      groupPolicy: discordConfig?.groupPolicy,
+      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+    });
+    const allowByPolicy = isDiscordGroupAllowedByPolicy({
+      groupPolicy,
+      guildAllowlisted: Boolean(guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    });
+    if (!allowByPolicy) {
+      return false;
+    }
+  }
+  const dmEnabled = discordConfig?.dm?.enabled ?? true;
+  const dmPolicy = discordConfig?.dmPolicy ?? discordConfig?.dm?.policy ?? "pairing";
+  if (isDirectMessage) {
+    if (!dmEnabled || dmPolicy === "disabled") {
+      return false;
+    }
+    const dmAccess = await resolveDiscordDmCommandAccess({
+      accountId,
+      dmPolicy,
+      configuredAllowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+      sender: {
+        id: sender.id,
+        name: sender.name,
+        tag: sender.tag,
+      },
+      allowNameMatching,
+      useAccessGroups,
+    });
+    return dmAccess.decision === "allow";
+  }
+  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
+    return false;
+  }
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig,
+    guildInfo,
+    memberRoleIds,
+    sender,
+    allowNameMatching,
+  });
+  const authorizers = useAccessGroups
+    ? [
+        {
+          configured: commandsAllowFromAccess.configured,
+          allowed: commandsAllowFromAccess.allowed,
+        },
+        { configured: ownerAllowList != null, allowed: ownerOk },
+        { configured: hasAccessRestrictions, allowed: memberAllowed },
+      ]
+    : [
+        {
+          configured: commandsAllowFromAccess.configured,
+          allowed: commandsAllowFromAccess.allowed,
+        },
+        { configured: hasAccessRestrictions, allowed: memberAllowed },
+      ];
+  return resolveCommandAuthorizedFromAuthorizers({
+    useAccessGroups,
+    authorizers,
+    modeWhenAccessGroupsOff: "configured",
+  });
+}
+
 function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
   cfg: ReturnType<typeof loadConfig>;
@@ -311,13 +479,23 @@ export function createDiscordNativeCommand(params: {
   const commandOptions = buildDiscordCommandOptions({
     command: commandDefinition,
     cfg,
-    resolveChoiceContext: async (interaction) =>
-      resolveDiscordNativeChoiceContext({
+    resolveChoiceContext: async (interaction) => {
+      const authorized = await resolveDiscordNativeAutocompleteAuthorized({
+        interaction,
+        cfg,
+        discordConfig,
+        accountId,
+      });
+      if (!authorized) {
+        return null;
+      }
+      return resolveDiscordNativeChoiceContext({
         interaction,
         cfg,
         accountId,
         threadBindings,
-      }),
+      });
+    },
   });
   const options = commandOptions
     ? (commandOptions satisfies CommandOptions)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord native `/think` autocomplete used config-default model context, not the effective Discord route's session model.
- Why it matters: users on an xhigh-capable session model (for example `openai-codex/gpt-5.4`) could miss `xhigh` in slash choices.
- What changed: native command option autocomplete now resolves the effective Discord route, reads provider/model from that route's session override, and passes it into `resolveCommandArgChoices`.
- What did NOT change (scope boundary): no changes to `/think` command semantics, backend thinking capability logic, or non-Discord channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48820
- Related #

## User-visible / Behavior Changes

- Discord native `/think` autocomplete now reflects the active effective-route session model override rather than only config defaults.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: anthropic default config + `openai-codex/gpt-5.4` session override
- Integration/channel (if any): Discord native slash commands
- Relevant config (redacted): `agents.defaults.model.primary=anthropic/claude-sonnet-4.5`

### Steps

1. Configure a default model that does not support `xhigh`.
2. Set the effective Discord route session override to `openai-codex/gpt-5.4`.
3. Trigger Discord native `/think` autocomplete.

### Expected

- `xhigh` appears in autocomplete choices for the effective-route session.

### Actual

- Before fix: choices reflected default model context and could omit `xhigh`.
- After fix: choices resolve from effective-route session context and include `xhigh`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Discord native-command test suite passes; added regression test covering session-override-aware `/think` autocomplete.
- Edge cases checked: fallback path when route/session resolution fails (returns null context and preserves prior behavior).
- What you did **not** verify: live Discord runtime interaction against a real guild.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/discord/src/monitor/native-command.ts`, `extensions/discord/src/monitor/native-command-ui.ts`
- Known bad symptoms reviewers should watch for: Discord `/think` autocomplete errors or missing choices.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: route/session override resolution can fail in autocomplete context.
  - Mitigation: code catches failures and falls back to prior default-model behavior.
