### PR TITLE
feat(xiaomi): add MiMo V2 Pro and MiMo V2 Omni models, switch to OpenAI completions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: add an expand-to-canvas button on assistant chat bubbles and in-app session navigation from Sessions and Cron views. Thanks @BunsDev.
 - Plugins/context engines: expose `delegateCompactionToRuntime(...)` on the public plugin SDK, refactor the legacy engine to use the shared helper, and clarify `ownsCompaction` delegation semantics for non-owning engines. (#49061) Thanks @jalehman.
 - Plugins/MiniMax: add MiniMax-M2.7 and MiniMax-M2.7-highspeed models and update the default model from M2.5 to M2.7. (#49691) Thanks @liyuan97.
+- Plugins/Xiaomi: switch the bundled Xiaomi provider to the `/v1` OpenAI-compatible endpoint and add MiMo V2 Pro plus MiMo V2 Omni to the built-in catalog. (#49214) thanks @DJjjjhao.
 
 ### Fixes
 

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use Xiaomi MiMo (mimo-v2-flash) with OpenClaw"
+summary: "Use Xiaomi MiMo models with OpenClaw"
 read_when:
   - You want Xiaomi MiMo models in OpenClaw
   - You need XIAOMI_API_KEY setup
@@ -8,15 +8,18 @@ title: "Xiaomi MiMo"
 
 # Xiaomi MiMo
 
-Xiaomi MiMo is the API platform for **MiMo** models. It provides REST APIs compatible with
-OpenAI and Anthropic formats and uses API keys for authentication. Create your API key in
-the [Xiaomi MiMo console](https://platform.xiaomimimo.com/#/console/api-keys). OpenClaw uses
-the `xiaomi` provider with a Xiaomi MiMo API key.
+Xiaomi MiMo is the API platform for **MiMo** models. OpenClaw uses the Xiaomi
+OpenAI-compatible endpoint with API-key authentication. Create your API key in the
+[Xiaomi MiMo console](https://platform.xiaomimimo.com/#/console/api-keys), then configure the
+bundled `xiaomi` provider with that key.
 
 ## Model overview
 
-- **mimo-v2-flash**: 262144-token context window, Anthropic Messages API compatible.
-- Base URL: `https://api.xiaomimimo.com/anthropic`
+- **mimo-v2-flash**: default text model, 262144-token context window
+- **mimo-v2-pro**: reasoning text model, 1048576-token context window
+- **mimo-v2-omni**: reasoning multimodal model with text and image input, 262144-token context window
+- Base URL: `https://api.xiaomimimo.com/v1`
+- API: `openai-completions`
 - Authorization: `Bearer $XIAOMI_API_KEY`
 
 ## CLI setup
@@ -37,8 +40,8 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
     mode: "merge",
     providers: {
       xiaomi: {
-        baseUrl: "https://api.xiaomimimo.com/anthropic",
-        api: "anthropic-messages",
+        baseUrl: "https://api.xiaomimimo.com/v1",
+        api: "openai-completions",
         apiKey: "XIAOMI_API_KEY",
         models: [
           {
@@ -50,6 +53,24 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
             contextWindow: 262144,
             maxTokens: 8192,
           },
+          {
+            id: "mimo-v2-pro",
+            name: "Xiaomi MiMo V2 Pro",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 1048576,
+            maxTokens: 32000,
+          },
+          {
+            id: "mimo-v2-omni",
+            name: "Xiaomi MiMo V2 Omni",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 262144,
+            maxTokens: 32000,
+          },
         ],
       },
     },
@@ -59,6 +80,7 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
 
 ## Notes
 
-- Model ref: `xiaomi/mimo-v2-flash`.
+- Default model ref: `xiaomi/mimo-v2-flash`.
+- Additional built-in models: `xiaomi/mimo-v2-pro`, `xiaomi/mimo-v2-omni`.
 - The provider is injected automatically when `XIAOMI_API_KEY` is set (or an auth profile exists).
 - See [/concepts/model-providers](/concepts/model-providers) for provider rules.

--- a/docs/zh-CN/providers/xiaomi.md
+++ b/docs/zh-CN/providers/xiaomi.md
@@ -2,28 +2,31 @@
 read_when:
   - 你想在 OpenClaw 中使用 Xiaomi MiMo 模型
   - 你需要设置 `XIAOMI_API_KEY`
-summary: 在 OpenClaw 中使用 Xiaomi MiMo（`mimo-v2-flash`）
+summary: 在 OpenClaw 中使用 Xiaomi MiMo 模型
 title: Xiaomi MiMo
 x-i18n:
-  generated_at: "2026-03-16T06:27:26Z"
+  generated_at: "2026-03-20T01:18:00Z"
   model: gpt-5.4
   provider: openai
-  source_hash: 366fd2297b2caf8c5ad944d7f1b6d233b248fe43aedd22a28352ae7f370d2435
+  source_hash: e0abfbe49f438807ce1c5cf5d7910e930c0d670f447f6eb53ca4e9af61cc0843
   source_path: providers/xiaomi.md
   workflow: 15
 ---
 
 # Xiaomi MiMo
 
-Xiaomi MiMo 是 **MiMo** 模型的 API 平台。它提供与
-OpenAI 和 Anthropic 格式兼容的 REST API，并使用 API key 进行认证。请在
-[Xiaomi MiMo console](https://platform.xiaomimimo.com/#/console/api-keys) 中创建你的 API key。OpenClaw 使用
-`xiaomi` 提供商配合 Xiaomi MiMo API key。
+Xiaomi MiMo 是 **MiMo** 模型的 API 平台。OpenClaw 使用 Xiaomi 提供的
+OpenAI 兼容端点，并通过 API key 认证。请在
+[Xiaomi MiMo console](https://platform.xiaomimimo.com/#/console/api-keys) 中创建你的 API key，然后用它配置内置的
+`xiaomi` 提供商。
 
 ## 模型概览
 
-- **mimo-v2-flash**：262144-token 上下文窗口，兼容 Anthropic Messages API。
-- Base URL：`https://api.xiaomimimo.com/anthropic`
+- **mimo-v2-flash**：默认文本模型，262144-token 上下文窗口
+- **mimo-v2-pro**：支持推理的文本模型，1048576-token 上下文窗口
+- **mimo-v2-omni**：支持推理的多模态模型，支持文本和图像输入，262144-token 上下文窗口
+- Base URL：`https://api.xiaomimimo.com/v1`
+- API：`openai-completions`
 - 认证方式：`Bearer $XIAOMI_API_KEY`
 
 ## CLI 设置
@@ -44,8 +47,8 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
     mode: "merge",
     providers: {
       xiaomi: {
-        baseUrl: "https://api.xiaomimimo.com/anthropic",
-        api: "anthropic-messages",
+        baseUrl: "https://api.xiaomimimo.com/v1",
+        api: "openai-completions",
         apiKey: "XIAOMI_API_KEY",
         models: [
           {
@@ -57,6 +60,24 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
             contextWindow: 262144,
             maxTokens: 8192,
           },
+          {
+            id: "mimo-v2-pro",
+            name: "Xiaomi MiMo V2 Pro",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 1048576,
+            maxTokens: 32000,
+          },
+          {
+            id: "mimo-v2-omni",
+            name: "Xiaomi MiMo V2 Omni",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 262144,
+            maxTokens: 32000,
+          },
         ],
       },
     },
@@ -66,6 +87,7 @@ openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key "$XIAOMI_API_KEY"
 
 ## 说明
 
-- 模型引用：`xiaomi/mimo-v2-flash`。
+- 默认模型引用：`xiaomi/mimo-v2-flash`。
+- 额外内置模型：`xiaomi/mimo-v2-pro`、`xiaomi/mimo-v2-omni`。
 - 当设置了 `XIAOMI_API_KEY`（或存在凭证配置文件）时，提供商会自动注入。
 - 有关提供商规则，请参阅 [/concepts/model-providers](/concepts/model-providers)。

--- a/extensions/xiaomi/provider-catalog.ts
+++ b/extensions/xiaomi/provider-catalog.ts
@@ -1,6 +1,6 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
 
-const XIAOMI_BASE_URL = "https://api.xiaomimimo.com/anthropic";
+const XIAOMI_BASE_URL = "https://api.xiaomimimo.com/v1";
 export const XIAOMI_DEFAULT_MODEL_ID = "mimo-v2-flash";
 const XIAOMI_DEFAULT_CONTEXT_WINDOW = 262144;
 const XIAOMI_DEFAULT_MAX_TOKENS = 8192;
@@ -14,7 +14,7 @@ const XIAOMI_DEFAULT_COST = {
 export function buildXiaomiProvider(): ModelProviderConfig {
   return {
     baseUrl: XIAOMI_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     models: [
       {
         id: XIAOMI_DEFAULT_MODEL_ID,
@@ -24,6 +24,24 @@ export function buildXiaomiProvider(): ModelProviderConfig {
         cost: XIAOMI_DEFAULT_COST,
         contextWindow: XIAOMI_DEFAULT_CONTEXT_WINDOW,
         maxTokens: XIAOMI_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "mimo-v2-pro",
+        name: "Xiaomi MiMo V2 Pro",
+        reasoning: true,
+        input: ["text"],
+        cost: XIAOMI_DEFAULT_COST,
+        contextWindow: 1048576,
+        maxTokens: 32000,
+      },
+      {
+        id: "mimo-v2-omni",
+        name: "Xiaomi MiMo V2 Omni",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: XIAOMI_DEFAULT_COST,
+        contextWindow: XIAOMI_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: 32000,
       },
     ],
   };

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -554,9 +554,14 @@ describe("applyXiaomiConfig", () => {
   it("adds Xiaomi provider with correct settings", () => {
     const cfg = applyXiaomiConfig({});
     expect(cfg.models?.providers?.xiaomi).toMatchObject({
-      baseUrl: "https://api.xiaomimimo.com/anthropic",
-      api: "anthropic-messages",
+      baseUrl: "https://api.xiaomimimo.com/v1",
+      api: "openai-completions",
     });
+    expect(cfg.models?.providers?.xiaomi?.models.map((m) => m.id)).toEqual([
+      "mimo-v2-flash",
+      "mimo-v2-pro",
+      "mimo-v2-omni",
+    ]);
     expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe("xiaomi/mimo-v2-flash");
   });
 
@@ -570,12 +575,14 @@ describe("applyXiaomiConfig", () => {
       }),
     );
 
-    expect(cfg.models?.providers?.xiaomi?.baseUrl).toBe("https://api.xiaomimimo.com/anthropic");
-    expect(cfg.models?.providers?.xiaomi?.api).toBe("anthropic-messages");
+    expect(cfg.models?.providers?.xiaomi?.baseUrl).toBe("https://api.xiaomimimo.com/v1");
+    expect(cfg.models?.providers?.xiaomi?.api).toBe("openai-completions");
     expect(cfg.models?.providers?.xiaomi?.apiKey).toBe("old-key");
     expect(cfg.models?.providers?.xiaomi?.models.map((m) => m.id)).toEqual([
       "custom-model",
       "mimo-v2-flash",
+      "mimo-v2-pro",
+      "mimo-v2-omni",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Add `mimo-v2-pro` (text, reasoning, 1M context) and `mimo-v2-omni` (text + image, reasoning, 262K context) to the Xiaomi provider catalog
- Switch API from `anthropic-messages` to `openai-completions` and update base URL from `/anthropic` to `/v1`

## Test plan
- [x] `pnpm run check` passes