### PR TITLE
Tests: pin Telegram fallback host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Docs: https://docs.openclaw.ai
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
 - Gateway/auth: add regression coverage that keeps device-less trusted-proxy Control UI sessions off privileged pairing approval RPCs. Thanks @vincentkoc.
 - Plugins/runtime-api: pin extension runtime-api export seams with explicit guardrail coverage so future surface creep becomes a deliberate diff. Thanks @vincentkoc.
+- Telegram/security: add regression coverage proving pinned fallback host overrides stay bound to Telegram and delegate non-matching hostnames back to the original lookup path. Thanks @vincentkoc.
 
 ### Breaking
 

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -109,6 +109,37 @@ describe("createPinnedDispatcher", () => {
     expect(originalLookup).not.toHaveBeenCalled();
   });
 
+  it("keeps the override bound to the matching hostname only", () => {
+    const originalLookup = vi.fn(
+      (_hostname: string, callback: (err: null, address: string, family: number) => void) => {
+        callback(null, "93.184.216.34", 4);
+      },
+    ) as unknown as PinnedHostname["lookup"];
+    const pinned: PinnedHostname = {
+      hostname: "api.telegram.org",
+      addresses: ["149.154.167.221"],
+      lookup: originalLookup,
+    };
+
+    createPinnedDispatcher(pinned, {
+      mode: "direct",
+      pinnedHostname: {
+        hostname: "api.telegram.org",
+        addresses: ["149.154.167.220"],
+      },
+    });
+
+    const firstCallArg = agentCtor.mock.calls.at(-1)?.[0] as
+      | { connect?: { lookup?: PinnedHostname["lookup"] } }
+      | undefined;
+    const lookup = firstCallArg?.connect?.lookup;
+    const callback = vi.fn();
+    lookup?.("example.com", callback);
+
+    expect(originalLookup).toHaveBeenCalledWith("example.com", expect.any(Function));
+    expect(callback).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+  });
+
   it("rejects pinned override addresses that violate SSRF policy", () => {
     const originalLookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const pinned: PinnedHostname = {


### PR DESCRIPTION
## Summary

- Problem: Telegram fallback dispatcher behavior needed an explicit regression proof that the pinned-IP override stays bound to `api.telegram.org`.
- Why it matters: this is the exact guardrail that prevents a fallback-path SSRF/hostname bypass from creeping back in.
- What changed: added a regression test in `src/infra/net/ssrf.dispatcher.test.ts` that proves the override only applies to the matching hostname and delegates non-matching hostnames to the original lookup.
- What did NOT change (scope boundary): no production code, no new network behavior, no new capabilities.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: None.

## Repro + Verification

### Environment

- OS: macOS workspace
- Runtime/container: local worktree
- Model/provider: n/a
- Integration/channel (if any): Telegram fallback SSRF guardrail
- Relevant config (redacted): none

### Steps

1. Install dependencies in the worktree with `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm install`.
2. Run the focused test with `PATH=/opt/homebrew/bin:$PATH ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/infra/net/ssrf.dispatcher.test.ts -t 'keeps the override bound to the matching hostname only' --maxWorkers 1 --pool=threads`.

### Expected

- Matching hostnames stay pinned to the Telegram fallback IP.
- Non-matching hostnames delegate to the original lookup instead of inheriting the pinned override.

### Actual

- Regression test added for the hostname-bound override behavior.
- Dependency install completed.
- The focused vitest invocation was started, but concurrent workspace Vitest load prevented a clean completion signal in this shell.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: pinned fallback override is host-bound in test code.
- Edge cases checked: non-matching hostname delegates to the original lookup path.
- What you did **not** verify: a fully green local vitest pass in this shell, due workspace contention.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `src/infra/net/ssrf.dispatcher.test.ts`
- Files/config to restore: `src/infra/net/ssrf.dispatcher.test.ts`
- Known bad symptoms reviewers should watch for: Telegram fallback tests no longer proving hostname-bounded behavior.

## Risks and Mitigations

- Risk: the regression test could be overly specific and miss a broader dispatcher bug.
  - Mitigation: it exercises the exact pinned override path and asserts the non-matching hostname fallback explicitly.
