### PR TITLE
fix(model-selection): infer provider from allowlist for bare model names

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -480,6 +480,29 @@ describe("model-selection", () => {
       });
     });
 
+    it("rejects bare model name when it matches multiple providers", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "provider-a/model-x" },
+            models: {
+              "provider-a/model-x": {},
+              "provider-b/model-x": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "model-x",
+        defaultProvider: "provider-c",
+      });
+
+      expect(result).toMatchObject({ error: expect.stringContaining("model not allowed") });
+    });
+
     it("strips trailing auth profile suffix before allowlist matching", () => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -454,6 +454,32 @@ describe("model-selection", () => {
       });
     });
 
+    it("infers provider from allowlist when bare model name has wrong default provider", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "provider-a/model-primary" },
+            models: {
+              "provider-a/model-primary": {},
+              "provider-b/model-cheap": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "model-cheap",
+        defaultProvider: "provider-a",
+      });
+
+      expect(result).toEqual({
+        key: "provider-b/model-cheap",
+        ref: { provider: "provider-b", model: "model-cheap" },
+      });
+    });
+
     it("strips trailing auth profile suffix before allowlist matching", () => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -574,13 +574,16 @@ export function resolveAllowedModelRef(params: {
   // in the allowlist, try to infer the provider from configured models.
   // This handles cases like typing "gpt-4o-mini" when the allowlist only has
   // "cs-openai/gpt-4o-mini" but the session default provider is "cs-anthropic".
+  // Use the raw trimmed input for inference instead of resolved.ref.model,
+  // because provider-specific normalization (e.g. "sonnet-4.6" → "claude-sonnet-4-6"
+  // for anthropic) may have altered the model name for the wrong provider.
   if (!status.allowed && !trimmed.includes("/")) {
     const inferredProvider = inferUniqueProviderFromConfiguredModels({
       cfg: params.cfg,
-      model: resolved.ref.model,
+      model: trimmed,
     });
     if (inferredProvider) {
-      const inferredRef = normalizeModelRef(inferredProvider, resolved.ref.model);
+      const inferredRef = normalizeModelRef(inferredProvider, trimmed);
       const inferredStatus = getModelRefStatus({
         cfg: params.cfg,
         catalog: params.catalog,

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -569,6 +569,31 @@ export function resolveAllowedModelRef(params: {
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
   });
+
+  // When the input has no provider prefix and the default-provider key is not
+  // in the allowlist, try to infer the provider from configured models.
+  // This handles cases like typing "gpt-4o-mini" when the allowlist only has
+  // "cs-openai/gpt-4o-mini" but the session default provider is "cs-anthropic".
+  if (!status.allowed && !trimmed.includes("/")) {
+    const inferredProvider = inferUniqueProviderFromConfiguredModels({
+      cfg: params.cfg,
+      model: resolved.ref.model,
+    });
+    if (inferredProvider) {
+      const inferredRef = normalizeModelRef(inferredProvider, resolved.ref.model);
+      const inferredStatus = getModelRefStatus({
+        cfg: params.cfg,
+        catalog: params.catalog,
+        ref: inferredRef,
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
+      });
+      if (inferredStatus.allowed) {
+        return { ref: inferredRef, key: inferredStatus.key };
+      }
+    }
+  }
+
   if (!status.allowed) {
     return { error: `model not allowed: ${status.key}` };
   }


### PR DESCRIPTION
## Summary

- When a user sets a model without a provider prefix (e.g., `gpt-4o-mini`), `resolveAllowedModelRef` falls back to the session's default provider, constructing a key like `cs-anthropic/gpt-4o-mini` — which fails the allowlist check even though `cs-openai/gpt-4o-mini` is explicitly configured.
- Before returning "model not allowed", now tries `inferUniqueProviderFromConfiguredModels` to find the correct provider from the configured allowlist.
- Only applies when the model maps to exactly one provider, keeping behavior safe for ambiguous cases.

## Reproduction

1. Configure two providers (e.g., `provider-a` for Anthropic, `provider-b` for OpenAI) with `provider-a` as default
2. Add `provider-b/gpt-4o-mini` to `agents.defaults.models` allowlist
3. Try `/model gpt-4o-mini` → **Before**: `model not allowed: provider-a/gpt-4o-mini` — **After**: resolves to `provider-b/gpt-4o-mini`

## Test plan

- [x] Added unit test: bare model name with wrong default provider infers correct provider from allowlist
- [ ] Existing tests pass (local test runner has a pre-existing Node.js ESM assertion error unrelated to this change)