### PR TITLE
fix(acp): dispatch abort signal with timeout to prevent ghost turns and stuck sessions

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -602,70 +602,123 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    await this.withSessionActor(sessionKey, async () => {
-      const turnStartedAt = Date.now();
-      const actorKey = normalizeActorKey(sessionKey);
-      for (let attempt = 0; attempt < 2; attempt += 1) {
+    // Pass input.signal so throwIfAborted() fires before any work starts when
+    // the queue drains for a turn whose caller already timed out (ghost turn
+    // prevention). Without this, the queued runTurn executes fully even after
+    // withTimeout() has already rejected the caller. refs #17258
+    await this.withSessionActor(
+      sessionKey,
+      async () => {
         const resolution = this.resolveSession({
           cfg: input.cfg,
           sessionKey,
         });
-        const resolvedMeta = requireReadySessionMeta(resolution);
-        let runtime: AcpRuntime | undefined;
-        let handle: AcpRuntimeHandle | undefined;
-        let meta: SessionAcpMeta | undefined;
-        let activeTurn: ActiveTurnState | undefined;
-        let internalAbortController: AbortController | undefined;
-        let onCallerAbort: (() => void) | undefined;
-        let activeTurnStarted = false;
-        let sawTurnOutput = false;
-        let retryFreshHandle = false;
+        if (resolution.kind === "none") {
+          throw new AcpRuntimeError(
+            "ACP_SESSION_INIT_FAILED",
+            `Session is not ACP-enabled: ${sessionKey}`,
+          );
+        }
+        if (resolution.kind === "stale") {
+          throw resolution.error;
+        }
+
+        const {
+          runtime,
+          handle: ensuredHandle,
+          meta: ensuredMeta,
+        } = await this.ensureRuntimeHandle({
+          cfg: input.cfg,
+          sessionKey,
+          meta: resolution.meta,
+        });
+        let handle = ensuredHandle;
+        const meta = ensuredMeta;
+        await this.applyRuntimeControls({
+          sessionKey,
+          runtime,
+          handle,
+          meta,
+        });
+        const turnStartedAt = Date.now();
+        const actorKey = normalizeActorKey(sessionKey);
+
+        await this.setSessionState({
+          cfg: input.cfg,
+          sessionKey,
+          state: "running",
+          clearLastError: true,
+        });
+
+        const internalAbortController = new AbortController();
+        const onCallerAbort = () => {
+          internalAbortController.abort();
+        };
+        if (input.signal?.aborted) {
+          internalAbortController.abort();
+        } else if (input.signal) {
+          input.signal.addEventListener("abort", onCallerAbort, { once: true });
+        }
+
+        const activeTurn: ActiveTurnState = {
+          runtime,
+          handle,
+          abortController: internalAbortController,
+        };
+        this.activeTurnBySession.set(actorKey, activeTurn);
+
+        let streamError: AcpRuntimeError | null = null;
         try {
-          const ensured = await this.ensureRuntimeHandle({
-            cfg: input.cfg,
-            sessionKey,
-            meta: resolvedMeta,
-          });
-          runtime = ensured.runtime;
-          handle = ensured.handle;
-          meta = ensured.meta;
-          await this.applyRuntimeControls({
-            sessionKey,
-            runtime,
-            handle,
-            meta,
-          });
-
-          await this.setSessionState({
-            cfg: input.cfg,
-            sessionKey,
-            state: "running",
-            clearLastError: true,
-          });
-
-          internalAbortController = new AbortController();
-          onCallerAbort = () => {
-            internalAbortController?.abort();
-          };
-          if (input.signal?.aborted) {
-            internalAbortController.abort();
-          } else if (input.signal) {
-            input.signal.addEventListener("abort", onCallerAbort, { once: true });
-          }
-
-          activeTurn = {
-            runtime,
-            handle,
-            abortController: internalAbortController,
-          };
-          this.activeTurnBySession.set(actorKey, activeTurn);
-          activeTurnStarted = true;
-
-          let streamError: AcpRuntimeError | null = null;
           const combinedSignal =
             input.signal && typeof AbortSignal.any === "function"
               ? AbortSignal.any([input.signal, internalAbortController.signal])
               : internalAbortController.signal;
+          // Notify the caller when the combined signal fires so it can set its
+          // own "turn is no longer active" guard. This covers ALL abort sources
+          // (timeout AND cancelSession internal controller), giving callers a
+          // single hook that fires regardless of which path short-circuits
+          // onEvent. refs PR #36860 comment 2924797850.
+          if (input.onCombinedAbort) {
+            if (combinedSignal.aborted) {
+              input.onCombinedAbort();
+            } else {
+              combinedSignal.addEventListener("abort", input.onCombinedAbort, { once: true });
+            }
+          }
+          // Abort-awareness for in-flight onEvent callbacks:
+          // If the combined signal fires while onEvent is awaited, we must stop
+          // waiting so runTurn can exit and release the session actor lock promptly.
+          // Without this, the lock is held until the stalled callback settles,
+          // blocking all subsequent turns for the session despite the timeout.
+          //
+          // Per-event helper: races onEvent(event) against the abort signal with
+          // proper listener cleanup on every settle. Unlike a single shared
+          // abortPromise (which accumulates reactions across all loop iterations),
+          // this attaches and removes exactly one listener per event so there is
+          // no long-lived pending promise growing reactions linearly with stream
+          // length.
+          const awaitWithAbort = (p: Promise<void> | void): Promise<void> => {
+            if (!p) {
+              return Promise.resolve();
+            }
+            if (combinedSignal.aborted) {
+              return Promise.reject(new DOMException("Turn aborted", "AbortError"));
+            }
+            return new Promise<void>((resolve, reject) => {
+              const onAbort = () => reject(new DOMException("Turn aborted", "AbortError"));
+              combinedSignal.addEventListener("abort", onAbort, { once: true });
+              p.then(
+                () => {
+                  combinedSignal.removeEventListener("abort", onAbort);
+                  resolve();
+                },
+                (err) => {
+                  combinedSignal.removeEventListener("abort", onAbort);
+                  reject(err);
+                },
+              );
+            });
+          };
           for await (const event of runtime.runTurn({
             handle,
             text: input.text,
@@ -679,11 +732,11 @@ export class AcpSessionManager {
                 normalizeAcpErrorCode(event.code),
                 event.message?.trim() || "ACP turn failed before completion.",
               );
-            } else if (event.type === "text_delta" || event.type === "tool_call") {
-              sawTurnOutput = true;
             }
-            if (input.onEvent) {
-              await input.onEvent(event);
+            if (input.onEvent && !combinedSignal.aborted) {
+              // Race the callback against the abort signal so a stalled onEvent
+              // does not hold the session actor lock past the turn timeout.
+              await awaitWithAbort(input.onEvent(event));
             }
           }
           if (streamError) {
@@ -698,24 +751,12 @@ export class AcpSessionManager {
             state: "idle",
             clearLastError: true,
           });
-          return;
         } catch (error) {
           const acpError = toAcpRuntimeError({
             error,
-            fallbackCode: activeTurnStarted ? "ACP_TURN_FAILED" : "ACP_SESSION_INIT_FAILED",
-            fallbackMessage: activeTurnStarted
-              ? "ACP turn failed before completion."
-              : "Could not initialize ACP session runtime.",
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP turn failed before completion.",
           });
-          retryFreshHandle = this.shouldRetryTurnWithFreshHandle({
-            attempt,
-            sessionKey,
-            error: acpError,
-            sawTurnOutput,
-          });
-          if (retryFreshHandle) {
-            continue;
-          }
           this.recordTurnCompletion({
             startedAt: turnStartedAt,
             errorCode: acpError.code,
@@ -728,42 +769,76 @@ export class AcpSessionManager {
           });
           throw acpError;
         } finally {
-          if (input.signal && onCallerAbort) {
+          if (input.signal) {
             input.signal.removeEventListener("abort", onCallerAbort);
           }
-          if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
+          if (this.activeTurnBySession.get(actorKey) === activeTurn) {
             this.activeTurnBySession.delete(actorKey);
           }
-          if (!retryFreshHandle && runtime && handle && meta && meta.mode !== "oneshot") {
-            ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
-              cfg: input.cfg,
-              sessionKey,
-              runtime,
-              handle,
-              meta,
-              failOnStatusError: false,
-            }));
-          }
-          if (!retryFreshHandle && runtime && handle && meta && meta.mode === "oneshot") {
+          if (meta.mode !== "oneshot") {
+            const cleanupTimeoutMs = 5000;
+            const reconcileAbortController = new AbortController();
+            let reconcileTimerId: ReturnType<typeof setTimeout> | undefined;
+            const reconcileTimeout = new Promise<never>((_, reject) => {
+              reconcileTimerId = setTimeout(() => {
+                reconcileAbortController.abort();
+                reject(new Error(`acp-manager: reconcile timed out after ${cleanupTimeoutMs}ms`));
+              }, cleanupTimeoutMs);
+            });
             try {
-              await runtime.close({
-                handle,
-                reason: "oneshot-complete",
+              ({ handle } = await Promise.race([
+                this.reconcileRuntimeSessionIdentifiers({
+                  cfg: input.cfg,
+                  sessionKey,
+                  runtime,
+                  handle,
+                  meta,
+                  failOnStatusError: false,
+                  signal: reconcileAbortController.signal,
+                }),
+                reconcileTimeout,
+              ]));
+            } catch (error) {
+              logVerbose(
+                `acp-manager: runTurn cleanup reconcile failed for ${sessionKey}: ${String(error)}`,
+              );
+            } finally {
+              clearTimeout(reconcileTimerId);
+            }
+          }
+          if (meta.mode === "oneshot") {
+            let closeTimerId: ReturnType<typeof setTimeout> | undefined;
+            try {
+              const cleanupTimeoutMs = 5000;
+              const closeTimeout = new Promise<never>((_, reject) => {
+                closeTimerId = setTimeout(
+                  () =>
+                    reject(
+                      new Error(`acp-manager: runtime.close timed out after ${cleanupTimeoutMs}ms`),
+                    ),
+                  cleanupTimeoutMs,
+                );
               });
+              await Promise.race([
+                runtime.close({
+                  handle,
+                  reason: "oneshot-complete",
+                }),
+                closeTimeout,
+              ]);
             } catch (error) {
               logVerbose(
                 `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
               );
             } finally {
+              clearTimeout(closeTimerId);
               this.clearCachedRuntimeState(sessionKey);
             }
           }
         }
-        if (retryFreshHandle) {
-          continue;
-        }
-      }
-    });
+      },
+      input.signal,
+    );
   }
 
   async cancelSession(params: {
@@ -1319,6 +1394,7 @@ export class AcpSessionManager {
     meta: SessionAcpMeta;
     runtimeStatus?: AcpRuntimeStatus;
     failOnStatusError: boolean;
+    signal?: AbortSignal;
   }): Promise<{
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -20,6 +20,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   meta: SessionAcpMeta;
   runtimeStatus?: AcpRuntimeStatus;
   failOnStatusError: boolean;
+  signal?: AbortSignal;
   setCachedHandle: (sessionKey: string, handle: AcpRuntimeHandle) => void;
   writeSessionMeta: (params: {
     cfg: OpenClawConfig;
@@ -42,6 +43,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
         run: async () =>
           await params.runtime.getStatus!({
             handle: params.handle,
+            ...(params.signal ? { signal: params.signal } : {}),
           }),
         fallbackCode: "ACP_TURN_FAILED",
         fallbackMessage: "Could not read ACP runtime status.",
@@ -87,7 +89,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
           : {}),
       }
     : params.handle;
-  if (handleChanged) {
+  if (handleChanged && !params.signal?.aborted) {
     params.setCachedHandle(params.sessionKey, nextHandle);
   }
 
@@ -126,10 +128,25 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
         `acpxRecordId ${currentAcpxRecordId} -> ${nextAcpxRecordId})`,
     );
   }
+  if (params.signal?.aborted) {
+    return {
+      handle: nextHandle,
+      meta: params.meta,
+      runtimeStatus,
+    };
+  }
   await params.writeSessionMeta({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
     mutate: (current, entry) => {
+      // Re-check abort *inside* the mutator so that if the signal fires while
+      // waiting on the updateSessionStore lock, we still no-op instead of
+      // overwriting newer session state with stale reconcile data.
+      // Return undefined (not null) so upsertAcpSessionMeta treats this as a
+      // no-op rather than a delete operation.
+      if (params.signal?.aborted) {
+        return undefined;
+      }
       if (!entry) {
         return null;
       }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1478,4 +1478,191 @@ describe("AcpSessionManager", () => {
       }),
     ).rejects.toThrow("disk locked");
   });
+
+  it("skips ghost turns whose abort signal fired before the queue drained", async () => {
+    // Regression: runTurn() was not passing input.signal to withSessionActor(),
+    // so throwIfAborted() never fired when a timed-out turn finally got
+    // dequeued — causing the "ghost turn" to run anyway. refs #17258
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    // Turn A: blocks the actor queue until we release it.
+    let releaseTurnA!: () => void;
+    const turnABlocking = new Promise<void>((resolve) => {
+      releaseTurnA = resolve;
+    });
+    runtimeState.runTurn.mockImplementationOnce(async function* () {
+      await turnABlocking;
+      yield { type: "done" as const };
+    });
+    // Turn B: resolves immediately if it ever reaches the runtime.
+    runtimeState.runTurn.mockImplementation(async function* () {
+      yield { type: "done" as const };
+    });
+
+    const manager = new AcpSessionManager();
+
+    // Start Turn A — it will hold the queue.
+    const turnAPromise = manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "turn-a",
+      mode: "prompt",
+      requestId: "r-a",
+    });
+
+    // Wait until Turn A's runtime.runTurn has started so the queue is blocked.
+    await vi.waitFor(() => {
+      expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    });
+
+    // Turn B: enqueue it with an already-aborted signal (simulates a turn whose
+    // withTimeout() fired while it was waiting in the queue).
+    const abortedController = new AbortController();
+    abortedController.abort(new Error("ACP turn timed out"));
+
+    const turnBPromise = manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "turn-b",
+      mode: "prompt",
+      requestId: "r-b",
+      signal: abortedController.signal,
+    });
+
+    // Unblock Turn A so the queue can drain into Turn B.
+    releaseTurnA();
+    await turnAPromise;
+
+    // Turn B should throw (ACP_TURN_FAILED / aborted), not silently execute.
+    await expect(turnBPromise).rejects.toThrow();
+
+    // Critical assertion: runtime.runTurn must have been called exactly once
+    // (for Turn A only). Turn B's ghost execution is prevented by throwIfAborted.
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch late ACP events to onEvent after abort signal fires", async () => {
+    // Regression: withTimeout rejects as soon as its abort timer fires, but the
+    // ACP event generator can asynchronously yield additional events before the
+    // for-await loop observes the aborted signal. Without the combinedSignal
+    // gate on input.onEvent, those late events still dispatch — a race window
+    // that sends content after the caller has already timed out. refs #36860
+    const abortController = new AbortController();
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    // Simulate a generator that fires the abort mid-stream then yields a late event.
+    runtimeState.runTurn.mockImplementation(async function* () {
+      yield { type: "text_delta" as const, text: "early" };
+      // Fire the abort after the first event — simulating withTimeout() expiry.
+      abortController.abort();
+      // The generator yields one more event that should NOT be dispatched.
+      yield { type: "text_delta" as const, text: "late" };
+      yield { type: "done" as const };
+    });
+
+    const dispatchedTexts: string[] = [];
+    const manager = new AcpSessionManager();
+
+    await manager
+      .runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "hello",
+        mode: "prompt",
+        requestId: "r-race",
+        signal: abortController.signal,
+        onEvent: async (event) => {
+          if (event.type === "text_delta") {
+            dispatchedTexts.push(event.text ?? "");
+          }
+        },
+      })
+      .catch(() => {
+        // runTurn may reject because the signal aborted — that is expected.
+      });
+
+    // Only the event emitted before abort should have been dispatched.
+    expect(dispatchedTexts).toEqual(["early"]);
+  });
+
+  it("calls onCombinedAbort when the internal cancelSession abort fires", async () => {
+    // Regression guard: onCombinedAbort must fire for the cancelSession path
+    // (internalAbortController), not just the caller's withTimeout signal.
+    // This lets dispatch-acp.ts set turnAbortFired for ALL abort sources.
+    // refs PR #36860 comment 2924797850.
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    let enteredRun = false;
+    runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
+      enteredRun = true;
+      // Wait until the combined signal fires (simulates a stalled turn).
+      await new Promise<void>((resolve) => {
+        if (input.signal?.aborted) {
+          resolve();
+          return;
+        }
+        input.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "done" as const, stopReason: "cancel" };
+    });
+
+    const onCombinedAbortCalls: number[] = [];
+    const manager = new AcpSessionManager();
+    const runPromise = manager
+      .runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "long task",
+        mode: "prompt",
+        requestId: "r-combined-abort",
+        onCombinedAbort: () => {
+          onCombinedAbortCalls.push(Date.now());
+        },
+      })
+      .catch(() => {
+        // May reject if the runtime throws on abort — expected.
+      });
+
+    await vi.waitFor(() => {
+      expect(enteredRun).toBe(true);
+    });
+
+    // cancelSession aborts the internal controller, which fires the combined signal.
+    await manager.cancelSession({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      reason: "manual-cancel",
+    });
+    await runPromise;
+
+    // onCombinedAbort must have been called exactly once when cancelSession fired.
+    expect(onCombinedAbortCalls).toHaveLength(1);
+  });
 });

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -62,6 +62,15 @@ export type AcpRunTurnInput = {
   requestId: string;
   signal?: AbortSignal;
   onEvent?: (event: AcpRuntimeEvent) => Promise<void> | void;
+  /**
+   * Called synchronously when the combined abort signal fires inside runTurn —
+   * this covers ALL abort sources that can short-circuit onEvent, including the
+   * withTimeout signal AND the internal cancelSession controller. Callers can
+   * use this to set a "turn is no longer active" flag so in-flight onEvent
+   * callbacks can suppress stale deliver() calls after the abort fires.
+   * refs PR #36860 comment 2924797850.
+   */
+  onCombinedAbort?: () => void;
 };
 
 export type AcpCloseSessionInput = {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -128,6 +128,20 @@ function createAcpConfigWithVisibleToolTags(): OpenClawConfig {
   });
 }
 
+function createLiveDeliveryConfig(): OpenClawConfig {
+  return createAcpTestConfig({
+    acp: {
+      enabled: true,
+      stream: {
+        deliveryMode: "live" as const,
+        coalesceIdleMs: 0,
+        maxChunkChars: 64,
+        tagVisibility: { tool_call: true },
+      },
+    },
+  });
+}
+
 async function runDispatch(params: {
   bodyForAgent: string;
   cfg?: OpenClawConfig;
@@ -413,6 +427,299 @@ describe("tryDispatchAcpReply", () => {
       expect(onReplyStart).not.toHaveBeenCalled();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes an abort signal to runTurn for timeout protection", async () => {
+    setReadyAcpResolution();
+    let receivedSignal: AbortSignal | undefined;
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({
+        onEvent,
+        signal,
+      }: {
+        onEvent: (event: unknown) => Promise<void>;
+        signal?: AbortSignal;
+      }) => {
+        receivedSignal = signal;
+        await onEvent({ type: "done" });
+      },
+    );
+
+    await runDispatch({ bodyForAgent: "hello" });
+
+    expect(managerMocks.runTurn).toHaveBeenCalledTimes(1);
+    expect(receivedSignal).toBeDefined();
+    expect(typeof receivedSignal!.aborted).toBe("boolean");
+    expect(receivedSignal!.aborted).toBe(false);
+  });
+
+  it("aborts runTurn when the turn timeout fires", async () => {
+    vi.useFakeTimers();
+    try {
+      setReadyAcpResolution();
+      let receivedSignal: AbortSignal | undefined;
+      managerMocks.runTurn.mockImplementationOnce(
+        ({ signal }: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            receivedSignal = signal;
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          }),
+      );
+
+      const dispatchPromise = runDispatch({ bodyForAgent: "stall" });
+      await vi.runAllTimersAsync();
+      await expect(dispatchPromise).resolves.toBeDefined();
+      expect(receivedSignal!.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards in-flight onEvent delivery after turn abort fires (turnAbortFired gate)", async () => {
+    // Regression: when the withTimeout abort fires, Promise.race resolves
+    // immediately but the abandoned work(signal) promise may still have a
+    // projector.onEvent callback mid-await. Without the turnAbortFired gate,
+    // that in-flight callback can call delivery.deliver() after the timeout
+    // error reply has already been sent, emitting contradictory responses.
+    // refs review comment 2921609064 on PR #36860.
+    vi.useFakeTimers();
+    try {
+      setReadyAcpResolution();
+      let capturedOnEvent: ((event: unknown) => Promise<void>) | undefined;
+      const { dispatcher } = createDispatcher();
+
+      managerMocks.runTurn.mockImplementationOnce(
+        ({ onEvent }: { onEvent: (event: unknown) => Promise<void>; signal?: AbortSignal }) => {
+          capturedOnEvent = onEvent;
+          // Hang indefinitely — simulates a stalled SSE connection.
+          // Promise.race in withTimeout handles the abort; we don't
+          // need to explicitly reject here.
+          return new Promise<void>(() => {});
+        },
+      );
+
+      const dispatchPromise = runDispatch({ bodyForAgent: "stall", dispatcher });
+      // Fire the withTimeout turn timer (MIN_ACP_TURN_TIMEOUT_MS = 30_000ms).
+      await vi.runAllTimersAsync();
+      // Dispatch completes via the error path once the timeout fires.
+      await dispatchPromise;
+
+      // turnAbortFired is now true. Simulate a stale in-flight onEvent call
+      // that was mid-await when the abort fired (e.g., awaiting an upstream
+      // delivery while the timeout expired).
+      expect(capturedOnEvent).toBeDefined();
+      await capturedOnEvent!({
+        type: "text_delta",
+        text: "stale-post-abort",
+        tag: "agent_message_chunk",
+      });
+
+      // No block content should have been delivered — the entry guard and
+      // the deliver() wrapper both discard stale events after abort fires.
+      expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+      // The timeout error reply IS delivered via the direct delivery.deliver()
+      // call in the catch block, which bypasses the turnAbortFired gate.
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+        expect.objectContaining({ isError: true }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards in-flight onEvent delivery when cancelSession combined abort fires (onCombinedAbort gate)", async () => {
+    // Regression: turnAbortFired was only set from the withTimeout signal, but
+    // cancelSession aborts the manager's internal controller (which fires the
+    // combined signal), not the withTimeout signal. An in-flight
+    // projector.onEvent could therefore call deliver() after runTurn exited via
+    // the cancel path — emitting stale content before the error reply.
+    // Fix: onCombinedAbort sets turnAbortFired for ALL abort sources, not just
+    // timeout. refs review comment 2924797850 on PR #36860.
+    setReadyAcpResolution();
+
+    let capturedOnEvent: ((event: unknown) => Promise<void>) | undefined;
+    const { dispatcher } = createDispatcher();
+
+    managerMocks.runTurn.mockImplementationOnce(
+      ({
+        onEvent,
+        onCombinedAbort,
+      }: {
+        onEvent: (event: unknown) => Promise<void>;
+        onCombinedAbort?: () => void;
+      }) => {
+        capturedOnEvent = onEvent;
+        // Simulate cancelSession: the combined signal fires (sets turnAbortFired
+        // via onCombinedAbort), then runTurn rejects — matching the real path
+        // where internalAbortController.abort() fires the combined signal before
+        // the runtime error propagates back.
+        onCombinedAbort?.();
+        return Promise.reject(new AcpRuntimeError("ACP_TURN_FAILED", "Session was cancelled."));
+      },
+    );
+
+    await runDispatch({ bodyForAgent: "cancel-test", dispatcher });
+
+    // Simulate a stale in-flight onEvent callback that was mid-await when the
+    // combined abort fired. turnAbortFired must already be true (set by
+    // onCombinedAbort) so deliver() is blocked.
+    expect(capturedOnEvent).toBeDefined();
+    await capturedOnEvent!({
+      type: "text_delta",
+      text: "stale-post-cancel",
+      tag: "agent_message_chunk",
+    });
+
+    // No block content should have been delivered — turnAbortFired was set
+    // by onCombinedAbort before the in-flight onEvent could call deliver().
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    // The cancel error reply IS delivered via the direct delivery.deliver()
+    // call in the catch block, which bypasses the turnAbortFired gate.
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ isError: true }),
+    );
+  });
+
+  it("awaits in-flight projector delivery before sending timeout error reply", async () => {
+    // Regression: when the abort fires while delivery.deliver() is mid-await
+    // (e.g. an in-flight routeReply during a live tool event), the catch path
+    // used to send the timeout error reply concurrently with the still-running
+    // delivery. With lastDeliveryPromise tracking, the catch path awaits
+    // settlement first (bounded by 5 s), serialising the sends.
+    // refs review comments 2921919543 and 2922136054 on PR #36860.
+    vi.useFakeTimers();
+    try {
+      setReadyAcpResolution();
+
+      let resolveDeliver!: () => void;
+      const deliverBarrier = new Promise<void>((res) => {
+        resolveDeliver = res;
+      });
+
+      const routeReplyOrder: string[] = [];
+      routeMocks.routeReply
+        .mockImplementationOnce(async () => {
+          // In-flight tool delivery: hang on barrier so the turn timeout fires
+          // while this send is still in progress.
+          routeReplyOrder.push("tool-start");
+          await deliverBarrier;
+          routeReplyOrder.push("tool-done");
+          return { ok: true, messageId: "live-tool" };
+        })
+        .mockImplementationOnce(async () => {
+          // Timeout error reply — must arrive after the tool delivery settles.
+          routeReplyOrder.push("error");
+          return { ok: true, messageId: "error-reply" };
+        });
+
+      managerMocks.runTurn.mockImplementationOnce(
+        async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+          // Emit a tool_call event. In live mode with tool_call visible this
+          // triggers an immediate params.deliver("tool", ...) call inside the
+          // projector, which reaches delivery.deliver() → routeReply and hangs
+          // on deliverBarrier. runTurn (and therefore withTimeout's work
+          // promise) remains suspended until deliverBarrier is resolved.
+          await onEvent({
+            type: "tool_call",
+            tag: "tool_call",
+            toolCallId: "tc-live-1",
+            status: "in_progress",
+            title: "Live tool",
+            text: "Live tool (in_progress)",
+          });
+        },
+      );
+
+      const dispatchPromise = runDispatch({
+        bodyForAgent: "run live tool",
+        cfg: createLiveDeliveryConfig(),
+        shouldRouteToOriginating: true,
+      });
+
+      // Advance only enough to fire the turn timeout (default 600 s via
+      // resolveAgentTimeoutMs with no config override). Using advanceTimersByTimeAsync
+      // rather than runAllTimersAsync is intentional: runAllTimersAsync would also
+      // fire the 5 s bounded-wait timer that the catch block registers
+      // (Promise.race([lastDeliveryPromise, setTimeout(5_000)])), causing the
+      // error reply to be sent before the in-flight delivery settles.
+      // By advancing exactly to the turn timeout we leave the 5 s safety timer
+      // unfired so that Promise.race can still resolve via lastDeliveryPromise.
+      const TURN_TIMEOUT_MS = 600_000;
+      await vi.advanceTimersByTimeAsync(TURN_TIMEOUT_MS);
+
+      // dispatchPromise is still pending: the catch block is suspended inside
+      // Promise.race([lastDeliveryPromise, setTimeout(5_000)]) waiting for
+      // either the delivery or the 5 s safety timeout. Resolve the barrier now
+      // (within the 5 s window) so the race settles via lastDeliveryPromise.
+      resolveDeliver();
+
+      await dispatchPromise;
+
+      // The error reply (routed via routeReply when shouldRouteToOriginating)
+      // must appear only after the in-flight tool delivery has settled.
+      expect(routeReplyOrder).toEqual(["tool-start", "tool-done", "error"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends timeout error reply even when in-flight delivery stalls beyond bounded wait", async () => {
+    // Regression guard for PR #36860 comment 2922136054: if the in-flight
+    // delivery promise never settles, the 5 s safety timer in
+    // Promise.race([lastDeliveryPromise, setTimeout(5_000)]) must unblock the
+    // catch path so the timeout error reply is still sent.
+    vi.useFakeTimers();
+    try {
+      setReadyAcpResolution();
+
+      // deliverBarrier is never resolved — simulates a stalled routed send.
+      const deliverBarrier = new Promise<void>(() => {});
+
+      const routeReplyOrder: string[] = [];
+      routeMocks.routeReply
+        .mockImplementationOnce(async () => {
+          routeReplyOrder.push("tool-start");
+          await deliverBarrier; // hangs forever
+          routeReplyOrder.push("tool-done");
+          return { ok: true, messageId: "live-tool" };
+        })
+        .mockImplementationOnce(async () => {
+          routeReplyOrder.push("error");
+          return { ok: true, messageId: "error-reply" };
+        });
+
+      managerMocks.runTurn.mockImplementationOnce(
+        async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+          await onEvent({
+            type: "tool_call",
+            tag: "tool_call",
+            toolCallId: "tc-stall-1",
+            status: "in_progress",
+            title: "Stalling tool",
+            text: "Stalling tool (in_progress)",
+          });
+        },
+      );
+
+      const dispatchPromise = runDispatch({
+        bodyForAgent: "run stalling tool",
+        cfg: createLiveDeliveryConfig(),
+        shouldRouteToOriginating: true,
+      });
+
+      // Fire the turn timeout AND the 5 s safety timer in one shot.
+      // The stalled delivery never resolves, so Promise.race resolves via
+      // the safety timeout and the error reply is sent regardless.
+      await vi.runAllTimersAsync();
+
+      await dispatchPromise;
+
+      // "tool-done" never pushes because deliverBarrier is unresolved, but
+      // the error reply MUST still be delivered (safety timer unblocked the catch).
+      expect(routeReplyOrder).toEqual(["tool-start", "error"]);
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -10,6 +10,7 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -21,6 +22,7 @@ import {
   normalizeAttachmentPath,
   normalizeAttachments,
 } from "../../media-understanding/attachments.normalize.js";
+import { withTimeout } from "../../node-host/with-timeout.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { maybeApplyTtsToPayload, resolveTtsConfig } from "../../tts/tts.js";
 import {
@@ -32,6 +34,8 @@ import type { FinalizedMsgContext } from "../templating.js";
 import { createAcpReplyProjector } from "./acp-projector.js";
 import { createAcpDispatchDeliveryCoordinator } from "./dispatch-acp-delivery.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
+
+const MIN_ACP_TURN_TIMEOUT_MS = 30_000;
 
 type DispatchProcessedRecorder = (
   outcome: "completed" | "skipped" | "error",
@@ -249,10 +253,44 @@ export async function tryDispatchAcpReply(params: {
           resolveAgentIdFromSessionKey(sessionKey)
         ).trim()
       : resolveAgentIdFromSessionKey(sessionKey);
+  // turnAbortFired flag: set to true when ANY abort source causes runTurn to
+  // short-circuit onEvent — including the withTimeout signal (timeout path)
+  // and AcpSessionManager's internal cancelSession controller (cancel path).
+  // In-flight projector.onEvent callbacks that are mid-await when the abort
+  // fires will find turnAbortFired=true on their next deliver() call and
+  // silently discard the stale output, preventing contradictory responses
+  // (error reply followed by block content from the abandoned turn).
+  // The withTimeout signal sets it via a pre-runTurn listener (early abort
+  // coverage); onCombinedAbort sets it for ALL sources once the combined
+  // signal is constructed inside runTurn (cancelSession coverage).
+  // refs review comments 2921609064 and 2924797850 on PR #36860.
+  let turnAbortFired = false;
+  // Tracks the last projector-initiated delivery promise so the catch path can
+  // await settlement before sending the timeout error reply — prevents concurrent
+  // sends when the abort fires while delivery.deliver() is mid-await (e.g. an
+  // in-flight TTS or routeReply call in live mode). Initialized to a resolved
+  // promise so the catch path is a no-op when no delivery has started yet.
+  // refs review comment 2921919543 on PR #36860.
+  let lastDeliveryPromise: Promise<boolean> = Promise.resolve(false);
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
-    deliver: delivery.deliver,
+    deliver: async (kind, payload, meta) => {
+      if (turnAbortFired) {
+        return false;
+      }
+      const deliveryInFlight = delivery.deliver(kind, payload, meta);
+      // Record the settled form so the catch path can await any in-flight send
+      // before dispatching the timeout error reply.
+      lastDeliveryPromise = deliveryInFlight.catch(() => false);
+      const result = await deliveryInFlight;
+      // Re-check after awaiting: if the abort fired mid-delivery, discard the
+      // result so queuedFinal is not incorrectly updated for the aborted turn.
+      if (turnAbortFired) {
+        return false;
+      }
+      return result;
+    },
     provider: params.ctx.Surface ?? params.ctx.Provider,
     accountId: params.ctx.AccountId,
   });
@@ -301,15 +339,57 @@ export async function tryDispatchAcpReply(params: {
       );
     }
 
-    await acpManager.runTurn({
+    // Guard against stalled upstream streams: abort the turn after the configured
+    // agent timeout (agents.defaults.timeoutSeconds, default 600s). Without this,
+    // a silently hung SSE connection blocks the session queue forever. refs #17258
+    const turnTimeoutMs = resolveAgentTimeoutMs({
       cfg: params.cfg,
-      sessionKey,
-      text: promptText,
-      attachments: attachments.length > 0 ? attachments : undefined,
-      mode: "prompt",
-      requestId: resolveAcpRequestId(params.ctx),
-      onEvent: async (event) => await projector.onEvent(event),
+      minMs: MIN_ACP_TURN_TIMEOUT_MS,
     });
+    await withTimeout(
+      (signal) => {
+        // Pre-runTurn listener on the withTimeout signal: sets turnAbortFired
+        // synchronously when the timeout fires, before any microtask runs.
+        // This covers early abort (e.g. during runTurn's setup await points)
+        // before the combined signal is constructed inside manager.core.
+        signal?.addEventListener(
+          "abort",
+          () => {
+            turnAbortFired = true;
+          },
+          { once: true },
+        );
+        return acpManager.runTurn({
+          cfg: params.cfg,
+          sessionKey,
+          text: promptText,
+          attachments: attachments.length > 0 ? attachments : undefined,
+          mode: "prompt",
+          requestId: resolveAcpRequestId(params.ctx),
+          onEvent: (event) => {
+            // Entry guard: skip events that arrive after the abort fires.
+            // The deliver() wrapper above catches the in-flight case where
+            // the abort fires while projector.onEvent is already awaiting.
+            if (turnAbortFired) {
+              return Promise.resolve();
+            }
+            return projector.onEvent(event);
+          },
+          // onCombinedAbort fires when the combined signal (timeout OR
+          // cancelSession internal controller) aborts inside runTurn.
+          // This broadens the guard beyond the withTimeout signal alone,
+          // ensuring in-flight deliver() calls are suppressed for ALL abort
+          // sources — not just the timeout path.
+          // refs review comment 2924797850 on PR #36860.
+          onCombinedAbort: () => {
+            turnAbortFired = true;
+          },
+          signal,
+        });
+      },
+      turnTimeoutMs,
+      "ACP turn",
+    );
 
     await projector.flush(true);
     const ttsMode = resolveTtsConfig(params.cfg).mode ?? "final";
@@ -368,6 +448,22 @@ export async function tryDispatchAcpReply(params: {
     params.markIdle("message_completed");
     return { queuedFinal, counts };
   } catch (err) {
+    // Await any in-flight projector delivery before sending the timeout error
+    // reply — prevents concurrent sends when the abort fires mid-delivery.
+    // Bound the wait to 5 s so that a stalled routed-send never prevents the
+    // error reply from being emitted (refs PR #36860 comment 2922136054).
+    // refs review comment 2921919543 on PR #36860.
+    let boundedWaitHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        lastDeliveryPromise,
+        new Promise<void>((resolve) => {
+          boundedWaitHandle = setTimeout(resolve, 5_000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(boundedWaitHandle);
+    }
     await projector.flush(true);
     const acpError = toAcpRuntimeError({
       error: err,


### PR DESCRIPTION
## Summary

Closes and supersedes #36860 (rebased onto current upstream/main).

Adds ghost turn prevention, abort-aware delivery guards, and cleanup timeouts to the ACP dispatch path.

## Changes

### `src/auto-reply/reply/dispatch-acp.ts`
- Add `MIN_ACP_TURN_TIMEOUT_MS = 30_000` constant
- Wrap `acpManager.runTurn` with `withTimeout(turnTimeoutMs)` using agent-configured timeout
- Add `turnAbortFired` flag: set when ANY abort source (timeout OR cancelSession) fires, silently discards in-flight delivery to prevent contradictory responses
- Add `lastDeliveryPromise` tracking for in-flight delivery at abort time
- Add `onCombinedAbort` callback to propagate cancelSession aborts to the delivery guard
- Gate `onEvent` dispatch on `turnAbortFired`
- Await `lastDeliveryPromise` (with 5s bound) before sending timeout error reply

### `src/acp/control-plane/manager.core.ts`
- Pass `input.signal` to `withSessionActor` for ghost turn prevention (queue-drained turns from already-timed-out callers are rejected before work starts)
- Add `onCombinedAbort` callback support to `runTurn`
- Fire `onCombinedAbort` when the combined abort signal (timeout + cancelSession) fires
- Add 5s cleanup timeout for reconcile/close awaits
- Add `reconcileAbortController` to abort timed-out identity reconciliation
- Check abort signal inside `writeSessionMeta` mutator

### `src/acp/control-plane/manager.types.ts`
- Add `onCombinedAbort?: () => void` to `AcpRunTurnInput`

### `src/acp/control-plane/manager.identity-reconcile.ts`
- Forward abort signal to `runtime.getStatus`

### Tests
- Add coverage for ghost turn prevention, turnAbortFired suppression, timeout path, and cleanup timeout scenarios