### PR TITLE
fix(memory): add voyage-4-large to VOYAGE_MAX_INPUT_TOKENS

### DIFF
--- a/src/memory/embeddings-voyage.ts
+++ b/src/memory/embeddings-voyage.ts
@@ -17,6 +17,7 @@ const VOYAGE_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage-3": 32000,
   "voyage-3-lite": 16000,
   "voyage-code-3": 32000,
+  "voyage-4-large": 128000,
 };
 
 export function normalizeVoyageModel(model: string): string {


### PR DESCRIPTION
lobster-biscuit

## Problem

The default Voyage embedding model `voyage-4-large` (set at line 14) is missing from the `VOYAGE_MAX_INPUT_TOKENS` lookup table (lines 16-20). When the lookup returns `undefined`, the token limit falls through to the generic 8192-byte fallback from `embedding-model-limits.ts` instead of the correct 128K tokens.

This means all users on the default embedding model get silently truncated embeddings — chunks are split at ~8KB instead of 128KB, degrading retrieval quality.

## Solution

Add `"voyage-4-large": 128000` to the lookup table. One line.

The 128K limit is per [Voyage API docs](https://docs.voyageai.com/docs/embeddings).

## Changes

- `src/memory/embeddings-voyage.ts` — add voyage-4-large entry (+1 line)

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Voyage embedding uses correct 128K token limit instead of 8192 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)