### PR TITLE
fix: allow HTTP LAN connections when dangerouslyDisableDeviceAuth=true

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { loadConfig } from "../../config/config.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -171,12 +172,19 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
     };
 
+    const configSnapshot = loadConfig();
+    const skipDeviceChallenge =
+      configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
     const connectNonce = randomUUID();
-    send({
-      type: "event",
-      event: "connect.challenge",
-      payload: { nonce: connectNonce, ts: Date.now() },
-    });
+    // Skip challenge when device auth is disabled (e.g., HTTP LAN connections
+    // where WebCrypto is unavailable in non-secure context)
+    if (!skipDeviceChallenge) {
+      send({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce: connectNonce, ts: Date.now() },
+      });
+    }
 
     const close = (code = 1000, reason?: string) => {
       if (closed) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1917,6 +1917,11 @@ export function renderApp(state: AppViewState) {
       </main>
       ${renderExecApprovalPrompt(state)}
       ${renderGatewayUrlConfirmation(state)}
+      <debug-drawer 
+        ?open=${state.debugDrawerOpen} 
+        .gatewayClient=${state.client}
+        @close=${() => (state.debugDrawerOpen = false)}
+      ></debug-drawer>
       ${nothing}
     </div>
   `;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,6 +1,8 @@
 import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
+import "./components/debug-drawer.ts";
+import { debugLog, isDebugEnabled, setDebugEnabled } from "./debug-connection.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
   handleChannelConfigSave as handleChannelConfigSaveInternal,
@@ -19,6 +21,7 @@ import {
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
 } from "./app-chat.ts";
+import "./components/debug-drawer.ts";
 import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import { connectGateway as connectGatewayInternal } from "./app-gateway.ts";
@@ -136,6 +139,7 @@ export class OpenClawApp extends LitElement {
   @state() lastError: string | null = null;
   @state() lastErrorCode: string | null = null;
   @state() eventLog: EventLogEntry[] = [];
+  @state() debugDrawerOpen = false;
   private eventLogBuffer: EventLogEntry[] = [];
   private toolStreamSyncTimer: number | null = null;
   private sidebarCloseTimer: number | null = null;
@@ -166,6 +170,7 @@ export class OpenClawApp extends LitElement {
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatManualRefreshInFlight = false;
   @state() navDrawerOpen = false;
+  @state() debugDrawerOpen = false;
 
   onSlashAction?: (action: string) => void;
 
@@ -457,6 +462,11 @@ export class OpenClawApp extends LitElement {
         this.paletteQuery = "";
         this.paletteActiveIndex = 0;
       }
+    }
+    // Ctrl+Shift+D to toggle debug drawer
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "D") {
+      e.preventDefault();
+      this.debugDrawerOpen = !this.debugDrawerOpen;
     }
   };
 

--- a/ui/src/ui/components/debug-drawer.ts
+++ b/ui/src/ui/components/debug-drawer.ts
@@ -1,0 +1,462 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import {
+  clearDebugLogs,
+  exportDebugLogsAsText,
+  getDebugLogs,
+  isDebugEnabled,
+  setDebugEnabled,
+  debugLog,
+  type DebugLogEntry,
+} from "./debug-connection.ts";
+
+/**
+ * Interface for gateway client that the app exposes
+ */
+interface GatewayClient {
+  request<T = unknown>(method: string, params?: unknown): Promise<T>;
+  connected: boolean;
+}
+
+@customElement("debug-drawer")
+export class DebugDrawer extends LitElement {
+  @property({ type: Boolean }) open = false;
+  @property({ type: Object }) gatewayClient?: GatewayClient;
+
+  @state() private logs: DebugLogEntry[] = [];
+  @state() private autoScroll = true;
+  @state() private gatewayLogs: string[] = [];
+  @state() private loadingGatewayLogs = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.refreshLogs();
+    // Poll for new logs
+    this._pollInterval = window.setInterval(() => this.refreshLogs(), 500);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._pollInterval) {
+      window.clearInterval(this._pollInterval);
+    }
+    if (this._gatewayLogsInterval) {
+      window.clearInterval(this._gatewayLogsInterval);
+    }
+  }
+
+  private _pollInterval: number | null = null;
+  private _gatewayLogsInterval: number | null = null;
+
+  private refreshLogs() {
+    this.logs = getDebugLogs();
+  }
+
+  private handleToggle() {
+    const newValue = !isDebugEnabled();
+    setDebugEnabled(newValue);
+    this.requestUpdate();
+
+    // Start/stop gateway logs polling
+    if (newValue && this.gatewayClient?.connected) {
+      this.loadGatewayLogs();
+      this._gatewayLogsInterval = window.setInterval(() => this.loadGatewayLogs(), 2000);
+    } else {
+      if (this._gatewayLogsInterval) {
+        window.clearInterval(this._gatewayLogsInterval);
+        this._gatewayLogsInterval = null;
+      }
+    }
+  }
+
+  private async loadGatewayLogs() {
+    if (!this.gatewayClient?.connected || this.loadingGatewayLogs) {
+      return;
+    }
+    this.loadingGatewayLogs = true;
+    try {
+      const result = (await this.gatewayClient.request<{ entries: string[] }>("logs.tail", {
+        limit: 50,
+        filter: "error warn",
+      })) as { entries?: string[] };
+      const entries = result?.entries ?? [];
+      if (entries.length > 0 && isDebugEnabled()) {
+        // Add to debug logs
+        entries.forEach((entry) => {
+          const level = entry.toLowerCase().includes("error")
+            ? "error"
+            : entry.toLowerCase().includes("warn")
+              ? "warn"
+              : "info";
+          debugLog.info("logs", entry);
+        });
+      }
+      this.gatewayLogs = entries.slice(-50);
+    } catch (err) {
+      // Silently ignore errors - gateway logs are optional
+    } finally {
+      this.loadingGatewayLogs = false;
+    }
+  }
+
+  private handleClear() {
+    clearDebugLogs();
+    this.gatewayLogs = [];
+    this.refreshLogs();
+  }
+
+  private async handleCopy() {
+    const debugText = exportDebugLogsAsText();
+    const gatewayText = this.gatewayLogs.join("\n");
+    const text = `=== Connection Debug Logs ===\n\n${debugText}\n\n=== Gateway Logs (last 50) ===\n\n${gatewayText}`;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
+  }
+
+  private handleClose() {
+    this.dispatchEvent(new CustomEvent("close"));
+  }
+
+  private handleScroll(e: Event) {
+    const target = e.target as HTMLElement;
+    const isAtBottom = target.scrollHeight - target.scrollTop <= target.clientHeight + 50;
+    this.autoScroll = isAtBottom;
+  }
+
+  render() {
+    const enabled = isDebugEnabled();
+
+    return html`
+      <div class=${classMap({ "debug-drawer-overlay": true, open: this.open })} @click=${this.handleClose}>
+        <div class=${classMap({ "debug-drawer": true, open: this.open })} @click=${(e: Event) => e.stopPropagation()}>
+          <div class="debug-drawer__header">
+            <div class="debug-drawer__title">
+              <span class="debug-drawer__icon">🔧</span>
+              Connection Debug
+            </div>
+            <div class="debug-drawer__controls">
+              <label class="debug-drawer__toggle">
+                <input type="checkbox" .checked=${enabled} @change=${this.handleToggle} />
+                <span>Debug Mode</span>
+              </label>
+              <button class="debug-drawer__btn" @click=${this.handleCopy} title="Copy to clipboard">
+                📋
+              </button>
+              <button class="debug-drawer__btn" @click=${this.handleClear} title="Clear logs">
+                🗑️
+              </button>
+              <button class="debug-drawer__btn" @click=${this.handleClose} title="Close">
+                ✕
+              </button>
+            </div>
+          </div>
+
+          ${!enabled
+            ? html`
+                <div class="debug-drawer__empty">
+                  Enable debug mode to capture connection logs.<br /><br />
+                  <small>Keyboard: Ctrl+Shift+D</small>
+                </div>
+              `
+            : this.logs.length === 0 && this.gatewayLogs.length === 0
+              ? html`
+                  <div class="debug-drawer__empty">
+                    No logs yet. Connection events will appear here.
+                  </div>
+                `
+              : html`
+                <div class="debug-drawer__content" @scroll=${this.handleScroll}>
+                  ${this.gatewayLogs.length > 0
+                    ? html`
+                        <div class="debug-drawer__section">
+                          <div class="debug-drawer__section-title">Gateway Logs</div>
+                          ${this.gatewayLogs.map(
+                            (log) => html`
+                              <div class="debug-drawer__gateway-entry">${log}</div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                  ${this.logs.map(
+                    (log) => html`
+                      <div class="debug-drawer__entry ${log.level}">
+                        <div class="debug-drawer__entry-header">
+                          <span class="debug-drawer__entry-time">${new Date(log.ts).toLocaleTimeString()}</span>
+                          <span class="debug-drawer__entry-level ${log.level}">${log.level}</span>
+                          <span class="debug-drawer__entry-source">${log.source}</span>
+                        </div>
+                        <div class="debug-drawer__entry-message">${log.message}</div>
+                        ${log.details
+                          ? html`
+                              <pre class="debug-drawer__entry-details">${JSON.stringify(log.details, null, 2)}</pre>
+                            `
+                          : nothing}
+                      </div>
+                    `,
+                  )}
+                </div>
+                <div class="debug-drawer__footer">
+                  <span class="debug-drawer__count">${this.logs.length} entries</span>
+                  <span class="debug-drawer__hint">Logs are ephemeral - cleared on tab close</span>
+                </div>
+              `}
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = `
+    .debug-drawer-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 9999;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s, visibility 0.2s;
+    }
+
+    .debug-drawer-overlay.open {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .debug-drawer {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 500px;
+      max-width: 90vw;
+      background: #1a1a2e;
+      border-left: 1px solid #333;
+      display: flex;
+      flex-direction: column;
+      transform: translateX(100%);
+      transition: transform 0.3s ease;
+    }
+
+    .debug-drawer.open {
+      transform: translateX(0);
+    }
+
+    .debug-drawer__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 16px;
+      background: #16213e;
+      border-bottom: 1px solid #333;
+    }
+
+    .debug-drawer__title {
+      font-size: 14px;
+      font-weight: 600;
+      color: #eee;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .debug-drawer__icon {
+      font-size: 16px;
+    }
+
+    .debug-drawer__controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .debug-drawer__toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: #aaa;
+      cursor: pointer;
+    }
+
+    .debug-drawer__toggle input {
+      cursor: pointer;
+    }
+
+    .debug-drawer__btn {
+      background: transparent;
+      border: none;
+      font-size: 14px;
+      cursor: pointer;
+      padding: 4px 8px;
+      border-radius: 4px;
+      color: #aaa;
+      transition: background 0.2s;
+    }
+
+    .debug-drawer__btn:hover {
+      background: #333;
+      color: #fff;
+    }
+
+    .debug-drawer__empty {
+      padding: 40px 20px;
+      text-align: center;
+      color: #666;
+      font-size: 13px;
+    }
+
+    .debug-drawer__content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px;
+      font-family: "SF Mono", "Monaco", "Consolas", monospace;
+      font-size: 11px;
+    }
+
+    .debug-drawer__section {
+      margin-bottom: 12px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid #333;
+    }
+
+    .debug-drawer__section-title {
+      font-size: 11px;
+      color: #888;
+      margin-bottom: 8px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .debug-drawer__gateway-entry {
+      padding: 4px 8px;
+      margin-bottom: 2px;
+      background: #0f0f1a;
+      border-radius: 2px;
+      color: #aaa;
+      font-size: 10px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .debug-drawer__entry {
+      padding: 8px;
+      margin-bottom: 4px;
+      background: #0f0f1a;
+      border-radius: 4px;
+      border-left: 3px solid #444;
+    }
+
+    .debug-drawer__entry.info {
+      border-left-color: #4a9eff;
+    }
+
+    .debug-drawer__entry.warn {
+      border-left-color: #ffa500;
+    }
+
+    .debug-drawer__entry.error {
+      border-left-color: #ff4a4a;
+    }
+
+    .debug-drawer__entry.debug {
+      border-left-color: #888;
+    }
+
+    .debug-drawer__entry-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+
+    .debug-drawer__entry-time {
+      color: #666;
+    }
+
+    .debug-drawer__entry-level {
+      padding: 1px 4px;
+      border-radius: 2px;
+      font-size: 10px;
+      text-transform: uppercase;
+    }
+
+    .debug-drawer__entry-level.info {
+      background: #4a9eff22;
+      color: #4a9eff;
+    }
+
+    .debug-drawer__entry-level.warn {
+      background: #ffa50022;
+      color: #ffa500;
+    }
+
+    .debug-drawer__entry-level.error {
+      background: #ff4a4a22;
+      color: #ff4a4a;
+    }
+
+    .debug-drawer__entry-level.debug {
+      background: #88888822;
+      color: #888;
+    }
+
+    .debug-drawer__entry-source {
+      color: #666;
+      font-size: 10px;
+    }
+
+    .debug-drawer__entry-message {
+      color: #ccc;
+      word-break: break-word;
+    }
+
+    .debug-drawer__entry-details {
+      margin-top: 4px;
+      padding: 4px;
+      background: #00000044;
+      border-radius: 2px;
+      color: #888;
+      font-size: 10px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .debug-drawer__footer {
+      padding: 8px 16px;
+      background: #16213e;
+      border-top: 1px solid #333;
+      display: flex;
+      justify-content: space-between;
+      font-size: 11px;
+      color: #666;
+    }
+
+    .debug-drawer__count {
+      color: #888;
+    }
+
+    .debug-drawer__hint {
+      font-style: italic;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "debug-drawer": DebugDrawer;
+  }
+}

--- a/ui/src/ui/debug-connection.ts
+++ b/ui/src/ui/debug-connection.ts
@@ -1,0 +1,134 @@
+/**
+ * Ephemeral debug log storage for connection diagnostics.
+ * Logs are stored in memory only and are cleared when the tab is closed.
+ * Uses sessionStorage for tab persistence across refreshes, but never localStorage.
+ */
+
+export type DebugLogLevel = "info" | "warn" | "error" | "debug";
+
+export type DebugLogEntry = {
+  id: string;
+  ts: number;
+  level: DebugLogLevel;
+  source: "websocket" | "gateway" | "lifecycle" | "logs";
+  message: string;
+  details?: unknown;
+};
+
+const MAX_LOG_ENTRIES = 500;
+const STORAGE_KEY = "openclaw_debug_logs";
+
+let logs: DebugLogEntry[] = [];
+let enabled = false;
+
+/**
+ * Check if debug mode is enabled.
+ */
+export function isDebugEnabled(): boolean {
+  return enabled;
+}
+
+/**
+ * Enable or disable debug mode.
+ * When enabled, logs are captured. When disabled, logs are not captured but existing logs are preserved.
+ */
+export function setDebugEnabled(value: boolean): void {
+  enabled = value;
+  if (enabled) {
+    // Load from sessionStorage on enable
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        logs = JSON.parse(stored);
+      }
+    } catch {
+      logs = [];
+    }
+  }
+}
+
+/**
+ * Clear all debug logs.
+ */
+export function clearDebugLogs(): void {
+  logs = [];
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Get all debug logs.
+ */
+export function getDebugLogs(): DebugLogEntry[] {
+  return [...logs];
+}
+
+/**
+ * Add a debug log entry.
+ * Only captures logs when debug mode is enabled.
+ */
+export function addDebugLog(
+  level: DebugLogLevel,
+  source: DebugLogLevel,
+  message: string,
+  details?: unknown,
+): void {
+  if (!enabled) {
+    return;
+  }
+
+  const entry: DebugLogEntry = {
+    id: crypto.randomUUID(),
+    ts: Date.now(),
+    level,
+    source: source as DebugLogEntry["source"],
+    message,
+    details,
+  };
+
+  logs.push(entry);
+
+  // Limit the number of stored entries
+  if (logs.length > MAX_LOG_ENTRIES) {
+    logs = logs.slice(-MAX_LOG_ENTRIES);
+  }
+
+  // Persist to sessionStorage
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+  } catch {
+    // Ignore storage errors (e.g., quota exceeded)
+  }
+}
+
+// Convenience functions for different log levels
+export const debugLog = {
+  info: (source: DebugLogEntry["source"], message: string, details?: unknown) =>
+    addDebugLog("info", source, message, details),
+  warn: (source: DebugLogEntry["source"], message: string, details?: unknown) =>
+    addDebugLog("warn", source, message, details),
+  error: (source: DebugLogEntry["source"], message: string, details?: unknown) =>
+    addDebugLog("error", source, message, details),
+  debug: (source: DebugLogEntry["source"], message: string, details?: unknown) =>
+    addDebugLog("debug", source, message, details),
+};
+
+/**
+ * Export logs as formatted text for clipboard copy.
+ */
+export function exportDebugLogsAsText(): string {
+  const lines = logs.map((entry) => {
+    const time = new Date(entry.ts).toISOString();
+    const level = entry.level.toUpperCase().padEnd(5);
+    const source = entry.source.padEnd(10);
+    let line = `[${time}] ${level} [${source}] ${entry.message}`;
+    if (entry.details) {
+      line += `\n  Details: ${JSON.stringify(entry.details, null, 2)}`;
+    }
+    return line;
+  });
+  return lines.join("\n");
+}

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -13,6 +13,7 @@ import {
 import { clearDeviceAuthToken, loadDeviceAuthToken, storeDeviceAuthToken } from "./device-auth.ts";
 import { loadOrCreateDeviceIdentity, signDevicePayload } from "./device-identity.ts";
 import { generateUUID } from "./uuid.ts";
+import { debugLog, isDebugEnabled } from "./debug-connection.ts";
 
 export type GatewayEventFrame = {
   type: "event";
@@ -184,8 +185,16 @@ export class GatewayBrowserClient {
     if (this.closed) {
       return;
     }
+    if (isDebugEnabled()) {
+      debugLog.info("websocket", `Connecting to ${this.opts.url}...`);
+    }
     this.ws = new WebSocket(this.opts.url);
-    this.ws.addEventListener("open", () => this.queueConnect());
+    this.ws.addEventListener("open", () => {
+      if (isDebugEnabled()) {
+        debugLog.info("websocket", "WebSocket connection opened");
+      }
+      this.queueConnect();
+    });
     this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data ?? "")));
     this.ws.addEventListener("close", (ev) => {
       const reason = String(ev.reason ?? "");
@@ -193,6 +202,13 @@ export class GatewayBrowserClient {
       this.pendingConnectError = undefined;
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
+      if (isDebugEnabled()) {
+        debugLog.info(
+          "websocket",
+          `WebSocket closed: code=${ev.code}, reason="${reason}"`,
+          connectError ? { error: connectError } : undefined,
+        );
+      }
       this.opts.onClose?.({ code: ev.code, reason, error: connectError });
       const connectErrorCode = resolveGatewayErrorDetailCode(connectError);
       if (
@@ -206,7 +222,10 @@ export class GatewayBrowserClient {
         this.scheduleReconnect();
       }
     });
-    this.ws.addEventListener("error", () => {
+    this.ws.addEventListener("error", (ev) => {
+      if (isDebugEnabled()) {
+        debugLog.error("websocket", "WebSocket error", ev);
+      }
       // ignored; close handler will fire
     });
   }
@@ -329,6 +348,15 @@ export class GatewayBrowserClient {
       .then((hello) => {
         this.pendingDeviceTokenRetry = false;
         this.deviceTokenRetryBudgetUsed = false;
+        if (isDebugEnabled()) {
+          debugLog.info(
+            "gateway",
+            "Connection established",
+            hello.server
+              ? { version: hello.server.version, connId: hello.server.connId }
+              : undefined,
+          );
+        }
         if (hello?.auth?.deviceToken && deviceIdentity) {
           storeDeviceAuthToken({
             deviceId: deviceIdentity.deviceId,
@@ -341,6 +369,17 @@ export class GatewayBrowserClient {
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
+        if (isDebugEnabled()) {
+          if (err instanceof GatewayRequestError) {
+            debugLog.error("gateway", "Connection failed", {
+              code: err.gatewayCode,
+              message: err.message,
+              details: err.details,
+            });
+          } else {
+            debugLog.error("gateway", "Connection failed", err);
+          }
+        }
         const connectErrorCode =
           err instanceof GatewayRequestError ? resolveGatewayErrorDetailCode(err) : null;
         const recoveryAdvice =
@@ -388,17 +427,26 @@ export class GatewayBrowserClient {
     try {
       parsed = JSON.parse(raw);
     } catch {
+      if (isDebugEnabled()) {
+        debugLog.warn("websocket", "Failed to parse message as JSON", { raw: raw.slice(0, 200) });
+      }
       return;
     }
 
     const frame = parsed as { type?: unknown };
     if (frame.type === "event") {
       const evt = parsed as GatewayEventFrame;
+      if (isDebugEnabled()) {
+        debugLog.debug("websocket", `Event: ${evt.event}`, evt.payload);
+      }
       if (evt.event === "connect.challenge") {
         const payload = evt.payload as { nonce?: unknown } | undefined;
         const nonce = payload && typeof payload.nonce === "string" ? payload.nonce : null;
         if (nonce) {
           this.connectNonce = nonce;
+          if (isDebugEnabled()) {
+            debugLog.info("websocket", "Received connect.challenge, sending connect handshake");
+          }
           void this.sendConnect();
         }
         return;
@@ -422,12 +470,21 @@ export class GatewayBrowserClient {
       const res = parsed as GatewayResponseFrame;
       const pending = this.pending.get(res.id);
       if (!pending) {
+        if (isDebugEnabled()) {
+          debugLog.warn("websocket", `Received response for unknown request ID: ${res.id}`);
+        }
         return;
       }
       this.pending.delete(res.id);
       if (res.ok) {
+        if (isDebugEnabled()) {
+          debugLog.debug("websocket", `Response OK for request ${res.id}`, res.payload);
+        }
         pending.resolve(res.payload);
       } else {
+        if (isDebugEnabled()) {
+          debugLog.warn("websocket", `Response error for request ${res.id}`, res.error);
+        }
         pending.reject(
           new GatewayRequestError({
             code: res.error?.code ?? "UNAVAILABLE",


### PR DESCRIPTION
When `gateway.controlUi.dangerouslyDisableDeviceAuth` is set to true, HTTP LAN connections fail because WebCrypto is not available in non-secure contexts. The client cannot sign the challenge, resulting in 'device identity required' errors.

This fix skips sending the device identity challenge when device auth is disabled, allowing HTTP LAN connections to work properly.