### PR TITLE
Agents: improve prompt cache hit rate and add prompt composition regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
+- Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
 
 ## 2026.3.13
 

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendBootstrapPromptWarning,
   analyzeBootstrapBudget,
   buildBootstrapInjectionStats,
   buildBootstrapPromptWarning,
@@ -106,14 +107,15 @@ describe("analyzeBootstrapBudget", () => {
 });
 
 describe("bootstrap prompt warnings", () => {
-  it("prepends warning details to the turn prompt instead of mutating the system prompt", () => {
-    const prompt = prependBootstrapPromptWarning("Please continue.", [
+  it("appends warning details to the turn prompt instead of mutating the system prompt", () => {
+    const prompt = appendBootstrapPromptWarning("Please continue.", [
       "AGENTS.md: 200 raw -> 0 injected",
     ]);
+    expect(prompt.startsWith("Please continue.")).toBe(true);
     expect(prompt).toContain("[Bootstrap truncation warning]");
     expect(prompt).toContain("Treat Project Context as partial");
     expect(prompt).toContain("- AGENTS.md: 200 raw -> 0 injected");
-    expect(prompt).toContain("Please continue.");
+    expect(prompt.endsWith("- AGENTS.md: 200 raw -> 0 injected")).toBe(true);
   });
 
   it("preserves raw prompt whitespace when appending warning details", () => {

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -116,19 +116,20 @@ describe("bootstrap prompt warnings", () => {
     expect(prompt).toContain("Please continue.");
   });
 
-  it("preserves raw prompt whitespace when prepending warning details", () => {
-    const prompt = prependBootstrapPromptWarning("  indented\nkeep tail  ", [
+  it("preserves raw prompt whitespace when appending warning details", () => {
+    const prompt = appendBootstrapPromptWarning("  indented\nkeep tail  ", [
       "AGENTS.md: 200 raw -> 0 injected",
     ]);
 
-    expect(prompt.endsWith("  indented\nkeep tail  ")).toBe(true);
+    expect(prompt).toContain("  indented\nkeep tail  ");
+    expect(prompt.indexOf("  indented\nkeep tail  ")).toBe(0);
   });
 
-  it("preserves exact heartbeat prompts without warning prefixes", () => {
+  it("preserves exact heartbeat prompts without warning suffixes", () => {
     const heartbeatPrompt = "Read HEARTBEAT.md. Reply HEARTBEAT_OK.";
 
     expect(
-      prependBootstrapPromptWarning(heartbeatPrompt, ["AGENTS.md: 200 raw -> 0 injected"], {
+      appendBootstrapPromptWarning(heartbeatPrompt, ["AGENTS.md: 200 raw -> 0 injected"], {
         preserveExactPrompt: heartbeatPrompt,
       }),
     ).toBe(heartbeatPrompt);

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -330,7 +330,7 @@ export function buildBootstrapPromptWarning(params: {
   };
 }
 
-export function prependBootstrapPromptWarning(
+export function appendBootstrapPromptWarning(
   prompt: string,
   warningLines?: string[],
   options?: {
@@ -352,6 +352,9 @@ export function prependBootstrapPromptWarning(
   ].join("\n");
   return prompt ? `${prompt}\n\n${warningBlock}` : warningBlock;
 }
+
+// Backward-compatible alias while older callers still import the prepend name.
+export const prependBootstrapPromptWarning = appendBootstrapPromptWarning;
 
 export function buildBootstrapTruncationReportMeta(params: {
   analysis: BootstrapBudgetAnalysis;

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -350,7 +350,7 @@ export function prependBootstrapPromptWarning(
     "Treat Project Context as partial and read the relevant files directly if details seem missing.",
     ...normalizedLines.map((line) => `- ${line}`),
   ].join("\n");
-  return prompt ? `${warningBlock}\n\n${prompt}` : warningBlock;
+  return prompt ? `${prompt}\n\n${warningBlock}` : warningBlock;
 }
 
 export function buildBootstrapTruncationReportMeta(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { appendBootstrapPromptWarning } from "../../bootstrap-budget.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
+import { buildAgentSystemPrompt } from "../../system-prompt.js";
 import {
   buildAfterTurnRuntimeContext,
   composeSystemPromptWithHookContext,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -162,6 +162,42 @@ describe("composeSystemPromptWithHookContext", () => {
       }),
     ).toBe("append only");
   });
+
+  it("keeps hook-composed system prompt stable when bootstrap warnings only change the user prompt", () => {
+    const baseSystemPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [{ path: "AGENTS.md", content: "Follow AGENTS guidance." }],
+      toolNames: ["read"],
+    });
+    const composedSystemPrompt = composeSystemPromptWithHookContext({
+      baseSystemPrompt,
+      appendSystemContext: "hook system context",
+    });
+    const turns = [
+      {
+        systemPrompt: composedSystemPrompt,
+        prompt: appendBootstrapPromptWarning("hello", ["AGENTS.md: 200 raw -> 0 injected"]),
+      },
+      {
+        systemPrompt: composedSystemPrompt,
+        prompt: appendBootstrapPromptWarning("hello again", []),
+      },
+      {
+        systemPrompt: composedSystemPrompt,
+        prompt: appendBootstrapPromptWarning("hello once more", [
+          "AGENTS.md: 200 raw -> 0 injected",
+        ]),
+      },
+    ];
+
+    expect(turns[0]?.systemPrompt).toBe(turns[1]?.systemPrompt);
+    expect(turns[1]?.systemPrompt).toBe(turns[2]?.systemPrompt);
+    expect(turns[0]?.prompt.startsWith("hello")).toBe(true);
+    expect(turns[1]?.prompt).toBe("hello again");
+    expect(turns[2]?.prompt.startsWith("hello once more")).toBe(true);
+    expect(turns[0]?.prompt).toContain("[Bootstrap truncation warning]");
+    expect(turns[2]?.prompt).toContain("[Bootstrap truncation warning]");
+  });
 });
 
 describe("resolvePromptModeForSession", () => {

--- a/src/agents/prompt-composition-scenarios.ts
+++ b/src/agents/prompt-composition-scenarios.ts
@@ -103,7 +103,6 @@ function buildSystemPrompt(params: {
   skillsPrompt?: string;
   reactionGuidance?: { level: "minimal" | "extensive"; channel: string };
   contextFiles?: Array<{ path: string; content: string }>;
-  bootstrapTruncationWarningLines?: string[];
 }) {
   const { runtimeInfo, userTimezone, userTime, userTimeFormat, toolNames, toolSummaries } =
     buildCommonSystemParams(params.workspaceDir);
@@ -122,7 +121,6 @@ function buildSystemPrompt(params: {
     skillsPrompt: params.skillsPrompt,
     reactionGuidance: params.reactionGuidance,
     contextFiles: params.contextFiles,
-    bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
   });
 }
 

--- a/src/agents/prompt-composition-scenarios.ts
+++ b/src/agents/prompt-composition-scenarios.ts
@@ -1,0 +1,654 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  buildInboundMetaSystemPrompt,
+  buildInboundUserContextPrefix,
+} from "../auto-reply/reply/inbound-meta.js";
+import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
+import {
+  appendBootstrapPromptWarning,
+  analyzeBootstrapBudget,
+  buildBootstrapPromptWarning,
+  type BootstrapBudgetAnalysis,
+} from "./bootstrap-budget.js";
+import { buildAgentSystemPrompt } from "./system-prompt.js";
+import { buildToolSummaryMap } from "./tool-summaries.js";
+
+export type PromptScenarioTurn = {
+  id: string;
+  label: string;
+  systemPrompt: string;
+  bodyPrompt: string;
+  notes: string[];
+};
+
+export type PromptScenario = {
+  scenario: string;
+  focus: string;
+  expectedStableSystemAfterTurnIds: string[];
+  turns: PromptScenarioTurn[];
+};
+
+type TemplateCtx = {
+  Provider: string;
+  Surface?: string;
+  OriginatingChannel?: string;
+  OriginatingTo?: string;
+  AccountId?: string;
+  ChatType?: string;
+  GroupSubject?: string;
+  GroupChannel?: string;
+  GroupSpace?: string;
+  SenderId?: string;
+  SenderName?: string;
+  SenderUsername?: string;
+  SenderE164?: string;
+  MessageSid?: string;
+  ReplyToId?: string;
+  ReplyToBody?: string;
+  WasMentioned?: boolean;
+  InboundHistory?: Array<{ sender: string; timestamp: number; body: string }>;
+  Body?: string;
+  BodyStripped?: string;
+};
+
+type BootstrapInjectionStat = {
+  name: string;
+  path: string;
+  missing: boolean;
+  rawChars: number;
+  injectedChars: number;
+  truncated: boolean;
+};
+
+function buildCommonSystemParams(workspaceDir: string) {
+  const toolNames = [
+    "bash",
+    "read",
+    "edit",
+    "grep",
+    "glob",
+    "message",
+    "memory_search",
+    "memory_get",
+    "web_search",
+    "web_fetch",
+  ];
+  const toolSummaries = buildToolSummaryMap(
+    toolNames.map((name) => ({ name, description: `${name} tool` }) as never),
+  );
+  return {
+    runtimeInfo: {
+      agentId: "main",
+      host: "cache-lab",
+      repoRoot: workspaceDir,
+      os: "Darwin 24.0.0",
+      arch: "arm64",
+      node: process.version,
+      model: "anthropic/claude-sonnet-4-5",
+      defaultModel: "anthropic/claude-sonnet-4-5",
+      shell: "zsh",
+    },
+    userTimezone: "America/Los_Angeles",
+    userTime: "Monday, March 16th, 2026 — 9:00 PM",
+    userTimeFormat: "12" as const,
+    toolNames,
+    toolSummaries,
+  };
+}
+
+function buildSystemPrompt(params: {
+  workspaceDir: string;
+  extraSystemPrompt?: string;
+  skillsPrompt?: string;
+  reactionGuidance?: { level: "minimal" | "extensive"; channel: string };
+  contextFiles?: Array<{ path: string; content: string }>;
+  bootstrapTruncationWarningLines?: string[];
+}) {
+  const { runtimeInfo, userTimezone, userTime, userTimeFormat, toolNames, toolSummaries } =
+    buildCommonSystemParams(params.workspaceDir);
+  return buildAgentSystemPrompt({
+    workspaceDir: params.workspaceDir,
+    extraSystemPrompt: params.extraSystemPrompt,
+    runtimeInfo,
+    userTimezone,
+    userTime,
+    userTimeFormat,
+    toolNames,
+    toolSummaries,
+    modelAliasLines: [],
+    promptMode: "full",
+    acpEnabled: true,
+    skillsPrompt: params.skillsPrompt,
+    reactionGuidance: params.reactionGuidance,
+    contextFiles: params.contextFiles,
+    bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
+  });
+}
+
+function buildAutoReplyBody(params: { ctx: TemplateCtx; body: string; eventLine?: string }) {
+  return [params.eventLine, buildInboundUserContextPrefix(params.ctx as never), params.body]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function createDirectScenario(workspaceDir: string): PromptScenario {
+  const baseCtx: TemplateCtx = {
+    Provider: "slack",
+    Surface: "slack",
+    OriginatingChannel: "slack",
+    OriginatingTo: "D123",
+    AccountId: "A1",
+    ChatType: "direct",
+    SenderId: "U1",
+    SenderName: "Alice",
+    Body: "hi",
+    BodyStripped: "hi",
+  };
+  return {
+    scenario: "auto-reply-direct",
+    focus:
+      "Normal direct-chat turns with ids, reply context, think hint, and runtime event body injection",
+    expectedStableSystemAfterTurnIds: ["t2", "t3", "t4"],
+    turns: [
+      {
+        id: "t1",
+        label: "Direct turn with reply context",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: buildInboundMetaSystemPrompt({
+            ...baseCtx,
+            MessageSid: "m1",
+            ReplyToId: "r1",
+            ReplyToBody: "prior message",
+            WasMentioned: true,
+          } as never),
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "m1",
+            ReplyToId: "r1",
+            ReplyToBody: "prior message",
+            WasMentioned: true,
+          },
+          body: "Please summarize yesterday's decision.",
+        }),
+        notes: ["Direct chat baseline", "Per-message ids and reply context change in body only"],
+      },
+      {
+        id: "t2",
+        label: "Direct turn with new message id",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: buildInboundMetaSystemPrompt({
+            ...baseCtx,
+            MessageSid: "m2",
+            ReplyToId: "r2",
+          } as never),
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "m2",
+            ReplyToId: "r2",
+          },
+          body: "Now open the read tool and inspect AGENTS.md.",
+        }),
+        notes: ["Steady-state direct turn", "No runtime event"],
+      },
+      {
+        id: "t3",
+        label: "Direct turn with runtime event and think hint",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: buildInboundMetaSystemPrompt({
+            ...baseCtx,
+            MessageSid: "m3",
+            ReplyToId: "r3",
+          } as never),
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "m3",
+            ReplyToId: "r3",
+          },
+          eventLine: "System: [t] Model switched.",
+          body: "low use tools if needed and tell me which file controls startup behavior",
+        }),
+        notes: ["Touches runtime event body path", "Touches think-hint parsing path"],
+      },
+      {
+        id: "t4",
+        label: "Direct turn after runtime event",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: buildInboundMetaSystemPrompt({
+            ...baseCtx,
+            MessageSid: "m4",
+            ReplyToId: "r4",
+          } as never),
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "m4",
+            ReplyToId: "r4",
+          },
+          body: "Repeat the startup file path only.",
+        }),
+        notes: ["Checks steady-state after event turn"],
+      },
+    ],
+  };
+}
+
+function createGroupScenario(workspaceDir: string): PromptScenario {
+  const baseCtx: TemplateCtx = {
+    Provider: "slack",
+    Surface: "slack",
+    OriginatingChannel: "slack",
+    OriginatingTo: "C123",
+    AccountId: "A1",
+    ChatType: "group",
+    GroupSubject: "ops",
+    GroupChannel: "#ops",
+    SenderId: "U2",
+    SenderName: "Bob",
+    Body: "hi",
+    BodyStripped: "hi",
+  };
+  const inbound1 = buildInboundMetaSystemPrompt({
+    ...baseCtx,
+    MessageSid: "g1",
+    WasMentioned: true,
+    InboundHistory: [{ sender: "Cara", timestamp: 1, body: "status?" }],
+  } as never);
+  const inboundLater = buildInboundMetaSystemPrompt({
+    ...baseCtx,
+    MessageSid: "g2",
+    WasMentioned: false,
+    InboundHistory: [
+      { sender: "Cara", timestamp: 1, body: "status?" },
+      { sender: "Dan", timestamp: 2, body: "please help" },
+    ],
+  } as never);
+  return {
+    scenario: "auto-reply-group",
+    focus: "Group chat bootstrap, steady state, and runtime event turns",
+    expectedStableSystemAfterTurnIds: ["t3"],
+    turns: [
+      {
+        id: "t1",
+        label: "First group turn with one-time intro",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: [inbound1, "GROUP_INTRO: You were just activated in this room."].join(
+            "\n\n",
+          ),
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "g1",
+            WasMentioned: true,
+            InboundHistory: [{ sender: "Cara", timestamp: 1, body: "status?" }],
+          },
+          body: "Can you investigate this issue?",
+        }),
+        notes: ["Expected first-turn bootstrap churn", "Not steady-state"],
+      },
+      {
+        id: "t2",
+        label: "Steady-state group turn",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: inboundLater,
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "g2",
+            WasMentioned: false,
+            InboundHistory: [
+              { sender: "Cara", timestamp: 1, body: "status?" },
+              { sender: "Dan", timestamp: 2, body: "please help" },
+            ],
+          },
+          body: "Give a short update.",
+        }),
+        notes: ["One-time intro gone", "Should settle afterward"],
+      },
+      {
+        id: "t3",
+        label: "Group turn with runtime event",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          extraSystemPrompt: inboundLater,
+        }),
+        bodyPrompt: buildAutoReplyBody({
+          ctx: {
+            ...baseCtx,
+            MessageSid: "g3",
+            WasMentioned: true,
+            InboundHistory: [
+              { sender: "Cara", timestamp: 1, body: "status?" },
+              { sender: "Dan", timestamp: 2, body: "please help" },
+              { sender: "Eve", timestamp: 3, body: "what changed?" },
+            ],
+          },
+          eventLine: "System: [t] Node connected.",
+          body: "Tell the room whether tools are available.",
+        }),
+        notes: ["Runtime event lands in body", "System prompt should stay stable vs t2"],
+      },
+    ],
+  };
+}
+
+async function createToolRichScenario(workspaceDir: string): Promise<PromptScenario> {
+  const skillsPrompt = [
+    "<available_skills>",
+    "<skill><name>checks</name><description>Run checks before landing changes.</description><location>/skills/checks/SKILL.md</location></skill>",
+    "<skill><name>release</name><description>Release OpenClaw safely.</description><location>/skills/release/SKILL.md</location></skill>",
+    "</available_skills>",
+  ].join("\n");
+  const contextFiles = [
+    {
+      path: "AGENTS.md",
+      content: await fs.readFile(path.join(workspaceDir, "AGENTS.md"), "utf-8"),
+    },
+    {
+      path: "TOOLS.md",
+      content: await fs.readFile(path.join(workspaceDir, "TOOLS.md"), "utf-8"),
+    },
+    {
+      path: "SOUL.md",
+      content: await fs.readFile(path.join(workspaceDir, "SOUL.md"), "utf-8"),
+    },
+  ];
+  const systemPrompt = buildSystemPrompt({
+    workspaceDir,
+    skillsPrompt,
+    reactionGuidance: { level: "extensive", channel: "Telegram" },
+    contextFiles,
+  });
+  return {
+    scenario: "tool-rich-agent-run",
+    focus:
+      "Tool-enabled system prompt with skills, reactions, workspace bootstrap, and a follow-up after fictional tool calls",
+    expectedStableSystemAfterTurnIds: ["t2"],
+    turns: [
+      {
+        id: "t1",
+        label: "Tool-rich turn asking for search, read, and file edits",
+        systemPrompt,
+        bodyPrompt: [
+          "Conversation info (untrusted metadata):",
+          "```json",
+          JSON.stringify({ message_id: "tool-1", sender_id: "U9", was_mentioned: true }, null, 2),
+          "```",
+          "",
+          "high Search the workspace, read AGENTS.md, inspect the failing test, and propose a patch.",
+        ].join("\n"),
+        notes: ["Touches tool list in system prompt", "Touches high-thinking hint in body"],
+      },
+      {
+        id: "t2",
+        label: "Follow-up after a fictional tool call",
+        systemPrompt,
+        bodyPrompt: [
+          "Conversation info (untrusted metadata):",
+          "```json",
+          JSON.stringify({ message_id: "tool-2", sender_id: "U9" }, null, 2),
+          "```",
+          "",
+          "Tool transcript summary (untrusted, for context):",
+          "```json",
+          JSON.stringify(
+            [
+              { role: "assistant", action: "tool_use", name: "read", target: "AGENTS.md" },
+              { role: "tool", name: "read", result: "Loaded AGENTS.md" },
+              { role: "assistant", action: "tool_use", name: "grep", target: "failing test" },
+              { role: "tool", name: "grep", result: "Matched src/foo.ts:42" },
+            ],
+            null,
+            2,
+          ),
+          "```",
+          "",
+          "Continue and explain the root cause.",
+        ].join("\n"),
+        notes: ["Simulates tool-call-heavy conversation", "System prompt should stay stable"],
+      },
+    ],
+  };
+}
+
+async function createBootstrapWarningScenario(workspaceDir: string): Promise<PromptScenario> {
+  const largeAgents = "# AGENTS.md\n\n" + "Rules.\n".repeat(5_000);
+  const largeTools = "# TOOLS.md\n\n" + "Notes.\n".repeat(3_000);
+  await writeWorkspaceFile({ dir: workspaceDir, name: "AGENTS.md", content: largeAgents });
+  await writeWorkspaceFile({ dir: workspaceDir, name: "TOOLS.md", content: largeTools });
+  const contextFiles = [
+    {
+      path: "AGENTS.md",
+      content: await fs.readFile(path.join(workspaceDir, "AGENTS.md"), "utf-8"),
+    },
+    {
+      path: "TOOLS.md",
+      content: await fs.readFile(path.join(workspaceDir, "TOOLS.md"), "utf-8"),
+    },
+  ];
+  const bootstrapStats: BootstrapInjectionStat[] = contextFiles.map((file, index) => ({
+    name: path.basename(file.path),
+    path: file.path,
+    missing: false,
+    rawChars: file.content.length,
+    injectedChars: index === 0 ? 1500 : 700,
+    truncated: true,
+  }));
+  const analysis = analyzeBootstrapBudget({
+    files: bootstrapStats,
+    bootstrapMaxChars: 1500,
+    bootstrapTotalMaxChars: 2200,
+  });
+  const warningFirst = buildBootstrapPromptWarning({
+    analysis,
+    mode: "once",
+    seenSignatures: [],
+  });
+  const warningSeen = buildBootstrapPromptWarning({
+    analysis,
+    mode: "once",
+    seenSignatures: warningFirst.warningSignaturesSeen,
+    previousSignature: warningFirst.signature,
+  });
+  const warningAlways = buildBootstrapPromptWarning({
+    analysis,
+    mode: "always",
+    seenSignatures: warningFirst.warningSignaturesSeen,
+    previousSignature: warningFirst.signature,
+  });
+  return {
+    scenario: "bootstrap-warning",
+    focus: "Workspace bootstrap truncation warnings inside # Project Context",
+    expectedStableSystemAfterTurnIds: ["t2", "t3"],
+    turns: [
+      {
+        id: "t1",
+        label: "First warning emission",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          contextFiles,
+        }),
+        bodyPrompt: appendBootstrapPromptWarning("hello", warningFirst.lines),
+        notes: ["Warning is appended to the turn body", "System prompt should stay stable"],
+      },
+      {
+        id: "t2",
+        label: "Same truncation signature after once-mode dedupe",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          contextFiles,
+        }),
+        bodyPrompt: appendBootstrapPromptWarning("hello again", warningSeen.lines),
+        notes: ["Once-mode removes warning lines", "Only the body tail changes now"],
+      },
+      {
+        id: "t3",
+        label: "Always-mode warning",
+        systemPrompt: buildSystemPrompt({
+          workspaceDir,
+          contextFiles,
+        }),
+        bodyPrompt: appendBootstrapPromptWarning("one more turn", warningAlways.lines),
+        notes: [
+          "Always-mode keeps warning in the body prompt tail",
+          "System prompt remains stable",
+        ],
+      },
+    ],
+  };
+}
+
+async function createMaintenanceScenario(workspaceDir: string): Promise<PromptScenario> {
+  await writeWorkspaceFile({
+    dir: workspaceDir,
+    name: "AGENTS.md",
+    content: [
+      "## Session Startup",
+      "Read AGENTS.md and MEMORY.md before responding.",
+      "",
+      "## Red Lines",
+      "Do not delete production data.",
+      "",
+      "## Safety",
+      "Never reveal secrets.",
+    ].join("\n"),
+  });
+  const memoryFlushPrompt = [
+    "Pre-compaction memory flush.",
+    "Store durable memories only in memory/2026-03-15.md (create memory/ if needed).",
+    "Treat workspace bootstrap/reference files such as MEMORY.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.",
+    "If nothing to store, reply with NO_REPLY.",
+    "Current time: Sunday, March 15th, 2026 — 9:30 PM (America/Los_Angeles) / 2026-03-16 04:30 UTC",
+  ].join("\n");
+  const memoryFlushSystemPrompt = buildSystemPrompt({
+    workspaceDir,
+    extraSystemPrompt: [
+      "Pre-compaction memory flush turn.",
+      "The session is near auto-compaction; capture durable memories to disk.",
+      "Store durable memories only in memory/YYYY-MM-DD.md (create memory/ if needed).",
+      "You may reply, but usually NO_REPLY is correct.",
+    ].join(" "),
+  });
+  const postCompaction = [
+    "[Post-compaction context refresh]",
+    "",
+    "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence.",
+    "",
+    "Critical rules from AGENTS.md:",
+    "",
+    "## Session Startup",
+    "Read AGENTS.md and MEMORY.md before responding.",
+    "",
+    "## Red Lines",
+    "Do not delete production data.",
+    "",
+    "Current time: Sunday, March 15th, 2026 — 9:30 PM (America/Los_Angeles) / 2026-03-16 04:30 UTC",
+  ].join("\n");
+  const postCompactionSystemPrompt = buildSystemPrompt({
+    workspaceDir,
+    extraSystemPrompt: buildInboundMetaSystemPrompt({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "D123",
+      AccountId: "A1",
+      ChatType: "direct",
+    } as never),
+  });
+  return {
+    scenario: "maintenance-prompts",
+    focus: "Memory flush and post-compaction maintenance prompts",
+    expectedStableSystemAfterTurnIds: [],
+    turns: [
+      {
+        id: "t1",
+        label: "Pre-compaction memory flush run",
+        systemPrompt: memoryFlushSystemPrompt,
+        bodyPrompt: memoryFlushPrompt,
+        notes: [
+          "Writes to memory/2026-03-15.md",
+          "Separate maintenance run; expected to differ from normal user turns",
+        ],
+      },
+      {
+        id: "t2",
+        label: "Post-compaction refresh context run",
+        systemPrompt: postCompactionSystemPrompt,
+        bodyPrompt: postCompaction,
+        notes: [
+          "Separate maintenance context payload",
+          "Expected to differ from normal user turns",
+        ],
+      },
+    ],
+  };
+}
+
+export async function createWorkspaceWithPromptCompositionFiles(): Promise<string> {
+  const workspaceDir = await makeTempWorkspace("openclaw-prompt-cache-");
+  await writeWorkspaceFile({
+    dir: workspaceDir,
+    name: "AGENTS.md",
+    content: [
+      "# AGENTS.md",
+      "",
+      "## Session Startup",
+      "Read AGENTS.md and TOOLS.md before making changes.",
+      "",
+      "## Red Lines",
+      "Do not rewrite user commits.",
+    ].join("\n"),
+  });
+  await writeWorkspaceFile({
+    dir: workspaceDir,
+    name: "TOOLS.md",
+    content: "# TOOLS.md\n\nUse rg before grep.\n",
+  });
+  await writeWorkspaceFile({
+    dir: workspaceDir,
+    name: "SOUL.md",
+    content: "# SOUL.md\n\nBe concise but kind.\n",
+  });
+  return workspaceDir;
+}
+
+export async function createPromptCompositionScenarios(): Promise<{
+  workspaceDir: string;
+  warningWorkspaceDir: string;
+  scenarios: PromptScenario[];
+  cleanup: () => Promise<void>;
+}> {
+  const workspaceDir = await createWorkspaceWithPromptCompositionFiles();
+  const warningWorkspaceDir = await makeTempWorkspace("openclaw-prompt-cache-warning-");
+  const scenarios = [
+    createDirectScenario(workspaceDir),
+    createGroupScenario(workspaceDir),
+    await createToolRichScenario(workspaceDir),
+    await createBootstrapWarningScenario(warningWorkspaceDir),
+    await createMaintenanceScenario(workspaceDir),
+  ];
+  return {
+    workspaceDir,
+    warningWorkspaceDir,
+    scenarios,
+    cleanup: async () => {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      await fs.rm(warningWorkspaceDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/src/agents/prompt-composition.test.ts
+++ b/src/agents/prompt-composition.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createPromptCompositionScenarios,
+  type PromptScenario,
+} from "./prompt-composition-scenarios.js";
+
+type ScenarioFixture = Awaited<ReturnType<typeof createPromptCompositionScenarios>>;
+
+function getTurn(scenario: PromptScenario, id: string) {
+  const turn = scenario.turns.find((entry) => entry.id === id);
+  expect(turn, `${scenario.scenario}:${id}`).toBeDefined();
+  return turn!;
+}
+
+describe("prompt composition invariants", () => {
+  let fixture: ScenarioFixture;
+
+  beforeAll(async () => {
+    fixture = await createPromptCompositionScenarios();
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+  });
+
+  it("keeps the system prompt stable after warmup for normal user-turn scenarios", () => {
+    for (const scenario of fixture.scenarios) {
+      if (scenario.expectedStableSystemAfterTurnIds.length === 0) {
+        continue;
+      }
+      for (const turnId of scenario.expectedStableSystemAfterTurnIds) {
+        const current = getTurn(scenario, turnId);
+        const index = scenario.turns.findIndex((entry) => entry.id === turnId);
+        const previous = scenario.turns[index - 1];
+        expect(previous, `${scenario.scenario}:${turnId}:previous`).toBeDefined();
+        expect(current.systemPrompt, `${scenario.scenario}:${turnId}`).toBe(previous.systemPrompt);
+      }
+    }
+  });
+
+  it("keeps bootstrap warnings out of the system prompt and preserves the original user prompt prefix", () => {
+    const scenario = fixture.scenarios.find((entry) => entry.scenario === "bootstrap-warning");
+    expect(scenario).toBeDefined();
+    const first = getTurn(scenario!, "t1");
+    const deduped = getTurn(scenario!, "t2");
+    const always = getTurn(scenario!, "t3");
+
+    expect(first.systemPrompt).not.toContain("[Bootstrap truncation warning]");
+    expect(first.bodyPrompt.startsWith("hello")).toBe(true);
+    expect(first.bodyPrompt).toContain("[Bootstrap truncation warning]");
+
+    expect(deduped.bodyPrompt).toBe("hello again");
+    expect(always.bodyPrompt.startsWith("one more turn")).toBe(true);
+    expect(always.bodyPrompt).toContain("[Bootstrap truncation warning]");
+  });
+
+  it("documents the intentional global exceptions so future churn is explicit", () => {
+    const groupScenario = fixture.scenarios.find((entry) => entry.scenario === "auto-reply-group");
+    const maintenanceScenario = fixture.scenarios.find(
+      (entry) => entry.scenario === "maintenance-prompts",
+    );
+
+    expect(groupScenario?.expectedStableSystemAfterTurnIds).toEqual(["t3"]);
+    expect(maintenanceScenario?.expectedStableSystemAfterTurnIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: bootstrap truncation warnings were moved toward append-only prompt composition, but the PR also needed durable regression coverage for multi-turn prompt stability.
- Why it matters: prompt-cache hit rate depends on stable prompt composition, and regressions here are easy to reintroduce when prompt-building paths evolve.
- What changed: bootstrap warning text now appends without rewriting the original prompt bytes, and the PR adds shared prompt-composition scenarios plus targeted/global regression tests.
- What did NOT change (scope boundary): this PR does not change plugin hook policy, group first-turn bootstrap behavior, or maintenance-prompt behavior beyond documenting them as explicit exceptions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #49237

## User-visible / Behavior Changes

- Bootstrap truncation warnings now preserve the original current-turn prompt prefix and append the warning block after it.
- Added prompt-composition regression coverage for direct chat, group chat, tool-rich agent runs, bootstrap-warning runs, and maintenance prompts.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A for targeted tests; Anthropic used separately during cache investigation before this PR
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test setup

### Steps

1. Build multi-turn prompt-composition scenarios that exercise direct chat, group chat, tool-rich runs, bootstrap-warning runs, and maintenance prompts.
2. Verify the system prompt remains stable after warmup for the scenarios that should be cache-stable.
3. Verify bootstrap warning text appends to the current turn prompt without rewriting the original prompt bytes.

### Expected

- Bootstrap warnings do not mutate the system-prompt path.
- Stable multi-turn scenarios keep the same system prompt after warmup.
- Known exceptions remain explicit and documented.

### Actual

- The new tests pass with the append-only bootstrap warning behavior and fail on the pre-fix branch shape that lacked the append helper/import alignment.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the targeted prompt-composition, bootstrap-warning, and attempt-layer tests; also verified the prompt-composition scenario module imports cleanly after the review fixes.
- Edge cases checked: bootstrap warning dedupe, exact heartbeat prompt preservation, known first-turn/maintenance exceptions.
- What you did **not** verify: a full clean-clone `pnpm test` wrapper pass on bare latest `main` still hits the broader local startup slowdown we investigated separately.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `6b04a0f400`, `a93ab705e6`, and `8748cd9bd7` from the PR branch.
- Files/config to restore: `src/agents/bootstrap-budget.ts`, `src/agents/bootstrap-budget.test.ts`, `src/agents/pi-embedded-runner/run/attempt.test.ts`, `src/agents/prompt-composition-scenarios.ts`, `src/agents/prompt-composition.test.ts`.
- Known bad symptoms reviewers should watch for: prompt-composition tests failing to load, bootstrap warnings reappearing at the front of the current turn, or stable scenario system prompts diverging unexpectedly after warmup.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the global prompt-composition test could become brittle if it tries to enforce stability on intentionally dynamic paths.
  - Mitigation: the scenario helper encodes the known exceptions explicitly instead of using a blanket append-only rule.
