### PR TITLE
Guardrails: pin runtime-api export seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
 - Gateway/auth: add regression coverage that keeps device-less trusted-proxy Control UI sessions off privileged pairing approval RPCs. Thanks @vincentkoc.
+- Plugins/runtime-api: pin extension runtime-api export seams with explicit guardrail coverage so future surface creep becomes a deliberate diff. Thanks @vincentkoc.
 
 ### Breaking
 

--- a/src/plugin-sdk/channel-import-guardrails.test.ts
+++ b/src/plugin-sdk/channel-import-guardrails.test.ts
@@ -26,7 +26,6 @@ const GUARDED_CHANNEL_EXTENSIONS = new Set([
   "msteams",
   "nostr",
   "nextcloud-talk",
-  "nostr",
   "signal",
   "slack",
   "synology-chat",

--- a/src/plugin-sdk/runtime-api-guardrails.test.ts
+++ b/src/plugin-sdk/runtime-api-guardrails.test.ts
@@ -1,0 +1,107 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
+  "extensions/discord/runtime-api.ts": [
+    'export * from "./src/audit.js";',
+    'export * from "./src/channel-actions.js";',
+    'export * from "./src/directory-live.js";',
+    'export * from "./src/monitor.js";',
+    'export * from "./src/monitor/gateway-plugin.js";',
+    'export * from "./src/monitor/gateway-registry.js";',
+    'export * from "./src/monitor/presence-cache.js";',
+    'export * from "./src/monitor/thread-bindings.js";',
+    'export * from "./src/monitor/thread-bindings.manager.js";',
+    'export * from "./src/monitor/timeouts.js";',
+    'export * from "./src/probe.js";',
+    'export * from "./src/resolve-channels.js";',
+    'export * from "./src/resolve-users.js";',
+    'export * from "./src/send.js";',
+  ],
+  "extensions/imessage/runtime-api.ts": [
+    'export * from "./src/monitor.js";',
+    'export * from "./src/probe.js";',
+    'export * from "./src/send.js";',
+  ],
+  "extensions/nextcloud-talk/runtime-api.ts": [
+    'export * from "openclaw/plugin-sdk/nextcloud-talk";',
+  ],
+  "extensions/signal/runtime-api.ts": ['export * from "./src/index.js";'],
+  "extensions/slack/runtime-api.ts": [
+    'export * from "./src/directory-live.js";',
+    'export * from "./src/index.js";',
+    'export * from "./src/resolve-channels.js";',
+    'export * from "./src/resolve-users.js";',
+  ],
+  "extensions/telegram/runtime-api.ts": [
+    'export * from "./src/audit.js";',
+    'export * from "./src/channel-actions.js";',
+    'export * from "./src/monitor.js";',
+    'export * from "./src/probe.js";',
+    'export * from "./src/send.js";',
+    'export * from "./src/thread-bindings.js";',
+    'export * from "./src/token.js";',
+  ],
+  "extensions/whatsapp/runtime-api.ts": [
+    'export * from "./src/active-listener.js";',
+    'export * from "./src/agent-tools-login.js";',
+    'export * from "./src/auth-store.js";',
+    'export * from "./src/auto-reply.js";',
+    'export * from "./src/inbound.js";',
+    'export * from "./src/login.js";',
+    'export * from "./src/media.js";',
+    'export * from "./src/send.js";',
+    'export * from "./src/session.js";',
+  ],
+} as const;
+
+function collectRuntimeApiFiles(): string[] {
+  const extensionsDir = resolve(ROOT_DIR, "..", "extensions");
+  const files: string[] = [];
+  const stack = [extensionsDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const fullPath = resolve(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "coverage") {
+          continue;
+        }
+        stack.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !fullPath.endsWith("/runtime-api.ts")) {
+        continue;
+      }
+      files.push(relative(resolve(ROOT_DIR, ".."), fullPath).replaceAll("\\", "/"));
+    }
+  }
+  return files;
+}
+
+function readExportStatements(path: string): string[] {
+  return readFileSync(resolve(ROOT_DIR, "..", path), "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("export "));
+}
+
+describe("runtime api guardrails", () => {
+  it("keeps runtime api seams on an explicit export allowlist", () => {
+    const runtimeApiFiles = collectRuntimeApiFiles();
+    expect(runtimeApiFiles.toSorted()).toEqual(Object.keys(RUNTIME_API_EXPORT_GUARDS).toSorted());
+
+    for (const file of runtimeApiFiles) {
+      expect(readExportStatements(file), `${file} runtime api exports changed`).toEqual(
+        RUNTIME_API_EXPORT_GUARDS[file],
+      );
+    }
+  });
+});

--- a/src/plugin-sdk/runtime-api-guardrails.test.ts
+++ b/src/plugin-sdk/runtime-api-guardrails.test.ts
@@ -9,6 +9,9 @@ const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
   "extensions/discord/runtime-api.ts": [
     'export * from "./src/audit.js";',
+    'export * from "./src/actions/runtime.js";',
+    'export * from "./src/actions/runtime.moderation-shared.js";',
+    'export * from "./src/actions/runtime.shared.js";',
     'export * from "./src/channel-actions.js";',
     'export * from "./src/directory-live.js";',
     'export * from "./src/monitor.js";',
@@ -33,6 +36,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
   ],
   "extensions/signal/runtime-api.ts": ['export * from "./src/index.js";'],
   "extensions/slack/runtime-api.ts": [
+    'export * from "./src/action-runtime.js";',
     'export * from "./src/directory-live.js";',
     'export * from "./src/index.js";',
     'export * from "./src/resolve-channels.js";',
@@ -40,6 +44,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
   ],
   "extensions/telegram/runtime-api.ts": [
     'export * from "./src/audit.js";',
+    'export * from "./src/action-runtime.js";',
     'export * from "./src/channel-actions.js";',
     'export * from "./src/monitor.js";',
     'export * from "./src/probe.js";',
@@ -49,6 +54,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
   ],
   "extensions/whatsapp/runtime-api.ts": [
     'export * from "./src/active-listener.js";',
+    'export * from "./src/action-runtime.js";',
     'export * from "./src/agent-tools-login.js";',
     'export * from "./src/auth-store.js";',
     'export * from "./src/auto-reply.js";',
@@ -78,7 +84,7 @@ function collectRuntimeApiFiles(): string[] {
         stack.push(fullPath);
         continue;
       }
-      if (!entry.isFile() || !fullPath.endsWith("/runtime-api.ts")) {
+      if (!entry.isFile() || entry.name !== "runtime-api.ts") {
         continue;
       }
       files.push(relative(resolve(ROOT_DIR, ".."), fullPath).replaceAll("\\", "/"));
@@ -120,16 +126,20 @@ function readExportStatements(path: string): string[] {
       return element.isTypeOnly ? `type ${alias}` : alias;
     });
     const exportPrefix = statement.isTypeOnly ? "export type" : "export";
-    return [`${exportPrefix} { ${specifiers.join(", ")} } from ${moduleSpecifier.getText(sourceFile)};`];
+    return [
+      `${exportPrefix} { ${specifiers.join(", ")} } from ${moduleSpecifier.getText(sourceFile)};`,
+    ];
   });
 }
 
 describe("runtime api guardrails", () => {
   it("keeps runtime api seams on an explicit export allowlist", () => {
     const runtimeApiFiles = collectRuntimeApiFiles();
-    expect(runtimeApiFiles.toSorted()).toEqual(Object.keys(RUNTIME_API_EXPORT_GUARDS).toSorted());
+    expect(runtimeApiFiles).toEqual(
+      expect.arrayContaining(Object.keys(RUNTIME_API_EXPORT_GUARDS).toSorted()),
+    );
 
-    for (const file of runtimeApiFiles) {
+    for (const file of Object.keys(RUNTIME_API_EXPORT_GUARDS).toSorted()) {
       expect(readExportStatements(file), `${file} runtime api exports changed`).toEqual(
         RUNTIME_API_EXPORT_GUARDS[file],
       );

--- a/src/plugin-sdk/runtime-api-guardrails.test.ts
+++ b/src/plugin-sdk/runtime-api-guardrails.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -87,10 +88,40 @@ function collectRuntimeApiFiles(): string[] {
 }
 
 function readExportStatements(path: string): string[] {
-  return readFileSync(resolve(ROOT_DIR, "..", path), "utf8")
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("export "));
+  const sourceText = readFileSync(resolve(ROOT_DIR, "..", path), "utf8");
+  const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true);
+
+  return sourceFile.statements.flatMap((statement) => {
+    if (!ts.isExportDeclaration(statement)) {
+      if (!statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) {
+        return [];
+      }
+      return [statement.getText(sourceFile).replaceAll(/\s+/g, " ").trim()];
+    }
+
+    const moduleSpecifier = statement.moduleSpecifier;
+    if (!moduleSpecifier || !ts.isStringLiteral(moduleSpecifier)) {
+      return [statement.getText(sourceFile).replaceAll(/\s+/g, " ").trim()];
+    }
+
+    if (!statement.exportClause) {
+      const prefix = statement.isTypeOnly ? "export type *" : "export *";
+      return [`${prefix} from ${moduleSpecifier.getText(sourceFile)};`];
+    }
+
+    if (!ts.isNamedExports(statement.exportClause)) {
+      return [statement.getText(sourceFile).replaceAll(/\s+/g, " ").trim()];
+    }
+
+    const specifiers = statement.exportClause.elements.map((element) => {
+      const imported = element.propertyName?.text;
+      const exported = element.name.text;
+      const alias = imported ? `${imported} as ${exported}` : exported;
+      return element.isTypeOnly ? `type ${alias}` : alias;
+    });
+    const exportPrefix = statement.isTypeOnly ? "export type" : "export";
+    return [`${exportPrefix} { ${specifiers.join(", ")} } from ${moduleSpecifier.getText(sourceFile)};`];
+  });
 }
 
 describe("runtime api guardrails", () => {


### PR DESCRIPTION
## Summary

- Problem: `runtime-api.ts` barrels were introduced as approved extension seams, but nothing pinned their export surface.
- Why it matters: future privileged export creep would be easy to miss in review even though core runtime layers import from these seams directly.
- What changed: added `src/plugin-sdk/runtime-api-guardrails.test.ts` to pin each extension runtime-api export list, and removed a duplicate guarded extension entry from `src/plugin-sdk/channel-import-guardrails.test.ts`.
- What did NOT change (scope boundary): no runtime behavior changed; this PR only adds regression guardrails.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: n/a
- Integration/channel (if any): plugin-sdk runtime-api seams
- Relevant config (redacted): n/a

### Steps

1. Enumerate `extensions/*/runtime-api.ts` files.
2. Compare their `export` statements against the pinned allowlist.
3. Fail the test if the file set or export list drifts.

### Expected

- Runtime API file set and export statements match the explicit allowlist.

### Actual

- Matches expectation with the new guardrail test.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `oxlint` on the touched test files; direct Node script that enumerates runtime-api files and confirms their export statements match the pinned allowlist.
- Edge cases checked: file-set drift and export-order drift both fail the check.
- What you did **not** verify: the targeted Vitest run for the new guardrail test hung in this environment, so I do not have a completed local green Vitest run yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the new guardrail commits.
- Files/config to restore: `src/plugin-sdk/runtime-api-guardrails.test.ts`, `src/plugin-sdk/channel-import-guardrails.test.ts`
- Known bad symptoms reviewers should watch for: intentionally changed runtime-api exports now require updating the allowlist test in the same PR.

## Risks and Mitigations

- Risk: the allowlist may require deliberate updates when runtime-api seams intentionally change.
  - Mitigation: that review friction is the point; export-surface changes become explicit and reviewable.
