### PR TITLE
fix: keep tui busy during follow-up waits

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -575,6 +575,28 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
 
+  it("shows awaiting follow-up when a final assistant message contains the sessions_yield marker", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-yield" },
+    });
+
+    handleChatEvent({
+      runId: "run-yield",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        content: [
+          {
+            type: "text",
+            text: "Waiting for child completion.\n\n[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]",
+          },
+        ],
+      },
+    });
+
+    expect(setActivityStatus).toHaveBeenCalledWith("awaiting follow-up");
+  });
+
   it("reloads history when a local run ends without a displayable final message", () => {
     const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-local-silent" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -3,6 +3,9 @@ import { asString, extractTextFromMessage, isCommandMessage } from "./tui-format
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, BtwEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
+const SESSIONS_YIELD_CONTEXT_MARKER =
+  "[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]";
+
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
   updateToolResult: (
@@ -119,7 +122,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const finalizeRun = (params: {
     runId: string;
     wasActiveRun: boolean;
-    status: "idle" | "error";
+    status: "idle" | "error" | "awaiting follow-up";
   }) => {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
@@ -262,6 +265,8 @@ export function createEventHandlers(context: EventHandlerContext) {
         state.showThinking,
         evt.errorMessage,
       );
+      const yieldedForFollowUp =
+        typeof finalText === "string" && finalText.includes(SESSIONS_YIELD_CONTEXT_MARKER);
       const suppressEmptyExternalPlaceholder =
         finalText === "(no output)" && !isLocalRunId?.(evt.runId);
       if (suppressEmptyExternalPlaceholder) {
@@ -272,7 +277,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       finalizeRun({
         runId: evt.runId,
         wasActiveRun,
-        status: stopReason === "error" ? "error" : "idle",
+        status:
+          stopReason === "error" ? "error" : yieldedForFollowUp ? "awaiting follow-up" : "idle",
       });
     }
     if (evt.state === "aborted") {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -281,4 +281,145 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.updatedAt).toBe(50);
     expect(btw.clear).toHaveBeenCalled();
   });
+
+  it("restores awaiting follow-up from history when the last assistant message contains the sessions_yield marker", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-3",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Waiting for child completion.\n\n[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]",
+            },
+          ],
+        },
+      ],
+    });
+    const setActivityStatus = vi.fn();
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: runLoadHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+        addUser: vi.fn(),
+        finalizeAssistant: vi.fn(),
+        startTool: vi.fn(() => ({ setResult: vi.fn() })),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus,
+    });
+
+    await runLoadHistory();
+
+    expect(setActivityStatus).toHaveBeenCalledWith("awaiting follow-up");
+  });
+
+  it("clears stale awaiting follow-up status when history no longer contains the marker", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-4",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "All done." }],
+        },
+      ],
+    });
+    const setActivityStatus = vi.fn();
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "awaiting follow-up",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: runLoadHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+        addUser: vi.fn(),
+        finalizeAssistant: vi.fn(),
+        startTool: vi.fn(() => ({ setResult: vi.fn() })),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus,
+    });
+
+    await runLoadHistory();
+
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
 });

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -10,6 +10,16 @@ import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
+const SESSIONS_YIELD_CONTEXT_MARKER =
+  "[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]";
+const BUSY_ACTIVITY_STATUSES = new Set([
+  "sending",
+  "waiting",
+  "streaming",
+  "running",
+  "awaiting follow-up",
+]);
+
 type SessionActionBtwPresenter = {
   clear: () => void;
 };
@@ -303,6 +313,7 @@ export function createSessionActions(context: SessionActionContext) {
       state.sessionInfo.fastMode = record.fastMode ?? state.sessionInfo.fastMode;
       state.sessionInfo.verboseLevel = record.verboseLevel ?? state.sessionInfo.verboseLevel;
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
+      let lastAssistantText = "";
       chatLog.clearAll();
       btw.clear();
       chatLog.addSystem(`session ${state.currentSessionKey}`);
@@ -330,6 +341,7 @@ export function createSessionActions(context: SessionActionContext) {
             includeThinking: state.showThinking,
           });
           if (text) {
+            lastAssistantText = text;
             chatLog.finalizeAssistant(text);
           }
           continue;
@@ -354,6 +366,13 @@ export function createSessionActions(context: SessionActionContext) {
             { isError: Boolean(message.isError) },
           );
         }
+      }
+      if (lastAssistantText.includes(SESSIONS_YIELD_CONTEXT_MARKER)) {
+        if (!BUSY_ACTIVITY_STATUSES.has(state.activityStatus)) {
+          setActivityStatus("awaiting follow-up");
+        }
+      } else if (state.activityStatus === "awaiting follow-up") {
+        setActivityStatus("idle");
       }
       state.historyLoaded = true;
     } catch (err) {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -599,7 +599,7 @@ export async function runTui(opts: TuiOptions) {
     );
   };
 
-  const busyStates = new Set(["sending", "waiting", "streaming", "running"]);
+  const busyStates = new Set(["sending", "waiting", "streaming", "running", "awaiting follow-up"]);
   let statusText: Text | null = null;
   let statusLoader: Loader | null = null;
 
@@ -660,6 +660,11 @@ export async function runTui(opts: TuiOptions) {
           phrases: waitingPhrase ? [waitingPhrase] : undefined,
         }),
       );
+      return;
+    }
+
+    if (activityStatus === "awaiting follow-up") {
+      statusLoader.setMessage(`awaiting follow-up event • ${elapsed} | ${connectionStatus}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

Keep the TUI visibly busy while a run is waiting on a follow-up event after `sessions_yield`.

Before this change, the TUI could appear idle even though work was still effectively in flight. The gap showed up when the final assistant message contained the `sessions_yield` follow-up context marker: the run had ended intentionally, but the UI status dropped back to an idle-looking state.

## What changed

- add `awaiting follow-up` as a busy TUI activity state
- detect the `sessions_yield` follow-up marker in final assistant output
- preserve `awaiting follow-up` when reloading session history
- clear stale `awaiting follow-up` state back to `idle` when history no longer contains the marker
- add focused tests for both live event handling and history restore behavior

## Files

- `src/tui/tui.ts`
- `src/tui/tui-event-handlers.ts`
- `src/tui/tui-session-actions.ts`
- `src/tui/tui-event-handlers.test.ts`
- `src/tui/tui-session-actions.test.ts`

## Validation

- direct smoke harness passed for:
  - final event -> `awaiting follow-up`
  - history restore -> `awaiting follow-up`
  - stale follow-up state -> `idle`
- local lint/format checks passed on the touched files

## Notes

A focused local Vitest run hit a Node internal assertion in this environment, so the behavior was additionally checked with a direct harness against the patched TUI logic.