### PR TITLE
feat: zsh autoload compatability

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -378,8 +378,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 
 function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
-  const script = `
-#compdef ${rootCmd}
+  const script = `#compdef ${rootCmd}
 
 _${rootCmd}_root_completion() {
   local -a commands
@@ -401,7 +400,13 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
-compdef _${rootCmd}_root_completion ${rootCmd}
+if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _${rootCmd}_root_completion "$@"
+else
+  compdef _${rootCmd}_root_completion ${rootCmd}
+fi
+
+
 `;
   return script;
 }


### PR DESCRIPTION
## Summary

- Problem: zsh completions do not work when auto loaded
- Why it matters: zsh completions must have the #compdef directive on the first line to work properly (works fine when sourced but not loaded automatically from fpath)
- What changed: zsh completion output
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra


## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: NixOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: zsh completions now load automatically from the file `openclaw completion --shell zsh` outputs

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None
