### PR TITLE
doctor: suppress transient memory probe timeout warning [AI-assisted]

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -7,7 +7,6 @@ import {
   buildBootstrapTruncationReportMeta,
   buildBootstrapTruncationSignature,
   formatBootstrapTruncationWarningLines,
-  prependBootstrapPromptWarning,
   resolveBootstrapWarningSignaturesSeen,
 } from "./bootstrap-budget.js";
 import { buildAgentSystemPrompt } from "./system-prompt.js";

--- a/src/agents/prompt-composition-scenarios.ts
+++ b/src/agents/prompt-composition-scenarios.ts
@@ -9,7 +9,6 @@ import {
   appendBootstrapPromptWarning,
   analyzeBootstrapBudget,
   buildBootstrapPromptWarning,
-  type BootstrapBudgetAnalysis,
 } from "./bootstrap-budget.js";
 import { buildAgentSystemPrompt } from "./system-prompt.js";
 import { buildToolSummaryMap } from "./tool-summaries.js";

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -103,6 +103,24 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("does not warn when local provider probe is unavailable due to gateway timeout", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: true,
+        ready: false,
+        error: "gateway memory probe unavailable: gateway timeout after 3000ms",
+      },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not warn when local provider has an explicit hf: modelPath", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -121,6 +121,27 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("still warns when local provider probe is unavailable because the gateway is too old", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: true,
+        ready: false,
+        error: "gateway memory probe unavailable: unknown method: doctor.memory.status",
+      },
+    });
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("gateway reports local embeddings are not ready");
+    expect(message).toContain("unknown method: doctor.memory.status");
+  });
+
   it("does not warn when local provider has an explicit hf: modelPath", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -121,6 +121,27 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("does not warn when local provider probe timeout includes multiline connection details", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: true,
+        ready: false,
+        error: [
+          "gateway memory probe unavailable: gateway timeout after 3000ms",
+          "Gateway target: ws://127.0.0.1:8765",
+        ].join("\n"),
+      },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("still warns when local provider probe is unavailable because the gateway is too old", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -48,7 +48,11 @@ export async function noteMemorySearchHealth(
         // Model path looks valid (explicit file, hf: URL, or default model).
         // If a gateway probe is available and reports not-ready, warn anyway —
         // the model download or node-llama-cpp setup may have failed at runtime.
-        if (opts?.gatewayMemoryProbe?.checked && !opts.gatewayMemoryProbe.ready) {
+        if (
+          opts?.gatewayMemoryProbe?.checked &&
+          !opts.gatewayMemoryProbe.ready &&
+          !isTransientGatewayMemoryProbeUnavailable(opts.gatewayMemoryProbe)
+        ) {
           const detail = opts.gatewayMemoryProbe.error?.trim();
           note(
             [
@@ -230,4 +234,17 @@ function buildGatewayProbeWarning(
   return detail
     ? `Gateway memory probe for default agent is not ready: ${detail}`
     : "Gateway memory probe for default agent is not ready.";
+}
+
+function isTransientGatewayMemoryProbeUnavailable(
+  probe:
+    | {
+        checked: boolean;
+        ready: boolean;
+        error?: string;
+      }
+    | undefined,
+): boolean {
+  const detail = probe?.error?.trim();
+  return Boolean(detail && /^gateway memory probe unavailable:/i.test(detail));
 }

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -248,6 +248,9 @@ function extractGatewayMemoryProbeUnavailableDetail(
   if (!detail) {
     return null;
   }
-  const match = /^gateway memory probe unavailable:\s*(.+)$/i.exec(detail);
-  return match?.[1]?.trim() || null;
+  const prefix = /^gateway memory probe unavailable:\s*/i;
+  if (!prefix.test(detail)) {
+    return null;
+  }
+  return detail.replace(prefix, "").trim() || null;
 }

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -218,15 +218,13 @@ function providerEnvVar(provider: string): string {
   }
 }
 
-function buildGatewayProbeWarning(
-  probe:
-    | {
-        checked: boolean;
-        ready: boolean;
-        error?: string;
-      }
-    | undefined,
-): string | null {
+type GatewayMemoryProbe = {
+  checked: boolean;
+  ready: boolean;
+  error?: string;
+};
+
+function buildGatewayProbeWarning(probe: GatewayMemoryProbe | undefined): string | null {
   if (!probe?.checked || probe.ready) {
     return null;
   }
@@ -236,15 +234,7 @@ function buildGatewayProbeWarning(
     : "Gateway memory probe for default agent is not ready.";
 }
 
-function isTransientGatewayMemoryProbeUnavailable(
-  probe:
-    | {
-        checked: boolean;
-        ready: boolean;
-        error?: string;
-      }
-    | undefined,
-): boolean {
+function isTransientGatewayMemoryProbeUnavailable(probe: GatewayMemoryProbe | undefined): boolean {
   const detail = probe?.error?.trim();
   return Boolean(detail && /^gateway memory probe unavailable:/i.test(detail));
 }

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -9,6 +9,7 @@ import { DEFAULT_LOCAL_MODEL } from "../memory/embeddings.js";
 import { hasConfiguredMemorySecretInput } from "../memory/secret-input.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
+import type { GatewayMemoryProbe } from "./doctor-gateway-health.js";
 
 /**
  * Check whether memory search has a usable embedding provider.
@@ -17,11 +18,7 @@ import { resolveUserPath } from "../utils.js";
 export async function noteMemorySearchHealth(
   cfg: OpenClawConfig,
   opts?: {
-    gatewayMemoryProbe?: {
-      checked: boolean;
-      ready: boolean;
-      error?: string;
-    };
+    gatewayMemoryProbe?: GatewayMemoryProbe;
   },
 ): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
@@ -218,12 +215,6 @@ function providerEnvVar(provider: string): string {
   }
 }
 
-type GatewayMemoryProbe = {
-  checked: boolean;
-  ready: boolean;
-  error?: string;
-};
-
 function buildGatewayProbeWarning(probe: GatewayMemoryProbe | undefined): string | null {
   if (!probe?.checked || probe.ready) {
     return null;
@@ -235,6 +226,28 @@ function buildGatewayProbeWarning(probe: GatewayMemoryProbe | undefined): string
 }
 
 function isTransientGatewayMemoryProbeUnavailable(probe: GatewayMemoryProbe | undefined): boolean {
+  const detail = extractGatewayMemoryProbeUnavailableDetail(probe);
+  return Boolean(
+    detail &&
+    [
+      /\btimeout\b/i,
+      /\btimed out\b/i,
+      /\bETIMEDOUT\b/i,
+      /\bECONNRESET\b/i,
+      /\bECONNREFUSED\b/i,
+      /\bEPIPE\b/i,
+      /fetch failed/i,
+    ].some((pattern) => pattern.test(detail)),
+  );
+}
+
+function extractGatewayMemoryProbeUnavailableDetail(
+  probe: GatewayMemoryProbe | undefined,
+): string | null {
   const detail = probe?.error?.trim();
-  return Boolean(detail && /^gateway memory probe unavailable:/i.test(detail));
+  if (!detail) {
+    return null;
+  }
+  const match = /^gateway memory probe unavailable:\s*(.+)$/i.exec(detail);
+  return match?.[1]?.trim() || null;
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` treats a gateway memory probe transport failure (`gateway memory probe unavailable: ...`) as proof that explicit local embeddings are not ready.
- Why it matters: this produces a false warning even when `openclaw memory status --deep` can report embeddings as ready.
- What changed: the explicit `provider: "local"` doctor path now ignores transient gateway probe-unavailable errors while still warning on concrete local readiness failures.
- What did NOT change (scope boundary): remote-provider checks, missing-key warnings, and concrete local probe failures (for example `node-llama-cpp not installed`) still warn exactly as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44426
- Related #44426

## User-visible / Behavior Changes

- `openclaw doctor` no longer emits the local-embeddings-not-ready warning when the only failure signal is a transient gateway memory probe timeout/unavailable error.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: local repo checkout
- Model/provider: not exercised live for this patch
- Integration/channel (if any): gateway doctor memory probe path
- Relevant config (redacted): explicit `agents.defaults.memorySearch.provider=local`

### Steps

1. Configure memory search to use the explicit local provider.
2. Run the doctor memory health path with a gateway probe result shaped like `gateway memory probe unavailable: gateway timeout after 3000ms`.
3. Confirm doctor does not emit the false local-embeddings-not-ready warning.
4. Confirm concrete readiness failures still warn.

### Expected

- Transient probe transport failures do not produce a false local embeddings readiness warning.
- Concrete local probe failures still produce the warning.

### Actual

- Verified by regression test after the patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `npm exec --yes pnpm@10.23.0 -- vitest run src/commands/doctor-memory-search.test.ts`
  - `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts`
  - `npm exec --yes pnpm@10.23.0 -- exec oxlint src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts`
- Edge cases checked:
  - concrete local probe failures still warn
  - ready probe still stays silent
- What you did **not** verify:
  - I did not reproduce this against a live local embeddings gateway on the issue reporter's environment.

Additional verification attempted:

- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`
  - `build` passed
  - `check` failed on unrelated current upstream lint in untouched files:
    - `src/agents/bootstrap-budget.test.ts`
    - `src/agents/prompt-composition-scenarios.ts`
- `npm exec --yes pnpm@10.23.0 -- test`
  - surfaced unrelated current upstream failures outside this change, including:
    - `src/plugins/contracts/runtime.contract.test.ts`
    - `src/memory/embeddings-gemini.test.ts`
    - `src/plugin-sdk/channel-import-guardrails.test.ts`
- `codex review --base origin/main`
  - attempted, but it failed in this environment due transport/network errors before producing a review

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; behavior falls back to the prior doctor warning logic.
- Files/config to restore: `src/commands/doctor-memory-search.ts`, `src/commands/doctor-memory-search.test.ts`
- Known bad symptoms reviewers should watch for: concrete local memory readiness failures being accidentally suppressed.

## Risks and Mitigations

- Risk: the transient-error matcher could hide a real local readiness issue if it is mislabeled as `gateway memory probe unavailable`.
  - Mitigation: the suppression is narrowly scoped to that exact transport/unavailable prefix; concrete readiness errors still warn and the regression test covers the intended timeout case.

AI-assisted: prepared with Codex in a supervised local coding session.
