### PR TITLE
tests: fix wsl and process-respawn test isolation on WSL2

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureFullEnv } from "../test-utils/env.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
 
@@ -33,6 +33,10 @@ function setPlatform(platform: string) {
     value: platform,
   });
 }
+
+beforeEach(() => {
+  delete process.env.OPENCLAW_NO_RESPAWN;
+});
 
 afterEach(() => {
   envSnapshot.restore();

--- a/src/infra/wsl.test.ts
+++ b/src/infra/wsl.test.ts
@@ -35,6 +35,9 @@ describe("wsl detection", () => {
   beforeEach(() => {
     vi.resetModules();
     envSnapshot = captureEnv(["WSL_INTEROP", "WSL_DISTRO_NAME", "WSLENV"]);
+    delete process.env.WSL_INTEROP;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSLENV;
     readFileSyncMock.mockReset();
     readFileMock.mockReset();
     setPlatform("linux");


### PR DESCRIPTION
## Summary

- Fix `wsl.test.ts`: WSL env vars (`WSL_DISTRO_NAME`, `WSL_INTEROP`, `WSLENV`) leaked into tests on WSL2 hosts, causing `isWSLEnv()` to short-circuit past mocked file reads. Now deleted in `beforeEach` after capturing for restore.
- Fix `process-respawn.test.ts`: `OPENCLAW_NO_RESPAWN=1` set in the host shell was baked into `captureFullEnv()`'s snapshot, making every test start with respawn disabled. Now cleared in `beforeEach`.

## Test plan

- [ ] `pnpm test -- src/infra/wsl.test.ts src/infra/process-respawn.test.ts` passes (was 15 failures, now 0)
- [ ] `pnpm test` passes (7,977 passed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)