### PR TITLE
docs: fix client mode from 'operator' to 'cli'

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -45,7 +45,7 @@ Client → Gateway:
       "id": "cli",
       "version": "1.2.3",
       "platform": "macos",
-      "mode": "operator"
+      "mode": "cli"
     },
     "role": "operator",
     "scopes": ["operator.read", "operator.write"],


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: docs doesn't align with source code.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Evidence
No `operator` defined:
https://github.com/openclaw/openclaw/blob/b31b68108882fba2163f73eb110574e5684df88e/src/gateway/protocol/client-info.ts#L22-L30