### PR TITLE
suppress duplicate warning for installed plugins overriding bundled ones

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2698,6 +2698,9 @@ module.exports = {
       if ("expectedDisabledError" in scenario) {
         expect(overridden?.error, scenario.label).toContain(scenario.expectedDisabledError);
       }
+      expect(
+        registry.diagnostics.some((diag) => String(diag.message).includes("duplicate plugin id")),
+      ).toBe(false);
     }
   });
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -159,7 +159,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
   });
 
-  it("reports explicit installed globals as the effective duplicate winner", () => {
+  it("suppresses duplicate warning for explicit installed globals that override bundled plugins", () => {
     const bundledDir = makeTempDir();
     const globalDir = makeTempDir();
     const manifest = { id: "zalouser", configSchema: { type: "object" } };
@@ -192,11 +192,7 @@ describe("loadPluginManifestRegistry", () => {
       ],
     });
 
-    expect(
-      registry.diagnostics.some((diag) =>
-        diag.message.includes("bundled plugin will be overridden by global plugin"),
-      ),
-    ).toBe(true);
+    expect(countDuplicateWarnings(registry)).toBe(0);
   });
 
   it("preserves provider auth env metadata from plugin manifests", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -274,6 +274,27 @@ function resolveDuplicatePrecedenceRank(params: {
   return 4;
 }
 
+function isIntentionalBundledInstallOverride(params: {
+  pluginId: string;
+  left: PluginCandidate;
+  right: PluginCandidate;
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const pair: [PluginCandidate, PluginCandidate] = [params.left, params.right];
+  const bundled = pair.find((candidate) => candidate.origin === "bundled");
+  const global = pair.find((candidate) => candidate.origin === "global");
+  if (!bundled || !global) {
+    return false;
+  }
+  return matchesInstalledPluginRecord({
+    pluginId: params.pluginId,
+    candidate: global,
+    config: params.config,
+    env: params.env,
+  });
+}
+
 export function loadPluginManifestRegistry(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -386,26 +407,36 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message:
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate,
-            config,
-            env,
-          }) <
-          resolveDuplicatePrecedenceRank({
-            pluginId: manifest.id,
-            candidate: existing.candidate,
-            config,
-            env,
-          })
-            ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
-            : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${candidate.source})`,
-      });
+      if (
+        !isIntentionalBundledInstallOverride({
+          pluginId: manifest.id,
+          left: existing.candidate,
+          right: candidate,
+          config,
+          env,
+        })
+      ) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message:
+            resolveDuplicatePrecedenceRank({
+              pluginId: manifest.id,
+              candidate,
+              config,
+              env,
+            }) <
+            resolveDuplicatePrecedenceRank({
+              pluginId: manifest.id,
+              candidate: existing.candidate,
+              config,
+              env,
+            })
+              ? `duplicate plugin id detected; ${existing.candidate.origin} plugin will be overridden by ${candidate.origin} plugin (${candidate.source})`
+              : `duplicate plugin id detected; ${candidate.origin} plugin will be overridden by ${existing.candidate.origin} plugin (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Summary

When a user explicitly installs a global plugin that overrides a bundled plugin (e.g. feishu), the manifest registry now recognises this as an intentional override and suppresses the `duplicate plugin id` diagnostic.

## Changes

- **`src/plugins/manifest-registry.ts`**: Added `isIntentionalBundledInstallOverride()` helper that checks if a duplicate is caused by an installed global plugin intentionally overriding its bundled counterpart. The duplicate warning is now skipped for these cases.
- **`src/plugins/manifest-registry.test.ts`**: Updated test to verify the warning is suppressed (not emitted) for intentional overrides.
- **`src/plugins/loader.test.ts`**: Added assertion confirming no spurious duplicate diagnostics appear in the installed-global-overrides-bundled scenario.

## Motivation

Users who install plugins globally (e.g. via `openclaw install feishu`) were seeing noisy `duplicate plugin id detected` warnings every time the gateway started, even though the override was intentional and expected.

Fixes #48443