### PR TITLE
feat: add AIsa provider plugin — unified Chinese model access (Qwen, Kimi, GLM, DeepSeek, MiniMax)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -234,6 +234,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/byteplus/**"
+"extensions: aisa":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/aisa/**"
 "extensions: anthropic":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -238,5 +238,9 @@
   {
     "source": "env var",
     "target": "环境变量"
+  },
+  {
+    "source": "AIsa",
+    "target": "AIsa"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1106,6 +1106,7 @@
               {
                 "group": "Providers",
                 "pages": [
+                  "providers/aisa",
                   "providers/anthropic",
                   "providers/bedrock",
                   "providers/cloudflare-ai-gateway",
@@ -1697,6 +1698,7 @@
               {
                 "group": "提供商",
                 "pages": [
+                  "zh-CN/providers/aisa",
                   "zh-CN/providers/anthropic",
                   "zh-CN/providers/bedrock",
                   "zh-CN/providers/claude-max-api-proxy",

--- a/docs/providers/aisa.md
+++ b/docs/providers/aisa.md
@@ -1,0 +1,56 @@
+---
+summary: "Use China's top AI models in OpenClaw via AIsa"
+read_when:
+  - You want to use Chinese AI models (Qwen, Kimi, GLM, DeepSeek, MiniMax) in OpenClaw
+  - You need AISA_API_KEY setup
+title: "AIsa"
+---
+
+# AIsa
+
+[AIsa](https://marketplace.aisa.one/) provides a unified OpenAI-compatible gateway for China's top AI models at `https://api.aisa.one/v1`. One API key gives you access to Qwen, Kimi, GLM, DeepSeek, MiniMax, and more.
+
+## Available models
+
+| Model | Developer | Input $/1M | Output $/1M | Context | Vision | Reasoning |
+|---|---|---|---|---|---|---|
+| `minimax-m2.1` | MiniMax | $0.21 | $0.84 | 200k | — | — |
+| `seed-1-8-251228` | ByteDance | $0.225 | $1.80 | 128k | — | ✓ |
+| `deepseek-v3.2` | DeepSeek | $0.28 | $0.42 | 128k | — | ✓ |
+| `kimi-k2.5` _(default)_ | Moonshot AI | $0.40 | $2.11 | 256k | — | ✓ |
+| `qwen3-max` | Alibaba | $0.72 | $3.60 | 256k | ✓ | ✓ |
+| `glm-5` | Zhipu AI | $1.00 | $3.20 | 200k | ✓ | ✓ |
+
+## CLI setup
+
+```bash
+export AISA_API_KEY="sk-..."
+openclaw onboard --auth-choice aisa-api-key
+```
+
+Or non-interactively:
+
+```bash
+openclaw onboard --aisa-api-key "sk-..."
+```
+
+Then set your default model:
+
+```bash
+openclaw models set aisa/kimi-k2.5
+```
+
+## Config snippet
+
+```json5
+{
+  env: { AISA_API_KEY: "sk-..." },
+  models: {
+    "aisa/kimi-k2.5": { alias: "AIsa" }
+  }
+}
+```
+
+## Get an API key
+
+Sign up at [marketplace.aisa.one](https://marketplace.aisa.one/) to get your API key.

--- a/docs/zh-CN/providers/aisa.md
+++ b/docs/zh-CN/providers/aisa.md
@@ -1,0 +1,56 @@
+---
+summary: "通过 AIsa 在 OpenClaw 中使用中国顶级 AI 模型"
+read_when:
+  - 你想在 OpenClaw 中使用中国 AI 模型（通义千问、Kimi、GLM、DeepSeek、MiniMax）
+  - 你需要配置 AISA_API_KEY
+title: "AIsa"
+---
+
+# AIsa
+
+[AIsa](https://marketplace.aisa.one/) 提供统一的 OpenAI 兼容网关，通过 `https://api.aisa.one/v1` 访问中国顶级 AI 模型。一个 API 密钥即可使用通义千问、Kimi、GLM、DeepSeek、MiniMax 等模型。
+
+## 可用模型
+
+| 模型 | 开发商 | 输入 $/1M | 输出 $/1M | 上下文 | 视觉 | 推理 |
+|---|---|---|---|---|---|---|
+| `minimax-m2.1` | MiniMax | $0.21 | $0.84 | 200k | — | — |
+| `seed-1-8-251228` | 字节跳动 | $0.225 | $1.80 | 128k | — | ✓ |
+| `deepseek-v3.2` | DeepSeek | $0.28 | $0.42 | 128k | — | ✓ |
+| `kimi-k2.5`（默认） | 月之暗面 | $0.40 | $2.11 | 256k | — | ✓ |
+| `qwen3-max` | 阿里巴巴 | $0.72 | $3.60 | 256k | ✓ | ✓ |
+| `glm-5` | 智谱 AI | $1.00 | $3.20 | 200k | ✓ | ✓ |
+
+## 命令行设置
+
+```bash
+export AISA_API_KEY="sk-..."
+openclaw onboard --auth-choice aisa-api-key
+```
+
+或非交互式：
+
+```bash
+openclaw onboard --aisa-api-key "sk-..."
+```
+
+然后设置默认模型：
+
+```bash
+openclaw models set aisa/kimi-k2.5
+```
+
+## 配置示例
+
+```json5
+{
+  env: { AISA_API_KEY: "sk-..." },
+  models: {
+    "aisa/kimi-k2.5": { alias: "AIsa" }
+  }
+}
+```
+
+## 获取 API 密钥
+
+前往 [marketplace.aisa.one](https://marketplace.aisa.one/) 注册获取 API 密钥。

--- a/extensions/aisa/index.ts
+++ b/extensions/aisa/index.ts
@@ -1,0 +1,52 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog";
+import { applyAisaConfig, AISA_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildAisaProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "aisa";
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "AIsa Provider",
+  description: "Bundled AIsa provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "AIsa",
+      docsPath: "/providers/aisa",
+      envVars: ["AISA_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "AIsa API key",
+          hint: "China's top AI models — Qwen, Kimi, GLM, DeepSeek, MiniMax — one API key",
+          optionKey: "aisaApiKey",
+          flagName: "--aisa-api-key",
+          envVar: "AISA_API_KEY",
+          promptMessage: "Enter AIsa API key",
+          defaultModel: AISA_DEFAULT_MODEL_REF,
+          expectedProviders: ["aisa"],
+          applyConfig: (cfg) => applyAisaConfig(cfg),
+          wizard: {
+            choiceId: "aisa-api-key",
+            choiceLabel: "AIsa API key",
+            groupId: "aisa",
+            groupLabel: "AIsa",
+            groupHint: "China's top AI models — Qwen, Kimi, GLM, DeepSeek, MiniMax — one API key",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: (ctx) =>
+          buildSingleProviderApiKeyCatalog({
+            ctx,
+            providerId: PROVIDER_ID,
+            buildProvider: buildAisaProvider,
+          }),
+      },
+    });
+  },
+});

--- a/extensions/aisa/onboard.ts
+++ b/extensions/aisa/onboard.ts
@@ -1,0 +1,29 @@
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { AISA_BASE_URL, buildAisaProvider } from "./provider-catalog.js";
+
+export const AISA_DEFAULT_MODEL_REF = "aisa/kimi-k2.5";
+
+export function applyAisaProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[AISA_DEFAULT_MODEL_REF] = {
+    ...models[AISA_DEFAULT_MODEL_REF],
+    alias: models[AISA_DEFAULT_MODEL_REF]?.alias ?? "AIsa",
+  };
+
+  const provider = buildAisaProvider();
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "aisa",
+    api: "openai-completions",
+    baseUrl: AISA_BASE_URL,
+    catalogModels: provider.models,
+  });
+}
+
+export function applyAisaConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyAisaProviderConfig(cfg), AISA_DEFAULT_MODEL_REF);
+}

--- a/extensions/aisa/openclaw.plugin.json
+++ b/extensions/aisa/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "aisa",
+  "providers": ["aisa"],
+  "providerAuthEnvVars": {
+    "aisa": ["AISA_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "aisa",
+      "method": "api-key",
+      "choiceId": "aisa-api-key",
+      "choiceLabel": "AIsa API key",
+      "choiceHint": "China's top AI models — Qwen, Kimi, GLM, DeepSeek, MiniMax — one API key",
+      "groupId": "aisa",
+      "groupLabel": "AIsa",
+      "groupHint": "China's top AI models — Qwen, Kimi, GLM, DeepSeek, MiniMax — one API key",
+      "optionKey": "aisaApiKey",
+      "cliFlag": "--aisa-api-key",
+      "cliOption": "--aisa-api-key <key>",
+      "cliDescription": "AIsa API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/aisa/package.json
+++ b/extensions/aisa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/aisa-provider",
+  "version": "2026.3.18",
+  "private": true,
+  "description": "OpenClaw AIsa provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/aisa/provider-catalog.test.ts
+++ b/extensions/aisa/provider-catalog.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  AISA_BASE_URL,
+  AISA_DEFAULT_CONTEXT_WINDOW,
+  AISA_DEFAULT_MAX_TOKENS,
+  AISA_DEFAULT_MODEL_ID,
+  buildAisaProvider,
+} from "./provider-catalog.js";
+
+describe("buildAisaProvider", () => {
+  it("returns correct base URL and API type", () => {
+    const provider = buildAisaProvider();
+    expect(provider.baseUrl).toBe("https://api.aisa.one/v1");
+    expect(provider.api).toBe("openai-completions");
+  });
+
+  it("includes six models", () => {
+    const provider = buildAisaProvider();
+    expect(provider.models).toHaveLength(6);
+    const ids = provider.models.map((m) => m.id);
+    expect(ids).toContain("kimi-k2.5");
+    expect(ids).toContain("qwen3-max");
+    expect(ids).toContain("minimax-m2.1");
+    expect(ids).toContain("glm-5");
+    expect(ids).toContain("deepseek-v3.2");
+    expect(ids).toContain("seed-1-8-251228");
+  });
+
+  it("marks vision models correctly", () => {
+    const provider = buildAisaProvider();
+    const visionModels = provider.models.filter((m) => m.input?.includes("image"));
+    const visionIds = visionModels.map((m) => m.id);
+    expect(visionIds).toContain("qwen3-max");
+    expect(visionIds).toContain("glm-5");
+    expect(visionIds).not.toContain("kimi-k2.5");
+    expect(visionIds).not.toContain("minimax-m2.1");
+  });
+
+  it("marks reasoning models correctly", () => {
+    const provider = buildAisaProvider();
+    const reasoningModels = provider.models.filter((m) => m.reasoning);
+    const reasoningIds = reasoningModels.map((m) => m.id);
+    expect(reasoningIds).toContain("kimi-k2.5");
+    expect(reasoningIds).toContain("qwen3-max");
+    expect(reasoningIds).toContain("glm-5");
+    expect(reasoningIds).not.toContain("deepseek-v3.2");
+    expect(reasoningIds).not.toContain("seed-1-8-251228");
+    expect(reasoningIds).not.toContain("minimax-m2.1");
+  });
+
+  it("exports expected constants", () => {
+    expect(AISA_BASE_URL).toBe("https://api.aisa.one/v1");
+    expect(AISA_DEFAULT_MODEL_ID).toBe("kimi-k2.5");
+    expect(AISA_DEFAULT_CONTEXT_WINDOW).toBe(256_000);
+    expect(AISA_DEFAULT_MAX_TOKENS).toBe(32_768);
+  });
+});

--- a/extensions/aisa/provider-catalog.ts
+++ b/extensions/aisa/provider-catalog.ts
@@ -1,0 +1,71 @@
+import type { ModelDefinitionConfig, ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
+
+export const AISA_BASE_URL = "https://api.aisa.one/v1";
+export const AISA_DEFAULT_MODEL_ID = "kimi-k2.5";
+export const AISA_DEFAULT_CONTEXT_WINDOW = 256000;
+export const AISA_DEFAULT_MAX_TOKENS = 32768;
+
+const AISA_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "minimax-m2.1",
+    name: "MiniMax M2.1",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 200000,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 0.21, output: 0.84 },
+  },
+  {
+    id: "seed-1-8-251228",
+    name: "Seed 1.8",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 0.225, output: 1.8 },
+  },
+  {
+    id: "deepseek-v3.2",
+    name: "DeepSeek V3.2",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 0.28, output: 0.42 },
+  },
+  {
+    id: "kimi-k2.5",
+    name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: AISA_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 0.4, output: 2.11 },
+  },
+  {
+    id: "qwen3-max",
+    name: "Qwen3 Max",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: AISA_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 0.72, output: 3.6 },
+  },
+  {
+    id: "glm-5",
+    name: "GLM-5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: AISA_DEFAULT_MAX_TOKENS,
+    cost: { input: 1.0, output: 3.2 },
+  },
+];
+
+export function buildAisaProvider(): ModelProviderConfig {
+  return {
+    baseUrl: AISA_BASE_URL,
+    api: "openai-completions",
+    models: AISA_MODEL_CATALOG,
+  };
+}


### PR DESCRIPTION
### Summary

**Problem:** Using Chinese AI models in OpenClaw today requires 5+ separate signups — Qwen (2K req/day free-tier cap), Moonshot/Kimi (split across two providers), MiniMax, Zhipu AI/GLM — each with their own API key, billing account, and rate limits.

**Solution:** [AIsa](https://marketplace.aisa.one/) aggregates all major Chinese models behind a single OpenAI-compatible endpoint (`https://api.aisa.one/v1`) with one API key and unified billing. This PR adds it as a provider plugin: implicit detection via `AISA_API_KEY`, interactive onboarding, CLI flag, provider config, and docs (EN + zh-CN).

Default model: `kimi-k2.5` (256k context, best cost/quality tradeoff at $0.40/$2.11 per 1M tokens).

---

### Models (AIsa pricing vs official)

| Model | Developer | AIsa Input $/1M | AIsa Output $/1M | Official Input | Official Output | Savings | Context |
|---|---|---|---|---|---|---|---|
| `minimax-m2.1` | MiniMax | $0.21 | $0.84 | $0.30 | $1.20 | **30% off** | 200k |
| `seed-1-8-251228` | ByteDance | $0.225 | $1.80 | $0.25 | $2.00 | **10% off** | 128k |
| `deepseek-v3.2` | DeepSeek | $0.28 | $0.42 | $0.28 | $0.42 | same | 128k |
| **`kimi-k2.5`** _(default)_ | Moonshot AI | $0.40 | $2.11 | $0.60 | $3.00 | **33% off** | 256k |
| `qwen3-max` | Alibaba | $0.72 | $3.60 | $1.20 | $6.00 | **40% off** | 256k |
| `glm-5` | Zhipu AI | $1.00 | $3.20 | $1.00 | $3.20 | same | 200k |

Official prices sourced from each provider's API pricing page (MiniMax, BytePlus, DeepSeek, Moonshot, Alibaba Cloud, Zhipu AI).

---

### Changes

- **`extensions/aisa/provider-catalog.ts`** — `buildAisaProvider()`, model catalog (6 models), constants
- **`extensions/aisa/index.ts`** — plugin entry: provider registration, auth method, catalog
- **`extensions/aisa/onboard.ts`** — `applyAisaConfig()` / `applyAisaProviderConfig()`
- **`extensions/aisa/openclaw.plugin.json`** — plugin manifest (env vars, auth choices, CLI flags)
- **`extensions/aisa/package.json`** — package metadata
- **`extensions/aisa/provider-catalog.test.ts`** — unit tests
- **`docs/providers/aisa.md`** + **`docs/zh-CN/providers/aisa.md`** — setup docs
- **`docs/docs.json`** — nav entries for both languages
- **`.github/labeler.yml`** — `extensions: aisa` label
- **`docs/.i18n/glossary.zh-CN.json`** — AIsa glossary entry

---

### Security Impact

- No new credential storage surface — uses existing `buildApiKeyCredential` path via plugin SDK.
- `AISA_API_KEY` env var follows the same implicit-provider pattern as `OPENAI_API_KEY`, `NVIDIA_API_KEY`, etc.
- Outbound traffic goes to `https://api.aisa.one/v1` (HTTPS only).

---

### Human Verification

- [x] `openclaw onboard --auth-choice aisa-api-key` prompts correctly and writes credentials
- [x] `AISA_API_KEY=sk-... openclaw models list` shows all 6 models
- [x] `openclaw models set aisa/kimi-k2.5` and a basic agent turn succeeds against live endpoint
- [x] `openclaw onboard --aisa-api-key <key>` non-interactive path works

---

### Follow-up Commitment (AIsa team)

**This PR is provider integration only.** It does not include reliability fixes for Chinese model quirks. Once this PR is merged, the AIsa team will submit separate follow-up PRs to address known issues:

1. **JSON-in-markdown stripping** — Chinese model backends frequently wrap JSON responses in code fences; needs a response post-processor to strip fences before tool-call parsing.
2. **Strict-JSON prompt injection** — Chinese model backends need stronger system-prompt hints to suppress prose wrapping around structured outputs.
3. **Silent auto-retry on format errors** — 1–2 automatic retries when a model returns malformed JSON, before surfacing an error to the user.
4. **Regression CI on model version bumps** — automated tests that run against `kimi-k2.5`, `qwen3-max`, and `glm-5` whenever AIsa bumps underlying model versions.

> **Ongoing ownership:** The AIsa team will take ongoing responsibility for QA of Chinese-model usage in OpenClaw. We will assign 1-2 engineers on a recurring cadence to run regression suites across Qwen/DeepSeek/Kimi/GLM/MiniMax/Seed behaviors in real agent flows, and upstream fixes promptly. If issues arise with any of these models in OpenClaw, assign directly to us.

---

### References

- https://x.com/steipete/status/2030517998084100396
- https://x.com/steipete/status/2032810398991241607
