### PR TITLE
Format: fix current oxfmt drift

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -80,10 +80,8 @@ vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
       const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
       return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
     },
-    resolveProviderCapabilitiesWithPlugin: (params: {
-      provider: string;
-      workspaceDir?: string;
-    }) => resolveProviderCapabilitiesWithPluginMock(params),
+    resolveProviderCapabilitiesWithPlugin: (params: { provider: string; workspaceDir?: string }) =>
+      resolveProviderCapabilitiesWithPluginMock(params),
   };
 });
 

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -89,11 +89,14 @@ function hasOpenAiAnthropicToolPayloadCompatFlag(model: { compat?: unknown }): b
   );
 }
 
-function requiresAnthropicToolPayloadCompatibilityForModel(model: {
-  api?: unknown;
-  provider?: unknown;
-  compat?: unknown;
-}, options?: AnthropicToolPayloadResolverOptions): boolean {
+function requiresAnthropicToolPayloadCompatibilityForModel(
+  model: {
+    api?: unknown;
+    provider?: unknown;
+    compat?: unknown;
+  },
+  options?: AnthropicToolPayloadResolverOptions,
+): boolean {
   if (model.api !== "anthropic-messages") {
     return false;
   }
@@ -107,10 +110,13 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
   return hasOpenAiAnthropicToolPayloadCompatFlag(model);
 }
 
-function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
-  provider?: unknown;
-  compat?: unknown;
-}, options?: AnthropicToolPayloadResolverOptions): boolean {
+function usesOpenAiFunctionAnthropicToolSchemaForModel(
+  model: {
+    provider?: unknown;
+    compat?: unknown;
+  },
+  options?: AnthropicToolPayloadResolverOptions,
+): boolean {
   if (
     typeof model.provider === "string" &&
     usesOpenAiFunctionAnthropicToolSchema(model.provider, options)
@@ -120,10 +126,13 @@ function usesOpenAiFunctionAnthropicToolSchemaForModel(model: {
   return hasOpenAiAnthropicToolPayloadCompatFlag(model);
 }
 
-function usesOpenAiStringModeAnthropicToolChoiceForModel(model: {
-  provider?: unknown;
-  compat?: unknown;
-}, options?: AnthropicToolPayloadResolverOptions): boolean {
+function usesOpenAiStringModeAnthropicToolChoiceForModel(
+  model: {
+    provider?: unknown;
+    compat?: unknown;
+  },
+  options?: AnthropicToolPayloadResolverOptions,
+): boolean {
   if (
     typeof model.provider === "string" &&
     usesOpenAiStringModeAnthropicToolChoice(model.provider, options)

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -1,6 +1,6 @@
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveProviderCapabilitiesWithPlugin } from "../plugins/provider-runtime.js";
 import { normalizeProviderId } from "./model-selection.js";
-import type { OpenClawConfig } from "../config/config.js";
 
 export type ProviderCapabilities = {
   anthropicToolSchemaMode: "native" | "openai-functions";
@@ -125,8 +125,7 @@ export function usesOpenAiStringModeAnthropicToolChoice(
   options?: ProviderCapabilityLookupOptions,
 ): boolean {
   return (
-    resolveProviderCapabilities(provider, options).anthropicToolChoiceMode ===
-    "openai-string-modes"
+    resolveProviderCapabilities(provider, options).anthropicToolChoiceMode === "openai-string-modes"
   );
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -63,7 +63,7 @@
   background: transparent;
 }
 
-.chat-thread-inner> :first-child {
+.chat-thread-inner > :first-child {
   margin-top: 0 !important;
 }
 
@@ -320,7 +320,7 @@
 }
 
 /* Hide the "Message" label - keep textarea only */
-.chat-compose__field>span {
+.chat-compose__field > span {
   display: none;
 }
 
@@ -391,7 +391,7 @@
   }
 }
 
-.agent-chat__input>textarea {
+.agent-chat__input > textarea {
   width: 100%;
   min-height: 40px;
   max-height: 150px;
@@ -407,7 +407,7 @@
   box-sizing: border-box;
 }
 
-.agent-chat__input>textarea::placeholder {
+.agent-chat__input > textarea::placeholder {
   color: var(--muted);
 }
 
@@ -549,7 +549,7 @@
   scrollbar-width: thin;
 }
 
-.slash-menu-group+.slash-menu-group {
+.slash-menu-group + .slash-menu-group {
   margin-top: 4px;
   padding-top: 4px;
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1019,11 +1019,11 @@
   position: relative;
 }
 
-.cron-filter-dropdown__details>summary {
+.cron-filter-dropdown__details > summary {
   list-style: none;
 }
 
-.cron-filter-dropdown__details>summary::-webkit-details-marker {
+.cron-filter-dropdown__details > summary::-webkit-details-marker {
   display: none;
 }
 
@@ -1645,7 +1645,6 @@
 }
 
 @media (max-width: 1100px) {
-
   .table-head,
   .table-row {
     grid-template-columns: 1fr;
@@ -1653,7 +1652,6 @@
 }
 
 @container (max-width: 1100px) {
-
   .table-head,
   .table-row {
     grid-template-columns: 1fr;
@@ -2306,7 +2304,6 @@
 }
 
 @keyframes chatStreamPulse {
-
   0%,
   100% {
     border-color: var(--border);
@@ -2341,7 +2338,7 @@
   height: 12px;
 }
 
-.chat-reading-indicator__dots>span {
+.chat-reading-indicator__dots > span {
   display: inline-block;
   width: 6px;
   height: 6px;
@@ -2353,16 +2350,15 @@
   will-change: transform, opacity;
 }
 
-.chat-reading-indicator__dots>span:nth-child(2) {
+.chat-reading-indicator__dots > span:nth-child(2) {
   animation-delay: 0.15s;
 }
 
-.chat-reading-indicator__dots>span:nth-child(3) {
+.chat-reading-indicator__dots > span:nth-child(3) {
   animation-delay: 0.3s;
 }
 
 @keyframes chatReadingDot {
-
   0%,
   80%,
   100% {
@@ -2377,7 +2373,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat-reading-indicator__dots>span {
+  .chat-reading-indicator__dots > span {
     animation: none;
     opacity: 0.6;
   }
@@ -3063,7 +3059,7 @@
   min-width: 0;
 }
 
-.agent-kv>div {
+.agent-kv > div {
   min-width: 0;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -3318,7 +3314,7 @@
   gap: 8px;
 }
 
-.agent-skills-header>span:last-child {
+.agent-skills-header > span:last-child {
   margin-left: auto;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -70,7 +70,7 @@
   padding-top: 0;
 }
 
-.shell--chat-focus .content>*+* {
+.shell--chat-focus .content > * + * {
   margin-top: 0;
 }
 
@@ -688,9 +688,11 @@
 
 .sidebar--collapsed .nav-item.active,
 .sidebar--collapsed .nav-item--active {
-  background: linear-gradient(180deg,
-      color-mix(in srgb, var(--accent) 14%, var(--bg-elevated) 86%) 0%,
-      color-mix(in srgb, var(--accent) 8%, var(--bg) 92%) 100%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 14%, var(--bg-elevated) 86%) 0%,
+    color-mix(in srgb, var(--accent) 8%, var(--bg) 92%) 100%
+  );
   border-color: color-mix(in srgb, var(--accent) 18%, var(--border) 82%);
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
@@ -853,7 +855,7 @@
   overflow-x: hidden;
 }
 
-.content>*+* {
+.content > * + * {
   margin-top: 20px;
 }
 
@@ -869,7 +871,7 @@
   padding-bottom: 0;
 }
 
-.content--chat>*+* {
+.content--chat > * + * {
   margin-top: 0;
 }
 
@@ -928,7 +930,7 @@
   padding-bottom: 0;
 }
 
-.content--chat .content-header>div:first-child {
+.content--chat .content-header > div:first-child {
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- fix the current `check` failure on the latest `origin/main` by formatting the exact 6 files called out by `oxfmt --check`
- include the 3 UI style files that were previously red plus the 3 currently failing agent/source files now reported by the latest `main` check job
- AI-assisted PR; `codex review --base origin/main` is not available in this environment (`codex: command not found`)

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
  - formatting is fixed, but `pnpm check` now proceeds to unrelated current `origin/main` TypeScript failures in Matrix/runtime-api, `src/commands/status*`, and `src/channels/plugins/actions/actions.test.ts`
- [ ] `pnpm test` started `node scripts/test-parallel.mjs`, launched Vitest, and then hung without producing shard results or a final summary

## Unrelated current failures
After fixing the formatting drift, the latest `origin/main` still has unrelated `pnpm check` TypeScript failures, including:
- `extensions/matrix/src/channel.ts`: missing `PAIRING_APPROVED_MESSAGE` export from `../runtime-api.js`
- `extensions/matrix/src/matrix/deps.ts` and related Matrix files: missing `RuntimeEnv` export from `runtime-api.js`
- `extensions/matrix/src/secret-input.ts`: missing `buildSecretInputSchema` export from `../runtime-api.js`
- `src/auto-reply/reply/commands-plugins.ts`: `compatibilityWarnings` shape mismatch
- `src/channels/plugins/actions/actions.test.ts`: missing `./discord.js` / `./telegram.js`
- `src/commands/status.scan.fast-json.ts`, `src/commands/status.test.ts`, and `src/wizard/setup.test.ts`: current type errors unrelated to this formatting-only change

This PR is intentionally formatting-only and does not attempt to fix those separate current failures.

Made with [Cursor](https://cursor.com)