### PR TITLE
fix: resolve SecretRef for skills.entries.<skill>.apiKey in embedded runs

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -518,11 +518,11 @@ export async function compactEmbeddedPiSessionDirect(
       skillsSnapshot: params.skillsSnapshot,
     });
     restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
+      ? await applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
-      : applySkillEnvOverrides({
+      : await applySkillEnvOverrides({
           skills: skillEntries ?? [],
           config: params.config,
         });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1418,11 +1418,11 @@ export async function runEmbeddedAttempt(
       skillsSnapshot: params.skillsSnapshot,
     });
     restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
+      ? await applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
-      : applySkillEnvOverrides({
+      : await applySkillEnvOverrides({
           skills: skillEntries ?? [],
           config: params.config,
         });

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -6,6 +6,7 @@ import { sanitizeEnvVars, validateEnvVarValue } from "../sandbox/sanitize-env-va
 import { resolveSkillConfig } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
 import type { SkillEntry, SkillSnapshot } from "./types.js";
+import { resolveSecretInputString } from "../../secrets/resolve-secret-input-string.js";
 
 const log = createSubsystemLogger("env-overrides");
 
@@ -133,14 +134,15 @@ function sanitizeSkillEnvOverrides(params: {
   return { allowed, blocked: [...blocked], warnings };
 }
 
-function applySkillConfigEnvOverrides(params: {
+async function applySkillConfigEnvOverrides(params: {
   updates: EnvUpdate[];
   skillConfig: SkillConfig;
+  config: OpenClawConfig;
   primaryEnv?: string | null;
   requiredEnv?: string[] | null;
   skillKey: string;
 }) {
-  const { updates, skillConfig, primaryEnv, requiredEnv, skillKey } = params;
+  const { updates, skillConfig, config, primaryEnv, requiredEnv, skillKey } = params;
   const allowedSensitiveKeys = new Set<string>();
   const normalizedPrimaryEnv = primaryEnv?.trim();
   if (normalizedPrimaryEnv) {
@@ -167,10 +169,12 @@ function applySkillConfigEnvOverrides(params: {
   }
 
   const resolvedApiKey =
-    normalizeResolvedSecretInputString({
+    (await resolveSecretInputString({
+      config,
       value: skillConfig.apiKey,
-      path: `skills.entries.${skillKey}.apiKey`,
-    }) ?? "";
+      env: process.env,
+      normalize: normalizeResolvedSecretInputString,
+    })) ?? "";
   const canInjectPrimaryEnv =
     normalizedPrimaryEnv &&
     (process.env[normalizedPrimaryEnv] === undefined ||
@@ -210,7 +214,7 @@ function createEnvReverter(updates: EnvUpdate[]) {
   };
 }
 
-export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+export async function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
   const { skills, config } = params;
   const updates: EnvUpdate[] = [];
 
@@ -221,9 +225,10 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
       continue;
     }
 
-    applySkillConfigEnvOverrides({
+    await applySkillConfigEnvOverrides({
       updates,
       skillConfig,
+      config: config ?? {} as OpenClawConfig,
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env,
       skillKey,
@@ -233,7 +238,7 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
   return createEnvReverter(updates);
 }
 
-export function applySkillEnvOverridesFromSnapshot(params: {
+export async function applySkillEnvOverridesFromSnapshot(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
 }) {
@@ -249,9 +254,10 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       continue;
     }
 
-    applySkillConfigEnvOverrides({
+    await applySkillConfigEnvOverrides({
       updates,
       skillConfig,
+      config: config ?? {} as OpenClawConfig,
       primaryEnv: skill.primaryEnv,
       requiredEnv: skill.requiredEnv,
       skillKey: skill.name,

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -1,12 +1,12 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { resolveSecretInputString } from "../../secrets/resolve-secret-input-string.js";
 import { isDangerousHostEnvVarName } from "../../infra/host-env-security.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { sanitizeEnvVars, validateEnvVarValue } from "../sandbox/sanitize-env-vars.js";
 import { resolveSkillConfig } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
 import type { SkillEntry, SkillSnapshot } from "./types.js";
-import { resolveSecretInputString } from "../../secrets/resolve-secret-input-string.js";
 
 const log = createSubsystemLogger("env-overrides");
 


### PR DESCRIPTION

## 问题背景
Issue #49427: skills.entries.<skill>.apiKey 的文件类型 SecretRef 在 embedded skill 启动时未能解析，报错 "unresolved SecretRef"。

## 根因分析
在 `src/agents/skills/env-overrides.ts` 中，代码使用同步函数 `normalizeResolvedSecretInputString` 来处理 apiKey，但该函数只会检查值是否已经是字符串，**不会**解析 SecretRef（文件引用）。

而 `tools.web.search.gemini.apiKey` 使用异步的 `resolveSecretInputString` 能正常工作。

## 修复方案
将 `env-overrides.ts` 中的 apiKey 解析改为使用异步的 `resolveSecretInputString`：
1. 导入 `resolveSecretInputString` 
2. 将 `applySkillConfigEnvOverrides` 改为 async 函数
3. 使用 await 调用 `resolveSecretInputString` 来解析 apiKey

## 测试方式
1. 配置 file secret provider
2. 在 skills.entries.<skill>.apiKey 中使用文件 SecretRef
3. 启动 embedded session，验证 apiKey 被正确解析

## 风险与影响范围
- 仅影响 skills.entries.<skill>.apiKey 的解析
- 不影响 tools.web.search.gemini.apiKey 等其他配置
- 需要调用者添加 await（已同步更新）