### PR TITLE
fix(googlechat): use agent identity.name in typing indicator fallback chain

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -113,7 +113,8 @@ async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTar
  * Resolve bot display name with fallback chain:
  * 1. Account config name
  * 2. Agent name from config
- * 3. "OpenClaw" as generic fallback
+ * 3. Agent identity name from config
+ * 4. "OpenClaw" as generic fallback
  */
 function resolveBotDisplayName(params: {
   accountName?: string;
@@ -127,6 +128,9 @@ function resolveBotDisplayName(params: {
   const agent = config.agents?.list?.find((a) => a.id === agentId);
   if (agent?.name?.trim()) {
     return agent.name.trim();
+  }
+  if (agent?.identity?.name?.trim()) {
+    return agent.identity.name.trim();
   }
   return "OpenClaw";
 }


### PR DESCRIPTION
## Problem

Closes #49350

When a Google Chat agent has `identity.name` configured but no direct `agent.name`, the typing indicator was falling back to the hardcoded `"OpenClaw is typing..."` string instead of the configured identity name.

## Root Cause

`resolveBotDisplayName` in `extensions/googlechat/src/monitor.ts` has a 3-step fallback chain:
1. Account config name (`account.config.name`)
2. Agent name (`agent.name`)
3. ❌ Hardcoded `"OpenClaw"`

It was missing a check for `agent.identity?.name`, which is the standard way users configure bot identity in OpenClaw (`IdentityConfig.name`).

## Fix

Add `agent.identity?.name` as a third fallback before the hardcoded `"OpenClaw"` string.

**Updated fallback chain:**
1. Account config name (`account.config.name`)
2. Agent name (`agent.name`)
3. ✅ Agent identity name (`agent.identity?.name`) ← **new**
4. `"OpenClaw"` as last resort

## Example

Config:
```json
{
  "agents": {
    "list": [{
      "id": "main",
      "identity": { "name": "Alvin" }
    }]
  }
}
```

**Before:** Shows `_OpenClaw is typing..._`
**After:** Shows `_Alvin is typing..._`

## Changes

- `extensions/googlechat/src/monitor.ts`: Added `agent?.identity?.name` check in `resolveBotDisplayName` (5 lines)
- Updated JSDoc comment to reflect the 4-step fallback chain