### PR TITLE
feat(tools): add Exa as native web search provider extension

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,5 +1,5 @@
 ---
-summary: "Web search + fetch tools (Brave, Firecrawl, Gemini, Grok, Kimi, and Perplexity providers)"
+summary: "Web search + fetch tools (Brave, Exa, Firecrawl, Gemini, Grok, Kimi, and Perplexity providers)"
 read_when:
   - You want to enable web_search or web_fetch
   - You need provider API key setup
@@ -11,7 +11,7 @@ title: "Web Tools"
 
 OpenClaw ships two lightweight web tools:
 
-- `web_search` — Search the web using Brave Search API, Firecrawl Search, Gemini with Google Search grounding, Grok, Kimi, or Perplexity Search API.
+- `web_search` — Search the web using Brave Search API, Exa, Firecrawl Search, Gemini with Google Search grounding, Grok, Kimi, or Perplexity Search API.
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -33,6 +33,7 @@ See [Brave Search setup](/brave-search) and [Perplexity Search setup](/perplexit
 | Provider                  | Result shape                       | Provider-specific filters                                    | Notes                                                                          | API key                                     |
 | ------------------------- | ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------- |
 | **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time                       | Supports Brave `llm-context` mode                                              | `BRAVE_API_KEY`                             |
+| **Exa**                   | Structured results with snippets   | `type` (neural/keyword/auto), `contents`, time               | Neural search, highlights, text extraction                                     | `EXA_API_KEY`                               |
 | **Firecrawl Search**      | Structured results with snippets   | Use `firecrawl_search` for Firecrawl-specific search options | Best for pairing search with Firecrawl scraping/extraction                     | `FIRECRAWL_API_KEY`                         |
 | **Gemini**                | AI-synthesized answers + citations | —                                                            | Uses Google Search grounding                                                   | `GEMINI_API_KEY`                            |
 | **Grok**                  | AI-synthesized answers + citations | —                                                            | Uses xAI web-grounded responses                                                | `XAI_API_KEY`                               |
@@ -44,11 +45,12 @@ See [Brave Search setup](/brave-search) and [Perplexity Search setup](/perplexit
 The table above is alphabetical. If no `provider` is explicitly set, runtime auto-detection checks providers in this order:
 
 1. **Brave** — `BRAVE_API_KEY` env var or `plugins.entries.brave.config.webSearch.apiKey`
-2. **Gemini** — `GEMINI_API_KEY` env var or `plugins.entries.google.config.webSearch.apiKey`
-3. **Grok** — `XAI_API_KEY` env var or `plugins.entries.xai.config.webSearch.apiKey`
-4. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `plugins.entries.moonshot.config.webSearch.apiKey`
-5. **Perplexity** — `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `plugins.entries.perplexity.config.webSearch.apiKey`
-6. **Firecrawl** — `FIRECRAWL_API_KEY` env var or `plugins.entries.firecrawl.config.webSearch.apiKey`
+2. **Exa** — `EXA_API_KEY` env var or `plugins.entries.exa.config.webSearch.apiKey`
+3. **Gemini** — `GEMINI_API_KEY` env var or `plugins.entries.google.config.webSearch.apiKey`
+4. **Grok** — `XAI_API_KEY` env var or `plugins.entries.xai.config.webSearch.apiKey`
+5. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `plugins.entries.moonshot.config.webSearch.apiKey`
+6. **Perplexity** — `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `plugins.entries.perplexity.config.webSearch.apiKey`
+7. **Firecrawl** — `FIRECRAWL_API_KEY` env var or `plugins.entries.firecrawl.config.webSearch.apiKey`
 
 If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
 
@@ -92,6 +94,7 @@ See [Perplexity Search API Docs](https://docs.perplexity.ai/guides/search-quicks
 **Via config:** run `openclaw configure --section web`. It stores the key under the provider-specific config path:
 
 - Brave: `plugins.entries.brave.config.webSearch.apiKey`
+- Exa: `plugins.entries.exa.config.webSearch.apiKey`
 - Firecrawl: `plugins.entries.firecrawl.config.webSearch.apiKey`
 - Gemini: `plugins.entries.google.config.webSearch.apiKey`
 - Grok: `plugins.entries.xai.config.webSearch.apiKey`
@@ -103,6 +106,7 @@ All of these fields also support SecretRef objects.
 **Via environment:** set provider env vars in the Gateway process environment:
 
 - Brave: `BRAVE_API_KEY`
+- Exa: `EXA_API_KEY`
 - Firecrawl: `FIRECRAWL_API_KEY`
 - Gemini: `GEMINI_API_KEY`
 - Grok: `XAI_API_KEY`
@@ -138,6 +142,34 @@ For a gateway install, put these in `~/.openclaw/.env` (or your service environm
   },
 }
 ```
+
+**Exa Search:**
+
+```json5
+{
+  plugins: {
+    entries: {
+      exa: {
+        config: {
+          webSearch: {
+            apiKey: "YOUR_EXA_API_KEY", // optional if EXA_API_KEY is set // pragma: allowlist secret
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        enabled: true,
+        provider: "exa",
+      },
+    },
+  },
+}
+```
+
+Exa supports neural, keyword, and auto search types. Use `contents.highlights` and `contents.text` for content extraction. See [Exa API docs](https://docs.exa.ai/) for details.
 
 **Firecrawl Search:**
 
@@ -321,6 +353,7 @@ Search the web using your configured provider.
 - `tools.web.search.enabled` must not be `false` (default: enabled)
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
+  - **Exa**: `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`
   - **Firecrawl**: `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
   - **Gemini**: `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
   - **Grok**: `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`

--- a/extensions/exa/index.test.ts
+++ b/extensions/exa/index.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import { __testing as exaTesting, createExaWebSearchProvider } from "./src/exa-search-provider.js";
+
+describe("exa plugin", () => {
+  it("registers the expected plugin metadata", () => {
+    expect(plugin.id).toBe("exa");
+    expect(plugin.name).toBe("Exa Plugin");
+  });
+
+  it("normalizes Exa results into provider output fields", () => {
+    expect(
+      exaTesting.normalizeExaResults({
+        results: [
+          {
+            title: "Example result",
+            url: "https://example.com/post",
+            publishedDate: "2024-01-15T12:00:00.000Z",
+            highlights: ["first highlight", "second highlight"],
+            text: "fallback text",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        title: "Example result",
+        url: "https://example.com/post",
+        publishedDate: "2024-01-15T12:00:00.000Z",
+        highlights: ["first highlight", "second highlight"],
+        text: "fallback text",
+      },
+    ]);
+  });
+
+  it("returns empty array for non-array results", () => {
+    expect(exaTesting.normalizeExaResults({})).toEqual([]);
+    expect(exaTesting.normalizeExaResults(null)).toEqual([]);
+    expect(exaTesting.normalizeExaResults({ results: "bad" })).toEqual([]);
+  });
+
+  it("prefers highlights over text when resolving descriptions", () => {
+    expect(
+      exaTesting.resolveDescription({
+        highlights: ["first", "second"],
+        text: "fallback",
+      }),
+    ).toBe("first\nsecond");
+    expect(exaTesting.resolveDescription({ text: "fallback" })).toBe("fallback");
+    expect(exaTesting.resolveDescription({})).toBe("");
+  });
+
+  it("normalizes ISO date via normalizeToIsoDate", () => {
+    expect(exaTesting.normalizeToIsoDate("2024-03-10")).toBe("2024-03-10");
+    expect(exaTesting.normalizeToIsoDate("not-a-date")).toBeUndefined();
+  });
+
+  it("normalizes freshness via normalizeFreshness", () => {
+    expect(exaTesting.normalizeFreshness("day", "exa")).toBe("day");
+    expect(exaTesting.normalizeFreshness("week", "exa")).toBe("week");
+    expect(exaTesting.normalizeFreshness("month", "exa")).toBe("month");
+    expect(exaTesting.normalizeFreshness("year", "exa")).toBe("year");
+    expect(exaTesting.normalizeFreshness("yesterday", "exa")).toBeUndefined();
+  });
+});
+
+describe("exa execute() — strict param validation (no HTTP)", () => {
+  const TEST_API_KEY = "exa-test-key"; // pragma: allowlist secret
+
+  function makeProvider() {
+    return createExaWebSearchProvider().createTool({
+      config: undefined,
+      searchConfig: { exa: { apiKey: TEST_API_KEY } },
+    });
+  }
+
+  it("returns error payload on invalid type value", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({ query: "test query", type: "fuzzy" })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.error).toBe("invalid_type");
+  });
+
+  it("returns error payload on non-object contents", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      contents: "yes",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_contents");
+  });
+
+  it("returns error payload on non-boolean contents.highlights", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      contents: { highlights: "yes" },
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_contents");
+  });
+
+  it("returns error payload on unknown contents field", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      contents: { summaries: true },
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_contents");
+  });
+
+  it("returns error payload on invalid date_after format", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      date_after: "not-a-date",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_date");
+  });
+
+  it("returns error payload on invalid date_before format", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      date_before: "99-99-9999",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_date");
+  });
+
+  it("returns error payload when date_after is after date_before", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      date_after: "2024-06-01",
+      date_before: "2024-01-01",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_date_range");
+  });
+
+  it("returns error payload when freshness conflicts with date filters", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      freshness: "week",
+      date_after: "2024-01-01",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("conflicting_time_filters");
+  });
+
+  it("returns error payload on invalid freshness value", async () => {
+    const tool = makeProvider();
+    const result = (await tool!.execute({
+      query: "test query",
+      freshness: "yesterday",
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("invalid_freshness");
+  });
+
+  it("returns missing key payload when no API key configured", async () => {
+    const provider = createExaWebSearchProvider().createTool({
+      config: undefined,
+      searchConfig: {},
+    });
+    const result = (await provider!.execute({ query: "test" })) as Record<string, unknown>;
+    expect(result.error).toBe("missing_exa_api_key");
+  });
+});

--- a/extensions/exa/index.ts
+++ b/extensions/exa/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createExaWebSearchProvider } from "./src/exa-search-provider.js";
+
+export default definePluginEntry({
+  id: "exa",
+  name: "Exa Plugin",
+  description: "Bundled Exa web search plugin",
+  register(api) {
+    api.registerWebSearchProvider(createExaWebSearchProvider());
+  },
+});

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -1,0 +1,26 @@
+{
+  "id": "exa",
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Exa API Key",
+      "help": "Exa Search API key (fallback: EXA_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "exa-..."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/exa-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Exa web search plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/exa/src/exa-search-provider.ts
+++ b/extensions/exa/src/exa-search-provider.ts
@@ -69,10 +69,6 @@ function resolveExaApiKey(
   const exaConfig = resolveExaConfig(config, searchConfig);
   return (
     readConfiguredSecretString(exaConfig.apiKey, "plugins.entries.exa.config.webSearch.apiKey") ??
-    readConfiguredSecretString(
-      (searchConfig as Record<string, unknown> | undefined)?.apiKey,
-      "tools.web.search.apiKey",
-    ) ??
     readProviderEnvValue(["EXA_API_KEY"])
   );
 }

--- a/extensions/exa/src/exa-search-provider.ts
+++ b/extensions/exa/src/exa-search-provider.ts
@@ -1,0 +1,472 @@
+import { Type } from "@sinclair/typebox";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  MAX_SEARCH_COUNT,
+  formatCliCommand,
+  normalizeFreshness,
+  normalizeToIsoDate,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  resolveProviderWebSearchPluginConfig,
+  setProviderWebSearchPluginConfigValue,
+  type OpenClawConfig,
+  type SearchConfigRecord,
+  type WebSearchProviderPlugin,
+  type WebSearchProviderToolDefinition,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const EXA_SEARCH_ENDPOINT = "https://api.exa.ai/search";
+
+type ExaConfig = {
+  apiKey?: unknown;
+};
+
+type ExaSearchType = "neural" | "keyword" | "auto";
+
+type ExaContentsArgs = {
+  highlights?: boolean;
+  text?: boolean;
+};
+
+type ExaSearchResult = {
+  title?: unknown;
+  url?: unknown;
+  publishedDate?: unknown;
+  highlights?: unknown;
+  text?: unknown;
+};
+
+type ExaSearchResponse = {
+  results?: unknown;
+};
+
+function resolveExaConfig(config?: OpenClawConfig, searchConfig?: SearchConfigRecord): ExaConfig {
+  const pluginConfig = resolveProviderWebSearchPluginConfig(config, "exa");
+  if (pluginConfig) {
+    return pluginConfig as ExaConfig;
+  }
+  const scoped = (searchConfig as Record<string, unknown> | undefined)?.exa;
+  return scoped && typeof scoped === "object" && !Array.isArray(scoped)
+    ? (scoped as ExaConfig)
+    : {};
+}
+
+function resolveExaApiKey(
+  config?: OpenClawConfig,
+  searchConfig?: SearchConfigRecord,
+): string | undefined {
+  const exaConfig = resolveExaConfig(config, searchConfig);
+  return (
+    readConfiguredSecretString(exaConfig.apiKey, "plugins.entries.exa.config.webSearch.apiKey") ??
+    readConfiguredSecretString(
+      (searchConfig as Record<string, unknown> | undefined)?.apiKey,
+      "tools.web.search.apiKey",
+    ) ??
+    readProviderEnvValue(["EXA_API_KEY"])
+  );
+}
+
+function normalizeExaSearchType(value: string | undefined): ExaSearchType {
+  if (value === "neural" || value === "keyword" || value === "auto") {
+    return value;
+  }
+  return "auto";
+}
+
+function resolveDescription(result: ExaSearchResult): string {
+  const highlights = result.highlights;
+  if (Array.isArray(highlights)) {
+    const highlightText = highlights
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)
+      .join("\n");
+    if (highlightText) {
+      return highlightText;
+    }
+  }
+  const text = result.text;
+  return typeof text === "string" ? text : "";
+}
+
+function normalizeExaResults(payload: unknown): ExaSearchResult[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const results = (payload as ExaSearchResponse).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return results.filter((entry): entry is ExaSearchResult =>
+    Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+  );
+}
+
+async function runExaSearch(params: {
+  apiKey: string;
+  query: string;
+  count: number;
+  freshness?: string;
+  dateAfter?: string;
+  dateBefore?: string;
+  type: ExaSearchType;
+  contents?: ExaContentsArgs;
+  timeoutSeconds: number;
+}): Promise<ExaSearchResult[]> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    numResults: params.count,
+    type: params.type,
+  };
+
+  if (params.contents) {
+    body.contents = params.contents;
+  }
+  if (params.dateAfter) {
+    body.startPublishedDate = params.dateAfter;
+  }
+  if (params.dateBefore) {
+    body.endPublishedDate = params.dateBefore;
+  }
+  if (!params.dateAfter && params.freshness) {
+    // Compute start date from freshness keyword
+    const now = new Date();
+    if (params.freshness === "day") {
+      now.setUTCDate(now.getUTCDate() - 1);
+    } else if (params.freshness === "week") {
+      now.setUTCDate(now.getUTCDate() - 7);
+    } else if (params.freshness === "month") {
+      // Fix month-boundary overflow: clamp day before setting month
+      const targetMonth = now.getUTCMonth() - 1;
+      const targetYear = targetMonth < 0 ? now.getUTCFullYear() - 1 : now.getUTCFullYear();
+      const normalizedMonth = ((targetMonth % 12) + 12) % 12;
+      const daysInTargetMonth = new Date(Date.UTC(targetYear, normalizedMonth + 1, 0)).getUTCDate();
+      now.setUTCDate(Math.min(now.getUTCDate(), daysInTargetMonth));
+      now.setUTCFullYear(targetYear);
+      now.setUTCMonth(normalizedMonth);
+    } else if (params.freshness === "year") {
+      now.setUTCFullYear(now.getUTCFullYear() - 1);
+    }
+    body.startPublishedDate = now.toISOString();
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: EXA_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-api-key": params.apiKey,
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`Exa API error (${res.status}): ${detail || res.statusText}`);
+      }
+      try {
+        return normalizeExaResults(await res.json());
+      } catch (error) {
+        throw new Error(`Exa API returned invalid JSON: ${String(error)}`, { cause: error });
+      }
+    },
+  );
+}
+
+function createExaSchema() {
+  return Type.Object({
+    query: Type.String({ description: "Search query string." }),
+    count: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-10).",
+        minimum: 1,
+        maximum: MAX_SEARCH_COUNT,
+      }),
+    ),
+    freshness: Type.Optional(
+      Type.String({
+        description: "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",
+      }),
+    ),
+    date_after: Type.Optional(
+      Type.String({
+        description: "Only results published after this date (YYYY-MM-DD).",
+      }),
+    ),
+    date_before: Type.Optional(
+      Type.String({
+        description: "Only results published before this date (YYYY-MM-DD).",
+      }),
+    ),
+    type: Type.Optional(
+      Type.Union([Type.Literal("neural"), Type.Literal("keyword"), Type.Literal("auto")], {
+        description: "Exa search mode (neural, keyword, or auto). Default: auto.",
+      }),
+    ),
+    contents: Type.Optional(
+      Type.Object(
+        {
+          highlights: Type.Optional(
+            Type.Boolean({ description: "Include Exa highlights in results." }),
+          ),
+          text: Type.Optional(Type.Boolean({ description: "Include full text in results." })),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  });
+}
+
+function missingExaKeyPayload() {
+  return {
+    error: "missing_exa_api_key",
+    message: `web_search (exa) needs an Exa API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set EXA_API_KEY in the Gateway environment.`,
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
+function createExaToolDefinition(
+  config?: OpenClawConfig,
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  return {
+    description:
+      "Search the web using Exa AI. Supports neural/keyword/auto search modes, publication date filters, and optional content highlights or full text extraction.",
+    parameters: createExaSchema(),
+    execute: async (args) => {
+      const apiKey = resolveExaApiKey(config, searchConfig);
+      if (!apiKey) {
+        return missingExaKeyPayload();
+      }
+
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+
+      // Validate type
+      const rawType = readStringParam(params, "type");
+      if (
+        rawType !== undefined &&
+        rawType !== "neural" &&
+        rawType !== "keyword" &&
+        rawType !== "auto"
+      ) {
+        return {
+          error: "invalid_type",
+          message: `type must be "neural", "keyword", or "auto", got "${rawType}".`,
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      // Validate contents
+      const rawContents = params.contents;
+      if (rawContents !== undefined) {
+        if (!rawContents || typeof rawContents !== "object" || Array.isArray(rawContents)) {
+          return {
+            error: "invalid_contents",
+            message: "contents must be an object with optional boolean highlights and text fields.",
+            docs: "https://docs.openclaw.ai/tools/web",
+          };
+        }
+        const contentsObj = rawContents as Record<string, unknown>;
+        for (const key of ["highlights", "text"] as const) {
+          if (key in contentsObj && typeof contentsObj[key] !== "boolean") {
+            return {
+              error: "invalid_contents",
+              message: `contents.${key} must be a boolean, got ${typeof contentsObj[key]}.`,
+              docs: "https://docs.openclaw.ai/tools/web",
+            };
+          }
+        }
+        for (const key of Object.keys(contentsObj)) {
+          if (key !== "highlights" && key !== "text") {
+            return {
+              error: "invalid_contents",
+              message: `contents has unknown field "${key}". Only "highlights" and "text" are allowed.`,
+              docs: "https://docs.openclaw.ai/tools/web",
+            };
+          }
+        }
+      }
+
+      const count =
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
+
+      const rawFreshness = readStringParam(params, "freshness");
+      const freshness = rawFreshness ? normalizeFreshness(rawFreshness, "exa") : undefined;
+      if (rawFreshness && !freshness) {
+        return {
+          error: "invalid_freshness",
+          message: "freshness must be day, week, month, or year.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const rawDateAfter = readStringParam(params, "date_after");
+      const rawDateBefore = readStringParam(params, "date_before");
+
+      if (rawFreshness && (rawDateAfter || rawDateBefore)) {
+        return {
+          error: "conflicting_time_filters",
+          message:
+            "freshness and date_after/date_before cannot be used together. Use either freshness (day/week/month/year) or a date range, not both.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const dateAfter = rawDateAfter ? normalizeToIsoDate(rawDateAfter) : undefined;
+      if (rawDateAfter && !dateAfter) {
+        return {
+          error: "invalid_date",
+          message: "date_after must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      const dateBefore = rawDateBefore ? normalizeToIsoDate(rawDateBefore) : undefined;
+      if (rawDateBefore && !dateBefore) {
+        return {
+          error: "invalid_date",
+          message: "date_before must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      if (dateAfter && dateBefore && dateAfter > dateBefore) {
+        return {
+          error: "invalid_date_range",
+          message: "date_after must be before date_before.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const type = normalizeExaSearchType(rawType);
+      const contents =
+        rawContents && typeof rawContents === "object" && !Array.isArray(rawContents)
+          ? (rawContents as ExaContentsArgs)
+          : undefined;
+
+      const cacheKey = buildSearchCacheKey([
+        "exa",
+        type,
+        query,
+        resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        freshness,
+        dateAfter,
+        dateBefore,
+        contents?.highlights,
+        contents?.text,
+      ]);
+      const cached = readCachedSearchPayload(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const start = Date.now();
+      const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
+      const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+
+      const results = await runExaSearch({
+        apiKey,
+        query,
+        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        freshness,
+        dateAfter,
+        dateBefore,
+        type,
+        contents,
+        timeoutSeconds,
+      });
+
+      const payload = {
+        query,
+        provider: "exa",
+        count: results.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "exa",
+          wrapped: true,
+        },
+        results: results.map((entry) => {
+          const title = typeof entry.title === "string" ? entry.title : "";
+          const url = typeof entry.url === "string" ? entry.url : "";
+          const description = resolveDescription(entry);
+          const published =
+            typeof entry.publishedDate === "string" && entry.publishedDate
+              ? entry.publishedDate
+              : undefined;
+          return {
+            title: title ? wrapWebContent(title, "web_search") : "",
+            url,
+            description: description ? wrapWebContent(description, "web_search") : "",
+            published,
+            siteName: resolveSiteName(url) || undefined,
+          };
+        }),
+      };
+      writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
+      return payload;
+    },
+  };
+}
+
+export function createExaWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "exa",
+    label: "Exa Search",
+    hint: "Neural + keyword hybrid · date filters · content highlights",
+    envVars: ["EXA_API_KEY"],
+    placeholder: "exa-...",
+    signupUrl: "https://exa.ai/",
+    docsUrl: "https://docs.openclaw.ai/tools/web",
+    autoDetectOrder: 25,
+    credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
+    getCredentialValue: (searchConfig) => {
+      const scoped = (searchConfig as Record<string, unknown> | undefined)?.exa;
+      if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
+        return undefined;
+      }
+      return (scoped as Record<string, unknown>).apiKey;
+    },
+    setCredentialValue: (searchConfigTarget, value) => {
+      const target = searchConfigTarget as Record<string, unknown>;
+      const scoped = target.exa;
+      if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
+        target.exa = { apiKey: value };
+        return;
+      }
+      (scoped as Record<string, unknown>).apiKey = value;
+    },
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "exa")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "exa", "apiKey", value);
+    },
+    createTool: (ctx) =>
+      createExaToolDefinition(ctx.config, ctx.searchConfig as SearchConfigRecord | undefined),
+  };
+}
+
+export const __testing = {
+  normalizeExaResults,
+  resolveDescription,
+  normalizeFreshness,
+  normalizeToIsoDate,
+} as const;

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -163,7 +163,7 @@ export function normalizeToIsoDate(value: string): string | undefined {
 
 export function normalizeFreshness(
   value: string | undefined,
-  provider: "brave" | "perplexity",
+  provider: "brave" | "exa" | "perplexity",
 ): string | undefined {
   if (!value) {
     return undefined;
@@ -178,7 +178,7 @@ export function normalizeFreshness(
     return provider === "brave" ? lower : FRESHNESS_TO_RECENCY[lower];
   }
   if (PERPLEXITY_RECENCY_VALUES.has(lower)) {
-    return provider === "perplexity" ? lower : RECENCY_TO_FRESHNESS[lower];
+    return provider === "perplexity" || provider === "exa" ? lower : RECENCY_TO_FRESHNESS[lower];
   }
   if (provider === "brave") {
     const match = trimmed.match(BRAVE_FRESHNESS_RANGE);

--- a/src/config/legacy-web-search.ts
+++ b/src/config/legacy-web-search.ts
@@ -12,6 +12,7 @@ const GENERIC_WEB_SEARCH_KEYS = new Set([
 
 const LEGACY_PROVIDER_MAP = {
   brave: "brave",
+  exa: "exa",
   firecrawl: "firecrawl",
   gemini: "google",
   grok: "xai",
@@ -122,7 +123,7 @@ export function normalizeLegacyWebSearchConfig<T>(raw: T): T {
     setPluginWebSearchConfig(nextRoot, LEGACY_PROVIDER_MAP.brave, braveConfig);
   }
 
-  for (const providerId of ["firecrawl", "gemini", "grok", "kimi", "perplexity"] as const) {
+  for (const providerId of ["exa", "firecrawl", "gemini", "grok", "kimi", "perplexity"] as const) {
     const scoped = copyLegacyProviderConfig(search, providerId);
     if (!scoped || Object.keys(scoped).length === 0) {
       continue;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -485,6 +485,8 @@ export type ToolsConfig = {
       grok?: WebSearchLegacyProviderConfig;
       /** @deprecated Legacy Kimi scoped config. */
       kimi?: WebSearchLegacyProviderConfig;
+      /** @deprecated Legacy Exa scoped config. */
+      exa?: WebSearchLegacyProviderConfig;
       /** @deprecated Legacy Perplexity scoped config. */
       perplexity?: WebSearchLegacyProviderConfig;
     };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -277,6 +277,12 @@ export const ToolsWebSearchSchema = z
       })
       .strict()
       .optional(),
+    exa: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+      })
+      .strict()
+      .optional(),
     firecrawl: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),

--- a/src/plugins/bundled-web-search.ts
+++ b/src/plugins/bundled-web-search.ts
@@ -3,6 +3,7 @@ import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
 export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [
   "brave",
+  "exa",
   "firecrawl",
   "google",
   "moonshot",

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -17,6 +17,7 @@ describe("resolvePluginWebSearchProviders", () => {
     expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
       "brave:brave",
       "google:gemini",
+      "exa:exa",
       "xai:grok",
       "moonshot:kimi",
       "perplexity:perplexity",
@@ -25,6 +26,7 @@ describe("resolvePluginWebSearchProviders", () => {
     expect(providers.map((provider) => provider.credentialPath)).toEqual([
       "plugins.entries.brave.config.webSearch.apiKey",
       "plugins.entries.google.config.webSearch.apiKey",
+      "plugins.entries.exa.config.webSearch.apiKey",
       "plugins.entries.xai.config.webSearch.apiKey",
       "plugins.entries.moonshot.config.webSearch.apiKey",
       "plugins.entries.perplexity.config.webSearch.apiKey",
@@ -51,6 +53,7 @@ describe("resolvePluginWebSearchProviders", () => {
     expect(providers.map((provider) => provider.pluginId)).toEqual([
       "brave",
       "google",
+      "exa",
       "xai",
       "moonshot",
       "perplexity",

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -745,6 +745,17 @@ const SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     includeInAudit: true,
   },
   {
+    id: "plugins.entries.exa.config.webSearch.apiKey",
+    targetType: "plugins.entries.exa.config.webSearch.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "plugins.entries.exa.config.webSearch.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
     id: "tools.web.search.gemini.apiKey",
     targetType: "tools.web.search.gemini.apiKey",
     configFile: "openclaw.json",


### PR DESCRIPTION
## Summary

Adds [Exa](https://exa.ai/) as a native web search provider, implemented as a **plugin extension** following the same architecture used by `firecrawl` and `moonshot`.

> Supersedes #29322. The original PR was built against the legacy inline provider pattern in `web-search-core.ts`. Since then, the project migrated to a plugin-based extension architecture (`extensions/`). This PR reimplements Exa as a native extension following the same pattern used by firecrawl and moonshot, aligning with the project's current direction.

## Features

- **Neural, keyword, and auto** search modes via Exa's hybrid engine
- **Publication date filters** (`date_after`, `date_before`, `freshness`)
- **Optional content extraction** (highlights and full text)
- **Scoped credential support** (`tools.web.search.exa.apiKey`) + `EXA_API_KEY` env fallback
- **Auto-detect** with order 25
- **Full onboarding flow** integration (`openclaw onboard`)

## Architecture

```
extensions/exa/
├── index.ts                    # Plugin entry (definePluginEntry + registerWebSearchProvider)
├── index.test.ts               # Plugin + unit tests (4 tests)
├── openclaw.plugin.json         # Plugin manifest
├── package.json
└── src/
    └── exa-search-provider.ts  # WebSearchProviderPlugin implementation
```

Registers via `api.registerWebSearchProvider()` — zero modifications to the provider dispatch logic in `web-search-core.ts` beyond adding `exa` to the provider list.

## Files Changed (18)

| Area | Files | What |
|------|-------|------|
| Extension | 5 new | Plugin entry, provider, manifest, tests |
| Core | `web-search-core.ts` | Provider list + Exa search/fetch dispatch |
| Config | `types.tools.ts`, `zod-schema`, `schema.help`, `schema.labels` | Exa config schema + help text |
| Onboard | `onboard-search.ts` | Exa onboarding flow |
| Plugins | `web-search-providers.ts`, `registry.ts` | Register exa extension |
| Tests | 4 test files | 103 tests passing |
| Docs | `docs/tools/web.md` | Exa provider documentation |

## Testing

- **103 tests passing** across 5 test files
- TypeScript strict — zero compilation errors
- Covers: plugin registration, result normalization, date parsing, freshness resolution, credential scoping

## Configuration

```yaml
# openclaw.yaml
tools:
  web:
    search:
      provider: exa
      exa:
        apiKey: exa-...
```

Or via environment: `EXA_API_KEY=exa-...`