### PR TITLE
Discord: handle channel rename and icon change system events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
+- Discord/system events: handle channel/thread rename, icon change, and channel follow system messages so they no longer trigger unwanted agent responses. (#24108)
 
 ## 2026.3.13
 

--- a/extensions/discord/src/monitor/system-events.ts
+++ b/extensions/discord/src/monitor/system-events.ts
@@ -9,6 +9,10 @@ export function resolveDiscordSystemEvent(message: Message, location: string): s
       return buildDiscordSystemEvent(message, location, "added a recipient");
     case MessageType.RecipientRemove:
       return buildDiscordSystemEvent(message, location, "removed a recipient");
+    case MessageType.ChannelNameChange:
+      return buildDiscordSystemEvent(message, location, "changed channel/thread name");
+    case MessageType.ChannelIconChange:
+      return buildDiscordSystemEvent(message, location, "changed channel icon");
     case MessageType.UserJoin:
       return buildDiscordSystemEvent(message, location, "user joined");
     case MessageType.GuildBoost:
@@ -19,6 +23,8 @@ export function resolveDiscordSystemEvent(message: Message, location: string): s
       return buildDiscordSystemEvent(message, location, "boosted the server (Tier 2 reached)");
     case MessageType.GuildBoostTier3:
       return buildDiscordSystemEvent(message, location, "boosted the server (Tier 3 reached)");
+    case MessageType.ChannelFollowAdd:
+      return buildDiscordSystemEvent(message, location, "added a channel follow");
     case MessageType.ThreadCreated:
       return buildDiscordSystemEvent(message, location, "created a thread");
     case MessageType.AutoModerationAction:


### PR DESCRIPTION
## Summary

- Problem: When a Discord thread/channel is renamed, Discord sends a `ChannelNameChange` (type 4) system message. This falls through `resolveDiscordSystemEvent()` to `default: return null`, causing the monitor to treat it as a regular user message and triggering an unwanted agent response. Same for `ChannelIconChange` (type 5) and `ChannelFollowAdd` (type 12).
- Why it matters: Users see unexpected bot replies every time a thread or channel is renamed, an icon is changed, or a channel follow is added.
- What changed: Added three new `case` branches in the `resolveDiscordSystemEvent` switch for `ChannelNameChange`, `ChannelIconChange`, and `ChannelFollowAdd`, returning descriptive system-event strings so they are handled like other system events instead of falling through to null.
- What did NOT change (scope boundary): No other system event types, no monitor logic, no other channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24108

## User-visible / Behavior Changes

Discord channel/thread renames, icon changes, and channel follows no longer trigger unwanted agent responses. These are now logged as system events, consistent with other Discord system message types.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel (if any): Discord

### Steps

1. Connect OpenClaw to a Discord server
2. Rename a thread or channel in a monitored guild
3. Observe that the bot no longer sends an agent response to the rename system message

### Expected

- No agent response triggered by channel/thread rename, icon change, or channel follow system messages

### Actual

- Previously, these system messages fell through to `default: return null` and were treated as regular user messages, triggering agent responses

## Evidence

- [x] Trace/log snippets
- Verified all three `MessageType` enum values exist in `@buape/carbon`: `ChannelNameChange` (4), `ChannelIconChange` (5), `ChannelFollowAdd` (12)
- Existing switch structure handles all other Discord system event types identically

## Human Verification (required)

- Verified scenarios: Confirmed enum values resolve correctly via `bun -e "import { MessageType } from '@buape/carbon'; console.log(MessageType.ChannelNameChange, MessageType.ChannelIconChange, MessageType.ChannelFollowAdd);"` → `4 5 12`
- Edge cases checked: Other system event types unaffected; default null fallback still applies to unhandled types
- What you did **not** verify: Live Discord server rename event (no test server available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the three new `case` branches in `extensions/discord/src/monitor/system-events.ts`
- Files/config to restore: `extensions/discord/src/monitor/system-events.ts`
- Known bad symptoms reviewers should watch for: None expected; worst case is reverting to the previous behavior of triggering agent responses on these system messages

## Risks and Mitigations

None