### PR TITLE
Fix gateway probe timeout and security audit JSON output

### DIFF
--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -195,7 +195,7 @@ export function registerGatewayCli(program: Command) {
     .option("--ssh-auto", "Try to derive an SSH target from Bonjour discovery", false)
     .option("--token <token>", "Gateway token (applies to all probes)")
     .option("--password <password>", "Gateway password (applies to all probes)")
-    .option("--timeout <ms>", "Overall probe budget in ms", "3000")
+    .option("--timeout <ms>", "Overall probe budget in ms", "10000")
     .option("--json", "Output JSON", false)
     .action(async (opts, command) => {
       await runGatewayCommand(async () => {

--- a/src/cli/security-cli.test.ts
+++ b/src/cli/security-cli.test.ts
@@ -1,0 +1,77 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCliRuntimeCapture } from "./test-runtime-capture.js";
+
+const loadConfig = vi.fn(() => ({ gateway: {} }));
+const runSecurityAudit = vi.fn(async () => ({
+  summary: { critical: 0, warn: 1, info: 2 },
+  findings: [],
+}));
+const fixSecurityFootguns = vi.fn(async () => ({
+  changes: [],
+  actions: [],
+  errors: [],
+}));
+const routeLogsToStderr = vi.fn();
+
+const { defaultRuntime } = createCliRuntimeCapture();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+}));
+
+vi.mock("../logging/console.js", () => ({
+  routeLogsToStderr: () => routeLogsToStderr(),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+vi.mock("../security/audit.js", () => ({
+  runSecurityAudit: (opts: unknown) => runSecurityAudit(opts),
+}));
+
+vi.mock("../security/fix.js", () => ({
+  fixSecurityFootguns: () => fixSecurityFootguns(),
+}));
+
+const { registerSecurityCli } = await import("./security-cli.js");
+
+let program: Command;
+
+function createProgram() {
+  const next = new Command();
+  next.exitOverride();
+  registerSecurityCli(next);
+  return next;
+}
+
+describe("security-cli --json", () => {
+  beforeEach(() => {
+    program = createProgram();
+    loadConfig.mockClear();
+    runSecurityAudit.mockClear();
+    fixSecurityFootguns.mockClear();
+    routeLogsToStderr.mockClear();
+  });
+
+  it("routes incidental logs to stderr and writes clean JSON to stdout", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await program.parseAsync(["security", "audit", "--json"], { from: "user" });
+
+    expect(routeLogsToStderr).toHaveBeenCalledTimes(1);
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(runSecurityAudit).toHaveBeenCalledTimes(1);
+    expect(stdoutWrite).toHaveBeenCalledTimes(1);
+    const payload = String(stdoutWrite.mock.calls[0]?.[0] ?? "");
+    expect(() => JSON.parse(payload)).not.toThrow();
+    expect(JSON.parse(payload)).toEqual({
+      summary: { critical: 0, warn: 1, info: 2 },
+      findings: [],
+    });
+
+    stdoutWrite.mockRestore();
+  });
+});

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { loadConfig } from "../config/config.js";
+import { routeLogsToStderr } from "../logging/console.js";
 import { defaultRuntime } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { fixSecurityFootguns } from "../security/fix.js";
@@ -49,6 +50,9 @@ export function registerSecurityCli(program: Command) {
     .option("--fix", "Apply safe fixes (tighten defaults + chmod state/config)", false)
     .option("--json", "Print JSON", false)
     .action(async (opts: SecurityAuditOptions) => {
+      if (opts.json) {
+        routeLogsToStderr();
+      }
       const fixResult = opts.fix ? await fixSecurityFootguns().catch((_err) => null) : null;
 
       const cfg = loadConfig();
@@ -60,8 +64,8 @@ export function registerSecurityCli(program: Command) {
       });
 
       if (opts.json) {
-        defaultRuntime.log(
-          JSON.stringify(fixResult ? { fix: fixResult, report } : report, null, 2),
+        process.stdout.write(
+          `${JSON.stringify(fixResult ? { fix: fixResult, report } : report, null, 2)}\n`,
         );
         return;
       }

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveProbeBudgetMs } from "./helpers.js";
+
+describe("resolveProbeBudgetMs", () => {
+  it("lets local loopback use the full requested timeout", () => {
+    expect(resolveProbeBudgetMs(3000, "localLoopback")).toBe(3000);
+    expect(resolveProbeBudgetMs(10000, "localLoopback")).toBe(10000);
+  });
+
+  it("keeps ssh tunnel capped", () => {
+    expect(resolveProbeBudgetMs(3000, "sshTunnel")).toBe(2000);
+    expect(resolveProbeBudgetMs(1500, "sshTunnel")).toBe(1500);
+  });
+
+  it("keeps discovered targets capped", () => {
+    expect(resolveProbeBudgetMs(3000, "bonjourLanHost")).toBe(1500);
+    expect(resolveProbeBudgetMs(1200, "configuredUrl")).toBe(1200);
+  });
+});

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -125,7 +125,7 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
 
 export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
   if (kind === "localLoopback") {
-    return Math.min(800, overallMs);
+    return overallMs;
   }
   if (kind === "sshTunnel") {
     return Math.min(2000, overallMs);


### PR DESCRIPTION
## Summary
- honor the full requested timeout for local gateway probes and raise the default probe budget to 10s
- make `openclaw security audit --json` write clean JSON to stdout while routing incidental logs to stderr
- add focused regression coverage for both behaviors

## Test plan
- [x] `pnpm vitest run src/commands/gateway-status/helpers.test.ts src/cli/security-cli.test.ts --reporter=dot`
- [ ] `openclaw gateway probe --json` returns healthy output on a slow local loopback path
- [ ] `openclaw security audit --json` parses cleanly even when plugin/runtime logs are present
- [ ] qa-diff verdict: not applicable

## Verification
- [GATE: CLEAR]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
