### PR TITLE
Gateway: cover trusted-proxy scope regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
+- Gateway/auth: add regression coverage that keeps device-less trusted-proxy Control UI sessions off privileged pairing approval RPCs. Thanks @vincentkoc.
 
 ### Breaking
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -252,9 +252,7 @@ export function registerControlUiAndPairingSuite(): void {
     await configureTrustedProxyControlUiAuth();
     const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
     const { requestDevicePairing } = await import("../infra/device-pairing.js");
-    const { identity } = await createOperatorIdentityFixture(
-      "openclaw-control-ui-trusted-proxy-",
-    );
+    const { identity } = await createOperatorIdentityFixture("openclaw-control-ui-trusted-proxy-");
     const pendingRequest = await requestDevicePairing({
       deviceId: identity.deviceId,
       publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -112,6 +112,12 @@ export function registerControlUiAndPairingSuite(): void {
     expect(talk.error?.message).toBe("missing scope: operator.read");
   };
 
+  const expectDevicePairApproveDenied = async (ws: WebSocket, requestId: string) => {
+    const approve = await rpcReq(ws, "device.pair.approve", { requestId });
+    expect(approve.ok).toBe(false);
+    expect(approve.error?.message).toBe("missing scope: operator.admin");
+  };
+
   const connectControlUiWithoutDeviceAndExpectOk = async (params: {
     ws: WebSocket;
     token?: string;
@@ -244,6 +250,19 @@ export function registerControlUiAndPairingSuite(): void {
 
   test("clears self-declared scopes for trusted-proxy control ui without device identity", async () => {
     await configureTrustedProxyControlUiAuth();
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { requestDevicePairing } = await import("../infra/device-pairing.js");
+    const { identity } = await createOperatorIdentityFixture(
+      "openclaw-control-ui-trusted-proxy-",
+    );
+    const pendingRequest = await requestDevicePairing({
+      deviceId: identity.deviceId,
+      publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+      role: "operator",
+      scopes: ["operator.admin"],
+      clientId: CONTROL_UI_CLIENT.id,
+      clientMode: CONTROL_UI_CLIENT.mode,
+    });
     await withGatewayServer(async ({ port }) => {
       const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
       try {
@@ -259,6 +278,7 @@ export function registerControlUiAndPairingSuite(): void {
         await expectStatusMissingScopeButHealthOk(ws);
         await expectAdminRpcDenied(ws);
         await expectTalkSecretsDenied(ws);
+        await expectDevicePairApproveDenied(ws, pendingRequest.request.requestId);
       } finally {
         ws.close();
       }


### PR DESCRIPTION
## Summary

- Problem: `ccf16cd889` strips self-declared scopes from device-less trusted-proxy Control UI sessions, but the regression coverage only exercised `status`, `set-heartbeats`, and `talk.config`.
- Why it matters: a future handshake/path regression could restore access to other privileged RPC families without tripping the existing test.
- What changed: the control-ui auth suite now seeds a pending pairing request and asserts `device.pair.approve` is denied with `missing scope: operator.admin` for a device-less trusted-proxy Control UI session.
- What did NOT change (scope boundary): no production auth logic changed; this PR only extends regression coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: n/a
- Integration/channel (if any): Gateway Control UI / trusted-proxy auth
- Relevant config (redacted): trusted-proxy Control UI auth enabled in suite

### Steps

1. Seed a pending pairing request in the control-ui auth suite.
2. Connect a trusted-proxy Control UI client without device identity but with self-declared `operator.admin`.
3. Call `device.pair.approve`.

### Expected

- RPC is denied with `missing scope: operator.admin`.

### Actual

- Matches expectation in the updated suite.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: static review of the denial path and lightweight lint on the touched file.
- Edge cases checked: denial still happens even when the session can connect and see `health`.
- What you did **not** verify: the targeted Vitest run for `src/gateway/server.auth.control-ui.test.ts` hung in this environment, so I do not have a completed local green test run yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this test-only commit.
- Files/config to restore: `src/gateway/server.auth.control-ui.suite.ts`
- Known bad symptoms reviewers should watch for: test fixture drift if pairing helpers change.

## Risks and Mitigations

- Risk: the suite could become more brittle if pairing setup semantics change.
  - Mitigation: the new assertion uses existing pairing helpers and only checks a clear scope error.
