### PR TITLE
fix(memory): add gemini-embedding-001 to GEMINI_MAX_INPUT_TOKENS

### DIFF
--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -26,6 +26,7 @@ const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1bet
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
 const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
   "text-embedding-004": 2048,
+  "gemini-embedding-001": 3072,
 };
 
 // --- gemini-embedding-2-preview support ---


### PR DESCRIPTION
lobster-biscuit

## Problem

The default Gemini embedding model `gemini-embedding-001` (set at line 26) is missing from the `GEMINI_MAX_INPUT_TOKENS` lookup table (lines 27-29). The token limit falls through to the `text-embedding-004` fallback of 2048 tokens instead of the correct 3072, silently truncating embeddings.

## Solution

Add `"gemini-embedding-001": 3072` to the lookup table. One line.

The 3072 limit is per [Gemini API docs](https://ai.google.dev/gemini-api/docs/models#gemini-embedding).

## Changes

- `src/memory/embeddings-gemini.ts` — add gemini-embedding-001 entry (+1 line)

## Test plan

- [x] TypeScript compiles
- [x] oxlint passes
- [ ] Gemini embedding uses correct 3072 token limit instead of 2048 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)