### PR TITLE
feat(plugins): add Strava extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -234,6 +234,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/duckduckgo/**"
+"extensions: strava":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/strava/**"
 "extensions: acpx":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/strava/README.md
+++ b/extensions/strava/README.md
@@ -1,0 +1,84 @@
+# @openclaw/strava
+
+Strava plugin for OpenClaw — AI running coach powered by your real activity data.
+
+## Overview
+
+This extension connects your Strava account to OpenClaw, giving the AI agent access to your training data so it can provide personalized coaching advice. It supports running, cycling, and swimming activities.
+
+**Tools provided:**
+
+- `strava_auth_status` — Check connection status; get an authorization URL if not connected
+- `strava_activities` — List recent activities with pace, distance, duration, heart rate, and more
+- `strava_activity_detail` — Per-km splits, laps, calories, gear, and device for a single activity
+- `strava_stats` — Aggregated recent, year-to-date, and all-time totals
+
+## Installation
+
+```bash
+openclaw plugins install @openclaw/strava
+```
+
+Or from a local directory:
+
+```bash
+openclaw plugins install /path/to/extensions/strava
+```
+
+## Setup
+
+1. **Create a Strava API app** at https://www.strava.com/settings/api
+   - Set the "Authorization Callback Domain" to `localhost`
+
+2. **Configure the plugin** with your Client ID and Client Secret:
+
+   ```bash
+   openclaw config set plugins.entries.strava.config.clientId "YOUR_CLIENT_ID"
+   openclaw config set plugins.entries.strava.config.clientSecret "YOUR_CLIENT_SECRET"
+   ```
+
+   Or add directly to `~/.openclaw/openclaw.json`:
+
+   ```json
+   {
+     "plugins": {
+       "entries": {
+         "strava": {
+           "enabled": true,
+           "config": {
+             "clientId": "YOUR_CLIENT_ID",
+             "clientSecret": "YOUR_CLIENT_SECRET"
+           }
+         }
+       }
+     }
+   }
+   ```
+
+3. **Restart the gateway** and verify the plugin loaded:
+
+   ```bash
+   openclaw plugins list
+   ```
+
+4. **Connect your Strava account** — ask the AI agent to check your Strava status. It will return an authorization URL. Open it in your browser to complete the OAuth flow.
+
+## Configuration
+
+| Key            | Required | Description                          |
+| -------------- | -------- | ------------------------------------ |
+| `clientId`     | Yes      | Strava API application Client ID     |
+| `clientSecret` | Yes      | Strava API application Client Secret |
+
+## Security
+
+- OAuth tokens are stored with `0600` permissions (owner-only read/write)
+- OAuth flow uses a CSRF state nonce to prevent unauthorized account linking
+- Token refresh only clears credentials on definitive auth failures (401/400), not transient errors
+- The plugin requests `activity:read_all` scope (read-only access to activities)
+
+## Testing
+
+```bash
+pnpm test:extension strava
+```

--- a/extensions/strava/index.ts
+++ b/extensions/strava/index.ts
@@ -1,0 +1,174 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as path from "node:path";
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { TokenStore, exchangeCode, buildAuthUrl, generateOAuthState } from "./src/oauth.js";
+import { createStravaTools } from "./src/tools.js";
+import type { StravaConfig } from "./src/types.js";
+
+const OAUTH_CALLBACK_PATH = "/api/plugins/strava/oauth/callback";
+const OAUTH_START_PATH = "/api/plugins/strava/oauth/start";
+const DEFAULT_GATEWAY_PORT = 18789;
+
+const stravaPlugin = {
+  id: "strava",
+  name: "Strava",
+  description:
+    "Connect your Strava account to let the AI agent read your running activities and act as a coach.",
+  register(api: OpenClawPluginApi) {
+    const pluginConfig = (api.pluginConfig ?? {}) as Record<string, unknown>;
+    const clientId = pluginConfig.clientId as string | undefined;
+    const clientSecret = pluginConfig.clientSecret as string | undefined;
+
+    if (!clientId || !clientSecret) {
+      api.logger.warn(
+        "strava: plugin not activated — set plugins.entries.strava.config.clientId and plugins.entries.strava.config.clientSecret in your config. " +
+          "Create a Strava API app at https://www.strava.com/settings/api",
+      );
+      return;
+    }
+
+    const config: StravaConfig = { clientId, clientSecret };
+    const gatewayPort = (api.config.gateway?.port as number | undefined) ?? DEFAULT_GATEWAY_PORT;
+    const callbackUrl = pluginConfig.callbackUrl as string | undefined;
+
+    // Use a strava subdirectory under the main state dir for token storage.
+    const stateDir = path.join(api.runtime.state.resolveStateDir(), "strava");
+    const tokenStore = new TokenStore(stateDir);
+
+    const getRedirectUri = () => {
+      // Explicit override takes priority (tunnels, custom domains).
+      if (callbackUrl) return callbackUrl;
+      const gwTls = (api.config.gateway as Record<string, unknown> | undefined)?.tls as
+        | Record<string, unknown>
+        | undefined;
+      const tls = !!gwTls?.enabled;
+      const scheme = tls ? "https" : "http";
+      // Derive from gateway bind config when not loopback.
+      const bind = api.config.gateway?.bind as string | undefined;
+      const customHost = api.config.gateway?.customBindHost as string | undefined;
+      if (bind === "custom" && customHost?.trim()) {
+        return `${scheme}://${customHost.trim()}:${gatewayPort}${OAUTH_CALLBACK_PATH}`;
+      }
+      // Default to localhost for loopback / unset bind.
+      return `${scheme}://localhost:${gatewayPort}${OAUTH_CALLBACK_PATH}`;
+    };
+
+    // Register the 4 Strava tools.
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    for (const tool of tools) {
+      api.registerTool(tool as AnyAgentTool, { optional: true });
+    }
+
+    // OAuth callback — receives the redirect from Strava after user authorizes.
+    api.registerHttpRoute({
+      path: OAUTH_CALLBACK_PATH,
+      auth: "plugin",
+      handler: async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+          const url = new URL(req.url!, `http://${req.headers.host}`);
+          const code = url.searchParams.get("code");
+          const state = url.searchParams.get("state");
+          const error = url.searchParams.get("error");
+
+          // Validate OAuth state nonce to prevent CSRF.
+          if (!state || !tokenStore.consumeState(state)) {
+            res.statusCode = 403;
+            res.setHeader("Content-Type", "text/html");
+            res.end(
+              htmlPage(
+                "Invalid State",
+                "OAuth state mismatch — this request may not have originated from your gateway. Please try connecting again.",
+              ),
+            );
+            return;
+          }
+
+          if (error) {
+            res.statusCode = 400;
+            res.setHeader("Content-Type", "text/html");
+            res.end(
+              htmlPage(
+                "Authorization Denied",
+                "You denied the Strava authorization request. You can close this tab.",
+              ),
+            );
+            return;
+          }
+
+          if (!code) {
+            res.statusCode = 400;
+            res.setHeader("Content-Type", "text/html");
+            res.end(htmlPage("Missing Code", "No authorization code received from Strava."));
+            return;
+          }
+
+          // Strava returns the granted scopes — reject if the user declined activity access.
+          const grantedScope = url.searchParams.get("scope") ?? "";
+          if (!grantedScope.includes("activity:read")) {
+            res.statusCode = 400;
+            res.setHeader("Content-Type", "text/html");
+            res.end(
+              htmlPage(
+                "Insufficient Permissions",
+                "The activity read permission is required. Please try connecting again and grant activity access.",
+              ),
+            );
+            return;
+          }
+
+          const tokens = await exchangeCode(config, code);
+          tokenStore.save(tokens);
+
+          api.logger.info(`strava: connected athlete ${tokens.athleteId}`);
+
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "text/html");
+          res.end(
+            htmlPage(
+              "Strava Connected!",
+              "Your Strava account is now linked. You can close this tab and ask your AI assistant about your runs.",
+            ),
+          );
+        } catch (err) {
+          api.logger.error(`strava: OAuth callback error: ${err}`);
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "text/html");
+          res.end(
+            htmlPage(
+              "Connection Failed",
+              "Something went wrong connecting to Strava. Check the gateway logs.",
+            ),
+          );
+        }
+      },
+    });
+
+    // Convenience redirect — visiting this URL starts the OAuth flow.
+    // Uses "gateway" auth so only authenticated users can initiate token binding.
+    api.registerHttpRoute({
+      path: OAUTH_START_PATH,
+      auth: "gateway",
+      handler: async (_req: IncomingMessage, res: ServerResponse) => {
+        const state = generateOAuthState();
+        tokenStore.saveState(state);
+        const authUrl = buildAuthUrl(clientId, getRedirectUri(), state);
+        res.statusCode = 302;
+        res.setHeader("Location", authUrl);
+        res.end();
+      },
+    });
+
+    api.logger.info("strava: plugin activated");
+  },
+};
+
+function htmlPage(title: string, message: string): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${title}</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}
+.card{background:#fff;border-radius:12px;padding:2rem;max-width:400px;text-align:center;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+h1{font-size:1.5rem;margin:0 0 1rem}</style>
+</head><body><div class="card"><h1>${title}</h1><p>${message}</p></div></body></html>`;
+}
+
+export default stravaPlugin;

--- a/extensions/strava/openclaw.plugin.json
+++ b/extensions/strava/openclaw.plugin.json
@@ -1,0 +1,33 @@
+{
+  "id": "strava",
+  "name": "Strava",
+  "description": "Connect your Strava account to let the AI agent read your running activities and act as a coach.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "clientId": { "type": "string" },
+      "clientSecret": { "type": "string" },
+      "callbackUrl": { "type": "string" }
+    },
+    "required": ["clientId", "clientSecret"]
+  },
+  "uiHints": {
+    "clientId": {
+      "label": "Strava Client ID",
+      "placeholder": "12345",
+      "help": "Create a Strava API app at strava.com/settings/api to get your Client ID."
+    },
+    "clientSecret": {
+      "label": "Strava Client Secret",
+      "sensitive": true,
+      "placeholder": "abcdef1234567890...",
+      "help": "Found under your Strava API app settings."
+    },
+    "callbackUrl": {
+      "label": "OAuth Callback URL (optional)",
+      "placeholder": "https://my-gateway.example.com:18789/api/plugins/strava/oauth/callback",
+      "help": "Override the OAuth redirect URI for tunnels, reverse proxies, or custom domains. Leave blank for localhost."
+    }
+  }
+}

--- a/extensions/strava/package.json
+++ b/extensions/strava/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@openclaw/strava",
+  "version": "2026.3.30",
+  "private": true,
+  "description": "OpenClaw Strava plugin — AI running coach powered by your activity data",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.49"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.30"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/strava/src/oauth.test.ts
+++ b/extensions/strava/src/oauth.test.ts
@@ -1,0 +1,162 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAuthUrl, exchangeCode, generateOAuthState, TokenStore } from "./oauth.js";
+import type { StravaTokens } from "./types.js";
+
+describe("exchangeCode", () => {
+  it("preserves athlete ID precision for large 64-bit values", async () => {
+    // A value above Number.MAX_SAFE_INTEGER — JSON.parse would corrupt this if
+    // the ID were round-tripped through a JS number first.
+    const largeId = "99999999999999999";
+    const mockBody = JSON.stringify({
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 9999999999,
+      athlete: { id: Number(largeId) }, // JSON.stringify loses precision here intentionally
+    }).replace(/"id":\d+/, `"id":${largeId}`); // patch raw JSON to have the real large value
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockBody),
+      }),
+    );
+
+    const tokens = await exchangeCode({ clientId: "cid", clientSecret: "csec" }, "code123");
+    expect(tokens.athleteId).toBe(largeId);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("buildAuthUrl", () => {
+  it("includes all required OAuth parameters", () => {
+    const url = buildAuthUrl("12345", "http://localhost:18789/callback", "abc123");
+    expect(url).toContain("client_id=12345");
+    expect(url).toContain("redirect_uri=");
+    expect(url).toContain("response_type=code");
+    expect(url).toContain("scope=activity%3Aread_all");
+    expect(url).toContain("approval_prompt=force");
+    expect(url).toContain("state=abc123");
+  });
+
+  it("uses custom scope when provided", () => {
+    const url = buildAuthUrl("12345", "http://localhost/cb", "state1", "read");
+    expect(url).toContain("scope=read");
+  });
+});
+
+describe("generateOAuthState", () => {
+  it("returns a hex string", () => {
+    const state = generateOAuthState();
+    expect(state).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("returns unique values", () => {
+    const a = generateOAuthState();
+    const b = generateOAuthState();
+    expect(a).not.toBe(b);
+  });
+
+  it("has sufficient length for CSRF protection", () => {
+    const state = generateOAuthState();
+    // 24 random bytes = 48 hex chars
+    expect(state.length).toBe(48);
+  });
+});
+
+describe("TokenStore", () => {
+  let tmpDir: string;
+  let store: TokenStore;
+
+  const testTokens: StravaTokens = {
+    accessToken: "access_123",
+    refreshToken: "refresh_456",
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    athleteId: "42",
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "strava-test-"));
+    store = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when no tokens saved", () => {
+    expect(store.load()).toBeNull();
+  });
+
+  it("saves and loads tokens", () => {
+    store.save(testTokens);
+    const loaded = store.load();
+    expect(loaded).toEqual(testTokens);
+  });
+
+  it("saves token file with restricted permissions (0600)", () => {
+    store.save(testTokens);
+    const filePath = path.join(tmpDir, "strava-tokens.json");
+    const stat = fs.statSync(filePath);
+    // eslint-disable-next-line no-bitwise
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens permissions when rewriting an existing token file", () => {
+    const filePath = path.join(tmpDir, "strava-tokens.json");
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(testTokens, null, 2), { mode: 0o644 });
+    fs.chmodSync(filePath, 0o644);
+
+    store.save(testTokens);
+
+    const stat = fs.statSync(filePath);
+    // eslint-disable-next-line no-bitwise
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("clears tokens", () => {
+    store.save(testTokens);
+    expect(store.load()).not.toBeNull();
+    store.clear();
+    expect(store.load()).toBeNull();
+  });
+
+  it("clear is safe when no tokens exist", () => {
+    expect(() => store.clear()).not.toThrow();
+  });
+
+  it("saves and consumes OAuth state nonce", () => {
+    store.saveState("test-state-123");
+    expect(store.consumeState("test-state-123")).toBe(true);
+    // Second call returns false (consumed)
+    expect(store.consumeState("test-state-123")).toBe(false);
+  });
+
+  it("consumeState returns false when no state saved", () => {
+    expect(store.consumeState("anything")).toBe(false);
+  });
+
+  it("preserves multiple state nonces concurrently", () => {
+    store.saveState("state-a");
+    store.saveState("state-b");
+    store.saveState("state-c");
+    // All three should be valid
+    expect(store.consumeState("state-a")).toBe(true);
+    expect(store.consumeState("state-c")).toBe(true);
+    expect(store.consumeState("state-b")).toBe(true);
+    // All consumed
+    expect(store.consumeState("state-a")).toBe(false);
+  });
+
+  it("creates directory if it does not exist", () => {
+    const nested = path.join(tmpDir, "nested", "deep");
+    const nestedStore = new TokenStore(nested);
+    nestedStore.save(testTokens);
+    expect(nestedStore.load()).toEqual(testTokens);
+  });
+});

--- a/extensions/strava/src/oauth.ts
+++ b/extensions/strava/src/oauth.ts
@@ -1,0 +1,231 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { StravaConfig, StravaTokens } from "./types.js";
+
+const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
+const STRAVA_TOKEN_URL = "https://www.strava.com/api/v3/oauth/token";
+
+/** Build the Strava OAuth authorization URL with a CSRF state nonce. */
+export function buildAuthUrl(
+  clientId: string,
+  redirectUri: string,
+  state: string,
+  scope = "activity:read_all",
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope,
+    approval_prompt: "force",
+    state,
+  });
+  return `${STRAVA_AUTH_URL}?${params.toString()}`;
+}
+
+/** Generate a random state nonce for OAuth CSRF protection. */
+export function generateOAuthState(): string {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+/** Exchange an authorization code for tokens. */
+export async function exchangeCode(config: StravaConfig, code: string): Promise<StravaTokens> {
+  const res = await fetch(STRAVA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code,
+      grant_type: "authorization_code",
+    }).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Strava token exchange failed (${res.status}): ${text}`);
+  }
+
+  // Parse as text first so we can extract athlete.id as a raw string before
+  // JSON.parse coerces it to a float64 (which would lose precision for IDs > 2^53-1).
+  const body = await res.text();
+  const data = JSON.parse(body) as {
+    access_token: string;
+    refresh_token: string;
+    expires_at: number;
+    athlete: { id: unknown };
+  };
+  const idMatch = /"athlete"\s*:\s*\{[^}]*"id"\s*:\s*(\d+)/.exec(body);
+  const athleteId = idMatch ? idMatch[1] : String(data.athlete.id);
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: data.expires_at,
+    athleteId,
+  };
+}
+
+/** Error from a token refresh attempt, with HTTP status for triage. */
+export class StravaRefreshError extends Error {
+  status = 0;
+}
+
+/** Refresh an expired access token. Returns new token pair (refresh token rotates). */
+export async function refreshTokens(
+  config: StravaConfig,
+  refreshToken: string,
+): Promise<StravaTokens> {
+  const res = await fetch(STRAVA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    const err = new StravaRefreshError(`Strava token refresh failed (${res.status}): ${text}`);
+    err.status = res.status;
+    throw err;
+  }
+
+  const data = (await res.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_at: number;
+  };
+
+  // Refresh response doesn't include athlete — we'll preserve the existing athleteId in the store.
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: data.expires_at,
+    athleteId: "", // caller must merge with existing athleteId
+  };
+}
+
+const TOKEN_FILE = "strava-tokens.json";
+const STATE_FILE = "oauth-state.json";
+
+function writeOwnerOnlyJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), { mode: 0o600 });
+  // `mode` only applies on create; chmod existing files too so retries/upgrades
+  // do not preserve broader permissions from an older write.
+  fs.chmodSync(filePath, 0o600);
+}
+
+/** Persistent token store backed by a JSON file. */
+export class TokenStore {
+  private dir: string;
+
+  constructor(stateDir: string) {
+    this.dir = stateDir;
+  }
+
+  private filePath(): string {
+    return path.join(this.dir, TOKEN_FILE);
+  }
+
+  private statePath(): string {
+    return path.join(this.dir, STATE_FILE);
+  }
+
+  save(tokens: StravaTokens): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+    writeOwnerOnlyJson(this.filePath(), tokens);
+  }
+
+  load(): StravaTokens | null {
+    try {
+      const raw = fs.readFileSync(this.filePath(), "utf-8");
+      return JSON.parse(raw) as StravaTokens;
+    } catch {
+      return null;
+    }
+  }
+
+  clear(): void {
+    try {
+      fs.unlinkSync(this.filePath());
+    } catch {
+      // already gone
+    }
+  }
+
+  /** Store an OAuth state nonce for CSRF validation. Keeps the last 5 nonces so
+   *  multiple auth URLs can be valid concurrently (e.g. agent asks twice, user
+   *  opens a second tab). */
+  saveState(state: string): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+    const existing = this.loadStates();
+    // Keep most recent 4 + the new one = 5 max.
+    const states = [...existing.slice(-4), state];
+    writeOwnerOnlyJson(this.statePath(), { states });
+  }
+
+  /** Check if a state nonce is valid and consume it. Returns true if matched. */
+  consumeState(state: string): boolean {
+    const states = this.loadStates();
+    const idx = states.indexOf(state);
+    if (idx === -1) return false;
+    states.splice(idx, 1);
+    try {
+      if (states.length === 0) {
+        fs.unlinkSync(this.statePath());
+      } else {
+        writeOwnerOnlyJson(this.statePath(), { states });
+      }
+    } catch {
+      // best-effort cleanup
+    }
+    return true;
+  }
+
+  private loadStates(): string[] {
+    try {
+      const raw = fs.readFileSync(this.statePath(), "utf-8");
+      const data = JSON.parse(raw) as { state?: string; states?: string[] };
+      // Handle legacy single-state format gracefully.
+      if (data.states) return [...data.states];
+      if (data.state) return [data.state];
+      return [];
+    } catch {
+      return [];
+    }
+  }
+}
+
+/** Margin in seconds before expiry to trigger a proactive refresh. */
+const REFRESH_MARGIN_SEC = 300; // 5 minutes
+
+/**
+ * Return a valid access token, refreshing if needed.
+ * Returns null if no tokens are stored (user hasn't connected).
+ */
+export async function ensureFreshToken(
+  store: TokenStore,
+  config: StravaConfig,
+): Promise<string | null> {
+  const tokens = store.load();
+  if (!tokens) return null;
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (tokens.expiresAt - nowSec > REFRESH_MARGIN_SEC) {
+    return tokens.accessToken;
+  }
+
+  // Token expired or about to — refresh it.
+  const refreshed = await refreshTokens(config, tokens.refreshToken);
+  const updated: StravaTokens = {
+    ...refreshed,
+    athleteId: tokens.athleteId, // preserve athlete ID
+  };
+  store.save(updated);
+  return updated.accessToken;
+}

--- a/extensions/strava/src/strava-client.test.ts
+++ b/extensions/strava/src/strava-client.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatPace, formatDuration, formatDistance, getActivities } from "./strava-client.js";
+
+describe("getActivities", () => {
+  it("preserves activity ID precision for large 64-bit values", async () => {
+    const largeId = "99999999999999999";
+    // JSON.stringify would lose precision on this number — patch the raw JSON.
+    const rawBody = JSON.stringify([
+      {
+        id: 1,
+        name: "run",
+        sport_type: "Run",
+        distance: 5000,
+        moving_time: 1800,
+        elapsed_time: 1900,
+        total_elevation_gain: 50,
+        average_speed: 2.78,
+        max_speed: 4.0,
+        average_heartrate: 150,
+        max_heartrate: 170,
+        start_date: "2026-01-01T08:00:00Z",
+        start_date_local: "2026-01-01T09:00:00+01:00",
+        timezone: "Europe/Madrid",
+        kudos_count: 3,
+      },
+    ]).replace(/"id":1/, `"id":${largeId}`);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve(rawBody) }),
+    );
+
+    const activities = await getActivities("tok");
+    expect(activities[0].id).toBe(largeId);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("formatPace", () => {
+  it("returns N/A for zero speed", () => {
+    expect(formatPace(0)).toBe("N/A");
+  });
+
+  it("returns N/A for negative speed", () => {
+    expect(formatPace(-1)).toBe("N/A");
+  });
+
+  it("formats a typical running pace", () => {
+    // 3.03 m/s ≈ 5:30 /km
+    expect(formatPace(3.03)).toBe("5:30 /km");
+  });
+
+  it("formats a fast pace", () => {
+    // 5.0 m/s = 200s/km = 3:20 /km
+    expect(formatPace(5.0)).toBe("3:20 /km");
+  });
+
+  it("never produces 60 seconds (rounding overflow)", () => {
+    // ~2.779 m/s would round to 5:60 with naive rounding
+    const pace = formatPace(2.779);
+    const match = pace.match(/^(\d+):(\d{2}) \/km$/);
+    expect(match).not.toBeNull();
+    const sec = Number.parseInt(match![2], 10);
+    expect(sec).toBeLessThan(60);
+  });
+
+  it("pads single-digit seconds with zero", () => {
+    // 4.0 m/s = 250s/km = 4:10 /km
+    expect(formatPace(4.0)).toBe("4:10 /km");
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds only", () => {
+    expect(formatDuration(45)).toBe("45s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(125)).toBe("2m 5s");
+  });
+
+  it("formats hours, minutes, and seconds", () => {
+    expect(formatDuration(3723)).toBe("1h 2m 3s");
+  });
+
+  it("handles zero", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+});
+
+describe("formatDistance", () => {
+  it("formats meters to km with two decimals", () => {
+    expect(formatDistance(10500)).toBe("10.50 km");
+  });
+
+  it("formats short distances", () => {
+    expect(formatDistance(500)).toBe("0.50 km");
+  });
+
+  it("handles zero", () => {
+    expect(formatDistance(0)).toBe("0.00 km");
+  });
+});

--- a/extensions/strava/src/strava-client.ts
+++ b/extensions/strava/src/strava-client.ts
@@ -1,0 +1,136 @@
+import type { StravaActivity, StravaActivityDetail, StravaAthleteStats } from "./types.js";
+
+const BASE_URL = "https://www.strava.com/api/v3";
+
+export class StravaApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "StravaApiError";
+  }
+}
+
+async function stravaFetch<T>(
+  token: string,
+  path: string,
+  params?: Record<string, string>,
+): Promise<T> {
+  const url = new URL(`${BASE_URL}${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== "") url.searchParams.set(k, v);
+    }
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.status === 401) {
+    throw new StravaApiError(
+      401,
+      "Strava token expired or revoked. Please reconnect your Strava account.",
+    );
+  }
+  if (res.status === 429) {
+    throw new StravaApiError(429, "Strava rate limit reached. Try again in a few minutes.");
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new StravaApiError(res.status, `Strava API error (${res.status}): ${text}`);
+  }
+
+  // Rewrite numeric "id" values to JSON strings before parsing so float64
+  // never touches them — Strava IDs are 64-bit and can exceed Number.MAX_SAFE_INTEGER.
+  const raw = await res.text();
+  const safe = raw.replace(/"id"\s*:\s*(\d+)/g, '"id":"$1"');
+  return JSON.parse(safe) as T;
+}
+
+export interface GetActivitiesOpts {
+  page?: number;
+  perPage?: number;
+  /** ISO date string — only activities after this date. */
+  after?: string;
+  /** ISO date string — only activities before this date. */
+  before?: string;
+}
+
+/** List the authenticated athlete's activities. */
+export async function getActivities(
+  token: string,
+  opts: GetActivitiesOpts = {},
+): Promise<StravaActivity[]> {
+  const params: Record<string, string> = {};
+  if (opts.perPage) params.per_page = String(opts.perPage);
+  if (opts.page) params.page = String(opts.page);
+  if (opts.after) {
+    const ts = new Date(opts.after).getTime();
+    if (Number.isNaN(ts)) throw new Error(`Invalid "after" date: ${opts.after}`);
+    params.after = String(Math.floor(ts / 1000));
+  }
+  if (opts.before) {
+    const ts = new Date(opts.before).getTime();
+    if (Number.isNaN(ts)) throw new Error(`Invalid "before" date: ${opts.before}`);
+    params.before = String(Math.floor(ts / 1000));
+  }
+
+  return stravaFetch<StravaActivity[]>(token, "/athlete/activities", params);
+}
+
+/** Get full details for a single activity. */
+export async function getActivity(
+  token: string,
+  activityId: string,
+): Promise<StravaActivityDetail> {
+  return stravaFetch<StravaActivityDetail>(token, `/activities/${activityId}`);
+}
+
+/** Lightweight check that the token is still valid (calls /athlete). */
+export async function verifyToken(token: string): Promise<boolean> {
+  try {
+    await stravaFetch<unknown>(token, "/athlete");
+    return true;
+  } catch (err) {
+    if (err instanceof StravaApiError && err.status === 401) return false;
+    throw err;
+  }
+}
+
+/** Get aggregated stats for an athlete. */
+export async function getAthleteStats(
+  token: string,
+  athleteId: string,
+): Promise<StravaAthleteStats> {
+  return stravaFetch<StravaAthleteStats>(token, `/athletes/${athleteId}/stats`);
+}
+
+// --- Formatting helpers ---
+
+/** Convert m/s to pace string like "5:30 /km". */
+export function formatPace(metersPerSecond: number): string {
+  if (metersPerSecond <= 0) return "N/A";
+  const totalSec = Math.round(1000 / metersPerSecond);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${String(sec).padStart(2, "0")} /km`;
+}
+
+/** Convert seconds to a readable duration like "1h 23m 45s". */
+export function formatDuration(seconds: number): string {
+  // Round to nearest second first to avoid fractional-second rollover (e.g. 59.7s → 60s).
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+/** Convert meters to km string like "10.50 km". */
+export function formatDistance(meters: number): string {
+  return `${(meters / 1000).toFixed(2)} km`;
+}

--- a/extensions/strava/src/tools.test.ts
+++ b/extensions/strava/src/tools.test.ts
@@ -1,0 +1,137 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenStore } from "./oauth.js";
+import { StravaRefreshError } from "./oauth.js";
+import { createStravaTools } from "./tools.js";
+
+describe("createStravaTools", () => {
+  let tmpDir: string;
+  let tokenStore: TokenStore;
+  const config = { clientId: "test-id", clientSecret: "test-secret" };
+  const getRedirectUri = () => "http://localhost:18789/api/plugins/strava/oauth/callback";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "strava-tools-test-"));
+    tokenStore = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("returns exactly 4 tools", () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    expect(tools).toHaveLength(4);
+  });
+
+  it("tools have correct names", () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual([
+      "strava_auth_status",
+      "strava_activities",
+      "strava_activity_detail",
+      "strava_stats",
+    ]);
+  });
+
+  it("auth_status returns not-connected with auth URL when no tokens", async () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const authTool = tools.find((t) => t.name === "strava_auth_status")!;
+    const result = await authTool.execute("test-id", {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connected).toBe(false);
+    expect(data.authUrl).toContain("client_id=test-id");
+    expect(data.authUrl).toContain("state=");
+    expect(data.message).toContain("authorize");
+  });
+
+  it("activities returns not-connected when no tokens", async () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const activitiesTool = tools.find((t) => t.name === "strava_activities")!;
+    const result = await activitiesTool.execute("test-id", {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connected).toBe(false);
+  });
+
+  it("activity_detail returns not-connected when no tokens", async () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const detailTool = tools.find((t) => t.name === "strava_activity_detail")!;
+    const result = await detailTool.execute("test-id", { activityId: "123" });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connected).toBe(false);
+  });
+
+  it("stats returns not-connected when no tokens", async () => {
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const statsTool = tools.find((t) => t.name === "strava_stats")!;
+    const result = await statsTool.execute("test-id", {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connected).toBe(false);
+  });
+});
+
+describe("getTokenOrNull error handling", () => {
+  let tmpDir: string;
+  let tokenStore: TokenStore;
+  const config = { clientId: "test-id", clientSecret: "test-secret" };
+  const getRedirectUri = () => "http://localhost:18789/callback";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "strava-err-test-"));
+    tokenStore = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("clears tokens on 401 StravaRefreshError", async () => {
+    // Save tokens that will trigger a refresh (expired)
+    tokenStore.save({
+      accessToken: "old",
+      refreshToken: "old-refresh",
+      expiresAt: 0, // expired
+      athleteId: "1",
+    });
+
+    // Mock fetch to return 401
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const authTool = tools.find((t) => t.name === "strava_auth_status")!;
+    const result = await authTool.execute("test-id", {});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.connected).toBe(false);
+    // Tokens should be cleared
+    expect(tokenStore.load()).toBeNull();
+  });
+
+  it("preserves tokens on transient 500 error", async () => {
+    tokenStore.save({
+      accessToken: "old",
+      refreshToken: "old-refresh",
+      expiresAt: 0, // expired
+      athleteId: "1",
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const tools = createStravaTools({ config, tokenStore, getRedirectUri });
+    const authTool = tools.find((t) => t.name === "strava_auth_status")!;
+
+    // Should throw (transient error propagated, not swallowed)
+    await expect(authTool.execute("test-id", {})).rejects.toThrow(StravaRefreshError);
+    // Tokens should still be there
+    expect(tokenStore.load()).not.toBeNull();
+  });
+});

--- a/extensions/strava/src/tools.ts
+++ b/extensions/strava/src/tools.ts
@@ -1,0 +1,328 @@
+import { Type } from "@sinclair/typebox";
+import type { TokenStore } from "./oauth.js";
+import { buildAuthUrl, ensureFreshToken, generateOAuthState, StravaRefreshError } from "./oauth.js";
+import { StravaApiError } from "./strava-client.js";
+import * as client from "./strava-client.js";
+import type { StravaConfig } from "./types.js";
+
+interface ToolDeps {
+  config: StravaConfig;
+  tokenStore: TokenStore;
+  getRedirectUri: () => string;
+}
+
+function notConnectedResult(deps: ToolDeps) {
+  const state = generateOAuthState();
+  deps.tokenStore.saveState(state);
+  const authUrl = buildAuthUrl(deps.config.clientId, deps.getRedirectUri(), state);
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          connected: false,
+          message: "Strava account not connected. The user needs to authorize via the link below.",
+          authUrl,
+        }),
+      },
+    ],
+  };
+}
+
+type ToolResult = { content: { type: "text"; text: string }[] };
+
+/** Wrap a tool execute fn to catch 401 StravaApiErrors (revoked token mid-session). */
+function withRevocationGuard<A extends unknown[]>(
+  deps: ToolDeps,
+  fn: (...args: A) => Promise<ToolResult>,
+) {
+  return async (...args: A): Promise<ToolResult> => {
+    try {
+      return await fn(...args);
+    } catch (err) {
+      if (err instanceof StravaApiError && err.status === 401) {
+        deps.tokenStore.clear();
+        return notConnectedResult(deps);
+      }
+      throw err;
+    }
+  };
+}
+
+async function getTokenOrNull(deps: ToolDeps): Promise<string | null> {
+  try {
+    return await ensureFreshToken(deps.tokenStore, deps.config);
+  } catch (err) {
+    // Only clear tokens on definitive auth failures (401, 400).
+    // Transient errors (network, 5xx) should not wipe valid credentials.
+    if (err instanceof StravaRefreshError && (err.status === 401 || err.status === 400)) {
+      deps.tokenStore.clear();
+      return null;
+    }
+    throw err;
+  }
+}
+
+function createAuthStatusTool(deps: ToolDeps) {
+  return {
+    name: "strava_auth_status",
+    label: "Strava Auth Status",
+    ownerOnly: true,
+    description:
+      "Check whether the user's Strava account is connected. If not connected, returns an authorization URL the user can visit to link their account.",
+    parameters: Type.Object({}),
+    async execute() {
+      const tokens = deps.tokenStore.load();
+      if (!tokens) return notConnectedResult(deps);
+
+      const token = await getTokenOrNull(deps);
+      if (!token) return notConnectedResult(deps);
+
+      // Verify the token is actually valid against Strava (catches revoked apps).
+      const valid = await client.verifyToken(token);
+      if (!valid) {
+        deps.tokenStore.clear();
+        return notConnectedResult(deps);
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              connected: true,
+              athleteId: tokens.athleteId,
+            }),
+          },
+        ],
+      };
+    },
+  };
+}
+
+function createActivitiesTool(deps: ToolDeps) {
+  return {
+    name: "strava_activities",
+    label: "Strava Activities",
+    ownerOnly: true,
+    description:
+      "List the user's recent Strava activities. Returns distance, pace, duration, heart rate, and other metrics. Use this to review recent training.",
+    parameters: Type.Object({
+      count: Type.Optional(
+        Type.Number({
+          description: "Number of activities to return (1-50, default 10).",
+          minimum: 1,
+          maximum: 50,
+        }),
+      ),
+      sportType: Type.Optional(
+        Type.String({
+          description: 'Filter by sport type, e.g. "Run", "Ride", "Swim", "TrailRun", "Walk".',
+        }),
+      ),
+      after: Type.Optional(
+        Type.String({
+          description: "Only activities after this date (ISO 8601, e.g. 2026-01-01).",
+        }),
+      ),
+      before: Type.Optional(
+        Type.String({
+          description: "Only activities before this date (ISO 8601, e.g. 2026-02-28).",
+        }),
+      ),
+    }),
+    execute: withRevocationGuard(deps, async (_id: string, params: Record<string, unknown>) => {
+      const token = await getTokenOrNull(deps);
+      if (!token) return notConnectedResult(deps);
+
+      const count = (params.count as number | undefined) ?? 10;
+      const after = params.after as string | undefined;
+      const before = params.before as string | undefined;
+      const sportType = params.sportType as string | undefined;
+
+      let activities: Awaited<ReturnType<typeof client.getActivities>>;
+
+      if (sportType) {
+        // Paginate until we collect enough matching activities or exhaust all
+        // data. Strava has no server-side sport filter, so we page through 50
+        // activities at a time and stop when the page comes back short.
+        activities = [];
+        const pageSize = 50; // max Strava allows
+        for (let page = 1; ; page++) {
+          const batch = await client.getActivities(token, {
+            perPage: pageSize,
+            page,
+            after,
+            before,
+          });
+          for (const a of batch) {
+            if (a.sport_type.toLowerCase() === sportType.toLowerCase()) {
+              activities.push(a);
+              if (activities.length >= count) break;
+            }
+          }
+          // Stop when we have enough results or no more data.
+          if (activities.length >= count || batch.length < pageSize) break;
+        }
+        activities = activities.slice(0, count);
+      } else {
+        activities = await client.getActivities(token, {
+          perPage: count,
+          after,
+          before,
+        });
+      }
+
+      const formatted = activities.map((a) => ({
+        id: a.id,
+        name: a.name,
+        sportType: a.sport_type,
+        date: a.start_date_local,
+        distance: client.formatDistance(a.distance),
+        distanceMeters: a.distance,
+        duration: client.formatDuration(a.moving_time),
+        movingTimeSeconds: a.moving_time,
+        pace: client.formatPace(a.average_speed),
+        averageSpeedMs: a.average_speed,
+        elevationGain: `${a.total_elevation_gain.toFixed(0)} m`,
+        averageHeartrate: a.average_heartrate ?? null,
+        maxHeartrate: a.max_heartrate ?? null,
+        sufferScore: a.suffer_score ?? null,
+      }));
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ activities: formatted }) }],
+      };
+    }),
+  };
+}
+
+function createActivityDetailTool(deps: ToolDeps) {
+  return {
+    name: "strava_activity_detail",
+    label: "Strava Activity Detail",
+    ownerOnly: true,
+    description:
+      "Get full details for a specific Strava activity including per-km splits, laps, heart rate, calories, and gear. Use the activity ID from strava_activities.",
+    parameters: Type.Object({
+      activityId: Type.String({ description: "The Strava activity ID (from strava_activities)." }),
+    }),
+    execute: withRevocationGuard(deps, async (_id: string, params: Record<string, unknown>) => {
+      const token = await getTokenOrNull(deps);
+      if (!token) return notConnectedResult(deps);
+
+      const activityId = params.activityId as string;
+      const detail = await client.getActivity(token, activityId);
+
+      const splits = (detail.splits_metric ?? []).map((s) => ({
+        km: s.split,
+        distance: client.formatDistance(s.distance),
+        duration: client.formatDuration(s.moving_time),
+        pace: client.formatPace(s.average_speed),
+        averageHeartrate: s.average_heartrate ?? null,
+      }));
+
+      const laps = (detail.laps ?? []).map((l) => ({
+        name: l.name,
+        distance: client.formatDistance(l.distance),
+        duration: client.formatDuration(l.moving_time),
+        pace: client.formatPace(l.average_speed),
+        averageHeartrate: l.average_heartrate ?? null,
+        maxHeartrate: l.max_heartrate ?? null,
+      }));
+
+      const result = {
+        id: detail.id,
+        name: detail.name,
+        sportType: detail.sport_type,
+        date: detail.start_date_local,
+        description: detail.description ?? null,
+        distance: client.formatDistance(detail.distance),
+        distanceMeters: detail.distance,
+        duration: client.formatDuration(detail.moving_time),
+        movingTimeSeconds: detail.moving_time,
+        elapsedTimeSeconds: detail.elapsed_time,
+        pace: client.formatPace(detail.average_speed),
+        elevationGain: `${detail.total_elevation_gain.toFixed(0)} m`,
+        calories: detail.calories,
+        averageHeartrate: detail.average_heartrate ?? null,
+        maxHeartrate: detail.max_heartrate ?? null,
+        averageCadence: detail.average_cadence ?? null,
+        gear: detail.gear?.name ?? null,
+        device: detail.device_name ?? null,
+        splits,
+        laps,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    }),
+  };
+}
+
+function createStatsTool(deps: ToolDeps) {
+  return {
+    name: "strava_stats",
+    label: "Strava Stats",
+    ownerOnly: true,
+    description:
+      "Get the user's aggregated Strava statistics: recent, year-to-date, and all-time totals for running, cycling, and swimming. Note: Strava only includes activities with Everyone visibility in these totals, so private or followers-only activities are excluded. For complete totals, sum activities from strava_activities instead.",
+    parameters: Type.Object({}),
+    execute: withRevocationGuard(deps, async () => {
+      const tokens = deps.tokenStore.load();
+      if (!tokens) return notConnectedResult(deps);
+
+      const token = await getTokenOrNull(deps);
+      if (!token) return notConnectedResult(deps);
+
+      const stats = await client.getAthleteStats(token, tokens.athleteId);
+
+      const fmt = (totals: {
+        count: number;
+        distance: number;
+        moving_time: number;
+        elevation_gain: number;
+      }) => ({
+        count: totals.count,
+        distance: client.formatDistance(totals.distance),
+        distanceMeters: totals.distance,
+        duration: client.formatDuration(totals.moving_time),
+        movingTimeSeconds: totals.moving_time,
+        elevationGain: `${totals.elevation_gain.toFixed(0)} m`,
+      });
+
+      const result = {
+        running: {
+          recent: fmt(stats.recent_run_totals),
+          ytd: fmt(stats.ytd_run_totals),
+          allTime: fmt(stats.all_run_totals),
+        },
+        cycling: {
+          recent: fmt(stats.recent_ride_totals),
+          ytd: fmt(stats.ytd_ride_totals),
+          allTime: fmt(stats.all_ride_totals),
+        },
+        swimming: {
+          recent: fmt(stats.recent_swim_totals),
+          ytd: fmt(stats.ytd_swim_totals),
+          allTime: fmt(stats.all_swim_totals),
+        },
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    }),
+  };
+}
+
+/** Create all Strava tools. */
+export function createStravaTools(deps: ToolDeps) {
+  return [
+    createAuthStatusTool(deps),
+    createActivitiesTool(deps),
+    createActivityDetailTool(deps),
+    createStatsTool(deps),
+  ];
+}

--- a/extensions/strava/src/types.ts
+++ b/extensions/strava/src/types.ts
@@ -1,0 +1,92 @@
+/** Stored OAuth tokens for a connected Strava athlete. */
+export interface StravaTokens {
+  accessToken: string;
+  refreshToken: string;
+  /** Unix epoch (seconds) when accessToken expires. */
+  expiresAt: number;
+  /** String to avoid JS number precision loss on 64-bit Strava IDs. */
+  athleteId: string;
+}
+
+/** Plugin config provided by the deployer. */
+export interface StravaConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+/** Summary activity returned by GET /athlete/activities. */
+export interface StravaActivity {
+  /** String to avoid JS number precision loss on 64-bit Strava IDs. */
+  id: string;
+  name: string;
+  sport_type: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  total_elevation_gain: number;
+  average_speed: number;
+  max_speed: number;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  average_cadence?: number;
+  start_date: string;
+  start_date_local: string;
+  timezone: string;
+  kudos_count: number;
+  suffer_score?: number;
+}
+
+/** Lap data within a detailed activity. */
+export interface StravaLap {
+  name: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  average_speed: number;
+  max_speed: number;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  lap_index: number;
+}
+
+/** Split data (per km or per mile). */
+export interface StravaSplit {
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  average_speed: number;
+  average_heartrate?: number;
+  split: number;
+}
+
+/** Full activity detail from GET /activities/{id}. */
+export interface StravaActivityDetail extends StravaActivity {
+  description?: string;
+  calories: number;
+  laps: StravaLap[];
+  splits_metric: StravaSplit[];
+  gear?: { id: string; name: string };
+  device_name?: string;
+}
+
+/** Totals for a sport type (run, ride, swim). */
+export interface StravaSportTotals {
+  count: number;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  elevation_gain: number;
+}
+
+/** Aggregated athlete stats from GET /athletes/{id}/stats. */
+export interface StravaAthleteStats {
+  recent_run_totals: StravaSportTotals;
+  recent_ride_totals: StravaSportTotals;
+  recent_swim_totals: StravaSportTotals;
+  ytd_run_totals: StravaSportTotals;
+  ytd_ride_totals: StravaSportTotals;
+  ytd_swim_totals: StravaSportTotals;
+  all_run_totals: StravaSportTotals;
+  all_ride_totals: StravaSportTotals;
+  all_swim_totals: StravaSportTotals;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,16 @@ importers:
 
   extensions/speech-core: {}
 
+  extensions/strava:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.49
+        version: 0.34.49
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/synology-chat: {}
 
   extensions/synthetic: {}


### PR DESCRIPTION
## Summary

I wanted to be able to ask my AI agent things like *"how did my long run compare to last week?"* or *"am I overtraining?"* — and have it actually look at my data, not just give generic advice. That requires connecting to Strava.

This adds a self-contained `strava` plugin extension. It handles the full OAuth2 flow, manages token refresh automatically, and exposes 4 tools the agent can call:

- **`strava_auth_status`** — checks if you're connected; if not, returns a link to authorize
- **`strava_activities`** — lists recent activities with distance, pace, HR, splits, etc.
- **`strava_activity_detail`** — full breakdown of a single activity (laps, splits, gear)
- **`strava_stats`** — all-time, year-to-date, and recent totals for run/ride/swim

No core openclaw code, gateway code, or other extensions were touched. This is entirely contained under `extensions/strava/`.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations
- [x] Auth / tokens

## Linked Issue/PR

None

## User-visible / Behavior Changes

- New plugin `@openclaw/strava` available for installation
- 4 new agent tools: `strava_auth_status`, `strava_activities`, `strava_activity_detail`, `strava_stats`
- New config keys: `plugins.entries.strava.config.clientId` and `plugins.entries.strava.config.clientSecret`

## Security Impact (required)

- New permissions/capabilities? `Yes` — read-only access to user's Strava activities via `activity:read_all` scope
- Secrets/tokens handling changed? `Yes` — OAuth tokens stored locally with `0600` permissions; CSRF state nonce validates OAuth callbacks
- New/changed network calls? `Yes` — calls to Strava OAuth (`/oauth/token`) and API (`/api/v3/`) endpoints
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes` — agent can read Strava activity data when user authorizes
- **Mitigation:** Read-only scope only; tokens restricted to owner; state nonce prevents CSRF; transient refresh errors preserve credentials (only 401/400 clears tokens)

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node 22+
- Integration: Strava API

### Steps

1. Install plugin: `openclaw plugins install /path/to/extensions/strava`
2. Configure client ID/secret from https://www.strava.com/settings/api
3. Restart gateway, verify `strava: plugin activated` in logs
4. Ask agent to check Strava status → get auth URL → authorize in browser
5. Ask agent about recent activities

### Expected

Plugin loads, OAuth flow completes, tools return real Strava data.

### Actual

Verified working on a self-hosted server with real activity data.

## Evidence

- [x] Failing test/log before + passing after
- 35 tests passing across 3 test files (`oauth.test.ts`, `strava-client.test.ts`, `tools.test.ts`)
- `pnpm test -- extensions/strava/src/` — all green

> **Note on CI:** `pnpm tsgo` has a pre-existing type error in `extensions/telegram/src/bot.ts` (grammy version mismatch) that is also present on `upstream/main`. Unrelated to this extension — no telegram files were modified.

## Human Verification (required)

- Verified: plugin install, config, OAuth flow, activity listing, and stats on a live server
- Edge cases tested: token refresh on expiry, transient network errors that preserve credentials, sport-type filtering across paginated results, pace and duration formatting edge cases
- Not verified: long-term token rotation over multiple days

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — new extension only, no changes to existing code
- Config/env changes? `Yes` — new optional config keys under `plugins.entries.strava.config`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: `openclaw config set plugins.entries.strava.enabled false` or `openclaw plugins uninstall strava`
- Files to restore: none (self-contained extension)
- Bad symptoms: OAuth callback 403s (state mismatch), missing tools in agent

## Risks and Mitigations

- Strava API rate limits (600 requests/15 min for read endpoints) — tool descriptions guide the agent to batch; no automatic polling