### PR TITLE
xAI: add web search credential metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/security: add regression coverage proving pinned fallback host overrides stay bound to Telegram and delegate non-matching hostnames back to the original lookup path. Thanks @vincentkoc.
 - Secrets/exec refs: require explicit `--allow-exec` for `secrets apply` write plans that contain exec SecretRefs/providers, and align audit/configure/apply dry-run behavior to skip exec checks unless opted in to prevent unexpected command side effects. (#49417) Thanks @restriction and @joshavant.
 - Tools/image generation: add bundled fal image generation support so `image_generate` can target `fal/*` models with `FAL_KEY`, including single-image edit flows via FLUX image-to-image. Thanks @vincentkoc.
+- xAI/web search: add missing Grok credential metadata so the bundled provider registration type-checks again. (#49472) thanks @scoootscooob.
 
 ### Breaking
 

--- a/extensions/imessage/runtime-api.ts
+++ b/extensions/imessage/runtime-api.ts
@@ -18,7 +18,10 @@ export {
   normalizeIMessageMessagingTarget,
 } from "../../src/channels/plugins/normalize/imessage.js";
 export { IMessageConfigSchema } from "../../src/config/zod-schema.providers-core.js";
-export { resolveIMessageGroupRequireMention, resolveIMessageGroupToolPolicy } from "./src/group-policy.js";
+export {
+  resolveIMessageGroupRequireMention,
+  resolveIMessageGroupToolPolicy,
+} from "./src/group-policy.js";
 
 export { monitorIMessageProvider } from "./src/monitor.js";
 export type { MonitorIMessageOpts } from "./src/monitor.js";

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -1,8 +1,5 @@
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-runtime";
-import {
-  PAIRING_APPROVED_MESSAGE,
-  resolveChannelMediaMaxBytes,
-} from "../runtime-api.js";
+import { PAIRING_APPROVED_MESSAGE, resolveChannelMediaMaxBytes } from "../runtime-api.js";
 import type { ResolvedIMessageAccount } from "./accounts.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import { probeIMessage } from "./probe.js";

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -1,6 +1,9 @@
 import { buildAccountScopedAllowlistConfigEditor } from "openclaw/plugin-sdk/allowlist-config-edit";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-runtime";
 import { buildOutboundBaseSessionKey } from "openclaw/plugin-sdk/core";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { type RoutePeer } from "openclaw/plugin-sdk/routing";
+import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import {
   collectStatusIssuesFromLastError,
   DEFAULT_ACCOUNT_ID,
@@ -8,9 +11,6 @@ import {
   normalizeIMessageMessagingTarget,
   type ChannelPlugin,
 } from "../runtime-api.js";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { type RoutePeer } from "openclaw/plugin-sdk/routing";
-import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import {
   resolveIMessageGroupRequireMention,

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -1,6 +1,6 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
-import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog";
 import {
   createMoonshotThinkingWrapper,
   resolveMoonshotThinkingType,

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -210,6 +210,8 @@ export function createXaiWebSearchProvider() {
     signupUrl: "https://console.x.ai/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 30,
+    credentialPath: "tools.web.search.grok.apiKey",
+    inactiveSecretPaths: ["tools.web.search.grok.apiKey"],
     getCredentialValue: (searchConfig?: Record<string, unknown>) =>
       getScopedCredentialValue(searchConfig, "grok"),
     setCredentialValue: (searchConfigTarget: Record<string, unknown>, value: unknown) =>

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -27,7 +27,6 @@ const { resolveKimiApiKey, resolveKimiModel, resolveKimiBaseUrl, extractKimiCita
   moonshotTesting;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
-const moonshotApiKeyEnv = ["MOONSHOT_API", "KEY"].join("_");
 const openRouterApiKeyEnv = ["OPENROUTER_API", "KEY"].join("_");
 const perplexityApiKeyEnv = ["PERPLEXITY_API", "KEY"].join("_");
 const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
@@ -231,10 +230,7 @@ describe("web_search kimi config resolution", () => {
   it("extracts citations from search_results", () => {
     expect(
       extractKimiCitations({
-        search_results: [
-          { url: "https://example.com/one" },
-          { url: "https://example.com/two" },
-        ],
+        search_results: [{ url: "https://example.com/one" }, { url: "https://example.com/two" }],
       }),
     ).toEqual(["https://example.com/one", "https://example.com/two"]);
   });


### PR DESCRIPTION
## Summary
Add the required `credentialPath` and `inactiveSecretPaths` metadata to the xAI web search provider registration.

## Why
Latest `main` requires those fields on `WebSearchProviderPlugin`, and without them `extensions/xai/web-search.ts` fails type-checking during `pnpm build`.

## Testing
- `pnpm build`
