### PR TITLE
fix(discord): preserve bound thread isolation across bot accounts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -590,6 +590,75 @@ describe("preflightDiscordMessage", () => {
     expect(result?.boundSessionKey).toBeUndefined();
   });
 
+  it("ignores stale foreign bindings when the owning account disables thread bindings", async () => {
+    const threadId = "thread-disabled-thread-bindings-foreign-owner-1";
+    const parentId = "channel-parent-disabled-thread-bindings-foreign-owner-1";
+    const message = createDiscordMessage({
+      id: "m-disabled-thread-bindings-foreign-owner-1",
+      channelId: threadId,
+      content: "hi <@openclaw-bot>",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const foreignManager = createThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+    await foreignManager.bindTarget({
+      threadId,
+      channelId: parentId,
+      targetKind: "subagent",
+      targetSessionKey: "agent:soren:subagent:child-1",
+      agentId: "soren",
+      webhookId: "wh-disabled-thread-bindings-foreign-1",
+      webhookToken: "tok-disabled-thread-bindings-foreign-1",
+    });
+    foreignManager.stop();
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: {
+          ...DEFAULT_PREFLIGHT_CFG,
+          channels: {
+            discord: {
+              accounts: {
+                atlas: {
+                  enabled: true,
+                  token: "discord-token-atlas",
+                  threadBindings: {
+                    enabled: false,
+                  },
+                },
+              },
+              threadBindings: {
+                enabled: true,
+              },
+            },
+          },
+        },
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId: threadId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createThreadClient({ threadId, parentId }),
+      }),
+      accountId: "soren",
+      threadBindings: createNoopThreadBindingManager("soren"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.boundSessionKey).toBeUndefined();
+  });
+
   it("uses the preflight config instead of the runtime snapshot for foreign-owner suppression", async () => {
     const threadId = "thread-runtime-snapshot-foreign-owner-1";
     const parentId = "channel-parent-runtime-snapshot-foreign-owner-1";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1,5 +1,9 @@
 import { ChannelType } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../../../src/config/config.js";
 
 const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
 
@@ -255,7 +259,9 @@ describe("resolvePreflightMentionRequirement", () => {
 
 describe("preflightDiscordMessage", () => {
   beforeEach(() => {
+    clearRuntimeConfigSnapshot();
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    threadBindingTesting.resetThreadBindingsForTests();
     transcribeFirstAudioMock.mockReset();
   });
 
@@ -422,6 +428,233 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.boundSessionKey).toBe(threadBinding.targetSessionKey);
     expect(result?.shouldRequireMention).toBe(false);
+  });
+
+  it("drops thread messages for non-owning Discord accounts when another bot owns the binding", async () => {
+    const threadId = "thread-foreign-owner-1";
+    const parentId = "channel-parent-foreign-owner-1";
+    const message = createMessage({
+      id: "m-foreign-owner-1",
+      channelId: threadId,
+      content: "tables don't render in Discord, reformat",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const foreignManager = createThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+    await foreignManager.bindTarget({
+      threadId,
+      channelId: parentId,
+      targetKind: "subagent",
+      targetSessionKey: "agent:soren:subagent:child-1",
+      agentId: "soren",
+      webhookId: "wh-foreign-1",
+      webhookToken: "tok-foreign-1",
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_CFG,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId: threadId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createThreadClient({ threadId, parentId }),
+      }),
+      accountId: "soren",
+      threadBindings: createNoopThreadBindingManager("soren"),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores stale foreign bindings when the owning Discord account is not configured", async () => {
+    const threadId = "thread-stale-foreign-owner-1";
+    const parentId = "channel-parent-stale-foreign-owner-1";
+    const message = createMessage({
+      id: "m-stale-foreign-owner-1",
+      channelId: threadId,
+      content: "hi <@openclaw-bot>",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const foreignManager = createThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+    await foreignManager.bindTarget({
+      threadId,
+      channelId: parentId,
+      targetKind: "subagent",
+      targetSessionKey: "agent:soren:subagent:child-1",
+      agentId: "soren",
+      webhookId: "wh-stale-foreign-1",
+      webhookToken: "tok-stale-foreign-1",
+    });
+    foreignManager.stop();
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_CFG,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId: threadId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createThreadClient({ threadId, parentId }),
+      }),
+      accountId: "soren",
+      threadBindings: createNoopThreadBindingManager("soren"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.boundSessionKey).toBeUndefined();
+  });
+
+  it("ignores stale foreign bindings when only root Discord thread bindings are configured", async () => {
+    const threadId = "thread-root-stale-foreign-owner-1";
+    const parentId = "channel-parent-root-stale-foreign-owner-1";
+    const message = createMessage({
+      id: "m-root-stale-foreign-owner-1",
+      channelId: threadId,
+      content: "hi <@openclaw-bot>",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const foreignManager = createThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+    await foreignManager.bindTarget({
+      threadId,
+      channelId: parentId,
+      targetKind: "subagent",
+      targetSessionKey: "agent:soren:subagent:child-1",
+      agentId: "soren",
+      webhookId: "wh-root-stale-foreign-1",
+      webhookToken: "tok-root-stale-foreign-1",
+    });
+    foreignManager.stop();
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: {
+          ...DEFAULT_CFG,
+          channels: {
+            discord: {
+              threadBindings: {
+                enabled: true,
+              },
+            },
+          },
+        },
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId: threadId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createThreadClient({ threadId, parentId }),
+      }),
+      accountId: "soren",
+      threadBindings: createNoopThreadBindingManager("soren"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.boundSessionKey).toBeUndefined();
+  });
+
+  it("uses the preflight config instead of the runtime snapshot for foreign-owner suppression", async () => {
+    const threadId = "thread-runtime-snapshot-foreign-owner-1";
+    const parentId = "channel-parent-runtime-snapshot-foreign-owner-1";
+    const message = createMessage({
+      id: "m-runtime-snapshot-foreign-owner-1",
+      channelId: threadId,
+      content: "hi <@openclaw-bot>",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    setRuntimeConfigSnapshot({
+      ...DEFAULT_CFG,
+      channels: {
+        discord: {
+          accounts: {
+            atlas: {
+              enabled: true,
+              token: "discord-token-atlas",
+              threadBindings: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const foreignManager = createThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+    await foreignManager.bindTarget({
+      threadId,
+      channelId: parentId,
+      targetKind: "subagent",
+      targetSessionKey: "agent:soren:subagent:child-1",
+      agentId: "soren",
+      webhookId: "wh-runtime-snapshot-foreign-1",
+      webhookToken: "tok-runtime-snapshot-foreign-1",
+    });
+    foreignManager.stop();
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_CFG,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId: threadId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createThreadClient({ threadId, parentId }),
+      }),
+      accountId: "soren",
+      threadBindings: createNoopThreadBindingManager("soren"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.boundSessionKey).toBeUndefined();
   });
 
   it("drops bot messages without mention when allowBots=mentions", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -31,6 +31,7 @@ import {
 } from "./message-handler.preflight.test-helpers.js";
 import {
   __testing as threadBindingTesting,
+  createNoopThreadBindingManager,
   createThreadBindingManager,
 } from "./thread-bindings.js";
 
@@ -433,7 +434,7 @@ describe("preflightDiscordMessage", () => {
   it("drops thread messages for non-owning Discord accounts when another bot owns the binding", async () => {
     const threadId = "thread-foreign-owner-1";
     const parentId = "channel-parent-foreign-owner-1";
-    const message = createMessage({
+    const message = createDiscordMessage({
       id: "m-foreign-owner-1",
       channelId: threadId,
       content: "tables don't render in Discord, reformat",
@@ -461,7 +462,7 @@ describe("preflightDiscordMessage", () => {
 
     const result = await preflightDiscordMessage({
       ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
+        cfg: DEFAULT_PREFLIGHT_CFG,
         discordConfig: {} as DiscordConfig,
         data: createGuildEvent({
           channelId: threadId,
@@ -481,7 +482,7 @@ describe("preflightDiscordMessage", () => {
   it("ignores stale foreign bindings when the owning Discord account is not configured", async () => {
     const threadId = "thread-stale-foreign-owner-1";
     const parentId = "channel-parent-stale-foreign-owner-1";
-    const message = createMessage({
+    const message = createDiscordMessage({
       id: "m-stale-foreign-owner-1",
       channelId: threadId,
       content: "hi <@openclaw-bot>",
@@ -511,7 +512,7 @@ describe("preflightDiscordMessage", () => {
 
     const result = await preflightDiscordMessage({
       ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
+        cfg: DEFAULT_PREFLIGHT_CFG,
         discordConfig: {} as DiscordConfig,
         data: createGuildEvent({
           channelId: threadId,
@@ -532,7 +533,7 @@ describe("preflightDiscordMessage", () => {
   it("ignores stale foreign bindings when only root Discord thread bindings are configured", async () => {
     const threadId = "thread-root-stale-foreign-owner-1";
     const parentId = "channel-parent-root-stale-foreign-owner-1";
-    const message = createMessage({
+    const message = createDiscordMessage({
       id: "m-root-stale-foreign-owner-1",
       channelId: threadId,
       content: "hi <@openclaw-bot>",
@@ -563,7 +564,7 @@ describe("preflightDiscordMessage", () => {
     const result = await preflightDiscordMessage({
       ...createPreflightArgs({
         cfg: {
-          ...DEFAULT_CFG,
+          ...DEFAULT_PREFLIGHT_CFG,
           channels: {
             discord: {
               threadBindings: {
@@ -592,7 +593,7 @@ describe("preflightDiscordMessage", () => {
   it("uses the preflight config instead of the runtime snapshot for foreign-owner suppression", async () => {
     const threadId = "thread-runtime-snapshot-foreign-owner-1";
     const parentId = "channel-parent-runtime-snapshot-foreign-owner-1";
-    const message = createMessage({
+    const message = createDiscordMessage({
       id: "m-runtime-snapshot-foreign-owner-1",
       channelId: threadId,
       content: "hi <@openclaw-bot>",
@@ -605,7 +606,7 @@ describe("preflightDiscordMessage", () => {
     });
 
     setRuntimeConfigSnapshot({
-      ...DEFAULT_CFG,
+      ...DEFAULT_PREFLIGHT_CFG,
       channels: {
         discord: {
           accounts: {
@@ -639,7 +640,7 @@ describe("preflightDiscordMessage", () => {
 
     const result = await preflightDiscordMessage({
       ...createPreflightArgs({
-        cfg: DEFAULT_CFG,
+        cfg: DEFAULT_PREFLIGHT_CFG,
         discordConfig: {} as DiscordConfig,
         data: createGuildEvent({
           channelId: threadId,

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -67,7 +67,10 @@ import {
 } from "./route-resolution.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
 import { resolveDiscordSystemEvent } from "./system-events.js";
-import { isRecentlyUnboundThreadWebhookMessage } from "./thread-bindings.js";
+import {
+  findActiveThreadBindingByThreadId,
+  isRecentlyUnboundThreadWebhookMessage,
+} from "./thread-bindings.js";
 import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./threading.js";
 
 export type {
@@ -360,6 +363,19 @@ export async function preflightDiscordMessage(
       conversationId: bindingConversationId,
       parentConversationId: earlyThreadParentId,
     }) ?? undefined;
+  if (!threadBinding && earlyThreadChannel) {
+    const foreignBinding = findActiveThreadBindingByThreadId({
+      cfg: params.cfg,
+      threadId: messageChannelId,
+      excludeAccountId: params.accountId,
+    });
+    if (foreignBinding) {
+      logVerbose(
+        `discord: drop thread message ${message.id} (thread owned by discord account ${foreignBinding.accountId} target=${foreignBinding.targetSessionKey})`,
+      );
+      return null;
+    }
+  }
   const configuredRoute =
     threadBinding == null
       ? resolveConfiguredAcpRoute({

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -12,8 +12,9 @@ import {
   normalizeAccountId,
   resolveAgentIdFromSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { listEnabledDiscordAccounts } from "../accounts.js";
+import { resolveDiscordAccountConfig } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
+import { resolveThreadBindingsEnabled } from "./thread-bindings.config.js";
 import {
   createThreadForBinding,
   createWebhookForChannel,
@@ -115,9 +116,20 @@ function isConfiguredDiscordThreadBindingAccount(
     return false;
   }
   const normalizedAccountId = normalizeAccountId(accountId);
-  return listEnabledDiscordAccounts(cfg).some(
-    (account) => account.accountId === normalizedAccountId,
-  );
+  const account = resolveDiscordAccountConfig(cfg, normalizedAccountId);
+  if (!account) {
+    return false;
+  }
+  const providerEnabled = cfg.channels.discord.enabled !== false;
+  const accountEnabled = account?.enabled !== false;
+  if (!providerEnabled || !accountEnabled) {
+    return false;
+  }
+  return resolveThreadBindingsEnabled({
+    channelEnabledRaw:
+      account?.threadBindings?.enabled ?? cfg.channels.discord.threadBindings?.enabled,
+    sessionEnabledRaw: cfg.session?.threadBindings?.enabled,
+  });
 }
 
 function createNoopManager(accountIdRaw?: string): ThreadBindingManager {

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -12,6 +12,7 @@ import {
   normalizeAccountId,
   resolveAgentIdFromSessionKey,
 } from "../../../../src/routing/session-key.js";
+import { listEnabledDiscordAccounts } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
 import {
   createThreadForBinding,
@@ -89,6 +90,34 @@ function resolveEffectiveBindingExpiresAt(params: {
     return Math.min(inactivityExpiresAt, maxAgeExpiresAt);
   }
   return inactivityExpiresAt ?? maxAgeExpiresAt;
+}
+
+function isActiveThreadBindingRecord(
+  record: ThreadBindingRecord,
+  manager?: Pick<ThreadBindingManager, "getIdleTimeoutMs" | "getMaxAgeMs"> | null,
+): boolean {
+  const defaultIdleTimeoutMs =
+    manager?.getIdleTimeoutMs() ?? DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS;
+  const defaultMaxAgeMs = manager?.getMaxAgeMs() ?? DEFAULT_THREAD_BINDING_MAX_AGE_MS;
+  const expiresAt = resolveEffectiveBindingExpiresAt({
+    record,
+    defaultIdleTimeoutMs,
+    defaultMaxAgeMs,
+  });
+  return expiresAt == null || Date.now() < expiresAt;
+}
+
+function isConfiguredDiscordThreadBindingAccount(
+  cfg: OpenClawConfig | null | undefined,
+  accountId: string,
+): boolean {
+  if (!cfg?.channels?.discord) {
+    return false;
+  }
+  const normalizedAccountId = normalizeAccountId(accountId);
+  return listEnabledDiscordAccounts(cfg).some(
+    (account) => account.accountId === normalizedAccountId,
+  );
 }
 
 function createNoopManager(accountIdRaw?: string): ThreadBindingManager {
@@ -682,6 +711,42 @@ export function createThreadBindingManager(
 
 export function createNoopThreadBindingManager(accountId?: string): ThreadBindingManager {
   return createNoopManager(accountId);
+}
+
+export function findActiveThreadBindingByThreadId(params: {
+  cfg?: OpenClawConfig | null;
+  threadId: string;
+  accountId?: string;
+  excludeAccountId?: string;
+}): ThreadBindingRecord | null {
+  const threadId = normalizeThreadId(params.threadId);
+  if (!threadId) {
+    return null;
+  }
+  const accountId = params.accountId ? normalizeAccountId(params.accountId) : undefined;
+  const excludeAccountId = params.excludeAccountId
+    ? normalizeAccountId(params.excludeAccountId)
+    : undefined;
+  for (const record of BINDINGS_BY_THREAD_ID.values()) {
+    if (record.threadId !== threadId) {
+      continue;
+    }
+    if (accountId && record.accountId !== accountId) {
+      continue;
+    }
+    if (excludeAccountId && record.accountId === excludeAccountId) {
+      continue;
+    }
+    const manager = MANAGERS_BY_ACCOUNT_ID.get(record.accountId);
+    if (!manager && !isConfiguredDiscordThreadBindingAccount(params.cfg, record.accountId)) {
+      continue;
+    }
+    if (!isActiveThreadBindingRecord(record, manager)) {
+      continue;
+    }
+    return record;
+  }
+  return null;
 }
 
 export function getThreadBindingManager(accountId?: string): ThreadBindingManager | null {

--- a/extensions/discord/src/monitor/thread-bindings.ts
+++ b/extensions/discord/src/monitor/thread-bindings.ts
@@ -44,5 +44,6 @@ export {
   __testing,
   createNoopThreadBindingManager,
   createThreadBindingManager,
+  findActiveThreadBindingByThreadId,
   getThreadBindingManager,
 } from "./thread-bindings.manager.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In multi-bot Discord setups, a thread created for `sessions_spawn(thread=true, mode="session")` could still be picked up by another bot account's general Discord routing instead of staying attached to the active bound subagent session.
- Why it matters: This breaks thread/session isolation and can cause follow-up messages to escape the intended session scope, producing replies from the wrong bot/session context.
- What changed: Discord preflight now suppresses generic routing when another Discord account already owns an active thread binding, using the current preflight config to ignore stale or removed-account bindings.
- What did NOT change (scope boundary): This does not add shared-thread routing, change same-account binding behavior, or introduce new config flags.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49373
- Related #

## User-visible / Behavior Changes

- Follow-up messages in a Discord thread bound to an active subagent session are no longer allowed to fall through to another bot account's general channel routing.
- Removed or stale bindings for non-running / non-configured Discord accounts no longer suppress valid follow-up messages.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local OpenClaw dev checkout
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): multi-account Discord setup with thread bindings enabled for bound subagent sessions

### Steps

1. Create a Discord thread via `sessions_spawn(agentId="soren", thread=true, mode="session")` from one bot/account.
2. Ensure the thread is bound to the spawned subagent session.
3. Send a follow-up message in that same Discord thread that is also visible to another configured Discord bot/account.

### Expected

- The follow-up routes only to the active bound subagent session that owns the thread.

### Actual

- Before this change, another bot/account could miss the binding and create or use a generic Discord channel session for the same thread.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added/ran focused regressions for cross-account thread ownership suppression, stale foreign binding ignore, root-thread-binding stale config ignore, and config-snapshot mismatch handling.
- Edge cases checked: foreign manager stopped but stale binding record remains; root Discord threadBindings enabled without active foreign account; explicit preflight config differs from runtime snapshot.
- What you did **not** verify: live Discord multi-bot end-to-end behavior in a running guild; full repo `pnpm test` is not green on this checkout due unrelated existing failures; `codex review --uncommitted` could not complete because of transport disconnects.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or temporarily disable Discord thread bindings for the affected account(s).
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`, `src/discord/monitor/thread-bindings.manager.ts`, `src/discord/monitor/thread-bindings.ts`, `src/discord/monitor/message-handler.preflight.test.ts`
- Known bad symptoms reviewers should watch for: valid follow-up messages in bound Discord threads being dropped unexpectedly, especially in multi-account setups.

## Risks and Mitigations

- Risk: foreign-owner suppression could incorrectly drop messages if stale bindings are treated as active owners.
  - Mitigation: suppression ignores stale bindings for removed/non-configured accounts and uses the active preflight config instead of global runtime snapshot state.

- Risk: multi-bot/shared-thread workflows may expect non-owning bots to continue responding in the same thread.
  - Mitigation: this PR intentionally preserves exclusive ownership semantics only for active bound-session threads and does not change unbound-thread behavior.

AI-assisted. Lightly tested locally with focused Discord regression tests and manual diff review.
