### PR TITLE
Matrix: avoid account helper import cycle

### DIFF
--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -1,5 +1,5 @@
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import { createAccountListHelpers } from "../../runtime-api.js";
+import { createAccountListHelpers } from "openclaw/plugin-sdk/account-resolution";
 import { hasConfiguredSecretInput } from "../secret-input.js";
 import type { CoreConfig, MatrixConfig } from "../types.js";
 import { resolveMatrixConfigForAccount } from "./client.js";


### PR DESCRIPTION
## Summary
- fix the current `pnpm test:contracts` Matrix failure on `origin/main` by avoiding the `runtime-api -> plugin-sdk/matrix -> extensions/matrix/api -> setup-surface -> accounts` import cycle
- switch `extensions/matrix/src/matrix/accounts.ts` to the narrower `openclaw/plugin-sdk/account-resolution` seam for `createAccountListHelpers`
- AI-assisted PR; `codex review --base origin/main` is not available in this environment (`codex: command not found`)

## Test plan
- [x] `pnpm build`
- [x] `bun -e "import('./extensions/matrix/src/matrix/accounts.ts').then((m)=>{console.log(typeof m.listMatrixAccountIds); console.log(typeof m.resolveDefaultMatrixAccountId);})"`
- [x] `bun -e "import('./src/channels/plugins/contracts/registry.ts').then(()=>console.log('registry import ok'))"`
- [ ] `pnpm check` still fails on current `origin/main` due unrelated formatting-only issues in `ui/src/styles/chat/layout.css`, `ui/src/styles/components.css`, and `ui/src/styles/layout.css`
- [ ] `pnpm test:extension matrix` started Vitest and then hung without producing a final summary
- [ ] `pnpm test:contracts` started Vitest and then hung without producing a final summary
- [ ] `pnpm test` started `node scripts/test-parallel.mjs` and then hung without producing shard results or a final summary

## Root cause
`extensions/matrix/src/matrix/accounts.ts` imported `createAccountListHelpers` from `../../runtime-api.js`. That re-exported `openclaw/plugin-sdk/matrix`, which in turn re-exported `../../extensions/matrix/api.js`. `extensions/matrix/api.ts` eagerly re-exported `setup-surface.ts`, and `setup-surface.ts` imports `./matrix/accounts.js`, creating a cycle that left `createAccountListHelpers` undefined during contracts loading.

This patch removes the broad Matrix runtime re-export from that path and imports `createAccountListHelpers` from the narrower `openclaw/plugin-sdk/account-resolution` seam instead.

Made with [Cursor](https://cursor.com)