### PR TITLE
Slack: fix main build by restoring directory-config import

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -21,6 +21,10 @@ import type { SlackActionContext } from "./action-runtime.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { createSlackActions } from "./channel-actions.js";
 import { createSlackWebClient } from "./client.js";
+import {
+  listSlackDirectoryGroupsFromConfig,
+  listSlackDirectoryPeersFromConfig,
+} from "./directory-config.js";
 import { resolveSlackGroupRequireMention, resolveSlackGroupToolPolicy } from "./group-policy.js";
 import { isSlackInteractiveRepliesEnabled } from "./interactive-replies.js";
 import { normalizeAllowListLower } from "./monitor/allow-list.js";

--- a/extensions/slack/src/runtime-api.ts
+++ b/extensions/slack/src/runtime-api.ts
@@ -12,7 +12,7 @@ export { buildComputedAccountStatusSnapshot } from "../../../src/plugin-sdk/stat
 export {
   listSlackDirectoryGroupsFromConfig,
   listSlackDirectoryPeersFromConfig,
-} from "../../../src/channels/plugins/directory-config.js";
+} from "./directory-config.js";
 export {
   looksLikeSlackTargetId,
   normalizeSlackMessagingTarget,


### PR DESCRIPTION
## Summary
`pnpm build` on clean `main` currently fails in `extensions/slack/src/runtime-api.ts` because the Slack runtime barrel still re-exports directory helpers from `src/channels/plugins/directory-config.js`, but that core module no longer exists.

This PR restores the export to the Slack extension-local module at `./directory-config.js`, which is where the directory helpers now live.

## Root cause
A recent Slack SDK/internalization refactor updated the implementation location for the directory helpers, but `extensions/slack/src/runtime-api.ts` kept the old core import path. That leaves `main` with an unresolved import during the build:

```text
Could not resolve '../../../src/channels/plugins/directory-config.js' in extensions/slack/src/runtime-api.ts
```

## Validation
- Reproduced the failure on clean `HEAD` in a disposable clone
- Confirmed the one-line import fix makes that clean-clone `pnpm build` succeed
- Ran `pnpm build` again from this branch in the working repo
