### PR TITLE
fix: defer daily session reset for recently active sessions

### DIFF
--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -9,6 +9,8 @@ export type SessionResetPolicy = {
   mode: SessionResetMode;
   atHour: number;
   idleMinutes?: number;
+  /** Minutes of grace after the daily boundary for recently active sessions. */
+  graceMinutes?: number;
 };
 
 export type SessionFreshness = {
@@ -116,7 +118,13 @@ export function resolveSessionResetPolicy(params: {
     idleMinutes = DEFAULT_IDLE_MINUTES;
   }
 
-  return { mode, atHour, idleMinutes };
+  const graceMinutesRaw = typeReset?.graceMinutes ?? baseReset?.graceMinutes;
+  const graceMinutes =
+    typeof graceMinutesRaw === "number" && Number.isFinite(graceMinutesRaw) && graceMinutesRaw > 0
+      ? Math.floor(graceMinutesRaw)
+      : undefined;
+
+  return { mode, atHour, idleMinutes, graceMinutes };
 }
 
 export function resolveChannelResetConfig(params: {
@@ -149,7 +157,18 @@ export function evaluateSessionFreshness(params: {
     params.policy.idleMinutes != null
       ? params.updatedAt + params.policy.idleMinutes * 60_000
       : undefined;
-  const staleDaily = dailyResetAt != null && params.updatedAt < dailyResetAt;
+  let staleDaily = dailyResetAt != null && params.updatedAt < dailyResetAt;
+  // Grace period: if the session was active within graceMinutes before the
+  // daily boundary, defer the reset so active late-night sessions aren't
+  // wiped mid-conversation (#49170).
+  if (staleDaily && dailyResetAt != null && params.policy.graceMinutes != null) {
+    const graceMs = params.policy.graceMinutes * 60_000;
+    const recentlyActive = params.updatedAt >= dailyResetAt - graceMs;
+    const withinGraceWindow = params.now < dailyResetAt + graceMs;
+    if (recentlyActive && withinGraceWindow) {
+      staleDaily = false;
+    }
+  }
   const staleIdle = idleExpiresAt != null && params.now > idleExpiresAt;
   return {
     fresh: !(staleDaily || staleIdle),

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -75,6 +75,8 @@ export type SessionResetConfig = {
   atHour?: number;
   /** Sliding idle window (minutes). When set with daily mode, whichever expires first wins. */
   idleMinutes?: number;
+  /** Grace period (minutes) for recently active sessions at the daily boundary. */
+  graceMinutes?: number;
 };
 export type SessionResetByTypeConfig = {
   direct?: SessionResetConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -18,6 +18,7 @@ const SessionResetConfigSchema = z
     mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
     atHour: z.number().int().min(0).max(23).optional(),
     idleMinutes: z.number().int().positive().optional(),
+    graceMinutes: z.number().int().positive().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Fixes #49170 — daily session reset no longer wipes sessions that were actively used right before the boundary.

## Problem

With `session.reset.mode: "daily"` (the default), a user chatting at 3:59 AM has their session context wiped at 4:00 AM. The reset is unconditional — it only checks if `updatedAt < dailyBoundaryTime`, with no consideration for recent activity.

## Fix

New config option `session.reset.graceMinutes`:

```json
{
  "session": {
    "reset": {
      "mode": "daily",
      "atHour": 4,
      "graceMinutes": 120
    }
  }
}
```

When set, if the session was active within `graceMinutes` before the daily boundary AND the current time is within `graceMinutes` after the boundary, the session is treated as fresh (reset deferred). Once the grace window passes, the session resets normally.

**Default:** `undefined` (no grace period, preserving existing behavior for all users).

## Example

- `atHour: 4`, `graceMinutes: 120`
- User chats at 3:45 AM → session `updatedAt` is within 2h before boundary
- At 4:00 AM: reset deferred (grace window active until 6:00 AM)
- At 6:01 AM: if no new activity, session resets normally

## Changes

- `src/config/sessions/reset.ts`: Added `graceMinutes` to `SessionResetPolicy`, grace period logic in `evaluateSessionFreshness()`
- `src/config/zod-schema.session.ts`: Added `graceMinutes` to schema
- `src/config/types.base.ts`: Added `graceMinutes` to `SessionResetConfig` type