### PR TITLE
fix(acpx): use Codex --cd flag for cwd

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -126,6 +126,8 @@ describe("AcpxRuntime", () => {
     expect(promptArgs).toContain("--ttl");
     expect(promptArgs).toContain("180");
     expect(promptArgs).toContain("--approve-all");
+    expect(promptArgs).toContain("--cd");
+    expect(promptArgs).not.toContain("--cwd");
   });
 
   it("uses sessions new with --resume-session when resumeSessionId is provided", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -882,7 +882,7 @@ export class AcpxRuntime implements AcpRuntime {
       "--format",
       "json",
       "--json-strict",
-      "--cwd",
+      "--cd",
       params.cwd,
       ...buildPermissionArgs(this.config.permissionMode),
       "--non-interactive-permissions",
@@ -906,7 +906,7 @@ export class AcpxRuntime implements AcpRuntime {
     command: string[];
     prefix?: string[];
   }): Promise<string[]> {
-    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
+    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cd", params.cwd];
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,


### PR DESCRIPTION
## Summary
- switch ACPX Codex launches from \--cwd\ to the supported \--cd\ flag
- keep the existing JSON-strict command prefix intact
- add a regression assertion covering the emitted prompt args

## Validation
- node .\\node_modules\\.pnpm\\vitest@4.1.0_@opentelemetry_28f149cb957c7d3e29d45946d01d2c5d\\node_modules\\vitest\\vitest.mjs run extensions/acpx/src/runtime.test.ts

Closes #49213