### PR TITLE
Sandbox: add Apple container backend

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,6 +194,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/copilot-proxy/**"
+"extensions: apple-container":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/apple-container/**"
 "extensions: diagnostics-otel":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -16,6 +16,7 @@ OpenClaw can run agents in isolated sandbox runtimes for security. The `sandbox`
 Today that usually means:
 
 - Docker sandbox containers
+- Apple container sandbox runtimes when `agents.defaults.sandbox.backend = "apple-container"`
 - SSH sandbox runtimes when `agents.defaults.sandbox.backend = "ssh"`
 - OpenShell sandbox runtimes when `agents.defaults.sandbox.backend = "openshell"`
 
@@ -135,6 +136,21 @@ openclaw sandbox recreate --all
 For OpenShell `remote` mode, recreate deletes the canonical remote workspace
 for that scope. The next run seeds it again from the local workspace.
 
+### After changing Apple container backend config
+
+```bash
+# Edit config:
+# - agents.defaults.sandbox.backend
+# - agents.defaults.sandbox.docker.network
+# - plugins.entries.apple-container.config.command
+# - plugins.entries.apple-container.config.timeoutSeconds
+
+openclaw sandbox recreate --all
+```
+
+For the Apple container backend, recreate removes the per-scope local Apple container runtime.
+The next run recreates it with the current image, mounts, labels, and network settings.
+
 ### After changing setupCommand
 
 ```bash
@@ -173,7 +189,7 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
     "defaults": {
       "sandbox": {
         "mode": "all", // off, non-main, all
-        "backend": "docker", // docker, ssh, openshell
+        "backend": "docker", // docker, apple-container, ssh, openshell
         "scope": "agent", // session, agent, shared
         "docker": {
           "image": "openclaw-sandbox:bookworm-slim",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1350,6 +1350,10 @@ noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived 
 </Accordion>
 
 Browser sandboxing and `sandbox.docker.binds` are currently Docker-only.
+The `apple-container` backend is opt-in, requires macOS 26+ on Apple silicon, and currently supports exec plus file tools only.
+When using `backend: "apple-container"`, set `plugins.entries.apple-container.config.command` if the Apple `container` CLI is not on `PATH`.
+`sandbox.docker.network = "none"` maps to Apple's native no-network mode; use `default` or a named Apple container network only when the sandbox needs network access.
+Non-default Docker-only hardening settings such as custom `capDrop` values, `seccompProfile`, `apparmorProfile`, `pidsLimit`, `memorySwap`, and `extraHosts` are rejected on that backend.
 
 Build images:
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -71,6 +71,10 @@ Apple container-specific config lives under `plugins.entries.apple-container.con
 
 Use `backend: "apple-container"` when you want local sandboxed `exec` and file tools on a macOS 26+ Apple silicon host without Docker Desktop.
 
+Like the Docker backend, agent tools run inside a Linux container and cannot directly reach macOS-native APIs (iMessage, Shortcuts, AppleScript).
+This is a general sandbox limitation, not specific to Apple Containers.
+Unlike Docker, this backend runs on Virtualization.framework, which may enable tighter host integration in the future.
+
 ```json5
 {
   agents: {

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -59,11 +59,59 @@ Not sandboxed:
 `agents.defaults.sandbox.backend` controls **which runtime** provides the sandbox:
 
 - `"docker"` (default): local Docker-backed sandbox runtime.
+- `"apple-container"`: Apple container-backed runtime for macOS Apple silicon hosts.
 - `"ssh"`: generic SSH-backed remote sandbox runtime.
 - `"openshell"`: OpenShell-backed sandbox runtime.
 
 SSH-specific config lives under `agents.defaults.sandbox.ssh`.
 OpenShell-specific config lives under `plugins.entries.openshell.config`.
+Apple container-specific config lives under `plugins.entries.apple-container.config`.
+
+### Apple container backend
+
+Use `backend: "apple-container"` when you want local sandboxed `exec` and file tools on a macOS 26+ Apple silicon host without Docker Desktop.
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        backend: "apple-container",
+        scope: "session",
+        workspaceAccess: "rw",
+        docker: {
+          image: "alpine:latest",
+          network: "none", // use "default" or a named Apple container network only when needed
+        },
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      "apple-container": {
+        enabled: true,
+        config: {
+          command: "container",
+          timeoutSeconds: 30,
+        },
+      },
+    },
+  },
+}
+```
+
+Current Apple container backend limits:
+
+- opt-in only; Docker remains the default backend
+- macOS 26+ on Apple silicon only
+- browser sandbox is not supported
+- `sandbox.docker.network = "none"` maps to Apple's native no-network mode; use `default` or a named Apple container network only when the sandbox needs egress
+- Docker-only hardening settings such as custom `capDrop` values, `seccompProfile`, `apparmorProfile`, `pidsLimit`, `memorySwap`, and `extraHosts` are rejected; the default Docker `capDrop: ["ALL"]` is accepted as a compatibility no-op
+- Docker-style browser/runtime parity is not claimed here; this backend is for exec and file tools only
+
+The backend reuses the normal sandbox registry, recreate, prune, and filesystem bridge behavior.
+It uses Apple's `container` CLI for create/start/stop/delete/inspect/exec and keeps the same workspace-mount model as the Docker backend.
 
 ### SSH backend
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -94,25 +94,29 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
 
-### Apple container backend smoke
+### Apple container backend e2e
 
-- Suggested manual smoke:
+- Command: `OPENCLAW_E2E_APPLE_CONTAINER=1 pnpm test:e2e -- extensions/apple-container/src/backend.e2e.test.ts`
+- Requires: macOS 26+ Apple silicon host with `container` CLI and `container system status` reporting `running`
+- `OPENCLAW_E2E_APPLE_CONTAINER=1` to enable the tests when running the broader e2e suite manually
+- Scope:
+  - Container lifecycle (create, start, inspect, delete)
+  - Exec with stdout capture
+  - File write through exec with bind-mounted workspace verified on the host
+  - Network isolation (`--network none` blocks outbound)
+  - Inspect returns null for nonexistent containers
+- Expectations:
+  - Opt-in only; tests skip gracefully when the host or CLI is unavailable
+  - Requires a pullable `alpine:latest` image
+  - Browser coverage is intentionally out of scope for this backend right now
+
+- Suggested manual smoke (in addition to the e2e suite):
 
 ```bash
 container system status --format json
 openclaw sandbox recreate --all
 openclaw sandbox list
 ```
-
-- Scope:
-  - Confirms the host is macOS Apple silicon
-  - Confirms `container system status --format json` reports `running`
-  - Creates a sandbox runtime with `backend: "apple-container"`
-  - Verifies simple exec plus file-tool read/write behavior
-- Expectations:
-  - Opt-in only
-  - Requires Apple's `container` CLI and a working local image/network setup
-  - Browser coverage is intentionally out of scope for this backend right now
 
 ### Live (real providers + real models)
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -94,6 +94,26 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
 
+### Apple container backend smoke
+
+- Suggested manual smoke:
+
+```bash
+container system status --format json
+openclaw sandbox recreate --all
+openclaw sandbox list
+```
+
+- Scope:
+  - Confirms the host is macOS Apple silicon
+  - Confirms `container system status --format json` reports `running`
+  - Creates a sandbox runtime with `backend: "apple-container"`
+  - Verifies simple exec plus file-tool read/write behavior
+- Expectations:
+  - Opt-in only
+  - Requires Apple's `container` CLI and a working local image/network setup
+  - Browser coverage is intentionally out of scope for this backend right now
+
 ### Live (real providers + real models)
 
 - Command: `pnpm test:live`

--- a/extensions/apple-container/index.ts
+++ b/extensions/apple-container/index.ts
@@ -1,0 +1,29 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
+import {
+  createAppleContainerSandboxBackendFactory,
+  createAppleContainerSandboxBackendManager,
+} from "./src/backend.js";
+import {
+  createAppleContainerPluginConfigSchema,
+  resolveAppleContainerPluginConfig,
+} from "./src/config.js";
+
+const plugin = {
+  id: "apple-container",
+  name: "Apple Container Sandbox",
+  description: "Apple container-backed sandbox runtime for agent exec and file tools.",
+  configSchema: createAppleContainerPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    if (api.registrationMode !== "full") {
+      return;
+    }
+    const pluginConfig = resolveAppleContainerPluginConfig(api.pluginConfig);
+    registerSandboxBackend("apple-container", {
+      factory: createAppleContainerSandboxBackendFactory({ pluginConfig }),
+      manager: createAppleContainerSandboxBackendManager({ pluginConfig }),
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/apple-container/openclaw.plugin.json
+++ b/extensions/apple-container/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "apple-container",
+  "name": "Apple Container Sandbox",
+  "description": "Sandbox backend powered by Apple's container CLI for macOS Apple silicon hosts.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "command": {
+        "type": "string"
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 1
+      }
+    }
+  },
+  "uiHints": {
+    "command": {
+      "label": "Container Command",
+      "help": "Path or command name for the Apple container CLI."
+    },
+    "timeoutSeconds": {
+      "label": "Command Timeout Seconds",
+      "help": "Timeout for Apple container CLI operations such as inspect, create, and exec.",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/apple-container/package.json
+++ b/extensions/apple-container/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/apple-container-sandbox",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Apple container sandbox backend",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/apple-container/src/backend.e2e.test.ts
+++ b/extensions/apple-container/src/backend.e2e.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  inspectAppleContainer,
+  runAppleContainerCli,
+  type RunAppleContainerCliResult,
+} from "./cli.js";
+import { resolveAppleContainerPluginConfig } from "./config.js";
+
+const OPENCLAW_APPLE_CONTAINER_E2E = process.env.OPENCLAW_E2E_APPLE_CONTAINER === "1";
+const OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS = 2 * 60_000;
+
+const DEFAULT_PLUGIN_CONFIG = resolveAppleContainerPluginConfig({});
+const TEST_IMAGE = "alpine:latest";
+
+async function appleContainerReady(): Promise<boolean> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    return false;
+  }
+  try {
+    const result = await runAppleContainerCli({
+      config: DEFAULT_PLUGIN_CONFIG,
+      args: ["system", "status", "--format", "json"],
+    });
+    const parsed = JSON.parse(result.stdout.toString("utf8")) as { status?: string };
+    return parsed.status === "running";
+  } catch {
+    return false;
+  }
+}
+
+async function removeContainer(name: string): Promise<void> {
+  await runAppleContainerCli({
+    config: DEFAULT_PLUGIN_CONFIG,
+    args: ["delete", "--force", name],
+    allowFailure: true,
+  });
+}
+
+function containerName(suffix: string): string {
+  return `openclaw-e2e-ac-${process.pid}-${suffix}`.slice(0, 63);
+}
+
+async function createAndStart(
+  name: string,
+  opts?: { network?: string; workspaceDir?: string },
+): Promise<void> {
+  const createArgs = [
+    "create",
+    "--name",
+    name,
+    "--label",
+    "openclaw.sandbox=1",
+    "--label",
+    "openclaw.e2e=1",
+  ];
+  if (opts?.network) {
+    createArgs.push("--network", opts.network);
+  }
+  if (opts?.workspaceDir) {
+    createArgs.push("--volume", `${opts.workspaceDir}:/workspace`);
+    createArgs.push("--workdir", "/workspace");
+  }
+  createArgs.push(TEST_IMAGE, "sleep", "infinity");
+  await runAppleContainerCli({ config: DEFAULT_PLUGIN_CONFIG, args: createArgs });
+  await runAppleContainerCli({ config: DEFAULT_PLUGIN_CONFIG, args: ["start", name] });
+}
+
+async function execInContainer(name: string, command: string): Promise<RunAppleContainerCliResult> {
+  return await runAppleContainerCli({
+    config: DEFAULT_PLUGIN_CONFIG,
+    args: ["exec", "-i", name, "/bin/sh", "-c", command],
+  });
+}
+
+describe("apple-container backend e2e", () => {
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "creates a container, execs a command, and verifies output",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const name = containerName("exec");
+      try {
+        await createAndStart(name);
+
+        const result = await execInContainer(name, "echo hello-from-apple-container");
+        expect(result.stdout.toString("utf8").trim()).toBe("hello-from-apple-container");
+        expect(result.code).toBe(0);
+      } finally {
+        await removeContainer(name);
+      }
+    },
+  );
+
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "writes a file through exec and reads it back on the host via bind mount",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ac-e2e-"));
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const name = containerName("fs");
+      try {
+        await createAndStart(name, { workspaceDir });
+
+        await execInContainer(
+          name,
+          "mkdir -p /workspace/nested && echo from-apple > /workspace/nested/hello.txt",
+        );
+
+        const content = await fs.readFile(path.join(workspaceDir, "nested", "hello.txt"), "utf8");
+        expect(content.trim()).toBe("from-apple");
+      } finally {
+        await removeContainer(name);
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "inspect returns container status and labels",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const name = containerName("inspect");
+      try {
+        await createAndStart(name);
+
+        const info = await inspectAppleContainer({
+          config: DEFAULT_PLUGIN_CONFIG,
+          containerId: name,
+        });
+        expect(info).not.toBeNull();
+        expect(info?.status).toBe("running");
+        expect(info?.configuration?.labels?.["openclaw.sandbox"]).toBe("1");
+        expect(info?.configuration?.labels?.["openclaw.e2e"]).toBe("1");
+      } finally {
+        await removeContainer(name);
+      }
+    },
+  );
+
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "network none prevents outbound connectivity",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const name = containerName("netno");
+      try {
+        await createAndStart(name, { network: "none" });
+
+        // wget with a short timeout; expect failure due to no network
+        const result = await runAppleContainerCli({
+          config: DEFAULT_PLUGIN_CONFIG,
+          args: [
+            "exec",
+            "-i",
+            name,
+            "/bin/sh",
+            "-c",
+            "wget -q -O /dev/null --timeout=3 http://1.1.1.1/ 2>&1; echo $?",
+          ],
+          allowFailure: true,
+        });
+        const exitStr = result.stdout.toString("utf8").trim().split("\n").pop() ?? "";
+        expect(Number(exitStr)).not.toBe(0);
+      } finally {
+        await removeContainer(name);
+      }
+    },
+  );
+
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "inspect returns null for nonexistent container",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const info = await inspectAppleContainer({
+        config: DEFAULT_PLUGIN_CONFIG,
+        containerId: "openclaw-e2e-nonexistent-container-name",
+      });
+      expect(info).toBeNull();
+    },
+  );
+
+  it.runIf(OPENCLAW_APPLE_CONTAINER_E2E)(
+    "delete removes the container and inspect returns null",
+    { timeout: OPENCLAW_APPLE_CONTAINER_E2E_TIMEOUT_MS },
+    async () => {
+      if (!(await appleContainerReady())) {
+        return;
+      }
+
+      const name = containerName("del");
+      await createAndStart(name);
+
+      await removeContainer(name);
+
+      const info = await inspectAppleContainer({
+        config: DEFAULT_PLUGIN_CONFIG,
+        containerId: name,
+      });
+      expect(info).toBeNull();
+    },
+  );
+});

--- a/extensions/apple-container/src/backend.test.ts
+++ b/extensions/apple-container/src/backend.test.ts
@@ -1,0 +1,290 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/sandbox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAppleContainerPluginConfig } from "./config.js";
+
+const cli = vi.hoisted(() => ({
+  assertAppleContainerSystemRunning: vi.fn(async () => undefined),
+  inspectAppleContainer: vi.fn(async () => null),
+  runAppleContainerCli: vi.fn(async () => ({
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    code: 0,
+  })),
+}));
+
+const sandbox = vi.hoisted(() => ({
+  readRegistry: vi.fn(async () => ({ entries: [] })),
+  updateRegistry: vi.fn(async () => undefined),
+}));
+
+vi.mock("./cli.js", () => cli);
+vi.mock("../../../src/agents/sandbox/registry.js", () => sandbox);
+
+describe("apple-container backend", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unsupported browser sandboxes during backend creation", async () => {
+    const { createAppleContainerSandboxBackendFactory } = await import("./backend.js");
+    const factory = createAppleContainerSandboxBackendFactory({
+      pluginConfig: resolveAppleContainerPluginConfig({}),
+    });
+
+    await expect(
+      factory({
+        sessionKey: "agent:main:test",
+        scopeKey: "agent:main",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/agent",
+        cfg: {
+          mode: "all",
+          backend: "apple-container",
+          scope: "agent",
+          workspaceAccess: "ro",
+          workspaceRoot: "/tmp",
+          docker: {
+            image: "alpine:latest",
+            containerPrefix: "openclaw-sbx-",
+            workdir: "/workspace",
+            readOnlyRoot: true,
+            tmpfs: ["/tmp"],
+            network: "bridge",
+            user: "1000:1000",
+            capDrop: ["ALL"],
+            env: { LANG: "C.UTF-8" },
+            binds: undefined,
+          },
+          ssh: {
+            command: "ssh",
+            workspaceRoot: "/tmp/openclaw-sandboxes",
+            strictHostKeyChecking: true,
+            updateHostKeys: true,
+          },
+          browser: {
+            enabled: true,
+            image: "browser",
+            containerPrefix: "browser-",
+            network: "openclaw-sandbox-browser",
+            cdpPort: 9222,
+            vncPort: 5900,
+            noVncPort: 6080,
+            headless: false,
+            enableNoVnc: true,
+            allowHostControl: false,
+            autoStart: true,
+            autoStartTimeoutMs: 1,
+          },
+          tools: { allow: [], deny: [] },
+          prune: { idleHours: 24, maxAgeDays: 7 },
+        },
+      }),
+    ).rejects.toThrow("does not support browser sandboxes");
+  });
+
+  it("builds exec argv with apple-container exec flags", async () => {
+    const { createAppleContainerSandboxBackendFactory } = await import("./backend.js");
+    cli.inspectAppleContainer.mockResolvedValue({
+      status: "running",
+      configuration: {
+        id: "openclaw-sbx-agent-main",
+        image: { reference: "alpine:latest" },
+        labels: { "openclaw.configHash": "hash-a" },
+      },
+    });
+    const factory = createAppleContainerSandboxBackendFactory({
+      pluginConfig: resolveAppleContainerPluginConfig({ command: "container" }),
+    });
+    const backend = await factory({
+      sessionKey: "agent:main:test",
+      scopeKey: "agent:main",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/agent",
+      cfg: {
+        mode: "all",
+        backend: "apple-container",
+        scope: "agent",
+        workspaceAccess: "ro",
+        workspaceRoot: "/tmp",
+        docker: {
+          image: "alpine:latest",
+          containerPrefix: "openclaw-sbx-",
+          workdir: "/workspace",
+          readOnlyRoot: true,
+          tmpfs: ["/tmp"],
+          network: "bridge",
+          user: "1000:1000",
+          capDrop: ["ALL"],
+          env: { LANG: "C.UTF-8" },
+          binds: undefined,
+        },
+        ssh: {
+          command: "ssh",
+          workspaceRoot: "/tmp/openclaw-sandboxes",
+          strictHostKeyChecking: true,
+          updateHostKeys: true,
+        },
+        browser: {
+          enabled: false,
+          image: "browser",
+          containerPrefix: "browser-",
+          network: "openclaw-sandbox-browser",
+          cdpPort: 9222,
+          vncPort: 5900,
+          noVncPort: 6080,
+          headless: false,
+          enableNoVnc: true,
+          allowHostControl: false,
+          autoStart: true,
+          autoStartTimeoutMs: 1,
+        },
+        tools: { allow: [], deny: [] },
+        prune: { idleHours: 24, maxAgeDays: 7 },
+      },
+    });
+
+    const spec = await backend.buildExecSpec({
+      command: "echo hi",
+      workdir: "/workspace",
+      env: { TEST: "1", PATH: "/custom/bin" },
+      usePty: true,
+    });
+
+    expect(spec.argv[0]).toBe("container");
+    expect(spec.argv).toContain("exec");
+    expect(spec.argv).toContain("--workdir");
+    expect(spec.argv).toContain("/workspace");
+    expect(spec.argv).toContain("--env");
+    expect(spec.argv).toContain("TEST=1");
+    expect(spec.argv).toContain("-t");
+  });
+
+  it('passes sandbox.docker.network="none" through to the Apple container CLI', async () => {
+    const { createAppleContainerSandboxBackendFactory } = await import("./backend.js");
+    cli.inspectAppleContainer.mockResolvedValue(null);
+    const factory = createAppleContainerSandboxBackendFactory({
+      pluginConfig: resolveAppleContainerPluginConfig({ command: "container" }),
+    });
+
+    await factory({
+      sessionKey: "agent:main:test",
+      scopeKey: "agent:main",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/agent",
+      cfg: {
+        mode: "all",
+        backend: "apple-container",
+        scope: "agent",
+        workspaceAccess: "ro",
+        workspaceRoot: "/tmp",
+        docker: {
+          image: "alpine:latest",
+          containerPrefix: "openclaw-sbx-",
+          workdir: "/workspace",
+          readOnlyRoot: true,
+          tmpfs: ["/tmp"],
+          network: "none",
+          user: "1000:1000",
+          capDrop: ["ALL"],
+          env: { LANG: "C.UTF-8" },
+          binds: undefined,
+        },
+        ssh: {
+          command: "ssh",
+          workspaceRoot: "/tmp/openclaw-sandboxes",
+          strictHostKeyChecking: true,
+          updateHostKeys: true,
+        },
+        browser: {
+          enabled: false,
+          image: "browser",
+          containerPrefix: "browser-",
+          network: "openclaw-sandbox-browser",
+          cdpPort: 9222,
+          vncPort: 5900,
+          noVncPort: 6080,
+          headless: false,
+          enableNoVnc: true,
+          allowHostControl: false,
+          autoStart: true,
+          autoStartTimeoutMs: 1,
+        },
+        tools: { allow: [], deny: [] },
+        prune: { idleHours: 24, maxAgeDays: 7 },
+      },
+    });
+
+    const createCall = cli.runAppleContainerCli.mock.calls.find(
+      ([call]) => Array.isArray(call.args) && call.args[0] === "create",
+    );
+    expect(createCall).toBeDefined();
+    expect(createCall?.[0].args).toContain("--network");
+    expect(createCall?.[0].args).toContain("none");
+
+    const imageInspectCall = cli.runAppleContainerCli.mock.calls.find(
+      ([call]) =>
+        Array.isArray(call.args) && call.args[0] === "image" && call.args[1] === "inspect",
+    );
+    expect(imageInspectCall).toBeUndefined();
+  });
+
+  it("describes and removes runtimes through inspect and delete", async () => {
+    const { createAppleContainerSandboxBackendManager } = await import("./backend.js");
+    cli.inspectAppleContainer.mockResolvedValue({
+      status: "running",
+      configuration: {
+        id: "openclaw-sbx-agent-main",
+        image: { reference: "alpine:latest" },
+      },
+    });
+    const manager = createAppleContainerSandboxBackendManager({
+      pluginConfig: resolveAppleContainerPluginConfig({}),
+    });
+
+    const config = {
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "apple-container",
+            docker: { image: "alpine:latest", network: "bridge" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const runtime = await manager.describeRuntime({
+      entry: {
+        containerName: "openclaw-sbx-agent-main",
+        backendId: "apple-container",
+        runtimeLabel: "openclaw-sbx-agent-main",
+        sessionKey: "agent:main",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "old:tag",
+      },
+      config,
+      agentId: "main",
+    });
+
+    expect(runtime.running).toBe(true);
+    expect(runtime.actualConfigLabel).toBe("alpine:latest");
+    expect(runtime.configLabelMatch).toBe(true);
+
+    await manager.removeRuntime({
+      entry: {
+        containerName: "openclaw-sbx-agent-main",
+        sessionKey: "agent:main",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "alpine:latest",
+      },
+      config,
+    });
+
+    expect(cli.runAppleContainerCli).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ["delete", "--force", "openclaw-sbx-agent-main"],
+      }),
+    );
+  });
+});

--- a/extensions/apple-container/src/backend.ts
+++ b/extensions/apple-container/src/backend.ts
@@ -6,23 +6,24 @@ import type {
   SandboxBackendFactory,
   SandboxBackendHandle,
   SandboxBackendManager,
+  SandboxConfig,
+  SandboxDockerConfig,
 } from "openclaw/plugin-sdk/sandbox";
-import { buildDockerExecArgs } from "../../../src/agents/bash-tools.shared.js";
-import { computeSandboxConfigHash } from "../../../src/agents/sandbox/config-hash.js";
-import { resolveSandboxConfigForAgent } from "../../../src/agents/sandbox/config.js";
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "../../../src/agents/sandbox/constants.js";
-import { readRegistry, updateRegistry } from "../../../src/agents/sandbox/registry.js";
-import { sanitizeEnvVars } from "../../../src/agents/sandbox/sanitize-env-vars.js";
 import {
+  computeSandboxConfigHash,
+  defaultRuntime,
+  formatCliCommand,
+  markOpenClawExecEnv,
+  readRegistry,
   resolveSandboxAgentId,
+  resolveSandboxConfigForAgent,
   resolveSandboxScopeKey,
+  SANDBOX_AGENT_WORKSPACE_MOUNT,
+  sanitizeEnvVars,
   slugifySessionKey,
-} from "../../../src/agents/sandbox/shared.js";
-import type { SandboxConfig, SandboxDockerConfig } from "../../../src/agents/sandbox/types.js";
-import { validateBindMounts } from "../../../src/agents/sandbox/validate-sandbox-security.js";
-import { formatCliCommand } from "../../../src/cli/command-format.js";
-import { markOpenClawExecEnv } from "../../../src/infra/openclaw-exec-env.js";
-import { defaultRuntime } from "../../../src/runtime.js";
+  updateRegistry,
+  validateBindMounts,
+} from "openclaw/plugin-sdk/sandbox";
 import {
   assertAppleContainerSystemRunning,
   inspectAppleContainer,
@@ -36,6 +37,39 @@ const HOT_CONTAINER_WINDOW_MS = 5 * 60 * 1000;
 type CreateAppleContainerSandboxBackendFactoryParams = {
   pluginConfig: ResolvedAppleContainerPluginConfig;
 };
+
+function buildAppleContainerExecArgs(params: {
+  containerName: string;
+  command: string;
+  workdir?: string;
+  env: Record<string, string>;
+  tty: boolean;
+}): string[] {
+  const args = ["exec", "-i"];
+  if (params.tty) {
+    args.push("-t");
+  }
+  if (params.workdir) {
+    args.push("--workdir", params.workdir);
+  }
+  for (const [key, value] of Object.entries(params.env)) {
+    // Skip PATH; handled via OPENCLAW_PREPEND_PATH to avoid poisoning the
+    // container's executable lookup with host paths.
+    if (key === "PATH") {
+      continue;
+    }
+    args.push("--env", `${key}=${value}`);
+  }
+  const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;
+  if (hasCustomPath) {
+    args.push("--env", `OPENCLAW_PREPEND_PATH=${params.env.PATH}`);
+  }
+  const pathExport = hasCustomPath
+    ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
+    : "";
+  args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
+  return args;
+}
 
 function normalizeDockerLimit(value?: string | number): string | undefined {
   if (value === undefined || value === null) {
@@ -293,23 +327,12 @@ class AppleContainerSandboxBackendImpl {
         return {
           argv: [
             this.params.pluginConfig.command,
-            ...buildDockerExecArgs({
+            ...buildAppleContainerExecArgs({
               containerName: this.params.containerName,
               command,
               workdir: workdir ?? this.params.createParams.cfg.docker.workdir,
               env,
               tty: usePty,
-            }).map((entry, index) => {
-              if (index === 0) {
-                return "exec";
-              }
-              if (entry === "-e") {
-                return "--env";
-              }
-              if (entry === "-w") {
-                return "--workdir";
-              }
-              return entry;
             }),
           ],
           env: process.env,

--- a/extensions/apple-container/src/backend.ts
+++ b/extensions/apple-container/src/backend.ts
@@ -1,0 +1,515 @@
+import type {
+  CreateSandboxBackendParams,
+  OpenClawConfig,
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+  SandboxBackendFactory,
+  SandboxBackendHandle,
+  SandboxBackendManager,
+} from "openclaw/plugin-sdk/sandbox";
+import { buildDockerExecArgs } from "../../../src/agents/bash-tools.shared.js";
+import { computeSandboxConfigHash } from "../../../src/agents/sandbox/config-hash.js";
+import { resolveSandboxConfigForAgent } from "../../../src/agents/sandbox/config.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "../../../src/agents/sandbox/constants.js";
+import { readRegistry, updateRegistry } from "../../../src/agents/sandbox/registry.js";
+import { sanitizeEnvVars } from "../../../src/agents/sandbox/sanitize-env-vars.js";
+import {
+  resolveSandboxAgentId,
+  resolveSandboxScopeKey,
+  slugifySessionKey,
+} from "../../../src/agents/sandbox/shared.js";
+import type { SandboxConfig, SandboxDockerConfig } from "../../../src/agents/sandbox/types.js";
+import { validateBindMounts } from "../../../src/agents/sandbox/validate-sandbox-security.js";
+import { formatCliCommand } from "../../../src/cli/command-format.js";
+import { markOpenClawExecEnv } from "../../../src/infra/openclaw-exec-env.js";
+import { defaultRuntime } from "../../../src/runtime.js";
+import {
+  assertAppleContainerSystemRunning,
+  inspectAppleContainer,
+  runAppleContainerCli,
+} from "./cli.js";
+import type { ResolvedAppleContainerPluginConfig } from "./config.js";
+import { resolveAppleContainerPluginConfig } from "./config.js";
+
+const HOT_CONTAINER_WINDOW_MS = 5 * 60 * 1000;
+
+type CreateAppleContainerSandboxBackendFactoryParams = {
+  pluginConfig: ResolvedAppleContainerPluginConfig;
+};
+
+function normalizeDockerLimit(value?: string | number): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function formatUlimitValue(
+  name: string,
+  value: string | number | { soft?: number; hard?: number },
+): string | null {
+  if (!name.trim()) {
+    return null;
+  }
+  if (typeof value === "number" || typeof value === "string") {
+    const raw = String(value).trim();
+    return raw ? `${name}=${raw}` : null;
+  }
+  const soft = typeof value.soft === "number" ? Math.max(0, value.soft) : undefined;
+  const hard = typeof value.hard === "number" ? Math.max(0, value.hard) : undefined;
+  if (soft === undefined && hard === undefined) {
+    return null;
+  }
+  if (soft === undefined) {
+    return `${name}=${hard}`;
+  }
+  if (hard === undefined) {
+    return `${name}=${soft}`;
+  }
+  return `${name}=${soft}:${hard}`;
+}
+
+function formatSandboxRecreateHint(params: { scope: SandboxConfig["scope"]; sessionKey: string }) {
+  if (params.scope === "session") {
+    return formatCliCommand(`openclaw sandbox recreate --session ${params.sessionKey}`);
+  }
+  if (params.scope === "agent") {
+    const agentId = resolveSandboxAgentId(params.sessionKey) ?? "main";
+    return formatCliCommand(`openclaw sandbox recreate --agent ${agentId}`);
+  }
+  return formatCliCommand("openclaw sandbox recreate --all");
+}
+
+function buildAppleContainerName(params: { prefix: string; scopeKey: string }): string {
+  const slug = params.scopeKey === "shared" ? "shared" : slugifySessionKey(params.scopeKey);
+  return `${params.prefix}${slug}`.slice(0, 63);
+}
+
+function buildAppleContainerCreateArgs(params: {
+  name: string;
+  cfg: SandboxDockerConfig;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  workspaceAccess: SandboxConfig["workspaceAccess"];
+  scopeKey: string;
+  createdAtMs?: number;
+  configHash?: string;
+}): string[] {
+  validateBindMounts(params.cfg.binds, {
+    allowedSourceRoots: [params.workspaceDir, params.agentWorkspaceDir],
+    allowSourcesOutsideAllowedRoots: params.cfg.dangerouslyAllowExternalBindSources === true,
+    allowReservedContainerTargets: params.cfg.dangerouslyAllowReservedContainerTargets === true,
+  });
+
+  const createdAtMs = params.createdAtMs ?? Date.now();
+  const args = ["create", "--name", params.name];
+  args.push("--label", "openclaw.sandbox=1");
+  args.push("--label", `openclaw.sessionKey=${params.scopeKey}`);
+  args.push("--label", `openclaw.createdAtMs=${createdAtMs}`);
+  if (params.configHash) {
+    args.push("--label", `openclaw.configHash=${params.configHash}`);
+  }
+  if (params.cfg.readOnlyRoot) {
+    args.push("--read-only");
+  }
+  for (const entry of params.cfg.tmpfs) {
+    args.push("--tmpfs", entry);
+  }
+  const normalizedNetwork = normalizeAppleContainerNetwork(params.cfg.network);
+  if (normalizedNetwork) {
+    args.push("--network", normalizedNetwork);
+  }
+  if (params.cfg.user) {
+    args.push("--user", params.cfg.user);
+  }
+  const envSanitization = sanitizeEnvVars(params.cfg.env ?? {});
+  for (const [key, value] of Object.entries(markOpenClawExecEnv(envSanitization.allowed))) {
+    args.push("--env", `${key}=${value}`);
+  }
+  const memory = normalizeDockerLimit(params.cfg.memory);
+  if (memory) {
+    args.push("--memory", memory);
+  }
+  if (typeof params.cfg.cpus === "number" && params.cfg.cpus > 0) {
+    args.push("--cpus", String(params.cfg.cpus));
+  }
+  for (const [name, value] of Object.entries(params.cfg.ulimits ?? {})) {
+    const formatted = formatUlimitValue(name, value);
+    if (formatted) {
+      args.push("--ulimit", formatted);
+    }
+  }
+  args.push(
+    "--volume",
+    buildVolumeSpec({
+      source: params.workspaceDir,
+      target: params.cfg.workdir,
+      readOnly: params.workspaceAccess !== "rw",
+    }),
+  );
+  if (params.workspaceAccess !== "none" && params.workspaceDir !== params.agentWorkspaceDir) {
+    args.push(
+      "--volume",
+      buildVolumeSpec({
+        source: params.agentWorkspaceDir,
+        target: SANDBOX_AGENT_WORKSPACE_MOUNT,
+        readOnly: params.workspaceAccess === "ro",
+      }),
+    );
+  }
+  for (const bind of params.cfg.binds ?? []) {
+    args.push("--volume", bind);
+  }
+  args.push("--workdir", params.cfg.workdir, params.cfg.image, "sleep", "infinity");
+  return args;
+}
+
+function normalizeAppleContainerNetwork(network: string | undefined): string | undefined {
+  const trimmed = network?.trim();
+  if (!trimmed || trimmed === "default" || trimmed === "bridge") {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function buildVolumeSpec(params: { source: string; target: string; readOnly: boolean }): string {
+  return `${params.source}:${params.target}${params.readOnly ? ":ro" : ""}`;
+}
+
+function isDefaultAppleContainerCompatCapDrop(capDrop: string[]): boolean {
+  return capDrop.length === 1 && capDrop[0] === "ALL";
+}
+
+function assertAppleContainerSupportedConfig(cfg: SandboxConfig): void {
+  if (cfg.browser.enabled) {
+    throw new Error('Sandbox backend "apple-container" does not support browser sandboxes yet.');
+  }
+  if (cfg.docker.network.startsWith("container:")) {
+    throw new Error(
+      `Sandbox backend "apple-container" does not support Docker namespace join semantics such as "${cfg.docker.network}".`,
+    );
+  }
+  if (cfg.docker.capDrop.length > 0 && !isDefaultAppleContainerCompatCapDrop(cfg.docker.capDrop)) {
+    throw new Error('Sandbox backend "apple-container" does not support sandbox.docker.capDrop.');
+  }
+  if (cfg.docker.seccompProfile) {
+    throw new Error(
+      'Sandbox backend "apple-container" does not support sandbox.docker.seccompProfile.',
+    );
+  }
+  if (cfg.docker.apparmorProfile) {
+    throw new Error(
+      'Sandbox backend "apple-container" does not support sandbox.docker.apparmorProfile.',
+    );
+  }
+  if (typeof cfg.docker.pidsLimit === "number" && cfg.docker.pidsLimit > 0) {
+    throw new Error('Sandbox backend "apple-container" does not support sandbox.docker.pidsLimit.');
+  }
+  if (cfg.docker.memorySwap !== undefined) {
+    throw new Error(
+      'Sandbox backend "apple-container" does not support sandbox.docker.memorySwap.',
+    );
+  }
+  if ((cfg.docker.extraHosts?.length ?? 0) > 0) {
+    throw new Error(
+      'Sandbox backend "apple-container" does not support sandbox.docker.extraHosts.',
+    );
+  }
+}
+
+async function createAppleContainer(params: {
+  pluginConfig: ResolvedAppleContainerPluginConfig;
+  name: string;
+  cfg: SandboxConfig;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  scopeKey: string;
+  configHash: string;
+}): Promise<void> {
+  const createArgs = buildAppleContainerCreateArgs({
+    name: params.name,
+    cfg: params.cfg.docker,
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+    workspaceAccess: params.cfg.workspaceAccess,
+    scopeKey: params.scopeKey,
+    configHash: params.configHash,
+  });
+  await runAppleContainerCli({
+    config: params.pluginConfig,
+    args: createArgs,
+  });
+  await runAppleContainerCli({
+    config: params.pluginConfig,
+    args: ["start", params.name],
+  });
+  if (params.cfg.docker.setupCommand?.trim()) {
+    await runAppleContainerCli({
+      config: params.pluginConfig,
+      args: ["exec", "-i", params.name, "/bin/sh", "-lc", params.cfg.docker.setupCommand],
+    });
+  }
+}
+
+type AppleContainerSandboxBackendImplParams = {
+  createParams: CreateSandboxBackendParams;
+  pluginConfig: ResolvedAppleContainerPluginConfig;
+  containerName: string;
+};
+
+class AppleContainerSandboxBackendImpl {
+  private ensurePromise: Promise<void> | null = null;
+
+  constructor(private readonly params: AppleContainerSandboxBackendImplParams) {}
+
+  async ensureRuntime(): Promise<void> {
+    if (this.ensurePromise) {
+      return await this.ensurePromise;
+    }
+    this.ensurePromise = this.ensureRuntimeInner();
+    try {
+      await this.ensurePromise;
+    } catch (error) {
+      this.ensurePromise = null;
+      throw error;
+    }
+  }
+
+  asHandle(): SandboxBackendHandle {
+    return {
+      id: "apple-container",
+      runtimeId: this.params.containerName,
+      runtimeLabel: this.params.containerName,
+      workdir: this.params.createParams.cfg.docker.workdir,
+      env: this.params.createParams.cfg.docker.env,
+      configLabel: this.params.createParams.cfg.docker.image,
+      configLabelKind: "Image",
+      buildExecSpec: async ({ command, workdir, env, usePty }) => {
+        await this.ensureRuntime();
+        return {
+          argv: [
+            this.params.pluginConfig.command,
+            ...buildDockerExecArgs({
+              containerName: this.params.containerName,
+              command,
+              workdir: workdir ?? this.params.createParams.cfg.docker.workdir,
+              env,
+              tty: usePty,
+            }).map((entry, index) => {
+              if (index === 0) {
+                return "exec";
+              }
+              if (entry === "-e") {
+                return "--env";
+              }
+              if (entry === "-w") {
+                return "--workdir";
+              }
+              return entry;
+            }),
+          ],
+          env: process.env,
+          stdinMode: usePty ? "pipe-open" : "pipe-closed",
+        };
+      },
+      runShellCommand: async (command) => await this.runShellCommand(command),
+    };
+  }
+
+  private async ensureRuntimeInner(): Promise<void> {
+    assertAppleContainerSupportedConfig(this.params.createParams.cfg);
+    await assertAppleContainerSystemRunning(this.params.pluginConfig);
+    const expectedHash = computeSandboxConfigHash({
+      docker: this.params.createParams.cfg.docker,
+      workspaceAccess: this.params.createParams.cfg.workspaceAccess,
+      workspaceDir: this.params.createParams.workspaceDir,
+      agentWorkspaceDir: this.params.createParams.agentWorkspaceDir,
+    });
+    const now = Date.now();
+    const inspect = await inspectAppleContainer({
+      config: this.params.pluginConfig,
+      containerId: this.params.containerName,
+    });
+    let hasContainer = Boolean(inspect?.configuration?.id);
+    let running = inspect?.status === "running";
+    let currentHash = inspect?.configuration?.labels?.["openclaw.configHash"] ?? null;
+    let hashMismatch = false;
+    let registryEntry:
+      | {
+          lastUsedAtMs: number;
+          configHash?: string;
+        }
+      | undefined;
+
+    if (hasContainer) {
+      const registry = await readRegistry();
+      registryEntry = registry.entries.find(
+        (entry) => entry.containerName === this.params.containerName,
+      );
+      currentHash = currentHash ?? registryEntry?.configHash ?? null;
+      hashMismatch = !currentHash || currentHash !== expectedHash;
+      if (hashMismatch) {
+        const lastUsedAtMs = registryEntry?.lastUsedAtMs;
+        const isHot =
+          running &&
+          (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_CONTAINER_WINDOW_MS);
+        if (isHot) {
+          const hint = formatSandboxRecreateHint({
+            scope: this.params.createParams.cfg.scope,
+            sessionKey: this.params.createParams.scopeKey,
+          });
+          defaultRuntime.log(
+            `Sandbox config changed for ${this.params.containerName} (recently used). Recreate to apply: ${hint}`,
+          );
+        } else {
+          await runAppleContainerCli({
+            config: this.params.pluginConfig,
+            args: ["delete", "--force", this.params.containerName],
+            allowFailure: true,
+          });
+          hasContainer = false;
+          running = false;
+        }
+      }
+    }
+
+    if (!hasContainer) {
+      await createAppleContainer({
+        pluginConfig: this.params.pluginConfig,
+        name: this.params.containerName,
+        cfg: this.params.createParams.cfg,
+        workspaceDir: this.params.createParams.workspaceDir,
+        agentWorkspaceDir: this.params.createParams.agentWorkspaceDir,
+        scopeKey: this.params.createParams.scopeKey,
+        configHash: expectedHash,
+      });
+    } else if (!running) {
+      await runAppleContainerCli({
+        config: this.params.pluginConfig,
+        args: ["start", this.params.containerName],
+      });
+      running = true;
+    }
+
+    await updateRegistry({
+      containerName: this.params.containerName,
+      backendId: "apple-container",
+      runtimeLabel: this.params.containerName,
+      sessionKey: this.params.createParams.scopeKey,
+      createdAtMs: now,
+      lastUsedAtMs: now,
+      image: this.params.createParams.cfg.docker.image,
+      configLabelKind: "Image",
+      configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
+    });
+  }
+
+  private async runShellCommand(
+    params: SandboxBackendCommandParams,
+  ): Promise<SandboxBackendCommandResult> {
+    await this.ensureRuntime();
+    const args = ["exec", "-i"];
+    if (this.params.createParams.cfg.docker.user) {
+      args.push("--user", this.params.createParams.cfg.docker.user);
+    }
+    if (this.params.createParams.cfg.docker.workdir) {
+      args.push("--workdir", this.params.createParams.cfg.docker.workdir);
+    }
+    args.push(
+      this.params.containerName,
+      "/bin/sh",
+      "-c",
+      params.script,
+      "openclaw-sandbox-fs",
+      ...(params.args ?? []),
+    );
+    return await runAppleContainerCli({
+      config: this.params.pluginConfig,
+      args,
+      input: params.stdin,
+      allowFailure: params.allowFailure,
+      signal: params.signal,
+    });
+  }
+}
+
+export function createAppleContainerSandboxBackendFactory(
+  params: CreateAppleContainerSandboxBackendFactoryParams,
+): SandboxBackendFactory {
+  return async (createParams) => {
+    assertAppleContainerSupportedConfig(createParams.cfg);
+    const containerName = buildAppleContainerName({
+      prefix: createParams.cfg.docker.containerPrefix,
+      scopeKey: createParams.scopeKey,
+    });
+    const impl = new AppleContainerSandboxBackendImpl({
+      createParams,
+      pluginConfig: params.pluginConfig,
+      containerName,
+    });
+    await impl.ensureRuntime();
+    return impl.asHandle();
+  };
+}
+
+export function createAppleContainerSandboxBackendManager(params: {
+  pluginConfig: ResolvedAppleContainerPluginConfig;
+}): SandboxBackendManager {
+  return {
+    async describeRuntime({ entry, config, agentId }) {
+      try {
+        const pluginConfig = resolveAppleContainerPluginConfigFromConfig(
+          config,
+          params.pluginConfig,
+        );
+        const cfg = resolveSandboxConfigForAgent(config, agentId);
+        const inspect = await inspectAppleContainer({
+          config: pluginConfig,
+          containerId: entry.containerName,
+        });
+        return {
+          running: inspect?.status === "running",
+          actualConfigLabel: inspect?.configuration?.image?.reference ?? entry.image,
+          configLabelMatch:
+            (inspect?.configuration?.image?.reference ?? entry.image) === cfg.docker.image,
+        };
+      } catch {
+        return {
+          running: false,
+          actualConfigLabel: entry.image,
+          configLabelMatch: false,
+        };
+      }
+    },
+    async removeRuntime({ entry, config }) {
+      try {
+        const pluginConfig = resolveAppleContainerPluginConfigFromConfig(
+          config,
+          params.pluginConfig,
+        );
+        await runAppleContainerCli({
+          config: pluginConfig,
+          args: ["delete", "--force", entry.containerName],
+          allowFailure: true,
+        });
+      } catch {
+        // ignore removal failures
+      }
+    },
+  };
+}
+
+function resolveAppleContainerPluginConfigFromConfig(
+  config: OpenClawConfig,
+  fallback: ResolvedAppleContainerPluginConfig,
+): ResolvedAppleContainerPluginConfig {
+  const pluginConfig = config.plugins?.entries?.["apple-container"]?.config;
+  if (!pluginConfig) {
+    return fallback;
+  }
+  return resolveAppleContainerPluginConfig(pluginConfig);
+}

--- a/extensions/apple-container/src/cli.test.ts
+++ b/extensions/apple-container/src/cli.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAppleContainerCommandMissingError,
+  createAppleContainerSystemStoppedError,
+  createAppleContainerUnsupportedHostError,
+} from "./cli.js";
+
+describe("apple-container cli errors", () => {
+  it("formats the missing command error", () => {
+    expect(createAppleContainerCommandMissingError("container").message).toContain(
+      "requires the Apple container CLI",
+    );
+  });
+
+  it("formats the unsupported host error", () => {
+    expect(createAppleContainerUnsupportedHostError().message).toContain(
+      "macOS Apple silicon hosts",
+    );
+  });
+
+  it("formats the stopped system error", () => {
+    expect(createAppleContainerSystemStoppedError("container").message).toContain(
+      "system status --format json",
+    );
+  });
+});

--- a/extensions/apple-container/src/cli.ts
+++ b/extensions/apple-container/src/cli.ts
@@ -1,0 +1,241 @@
+import { spawn } from "node:child_process";
+import type { ResolvedAppleContainerPluginConfig } from "./config.js";
+
+type AppleContainerSystemStatus = {
+  status?: string;
+};
+
+type AppleContainerResources = {
+  cpus?: number;
+  memoryInBytes?: number;
+};
+
+type AppleContainerMount = {
+  source?: string;
+  destination?: string;
+  readonly?: boolean;
+  options?: string[];
+};
+
+type AppleContainerUser = {
+  raw?: { userString?: string };
+  id?: { uid?: number; gid?: number };
+};
+
+type AppleContainerInitProcess = {
+  workingDirectory?: string;
+  environment?: string[];
+  user?: AppleContainerUser;
+  rlimits?: Array<{ type?: string; soft?: number; hard?: number }>;
+};
+
+type AppleContainerConfiguration = {
+  id?: string;
+  labels?: Record<string, string>;
+  image?: { reference?: string };
+  readOnly?: boolean;
+  mounts?: AppleContainerMount[];
+  resources?: AppleContainerResources;
+  initProcess?: AppleContainerInitProcess;
+};
+
+export type AppleContainerInspectEntry = {
+  status?: string;
+  configuration?: AppleContainerConfiguration;
+};
+
+export type RunAppleContainerCliResult = {
+  stdout: Buffer;
+  stderr: Buffer;
+  code: number;
+};
+
+type RunAppleContainerCliOptions = {
+  config: ResolvedAppleContainerPluginConfig;
+  args: string[];
+  input?: Buffer | string;
+  allowFailure?: boolean;
+  signal?: AbortSignal;
+};
+
+function createAbortError(): Error {
+  const err = new Error("Aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+export function createAppleContainerCommandMissingError(command: string): Error {
+  return Object.assign(
+    new Error(
+      `Sandbox backend "apple-container" requires the Apple container CLI, but "${command}" was not found in PATH. Install Apple's container runtime or set agents.defaults.sandbox.backend=docker.`,
+    ),
+    { code: "INVALID_CONFIG" },
+  );
+}
+
+export function createAppleContainerUnsupportedHostError(): Error {
+  return Object.assign(
+    new Error('Sandbox backend "apple-container" is supported only on macOS Apple silicon hosts.'),
+    { code: "INVALID_CONFIG" },
+  );
+}
+
+export function createAppleContainerSystemStoppedError(command: string): Error {
+  return Object.assign(
+    new Error(
+      `Sandbox backend "apple-container" requires the Apple container system to be running. Check \`${command} system status --format json\` and start it before retrying.`,
+    ),
+    { code: "INVALID_CONFIG" },
+  );
+}
+
+function createAppleContainerCommandError(
+  command: string,
+  args: string[],
+  stderr: Buffer,
+  stdout: Buffer,
+  code: number,
+): Error {
+  const detail =
+    stderr.toString("utf8").trim() || stdout.toString("utf8").trim() || `${command} failed`;
+  return Object.assign(new Error(detail || `${command} ${args.join(" ")} failed`), {
+    code,
+    stdout,
+    stderr,
+  });
+}
+
+export async function runAppleContainerCli(
+  options: RunAppleContainerCliOptions,
+): Promise<RunAppleContainerCliResult> {
+  return await new Promise<RunAppleContainerCliResult>((resolve, reject) => {
+    const child = spawn(options.config.command, options.args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
+      timeoutId = null;
+      child.kill("SIGKILL");
+    }, options.config.timeoutMs);
+    let aborted = false;
+
+    const signal = options.signal;
+    const handleAbort = () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      child.kill("SIGTERM");
+    };
+    if (signal) {
+      if (signal.aborted) {
+        handleAbort();
+      } else {
+        signal.addEventListener("abort", handleAbort);
+      }
+    }
+
+    child.stdout?.on("data", (chunk) => {
+      stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+
+    child.on("error", (error) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (signal) {
+        signal.removeEventListener("abort", handleAbort);
+      }
+      const errno = (error as NodeJS.ErrnoException).code;
+      if (errno === "ENOENT") {
+        reject(createAppleContainerCommandMissingError(options.config.command));
+        return;
+      }
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (signal) {
+        signal.removeEventListener("abort", handleAbort);
+      }
+      if (aborted || signal?.aborted) {
+        reject(createAbortError());
+        return;
+      }
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      const exitCode = code ?? 0;
+      if (exitCode !== 0 && !options.allowFailure) {
+        reject(
+          createAppleContainerCommandError(
+            options.config.command,
+            options.args,
+            stderr,
+            stdout,
+            exitCode,
+          ),
+        );
+        return;
+      }
+      resolve({ stdout, stderr, code: exitCode });
+    });
+
+    if (options.input !== undefined && child.stdin) {
+      child.stdin.end(options.input);
+    } else {
+      child.stdin?.end();
+    }
+  });
+}
+
+export async function assertAppleContainerHostSupport(): Promise<void> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw createAppleContainerUnsupportedHostError();
+  }
+}
+
+export async function assertAppleContainerSystemRunning(
+  config: ResolvedAppleContainerPluginConfig,
+): Promise<void> {
+  await assertAppleContainerHostSupport();
+  const result = await runAppleContainerCli({
+    config,
+    args: ["system", "status", "--format", "json"],
+  });
+  let parsed: AppleContainerSystemStatus | null = null;
+  try {
+    parsed = JSON.parse(result.stdout.toString("utf8")) as AppleContainerSystemStatus;
+  } catch {
+    throw createAppleContainerSystemStoppedError(config.command);
+  }
+  if (parsed?.status !== "running") {
+    throw createAppleContainerSystemStoppedError(config.command);
+  }
+}
+
+export async function inspectAppleContainer(params: {
+  config: ResolvedAppleContainerPluginConfig;
+  containerId: string;
+}): Promise<AppleContainerInspectEntry | null> {
+  const result = await runAppleContainerCli({
+    config: params.config,
+    args: ["inspect", params.containerId],
+    allowFailure: true,
+  });
+  if (result.code !== 0) {
+    return null;
+  }
+  const raw = result.stdout.toString("utf8").trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = JSON.parse(raw) as AppleContainerInspectEntry[];
+  return parsed[0] ?? null;
+}

--- a/extensions/apple-container/src/cli.ts
+++ b/extensions/apple-container/src/cli.ts
@@ -114,8 +114,10 @@ export async function runAppleContainerCli(
     });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
+    let timedOut = false;
     let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
       timeoutId = null;
+      timedOut = true;
       child.kill("SIGKILL");
     }, options.config.timeoutMs);
     let aborted = false;
@@ -165,13 +167,22 @@ export async function runAppleContainerCli(
       if (signal) {
         signal.removeEventListener("abort", handleAbort);
       }
+      if (timedOut) {
+        reject(
+          new Error(
+            `${options.config.command} ${options.args.join(" ")} timed out after ${options.config.timeoutMs}ms`,
+          ),
+        );
+        return;
+      }
       if (aborted || signal?.aborted) {
         reject(createAbortError());
         return;
       }
       const stdout = Buffer.concat(stdoutChunks);
       const stderr = Buffer.concat(stderrChunks);
-      const exitCode = code ?? 0;
+      // Treat signal-killed processes (code === null) as failure
+      const exitCode = code ?? 1;
       if (exitCode !== 0 && !options.allowFailure) {
         reject(
           createAppleContainerCommandError(
@@ -236,6 +247,10 @@ export async function inspectAppleContainer(params: {
   if (!raw) {
     return null;
   }
-  const parsed = JSON.parse(raw) as AppleContainerInspectEntry[];
-  return parsed[0] ?? null;
+  try {
+    const parsed = JSON.parse(raw) as AppleContainerInspectEntry[];
+    return parsed[0] ?? null;
+  } catch {
+    return null;
+  }
 }

--- a/extensions/apple-container/src/config.ts
+++ b/extensions/apple-container/src/config.ts
@@ -1,0 +1,111 @@
+import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk/core";
+
+export type AppleContainerPluginConfig = {
+  command?: string;
+  timeoutSeconds?: number;
+};
+
+export type ResolvedAppleContainerPluginConfig = {
+  command: string;
+  timeoutMs: number;
+};
+
+const DEFAULT_COMMAND = "container";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type ParseSuccess = { success: true; data?: AppleContainerPluginConfig };
+type ParseFailure = {
+  success: false;
+  error: {
+    issues: Array<{ path: Array<string | number>; message: string }>;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function createAppleContainerPluginConfigSchema(): OpenClawPluginConfigSchema {
+  const safeParse = (value: unknown): ParseSuccess | ParseFailure => {
+    if (value === undefined) {
+      return { success: true, data: undefined };
+    }
+    if (!isRecord(value)) {
+      return {
+        success: false,
+        error: { issues: [{ path: [], message: "expected config object" }] },
+      };
+    }
+    const allowedKeys = new Set(["command", "timeoutSeconds"]);
+    for (const key of Object.keys(value)) {
+      if (!allowedKeys.has(key)) {
+        return {
+          success: false,
+          error: { issues: [{ path: [key], message: `unknown config key: ${key}` }] },
+        };
+      }
+    }
+
+    if (
+      value.timeoutSeconds !== undefined &&
+      (typeof value.timeoutSeconds !== "number" ||
+        !Number.isFinite(value.timeoutSeconds) ||
+        value.timeoutSeconds < 1)
+    ) {
+      return {
+        success: false,
+        error: {
+          issues: [{ path: ["timeoutSeconds"], message: "timeoutSeconds must be a number >= 1" }],
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        command: trimString(value.command),
+        timeoutSeconds: value.timeoutSeconds as number | undefined,
+      },
+    };
+  };
+
+  return {
+    safeParse,
+    jsonSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        command: { type: "string" },
+        timeoutSeconds: { type: "number", minimum: 1 },
+      },
+    },
+  };
+}
+
+export function resolveAppleContainerPluginConfig(
+  value: unknown,
+): ResolvedAppleContainerPluginConfig {
+  const parsed = createAppleContainerPluginConfigSchema().safeParse?.(value);
+  if (!parsed || !parsed.success) {
+    const issues = parsed && !parsed.success ? parsed.error?.issues : undefined;
+    const message =
+      issues?.map((issue: { message: string }) => issue.message).join(", ") || "invalid config";
+    throw new Error(`Invalid apple-container plugin config: ${message}`);
+  }
+  const raw = parsed.data ?? {};
+  return {
+    command: raw.command ?? DEFAULT_COMMAND,
+    timeoutMs:
+      typeof raw.timeoutSeconds === "number"
+        ? Math.floor(raw.timeoutSeconds * 1000)
+        : DEFAULT_TIMEOUT_MS,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,8 @@ importers:
 
   extensions/anthropic: {}
 
+  extensions/apple-container: {}
+
   extensions/bluebubbles:
     dependencies:
       zod:

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -5,10 +5,12 @@ export {
   resolveSandboxPruneConfig,
   resolveSandboxScope,
 } from "./sandbox/config.js";
+export { computeSandboxConfigHash } from "./sandbox/config-hash.js";
 export {
   DEFAULT_SANDBOX_BROWSER_IMAGE,
   DEFAULT_SANDBOX_COMMON_IMAGE,
   DEFAULT_SANDBOX_IMAGE,
+  SANDBOX_AGENT_WORKSPACE_MOUNT,
 } from "./sandbox/constants.js";
 export { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
 export {
@@ -27,10 +29,18 @@ export {
   type SandboxBrowserInfo,
   type SandboxContainerInfo,
 } from "./sandbox/manage.js";
+export { readRegistry, updateRegistry } from "./sandbox/registry.js";
 export {
   formatSandboxToolPolicyBlockedMessage,
   resolveSandboxRuntimeStatus,
 } from "./sandbox/runtime-status.js";
+export { sanitizeEnvVars } from "./sandbox/sanitize-env-vars.js";
+export {
+  resolveSandboxAgentId,
+  resolveSandboxScopeKey,
+  slugifySessionKey,
+} from "./sandbox/shared.js";
+export { validateBindMounts } from "./sandbox/validate-sandbox-security.js";
 
 export { resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 export type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./sandbox/fs-bridge.js";

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -73,6 +73,42 @@ async function isDockerAvailable(): Promise<boolean> {
   }
 }
 
+function parseAppleContainerSystemStatus(stdout: string): "running" | "stopped" | null {
+  const raw = stdout.trim();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { status?: string };
+    return parsed.status === "running" ? "running" : parsed.status ? "stopped" : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getAppleContainerSystemStatus(): Promise<"running" | "unavailable" | "stopped"> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    return "unavailable";
+  }
+  try {
+    const result = await runExec("container", ["system", "status", "--format", "json"], {
+      timeoutMs: 5_000,
+    });
+    return parseAppleContainerSystemStatus(result.stdout) ?? "unavailable";
+  } catch (error) {
+    const errno = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (errno === "ENOENT") {
+      return "unavailable";
+    }
+    const stdout = (error as { stdout?: string } | undefined)?.stdout ?? "";
+    const parsed = parseAppleContainerSystemStatus(stdout);
+    if (parsed) {
+      return parsed;
+    }
+    return "unavailable";
+  }
+}
+
 async function dockerImageExists(image: string): Promise<boolean> {
   try {
     await runExec("docker", ["image", "inspect", image], { timeoutMs: 5_000 });
@@ -192,6 +228,28 @@ export async function maybeRepairSandboxImages(
   }
   const backend = resolveSandboxBackend(cfg);
   if (backend !== "docker") {
+    if (backend === "apple-container") {
+      const status = await getAppleContainerSystemStatus();
+      if (status === "unavailable") {
+        note(
+          [
+            'Sandbox backend "apple-container" selected.',
+            "It requires a macOS Apple silicon host with Apple's `container` CLI installed.",
+            "If that is not available here, switch back to Docker: openclaw config set agents.defaults.sandbox.backend docker",
+          ].join("\n"),
+          "Sandbox",
+        );
+      } else if (status === "stopped") {
+        note(
+          [
+            'Sandbox backend "apple-container" selected, but `container system` is not running.',
+            "Start Apple Containers, then re-run doctor or retry the sandboxed command.",
+            "Check status with: container system status --format json",
+          ].join("\n"),
+          "Sandbox",
+        );
+      }
+    }
     if (sandbox.browser?.enabled) {
       note(
         `Sandbox backend "${backend}" selected. Docker browser health checks are skipped; browser sandbox currently requires the docker backend.`,

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -86,12 +86,14 @@ function parseAppleContainerSystemStatus(stdout: string): "running" | "stopped" 
   }
 }
 
-async function getAppleContainerSystemStatus(): Promise<"running" | "unavailable" | "stopped"> {
+async function getAppleContainerSystemStatus(
+  command = "container",
+): Promise<"running" | "unavailable" | "stopped"> {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     return "unavailable";
   }
   try {
-    const result = await runExec("container", ["system", "status", "--format", "json"], {
+    const result = await runExec(command, ["system", "status", "--format", "json"], {
       timeoutMs: 5_000,
     });
     return parseAppleContainerSystemStatus(result.stdout) ?? "unavailable";
@@ -229,7 +231,11 @@ export async function maybeRepairSandboxImages(
   const backend = resolveSandboxBackend(cfg);
   if (backend !== "docker") {
     if (backend === "apple-container") {
-      const status = await getAppleContainerSystemStatus();
+      const appleContainerCommand =
+        (
+          cfg.plugins?.entries?.["apple-container"]?.config as { command?: string } | undefined
+        )?.command?.trim() || "container";
+      const status = await getAppleContainerSystemStatus(appleContainerCommand);
       if (status === "unavailable") {
         note(
           [

--- a/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
+++ b/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -25,6 +25,8 @@ vi.mock("../terminal/note.js", () => ({
 const { maybeRepairSandboxImages } = await import("./doctor-sandbox.js");
 
 describe("maybeRepairSandboxImages", () => {
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalArchDescriptor = Object.getOwnPropertyDescriptor(process, "arch");
   const mockRuntime: RuntimeEnv = {
     log: vi.fn(),
     error: vi.fn(),
@@ -37,14 +39,29 @@ describe("maybeRepairSandboxImages", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    Object.defineProperty(process, "arch", { value: "arm64", configurable: true });
   });
 
-  function createSandboxConfig(mode: "off" | "all" | "non-main"): OpenClawConfig {
+  afterAll(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+    if (originalArchDescriptor) {
+      Object.defineProperty(process, "arch", originalArchDescriptor);
+    }
+  });
+
+  function createSandboxConfig(
+    mode: "off" | "all" | "non-main",
+    backend: "docker" | "apple-container" = "docker",
+  ): OpenClawConfig {
     return {
       agents: {
         defaults: {
           sandbox: {
             mode,
+            backend,
           },
         },
       },
@@ -104,5 +121,47 @@ describe("maybeRepairSandboxImages", () => {
         typeof call[0] === "string" && call[0].toLowerCase().includes("docker not available"),
     );
     expect(dockerUnavailableWarning).toBeUndefined();
+  });
+
+  it("warns when apple-container is installed but not running", async () => {
+    runExec.mockRejectedValue(
+      Object.assign(new Error("apiserver is not running"), {
+        stdout: JSON.stringify({ status: "not running" }),
+        stderr: "",
+        code: 1,
+      }),
+    );
+
+    await maybeRepairSandboxImages(
+      createSandboxConfig("all", "apple-container"),
+      mockRuntime,
+      mockPrompter,
+    );
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Sandbox backend "apple-container" selected, but `container system` is not running.',
+      ),
+      "Sandbox",
+    );
+  });
+
+  it("warns when apple-container CLI is unavailable", async () => {
+    runExec.mockRejectedValue(
+      Object.assign(new Error("container not found"), {
+        code: "ENOENT",
+      }),
+    );
+
+    await maybeRepairSandboxImages(
+      createSandboxConfig("all", "apple-container"),
+      mockRuntime,
+      mockPrompter,
+    );
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining('Sandbox backend "apple-container" selected.'),
+      "Sandbox",
+    );
   });
 });

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -13,7 +13,9 @@ export type {
   SandboxBackendManager,
   SandboxBackendRegistration,
   SandboxBackendRuntimeInfo,
+  SandboxConfig,
   SandboxContext,
+  SandboxDockerConfig,
   SandboxResolvedPath,
   SandboxSshConfig,
   SshSandboxSession,
@@ -25,18 +27,32 @@ export {
   buildExecRemoteCommand,
   buildRemoteCommand,
   buildSshSandboxArgv,
+  computeSandboxConfigHash,
   createRemoteShellSandboxFsBridge,
   createSshSandboxSessionFromConfigText,
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
   getSandboxBackendFactory,
   getSandboxBackendManager,
+  readRegistry,
   registerSandboxBackend,
   requireSandboxBackendFactory,
+  resolveSandboxAgentId,
+  resolveSandboxConfigForAgent,
+  resolveSandboxScopeKey,
   runSshSandboxCommand,
+  SANDBOX_AGENT_WORKSPACE_MOUNT,
+  sanitizeEnvVars,
   shellEscape,
+  slugifySessionKey,
+  updateRegistry,
   uploadDirectoryToSshTarget,
+  validateBindMounts,
 } from "../agents/sandbox.js";
+
+export { formatCliCommand } from "../cli/command-format.js";
+export { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+export { defaultRuntime } from "../runtime.js";
 
 export {
   runPluginCommandWithTimeout,


### PR DESCRIPTION
## Summary

Adds an Apple container sandbox backend as an opt-in plugin extension, allowing macOS 26+ Apple silicon hosts to run sandboxed agent exec and file tools without Docker Desktop.

- **Why**: Mac Mini/Studio servers and CI hosts increasingly run always-on agents. Docker Desktop requires a paid license for commercial use (250+ employees / $10M+ revenue) and adds persistent daemon overhead. Apple Containers ship free with macOS 26, give per-container VM isolation (stronger than Docker's shared-kernel model), and are a native macOS citizen with no extra app to manage.
- **What changed**: new `extensions/apple-container/` plugin with backend factory, manager, CLI wrapper, config schema, unit tests, and 6 e2e tests. Doctor integration checks Apple container system status. Docs updated across sandbox, configuration reference, and testing guides.
- **Scope boundary**: exec and file tools only. Browser sandbox is explicitly unsupported. Docker remains the default backend. The sandbox Linux limitation (no macOS-native API access like iMessage/Shortcuts) is shared with Docker and documented as such.

## Change Type

- [x] New feature

## Scope

- [x] Gateway
- [x] Agents (sandbox)

## Linked Issue/PR

Related to #12405 (pluggable sandbox backends). Prior attempt #17805 was closed as `dirty`; #19229 (clean reopen) is stale. This branch is a clean 3-commit implementation using the plugin SDK boundary.

## User-visible / Behavior Changes

- New `backend: "apple-container"` option for `agents.defaults.sandbox.backend`
- New plugin config at `plugins.entries.apple-container.config` (`command`, `timeoutSeconds`)
- `openclaw doctor` checks Apple container system availability when this backend is selected
- No behavior change for existing users (Docker remains default)

## Security Impact

- [x] Changes exec surface: agent tools run in per-container lightweight VMs via Virtualization.framework (stronger isolation than Docker's shared-kernel namespace model)
- [ ] Changes permissions model
- [ ] Changes secret handling
- [ ] Changes network calls
- [ ] Changes data access

## Repro + Verification

```bash
# Requires macOS 26+ Apple silicon with container CLI
container system status --format json  # must report "running"

# Run e2e tests
OPENCLAW_E2E_APPLE_CONTAINER=1 pnpm vitest run --config vitest.e2e.config.ts extensions/apple-container/src/backend.e2e.test.ts
```

## Evidence

6/6 e2e tests passing on Apple silicon:
- Container lifecycle (create/start/exec/delete)
- File write through exec verified on host via bind mount
- Inspect returns status + labels
- `--network none` blocks outbound connectivity
- Inspect returns null for nonexistent containers
- Delete + verify gone

## Human Verification

- [x] All 6 e2e tests run against real Apple container runtime
- [x] Unit tests cover browser rejection, exec argv construction, network passthrough, manager describe/remove
- [x] Doctor integration verified for unavailable/stopped states
- [ ] Not verified: interaction with per-agent sandbox scope overrides (unit-tested only)
- [ ] Not verified: long-running container stability under load

## Compatibility / Migration

- Fully backward compatible; no config migration needed
- Docker backend behavior unchanged
- New config keys are additive and opt-in

## Risks and Mitigations

- **SDK surface expansion**: plugin imports 12+ helpers from `openclaw/plugin-sdk/sandbox`. This is the same set of functions the Docker backend uses internally. Open to discussion on whether these should be narrowed.
- **macOS 26 only**: gated by platform + arch checks; graceful errors on unsupported hosts.
- **No CI coverage**: GitHub Actions runners are x86 Linux. E2e tests are gated behind `OPENCLAW_E2E_APPLE_CONTAINER=1`, same pattern as OpenShell e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)