### PR TITLE
fix(pi-extensions): improve VS Code launch reliability on Windows in /diff and /files

### DIFF
--- a/.pi/extensions/diff.ts
+++ b/.pi/extensions/diff.ts
@@ -75,12 +75,40 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
+      const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+      const quoteCmdArg = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
+      const openWithCode = async (file: string) => {
+        if (process.platform === "win32") {
+          if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(file)) {
+            ctx.ui.notify(
+              `Refusing to open ${file}: path contains Windows cmd metacharacters (& | < > ^ % or newline).`,
+              "error",
+            );
+            return null;
+          }
+          const commandLine = `code -g ${quoteCmdArg(file)}`;
+          return pi.exec("cmd", ["/d", "/s", "/c", commandLine], { cwd: ctx.cwd });
+        }
+        return pi.exec("code", ["-g", file], { cwd: ctx.cwd });
+      };
+
       const openSelected = async (fileInfo: FileInfo): Promise<void> => {
         try {
           // Open in VS Code diff view.
           // For untracked files, git difftool won't work, so fall back to just opening the file.
           if (fileInfo.status === "?") {
-            await pi.exec("code", ["-g", fileInfo.file], { cwd: ctx.cwd });
+            const openResult = await openWithCode(fileInfo.file);
+            if (!openResult) {
+              return;
+            }
+            if (openResult.code !== 0) {
+              const openStderr = openResult.stderr.trim();
+              ctx.ui.notify(
+                `Failed to open ${fileInfo.file} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+                "error",
+              );
+            }
             return;
           }
 
@@ -92,7 +120,27 @@ export default function (pi: ExtensionAPI) {
             },
           );
           if (diffResult.code !== 0) {
-            await pi.exec("code", ["-g", fileInfo.file], { cwd: ctx.cwd });
+            const diffStderr = diffResult.stderr.trim();
+            ctx.ui.notify(
+              `Failed to show diff with vscode for ${fileInfo.file} (exit ${diffResult.code})${diffStderr ? `: ${diffStderr}` : ""}`,
+              "error",
+            );
+            ctx.ui.notify(
+              "Troubleshooting: check git difftool config (e.g. `git config --get difftool.vscode.cmd`).",
+              "info",
+            );
+
+            const openResult = await openWithCode(fileInfo.file);
+            if (!openResult) {
+              return;
+            }
+            if (openResult.code !== 0) {
+              const openStderr = openResult.stderr.trim();
+              ctx.ui.notify(
+                `Failed to open ${fileInfo.file} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+                "error",
+              );
+            }
           }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);

--- a/.pi/extensions/files.ts
+++ b/.pi/extensions/files.ts
@@ -96,9 +96,37 @@ export default function (pi: ExtensionAPI) {
         (a, b) => b.lastTimestamp - a.lastTimestamp,
       );
 
+      const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+      const quoteCmdArg = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
+      const openWithCode = async (path: string) => {
+        if (process.platform === "win32") {
+          if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(path)) {
+            ctx.ui.notify(
+              `Refusing to open ${path}: path contains Windows cmd metacharacters (& | < > ^ % or newline).`,
+              "error",
+            );
+            return null;
+          }
+          const commandLine = `code -g ${quoteCmdArg(path)}`;
+          return pi.exec("cmd", ["/d", "/s", "/c", commandLine], { cwd: ctx.cwd });
+        }
+        return pi.exec("code", ["-g", path], { cwd: ctx.cwd });
+      };
+
       const openSelected = async (file: FileEntry): Promise<void> => {
         try {
-          await pi.exec("code", ["-g", file.path], { cwd: ctx.cwd });
+          const openResult = await openWithCode(file.path);
+          if (!openResult) {
+            return;
+          }
+          if (openResult.code !== 0) {
+            const openStderr = openResult.stderr.trim();
+            ctx.ui.notify(
+              `Failed to open ${file.path} (exit ${openResult.code})${openStderr ? `: ${openStderr}` : ""}`,
+              "error",
+            );
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           ctx.ui.notify(`Failed to open ${file.path}: ${message}`, "error");


### PR DESCRIPTION
Aligns `.pi/extensions/diff.ts` and `.pi/extensions/files.ts` with the Windows VS Code launch and `/diff` error-reporting enhancement from `pi-mono`, plus the follow-up Windows cmd hardening:

- https://github.com/badlogic/pi-mono/pull/2288
- https://github.com/badlogic/pi-mono/pull/2329

### Problem

- On Windows, direct `pi.exec("code", ["-g", ...])` can fail, and when it fails no error info is shown in `/diff` and `/files`.
- In `/diff`, when `git difftool --tool=vscode` fails (for example, missing difftool config), the failure reason is not shown.
- Using `cmd /c` with unvalidated file paths can allow cmd metacharacter parsing (`& | < > ^ %` or newline).

### Changes

- Add local `openWithCode()` in both files:
  - Windows: `cmd /d /s /c code -g <file>`
  - Non-Windows: `code -g <file>`
- Replace direct `pi.exec("code", ...)` calls with `openWithCode(...)`.
- Add explicit open-failure notification (exit code + stderr) for `/diff` and `/files`.
- In `/diff`, when `git difftool` fails:
  - show error with exit code + stderr
  - show troubleshooting hint:
    `git config --get difftool.vscode.cmd`
  - keep existing fallback behavior unchanged.
- Harden Windows cmd launch:
  - refuse unsafe file paths containing cmd metacharacters (`& | < > ^ %` or newline)
  - quote safe file path argument before invoking `cmd /c`.
