### PR TITLE
fix(ci): Windows test fixes — bundle-mcp realpath + echo-transcript vi.mock [AI]

### DIFF
--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -117,7 +117,11 @@ function expandBundleRootPlaceholders(value: string, rootDir: string): string {
   if (!value.includes(CLAUDE_PLUGIN_ROOT_PLACEHOLDER)) {
     return value;
   }
-  return value.split(CLAUDE_PLUGIN_ROOT_PLACEHOLDER).join(rootDir);
+  // After substituting the rootDir (which may use OS-native separators on
+  // Windows) the remainder of the template string may still have forward
+  // slashes, producing mixed separators like C:\foo/bar.  Normalize to make
+  // the result consistent on all platforms.
+  return path.normalize(value.split(CLAUDE_PLUGIN_ROOT_PLACEHOLDER).join(rootDir));
 }
 
 function absolutizeBundleMcpServer(params: {

--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -236,9 +236,17 @@ function loadBundleMcpConfig(params: {
   rootDir: string;
   bundleFormat: PluginBundleFormat;
 }): { config: BundleMcpConfig; diagnostics: string[] } {
+  // Normalize to the real path so that absolutized cwd/args are canonical on
+  // all platforms (on Windows, fs.mkdtemp can return 8.3 short-path forms).
+  let rootDir = params.rootDir;
+  try {
+    rootDir = fs.realpathSync(rootDir);
+  } catch {
+    // keep original if the directory doesn't exist yet
+  }
   const manifestRelativePath = MANIFEST_PATH_BY_FORMAT[params.bundleFormat];
   const manifestLoaded = readPluginJsonObject({
-    rootDir: params.rootDir,
+    rootDir,
     relativePath: manifestRelativePath,
     allowMissing: params.bundleFormat === "claude",
   });
@@ -249,14 +257,14 @@ function loadBundleMcpConfig(params: {
   let merged: BundleMcpConfig = { mcpServers: {} };
   const filePaths = resolveBundleMcpConfigPaths({
     raw: manifestLoaded.raw,
-    rootDir: params.rootDir,
+    rootDir,
     bundleFormat: params.bundleFormat,
   });
   for (const relativePath of filePaths) {
     merged = applyMergePatch(
       merged,
       loadBundleFileBackedMcpConfig({
-        rootDir: params.rootDir,
+        rootDir,
         relativePath,
       }),
     ) as BundleMcpConfig;
@@ -266,7 +274,7 @@ function loadBundleMcpConfig(params: {
     merged,
     loadBundleInlineMcpConfig({
       raw: manifestLoaded.raw,
-      baseDir: params.rootDir,
+      baseDir: rootDir,
     }),
   ) as BundleMcpConfig;
 

--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -117,11 +117,17 @@ function expandBundleRootPlaceholders(value: string, rootDir: string): string {
   if (!value.includes(CLAUDE_PLUGIN_ROOT_PLACEHOLDER)) {
     return value;
   }
-  // After substituting the rootDir (which may use OS-native separators on
-  // Windows) the remainder of the template string may still have forward
-  // slashes, producing mixed separators like C:\foo/bar.  Normalize to make
-  // the result consistent on all platforms.
-  return path.normalize(value.split(CLAUDE_PLUGIN_ROOT_PLACEHOLDER).join(rootDir));
+  const expanded = value.split(CLAUDE_PLUGIN_ROOT_PLACEHOLDER).join(rootDir);
+  // Only normalize when the value is a pure path that starts with the
+  // placeholder (e.g. "${CLAUDE_PLUGIN_ROOT}/bin/server").  Calling
+  // path.normalize on flag-embedded values like
+  // "--config=${CLAUDE_PLUGIN_ROOT}/cfg.json" could corrupt the flag prefix
+  // on some platforms.  Windows accepts both separators in flag-embedded
+  // paths so skipping normalization there is safe.
+  if (value.startsWith(CLAUDE_PLUGIN_ROOT_PLACEHOLDER)) {
+    return path.normalize(expanded);
+  }
+  return expanded;
 }
 
 function absolutizeBundleMcpServer(params: {

--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -237,10 +237,13 @@ function loadBundleMcpConfig(params: {
   bundleFormat: PluginBundleFormat;
 }): { config: BundleMcpConfig; diagnostics: string[] } {
   // Normalize to the real path so that absolutized cwd/args are canonical on
-  // all platforms (on Windows, fs.mkdtemp can return 8.3 short-path forms).
+  // all platforms. On Windows, fs.mkdtemp (via os.tmpdir()) can return 8.3
+  // short-path forms (e.g. RUNNER~1). fs.realpathSync.native uses the OS
+  // GetFinalPathNameByHandle API which resolves 8.3 short paths to their
+  // long-path equivalents, matching what fs.realpath (async) returns.
   let rootDir = params.rootDir;
   try {
-    rootDir = fs.realpathSync(rootDir);
+    rootDir = fs.realpathSync.native(rootDir);
   } catch {
     // keep original if the directory doesn't exist yet
   }

--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -254,8 +254,13 @@ function loadBundleMcpConfig(params: {
   let rootDir = params.rootDir;
   try {
     rootDir = fs.realpathSync.native(rootDir);
-  } catch {
-    // keep original if the directory doesn't exist yet
+  } catch (err) {
+    // Only swallow ENOENT (directory doesn't exist yet); re-throw permission
+    // errors, I/O failures, and other unexpected errors so they are not
+    // silently discarded.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
   }
   const manifestRelativePath = MANIFEST_PATH_BY_FORMAT[params.bundleFormat];
   const manifestLoaded = readPluginJsonObject({


### PR DESCRIPTION
## Summary

Recreated from a clean branch (previous PR #48905 was closed as dirty).

- **bundle-mcp Windows short-path fix**: `loadBundleMcpConfig` now normalises `rootDir` with `fs.realpathSync.native` so absolutised `cwd`/`args` use the long-path form (`runneradmin`) rather than the 8.3 short form (`RUNNER~1`) on Windows CI.
- **bundle-mcp placeholder path fix**: `expandBundleRootPlaceholders` calls `path.normalize` only when the value is a pure path starting with the placeholder, avoiding corruption of flag-embedded values like `--config=${CLAUDE_PLUGIN_ROOT}/cfg.json`.
- **echo-transcript test fix**: replaced `vi.mock("../agents/model-auth.js")` with `vi.spyOn()` on the imported namespace — `vi.mock` does not intercept already-bound ESM live bindings in `runner.entries.ts`, causing the real `resolveApiKeyForProvider` to throw silently and all 6 audio transcription tests to fail.
- **test hygiene**: add missing `useNoBundledPlugins()` call to bundle MCP loader test.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] CI/CD / infra

## Linked Issue/PR

- Replaces closed PR #48905

## User-visible / Behavior Changes

None on Linux/macOS. On Windows, `cwd` and absolutised `args` in bundle MCP server configs will always be long-path form.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

**bundle-mcp**: `pnpm test -- src/plugins/bundle-mcp.test.ts` → 3 tests pass  
**echo-transcript**: `pnpm test -- src/media-understanding/apply.echo-transcript.test.ts` → 10 tests pass

## Evidence

- [x] Failing test/log before + passing after

## Human Verification

- [x] Verified locally — all 13 affected tests pass
- [ ] Windows CI shards pass

## AI Checklist

- [x] **AI-assisted** — generated by Claude Sonnet 4.6 via Claude Code
- [x] **Testing degree** — fully tested locally; Windows path fix relies on CI for final validation
- [x] **Understanding confirmed** — root causes verified in code before fixing