### PR TITLE
fix(ollama): don't auto-pull glm-4.7-flash during Local mode onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.
 - Plugins/bundler TDZ: fix `RESERVED_COMMANDS` temporal dead zone error that prevented device-pair, phone-control, and talk-voice plugins from registering when the bundler placed the commands module after call sites in the same output chunk. Thanks @BunsDev.
 - Plugins/imports: fix stale googlechat runtime-api import paths and signal SDK circular re-exports broken by recent plugin-sdk refactors. Thanks @BunsDev.
 - Google auth/Node 25: patch `gaxios` to use native fetch without injecting `globalThis.window`, while translating proxy and mTLS transport settings so Google Vertex and Google Chat auth keep working on Node 25. (#47914) Thanks @pdd-cli.

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/extensions/plugin-api.js";
+import plugin from "./index.js";
+
+const promptAndConfigureOllamaMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    config: {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    },
+  })),
+);
+const ensureOllamaModelPulledMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("openclaw/plugin-sdk/ollama-setup", () => ({
+  promptAndConfigureOllama: promptAndConfigureOllamaMock,
+  ensureOllamaModelPulled: ensureOllamaModelPulledMock,
+  configureOllamaNonInteractive: vi.fn(),
+  buildOllamaProvider: vi.fn(),
+}));
+
+function registerProvider() {
+  const registerProviderMock = vi.fn();
+
+  plugin.register(
+    createTestPluginApi({
+      id: "ollama",
+      name: "Ollama",
+      source: "test",
+      config: {},
+      runtime: {} as never,
+      registerProvider: registerProviderMock,
+    }),
+  );
+
+  expect(registerProviderMock).toHaveBeenCalledTimes(1);
+  return registerProviderMock.mock.calls[0]?.[0];
+}
+
+describe("ollama plugin", () => {
+  it("does not preselect a default model during provider auth setup", async () => {
+    const provider = registerProvider();
+
+    const result = await provider.auth[0].run({
+      config: {},
+      prompter: {} as never,
+    });
+
+    expect(promptAndConfigureOllamaMock).toHaveBeenCalledWith({
+      cfg: {},
+      prompter: {},
+    });
+    expect(result.configPatch).toEqual({
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434",
+            api: "ollama",
+            models: [],
+          },
+        },
+      },
+    });
+    expect(result.defaultModel).toBeUndefined();
+  });
+
+  it("pulls the model the user actually selected", async () => {
+    const provider = registerProvider();
+    const config = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434",
+            models: [],
+          },
+        },
+      },
+    };
+    const prompter = {} as never;
+
+    await provider.onModelSelected?.({
+      config,
+      model: "ollama/glm-4.7-flash",
+      prompter,
+    });
+
+    expect(ensureOllamaModelPulledMock).toHaveBeenCalledWith({
+      config,
+      model: "ollama/glm-4.7-flash",
+      prompter,
+    });
+  });
+});

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -49,7 +49,6 @@ export default definePluginEntry({
                 },
               ],
               configPatch: result.config,
-              defaultModel: `ollama/${result.defaultModelId}`,
             };
           },
           runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) => {
@@ -118,7 +117,7 @@ export default definePluginEntry({
           return;
         }
         const providerSetup = await loadProviderSetup();
-        await providerSetup.ensureOllamaModelPulled({ config, prompter });
+        await providerSetup.ensureOllamaModelPulled({ config, model, prompter });
       },
     });
   },

--- a/src/commands/ollama-setup.test.ts
+++ b/src/commands/ollama-setup.test.ts
@@ -14,15 +14,11 @@ vi.mock("../agents/auth-profiles.js", () => ({
 }));
 
 const openUrlMock = vi.hoisted(() => vi.fn(async () => false));
-vi.mock("./onboard-helpers.js", async (importOriginal) => {
-  const original = await importOriginal<typeof import("./onboard-helpers.js")>();
-  return { ...original, openUrl: openUrlMock };
-});
-
 const isRemoteEnvironmentMock = vi.hoisted(() => vi.fn(() => false));
-vi.mock("./oauth-env.js", () => ({
-  isRemoteEnvironment: isRemoteEnvironmentMock,
-}));
+vi.mock("../plugins/setup-browser.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../plugins/setup-browser.js")>();
+  return { ...original, openUrl: openUrlMock, isRemoteEnvironment: isRemoteEnvironmentMock };
+});
 
 function createOllamaFetchMock(params: {
   tags?: string[];
@@ -104,26 +100,28 @@ describe("ollama setup", () => {
     isRemoteEnvironmentMock.mockReset().mockReturnValue(false);
   });
 
-  it("returns suggested default model for local mode", async () => {
+  it("puts suggested local model first in local mode", async () => {
     const prompter = createModePrompter("local");
 
     const fetchMock = createOllamaFetchMock({ tags: ["llama3:8b"] });
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+    const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(result.defaultModelId).toBe("glm-4.7-flash");
+    expect(modelIds?.[0]).toBe("glm-4.7-flash");
   });
 
-  it("returns suggested default model for remote mode", async () => {
+  it("puts suggested cloud model first in remote mode", async () => {
     const prompter = createModePrompter("remote");
 
     const fetchMock = createOllamaFetchMock({ tags: ["llama3:8b"] });
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+    const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(result.defaultModelId).toBe("kimi-k2.5:cloud");
+    expect(modelIds?.[0]).toBe("kimi-k2.5:cloud");
   });
 
   it("mode selection affects model ordering (local)", async () => {
@@ -134,7 +132,6 @@ describe("ollama setup", () => {
 
     const result = await promptAndConfigureOllama({ cfg: {}, prompter });
 
-    expect(result.defaultModelId).toBe("glm-4.7-flash");
     const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
     expect(modelIds?.[0]).toBe("glm-4.7-flash");
     expect(modelIds).toContain("llama3:8b");
@@ -238,6 +235,7 @@ describe("ollama setup", () => {
 
       await ensureOllamaModelPulled({
         config: createDefaultOllamaConfig("ollama/glm-4.7-flash"),
+        model: "ollama/glm-4.7-flash",
         prompter,
       });
 
@@ -253,6 +251,7 @@ describe("ollama setup", () => {
 
       await ensureOllamaModelPulled({
         config: createDefaultOllamaConfig("ollama/glm-4.7-flash"),
+        model: "ollama/glm-4.7-flash",
         prompter,
       });
 
@@ -266,6 +265,7 @@ describe("ollama setup", () => {
 
       await ensureOllamaModelPulled({
         config: createDefaultOllamaConfig("ollama/kimi-k2.5:cloud"),
+        model: "ollama/kimi-k2.5:cloud",
         prompter,
       });
 
@@ -281,6 +281,7 @@ describe("ollama setup", () => {
         config: {
           agents: { defaults: { model: { primary: "openai/gpt-4o" } } },
         },
+        model: "openai/gpt-4o",
         prompter,
       });
 

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -55,15 +55,8 @@ const accountHelpersSdk = await import("openclaw/plugin-sdk/account-helpers");
 const allowlistEditSdk = await import("openclaw/plugin-sdk/allowlist-config-edit");
 
 describe("plugin-sdk subpath exports", () => {
-  it("keeps the curated public list free of bundled extension facades", () => {
+  it("keeps legacy compat out of the curated public list", () => {
     expect(pluginSdkSubpaths).not.toContain("compat");
-    expect(pluginSdkSubpaths).not.toContain("signal");
-    expect(pluginSdkSubpaths).not.toContain("msteams");
-    expect(pluginSdkSubpaths).not.toContain("googlechat");
-    expect(pluginSdkSubpaths).not.toContain("mattermost");
-    expect(pluginSdkSubpaths).not.toContain("matrix");
-    expect(pluginSdkSubpaths).not.toContain("zalo");
-    expect(pluginSdkSubpaths).not.toContain("zalouser");
   });
 
   it("keeps core focused on generic shared exports", () => {

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -13,6 +13,7 @@ import type {
 import * as directoryRuntimeSdk from "openclaw/plugin-sdk/directory-runtime";
 import * as discordSdk from "openclaw/plugin-sdk/discord";
 import * as imessageSdk from "openclaw/plugin-sdk/imessage";
+import * as imessageCoreSdk from "openclaw/plugin-sdk/imessage-core";
 import * as lazyRuntimeSdk from "openclaw/plugin-sdk/lazy-runtime";
 import * as ollamaSetupSdk from "openclaw/plugin-sdk/ollama-setup";
 import * as providerModelsSdk from "openclaw/plugin-sdk/provider-models";
@@ -235,6 +236,13 @@ describe("plugin-sdk subpath exports", () => {
     expect(typeof imessageSdk.resolveIMessageConfigAllowFrom).toBe("function");
     expect(typeof imessageSdk.looksLikeIMessageTargetId).toBe("function");
     expect("resolveIMessageAccount" in asExports(imessageSdk)).toBe(false);
+  });
+
+  it("exports iMessage core helpers", () => {
+    expect(typeof imessageCoreSdk.buildChannelConfigSchema).toBe("function");
+    expect(typeof imessageCoreSdk.parseChatTargetPrefixesOrThrow).toBe("function");
+    expect(typeof imessageCoreSdk.resolveServicePrefixedTarget).toBe("function");
+    expect(typeof imessageCoreSdk.IMessageConfigSchema).toBe("object");
   });
 
   it("exports WhatsApp helpers", () => {

--- a/src/plugins/provider-ollama-setup.ts
+++ b/src/plugins/provider-ollama-setup.ts
@@ -293,7 +293,7 @@ async function storeOllamaCredential(agentDir?: string): Promise<void> {
 export async function promptAndConfigureOllama(params: {
   cfg: OpenClawConfig;
   prompter: WizardPrompter;
-}): Promise<{ config: OpenClawConfig; defaultModelId: string }> {
+}): Promise<{ config: OpenClawConfig }> {
   const { prompter } = params;
 
   // 1. Prompt base URL
@@ -398,14 +398,13 @@ export async function promptAndConfigureOllama(params: {
     ...modelNames.filter((name) => !suggestedModels.includes(name)),
   ];
 
-  const defaultModelId = suggestedModels[0] ?? OLLAMA_DEFAULT_MODEL;
   const config = applyOllamaProviderConfig(
     params.cfg,
     baseUrl,
     orderedModelNames,
     discoveredModelsByName,
   );
-  return { config, defaultModelId };
+  return { config };
 }
 
 /** Non-interactive: auto-discover models and configure provider. */
@@ -512,15 +511,14 @@ export async function configureOllamaNonInteractive(params: {
 /** Pull the configured default Ollama model if it isn't already available locally. */
 export async function ensureOllamaModelPulled(params: {
   config: OpenClawConfig;
+  model: string;
   prompter: WizardPrompter;
 }): Promise<void> {
-  const modelCfg = params.config.agents?.defaults?.model;
-  const modelId = typeof modelCfg === "string" ? modelCfg : modelCfg?.primary;
-  if (!modelId?.startsWith("ollama/")) {
+  if (!params.model.startsWith("ollama/")) {
     return;
   }
   const baseUrl = params.config.models?.providers?.ollama?.baseUrl ?? OLLAMA_DEFAULT_BASE_URL;
-  const modelName = modelId.slice("ollama/".length);
+  const modelName = params.model.slice("ollama/".length);
   if (isOllamaCloudModel(modelName)) {
     return;
   }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -410,6 +410,33 @@ describe("runSetupWizard", () => {
     }
   });
 
+  it("prompts for a model during explicit interactive Ollama setup", async () => {
+    promptDefaultModel.mockClear();
+    const prompter = buildWizardPrompter({});
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "ollama",
+        installDaemon: false,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowKeep: false,
+      }),
+    );
+  });
+
   it("shows plugin compatibility notices for an existing valid config", async () => {
     buildPluginCompatibilityNotices.mockReturnValue([
       {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -482,7 +482,9 @@ export async function runSetupWizard(
     }
   }
 
-  if (authChoiceFromPrompt && authChoice !== "custom-api-key") {
+  const shouldPromptModelSelection =
+    authChoice !== "custom-api-key" && (authChoiceFromPrompt || authChoice === "ollama");
+  if (shouldPromptModelSelection) {
     const modelSelection = await promptDefaultModel({
       config: nextConfig,
       prompter,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -486,7 +486,8 @@ export async function runSetupWizard(
     const modelSelection = await promptDefaultModel({
       config: nextConfig,
       prompter,
-      allowKeep: true,
+      // For ollama, don't allow "keep current" since we may need to download the selected model
+      allowKeep: authChoice !== "ollama",
       ignoreAllowlist: true,
       includeProviderPluginSetups: true,
       preferredProvider: await resolvePreferredProviderForAuthChoice({


### PR DESCRIPTION
## Summary

- **Problem:** During `openclaw onboard` with Ollama in Local mode, `glm-4.7-flash` was auto-pulled before the user reached the model picker.
- **Why it matters:** Pulling a large model the user didn't ask for wastes storage and time.
- **What changed:** `ensureOllamaModelPulled` now takes an explicit `model` string (the model the user actually selected) instead of inferring it from config. The interactive `promptAndConfigureOllama` no longer returns `defaultModelId`, so nothing is pulled before the picker. `allowKeep` in the setup wizard is also forced to `false` for Ollama so the picker always runs the `onModelSelected` callback and the selected model can be pulled if needed.
- **What did NOT change:** Non-interactive (`--non-interactive`) onboarding still pulls the default or explicitly requested model when it isn't already present.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44971
- Related #

## User-visible / Behavior Changes

- Ollama Local mode onboarding no longer auto-pulls `glm-4.7-flash` before the model picker is shown.
- The model picker is always shown for Ollama (no "keep current" shortcut), so the selected model can be downloaded if it isn't already present.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (the pull was already possible; it just no longer fires unconditionally)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Bun
- Model/provider: Ollama (local)
- Integration/channel (if any): N/A
- Relevant config (redacted): default QuickStart

### Steps

1. Run `openclaw onboard`
2. Accept personal-use default → QuickStart
3. Select **Ollama** as provider
4. Accept default base URL (`http://127.0.0.1:11434`)
5. Select **Local** mode

### Expected

- Model picker appears immediately with locally discovered models listed; no download begins until the user selects a model that isn't already present.

### Actual (before fix)

- `glm-4.7-flash` began downloading automatically before the picker was shown.

## Evidence

- [x] Failing test/log before + passing after
- [x] Manual testing

After the fix, the onboard flow drops the user directly into the model picker without any download:

```
◇  Ollama mode
│  Local
│
◆  Default model
│  ○ Enter model manually
│  ● ollama/glm-4.7-flash
│  ○ ollama/gemma3
```

- [x] Tests: added `model` parameter to three `ensureOllamaModelPulled` test cases in `src/commands/ollama-setup.test.ts`.

## Human Verification (required)

- Verified scenarios: ran `openclaw onboard` end-to-end in Local mode, confirmed no pull fires before model picker, confirmed model is pulled after selection when not already present.
- Edge cases checked: non-interactive path unchanged, cloud model skip logic unchanged.
- What you did **not** verify: 

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `src/plugins/provider-ollama-setup.ts` and `extensions/ollama/index.ts` to restore the old `ensureOllamaModelPulled` signature.
- Files/config to restore: none
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

- Risk: user selects a model in Local mode that isn't present and skips or cancels the download prompt.
  - Mitigation: `ensureOllamaModelPulled` still fires after model selection via the `onModelSelected` hook in the plugin, the download prompt is shown at that point.
