### PR TITLE
tests(acp): mock resolveProviderXHighThinking for xhigh thinking-level tests

### DIFF
--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -8,10 +8,22 @@ import type {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
+import * as providerRuntime from "../plugins/provider-runtime.js";
 import { resetProviderRuntimeHookCacheForTest } from "../plugins/provider-runtime.js";
 import { createInMemorySessionStore } from "./session.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+// Bundled plugin hooks (supportsXHighThinking) require a full dist-runtime build
+// which is not present in the test environment.  Stub the runtime hook for the
+// well-known openai/gpt-5.4 model so thinking-level tests see the expected list.
+vi.spyOn(providerRuntime, "resolveProviderXHighThinking").mockImplementation((params) => {
+  const modelId = params.context.modelId?.toLowerCase() ?? "";
+  if (params.provider === "openai" && (modelId === "gpt-5.4" || modelId === "gpt-5.4-pro")) {
+    return true;
+  }
+  return undefined;
+});
 
 function createNewSessionRequest(cwd = "/tmp"): NewSessionRequest {
   return {


### PR DESCRIPTION
## Summary

- Stubs `resolveProviderXHighThinking` via `vi.spyOn` in `translator.session-rate-limit.test.ts`
- Bundled plugin hooks (`supportsXHighThinking`) require a full `dist-runtime` build which is absent in the test environment; without this mock the `xhigh` mode never appears in `availableModes`, causing the thinking-level assertions to fail
- Returns `true` for `openai`/`gpt-5.4` (and `gpt-5.4-pro`), `undefined` for all other models — matching the actual OpenAI plugin behaviour

## Test plan

- [x] `pnpm test -- src/acp/translator.session-rate-limit.test.ts` — all 21 tests pass locally
- [ ] Windows CI shards green (pre-existing failure this fixes)

## Context

This is one of the pre-existing Windows CI failures identified when syncing the fork with upstream/main. The other three failures were already fixed upstream; this is the last remaining one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)