### PR TITLE
fix(sessions): clean expired archive artifacts during maintenance

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -9,6 +9,10 @@ import {
 describe("session artifact helpers", () => {
   it("classifies archived artifact file names", () => {
     expect(isSessionArchiveArtifactName("abc.jsonl.deleted.2026-01-01T00-00-00.000Z")).toBe(true);
+    expect(isSessionArchiveArtifactName("abc.jsonl.deleted.2026-01-01T00-00-00.000+00-00")).toBe(
+      true,
+    );
+    expect(isSessionArchiveArtifactName("abc.jsonl.deleted.20260101-000000")).toBe(true);
     expect(isSessionArchiveArtifactName("abc.jsonl.reset.2026-01-01T00-00-00.000Z")).toBe(true);
     expect(isSessionArchiveArtifactName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(true);
     expect(isSessionArchiveArtifactName("sessions.json.bak.1737420882")).toBe(true);
@@ -34,5 +38,9 @@ describe("session artifact helpers", () => {
     expect(parseSessionArchiveTimestamp(file, "deleted")).toBe(now);
     expect(parseSessionArchiveTimestamp(file, "reset")).toBeNull();
     expect(parseSessionArchiveTimestamp("keep.deleted.keep.jsonl", "deleted")).toBeNull();
+    expect(
+      parseSessionArchiveTimestamp("abc.jsonl.deleted.2026-02-23T12-34-56.000+00-00", "deleted"),
+    ).toBe(now);
+    expect(parseSessionArchiveTimestamp("abc.jsonl.deleted.20260223-123456", "deleted")).toBe(now);
   });
 });

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -1,7 +1,13 @@
 export type SessionArchiveReason = "bak" | "reset" | "deleted";
 
-const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
+const ISO_ARCHIVE_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}-\d{2})$/;
+const COMPACT_ARCHIVE_TIMESTAMP_RE = /^\d{8}-\d{6}$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
+
+function isArchiveTimestamp(raw: string): boolean {
+  return ISO_ARCHIVE_TIMESTAMP_RE.test(raw) || COMPACT_ARCHIVE_TIMESTAMP_RE.test(raw);
+}
 
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
@@ -10,7 +16,7 @@ function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boole
     return false;
   }
   const raw = fileName.slice(index + marker.length);
-  return ARCHIVE_TIMESTAMP_RE.test(raw);
+  return isArchiveTimestamp(raw);
 }
 
 export function isSessionArchiveArtifactName(fileName: string): boolean {
@@ -39,6 +45,21 @@ export function formatSessionArchiveTimestamp(nowMs = Date.now()): string {
 }
 
 function restoreSessionArchiveTimestamp(raw: string): string {
+  const compact = raw.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+  if (compact) {
+    const [, year, month, day, hour, minute, second] = compact;
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+  }
+
+  const iso = raw.match(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})(\.\d{3})?(Z|[+-]\d{2}-\d{2})$/,
+  );
+  if (iso) {
+    const [, datePart, hour, minute, second, millis = "", zone] = iso;
+    const normalizedZone = zone === "Z" ? "Z" : zone.replace(/([+-]\d{2})-(\d{2})$/, "$1:$2");
+    return `${datePart}T${hour}:${minute}:${second}${millis}${normalizedZone}`;
+  }
+
   const [datePart, timePart] = raw.split("T");
   if (!datePart || !timePart) {
     return raw;
@@ -59,7 +80,7 @@ export function parseSessionArchiveTimestamp(
   if (!raw) {
     return null;
   }
-  if (!ARCHIVE_TIMESTAMP_RE.test(raw)) {
+  if (!isArchiveTimestamp(raw)) {
     return null;
   }
   const timestamp = Date.parse(restoreSessionArchiveTimestamp(raw));

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -59,12 +59,7 @@ function restoreSessionArchiveTimestamp(raw: string): string {
     const normalizedZone = zone === "Z" ? "Z" : zone.replace(/([+-]\d{2})-(\d{2})$/, "$1:$2");
     return `${datePart}T${hour}:${minute}:${second}${millis}${normalizedZone}`;
   }
-
-  const [datePart, timePart] = raw.split("T");
-  if (!datePart || !timePart) {
-    return raw;
-  }
-  return `${datePart}T${timePart.replace(/-/g, ":")}`;
+  return raw;
 }
 
 export function parseSessionArchiveTimestamp(

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -181,6 +181,30 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expect(fs.stat(bakArchived)).resolves.toBeDefined();
   });
 
+  it("cleans up deleted archives even when no live sessions were pruned", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      fresh: { sessionId: "fresh-session", updatedAt: now },
+    };
+    const oldArchived = path.join(
+      testDir,
+      `old-session.jsonl.deleted.${archiveTimestamp(now - 9 * DAY_MS)}`,
+    );
+    const recentArchived = path.join(
+      testDir,
+      `recent-session.jsonl.deleted.${archiveTimestamp(now - 2 * DAY_MS)}`,
+    );
+    await fs.writeFile(oldArchived, "old", "utf-8");
+    await fs.writeFile(recentArchived, "recent", "utf-8");
+
+    await saveSessionStore(storePath, store);
+
+    await expect(fs.stat(oldArchived)).rejects.toThrow();
+    await expect(fs.stat(recentArchived)).resolves.toBeDefined();
+  });
+
   it("cleans up reset archives using resetArchiveRetention", async () => {
     mockLoadConfig.mockReturnValue({
       session: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -479,9 +479,8 @@ async function saveSessionStoreUnlocked(
       for (const archivedDir of archivedForDeletedSessions) {
         archivedDirs.add(archivedDir);
       }
-      if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
-        const targetDirs =
-          archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
+      if (maintenance.pruneAfterMs >= 0 || maintenance.resetArchiveRetentionMs != null) {
+        const targetDirs = [path.dirname(path.resolve(storePath)), ...archivedDirs];
         await cleanupArchivedSessionTranscripts({
           directories: targetDirs,
           olderThanMs: maintenance.pruneAfterMs,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -479,20 +479,18 @@ async function saveSessionStoreUnlocked(
       for (const archivedDir of archivedForDeletedSessions) {
         archivedDirs.add(archivedDir);
       }
-      if (maintenance.pruneAfterMs >= 0 || maintenance.resetArchiveRetentionMs != null) {
-        const targetDirs = [path.dirname(path.resolve(storePath)), ...archivedDirs];
+      const targetDirs = [path.dirname(path.resolve(storePath)), ...archivedDirs];
+      await cleanupArchivedSessionTranscripts({
+        directories: targetDirs,
+        olderThanMs: maintenance.pruneAfterMs,
+        reason: "deleted",
+      });
+      if (maintenance.resetArchiveRetentionMs != null) {
         await cleanupArchivedSessionTranscripts({
           directories: targetDirs,
-          olderThanMs: maintenance.pruneAfterMs,
-          reason: "deleted",
+          olderThanMs: maintenance.resetArchiveRetentionMs,
+          reason: "reset",
         });
-        if (maintenance.resetArchiveRetentionMs != null) {
-          await cleanupArchivedSessionTranscripts({
-            directories: targetDirs,
-            olderThanMs: maintenance.resetArchiveRetentionMs,
-            reason: "reset",
-          });
-        }
       }
 
       // Rotate the on-disk file if it exceeds the size threshold.


### PR DESCRIPTION
## Summary

- Problem: enforced session maintenance only cleaned archived deleted transcripts when the same save also archived a live-session removal, so stale `.deleted.*` artifacts could survive indefinitely in otherwise healthy stores.
- Why it matters: session directories keep accumulating expired deleted/reset artifacts even though the maintenance docs describe retention-based cleanup.
- What changed: always run deleted/reset archive cleanup against the store directory during enforced maintenance, and broaden archive timestamp parsing so older filename variants are still eligible for retention cleanup.
- What did NOT change (scope boundary): this does not change live-session retention policy, lock timeouts, or add new maintenance knobs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #22506
- Related #48950

## User-visible / Behavior Changes

Expired `.deleted.*` and `.reset.*` session archive artifacts are now cleaned up more reliably during enforced session maintenance, including legacy timestamp filename variants.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22 source checkout
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): session maintenance `mode: enforce`

### Steps

1. Create a sessions store with enforced maintenance enabled.
2. Place an expired `.deleted.*` transcript and a fresh `.deleted.*` transcript in the store directory.
3. Save the session store without pruning any live sessions.

### Expected

- The expired archive is removed and the fresh archive remains.

### Actual

- Before this change, the expired archive could remain because cleanup only ran when the same save had already archived a deleted live session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran a direct maintenance save against a temp sessions directory and confirmed an expired `.deleted.*` artifact was pruned while a recent artifact remained; verified legacy archive filename variants like `2026-02-23T12-34-56.000+00-00` and `20260223-123456` parse into retention timestamps.
- Edge cases checked: cleanup still runs when no live sessions were pruned, and legacy timestamp formats remain eligible for cleanup.
- What you did **not** verify: a long-lived production directory with thousands of archived files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; maintenance returns to the previous archive-cleanup behavior.
- Files/config to restore: `src/config/sessions/store.ts`, `src/config/sessions/artifacts.ts`
- Known bad symptoms reviewers should watch for: unexpected deletion of recent session archives or retention cleanup skipping legacy-named artifacts.

## Risks and Mitigations

- Risk: broader timestamp parsing could classify an unexpected filename as an archive artifact.
  - Mitigation: parsing stays limited to the existing `.bak`, `.deleted`, and `.reset` suffix patterns and adds targeted tests for the accepted legacy formats.
