### PR TITLE
fix: use max_completion_tokens for OpenAI models that require it

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -156,7 +156,7 @@ describe("promptCustomApiConfig", () => {
       text: ["http://localhost:11434/v1", "", "bad-model", "good-model", "custom", ""],
       select: ["plaintext", "openai", "model"],
     });
-    stubFetchSequence([{ ok: false, status: 400 }, { ok: true }]);
+    stubFetchSequence([{ ok: false, status: 400 }, { ok: false, status: 400 }, { ok: true }]);
     await runPromptCustomApi(prompter);
 
     expect(prompter.text).toHaveBeenCalledTimes(6);

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -174,7 +174,7 @@ describe("promptCustomApiConfig", () => {
     expectOpenAiCompatResult({ prompter, textCalls: 5, selectCalls: 2, result });
   });
 
-  it("uses expanded max_tokens for openai verification probes", async () => {
+  it("uses max_completion_tokens for openai verification probes (newer models)", async () => {
     const prompter = createTestPrompter({
       text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
       select: ["plaintext", "openai"],
@@ -185,7 +185,27 @@ describe("promptCustomApiConfig", () => {
 
     const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
     expect(firstCall?.body).toBeDefined();
-    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+    const parsedBody = JSON.parse(firstCall?.body ?? "{}");
+    expect(parsedBody).toMatchObject({ max_completion_tokens: 1 });
+    expect(parsedBody).not.toHaveProperty("max_tokens");
+  });
+
+  it("falls back to max_tokens for openai verification probes when max_completion_tokens is rejected", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
+      select: ["plaintext", "openai"],
+    });
+    // First call (max_completion_tokens) returns 400, second call (max_tokens) succeeds
+    const fetchMock = stubFetchSequence([{ ok: false, status: 400 }, { ok: true }]);
+
+    await runPromptCustomApi(prompter);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondCall = fetchMock.mock.calls[1]?.[1] as { body?: string } | undefined;
+    expect(secondCall?.body).toBeDefined();
+    const parsedBody = JSON.parse(secondCall?.body ?? "{}");
+    expect(parsedBody).toMatchObject({ max_tokens: 1 });
+    expect(parsedBody).not.toHaveProperty("max_completion_tokens");
   });
 
   it("uses azure-specific headers and body for openai verification probes", async () => {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -340,6 +340,23 @@ async function requestOpenAiVerification(params: {
       },
     });
   } else {
+    // Newer OpenAI models (gpt-5.x and others) require max_completion_tokens instead of
+    // max_tokens. Try max_completion_tokens first; fall back to max_tokens for providers
+    // that only support the legacy parameter.
+    const resultWithMaxCompletionTokens = await requestVerification({
+      endpoint,
+      headers,
+      body: {
+        model: params.modelId,
+        messages: [{ role: "user", content: "Hi" }],
+        max_completion_tokens: 1,
+        stream: false,
+      },
+    });
+    if (resultWithMaxCompletionTokens.ok || resultWithMaxCompletionTokens.status === 401) {
+      return resultWithMaxCompletionTokens;
+    }
+    // Fall back to max_tokens for older OpenAI-compatible providers
     return await requestVerification({
       endpoint,
       headers,

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -356,6 +356,15 @@ async function requestOpenAiVerification(params: {
     if (resultWithMaxCompletionTokens.ok || resultWithMaxCompletionTokens.status === 401) {
       return resultWithMaxCompletionTokens;
     }
+    // Only fall back when the endpoint explicitly rejected our request (4xx client error).
+    // Server errors (5xx) and network failures (status undefined) should propagate as-is
+    // to avoid masking real connectivity issues or creating false-positive verifications.
+    if (
+      resultWithMaxCompletionTokens.status === undefined ||
+      resultWithMaxCompletionTokens.status >= 500
+    ) {
+      return resultWithMaxCompletionTokens;
+    }
     // Fall back to max_tokens for older OpenAI-compatible providers
     return await requestVerification({
       endpoint,


### PR DESCRIPTION
## Summary

Fixes the onboarding verification probe to send `max_completion_tokens` instead of `max_tokens` for OpenAI-compatible endpoints, resolving failures with GPT-5.4 and newer OpenAI models.

## Problem

GPT-5.4 and newer OpenAI models reject the `max_tokens` parameter and require `max_completion_tokens` instead:

```json
{
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}
```

The onboarding verification probe in `requestOpenAiVerification` was sending `max_tokens: 1` for all non-Azure OpenAI-compatible endpoints, which caused verification to fail for newer models.

## Changes

- **`src/commands/onboard-custom.ts`**: Updated `requestOpenAiVerification` to try `max_completion_tokens` first (required by gpt-5.x and newer OpenAI models), with an automatic fallback to `max_tokens` for older OpenAI-compatible providers that only support the legacy parameter.
- **`src/commands/onboard-custom.test.ts`**: Updated existing test and added a new test to cover the fallback path.

## Why this approach

The probe-then-fallback strategy maintains backward compatibility with older OpenAI-compatible providers (e.g., self-hosted deployments, proxies) that only support `max_tokens`, while correctly supporting newer OpenAI models that require `max_completion_tokens`.

Note: The runtime request path already handles this correctly via the `pi-ai` library's `detectCompat` function which defaults to `max_completion_tokens` for standard OpenAI endpoints.

## Testing

- Updated existing test to verify `max_completion_tokens` is sent on the first probe attempt
- Added new test to verify the `max_tokens` fallback path when `max_completion_tokens` is rejected

Fixes openclaw/openclaw#49173