### PR TITLE
fix(azure): include azure-openai-responses in reasoning block downgrade

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -564,7 +564,9 @@ export async function sanitizeSessionHistory(params: {
   );
 
   const isOpenAIResponsesApi =
-    params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses" ||
+    params.modelApi === "azure-openai-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
   const priorSnapshot = hasSnapshot ? readLastModelSnapshot(params.sessionManager) : null;
   const modelChanged = priorSnapshot


### PR DESCRIPTION
lobster-biscuit

Closes #49167

## Problem

Azure OpenAI users hit `400 Bad Request` errors ("required following item") when conversation history contains reasoning blocks from prior turns.

`downgradeOpenAIReasoningBlocks()` strips orphan reasoning items before sending to the Responses API, but the guard only checks for `openai-responses` and `openai-codex-responses` — it misses `azure-openai-responses`. So reasoning blocks survive in the history and Azure rejects them.

## Solution

Add `azure-openai-responses` to the `isOpenAIResponsesApi` check in `google.ts:566-567`.

This is consistent with `openai-stream-wrappers.ts:12` which already includes `azure-openai-responses` in `OPENAI_RESPONSES_PROVIDERS`.

## Changes

- `src/agents/pi-embedded-runner/google.ts` — add `azure-openai-responses` to the modelApi check (+2 lines)

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Azure OpenAI reasoning model no longer returns 400 on multi-turn conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)