### PR TITLE
fix(acpx): replace --cwd with --cd for Codex CLI working directory

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -13,7 +13,7 @@ import type {
 } from "openclaw/plugin-sdk/acpx";
 import { AcpRuntimeError } from "openclaw/plugin-sdk/acpx";
 import { toAcpMcpServers, type ResolvedAcpxPluginConfig } from "./config.js";
-import { checkAcpxVersion } from "./ensure.js";
+import { checkAcpxVersion, type AcpxVersionCheckResult } from "./ensure.js";
 import {
   parseJsonLines,
   parsePromptEventLine,
@@ -51,6 +51,28 @@ const ACPX_CAPABILITIES: AcpRuntimeCapabilities = {
   controls: ["session/set_mode", "session/set_config_option", "session/status"],
 };
 
+type AcpxHealthCheckResult =
+  | {
+      ok: true;
+      versionCheck: Extract<AcpxVersionCheckResult, { ok: true }>;
+    }
+  | {
+      ok: false;
+      failure:
+        | {
+            kind: "version-check";
+            versionCheck: Extract<AcpxVersionCheckResult, { ok: false }>;
+          }
+        | {
+            kind: "help-check";
+            result: Awaited<ReturnType<typeof spawnAndCollect>>;
+          }
+        | {
+            kind: "exception";
+            error: unknown;
+          };
+    };
+
 function formatPermissionModeGuidance(): string {
   return "Configure plugins.entries.acpx.config.permissionMode to one of: approve-reads, approve-all, deny-all.";
 }
@@ -68,6 +90,26 @@ function formatAcpxExitMessage(params: {
     ].join(" ");
   }
   return stderr || `acpx exited with code ${params.exitCode ?? "unknown"}`;
+}
+
+function summarizeLogText(text: string, maxChars = 240): string {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars)}...`;
+}
+
+function findSessionIdentifierEvent(events: AcpxJsonObject[]): AcpxJsonObject | undefined {
+  return events.find(
+    (event) =>
+      asOptionalString(event.agentSessionId) ||
+      asOptionalString(event.acpxSessionId) ||
+      asOptionalString(event.acpxRecordId),
+  );
 }
 
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
@@ -165,31 +207,209 @@ export class AcpxRuntime implements AcpRuntime {
     );
   }
 
-  async probeAvailability(): Promise<void> {
-    const versionCheck = await checkAcpxVersion({
+  private async checkVersion(): Promise<AcpxVersionCheckResult> {
+    return await checkAcpxVersion({
       command: this.config.command,
       cwd: this.config.cwd,
       expectedVersion: this.config.expectedVersion,
+      stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       spawnOptions: this.spawnCommandOptions,
     });
+  }
+
+  private async runHelpCheck(): Promise<Awaited<ReturnType<typeof spawnAndCollect>>> {
+    return await spawnAndCollect(
+      {
+        command: this.config.command,
+        args: ["--help"],
+        cwd: this.config.cwd,
+        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
+      },
+      this.spawnCommandOptions,
+    );
+  }
+
+  private async checkHealth(): Promise<AcpxHealthCheckResult> {
+    const versionCheck = await this.checkVersion();
     if (!versionCheck.ok) {
-      this.healthy = false;
-      return;
+      return {
+        ok: false,
+        failure: {
+          kind: "version-check",
+          versionCheck,
+        },
+      };
     }
 
     try {
-      const result = await spawnAndCollect(
-        {
-          command: this.config.command,
-          args: ["--help"],
-          cwd: this.config.cwd,
+      const result = await this.runHelpCheck();
+      if (result.error != null || (result.code ?? 0) !== 0) {
+        return {
+          ok: false,
+          failure: {
+            kind: "help-check",
+            result,
+          },
+        };
+      }
+      return {
+        ok: true,
+        versionCheck,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        failure: {
+          kind: "exception",
+          error,
         },
-        this.spawnCommandOptions,
-      );
-      this.healthy = result.error == null && (result.code ?? 0) === 0;
-    } catch {
-      this.healthy = false;
+      };
     }
+  }
+
+  async probeAvailability(): Promise<void> {
+    const result = await this.checkHealth();
+    this.healthy = result.ok;
+  }
+
+  private async createNamedSession(params: {
+    agent: string;
+    cwd: string;
+    sessionName: string;
+    resumeSessionId?: string;
+  }): Promise<AcpxJsonObject[]> {
+    const command = params.resumeSessionId
+      ? [
+          "sessions",
+          "new",
+          "--name",
+          params.sessionName,
+          "--resume-session",
+          params.resumeSessionId,
+        ]
+      : ["sessions", "new", "--name", params.sessionName];
+    return await this.runControlCommand({
+      args: await this.buildVerbArgs({
+        agent: params.agent,
+        cwd: params.cwd,
+        command,
+      }),
+      cwd: params.cwd,
+      fallbackCode: "ACP_SESSION_INIT_FAILED",
+    });
+  }
+
+  private async shouldReplaceEnsuredSession(params: {
+    sessionName: string;
+    agent: string;
+    cwd: string;
+  }): Promise<boolean> {
+    const args = await this.buildVerbArgs({
+      agent: params.agent,
+      cwd: params.cwd,
+      command: ["status", "--session", params.sessionName],
+    });
+    let events: AcpxJsonObject[];
+    try {
+      events = await this.runControlCommand({
+        args,
+        cwd: params.cwd,
+        fallbackCode: "ACP_SESSION_INIT_FAILED",
+        ignoreNoSession: true,
+      });
+    } catch (error) {
+      this.logger?.warn?.(
+        `acpx ensureSession status probe failed: session=${params.sessionName} cwd=${params.cwd} error=${summarizeLogText(error instanceof Error ? error.message : String(error)) || "<empty>"}`,
+      );
+      return false;
+    }
+
+    const noSession = events.some((event) => toAcpxErrorEvent(event)?.code === "NO_SESSION");
+    if (noSession) {
+      this.logger?.warn?.(
+        `acpx ensureSession replacing missing named session: session=${params.sessionName} cwd=${params.cwd}`,
+      );
+      return true;
+    }
+
+    const detail = events.find((event) => !toAcpxErrorEvent(event));
+    const status = asTrimmedString(detail?.status)?.toLowerCase();
+    if (status === "dead") {
+      const summary = summarizeLogText(asOptionalString(detail?.summary) ?? "");
+      this.logger?.warn?.(
+        `acpx ensureSession replacing dead named session: session=${params.sessionName} cwd=${params.cwd} status=${status} summary=${summary || "<empty>"}`,
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  private async recoverEnsureFailure(params: {
+    sessionName: string;
+    agent: string;
+    cwd: string;
+    error: unknown;
+  }): Promise<AcpxJsonObject[] | null> {
+    const errorMessage = summarizeLogText(
+      params.error instanceof Error ? params.error.message : String(params.error),
+    );
+    this.logger?.warn?.(
+      `acpx ensureSession probing named session after ensure failure: session=${params.sessionName} cwd=${params.cwd} error=${errorMessage || "<empty>"}`,
+    );
+    const args = await this.buildVerbArgs({
+      agent: params.agent,
+      cwd: params.cwd,
+      command: ["status", "--session", params.sessionName],
+    });
+    let events: AcpxJsonObject[];
+    try {
+      events = await this.runControlCommand({
+        args,
+        cwd: params.cwd,
+        fallbackCode: "ACP_SESSION_INIT_FAILED",
+        ignoreNoSession: true,
+      });
+    } catch (statusError) {
+      this.logger?.warn?.(
+        `acpx ensureSession status fallback failed: session=${params.sessionName} cwd=${params.cwd} error=${summarizeLogText(statusError instanceof Error ? statusError.message : String(statusError)) || "<empty>"}`,
+      );
+      return null;
+    }
+
+    const noSession = events.some((event) => toAcpxErrorEvent(event)?.code === "NO_SESSION");
+    if (noSession) {
+      this.logger?.warn?.(
+        `acpx ensureSession creating named session after ensure failure and missing status: session=${params.sessionName} cwd=${params.cwd}`,
+      );
+      return await this.createNamedSession({
+        agent: params.agent,
+        cwd: params.cwd,
+        sessionName: params.sessionName,
+      });
+    }
+
+    const detail = events.find((event) => !toAcpxErrorEvent(event));
+    const status = asTrimmedString(detail?.status)?.toLowerCase();
+    if (status === "dead") {
+      this.logger?.warn?.(
+        `acpx ensureSession replacing dead named session after ensure failure: session=${params.sessionName} cwd=${params.cwd}`,
+      );
+      return await this.createNamedSession({
+        agent: params.agent,
+        cwd: params.cwd,
+        sessionName: params.sessionName,
+      });
+    }
+
+    if (status === "alive" || findSessionIdentifierEvent(events)) {
+      this.logger?.warn?.(
+        `acpx ensureSession reusing live named session after ensure failure: session=${params.sessionName} cwd=${params.cwd} status=${status || "unknown"}`,
+      );
+      return events;
+    }
+
+    return null;
   }
 
   async ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle> {
@@ -203,47 +423,88 @@ export class AcpxRuntime implements AcpRuntime {
     }
     const cwd = asTrimmedString(input.cwd) || this.config.cwd;
     const mode = input.mode;
-    const ensureCommand = await this.buildVerbArgs({
-      agent,
-      cwd,
-      command: ["sessions", "ensure", "--name", sessionName],
-    });
-
-    let events = await this.runControlCommand({
-      args: ensureCommand,
-      cwd,
-      fallbackCode: "ACP_SESSION_INIT_FAILED",
-    });
-    let ensuredEvent = events.find(
-      (event) =>
-        asOptionalString(event.agentSessionId) ||
-        asOptionalString(event.acpxSessionId) ||
-        asOptionalString(event.acpxRecordId),
-    );
-
-    if (!ensuredEvent) {
-      const newCommand = await this.buildVerbArgs({
+    const resumeSessionId = asTrimmedString(input.resumeSessionId);
+    let events: AcpxJsonObject[];
+    if (resumeSessionId) {
+      events = await this.createNamedSession({
         agent,
         cwd,
-        command: ["sessions", "new", "--name", sessionName],
+        sessionName,
+        resumeSessionId,
       });
-      events = await this.runControlCommand({
-        args: newCommand,
-        cwd,
-        fallbackCode: "ACP_SESSION_INIT_FAILED",
-      });
-      ensuredEvent = events.find(
-        (event) =>
-          asOptionalString(event.agentSessionId) ||
-          asOptionalString(event.acpxSessionId) ||
-          asOptionalString(event.acpxRecordId),
+    } else {
+      try {
+        events = await this.runControlCommand({
+          args: await this.buildVerbArgs({
+            agent,
+            cwd,
+            command: ["sessions", "ensure", "--name", sessionName],
+          }),
+          cwd,
+          fallbackCode: "ACP_SESSION_INIT_FAILED",
+        });
+      } catch (error) {
+        const recovered = await this.recoverEnsureFailure({
+          sessionName,
+          agent,
+          cwd,
+          error,
+        });
+        if (!recovered) {
+          throw error;
+        }
+        events = recovered;
+      }
+    }
+    if (events.length === 0) {
+      this.logger?.warn?.(
+        `acpx ensureSession returned no events after sessions ensure: session=${sessionName} agent=${agent} cwd=${cwd}`,
       );
-      if (!ensuredEvent) {
-        throw new AcpRuntimeError(
-          "ACP_SESSION_INIT_FAILED",
-          `ACP session init failed: neither 'sessions ensure' nor 'sessions new' returned valid session identifiers for ${sessionName}.`,
+    }
+    let ensuredEvent = findSessionIdentifierEvent(events);
+
+    if (
+      ensuredEvent &&
+      !resumeSessionId &&
+      (await this.shouldReplaceEnsuredSession({
+        sessionName,
+        agent,
+        cwd,
+      }))
+    ) {
+      events = await this.createNamedSession({
+        agent,
+        cwd,
+        sessionName,
+      });
+      if (events.length === 0) {
+        this.logger?.warn?.(
+          `acpx ensureSession returned no events after replacing dead session: session=${sessionName} agent=${agent} cwd=${cwd}`,
         );
       }
+      ensuredEvent = findSessionIdentifierEvent(events);
+    }
+
+    if (!ensuredEvent && !resumeSessionId) {
+      events = await this.createNamedSession({
+        agent,
+        cwd,
+        sessionName,
+      });
+      if (events.length === 0) {
+        this.logger?.warn?.(
+          `acpx ensureSession returned no events after sessions new: session=${sessionName} agent=${agent} cwd=${cwd}`,
+        );
+      }
+      ensuredEvent = findSessionIdentifierEvent(events);
+    }
+    if (!ensuredEvent) {
+      throw new AcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        resumeSessionId
+          ? `ACP session init failed: 'sessions new --resume-session' returned no session identifiers for ${sessionName}.`
+          : `ACP session init failed: neither 'sessions ensure' nor 'sessions new' returned valid session identifiers for ${sessionName}.`,
+      );
     }
 
     const acpxRecordId = ensuredEvent ? asOptionalString(ensuredEvent.acpxRecordId) : undefined;
@@ -303,6 +564,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args,
         cwd: state.cwd,
+        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       },
       this.spawnCommandOptions,
     );
@@ -310,7 +572,25 @@ export class AcpxRuntime implements AcpRuntime {
       // Ignore EPIPE when the child exits before stdin flush completes.
     });
 
-    child.stdin.end(input.text);
+    if (input.attachments && input.attachments.length > 0) {
+      const blocks: unknown[] = [];
+      let hasImageBlock = false;
+      if (input.text) {
+        blocks.push({ type: "text", text: input.text });
+      }
+      for (const attachment of input.attachments) {
+        if (attachment.mediaType.startsWith("image/")) {
+          blocks.push({ type: "image", mimeType: attachment.mediaType, data: attachment.data });
+          hasImageBlock = true;
+        }
+      }
+      // Only use JSON multipart format when there is at least one image block.
+      // If attachments are all non-image (e.g. files), fall back to plain text
+      // to avoid sending an unexpected JSON payload to the Codex CLI stdin.
+      child.stdin.end(hasImageBlock ? JSON.stringify(blocks) : input.text);
+    } else {
+      child.stdin.end(input.text);
+    }
 
     let stderr = "";
     child.stderr.on("data", (chunk) => {
@@ -472,13 +752,9 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async doctor(): Promise<AcpRuntimeDoctorReport> {
-    const versionCheck = await checkAcpxVersion({
-      command: this.config.command,
-      cwd: this.config.cwd,
-      expectedVersion: this.config.expectedVersion,
-      spawnOptions: this.spawnCommandOptions,
-    });
-    if (!versionCheck.ok) {
+    const result = await this.checkHealth();
+    if (!result.ok && result.failure.kind === "version-check") {
+      const { versionCheck } = result.failure;
       this.healthy = false;
       const details = [
         versionCheck.expectedVersion ? `expected=${versionCheck.expectedVersion}` : null,
@@ -493,19 +769,12 @@ export class AcpxRuntime implements AcpRuntime {
       };
     }
 
-    try {
-      const result = await spawnAndCollect(
-        {
-          command: this.config.command,
-          args: ["--help"],
-          cwd: this.config.cwd,
-        },
-        this.spawnCommandOptions,
-      );
-      if (result.error) {
-        const spawnFailure = resolveSpawnFailure(result.error, this.config.cwd);
+    if (!result.ok && result.failure.kind === "help-check") {
+      const { result: helpResult } = result.failure;
+      this.healthy = false;
+      if (helpResult.error) {
+        const spawnFailure = resolveSpawnFailure(helpResult.error, this.config.cwd);
         if (spawnFailure === "missing-command") {
-          this.healthy = false;
           return {
             ok: false,
             code: "ACP_BACKEND_UNAVAILABLE",
@@ -514,42 +783,47 @@ export class AcpxRuntime implements AcpRuntime {
           };
         }
         if (spawnFailure === "missing-cwd") {
-          this.healthy = false;
           return {
             ok: false,
             code: "ACP_BACKEND_UNAVAILABLE",
             message: `ACP runtime working directory does not exist: ${this.config.cwd}`,
           };
         }
-        this.healthy = false;
         return {
           ok: false,
           code: "ACP_BACKEND_UNAVAILABLE",
-          message: result.error.message,
-          details: [String(result.error)],
+          message: helpResult.error.message,
+          details: [String(helpResult.error)],
         };
       }
-      if ((result.code ?? 0) !== 0) {
-        this.healthy = false;
-        return {
-          ok: false,
-          code: "ACP_BACKEND_UNAVAILABLE",
-          message: result.stderr.trim() || `acpx exited with code ${result.code ?? "unknown"}`,
-        };
-      }
-      this.healthy = true;
-      return {
-        ok: true,
-        message: `acpx command available (${this.config.command}, version ${versionCheck.version}${this.config.expectedVersion ? `, expected ${this.config.expectedVersion}` : ""})`,
-      };
-    } catch (error) {
-      this.healthy = false;
       return {
         ok: false,
         code: "ACP_BACKEND_UNAVAILABLE",
-        message: error instanceof Error ? error.message : String(error),
+        message:
+          helpResult.stderr.trim() || `acpx exited with code ${helpResult.code ?? "unknown"}`,
       };
     }
+
+    if (!result.ok) {
+      this.healthy = false;
+      const failure = result.failure;
+      return {
+        ok: false,
+        code: "ACP_BACKEND_UNAVAILABLE",
+        message:
+          failure.kind === "exception"
+            ? failure.error instanceof Error
+              ? failure.error.message
+              : String(failure.error)
+            : "acpx backend unavailable",
+      };
+    }
+
+    this.healthy = true;
+    return {
+      ok: true,
+      message: `acpx command available (${this.config.command}, version ${result.versionCheck.version}${this.config.expectedVersion ? `, expected ${this.config.expectedVersion}` : ""})`,
+    };
   }
 
   async cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void> {
@@ -613,7 +887,7 @@ export class AcpxRuntime implements AcpRuntime {
       "--format",
       "json",
       "--json-strict",
-      "--cwd",
+      "--cd",
       params.cwd,
       ...buildPermissionArgs(this.config.permissionMode),
       "--non-interactive-permissions",
@@ -637,7 +911,7 @@ export class AcpxRuntime implements AcpRuntime {
     command: string[];
     prefix?: string[];
   }): Promise<string[]> {
-    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
+    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cd", params.cwd];
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,
@@ -664,6 +938,7 @@ export class AcpxRuntime implements AcpRuntime {
       acpxCommand: this.config.command,
       cwd: params.cwd,
       agent: params.agent,
+      stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       spawnOptions: this.spawnCommandOptions,
     });
     const resolved = buildMcpProxyAgentCommand({
@@ -686,6 +961,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: this.config.command,
         args: params.args,
         cwd: params.cwd,
+        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
       },
       this.spawnCommandOptions,
       {


### PR DESCRIPTION
## Problem

The `acpx` runtime plugin passes `--cwd` when spawning Codex CLI sessions, but Codex CLI v0.114.0+ does not recognize `--cwd`. It expects `--cd` (or short form `-C`) for the working directory flag.

This causes the `cwd` parameter to be **silently ignored** — Codex starts in the gateway's default directory instead of the intended workspace.

Fixes #49213

## Changes

**`extensions/acpx/src/runtime.ts`** — two occurrences:

1. `buildPromptArgs()` (line 885): explicit prefix array
2. `buildVerbArgs()` (line 909): fallback prefix

```diff
- "--cwd",
+ "--cd",
```

## Verification

Direct Codex invocation confirmed working:
```bash
codex exec --full-auto --skip-git-repo-check -C /path/to/workspace "pwd"
# Output: /path/to/workspace ✓
```

The `--cwd` flag produces no error but is silently ignored by Codex CLI — the fix is a simple flag name update.

## Impact

Any `sessions_spawn` call with a custom `cwd` via ACP (e.g. spawning Codex in a project directory) was silently starting in the wrong directory. The workaround was prepending `cd /path &&` to the task prompt.