### PR TITLE
fix(whatsapp): use globalThis singleton for active-listener Map

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -30,7 +30,16 @@ export type ActiveWebListener = {
 
 let _currentListener: ActiveWebListener | null = null;
 
-const listeners = new Map<string, ActiveWebListener>();
+// Use a global singleton to survive bundler code-splitting that may duplicate
+// this module across multiple chunks (each chunk would get its own Map).
+const GLOBAL_KEY = "__openclaw_active_web_listeners__";
+const listeners: Map<string, ActiveWebListener> =
+  ((globalThis as Record<string, unknown>)[GLOBAL_KEY] as Map<string, ActiveWebListener>) ??
+  (() => {
+    const m = new Map<string, ActiveWebListener>();
+    (globalThis as Record<string, unknown>)[GLOBAL_KEY] = m;
+    return m;
+  })();
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;


### PR DESCRIPTION
## Summary

- Fix WhatsApp outbound tool-sends failing with "No active WhatsApp Web listener" while inbound and auto-replies work fine
- Root cause: bundler duplicates `active-listener.ts` module across chunks, creating separate `listeners` Maps for the monitor path vs the tool-send path
- Fix: store the Map on `globalThis` so all chunks share the same instance

Fixes #49209

## Test plan

- [ ] Build with `pnpm build`, verify no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- [ ] Start gateway with WhatsApp configured
- [ ] Verify inbound auto-reply still works (message the bot on WhatsApp)
- [ ] Verify outbound tool-send works (trigger a WhatsApp send from Telegram or another channel)
- [ ] Verify `channels status --probe` shows WhatsApp as linked/connected