### PR TITLE
Slack: fix runtime api directory import

### DIFF
--- a/extensions/slack/src/runtime-api.ts
+++ b/extensions/slack/src/runtime-api.ts
@@ -12,7 +12,7 @@ export { buildComputedAccountStatusSnapshot } from "../../../src/plugin-sdk/stat
 export {
   listSlackDirectoryGroupsFromConfig,
   listSlackDirectoryPeersFromConfig,
-} from "../../../src/channels/plugins/directory-config.js";
+} from "./directory-config.js";
 export {
   looksLikeSlackTargetId,
   normalizeSlackMessagingTarget,


### PR DESCRIPTION
## Summary
Fix the Slack runtime API barrel to import directory helpers from the extension-owned `directory-config.ts` module.

## Why
Latest `main` deleted the old core `src/channels/plugins/directory-config.ts` path, which leaves `extensions/slack/src/runtime-api.ts` importing a file that no longer exists and breaks `pnpm build`.

## Testing
- `pnpm build`
