### PR TITLE
fix: break Synology Chat plugin-sdk reexport cycle

### DIFF
--- a/src/plugin-sdk/synology-chat.ts
+++ b/src/plugin-sdk/synology-chat.ts
@@ -20,4 +20,4 @@ export { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
 export {
   synologyChatSetupAdapter,
   synologyChatSetupWizard,
-} from "../../extensions/synology-chat/api.js";
+} from "../../extensions/synology-chat/src/setup-surface.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm build` on `main` fails with `[CIRCULAR_REEXPORT]` errors for `synologyChatSetupAdapter` and `synologyChatSetupWizard`.
- Why it matters: contributors cannot build the repo from the current default branch.
- What changed: `src/plugin-sdk/synology-chat.ts` now reexports the Synology Chat setup symbols directly from `extensions/synology-chat/src/setup-surface.js`.
- What did NOT change (scope boundary): no runtime Synology Chat behavior, config shape, or public symbol names changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 / Darwin 24.6.0 arm64
- Runtime/container: Node v22.17.0, pnpm build
- Model/provider: N/A
- Integration/channel (if any): Synology Chat plugin SDK subpath
- Relevant config (redacted): none

### Steps

1. Check out the current `main` branch.
2. Run `pnpm build`.
3. Observe the `[CIRCULAR_REEXPORT]` failure in `src/plugin-sdk/synology-chat.ts`.
4. Apply this patch and rerun `pnpm build`.

### Expected

- The repository build completes successfully.

### Actual

- Before this fix, the build failed because `src/plugin-sdk/synology-chat.ts` reexported through `extensions/synology-chat/api.ts`, which reexports `openclaw/plugin-sdk/synology-chat` back into the same entrypoint.
- After this fix, `pnpm build` completes successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the build failure from `main`, changed the reexport target, reran `pnpm build`, and confirmed success.
- Edge cases checked: preserved the same exported symbol names on the `openclaw/plugin-sdk/synology-chat` surface.
- What you did **not** verify: no runtime Synology Chat webhook flow was exercised because this change only affects module wiring at build time.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the prior reexport path.
- Files/config to restore: `src/plugin-sdk/synology-chat.ts`
- Known bad symptoms reviewers should watch for: `pnpm build` regressing back to `[CIRCULAR_REEXPORT]` errors for the Synology Chat plugin SDK entry.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: direct import path changes could surprise consumers if they depended on the extension API shim for side effects.
  - Mitigation: the imported module already provided the concrete exported symbols, and the extension API shim remains unchanged.
