### PR TITLE
fix: Discord DM allowFrom merging — combine global + account lists instead of override

### DIFF
--- a/extensions/discord/src/accounts.test.ts
+++ b/extensions/discord/src/accounts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
-  it("prefers accounts.default.allowFrom over top-level for default account", () => {
+  it("merges top-level and account-scoped allowFrom for default account", () => {
     const resolved = resolveDiscordAccount({
       cfg: {
         channels: {
@@ -17,7 +17,29 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
       accountId: "default",
     });
 
-    expect(resolved.config.allowFrom).toEqual(["default"]);
+    expect(resolved.config.allowFrom).toEqual(expect.arrayContaining(["top", "default"]));
+    expect(resolved.config.allowFrom).toHaveLength(2);
+  });
+
+  it("deduplicates merged allowFrom entries", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            allowFrom: ["shared-id", "top-only"],
+            accounts: {
+              default: { allowFrom: ["shared-id", "account-only"], token: "token-default" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(
+      expect.arrayContaining(["shared-id", "top-only", "account-only"]),
+    );
+    expect(resolved.config.allowFrom).toHaveLength(3);
   });
 
   it("falls back to top-level allowFrom for named account without override", () => {
@@ -36,6 +58,23 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
     });
 
     expect(resolved.config.allowFrom).toEqual(["top"]);
+  });
+
+  it("uses only account allowFrom when top-level is absent", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              work: { allowFrom: ["work-user"], token: "token-work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.allowFrom).toEqual(["work-user"]);
   });
 
   it("does not inherit default account allowFrom for named account when top-level is absent", () => {

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -36,7 +36,17 @@ export function mergeDiscordAccountConfig(
     accounts?: unknown;
   };
   const account = resolveDiscordAccountConfig(cfg, accountId) ?? {};
-  return { ...base, ...account };
+  const merged = { ...base, ...account };
+
+  // Merge allowFrom arrays instead of overriding — a user ID in the global
+  // list should still be allowed even when the account defines its own list.
+  const baseAllowFrom = base.allowFrom;
+  const accountAllowFrom = account.allowFrom;
+  if (baseAllowFrom && accountAllowFrom) {
+    merged.allowFrom = [...new Set([...baseAllowFrom, ...accountAllowFrom])];
+  }
+
+  return merged;
 }
 
 export function createDiscordActionGate(params: {


### PR DESCRIPTION
Fixes #48641

## Root Cause

In `extensions/discord/src/accounts.ts`, `mergeDiscordAccountConfig()` used:

```ts
return { ...base, ...account };
```

This means any account-scoped `allowFrom` completely replaced the global `allowFrom`. When a user ID was only in the global list but the account defined its own list, that user's DMs were silently dropped.

## Fix

`mergeDiscordAccountConfig()` now merges `allowFrom` arrays instead of replacing them:
- If both global and account-scoped lists exist, combine them (deduplicated via Set)
- Users in the global allowlist remain allowed even when an account defines its own list
- Preserves fallback semantics: account inherits global if account has no override

## Tests

5 test cases in `extensions/discord/src/accounts.test.ts`:
- Merging top-level + account-scoped allowFrom
- Deduplication of merged entries
- Fallback to top-level when account has no override
- Account-only allowFrom when top-level is absent
- No inheritance of default account allowFrom for named accounts

## Note

The same `{ ...base, ...account }` pattern exists in Slack, Signal, and Telegram account merges. This PR keeps scope tight to Discord per #48641 — follow-up PRs can address the others.

---
*AI-assisted (Claude) — fully tested locally against existing test suite.*