### PR TITLE
fix(loop-detection): block browser search storms

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -20,6 +20,7 @@ Enable it only where needed, because it can block legitimate repeated calls with
 - Detect repetitive sequences that do not make progress.
 - Detect high-frequency no-result loops (same tool, same inputs, repeated errors).
 - Detect specific repeated-call patterns for known polling tools.
+- Detect browser search storms where the agent keeps opening search-result pages while changing queries or engines.
 
 ## Configuration block
 
@@ -33,11 +34,14 @@ Global defaults:
       historySize: 30,
       warningThreshold: 10,
       criticalThreshold: 20,
+      browserSearchWarningThreshold: 4,
+      browserSearchCriticalThreshold: 8,
       globalCircuitBreakerThreshold: 30,
       detectors: {
         genericRepeat: true,
         knownPollNoProgress: true,
         pingPong: true,
+        browserSearchStorm: true,
       },
     },
   },
@@ -71,20 +75,27 @@ Per-agent override (optional):
 - `historySize`: number of recent tool calls kept for analysis.
 - `warningThreshold`: threshold before classifying a pattern as warning-only.
 - `criticalThreshold`: threshold for blocking repetitive loop patterns.
+- `browserSearchWarningThreshold`: warning threshold for browser search storms across changing queries.
+- `browserSearchCriticalThreshold`: critical threshold for browser search storms across changing queries.
 - `globalCircuitBreakerThreshold`: global no-progress breaker threshold.
 - `detectors.genericRepeat`: detects repeated same-tool + same-params patterns.
 - `detectors.knownPollNoProgress`: detects known polling-like patterns with no state change.
 - `detectors.pingPong`: detects alternating ping-pong patterns.
+- `detectors.browserSearchStorm`: detects repeated browser opens/navigations to search-result pages across changing queries or engines.
 
 ## Recommended setup
 
 - Start with `enabled: true`, defaults unchanged.
 - Keep thresholds ordered as `warningThreshold < criticalThreshold < globalCircuitBreakerThreshold`.
+- Keep browser-search thresholds ordered as `browserSearchWarningThreshold < browserSearchCriticalThreshold`.
 - If false positives occur:
   - raise `warningThreshold` and/or `criticalThreshold`
+  - raise `browserSearchWarningThreshold` and/or `browserSearchCriticalThreshold`
   - (optionally) raise `globalCircuitBreakerThreshold`
   - disable only the detector causing issues
   - reduce `historySize` for less strict historical context
+
+Browser-search thresholds are intentionally lower than generic-repeat thresholds because real search loops often interleave `browser open` / `browser navigate` with `browser snapshot`, so waiting for the generic defaults can be too late.
 
 ## Logs and expected behavior
 
@@ -93,6 +104,7 @@ This protects users from runaway token spend and lockups while preserving normal
 
 - Prefer warning and temporary suppression first.
 - Escalate only when repeated evidence accumulates.
+- Browser-search storms become especially risky when they fan out into many real network requests from a small number of tool calls.
 
 ## Notes
 

--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -75,13 +75,13 @@ Per-agent override (optional):
 - `historySize`: number of recent tool calls kept for analysis.
 - `warningThreshold`: threshold before classifying a pattern as warning-only.
 - `criticalThreshold`: threshold for blocking repetitive loop patterns.
-- `browserSearchWarningThreshold`: warning threshold for browser search storms across changing queries.
-- `browserSearchCriticalThreshold`: critical threshold for browser search storms across changing queries.
+- `browserSearchWarningThreshold`: warning threshold for browser search storms across an active streak of changing queries or engines.
+- `browserSearchCriticalThreshold`: critical threshold for browser search storms across an active streak of changing queries or engines.
 - `globalCircuitBreakerThreshold`: global no-progress breaker threshold.
 - `detectors.genericRepeat`: detects repeated same-tool + same-params patterns.
 - `detectors.knownPollNoProgress`: detects known polling-like patterns with no state change.
 - `detectors.pingPong`: detects alternating ping-pong patterns.
-- `detectors.browserSearchStorm`: detects repeated browser opens/navigations to search-result pages across changing queries or engines.
+- `detectors.browserSearchStorm`: detects repeated browser opens/navigations to search-result pages across an active streak of changing queries or engines.
 
 ## Recommended setup
 

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -250,6 +250,40 @@ describe("before_tool_call loop detection behavior", () => {
     });
   });
 
+  it("emits warnings for separate browser search storms within the same session", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        await tool.execute(`browser-search-first-${i}`, paramsForQuery(`first issue ${i}`));
+      }
+      await tool.execute(
+        `browser-search-first-${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        paramsForQuery(`first issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`),
+      );
+
+      await tool.execute("browser-search-reset-0", paramsForQuery("steady follow-up"));
+      await tool.execute("browser-search-reset-1", paramsForQuery("steady follow-up"));
+
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        await tool.execute(`browser-search-second-${i}`, paramsForQuery(`second issue ${i}`));
+      }
+      await tool.execute(
+        `browser-search-second-${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        paramsForQuery(`second issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`),
+      );
+
+      const browserWarns = emitted.filter(
+        (evt) => evt.level === "warning" && evt.detector === "browser_search_storm",
+      );
+      expect(browserWarns).toHaveLength(2);
+      expect(browserWarns.map((evt) => evt.count)).toEqual([
+        BROWSER_SEARCH_WARNING_THRESHOLD,
+        BROWSER_SEARCH_WARNING_THRESHOLD,
+      ]);
+    });
+  });
+
   it("blocks browser search storms at critical threshold and emits critical diagnostic events", async () => {
     await withToolLoopEvents(async (emitted) => {
       const { tool, paramsForQuery } = createBrowserSearchFixture();

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -250,6 +250,38 @@ describe("before_tool_call loop detection behavior", () => {
     });
   });
 
+  it("evaluates browser search storms after before_tool_call rewrites the URL", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runBeforeToolCall.mockImplementation(
+      async ({ params }: { params: { url?: string } }) => ({
+        params: {
+          url:
+            typeof params?.url === "string"
+              ? "https://www.google.com/search?q=openclaw+canonical"
+              : params?.url,
+        },
+      }),
+    );
+
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i <= BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        await tool.execute(
+          `browser-search-canonical-${i}`,
+          paramsForQuery(`openclaw raw variant ${i}`),
+          undefined,
+          undefined,
+        );
+      }
+
+      const browserWarns = emitted.filter(
+        (evt) => evt.level === "warning" && evt.detector === "browser_search_storm",
+      );
+      expect(browserWarns).toHaveLength(0);
+    });
+  });
+
   it("emits warnings for separate browser search storms within the same session", async () => {
     await withToolLoopEvents(async (emitted) => {
       const { tool, paramsForQuery } = createBrowserSearchFixture();

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -7,7 +7,12 @@ import {
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
+import {
+  BROWSER_SEARCH_CRITICAL_THRESHOLD,
+  BROWSER_SEARCH_WARNING_THRESHOLD,
+  CRITICAL_THRESHOLD,
+  GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+} from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 vi.mock("../plugins/hook-runner-global.js");
@@ -132,10 +137,28 @@ describe("before_tool_call loop detection behavior", () => {
     };
   }
 
+  function createBrowserSearchFixture() {
+    const execute = vi
+      .fn()
+      .mockImplementation(async (_toolCallId: string, params: { url: string }) => {
+        return {
+          content: [{ type: "text", text: `results for ${params.url}` }],
+          details: { url: params.url },
+        };
+      });
+    return {
+      tool: createWrappedTool("browser", execute),
+      paramsForQuery: (query: string, host = "www.google.com") => ({
+        action: "open",
+        url: `https://${host}/search?q=${encodeURIComponent(query)}`,
+      }),
+    };
+  }
+
   function expectCriticalLoopEvent(
     loopEvent: DiagnosticToolLoopEvent | undefined,
     params: {
-      detector: "ping_pong" | "known_poll_no_progress";
+      detector: "ping_pong" | "known_poll_no_progress" | "browser_search_storm";
       toolName: string;
       count?: number;
     },
@@ -191,6 +214,71 @@ describe("before_tool_call loop detection behavior", () => {
         tool.execute(`poll-progress-${i}`, params, undefined, undefined),
       ).resolves.toBeDefined();
     }
+  });
+
+  it("emits structured warning diagnostic events for browser search storms", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        await tool.execute(
+          `browser-search-${i}`,
+          paramsForQuery(`openclaw issue ${i}`),
+          undefined,
+          undefined,
+        );
+      }
+
+      await tool.execute(
+        `browser-search-${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        paramsForQuery(`openclaw issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`),
+        undefined,
+        undefined,
+      );
+
+      const browserWarns = emitted.filter(
+        (evt) => evt.level === "warning" && evt.detector === "browser_search_storm",
+      );
+      expect(browserWarns).toHaveLength(1);
+      const loopEvent = browserWarns[0];
+      expect(loopEvent?.type).toBe("tool.loop");
+      expect(loopEvent?.level).toBe("warning");
+      expect(loopEvent?.action).toBe("warn");
+      expect(loopEvent?.detector).toBe("browser_search_storm");
+      expect(loopEvent?.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      expect(loopEvent?.toolName).toBe("browser");
+    });
+  });
+
+  it("blocks browser search storms at critical threshold and emits critical diagnostic events", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, paramsForQuery } = createBrowserSearchFixture();
+
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD; i += 1) {
+        await tool.execute(
+          `browser-search-critical-${i}`,
+          paramsForQuery(`openclaw fix ${i}`, i % 2 === 0 ? "www.google.com" : "www.bing.com"),
+          undefined,
+          undefined,
+        );
+      }
+
+      await expect(
+        tool.execute(
+          `browser-search-critical-${BROWSER_SEARCH_CRITICAL_THRESHOLD}`,
+          paramsForQuery(`openclaw fix ${BROWSER_SEARCH_CRITICAL_THRESHOLD}`, "www.bing.com"),
+          undefined,
+          undefined,
+        ),
+      ).rejects.toThrow("CRITICAL");
+
+      const loopEvent = emitted.at(-1);
+      expectCriticalLoopEvent(loopEvent, {
+        detector: "browser_search_storm",
+        toolName: "browser",
+        count: BROWSER_SEARCH_CRITICAL_THRESHOLD,
+      });
+    });
   });
 
   it("keeps generic repeated calls warn-only below global breaker", async () => {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -4,7 +4,10 @@ import {
   resetDiagnosticEventsForTest,
   type DiagnosticToolLoopEvent,
 } from "../infra/diagnostic-events.js";
-import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "../logging/diagnostic-session-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import {
@@ -312,6 +315,34 @@ describe("before_tool_call loop detection behavior", () => {
       },
       (evt) => evt.level === "warning",
     );
+  });
+
+  it("closes hook-blocked loop-history entries with an error outcome", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      block: true,
+      blockReason: "blocked by policy",
+    });
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "should not run" }],
+      details: { ok: true },
+    });
+    const tool = createWrappedTool("read", execute);
+
+    await expect(
+      tool.execute("blocked-read-finalized", { path: "/forbidden.txt" }, undefined, undefined),
+    ).rejects.toThrow("blocked by policy");
+
+    const sessionState = getDiagnosticSessionState({
+      sessionKey: enabledLoopDetectionContext.sessionKey,
+      sessionId: enabledLoopDetectionContext.agentId,
+    });
+    const blockedEntry = sessionState.toolCallHistory?.find(
+      (call) => call.toolCallId === "blocked-read-finalized",
+    );
+
+    expect(blockedEntry?.resultHash).toMatch(/^error:/);
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("emits warnings for separate browser search storms within the same session", async () => {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   BROWSER_SEARCH_WARNING_THRESHOLD,
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  WARNING_THRESHOLD,
 } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -280,6 +281,37 @@ describe("before_tool_call loop detection behavior", () => {
       );
       expect(browserWarns).toHaveLength(0);
     });
+  });
+
+  it("records hook-blocked calls so repeated forbidden actions still emit loop warnings", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      block: true,
+      blockReason: "blocked by policy",
+    });
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "should not run" }],
+      details: { ok: true },
+    });
+    const tool = createWrappedTool("read", execute);
+
+    await withToolLoopEvents(
+      async (emitted) => {
+        for (let i = 0; i <= WARNING_THRESHOLD; i += 1) {
+          await expect(
+            tool.execute(`blocked-read-${i}`, { path: "/forbidden.txt" }, undefined, undefined),
+          ).rejects.toThrow("blocked by policy");
+        }
+
+        const genericWarns = emitted.filter(
+          (evt) => evt.level === "warning" && evt.detector === "generic_repeat",
+        );
+        expect(genericWarns).toHaveLength(1);
+        expect(genericWarns[0]?.count).toBe(WARNING_THRESHOLD);
+        expect(execute).not.toHaveBeenCalled();
+      },
+      (evt) => evt.level === "warning",
+    );
   });
 
   it("emits warnings for separate browser search storms within the same session", async () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -95,6 +95,47 @@ export async function runBeforeToolCallHook(args: {
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
+  let effectiveParams = params;
+
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("before_tool_call")) {
+    try {
+      const normalizedParams = isPlainObject(params) ? params : {};
+      const toolContext = {
+        toolName,
+        ...(args.ctx?.agentId ? { agentId: args.ctx.agentId } : {}),
+        ...(args.ctx?.sessionKey ? { sessionKey: args.ctx.sessionKey } : {}),
+        ...(args.ctx?.sessionId ? { sessionId: args.ctx.sessionId } : {}),
+        ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
+        ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
+      };
+      const hookResult = await hookRunner.runBeforeToolCall(
+        {
+          toolName,
+          params: normalizedParams,
+          ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
+          ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
+        },
+        toolContext,
+      );
+
+      if (hookResult?.block) {
+        return {
+          blocked: true,
+          reason: hookResult.blockReason || "Tool call blocked by plugin hook",
+        };
+      }
+
+      if (hookResult?.params && isPlainObject(hookResult.params)) {
+        effectiveParams = isPlainObject(params)
+          ? { ...params, ...hookResult.params }
+          : hookResult.params;
+      }
+    } catch (err) {
+      const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
+      log.warn(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+    }
+  }
 
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
@@ -104,7 +145,12 @@ export async function runBeforeToolCallHook(args: {
       sessionId: args.ctx?.agentId,
     });
 
-    const loopResult = detectToolCallLoop(sessionState, toolName, params, args.ctx.loopDetection);
+    const loopResult = detectToolCallLoop(
+      sessionState,
+      toolName,
+      effectiveParams,
+      args.ctx.loopDetection,
+    );
 
     if (loopResult.stuck) {
       if (loopResult.level === "critical") {
@@ -124,72 +170,35 @@ export async function runBeforeToolCallHook(args: {
           blocked: true,
           reason: loopResult.message,
         };
-      } else {
-        const warningKey = loopResult.warningKey ?? `${loopResult.detector}:${toolName}`;
-        if (shouldEmitLoopWarning(sessionState, warningKey, loopResult.count)) {
-          log.warn(`Loop warning for ${toolName}: ${loopResult.message}`);
-          logToolLoopAction({
-            sessionKey: args.ctx.sessionKey,
-            sessionId: args.ctx?.agentId,
-            toolName,
-            level: "warning",
-            action: "warn",
-            detector: loopResult.detector,
-            count: loopResult.count,
-            message: loopResult.message,
-            pairedToolName: loopResult.pairedToolName,
-          });
-        }
+      }
+
+      const warningKey = loopResult.warningKey ?? `${loopResult.detector}:${toolName}`;
+      if (shouldEmitLoopWarning(sessionState, warningKey, loopResult.count)) {
+        log.warn(`Loop warning for ${toolName}: ${loopResult.message}`);
+        logToolLoopAction({
+          sessionKey: args.ctx.sessionKey,
+          sessionId: args.ctx?.agentId,
+          toolName,
+          level: "warning",
+          action: "warn",
+          detector: loopResult.detector,
+          count: loopResult.count,
+          message: loopResult.message,
+          pairedToolName: loopResult.pairedToolName,
+        });
       }
     }
 
-    recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
-  }
-
-  const hookRunner = getGlobalHookRunner();
-  if (!hookRunner?.hasHooks("before_tool_call")) {
-    return { blocked: false, params: args.params };
-  }
-
-  try {
-    const normalizedParams = isPlainObject(params) ? params : {};
-    const toolContext = {
+    recordToolCall(
+      sessionState,
       toolName,
-      ...(args.ctx?.agentId ? { agentId: args.ctx.agentId } : {}),
-      ...(args.ctx?.sessionKey ? { sessionKey: args.ctx.sessionKey } : {}),
-      ...(args.ctx?.sessionId ? { sessionId: args.ctx.sessionId } : {}),
-      ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
-      ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
-    };
-    const hookResult = await hookRunner.runBeforeToolCall(
-      {
-        toolName,
-        params: normalizedParams,
-        ...(args.ctx?.runId ? { runId: args.ctx.runId } : {}),
-        ...(args.toolCallId ? { toolCallId: args.toolCallId } : {}),
-      },
-      toolContext,
+      effectiveParams,
+      args.toolCallId,
+      args.ctx.loopDetection,
     );
-
-    if (hookResult?.block) {
-      return {
-        blocked: true,
-        reason: hookResult.blockReason || "Tool call blocked by plugin hook",
-      };
-    }
-
-    if (hookResult?.params && isPlainObject(hookResult.params)) {
-      if (isPlainObject(params)) {
-        return { blocked: false, params: { ...params, ...hookResult.params } };
-      }
-      return { blocked: false, params: hookResult.params };
-    }
-  } catch (err) {
-    const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
-    log.warn(`before_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
   }
 
-  return { blocked: false, params };
+  return { blocked: false, params: effectiveParams };
 }
 
 export function wrapToolWithBeforeToolCallHook(

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -42,7 +42,8 @@ function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: n
     state.toolLoopWarningBuckets = new Map();
   }
   const bucket = Math.floor(count / LOOP_WARNING_BUCKET_SIZE);
-  const lastBucket = state.toolLoopWarningBuckets.get(warningKey) ?? 0;
+  // Use -1 so the first warning in bucket 0 can emit once instead of being suppressed.
+  const lastBucket = state.toolLoopWarningBuckets.get(warningKey) ?? -1;
   if (bucket <= lastBucket) {
     return false;
   }

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -78,6 +78,7 @@ async function recordLoopOutcome(args: {
       toolName: args.toolName,
       toolParams: args.toolParams,
       toolCallId: args.toolCallId,
+      runId: args.ctx.runId,
       result: args.result,
       error: args.error,
       config: args.ctx.loopDetection,
@@ -133,6 +134,7 @@ async function applyLoopProtection(args: {
           args.toolParams,
           args.toolCallId,
           args.ctx.loopDetection,
+          args.ctx.runId,
         );
       }
       return {
@@ -163,6 +165,7 @@ async function applyLoopProtection(args: {
     args.toolParams,
     args.toolCallId,
     args.ctx.loopDetection,
+    args.ctx.runId,
   );
   return {};
 }
@@ -207,12 +210,22 @@ export async function runBeforeToolCallHook(args: {
           toolCallId: args.toolCallId,
           recordAttemptOnCritical: true,
         });
+        const blockedReason =
+          loopProtectionResult.blockedReason ||
+          hookResult.blockReason ||
+          "Tool call blocked by plugin hook";
+        // Hook-blocked attempts should still close out their history rows as failures so later
+        // runs with colliding provider toolCallIds cannot rewrite stale unfinished entries.
+        await recordLoopOutcome({
+          ctx: args.ctx,
+          toolName,
+          toolParams: effectiveParams,
+          toolCallId: args.toolCallId,
+          error: blockedReason,
+        });
         return {
           blocked: true,
-          reason:
-            loopProtectionResult.blockedReason ||
-            hookResult.blockReason ||
-            "Tool call blocked by plugin hook",
+          reason: blockedReason,
         };
       }
 

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -87,6 +87,86 @@ async function recordLoopOutcome(args: {
   }
 }
 
+async function applyLoopProtection(args: {
+  ctx?: HookContext;
+  toolName: string;
+  toolParams: unknown;
+  toolCallId?: string;
+  recordAttemptOnCritical?: boolean;
+}): Promise<{ blockedReason?: string }> {
+  if (!args.ctx?.sessionKey) {
+    return {};
+  }
+
+  const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
+    await loadBeforeToolCallRuntime();
+  const sessionState = getDiagnosticSessionState({
+    sessionKey: args.ctx.sessionKey,
+    sessionId: args.ctx?.agentId,
+  });
+
+  const loopResult = detectToolCallLoop(
+    sessionState,
+    args.toolName,
+    args.toolParams,
+    args.ctx.loopDetection,
+  );
+
+  if (loopResult.stuck) {
+    if (loopResult.level === "critical") {
+      log.error(`Blocking ${args.toolName} due to critical loop: ${loopResult.message}`);
+      logToolLoopAction({
+        sessionKey: args.ctx.sessionKey,
+        sessionId: args.ctx?.agentId,
+        toolName: args.toolName,
+        level: "critical",
+        action: "block",
+        detector: loopResult.detector,
+        count: loopResult.count,
+        message: loopResult.message,
+        pairedToolName: loopResult.pairedToolName,
+      });
+      if (args.recordAttemptOnCritical) {
+        recordToolCall(
+          sessionState,
+          args.toolName,
+          args.toolParams,
+          args.toolCallId,
+          args.ctx.loopDetection,
+        );
+      }
+      return {
+        blockedReason: loopResult.message,
+      };
+    }
+
+    const warningKey = loopResult.warningKey ?? `${loopResult.detector}:${args.toolName}`;
+    if (shouldEmitLoopWarning(sessionState, warningKey, loopResult.count)) {
+      log.warn(`Loop warning for ${args.toolName}: ${loopResult.message}`);
+      logToolLoopAction({
+        sessionKey: args.ctx.sessionKey,
+        sessionId: args.ctx?.agentId,
+        toolName: args.toolName,
+        level: "warning",
+        action: "warn",
+        detector: loopResult.detector,
+        count: loopResult.count,
+        message: loopResult.message,
+        pairedToolName: loopResult.pairedToolName,
+      });
+    }
+  }
+
+  recordToolCall(
+    sessionState,
+    args.toolName,
+    args.toolParams,
+    args.toolCallId,
+    args.ctx.loopDetection,
+  );
+  return {};
+}
+
 export async function runBeforeToolCallHook(args: {
   toolName: string;
   params: unknown;
@@ -120,9 +200,19 @@ export async function runBeforeToolCallHook(args: {
       );
 
       if (hookResult?.block) {
+        const loopProtectionResult = await applyLoopProtection({
+          ctx: args.ctx,
+          toolName,
+          toolParams: effectiveParams,
+          toolCallId: args.toolCallId,
+          recordAttemptOnCritical: true,
+        });
         return {
           blocked: true,
-          reason: hookResult.blockReason || "Tool call blocked by plugin hook",
+          reason:
+            loopProtectionResult.blockedReason ||
+            hookResult.blockReason ||
+            "Tool call blocked by plugin hook",
         };
       }
 
@@ -137,65 +227,17 @@ export async function runBeforeToolCallHook(args: {
     }
   }
 
-  if (args.ctx?.sessionKey) {
-    const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
-      await loadBeforeToolCallRuntime();
-    const sessionState = getDiagnosticSessionState({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx?.agentId,
-    });
-
-    const loopResult = detectToolCallLoop(
-      sessionState,
-      toolName,
-      effectiveParams,
-      args.ctx.loopDetection,
-    );
-
-    if (loopResult.stuck) {
-      if (loopResult.level === "critical") {
-        log.error(`Blocking ${toolName} due to critical loop: ${loopResult.message}`);
-        logToolLoopAction({
-          sessionKey: args.ctx.sessionKey,
-          sessionId: args.ctx?.agentId,
-          toolName,
-          level: "critical",
-          action: "block",
-          detector: loopResult.detector,
-          count: loopResult.count,
-          message: loopResult.message,
-          pairedToolName: loopResult.pairedToolName,
-        });
-        return {
-          blocked: true,
-          reason: loopResult.message,
-        };
-      }
-
-      const warningKey = loopResult.warningKey ?? `${loopResult.detector}:${toolName}`;
-      if (shouldEmitLoopWarning(sessionState, warningKey, loopResult.count)) {
-        log.warn(`Loop warning for ${toolName}: ${loopResult.message}`);
-        logToolLoopAction({
-          sessionKey: args.ctx.sessionKey,
-          sessionId: args.ctx?.agentId,
-          toolName,
-          level: "warning",
-          action: "warn",
-          detector: loopResult.detector,
-          count: loopResult.count,
-          message: loopResult.message,
-          pairedToolName: loopResult.pairedToolName,
-        });
-      }
-    }
-
-    recordToolCall(
-      sessionState,
-      toolName,
-      effectiveParams,
-      args.toolCallId,
-      args.ctx.loopDetection,
-    );
+  const loopProtectionResult = await applyLoopProtection({
+    ctx: args.ctx,
+    toolName,
+    toolParams: effectiveParams,
+    toolCallId: args.toolCallId,
+  });
+  if (loopProtectionResult.blockedReason) {
+    return {
+      blocked: true,
+      reason: loopProtectionResult.blockedReason,
+    };
   }
 
   return { blocked: false, params: effectiveParams };

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -595,6 +595,24 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck).toBe(false);
     });
 
+    it("resets the browser search storm streak once searches settle on one query", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw initial", "openclaw varied", "openclaw varied", "openclaw varied"],
+      });
+
+      const current = createBrowserSearchFixture("openclaw varied");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks browser search storms at critical threshold", () => {
       const state = createState();
       recordSuccessfulBrowserSearchCalls({
@@ -649,6 +667,30 @@ describe("tool-loop-detection", () => {
         expect(loopResult.detector).toBe("browser_search_storm");
         expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
       }
+    });
+
+    it("does not treat duckduckgo.com/html without a trailing slash as a search hop", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        const fixture = createBrowserSearchFixture(`duck issue ${i}`, "duckduckgo.com", {
+          path: "/html",
+          queryParam: "q",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("duck issue next", "duckduckgo.com", {
+        path: "/html",
+        queryParam: "q",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
     });
 
     it("does not treat google.evil.com search pages as Google search hops", () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -114,6 +114,17 @@ function createBrowserSearchFixture(
   } as const;
 }
 
+function createBrowserPageFixture(url: string) {
+  return {
+    toolName: "browser",
+    params: { action: "open", url },
+    result: {
+      content: [{ type: "text", text: `opened ${url}` }],
+      details: { url },
+    },
+  } as const;
+}
+
 function recordSuccessfulBrowserSearchCalls(params: {
   state: SessionState;
   queries: string[];
@@ -603,6 +614,57 @@ describe("tool-loop-detection", () => {
       });
 
       const current = createBrowserSearchFixture("openclaw varied");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("resets the browser search storm streak after opening a non-search page", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw issue 0", "openclaw issue 1", "openclaw issue 2", "openclaw issue 3"],
+      });
+
+      const openedResultPage = createBrowserPageFixture("https://example.com/openclaw/result");
+      recordSuccessfulCall(
+        state,
+        openedResultPage.toolName,
+        openedResultPage.params,
+        openedResultPage.result,
+        4,
+      );
+
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw follow-up 0", "openclaw follow-up 1", "openclaw follow-up 2"],
+        startIndex: 5,
+      });
+
+      const current = createBrowserSearchFixture("openclaw follow-up next");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("only counts the non-repeating active browser-search tail", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw issue A", "openclaw issue B", "openclaw issue A", "openclaw issue C"],
+      });
+
+      const current = createBrowserSearchFixture("openclaw issue D");
       const loopResult = detectToolCallLoop(
         state,
         current.toolName,

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -104,6 +104,7 @@ function createBrowserSearchFixture(
     queryParam?: string;
     action?: "open" | "navigate";
     urlField?: "url" | "targetUrl";
+    targetId?: string;
   },
 ) {
   const path = options?.path ?? "/search";
@@ -116,7 +117,10 @@ function createBrowserSearchFixture(
     params: { action, [urlField]: url },
     result: {
       content: [{ type: "text", text: `results for ${query}` }],
-      details: { url },
+      details: {
+        url,
+        ...(options?.targetId ? { targetId: options.targetId } : {}),
+      },
     },
   } as const;
 }
@@ -139,6 +143,48 @@ function createBrowserActClickFixture(ref = "1") {
     result: {
       content: [{ type: "text", text: `clicked ${ref}` }],
       details: { ok: true },
+    },
+  } as const;
+}
+
+function createBrowserActTypeFixture(
+  query: string,
+  targetId = "tab-search",
+  options?: { submit?: boolean },
+) {
+  return {
+    toolName: "browser",
+    params: {
+      action: "act",
+      request: {
+        kind: "type",
+        targetId,
+        ref: "qbox",
+        text: query,
+        ...(options?.submit !== undefined ? { submit: options.submit } : {}),
+      },
+    },
+    result: {
+      content: [{ type: "text", text: `typed ${query}` }],
+      details: { ok: true, targetId },
+    },
+  } as const;
+}
+
+function createBrowserActPressFixture(key = "Enter", targetId = "tab-search") {
+  return {
+    toolName: "browser",
+    params: {
+      action: "act",
+      request: {
+        kind: "press",
+        targetId,
+        key,
+      },
+    },
+    result: {
+      content: [{ type: "text", text: `pressed ${key}` }],
+      details: { ok: true, targetId },
     },
   } as const;
 }
@@ -393,6 +439,40 @@ describe("tool-loop-detection", () => {
         originalQueryHash,
       );
       expect(state.toolCallHistory?.[0]?.resultHash).toBeDefined();
+    });
+
+    it("does not rewrite unfinished entries when toolCallId collides across runs", () => {
+      const state = createState();
+      const sharedToolCallId = "shared-call";
+
+      recordToolCall(
+        state,
+        "read",
+        { path: "/run-a.txt" },
+        sharedToolCallId,
+        enabledLoopDetectionConfig,
+        "run-a",
+      );
+
+      recordToolCallOutcome(state, {
+        toolName: "read",
+        toolParams: { path: "/run-b.txt" },
+        toolCallId: sharedToolCallId,
+        runId: "run-b",
+        result: {
+          content: [{ type: "text", text: "run b output" }],
+          details: { ok: true },
+        },
+        config: enabledLoopDetectionConfig,
+      });
+
+      expect(state.toolCallHistory).toHaveLength(2);
+      const runAEntry = state.toolCallHistory?.find((call) => call.runId === "run-a");
+      const runBEntry = state.toolCallHistory?.find((call) => call.runId === "run-b");
+      expect(runAEntry?.argsHash).toBe(hashToolCall("read", { path: "/run-a.txt" }));
+      expect(runAEntry?.resultHash).toBeUndefined();
+      expect(runBEntry?.argsHash).toBe(hashToolCall("read", { path: "/run-b.txt" }));
+      expect(runBEntry?.resultHash).toBeDefined();
     });
   });
 
@@ -805,6 +885,108 @@ describe("tool-loop-detection", () => {
 
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      }
+    });
+
+    it("matches in-tab browser search submissions via act type submit", () => {
+      const state = createState();
+      const targetId = "tab-submit";
+      const openedSearch = createBrowserSearchFixture("submit issue 0", "www.google.com", {
+        targetId,
+      });
+
+      recordSuccessfulCall(
+        state,
+        openedSearch.toolName,
+        openedSearch.params,
+        openedSearch.result,
+        0,
+      );
+
+      for (let i = 1; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        const typedSearch = createBrowserActTypeFixture(`submit issue ${i}`, targetId, {
+          submit: true,
+        });
+        recordSuccessfulCall(
+          state,
+          typedSearch.toolName,
+          typedSearch.params,
+          typedSearch.result,
+          i,
+        );
+      }
+
+      const current = createBrowserActTypeFixture(
+        `submit issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        targetId,
+        { submit: true },
+      );
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      }
+    });
+
+    it("matches in-tab browser search submissions via act press Enter", () => {
+      const state = createState();
+      const targetId = "tab-enter";
+      const openedSearch = createBrowserSearchFixture("enter issue 0", "www.google.com", {
+        targetId,
+      });
+      recordSuccessfulCall(
+        state,
+        openedSearch.toolName,
+        openedSearch.params,
+        openedSearch.result,
+        0,
+      );
+
+      for (let i = 1; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        const draft = createBrowserActTypeFixture(`enter issue ${i}`, targetId, {
+          submit: false,
+        });
+        const press = createBrowserActPressFixture("Enter", targetId);
+        recordSuccessfulCall(state, draft.toolName, draft.params, draft.result, i * 2 - 1);
+        recordSuccessfulCall(state, press.toolName, press.params, press.result, i * 2);
+      }
+
+      const currentDraft = createBrowserActTypeFixture(
+        `enter issue ${BROWSER_SEARCH_WARNING_THRESHOLD}`,
+        targetId,
+        {
+          submit: false,
+        },
+      );
+      recordSuccessfulCall(
+        state,
+        currentDraft.toolName,
+        currentDraft.params,
+        currentDraft.result,
+        BROWSER_SEARCH_WARNING_THRESHOLD * 2 - 1,
+      );
+
+      const current = createBrowserActPressFixture("Enter", targetId);
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
         expect(loopResult.detector).toBe("browser_search_storm");
         expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
       }

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
+  BROWSER_SEARCH_CRITICAL_THRESHOLD,
+  BROWSER_SEARCH_WARNING_THRESHOLD,
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   TOOL_CALL_HISTORY_SIZE,
@@ -92,6 +94,46 @@ function createPingPongFixture() {
     readParams: { path: "/a.txt" },
     listParams: { dir: "/workspace" },
   };
+}
+
+function createBrowserSearchFixture(
+  query: string,
+  host = "www.google.com",
+  options?: { path?: string; queryParam?: string },
+) {
+  const path = options?.path ?? "/search";
+  const queryParam = options?.queryParam ?? "q";
+  const url = `https://${host}${path}?${queryParam}=${encodeURIComponent(query)}`;
+  return {
+    toolName: "browser",
+    params: { action: "open", url },
+    result: {
+      content: [{ type: "text", text: `results for ${query}` }],
+      details: { url },
+    },
+  } as const;
+}
+
+function recordSuccessfulBrowserSearchCalls(params: {
+  state: SessionState;
+  queries: string[];
+  hostAtIndex?: (index: number) => string;
+  startIndex?: number;
+}) {
+  const startIndex = params.startIndex ?? 0;
+  for (let i = 0; i < params.queries.length; i += 1) {
+    const fixture = createBrowserSearchFixture(
+      params.queries[i] ?? `query-${i}`,
+      params.hostAtIndex?.(i) ?? "www.google.com",
+    );
+    recordSuccessfulCall(
+      params.state,
+      fixture.toolName,
+      fixture.params,
+      fixture.result,
+      startIndex + i,
+    );
+  }
 }
 
 function detectLoopAfterRepeatedCalls(params: {
@@ -245,6 +287,83 @@ describe("tool-loop-detection", () => {
 
       expect(state.toolCallHistory).toHaveLength(4);
       expect(state.toolCallHistory?.[0]?.argsHash).toBe(hashToolCall("tool", { iteration: 6 }));
+    });
+
+    it("skips browser loop hints when browserSearchStorm is disabled", () => {
+      const state = createState();
+
+      recordToolCall(
+        state,
+        "browser",
+        { action: "open", url: "https://www.google.com/search?q=openclaw" },
+        "browser-disabled",
+        {
+          enabled: true,
+          detectors: {
+            browserSearchStorm: false,
+          },
+        },
+      );
+
+      expect(state.toolCallHistory?.[0]?.loopHint).toBeUndefined();
+    });
+  });
+
+  describe("recordToolCallOutcome", () => {
+    it("skips browser loop hints when browserSearchStorm is disabled", () => {
+      const state = createState();
+
+      recordToolCallOutcome(state, {
+        toolName: "browser",
+        toolParams: { action: "open", url: "https://www.google.com/search?q=openclaw" },
+        toolCallId: "browser-outcome-disabled",
+        result: {
+          content: [{ type: "text", text: "results" }],
+          details: { ok: true },
+        },
+        config: {
+          enabled: true,
+          detectors: {
+            browserSearchStorm: false,
+          },
+        },
+      });
+
+      expect(state.toolCallHistory?.[0]?.loopHint).toBeUndefined();
+    });
+
+    it("updates the pre-hook browser entry instead of appending a second adjusted search", () => {
+      const state = createState();
+      const toolCallId = "browser-adjusted";
+      const originalParams = {
+        action: "open",
+        url: "https://www.google.com/search?q=openclaw",
+      };
+      const adjustedParams = {
+        action: "open",
+        url: "https://www.google.com/search?q=openclaw+bug",
+      };
+
+      recordToolCall(state, "browser", originalParams, toolCallId, enabledLoopDetectionConfig);
+      const originalQueryHash = state.toolCallHistory?.[0]?.loopHint?.browserSearch?.queryHash;
+
+      recordToolCallOutcome(state, {
+        toolName: "browser",
+        toolParams: adjustedParams,
+        toolCallId,
+        result: {
+          content: [{ type: "text", text: "results" }],
+          details: { ok: true },
+        },
+        config: enabledLoopDetectionConfig,
+      });
+
+      expect(state.toolCallHistory).toHaveLength(1);
+      expect(state.toolCallHistory?.[0]?.argsHash).toBe(hashToolCall("browser", adjustedParams));
+      expect(state.toolCallHistory?.[0]?.loopHint?.browserSearch?.queryHash).not.toBe(
+        originalQueryHash,
+      );
+      expect(state.toolCallHistory?.[0]?.resultHash).toBeDefined();
     });
   });
 
@@ -425,6 +544,173 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "process", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("warns on browser search storms across changing queries", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: Array.from(
+          { length: BROWSER_SEARCH_WARNING_THRESHOLD },
+          (_, index) => `openclaw issue ${index}`,
+        ),
+      });
+
+      const current = createBrowserSearchFixture("openclaw issue next");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+        expect(loopResult.message).toContain("Browser search pages have been opened");
+      }
+    });
+
+    it("does not warn on the first query change after identical history", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: Array.from(
+          { length: BROWSER_SEARCH_WARNING_THRESHOLD },
+          () => "openclaw repeated query",
+        ),
+      });
+
+      const current = createBrowserSearchFixture("openclaw first variation");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("blocks browser search storms at critical threshold", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: Array.from(
+          { length: BROWSER_SEARCH_CRITICAL_THRESHOLD },
+          (_, index) => `openclaw loop detection ${index}`,
+        ),
+        hostAtIndex: (index) => (index % 2 === 0 ? "www.google.com" : "www.bing.com"),
+      });
+
+      const current = createBrowserSearchFixture("openclaw loop detection next", "www.bing.com");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_CRITICAL_THRESHOLD);
+        expect(loopResult.message).toContain("CRITICAL");
+      }
+    });
+
+    it("matches Yandex search pages with a trailing slash", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        const fixture = createBrowserSearchFixture(`yandex issue ${i}`, "yandex.com", {
+          path: "/search/",
+          queryParam: "text",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("yandex issue next", "yandex.com", {
+        path: "/search/",
+        queryParam: "text",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      }
+    });
+
+    it("does not treat google.evil.com search pages as Google search hops", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        const fixture = createBrowserSearchFixture(`evil google issue ${i}`, "google.evil.com");
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("evil google issue next", "google.evil.com");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("does not treat yandex.evil.com search pages as Yandex search hops", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        const fixture = createBrowserSearchFixture(`evil yandex issue ${i}`, "yandex.evil.com", {
+          path: "/search/",
+          queryParam: "text",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("evil yandex issue next", "yandex.evil.com", {
+        path: "/search/",
+        queryParam: "text",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("does not flag normal browser page opens as a browser search storm", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_CRITICAL_THRESHOLD + 2; i += 1) {
+        recordSuccessfulCall(
+          state,
+          "browser",
+          { action: "open", url: `https://example.com/page-${i}` },
+          { content: [{ type: "text", text: `page ${i}` }], details: { ok: true } },
+          i,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "browser",
+        { action: "open", url: "https://example.com/final" },
+        enabledLoopDetectionConfig,
+      );
       expect(loopResult.stuck).toBe(false);
     });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -599,7 +599,7 @@ describe("tool-loop-detection", () => {
         expect(loopResult.level).toBe("warning");
         expect(loopResult.detector).toBe("browser_search_storm");
         expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
-        expect(loopResult.message).toContain("Browser search pages have been opened");
+        expect(loopResult.message).toContain("prior browser search-page opens");
       }
     });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -99,14 +99,21 @@ function createPingPongFixture() {
 function createBrowserSearchFixture(
   query: string,
   host = "www.google.com",
-  options?: { path?: string; queryParam?: string },
+  options?: {
+    path?: string;
+    queryParam?: string;
+    action?: "open" | "navigate";
+    urlField?: "url" | "targetUrl";
+  },
 ) {
   const path = options?.path ?? "/search";
   const queryParam = options?.queryParam ?? "q";
   const url = `https://${host}${path}?${queryParam}=${encodeURIComponent(query)}`;
+  const action = options?.action ?? "open";
+  const urlField = options?.urlField ?? "url";
   return {
     toolName: "browser",
-    params: { action: "open", url },
+    params: { action, [urlField]: url },
     result: {
       content: [{ type: "text", text: `results for ${query}` }],
       details: { url },
@@ -121,6 +128,17 @@ function createBrowserPageFixture(url: string) {
     result: {
       content: [{ type: "text", text: `opened ${url}` }],
       details: { url },
+    },
+  } as const;
+}
+
+function createBrowserActClickFixture(ref = "1") {
+  return {
+    toolName: "browser",
+    params: { action: "act", request: { kind: "click", ref } },
+    result: {
+      content: [{ type: "text", text: `clicked ${ref}` }],
+      details: { ok: true },
     },
   } as const;
 }
@@ -657,6 +675,39 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck).toBe(false);
     });
 
+    it("resets the browser search storm streak after browser act click navigation", () => {
+      const state = createState();
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw issue 0", "openclaw issue 1", "openclaw issue 2", "openclaw issue 3"],
+      });
+
+      const clickedResult = createBrowserActClickFixture("5");
+      recordSuccessfulCall(
+        state,
+        clickedResult.toolName,
+        clickedResult.params,
+        clickedResult.result,
+        4,
+      );
+
+      recordSuccessfulBrowserSearchCalls({
+        state,
+        queries: ["openclaw follow-up 0", "openclaw follow-up 1", "openclaw follow-up 2"],
+        startIndex: 5,
+      });
+
+      const current = createBrowserSearchFixture("openclaw follow-up next");
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("only counts the non-repeating active browser-search tail", () => {
       const state = createState();
       recordSuccessfulBrowserSearchCalls({
@@ -716,6 +767,34 @@ describe("tool-loop-detection", () => {
       const current = createBrowserSearchFixture("yandex issue next", "yandex.com", {
         path: "/search/",
         queryParam: "text",
+      });
+      const loopResult = detectToolCallLoop(
+        state,
+        current.toolName,
+        current.params,
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("browser_search_storm");
+        expect(loopResult.count).toBe(BROWSER_SEARCH_WARNING_THRESHOLD);
+      }
+    });
+
+    it("matches browser search pages opened via navigate targetUrl", () => {
+      const state = createState();
+      for (let i = 0; i < BROWSER_SEARCH_WARNING_THRESHOLD; i += 1) {
+        const fixture = createBrowserSearchFixture(`navigate issue ${i}`, "www.google.com", {
+          action: "navigate",
+          urlField: "targetUrl",
+        });
+        recordSuccessfulCall(state, fixture.toolName, fixture.params, fixture.result, i);
+      }
+
+      const current = createBrowserSearchFixture("navigate issue next", "www.google.com", {
+        action: "navigate",
+        urlField: "targetUrl",
       });
       const loopResult = detectToolCallLoop(
         state,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -201,6 +201,25 @@ function normalizeHostname(hostname: string): string {
   return lowered.startsWith("www.") ? lowered.slice(4) : lowered;
 }
 
+function extractBrowserActKind(params: Record<string, unknown>): string | undefined {
+  const request = isPlainObject(params.request) ? params.request : undefined;
+  if (typeof request?.kind === "string") {
+    return request.kind;
+  }
+  return typeof params.kind === "string" ? params.kind : undefined;
+}
+
+function isBrowserNavigationBoundary(toolName: string, params: unknown): boolean {
+  if (toolName !== "browser" || !isPlainObject(params)) {
+    return false;
+  }
+  const action = params.action;
+  if (action === "open" || action === "navigate") {
+    return true;
+  }
+  return action === "act" && extractBrowserActKind(params) === "click";
+}
+
 function extractBrowserNavigationUrl(toolName: string, params: unknown): URL | undefined {
   if (toolName !== "browser" || !isPlainObject(params)) {
     return undefined;
@@ -275,10 +294,12 @@ function extractToolCallLoopHint(
     return undefined;
   }
   const navigationUrl = extractBrowserNavigationUrl(toolName, params);
-  if (!navigationUrl) {
+  if (!navigationUrl && !isBrowserNavigationBoundary(toolName, params)) {
     return undefined;
   }
-  const browserSearch = extractBrowserSearchLoopHintFromUrl(navigationUrl);
+  const browserSearch = navigationUrl
+    ? extractBrowserSearchLoopHintFromUrl(navigationUrl)
+    : undefined;
   if (browserSearch) {
     return { browserNavigation: true, browserSearch };
   }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -183,6 +183,11 @@ type BrowserSearchHistoryEntry = BrowserSearchLoopRecord & {
   timestamp: number;
 };
 
+type BrowserTargetSearchContext = {
+  search?: BrowserSearchLoopRecord;
+  draftQueryHash?: string;
+};
+
 const GOOGLE_SEARCH_HOST_PATTERN = /(^|\.)google\.(?:com|[a-z]{2,3}|co\.[a-z]{2}|com\.[a-z]{2})$/;
 const YANDEX_SEARCH_HOST_PATTERN = /(^|\.)yandex\.(?:com|ru|by|kz|ua|net)$/;
 
@@ -207,6 +212,38 @@ function extractBrowserActKind(params: Record<string, unknown>): string | undefi
     return request.kind;
   }
   return typeof params.kind === "string" ? params.kind : undefined;
+}
+
+function extractBrowserActStringParam(
+  params: Record<string, unknown>,
+  key: "key" | "targetId" | "text",
+): string | undefined {
+  const request = isPlainObject(params.request) ? params.request : undefined;
+  const requestValue = request?.[key];
+  if (typeof requestValue === "string") {
+    const trimmed = requestValue.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  const value = params[key];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function extractBrowserActBooleanParam(
+  params: Record<string, unknown>,
+  key: "submit",
+): boolean | undefined {
+  const request = isPlainObject(params.request) ? params.request : undefined;
+  const requestValue = request?.[key];
+  if (typeof requestValue === "boolean") {
+    return requestValue;
+  }
+  return typeof params[key] === "boolean" ? params[key] : undefined;
 }
 
 function isBrowserNavigationBoundary(toolName: string, params: unknown): boolean {
@@ -253,6 +290,41 @@ function extractBrowserNavigationUrl(toolName: string, params: unknown): URL | u
   return parsedUrl;
 }
 
+function extractBrowserResultDetails(result: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(result) || !isPlainObject(result.details)) {
+    return undefined;
+  }
+  return result.details;
+}
+
+function extractBrowserResultTargetId(result: unknown): string | undefined {
+  const details = extractBrowserResultDetails(result);
+  if (typeof details?.targetId !== "string") {
+    return undefined;
+  }
+  const trimmed = details.targetId.trim();
+  return trimmed || undefined;
+}
+
+function extractBrowserTargetId(
+  toolName: string,
+  params: unknown,
+  result?: unknown,
+): string | undefined {
+  if (toolName !== "browser" || !isPlainObject(params)) {
+    return undefined;
+  }
+  return extractBrowserActStringParam(params, "targetId") ?? extractBrowserResultTargetId(result);
+}
+
+function hashBrowserSearchQuery(query: string): string | undefined {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return digestStable(trimmed.toLowerCase());
+}
+
 function extractBrowserSearchLoopHintFromUrl(parsedUrl: URL): BrowserSearchLoopRecord | undefined {
   const host = normalizeHostname(parsedUrl.hostname);
   const path = parsedUrl.pathname.toLowerCase();
@@ -273,37 +345,141 @@ function extractBrowserSearchLoopHintFromUrl(parsedUrl: URL): BrowserSearchLoopR
   return undefined;
 }
 
-function extractBrowserSearchLoopHint(
+function isSuccessfulToolCallRecord(record: ToolCallRecord): boolean {
+  return typeof record.resultHash === "string" && !record.resultHash.startsWith("error:");
+}
+
+function findRecentBrowserTargetContext(
+  history: ToolCallRecord[] | undefined,
+  targetId: string,
+): BrowserTargetSearchContext {
+  if (!history?.length) {
+    return {};
+  }
+
+  const context: BrowserTargetSearchContext = {};
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (!record || !isSuccessfulToolCallRecord(record)) {
+      continue;
+    }
+    const loopHint = record.loopHint;
+    if (!loopHint || loopHint.browserTargetId !== targetId) {
+      continue;
+    }
+    if (loopHint.browserNavigation && !loopHint.browserSearch) {
+      break;
+    }
+    if (!context.draftQueryHash && loopHint.browserSearchDraftQueryHash) {
+      context.draftQueryHash = loopHint.browserSearchDraftQueryHash;
+    }
+    if (!context.search && loopHint.browserSearch) {
+      context.search = loopHint.browserSearch;
+      if (context.draftQueryHash) {
+        break;
+      }
+    }
+  }
+
+  return context;
+}
+
+function extractBrowserSearchDraftQueryHash(toolName: string, params: unknown): string | undefined {
+  if (toolName !== "browser" || !isPlainObject(params) || params.action !== "act") {
+    return undefined;
+  }
+  if (extractBrowserActKind(params) !== "type") {
+    return undefined;
+  }
+  const text = extractBrowserActStringParam(params, "text");
+  return text ? hashBrowserSearchQuery(text) : undefined;
+}
+
+function extractBrowserSubmittedSearchLoopHint(
   toolName: string,
   params: unknown,
+  history: ToolCallRecord[] | undefined,
 ): BrowserSearchLoopRecord | undefined {
-  const parsedUrl = extractBrowserNavigationUrl(toolName, params);
-  if (!parsedUrl) {
+  if (toolName !== "browser" || !isPlainObject(params) || params.action !== "act") {
     return undefined;
   }
 
-  return extractBrowserSearchLoopHintFromUrl(parsedUrl);
+  const actKind = extractBrowserActKind(params);
+  if (actKind !== "type" && actKind !== "press") {
+    return undefined;
+  }
+
+  const targetId = extractBrowserTargetId(toolName, params);
+  if (!targetId) {
+    return undefined;
+  }
+
+  const context = findRecentBrowserTargetContext(history, targetId);
+  const host = context.search?.host;
+  if (!host) {
+    return undefined;
+  }
+
+  if (actKind === "type") {
+    if (extractBrowserActBooleanParam(params, "submit") !== true) {
+      return undefined;
+    }
+    const text = extractBrowserActStringParam(params, "text");
+    const queryHash = text ? hashBrowserSearchQuery(text) : undefined;
+    return queryHash ? { host, queryHash } : undefined;
+  }
+
+  const key = extractBrowserActStringParam(params, "key")?.toLowerCase();
+  if (key !== "enter") {
+    return undefined;
+  }
+  const queryHash = context.draftQueryHash ?? context.search?.queryHash;
+  return queryHash ? { host, queryHash } : undefined;
+}
+
+function extractBrowserSearchLoopHint(
+  toolName: string,
+  params: unknown,
+  history?: ToolCallRecord[],
+): BrowserSearchLoopRecord | undefined {
+  const parsedUrl = extractBrowserNavigationUrl(toolName, params);
+  if (parsedUrl) {
+    return extractBrowserSearchLoopHintFromUrl(parsedUrl);
+  }
+  return extractBrowserSubmittedSearchLoopHint(toolName, params, history);
 }
 
 function extractToolCallLoopHint(
   toolName: string,
   params: unknown,
-  options?: { browserSearchStormEnabled?: boolean },
+  options?: { browserSearchStormEnabled?: boolean; history?: ToolCallRecord[]; result?: unknown },
 ): ToolCallRecord["loopHint"] {
   if (options?.browserSearchStormEnabled === false) {
     return undefined;
   }
-  const navigationUrl = extractBrowserNavigationUrl(toolName, params);
-  if (!navigationUrl && !isBrowserNavigationBoundary(toolName, params)) {
+
+  const browserSearch = extractBrowserSearchLoopHint(toolName, params, options?.history);
+  const browserNavigation = isBrowserNavigationBoundary(toolName, params) || Boolean(browserSearch);
+  const browserTargetId = extractBrowserTargetId(toolName, params, options?.result);
+  const browserSearchDraftQueryHash = extractBrowserSearchDraftQueryHash(toolName, params);
+  if (!browserNavigation && !browserTargetId && !browserSearchDraftQueryHash) {
     return undefined;
   }
-  const browserSearch = navigationUrl
-    ? extractBrowserSearchLoopHintFromUrl(navigationUrl)
-    : undefined;
-  if (browserSearch) {
-    return { browserNavigation: true, browserSearch };
+
+  const loopHint: NonNullable<ToolCallRecord["loopHint"]> = {};
+  if (browserNavigation) {
+    loopHint.browserNavigation = true;
   }
-  return { browserNavigation: true };
+  if (browserSearch) {
+    loopHint.browserSearch = browserSearch;
+  }
+  if (browserSearchDraftQueryHash) {
+    loopHint.browserSearchDraftQueryHash = browserSearchDraftQueryHash;
+  }
+  if (browserTargetId) {
+    loopHint.browserTargetId = browserTargetId;
+  }
+  return loopHint;
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {
@@ -605,7 +781,7 @@ export function detectToolCallLoop(
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
   const browserSearch = resolvedConfig.detectors.browserSearchStorm
-    ? extractBrowserSearchLoopHint(toolName, params)
+    ? extractBrowserSearchLoopHint(toolName, params, history)
     : undefined;
 
   if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
@@ -784,6 +960,7 @@ export function recordToolCall(
   params: unknown,
   toolCallId?: string,
   config?: ToolLoopDetectionConfig,
+  runId?: string,
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
@@ -794,8 +971,10 @@ export function recordToolCall(
     toolName,
     argsHash: hashToolCall(toolName, params),
     toolCallId,
+    runId,
     loopHint: extractToolCallLoopHint(toolName, params, {
       browserSearchStormEnabled: resolvedConfig.detectors.browserSearchStorm,
+      history: state.toolCallHistory,
     }),
     timestamp: Date.now(),
   });
@@ -814,6 +993,7 @@ export function recordToolCallOutcome(
     toolName: string;
     toolParams: unknown;
     toolCallId?: string;
+    runId?: string;
     result?: unknown;
     error?: unknown;
     config?: ToolLoopDetectionConfig;
@@ -837,6 +1017,8 @@ export function recordToolCallOutcome(
   const argsHash = hashToolCall(params.toolName, params.toolParams);
   const loopHint = extractToolCallLoopHint(params.toolName, params.toolParams, {
     browserSearchStormEnabled: resolvedConfig.detectors.browserSearchStorm,
+    history: state.toolCallHistory,
+    result: params.result,
   });
   let matched = false;
   for (let i = state.toolCallHistory.length - 1; i >= 0; i -= 1) {
@@ -850,8 +1032,12 @@ export function recordToolCallOutcome(
     if (call.resultHash !== undefined) {
       continue;
     }
+    if ((call.runId ?? undefined) !== (params.runId ?? undefined)) {
+      continue;
+    }
     if (params.toolCallId && call.toolCallId === params.toolCallId) {
       call.argsHash = argsHash;
+      call.runId = params.runId;
       call.loopHint = loopHint;
       call.resultHash = resultHash;
       matched = true;
@@ -874,6 +1060,7 @@ export function recordToolCallOutcome(
       toolName: params.toolName,
       argsHash,
       toolCallId: params.toolCallId,
+      runId: params.runId,
       resultHash,
       loopHint,
       timestamp: Date.now(),

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
-import type { SessionState } from "../logging/diagnostic-session-state.js";
+import type { SessionState, ToolCallRecord } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPlainObject } from "../utils.js";
 
@@ -10,7 +10,8 @@ export type LoopDetectorKind =
   | "generic_repeat"
   | "known_poll_no_progress"
   | "global_circuit_breaker"
-  | "ping_pong";
+  | "ping_pong"
+  | "browser_search_storm";
 
 export type LoopDetectionResult =
   | { stuck: false }
@@ -27,17 +28,22 @@ export type LoopDetectionResult =
 export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
+export const BROWSER_SEARCH_WARNING_THRESHOLD = 4;
+export const BROWSER_SEARCH_CRITICAL_THRESHOLD = 8;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
+  browserSearchWarningThreshold: BROWSER_SEARCH_WARNING_THRESHOLD,
+  browserSearchCriticalThreshold: BROWSER_SEARCH_CRITICAL_THRESHOLD,
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   detectors: {
     genericRepeat: true,
     knownPollNoProgress: true,
     pingPong: true,
+    browserSearchStorm: true,
   },
 };
 
@@ -46,11 +52,14 @@ type ResolvedLoopDetectionConfig = {
   historySize: number;
   warningThreshold: number;
   criticalThreshold: number;
+  browserSearchWarningThreshold: number;
+  browserSearchCriticalThreshold: number;
   globalCircuitBreakerThreshold: number;
   detectors: {
     genericRepeat: boolean;
     knownPollNoProgress: boolean;
     pingPong: boolean;
+    browserSearchStorm: boolean;
   };
 };
 
@@ -70,6 +79,14 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     config?.criticalThreshold,
     DEFAULT_LOOP_DETECTION_CONFIG.criticalThreshold,
   );
+  let browserSearchWarningThreshold = asPositiveInt(
+    config?.browserSearchWarningThreshold,
+    DEFAULT_LOOP_DETECTION_CONFIG.browserSearchWarningThreshold,
+  );
+  let browserSearchCriticalThreshold = asPositiveInt(
+    config?.browserSearchCriticalThreshold,
+    DEFAULT_LOOP_DETECTION_CONFIG.browserSearchCriticalThreshold,
+  );
   let globalCircuitBreakerThreshold = asPositiveInt(
     config?.globalCircuitBreakerThreshold,
     DEFAULT_LOOP_DETECTION_CONFIG.globalCircuitBreakerThreshold,
@@ -77,6 +94,9 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
 
   if (criticalThreshold <= warningThreshold) {
     criticalThreshold = warningThreshold + 1;
+  }
+  if (browserSearchCriticalThreshold <= browserSearchWarningThreshold) {
+    browserSearchCriticalThreshold = browserSearchWarningThreshold + 1;
   }
   if (globalCircuitBreakerThreshold <= criticalThreshold) {
     globalCircuitBreakerThreshold = criticalThreshold + 1;
@@ -87,6 +107,8 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     historySize: asPositiveInt(config?.historySize, DEFAULT_LOOP_DETECTION_CONFIG.historySize),
     warningThreshold,
     criticalThreshold,
+    browserSearchWarningThreshold,
+    browserSearchCriticalThreshold,
     globalCircuitBreakerThreshold,
     detectors: {
       genericRepeat:
@@ -95,6 +117,9 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
         config?.detectors?.knownPollNoProgress ??
         DEFAULT_LOOP_DETECTION_CONFIG.detectors.knownPollNoProgress,
       pingPong: config?.detectors?.pingPong ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.pingPong,
+      browserSearchStorm:
+        config?.detectors?.browserSearchStorm ??
+        DEFAULT_LOOP_DETECTION_CONFIG.detectors.browserSearchStorm,
     },
   };
 }
@@ -142,6 +167,101 @@ function stableStringifyFallback(value: unknown): string {
     }
     return Object.prototype.toString.call(value);
   }
+}
+
+type BrowserSearchMatcher = {
+  hostPattern: RegExp;
+  pathPattern: RegExp;
+  queryParam: string;
+};
+
+type BrowserSearchLoopRecord = NonNullable<
+  NonNullable<ToolCallRecord["loopHint"]>["browserSearch"]
+>;
+
+const GOOGLE_SEARCH_HOST_PATTERN = /(^|\.)google\.(?:com|[a-z]{2,3}|co\.[a-z]{2}|com\.[a-z]{2})$/;
+const YANDEX_SEARCH_HOST_PATTERN = /(^|\.)yandex\.(?:com|ru|by|kz|ua|net)$/;
+
+const BROWSER_SEARCH_MATCHERS: BrowserSearchMatcher[] = [
+  { hostPattern: GOOGLE_SEARCH_HOST_PATTERN, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)bing\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)search\.brave\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
+  { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html)?\/?$/, queryParam: "q" },
+  { hostPattern: /(^|\.)baidu\.com$/, pathPattern: /^\/s$/, queryParam: "wd" },
+  { hostPattern: /(^|\.)yahoo\.com$/, pathPattern: /^\/search$/, queryParam: "p" },
+  { hostPattern: YANDEX_SEARCH_HOST_PATTERN, pathPattern: /^\/search\/?$/, queryParam: "text" },
+];
+
+function normalizeHostname(hostname: string): string {
+  const lowered = hostname.toLowerCase();
+  return lowered.startsWith("www.") ? lowered.slice(4) : lowered;
+}
+
+function extractBrowserSearchLoopHint(
+  toolName: string,
+  params: unknown,
+): BrowserSearchLoopRecord | undefined {
+  if (toolName !== "browser" || !isPlainObject(params)) {
+    return undefined;
+  }
+  const action = params.action;
+  if (action !== "open" && action !== "navigate") {
+    return undefined;
+  }
+
+  const rawUrl =
+    typeof params.targetUrl === "string"
+      ? params.targetUrl
+      : typeof params.url === "string"
+        ? params.url
+        : undefined;
+  if (!rawUrl) {
+    return undefined;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    return undefined;
+  }
+
+  const host = normalizeHostname(parsedUrl.hostname);
+  const path = parsedUrl.pathname.toLowerCase();
+  for (const matcher of BROWSER_SEARCH_MATCHERS) {
+    if (!matcher.hostPattern.test(host) || !matcher.pathPattern.test(path)) {
+      continue;
+    }
+    const rawQuery = parsedUrl.searchParams.get(matcher.queryParam)?.trim();
+    if (!rawQuery) {
+      continue;
+    }
+    return {
+      host,
+      queryHash: digestStable(rawQuery.toLowerCase()),
+    };
+  }
+
+  return undefined;
+}
+
+function extractToolCallLoopHint(
+  toolName: string,
+  params: unknown,
+  options?: { browserSearchStormEnabled?: boolean },
+): ToolCallRecord["loopHint"] {
+  if (options?.browserSearchStormEnabled === false) {
+    return undefined;
+  }
+  const browserSearch = extractBrowserSearchLoopHint(toolName, params);
+  if (browserSearch) {
+    return { browserSearch };
+  }
+  return undefined;
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {
@@ -365,6 +485,22 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
   return [signatureA, signatureB].toSorted().join("|");
 }
 
+function getBrowserSearchStormStats(history: ToolCallRecord[]): {
+  count: number;
+  uniqueHistoryHosts: number;
+  uniqueHistoryQueries: number;
+} {
+  const recentSearches = history
+    .map((record) => record.loopHint?.browserSearch)
+    .filter((search): search is BrowserSearchLoopRecord => Boolean(search));
+
+  return {
+    count: recentSearches.length,
+    uniqueHistoryHosts: new Set(recentSearches.map((search) => search.host)).size,
+    uniqueHistoryQueries: new Set(recentSearches.map((search) => search.queryHash)).size,
+  };
+}
+
 /**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
@@ -385,6 +521,9 @@ export function detectToolCallLoop(
   const noProgressStreak = noProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
+  const browserSearch = resolvedConfig.detectors.browserSearchStorm
+    ? extractBrowserSearchLoopHint(toolName, params)
+    : undefined;
 
   if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
@@ -470,6 +609,49 @@ export function detectToolCallLoop(
     };
   }
 
+  if (browserSearch) {
+    const browserSearchStats = getBrowserSearchStormStats(history);
+    // TODO: This detector only sees browser-search entries still present in the bounded history
+    // window, so interspersed non-search calls can evict older search hops before thresholds trip.
+    // Require variety to already exist in history so the current search alone does not trip the
+    // storm signal on its first query or engine change.
+    const hasVariedSearches =
+      browserSearchStats.uniqueHistoryQueries >= 2 || browserSearchStats.uniqueHistoryHosts >= 2;
+    if (
+      hasVariedSearches &&
+      browserSearchStats.count >= resolvedConfig.browserSearchCriticalThreshold
+    ) {
+      log.error(
+        `Critical browser search storm detected: repeated search-page opens count=${browserSearchStats.count}`,
+      );
+      return {
+        stuck: true,
+        level: "critical",
+        detector: "browser_search_storm",
+        count: browserSearchStats.count,
+        message: `CRITICAL: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. This appears to be a browser search storm. Session execution blocked to prevent runaway browsing and network amplification.`,
+        warningKey: "browser-search:storm",
+      };
+    }
+
+    if (
+      hasVariedSearches &&
+      browserSearchStats.count >= resolvedConfig.browserSearchWarningThreshold
+    ) {
+      log.warn(
+        `Browser search storm warning: repeated search-page opens count=${browserSearchStats.count}`,
+      );
+      return {
+        stuck: true,
+        level: "warning",
+        detector: "browser_search_storm",
+        count: browserSearchStats.count,
+        message: `WARNING: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. Stop broad browser searching and either narrow the task, use web_search/web_fetch, or report failure.`,
+        warningKey: "browser-search:storm",
+      };
+    }
+  }
+
   // Generic detector: warn-only for repeated identical calls.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
@@ -514,6 +696,9 @@ export function recordToolCall(
     toolName,
     argsHash: hashToolCall(toolName, params),
     toolCallId,
+    loopHint: extractToolCallLoopHint(toolName, params, {
+      browserSearchStormEnabled: resolvedConfig.detectors.browserSearchStorm,
+    }),
     timestamp: Date.now(),
   });
 
@@ -552,21 +737,35 @@ export function recordToolCallOutcome(
   }
 
   const argsHash = hashToolCall(params.toolName, params.toolParams);
+  const loopHint = extractToolCallLoopHint(params.toolName, params.toolParams, {
+    browserSearchStormEnabled: resolvedConfig.detectors.browserSearchStorm,
+  });
   let matched = false;
   for (let i = state.toolCallHistory.length - 1; i >= 0; i -= 1) {
     const call = state.toolCallHistory[i];
     if (!call) {
       continue;
     }
-    if (params.toolCallId && call.toolCallId !== params.toolCallId) {
-      continue;
-    }
-    if (call.toolName !== params.toolName || call.argsHash !== argsHash) {
+    if (call.toolName !== params.toolName) {
       continue;
     }
     if (call.resultHash !== undefined) {
       continue;
     }
+    if (params.toolCallId && call.toolCallId === params.toolCallId) {
+      call.argsHash = argsHash;
+      call.loopHint = loopHint;
+      call.resultHash = resultHash;
+      matched = true;
+      break;
+    }
+    if (params.toolCallId && call.toolCallId !== params.toolCallId) {
+      continue;
+    }
+    if (call.argsHash !== argsHash) {
+      continue;
+    }
+    call.loopHint = loopHint;
     call.resultHash = resultHash;
     matched = true;
     break;
@@ -578,6 +777,7 @@ export function recordToolCallOutcome(
       argsHash,
       toolCallId: params.toolCallId,
       resultHash,
+      loopHint,
       timestamp: Date.now(),
     });
   }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -684,7 +684,8 @@ export function detectToolCallLoop(
       browserSearchStats.uniqueQueries >= 2 || browserSearchStats.uniqueHosts >= 2;
     // Anchor warning suppression to the streak boundary when possible so separate storms in one
     // session do not suppress each other and bounded-history eviction is less likely to re-emit
-    // warnings for the same ongoing storm.
+    // warnings for the same ongoing storm. With the default 4/8 browser-search thresholds this
+    // detector only emits one bucket-0 warning before the critical branch takes over.
     const browserSearchWarningKey = browserSearchStats.warningKey;
     if (
       hasVariedSearches &&

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -201,10 +201,7 @@ function normalizeHostname(hostname: string): string {
   return lowered.startsWith("www.") ? lowered.slice(4) : lowered;
 }
 
-function extractBrowserSearchLoopHint(
-  toolName: string,
-  params: unknown,
-): BrowserSearchLoopRecord | undefined {
+function extractBrowserNavigationUrl(toolName: string, params: unknown): URL | undefined {
   if (toolName !== "browser" || !isPlainObject(params)) {
     return undefined;
   }
@@ -234,6 +231,10 @@ function extractBrowserSearchLoopHint(
     return undefined;
   }
 
+  return parsedUrl;
+}
+
+function extractBrowserSearchLoopHintFromUrl(parsedUrl: URL): BrowserSearchLoopRecord | undefined {
   const host = normalizeHostname(parsedUrl.hostname);
   const path = parsedUrl.pathname.toLowerCase();
   for (const matcher of BROWSER_SEARCH_MATCHERS) {
@@ -253,6 +254,18 @@ function extractBrowserSearchLoopHint(
   return undefined;
 }
 
+function extractBrowserSearchLoopHint(
+  toolName: string,
+  params: unknown,
+): BrowserSearchLoopRecord | undefined {
+  const parsedUrl = extractBrowserNavigationUrl(toolName, params);
+  if (!parsedUrl) {
+    return undefined;
+  }
+
+  return extractBrowserSearchLoopHintFromUrl(parsedUrl);
+}
+
 function extractToolCallLoopHint(
   toolName: string,
   params: unknown,
@@ -261,11 +274,15 @@ function extractToolCallLoopHint(
   if (options?.browserSearchStormEnabled === false) {
     return undefined;
   }
-  const browserSearch = extractBrowserSearchLoopHint(toolName, params);
-  if (browserSearch) {
-    return { browserSearch };
+  const navigationUrl = extractBrowserNavigationUrl(toolName, params);
+  if (!navigationUrl) {
+    return undefined;
   }
-  return undefined;
+  const browserSearch = extractBrowserSearchLoopHintFromUrl(navigationUrl);
+  if (browserSearch) {
+    return { browserNavigation: true, browserSearch };
+  }
+  return { browserNavigation: true };
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {
@@ -502,27 +519,30 @@ function getBrowserSearchStormStats(
   uniqueQueries: number;
   warningKey: string;
 } {
-  const recentSearches = history
-    .flatMap((record) =>
-      record.loopHint?.browserSearch
-        ? [{ ...record.loopHint.browserSearch, timestamp: record.timestamp }]
-        : [],
-    )
-    .filter((search): search is BrowserSearchHistoryEntry => Boolean(search));
-
   const activeStreak: BrowserSearchHistoryEntry[] = [];
-  let nextSignature = browserSearchSignature(currentSearch);
-  for (let i = recentSearches.length - 1; i >= 0; i -= 1) {
-    const search = recentSearches[i];
+  const seenSignatures = new Set<string>([browserSearchSignature(currentSearch)]);
+  let boundaryTimestamp: number | undefined;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (!record) {
+      continue;
+    }
+    const loopHint = record.loopHint;
+    if (loopHint?.browserNavigation && !loopHint.browserSearch) {
+      boundaryTimestamp = record.timestamp;
+      break;
+    }
+    const search = loopHint?.browserSearch;
     if (!search) {
       continue;
     }
     const signature = browserSearchSignature(search);
-    if (signature === nextSignature) {
+    if (seenSignatures.has(signature)) {
+      boundaryTimestamp = record.timestamp;
       break;
     }
-    activeStreak.unshift(search);
-    nextSignature = signature;
+    seenSignatures.add(signature);
+    activeStreak.unshift({ ...search, timestamp: record.timestamp });
   }
 
   const oldestActiveSearch = activeStreak[0];
@@ -535,9 +555,11 @@ function getBrowserSearchStormStats(
     count: activeStreak.length,
     uniqueHosts: uniqueHosts.size,
     uniqueQueries: uniqueQueries.size,
-    warningKey: oldestActiveSearch
-      ? `browser-search:storm:${oldestActiveSearch.timestamp}:${oldestActiveSearch.host}:${oldestActiveSearch.queryHash}`
-      : `browser-search:storm:${currentSearch.host}:${currentSearch.queryHash}`,
+    warningKey: boundaryTimestamp
+      ? `browser-search:storm:after:${boundaryTimestamp}`
+      : oldestActiveSearch
+        ? `browser-search:storm:from:${oldestActiveSearch.timestamp}:${oldestActiveSearch.host}:${oldestActiveSearch.queryHash}`
+        : `browser-search:storm:${currentSearch.host}:${currentSearch.queryHash}`,
   };
 }
 
@@ -652,28 +674,31 @@ export function detectToolCallLoop(
   if (browserSearch) {
     const browserSearchStats = getBrowserSearchStormStats(history, browserSearch);
     // TODO: This detector only sees browser-search entries still present in the bounded history
-    // window, so interspersed non-search calls can evict older search hops before thresholds trip.
+    // window, so interspersed non-search calls can evict older search hops before thresholds trip
+    // and may eventually shift the warning-dedup boundary for a very long-lived storm.
     // Restrict this detector to the active streak of changing searches. Once the agent settles
-    // into repeating the same search again, the storm streak resets to avoid blocking follow-up
-    // work solely because older variety is still present elsewhere in the bounded history.
+    // into repeating the same search again, or opens a non-search page and starts making
+    // progress, the storm streak resets to avoid blocking follow-up work solely because older
+    // variety is still present elsewhere in the bounded history.
     const hasVariedSearches =
       browserSearchStats.uniqueQueries >= 2 || browserSearchStats.uniqueHosts >= 2;
-    // Anchor warning suppression to the first search in the active streak so separate storms in
-    // one session do not suppress each other while the same storm still warns only once per bucket.
+    // Anchor warning suppression to the streak boundary when possible so separate storms in one
+    // session do not suppress each other and bounded-history eviction is less likely to re-emit
+    // warnings for the same ongoing storm.
     const browserSearchWarningKey = browserSearchStats.warningKey;
     if (
       hasVariedSearches &&
       browserSearchStats.count >= resolvedConfig.browserSearchCriticalThreshold
     ) {
       log.error(
-        `Critical browser search storm detected: repeated search-page opens count=${browserSearchStats.count}`,
+        `Critical browser search storm detected: priorSearchCount=${browserSearchStats.count}`,
       );
       return {
         stuck: true,
         level: "critical",
         detector: "browser_search_storm",
         count: browserSearchStats.count,
-        message: `CRITICAL: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. This appears to be a browser search storm. Session execution blocked to prevent runaway browsing and network amplification.`,
+        message: `CRITICAL: Detected ${browserSearchStats.count} prior browser search-page opens in the active streak across changing queries or search engines. This current call continues that browser search storm, so session execution is blocked to prevent runaway browsing and network amplification.`,
         warningKey: browserSearchWarningKey,
       };
     }
@@ -682,15 +707,13 @@ export function detectToolCallLoop(
       hasVariedSearches &&
       browserSearchStats.count >= resolvedConfig.browserSearchWarningThreshold
     ) {
-      log.warn(
-        `Browser search storm warning: repeated search-page opens count=${browserSearchStats.count}`,
-      );
+      log.warn(`Browser search storm warning: priorSearchCount=${browserSearchStats.count}`);
       return {
         stuck: true,
         level: "warning",
         detector: "browser_search_storm",
         count: browserSearchStats.count,
-        message: `WARNING: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. Stop broad browser searching and either narrow the task, use web_search/web_fetch, or report failure.`,
+        message: `WARNING: Detected ${browserSearchStats.count} prior browser search-page opens in the active streak across changing queries or search engines. The current call continues that browser search storm; stop broad browser searching and either narrow the task, use web_search/web_fetch, or report failure.`,
         warningKey: browserSearchWarningKey,
       };
     }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -179,6 +179,10 @@ type BrowserSearchLoopRecord = NonNullable<
   NonNullable<ToolCallRecord["loopHint"]>["browserSearch"]
 >;
 
+type BrowserSearchHistoryEntry = BrowserSearchLoopRecord & {
+  timestamp: number;
+};
+
 const GOOGLE_SEARCH_HOST_PATTERN = /(^|\.)google\.(?:com|[a-z]{2,3}|co\.[a-z]{2}|com\.[a-z]{2})$/;
 const YANDEX_SEARCH_HOST_PATTERN = /(^|\.)yandex\.(?:com|ru|by|kz|ua|net)$/;
 
@@ -186,7 +190,7 @@ const BROWSER_SEARCH_MATCHERS: BrowserSearchMatcher[] = [
   { hostPattern: GOOGLE_SEARCH_HOST_PATTERN, pathPattern: /^\/search$/, queryParam: "q" },
   { hostPattern: /(^|\.)bing\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
   { hostPattern: /(^|\.)search\.brave\.com$/, pathPattern: /^\/search$/, queryParam: "q" },
-  { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html)?\/?$/, queryParam: "q" },
+  { hostPattern: /(^|\.)duckduckgo\.com$/, pathPattern: /^\/(?:html\/)?$/, queryParam: "q" },
   { hostPattern: /(^|\.)baidu\.com$/, pathPattern: /^\/s$/, queryParam: "wd" },
   { hostPattern: /(^|\.)yahoo\.com$/, pathPattern: /^\/search$/, queryParam: "p" },
   { hostPattern: YANDEX_SEARCH_HOST_PATTERN, pathPattern: /^\/search\/?$/, queryParam: "text" },
@@ -485,19 +489,55 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
   return [signatureA, signatureB].toSorted().join("|");
 }
 
-function getBrowserSearchStormStats(history: ToolCallRecord[]): {
+function browserSearchSignature(search: BrowserSearchLoopRecord): string {
+  return `${search.host}:${search.queryHash}`;
+}
+
+function getBrowserSearchStormStats(
+  history: ToolCallRecord[],
+  currentSearch: BrowserSearchLoopRecord,
+): {
   count: number;
-  uniqueHistoryHosts: number;
-  uniqueHistoryQueries: number;
+  uniqueHosts: number;
+  uniqueQueries: number;
+  warningKey: string;
 } {
   const recentSearches = history
-    .map((record) => record.loopHint?.browserSearch)
-    .filter((search): search is BrowserSearchLoopRecord => Boolean(search));
+    .flatMap((record) =>
+      record.loopHint?.browserSearch
+        ? [{ ...record.loopHint.browserSearch, timestamp: record.timestamp }]
+        : [],
+    )
+    .filter((search): search is BrowserSearchHistoryEntry => Boolean(search));
+
+  const activeStreak: BrowserSearchHistoryEntry[] = [];
+  let nextSignature = browserSearchSignature(currentSearch);
+  for (let i = recentSearches.length - 1; i >= 0; i -= 1) {
+    const search = recentSearches[i];
+    if (!search) {
+      continue;
+    }
+    const signature = browserSearchSignature(search);
+    if (signature === nextSignature) {
+      break;
+    }
+    activeStreak.unshift(search);
+    nextSignature = signature;
+  }
+
+  const oldestActiveSearch = activeStreak[0];
+  const uniqueHosts = new Set(activeStreak.map((search) => search.host));
+  uniqueHosts.add(currentSearch.host);
+  const uniqueQueries = new Set(activeStreak.map((search) => search.queryHash));
+  uniqueQueries.add(currentSearch.queryHash);
 
   return {
-    count: recentSearches.length,
-    uniqueHistoryHosts: new Set(recentSearches.map((search) => search.host)).size,
-    uniqueHistoryQueries: new Set(recentSearches.map((search) => search.queryHash)).size,
+    count: activeStreak.length,
+    uniqueHosts: uniqueHosts.size,
+    uniqueQueries: uniqueQueries.size,
+    warningKey: oldestActiveSearch
+      ? `browser-search:storm:${oldestActiveSearch.timestamp}:${oldestActiveSearch.host}:${oldestActiveSearch.queryHash}`
+      : `browser-search:storm:${currentSearch.host}:${currentSearch.queryHash}`,
   };
 }
 
@@ -610,13 +650,17 @@ export function detectToolCallLoop(
   }
 
   if (browserSearch) {
-    const browserSearchStats = getBrowserSearchStormStats(history);
+    const browserSearchStats = getBrowserSearchStormStats(history, browserSearch);
     // TODO: This detector only sees browser-search entries still present in the bounded history
     // window, so interspersed non-search calls can evict older search hops before thresholds trip.
-    // Require variety to already exist in history so the current search alone does not trip the
-    // storm signal on its first query or engine change.
+    // Restrict this detector to the active streak of changing searches. Once the agent settles
+    // into repeating the same search again, the storm streak resets to avoid blocking follow-up
+    // work solely because older variety is still present elsewhere in the bounded history.
     const hasVariedSearches =
-      browserSearchStats.uniqueHistoryQueries >= 2 || browserSearchStats.uniqueHistoryHosts >= 2;
+      browserSearchStats.uniqueQueries >= 2 || browserSearchStats.uniqueHosts >= 2;
+    // Anchor warning suppression to the first search in the active streak so separate storms in
+    // one session do not suppress each other while the same storm still warns only once per bucket.
+    const browserSearchWarningKey = browserSearchStats.warningKey;
     if (
       hasVariedSearches &&
       browserSearchStats.count >= resolvedConfig.browserSearchCriticalThreshold
@@ -630,7 +674,7 @@ export function detectToolCallLoop(
         detector: "browser_search_storm",
         count: browserSearchStats.count,
         message: `CRITICAL: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. This appears to be a browser search storm. Session execution blocked to prevent runaway browsing and network amplification.`,
-        warningKey: "browser-search:storm",
+        warningKey: browserSearchWarningKey,
       };
     }
 
@@ -647,8 +691,17 @@ export function detectToolCallLoop(
         detector: "browser_search_storm",
         count: browserSearchStats.count,
         message: `WARNING: Browser search pages have been opened ${browserSearchStats.count} times across changing queries or search engines. Stop broad browser searching and either narrow the task, use web_search/web_fetch, or report failure.`,
-        warningKey: "browser-search:storm",
+        warningKey: browserSearchWarningKey,
       };
+    }
+
+    if (
+      !hasVariedSearches &&
+      browserSearchStats.count >= resolvedConfig.browserSearchWarningThreshold
+    ) {
+      log.debug(
+        `Browser search detector idle: active streak lacks query/engine variety count=${browserSearchStats.count} host=${browserSearch.host}`,
+      );
     }
   }
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -290,6 +290,48 @@ describe("config schema", () => {
     }
   });
 
+  it("rejects browser search warning threshold when it exceeds the default critical threshold", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchWarningThreshold: 10,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchWarningThreshold"],
+            message:
+              "tools.loopDetection.browserSearchWarningThreshold must be lower than the effective browserSearchCriticalThreshold (8).",
+          }),
+        ]),
+      );
+    }
+  });
+
+  it("rejects browser search critical threshold when it is not above the default warning threshold", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchCriticalThreshold: 4,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchCriticalThreshold"],
+            message:
+              "tools.loopDetection.browserSearchCriticalThreshold must be higher than the effective browserSearchWarningThreshold (4).",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("rejects browser search loop detection config when thresholds are below 2", () => {
     const parsed = ToolsSchema.safeParse({
       loopDetection: {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -246,6 +246,75 @@ describe("config schema", () => {
     ).toThrow();
   });
 
+  it("accepts browser search loop detection config in the runtime zod schema", () => {
+    const parsed = ToolsSchema.parse({
+      loopDetection: {
+        enabled: true,
+        browserSearchWarningThreshold: 4,
+        browserSearchCriticalThreshold: 8,
+        detectors: {
+          browserSearchStorm: true,
+        },
+      },
+    });
+
+    expect(parsed?.loopDetection).toMatchObject({
+      enabled: true,
+      browserSearchWarningThreshold: 4,
+      browserSearchCriticalThreshold: 8,
+      detectors: {
+        browserSearchStorm: true,
+      },
+    });
+  });
+
+  it("rejects browser search loop detection config when warning threshold is not lower than critical", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchWarningThreshold: 8,
+        browserSearchCriticalThreshold: 4,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchCriticalThreshold"],
+            message:
+              "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
+          }),
+        ]),
+      );
+    }
+  });
+
+  it("rejects browser search loop detection config when thresholds are below 2", () => {
+    const parsed = ToolsSchema.safeParse({
+      loopDetection: {
+        browserSearchWarningThreshold: 1,
+        browserSearchCriticalThreshold: 1,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchWarningThreshold"],
+            message: "tools.loopDetection.browserSearchWarningThreshold must be at least 2.",
+          }),
+          expect.objectContaining({
+            path: ["loopDetection", "browserSearchCriticalThreshold"],
+            message: "tools.loopDetection.browserSearchCriticalThreshold must be at least 2.",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("keeps tags in the allowed taxonomy", () => {
     const withTags = applyDerivedTags({
       "gateway.auth.token": {},

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -148,6 +148,8 @@ export type ToolLoopDetectionDetectorConfig = {
   knownPollNoProgress?: boolean;
   /** Enable warning/blocking for no-progress ping-pong alternating patterns. */
   pingPong?: boolean;
+  /** Enable warning/blocking for repeated browser search-page opens across changing queries. */
+  browserSearchStorm?: boolean;
 };
 
 export type ToolLoopDetectionConfig = {
@@ -159,6 +161,10 @@ export type ToolLoopDetectionConfig = {
   warningThreshold?: number;
   /** Critical threshold for blocking repetitive loops (default: 20). */
   criticalThreshold?: number;
+  /** Warning threshold for browser search storms across changing queries (default: 4). */
+  browserSearchWarningThreshold?: number;
+  /** Critical threshold for browser search storms across changing queries (default: 8). */
+  browserSearchCriticalThreshold?: number;
   /** Global no-progress breaker threshold (default: 30). */
   globalCircuitBreakerThreshold?: number;
   /** Detector toggles. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -460,6 +460,7 @@ const ToolLoopDetectionDetectorSchema = z
     genericRepeat: z.boolean().optional(),
     knownPollNoProgress: z.boolean().optional(),
     pingPong: z.boolean().optional(),
+    browserSearchStorm: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -470,6 +471,16 @@ const ToolLoopDetectionSchema = z
     historySize: z.number().int().positive().optional(),
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
+    browserSearchWarningThreshold: z
+      .number()
+      .int()
+      .min(2, "tools.loopDetection.browserSearchWarningThreshold must be at least 2.")
+      .optional(),
+    browserSearchCriticalThreshold: z
+      .number()
+      .int()
+      .min(2, "tools.loopDetection.browserSearchCriticalThreshold must be at least 2.")
+      .optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })
@@ -484,6 +495,18 @@ const ToolLoopDetectionSchema = z
         code: z.ZodIssueCode.custom,
         path: ["criticalThreshold"],
         message: "tools.loopDetection.warningThreshold must be lower than criticalThreshold.",
+      });
+    }
+    if (
+      value.browserSearchWarningThreshold !== undefined &&
+      value.browserSearchCriticalThreshold !== undefined &&
+      value.browserSearchWarningThreshold >= value.browserSearchCriticalThreshold
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["browserSearchCriticalThreshold"],
+        message:
+          "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
       });
     }
     if (

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -465,6 +465,9 @@ const ToolLoopDetectionDetectorSchema = z
   .strict()
   .optional();
 
+const DEFAULT_BROWSER_SEARCH_WARNING_THRESHOLD = 4;
+const DEFAULT_BROWSER_SEARCH_CRITICAL_THRESHOLD = 8;
+
 const ToolLoopDetectionSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -498,15 +501,24 @@ const ToolLoopDetectionSchema = z
       });
     }
     if (
-      value.browserSearchWarningThreshold !== undefined &&
-      value.browserSearchCriticalThreshold !== undefined &&
-      value.browserSearchWarningThreshold >= value.browserSearchCriticalThreshold
+      (value.browserSearchWarningThreshold ?? DEFAULT_BROWSER_SEARCH_WARNING_THRESHOLD) >=
+      (value.browserSearchCriticalThreshold ?? DEFAULT_BROWSER_SEARCH_CRITICAL_THRESHOLD)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ["browserSearchCriticalThreshold"],
+        path:
+          value.browserSearchCriticalThreshold !== undefined ||
+          value.browserSearchWarningThreshold === undefined
+            ? ["browserSearchCriticalThreshold"]
+            : ["browserSearchWarningThreshold"],
         message:
-          "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
+          value.browserSearchCriticalThreshold === undefined &&
+          value.browserSearchWarningThreshold !== undefined
+            ? `tools.loopDetection.browserSearchWarningThreshold must be lower than the effective browserSearchCriticalThreshold (${DEFAULT_BROWSER_SEARCH_CRITICAL_THRESHOLD}).`
+            : value.browserSearchWarningThreshold === undefined &&
+                value.browserSearchCriticalThreshold !== undefined
+              ? `tools.loopDetection.browserSearchCriticalThreshold must be higher than the effective browserSearchWarningThreshold (${DEFAULT_BROWSER_SEARCH_WARNING_THRESHOLD}).`
+              : "tools.loopDetection.browserSearchWarningThreshold must be lower than browserSearchCriticalThreshold.",
       });
     }
     if (

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -141,7 +141,12 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   toolName: string;
   level: "warning" | "critical";
   action: "warn" | "block";
-  detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+  detector:
+    | "generic_repeat"
+    | "known_poll_no_progress"
+    | "global_circuit_breaker"
+    | "ping_pong"
+    | "browser_search_storm";
   count: number;
   message: string;
   pairedToolName?: string;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -11,11 +11,21 @@ export type SessionState = {
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
 };
 
+export type BrowserSearchLoopHint = {
+  host: string;
+  queryHash: string;
+};
+
+export type ToolCallLoopHint = {
+  browserSearch?: BrowserSearchLoopHint;
+};
+
 export type ToolCallRecord = {
   toolName: string;
   argsHash: string;
   toolCallId?: string;
   resultHash?: string;
+  loopHint?: ToolCallLoopHint;
   timestamp: number;
 };
 

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -19,12 +19,15 @@ export type BrowserSearchLoopHint = {
 export type ToolCallLoopHint = {
   browserNavigation?: boolean;
   browserSearch?: BrowserSearchLoopHint;
+  browserSearchDraftQueryHash?: string;
+  browserTargetId?: string;
 };
 
 export type ToolCallRecord = {
   toolName: string;
   argsHash: string;
   toolCallId?: string;
+  runId?: string;
   resultHash?: string;
   loopHint?: ToolCallLoopHint;
   timestamp: number;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -17,6 +17,7 @@ export type BrowserSearchLoopHint = {
 };
 
 export type ToolCallLoopHint = {
+  browserNavigation?: boolean;
   browserSearch?: BrowserSearchLoopHint;
 };
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -286,7 +286,12 @@ export function logToolLoopAction(
     toolName: string;
     level: "warning" | "critical";
     action: "warn" | "block";
-    detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+    detector:
+      | "generic_repeat"
+      | "known_poll_no_progress"
+      | "global_circuit_breaker"
+      | "ping_pong"
+      | "browser_search_storm";
     count: number;
     message: string;
     pairedToolName?: string;


### PR DESCRIPTION
## Problem
- Browser-heavy agents could repeatedly open search result pages across changing queries/engines without tripping the existing loop detectors.
- The prior clean PR ended up with the wrong commit email mapping and an extra GitHub `web-flow` merge commit, so I reopened this as a fresh clean branch.

## What Changed
- add the `browser_search_storm` detector for repeated browser opens to known search-engine result pages
- keep browser URL parsing fully disabled when `detectors.browserSearchStorm` is off, including history recording
- require search-query / engine variety to already exist in bounded history before warning or blocking
- update `recordToolCallOutcome` to rewrite the pre-hook history row by `toolCallId` so hook-adjusted browser params do not double-count
- keep the warning-bucket `?? -1` sentinel fix and runtime config/schema wiring from the original change set
- add unit coverage for disabled-detector recording, first-variation behavior, and adjusted-param deduplication

## Verification
- `pnpm exec oxlint --type-aware src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.before-tool-call.e2e.test.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/config/schema.test.ts src/config/zod-schema.agent-runtime.ts`
- `node --import tsx -e '...loop detection smoke...'`

## Notes
- `pnpm exec vitest run ...` still stalls in this temporary clean clone, consistent with the earlier fresh-clone verification issue, so I used targeted smoke assertions for the newly changed paths.