### PR TITLE
fix(channels): resolve bundled channels without pre-loading plugin registry

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,53 @@
+# OpenClaw Onboard Discord Investigation
+
+## What This Is
+
+An investigation and fix effort for the `openclaw onboard` command when setting up a Discord channel. The onboarding flow completes without obvious errors but leaves the system in a non-functional state — the goal is to run it locally, observe exactly where things go wrong, and fix the root cause.
+
+## Core Value
+
+Running `openclaw onboard` for Discord should leave a fully working setup where messages sent to the bot are processed and answered by Claude.
+
+## Requirements
+
+### Validated
+
+- ✓ `openclaw onboard` command exists and runs — existing
+- ✓ Discord channel integration is implemented — existing
+- ✓ Gateway run/start infrastructure is in place — existing
+- ✓ AI provider configuration (Claude API) is handled — existing
+
+### Active
+
+- [ ] Identify exactly what state `openclaw onboard` leaves behind after Discord setup
+- [ ] Determine what "isn't running properly" means — gateway, AI provider, channel config, or daemon
+- [ ] Fix the broken behavior so Discord messages route to Claude and responses return
+- [ ] Verify end-to-end: send message in Discord → get AI reply
+
+### Out of Scope
+
+- Other channels (Telegram, iMessage, etc.) — focus is Discord only
+- UI/UX improvements to onboarding flow — fix behavior first
+- New features — investigation and fix only
+
+## Context
+
+This is the openclaw monorepo. The `openclaw onboard` command is the CLI entry point for new user setup. Discord integration lives in `src/discord/`. The onboard command is in `src/commands/`. The codebase map in `.planning/codebase/` has full details on architecture and integrations.
+
+The owner (jbrahy) is running this locally on macOS. Gateway runs as a menubar app or via `openclaw gateway run`.
+
+## Constraints
+
+- **Platform**: macOS — gateway restarts via app, not LaunchAgent
+- **Scope**: Discord channel only for this investigation
+- **Approach**: Run it live and observe, not speculate
+
+## Key Decisions
+
+| Decision                       | Rationale                            | Outcome   |
+| ------------------------------ | ------------------------------------ | --------- |
+| Run onboard live before fixing | See actual failure rather than guess | — Pending |
+
+---
+
+_Last updated: 2026-03-17 after initialization_

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,64 @@
+# Requirements: OpenClaw Onboard Discord Investigation
+
+**Defined:** 2026-03-17
+**Core Value:** Running `openclaw onboard` for Discord should leave a fully working setup
+
+## v1 Requirements
+
+### Investigation
+
+- [ ] **INV-01**: Build openclaw locally and confirm it runs (`pnpm install && pnpm build`)
+- [ ] **INV-02**: Run `openclaw onboard` end-to-end for Discord and observe all output
+- [ ] **INV-03**: Identify the exact failure point — what state is left behind that doesn't work
+
+### Diagnosis
+
+- [ ] **DIAG-01**: Determine whether the failure is in gateway startup, AI provider config, Discord bot config, or channel routing
+- [ ] **DIAG-02**: Trace the onboard command code path to find the root cause
+- [ ] **DIAG-03**: Confirm root cause with a reproducible failure scenario
+
+### Fix
+
+- [ ] **FIX-01**: Implement fix for root cause identified in diagnosis
+- [ ] **FIX-02**: Add or update test coverage for the fixed behavior
+- [ ] **FIX-03**: Verify end-to-end: Discord message → AI reply works after onboarding
+
+## v2 Requirements
+
+### Hardening
+
+- **HARD-01**: Add post-onboard health check that warns user if setup is incomplete
+- **HARD-02**: Improve onboard error messaging to surface failures clearly
+
+## Out of Scope
+
+| Feature                | Reason                                       |
+| ---------------------- | -------------------------------------------- |
+| Other channels         | Focus on Discord only for this investigation |
+| Onboarding UX redesign | Fix behavior first, polish later             |
+| New features           | Investigation and fix only                   |
+
+## Traceability
+
+| Requirement | Phase   | Status  |
+| ----------- | ------- | ------- |
+| INV-01      | Phase 1 | Pending |
+| INV-02      | Phase 1 | Pending |
+| INV-03      | Phase 1 | Pending |
+| DIAG-01     | Phase 2 | Pending |
+| DIAG-02     | Phase 2 | Pending |
+| DIAG-03     | Phase 2 | Pending |
+| FIX-01      | Phase 3 | Pending |
+| FIX-02      | Phase 3 | Pending |
+| FIX-03      | Phase 3 | Pending |
+
+**Coverage:**
+
+- v1 requirements: 9 total
+- Mapped to phases: 9
+- Unmapped: 0 ✓
+
+---
+
+_Requirements defined: 2026-03-17_
+_Last updated: 2026-03-17 after initial definition_

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,67 @@
+# Roadmap: OpenClaw Onboard Discord Investigation
+
+## Overview
+
+Three sequential phases move from observation to diagnosis to fix. Phase 1 establishes a working local build and captures the exact failure state. Phase 2 traces the code path to a confirmed root cause. Phase 3 fixes the root cause, adds test coverage, and verifies the end-to-end Discord flow works.
+
+## Phases
+
+**Phase Numbering:**
+
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Observe** - Build locally and capture what state onboarding leaves behind
+- [ ] **Phase 2: Diagnose** - Trace code path and confirm root cause with a reproducible scenario
+- [ ] **Phase 3: Fix** - Implement fix, add test coverage, and verify Discord end-to-end
+
+## Phase Details
+
+### Phase 1: Observe
+
+**Goal**: The exact failure state after running `openclaw onboard` for Discord is known and documented
+**Depends on**: Nothing (first phase)
+**Requirements**: INV-01, INV-02, INV-03
+**Success Criteria** (what must be TRUE):
+
+1. `pnpm install && pnpm build` completes without errors and the CLI runs
+2. `openclaw onboard` has been run end-to-end for Discord and all output is captured
+3. The specific broken state is documented — which component is missing or misconfigured
+   **Plans**: TBD
+
+### Phase 2: Diagnose
+
+**Goal**: Root cause of the broken onboard state is identified and reproducible
+**Depends on**: Phase 1
+**Requirements**: DIAG-01, DIAG-02, DIAG-03
+**Success Criteria** (what must be TRUE):
+
+1. The failure layer is named — gateway startup, AI provider config, Discord bot config, or channel routing
+2. The specific code location (file and function) responsible for the failure is identified
+3. A reproducible scenario exists that reliably triggers the failure before any fix is applied
+   **Plans**: TBD
+
+### Phase 3: Fix
+
+**Goal**: `openclaw onboard` for Discord leaves a fully working setup where Discord messages get AI replies
+**Depends on**: Phase 2
+**Requirements**: FIX-01, FIX-02, FIX-03
+**Success Criteria** (what must be TRUE):
+
+1. The root cause code is changed and the fix is committed
+2. A test (new or updated) fails before the fix and passes after
+3. A Discord message sent to the bot after running `openclaw onboard` receives an AI reply
+   **Plans**: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3
+
+| Phase       | Plans Complete | Status      | Completed |
+| ----------- | -------------- | ----------- | --------- |
+| 1. Observe  | 0/TBD          | Not started | -         |
+| 2. Diagnose | 0/TBD          | Not started | -         |
+| 3. Fix      | 0/TBD          | Not started | -         |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,61 @@
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-03-17)
+
+**Core value:** Running `openclaw onboard` for Discord should leave a fully working setup where messages sent to the bot are processed and answered by Claude
+**Current focus:** Phase 1 — Observe
+
+## Current Position
+
+Phase: 1 of 3 (Observe)
+Plan: 0 of TBD in current phase
+Status: Ready to plan
+Last activity: 2026-03-17 — Roadmap created
+
+Progress: [░░░░░░░░░░] 0%
+
+## Performance Metrics
+
+**Velocity:**
+
+- Total plans completed: 0
+- Average duration: -
+- Total execution time: 0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+| ----- | ----- | ----- | -------- |
+| -     | -     | -     | -        |
+
+**Recent Trend:**
+
+- Last 5 plans: -
+- Trend: -
+
+_Updated after each plan completion_
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Init: Run onboard live before fixing — see actual failure rather than guess (pending)
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+None yet.
+
+## Session Continuity
+
+Last session: 2026-03-17
+Stopped at: Roadmap created, Phase 1 ready to plan
+Resume file: None

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,270 @@
+# Architecture
+
+**Analysis Date:** 2026-03-17
+
+## Pattern Overview
+
+**Overall:** Multi-channel AI gateway with modular provider, channel, and agent layers.
+
+**Key Characteristics:**
+
+- **Plugin-based extensibility**: Core channels and LLM providers packaged as extensions in `extensions/`
+- **Session-driven routing**: Inbound messages routed through agent selection layer to session-specific agent instances
+- **Config-driven behavior**: System behavior parameterized via JSON5 config, not hardcoded
+- **Multi-channel message handling**: Channels (Discord, Telegram, Slack, Signal, iMessage, WhatsApp, etc.) abstract transport; core routing logic is channel-agnostic
+- **ACP (Agent Control Protocol) integration**: Native support for agent-to-agent communication and spawning via `src/acp/`
+
+## Layers
+
+**CLI Layer:**
+
+- Purpose: Command-line interface; entry point for user interactions and daemon management
+- Location: `src/cli/`, `src/entry.ts`
+- Contains: CLI argument parsing, command registration, option definitions
+- Depends on: Config, daemon, gateway, runtime
+- Used by: Direct user invocation; `openclaw` binary in `openclaw.mjs`
+
+**Command Layer:**
+
+- Purpose: Top-level operations (agent runs, channel setup, model/auth selection, onboarding)
+- Location: `src/commands/`
+- Contains: Command implementations (agent, gateway-status, channels, models, setup, onboard-non-interactive)
+- Depends on: Agents, gateway, config, routing
+- Used by: CLI layer
+
+**Gateway Layer:**
+
+- Purpose: WebSocket server managing real-time message routing, multi-channel aggregation, agent spawning
+- Location: `src/gateway/`
+- Contains: WebSocket server (`src/gateway/server/ws-connection.ts`), channel integrations, health checks, protocol handlers
+- Depends on: Channels, agents, routing, sessions, auth profiles
+- Used by: External clients connecting via WebSocket; daemon process
+
+**Routing Layer:**
+
+- Purpose: Determine which agent handles an inbound message from which channel
+- Location: `src/routing/`
+- Contains: Route resolution logic (`resolve-route.ts`), session key generation, account/agent/peer mapping, binding rules
+- Depends on: Config, session keys
+- Used by: Gateway, agent command layer
+
+**Agent Layer:**
+
+- Purpose: AI agent orchestration, model selection, auth profile management, spawned sub-agents, CLI execution
+- Location: `src/agents/`
+- Contains: Agent command handler (`agent-command.ts`), model selection, auth profile store, spawned process management, PI agent integration
+- Depends on: Config, auth profiles, models, providers, sessions, ACP
+- Used by: Commands, gateway
+
+**Session Management:**
+
+- Purpose: Persist and retrieve agent conversation state, transcripts, model/auth overrides
+- Location: `src/config/sessions/`, `src/sessions/`
+- Contains: Session store (JSON), transcript files, session entry types, level/model overrides
+- Depends on: Config paths, file I/O
+- Used by: Agents, commands, gateway
+
+**Channel Transport Layer:**
+
+- Purpose: Abstract message transport across multiple platforms
+- Location: `src/channels/`, `extensions/*/src/channel.ts`
+- Contains: Channel configuration, message parsing, account snapshots, allowlist enforcement, routing attributes
+- Depends on: Routing, config
+- Used by: Gateway
+
+**Configuration Layer:**
+
+- Purpose: Load, validate, cache, and provide access to system configuration
+- Location: `src/config/`
+- Contains: Config types, I/O, validation, migrations, paths, runtime snapshots
+- Depends on: File system
+- Used by: All layers
+
+**Provider/Model Layer:**
+
+- Purpose: LLM provider integrations (Anthropic, Google, OpenAI, etc.)
+- Location: `extensions/*/` (anthropic, google, openai, etc.), `src/providers/`
+- Contains: Provider-specific auth, model listings, API adapters
+- Depends on: Auth profiles, config
+- Used by: Agent layer (model selection and execution)
+
+**Auth Profile Layer:**
+
+- Purpose: Manage user authentication credentials for providers and channels
+- Location: `src/agents/auth-profiles/`
+- Contains: Auth store, token management, cooldown tracking, profile resolution
+- Depends on: Secrets, config
+- Used by: Agents, providers
+
+**Plugin/Extension System:**
+
+- Purpose: Load and manage bundled + user-installed extensions
+- Location: `src/plugins/`, `extensions/`
+- Contains: Plugin registry, manifest loading, MCP bridge support
+- Depends on: Bundle loader, config
+- Used by: Gateway, agents (channel and provider plugins)
+
+**Daemon Layer:**
+
+- Purpose: Background process lifecycle management (launchd on macOS, systemd on Linux/Windows services)
+- Location: `src/daemon/`
+- Contains: Daemon process management, plist generation, restart handoff
+- Depends on: Config, runtime
+- Used by: CLI (daemon start/stop/restart commands)
+
+**ACP (Agent Control Protocol) Layer:**
+
+- Purpose: Agent-to-agent communication and spawning
+- Location: `src/acp/`
+- Contains: ACP server/client, spawning policy, provenance tracking
+- Depends on: Gateway protocol, agents
+- Used by: Agents (sub-agent spawning), external ACP clients
+
+## Data Flow
+
+**Inbound Message Path:**
+
+1. **Channel receives message** → Message arrives on Slack, Discord, WhatsApp, etc.
+2. **Gateway channel transport** → `src/gateway/server-channels.ts` receives message from channel plugin
+3. **Route resolution** → `src/routing/resolve-route.ts` determines which agent/session handles it based on config bindings
+4. **Session retrieval** → `src/config/sessions/` loads previous conversation state
+5. **Agent command execution** → `src/agents/agent-command.ts` invokes model with context
+6. **Model selection** → `src/agents/model-selection.ts` picks model based on config/auth/model overrides
+7. **Provider API call** → Extension plugin (e.g., `extensions/anthropic/`) makes API request
+8. **Response processing** → Agent formats response via `src/auto-reply/reply/`
+9. **Session persistence** → Updated session written back to `src/config/sessions/`
+10. **Channel delivery** → `src/gateway/server-channels.ts` routes response back to originating channel
+
+**State Management:**
+
+- **Sessions** live in `~/.openclaw/sessions/` — one JSON file per agent + conversation thread
+- **Transcripts** stored as `*.jsonl` in session directory — append-only event log
+- **Config** cached in memory with refresh hooks — changes detected via file monitoring
+- **Auth profiles** cached in `~/.openclaw/auth-profiles/` — modified with cooldown tracking + last-used state
+- **Agent execution context** temporary — cleared after agent run completes
+
+**Gateway-to-Client Communication:**
+
+- WebSocket connection established by client (macOS app, web UI, external gateway client)
+- Messages exchanged via JSON-RPC protocol (`src/gateway/protocol/`)
+- Gateway pushes channel presence, message updates, health status to clients
+- Clients request agent runs, channel operations, configuration changes
+
+## Key Abstractions
+
+**Session Key:**
+
+- Purpose: Unique identifier for agent + channel + peer conversation
+- Examples: `agent:main:main`, `agent:main:discord:@user123`
+- Pattern: `agent:<agent_id>:<channel>:<peer_id>` (peer_id omitted for "main" session)
+- Used in: Session store paths, routing, transcript identification
+
+**Route Binding:**
+
+- Purpose: Map incoming message source to target agent
+- Examples: Direct peer binding, role-based (Discord), guild/team, default channel fallback
+- Matches: Channel + peer ID → agent ID (with hierarchical fallback: peer → parent peer → guild+roles → guild → team → account → channel → default)
+- File: `src/routing/resolve-route.ts`
+
+**Model Selection:**
+
+- Purpose: Pick LLM provider + model for agent execution
+- Order: Session override → Agent config → Global default
+- Includes: Fallback chain if primary model fails
+- Files: `src/agents/model-selection.ts`, `src/sessions/model-overrides.ts`
+
+**Auth Profile:**
+
+- Purpose: Credential container for LLM/channel providers
+- Structure: Provider ID → tokens/secrets + cooldown state + last-used timestamp
+- Resolution: Config order → last-used → round-robin fallback
+- Files: `src/agents/auth-profiles.ts`, `src/agents/auth-profiles/resolve-auth-profile-order.ts`
+
+**Channel Transport:**
+
+- Purpose: Bidirectional message abstraction
+- Provides: Inbound/outbound message parsing, account snapshots, allowlisting
+- Lives in: `src/channels/` (core logic), `extensions/*/src/channel.ts` (implementations)
+
+**Config Snapshot:**
+
+- Purpose: Immutable in-memory representation of current config state
+- Updated: On file change via watcher
+- Cached: To avoid repeated file I/O
+- Files: `src/config/io.ts` (loader), `src/config/runtime-overrides.ts` (in-memory state)
+
+**Agent Command:**
+
+- Purpose: Encapsulate a single agent execution request
+- Includes: Session ID, model override, auth override, message content, metadata
+- Returns: Streaming response events or batch result
+- File: `src/agents/agent-command.ts`
+
+## Entry Points
+
+**CLI Entry:**
+
+- Location: `src/entry.ts`
+- Triggers: User runs `openclaw` binary or `openclaw <command>`
+- Responsibilities: Parse argv, setup runtime, invoke command handler or daemon startup
+
+**Gateway Server:**
+
+- Location: `src/gateway/server-shared.ts` (initialization), `src/gateway/server/ws-connection.ts` (WebSocket handler)
+- Triggers: `openclaw gateway run` command or daemon startup
+- Responsibilities: Listen on port, accept WebSocket clients, route messages, health checks
+
+**Agent Command:**
+
+- Location: `src/agents/agent-command.ts`
+- Triggers: User message routed to agent, `openclaw agent` CLI command
+- Responsibilities: Load session, select model, invoke AI, format response, persist state
+
+**Channel Handler:**
+
+- Location: `extensions/<channel>/src/channel.ts` (e.g., `extensions/discord/src/channel.ts`)
+- Triggers: Inbound message from platform (Discord webhook, Telegram polling, etc.)
+- Responsibilities: Parse platform message, emit gateway events, handle outbound delivery
+
+## Error Handling
+
+**Strategy:** Errors caught at layer boundaries; context-specific retry/fallback logic.
+
+**Patterns:**
+
+- **Model Fallback** (`src/agents/model-fallback.ts`): If primary model fails, attempt next in chain
+- **Auth Cooldown** (`src/agents/auth-profiles.ts`): Failed auth marked with cooldown timer; next attempt after cooldown
+- **Failover** (`src/agents/failover-error.ts`): Structured error for model selection failures
+- **Session Recovery** (`src/config/sessions/`): If transcript corrupted, fallback to last-good snapshot
+- **Gateway Disconnection** (`src/gateway/protocol/`): Client connection drops; server holds session state; client reconnects
+- **Port Conflict** (`src/infra/net/`): Daemon port in use; suggest alternative or kill incumbent
+
+## Cross-Cutting Concerns
+
+**Logging:**
+
+- Subsystem logger via `src/logging/subsystem.ts` (structured, with prefix)
+- Config controls verbosity via `config.logging.level`
+- Agent event logging via `src/infra/agent-events.ts`
+
+**Validation:**
+
+- Config validation via `src/config/validation.ts` (JSON schema)
+- Message validation via channel transport layer
+- Type safety via TypeScript strict mode
+
+**Authentication:**
+
+- API tokens stored in auth profile store (`~/.openclaw/auth-profiles/`)
+- Secrets manager integration for credential retrieval
+- Session-level auth overrides via `src/agents/auth-profiles/session-override.ts`
+
+**Concurrency:**
+
+- Agent sessions isolated by session key; concurrent agents run independently
+- File I/O protected by locking mechanism in session store
+- WebSocket connections concurrent; gateway manages multiplexing
+
+---
+
+_Architecture analysis: 2026-03-17_

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,299 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-17
+
+## Tech Debt
+
+**Monolithic Agent Runner Implementation:**
+
+- Issue: `src/agents/pi-embedded-runner/run/attempt.ts` is 2,900 lines with heavy responsibility coupling
+- Files: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/run.ts` (1,700 lines)
+- Impact: Difficult to test individual concerns, high risk of regression when modifying tool execution, session state management, or prompt building
+- Fix approach: Extract tool state management, prompt building, and session lifecycle into separate modules with clear boundaries
+
+**Large Configuration and Schema Files:**
+
+- Issue: Configuration schema and help text scattered across large files without clear modularization
+- Files: `src/config/schema.help.ts` (1,636 lines), `src/config/zod-schema.providers-core.ts` (1,537 lines), `src/config/io.ts` (1,559 lines)
+- Impact: Hard to locate provider-specific config logic, increases merge conflicts, makes testing individual providers difficult
+- Fix approach: Split provider schemas into separate modules per provider category (cloud providers, self-hosted, OAuth flows)
+
+**Large Type Definition Files:**
+
+- Issue: `src/plugins/types.ts` is 1,904 lines defining all plugin-related types in a single module
+- Files: `src/plugins/types.ts`
+- Impact: Slow editor autocomplete, difficult to find specific type definitions, interdependencies make refactoring risky
+- Fix approach: Split into logical domains: `plugin-hooks.ts`, `plugin-runtime.ts`, `plugin-config.ts`, `plugin-metadata.ts`
+
+**Markdown IR Rendering Bug:**
+
+- Issue: Blockquote spacing produces triple newlines instead of double newlines
+- Files: `src/markdown/ir.blockquote-spacing.test.ts`, `src/markdown/ir.ts` (implementation not yet fixed)
+- Impact: Markdown display in chat shows incorrect whitespace between blockquotes and following content
+- Fix approach: Fix `blockquote_close` handler to not add extra newline; `blockquote_close` should allow inner content's spacing to handle separation
+- Status: Test written (documents expected behavior) but implementation not yet patched
+
+**QMD Multi-Collection Workaround:**
+
+- Issue: QMD doesn't support true multi-collection queries; implemented workaround that queries each collection separately
+- Files: `src/memory/qmd-manager.ts` (lines 1932-1942), environment variable workaround at line 203-205
+- Impact: Performance degradation with N collections (N separate qmd calls); workaround for upstream bug `https://github.com/tobi/qmd/issues/132`
+- Current mitigation: Per-collection query aggregation with deduplication by result key
+- Recommendations: Track upstream qmd issue; consider batching mechanism or migration to alternative vector search if multi-collection performance becomes bottleneck
+
+**Chat Event Error Categorization:**
+
+- Issue: ACP translator cannot distinguish between transient errors (timeouts, rate-limits) and deliberate refusals
+- Files: `src/acp/translator.ts` (line 827)
+- Impact: Clients treat all backend errors as intentional refusals rather than transient failures, preventing proper retry logic
+- Fix approach: Add structured `errorKind` field to ChatEventSchema (e.g., "refusal" | "timeout" | "rate_limit")
+
+## Known Bugs
+
+**Typing Loop Restart After Run Completion:**
+
+- Symptoms: Auto-reply typing loop can restart itself after the run is already marked complete, causing spurious `onReplyStart` calls
+- Files: `src/auto-reply/reply/typing-persistence.test.ts` (test documents the bug), `src/auto-reply/reply/typing.ts` (implementation)
+- Trigger: Call `markRunComplete()`, then advance time past the typing interval without calling `markDispatchIdle()`
+- Workaround: Ensure both `markRunComplete()` and `markDispatchIdle()` are called in sequence before cleanup
+- Root cause: Typing loop checks `runComplete` flag but doesn't immediately abort pending intervals; intervals can still fire if cleanup is delayed
+
+**Bootstrap Prompt Warning Signature Deduplication:**
+
+- Symptoms: Duplicate bootstrap truncation warnings shown across multiple agent runs
+- Files: `src/agents/bootstrap-budget.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`
+- Impact: Users see repetitive warnings for the same truncation condition
+- Current state: Signature tracking mechanism in place but may not persist correctly across session boundaries
+
+## Security Considerations
+
+**Environment Variable Filtering in Bash Execution:**
+
+- Risk: Dangerous environment variables (LD_PRELOAD, LD_LIBRARY_PATH, etc.) can be passed to bash tools if not properly filtered
+- Files: `src/agents/bash-tools.exec-runtime.ts` (lines 61-70)
+- Current mitigation: "Fail Closed" approach blocks known dangerous variables; custom PATH forbidden during host execution
+- Recommendations: Whitelist known-safe variables instead of blacklist; regularly audit for new LD\_\* variables; document PATH policy in tool help text
+
+**Secret Scanning in Skills:**
+
+- Risk: Skill files may embed API keys or credentials that aren't caught by simple pattern matching
+- Files: `src/security/skill-scanner.ts`
+- Current mitigation: Pattern-based scanning for common secret formats
+- Recommendations: Add entropy-based secret detection; consider scanning dependencies in skill node_modules; enforce `npm audit` in skill installs
+
+**Plugin Code Execution:**
+
+- Risk: Plugins can execute arbitrary untrusted code through unsafe operations
+- Files: `src/plugins/loader.ts` (1,386 lines), `src/security/audit.ts` (1,318 lines)
+- Current mitigation: Audit trail for plugin operations; restricted capabilities based on hook permissions
+- Recommendations: Consider runtime sandboxing for untrusted plugins; document security model in plugin SDK
+
+## Performance Bottlenecks
+
+**Web Search Core Module:**
+
+- Problem: `src/agents/tools/web-search-core.ts` is 2,242 lines with complex query parsing, filtering, and result ranking logic
+- Files: `src/agents/tools/web-search-core.ts`
+- Cause: Monolithic implementation handling provider selection, query normalization, ranking algorithms, and filtering all in one file
+- Improvement path: Profile actual search latencies; extract ranking/filtering into pluggable strategies; cache provider selection decisions
+
+**Agent Runner Session Management:**
+
+- Problem: Session write lock acquired for entire agent run; potential contention under concurrent messages to same session
+- Files: `src/agents/pi-embedded-runner/run/attempt.ts` (lines 85-87), `src/agents/session-write-lock.ts`
+- Impact: Serializes agent runs on same session; under high load, lock hold time could block subsequent runs
+- Improvement path: Analyze lock hold patterns; consider splitting into fine-grained locks (state lock, transcript lock); implement backpressure mechanisms
+
+**QMD Vector Search:**
+
+- Problem: Multi-collection search requires N separate qmd subprocess calls (documented at line 1937 of qmd-manager.ts)
+- Impact: Scales linearly with collection count; each call incurs subprocess overhead
+- Improvement path: Track upstream qmd multi-collection support; implement client-side result merging caching layer; consider batch API if qmd adds it
+
+**Memory Embedding Generation:**
+
+- Problem: Full embedding generation on large transcripts may be I/O and compute-intensive
+- Files: `src/memory/embeddings-debug.ts`, `src/memory/manager-sync-ops.ts` (1,391 lines)
+- Improvement path: Profile embedding latencies; implement chunking strategy; consider async embedding generation during idle periods
+
+## Fragile Areas
+
+**Session File Repair Logic:**
+
+- Files: `src/agents/session-file-repair.ts`, `src/agents/session-transcript-repair.ts`
+- Why fragile: Session files must recover from incomplete writes, tool result pairing errors, and transcript corruption; repair logic is complex
+- Safe modification: Add new repair rules only after comprehensive testing with corrupted session corpus; maintain backward compatibility with older session formats
+- Test coverage: Gaps in cross-database session format variations; coverage of edge cases like partial tool calls
+
+**Tool Call ID Sanitization:**
+
+- Files: `src/agents/tool-call-id.ts` (handles CloudCodeAssist-specific tool ID formats)
+- Why fragile: Different AI providers format tool IDs differently; sanitization must preserve roundtrip identity without collision
+- Safe modification: Test against all provider models before merging; maintain mapping table of known ID formats
+- Test coverage: Missing tests for provider-specific ID collision scenarios
+
+**Sandbox Filesystem Policy:**
+
+- Files: `src/agents/sandbox.ts`, `src/agents/sandbox/runtime-status.ts`, `src/agents/tool-fs-policy.ts`
+- Why fragile: Policy decisions affect security boundary; mistakes can allow tool escape or data exfiltration
+- Safe modification: Changes require security review; test with intentional escape attempts; verify policy still blocks known exploits
+- Test coverage: Limited end-to-end sandbox escape testing; coverage of symlink traversal, bind mount attacks
+
+**Plugin Hook Execution:**
+
+- Files: `src/plugins/hook-runner-global.ts`, `src/plugins/hook-runner.ts`
+- Why fragile: Hooks can modify core behavior (message routing, tool execution); errors in hook execution can cascade
+- Safe modification: Wrap hook calls in try-catch; add hook execution timeouts; log all hook invocations; implement hook dry-run mode
+- Test coverage: Limited testing of hook error propagation; coverage of hook order dependencies
+
+**Routing Bindings Cache:**
+
+- Files: `src/routing/resolve-route.ts` (bindings cache at WeakMap)
+- Why fragile: Cache invalidation tied to config object identity; if config mutated, cache becomes stale
+- Safe modification: Document that config objects must be immutable; add cache invalidation hooks on config changes
+- Test coverage: Missing tests for cache invalidation after config updates; coverage of binding resolution consistency under config churn
+
+## Scaling Limits
+
+**Session Key Uniqueness:**
+
+- Current capacity: Session keys based on UUID4 (2^122 theoretical space)
+- Limit: No known hard limit; distributed session storage (multi-gateway) requires unique key coordination
+- Scaling path: Implement distributed session ID generation (snowflake-style) if multi-gateway mode becomes default; add session key collision detection
+
+**QMD Collection Count:**
+
+- Current capacity: Per-database limits not documented; empirical testing needed
+- Limit: Linear degradation observed when querying 10+ collections (requires N subprocess calls)
+- Scaling path: Implement collection sharding strategy; investigate qmd batching; consider alternative vector store (lancedb, pgvector) if single-database bottleneck
+
+**Agent Bootstrap File Injection:**
+
+- Current capacity: Bootstrap truncation warnings at 100KB total (configurable)
+- Limit: Large workspaces with many .clawcode files can exceed injection budget without warning until runtime
+- Scaling path: Implement pre-flight bootstrap budget check during session startup; add analytics for bootstrap utilization per workspace
+
+**Memory Manager Sync Operations:**
+
+- Current capacity: Synchronous QMD operations block gateway on memory writes
+- Limit: High latency (>100ms) observed under load with large embeddings
+- Scaling path: Implement async embedding pipeline; use worker threads for embedding computation; add memory operation queueing with backpressure
+
+**Plugin Loader Initialization:**
+
+- Current capacity: Plugin discovery and loading is synchronous; scales with plugin count
+- Limit: >50 plugins can add 2-5s to startup time
+- Scaling path: Implement lazy plugin loading; parallelize plugin discovery; cache plugin metadata
+
+## Dependencies at Risk
+
+**QMD Upstream Bug #132:**
+
+- Risk: Multi-collection query support missing; workaround implemented but inelegant
+- Impact: Performance degradation with multiple collections; complexity in memory manager
+- Migration plan: Monitor upstream qmd repository; implement fallback to lancedb if qmd unmaintained; evaluate alternative vector stores (pgvector, weaviate)
+
+**File-Type Library:**
+
+- Risk: File type detection via magic bytes can be slow on large files; dependency actively maintained but narrow scope
+- Impact: Media upload processing latency; potential for false positives on edge case formats
+- Monitoring: Track file-type version updates; test with problematic file formats in CI
+
+**Sharp Image Library:**
+
+- Risk: Native binding dependency; compilation issues on edge platforms (M1/M2, Windows ARM64)
+- Impact: Deployment failures on non-x86 systems; versioning must match native binary availability
+- Monitoring: Test builds across platforms in CI; maintain platform-specific override in package.json
+
+**Hono Framework Pinning:**
+
+- Risk: Pinned to exact version 4.12.7 (package.json override); prevents security updates to minor/patch releases
+- Impact: If critical vulnerability in Hono discovered, requires manual version bump and testing
+- Recommendations: Audit why exact pinning necessary; move to semver range if possible; set up Dependabot alerts for overridden dependencies
+
+**@mariozechner/pi-coding-agent Package Extension:**
+
+- Risk: Package extensions applied (see packageExtensions in package.json); these are workarounds for upstream package issues
+- Impact: Upgrades may require re-applying extensions; extension drift not tracked separately
+- Recommendations: Document what each extension fixes; monitor upstream for resolution; test extension removal periodically
+
+## Missing Critical Features
+
+**Distributed Session Storage:**
+
+- Problem: Session files are local filesystem only; multi-gateway deployments cannot share sessions
+- Blocks: Horizontal scaling for reliability; load balancing across gateway instances
+- Impact: Single-machine bottleneck for session storage and retrieval
+
+**Multi-Collection Vector Search API:**
+
+- Problem: QMD workaround queries collections serially; no batch API
+- Blocks: Efficient memory search across large document collections; semantic cross-collection queries
+- Impact: Performance degradation proportional to collection count
+
+**Hook Execution Ordering:**
+
+- Problem: Plugin hook execution order not documented or guaranteed; hook dependencies not expressible
+- Blocks: Complex multi-plugin setups; plugin hooks cannot safely depend on other plugin hooks executing first
+- Impact: Plugin interaction matrix grows exponentially with plugin count
+
+**Sandbox Capability Grants:**
+
+- Problem: Sandbox restrictions are all-or-nothing (ro vs rw); fine-grained capability model not available
+- Blocks: Sophisticated security policies (e.g., allow read-only access to /tmp but deny home directory)
+- Impact: Operators must choose between full sandbox (restrictive) or no sandbox (permissive)
+
+## Test Coverage Gaps
+
+**Plugin Interaction Matrix:**
+
+- What's not tested: Interactions between pairs of plugins that modify shared state (routing, config, tool behavior)
+- Files: `src/plugins/` test files; missing comprehensive multi-plugin integration tests
+- Risk: Plugin A works alone, Plugin B works alone, but A+B together deadlock or corrupt config
+- Priority: High (plugin ecosystem is critical extension point)
+
+**Session File Corruption Recovery:**
+
+- What's not tested: Recovery from various corruption scenarios (truncated JSON, missing tool results, malformed timestamps)
+- Files: `src/agents/session-file-repair.ts`, missing edge case test suite
+- Risk: Silent data loss or corruption during repair; repair logic could make things worse
+- Priority: High (data integrity)
+
+**Sandbox Escape Scenarios:**
+
+- What's not tested: Deliberate sandbox escape attempts (symlink traversal, bind mount abuse, setuid escalation)
+- Files: `src/agents/sandbox.ts` integration tests
+- Risk: Sandbox can be bypassed by determined agent; security boundary not validated
+- Priority: Critical (security boundary)
+
+**Memory Manager Embedding Inconsistency:**
+
+- What's not tested: Consistency of embeddings across multiple QMD instances or after database corruption
+- Files: `src/memory/qmd-manager.test.ts` (2,805 lines but gaps in consistency tests)
+- Risk: Embeddings go out of sync with transcript content; memory search returns incorrect context
+- Priority: High (core feature reliability)
+
+**ACP Protocol Edge Cases:**
+
+- What's not tested: Handling of out-of-order events, missing events, duplicate events in ACP stream
+- Files: `src/acp/translator.ts` (1,224 lines)
+- Risk: Protocol state machine mishandles edge cases; messages lost or duplicated
+- Priority: Medium (reliability under network issues)
+
+**Tool Execution Timeout and Interruption:**
+
+- What's not tested: Behavior when tool timeout fires while result is being processed; interruption during cleanup
+- Files: `src/agents/pi-embedded-runner/run/attempt.ts` (sparse timeout test coverage)
+- Risk: Tool results lost or partially applied; state corruption during timeout race
+- Priority: Medium (reliability under load)
+
+**Configuration Reload Safety:**
+
+- What's not tested: Config reload while agent is running; reload with conflicting provider changes
+- Files: `src/config/io.ts`, `src/gateway/server-methods/` (config mutation points)
+- Risk: Agent uses stale config; new config conflicts with in-flight operations
+- Priority: Medium (operational safety)
+
+---
+
+_Concerns audit: 2026-03-17_

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,204 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-17
+
+## Naming Patterns
+
+**Files:**
+
+- Kebab-case for all file names: `pairing-challenge.ts`, `channel-plugins.ts`, `infra-store.test.ts`
+- Test files: `*.test.ts` for unit tests, `*.e2e.test.ts` for end-to-end tests
+- Live/integration tests: `*.live.test.ts` for tests requiring real credentials/external services
+- Type files use `.ts` extension (no `.d.ts` unless auto-generated)
+
+**Functions:**
+
+- camelCase for all function names: `issuePairingChallenge()`, `ensureDir()`, `buildPairingReply()`
+- Async functions return `Promise<T>`: e.g., `async function readSessionStoreJson5(): Promise<Result<Store>>`
+- Factory functions prefixed with `create`: `createTestRegistry()`, `createStubPlugin()`, `createDefaultRegistry()`
+- Predicate functions prefixed with `is` or `should`: `isSelfChatMode()`, `isRecord()`, `assertWebChannel()`
+- Helper utilities use descriptive verbs: `normalizeE164()`, `toWhatsappJid()`, `shortenHomePath()`
+
+**Variables:**
+
+- camelCase for all variables and constants: `tempHome`, `testEnv`, `entryPoints`
+- Enum-like constants (readonly records) in camelCase: not UPPER_CASE
+- Callback parameters are explicit in types, not inferred
+
+**Types:**
+
+- PascalCase for types: `PairingChallengeParams`, `ChannelPlugin`, `ChannelId`
+- Use generic suffixes: `Adapter`, `Config`, `Context`, `Result`, `State`
+- Discriminated unions with explicit `role` or `type` fields: see `buildAgentMessageFromConversationEntries()` pattern
+- Type re-exports via barrel files are aggregated (`.ts/types.ts` patterns)
+
+## Code Style
+
+**Formatting:**
+
+- Tool: Oxfmt (via `pnpm format` and `pnpm format:fix`)
+- Config: `.oxlintrc.json` (not `.prettierrc`, which exists for docs only)
+- All TypeScript code formatted via Oxfmt; pre-commit hooks enforce this
+- Run `pnpm check` before commits to catch formatting issues
+
+**Linting:**
+
+- Tool: Oxlint (`oxlint --type-aware`)
+- Config: `.oxlintrc.json`
+- Plugins: `unicorn`, `typescript`, `oxc`
+- Key rules:
+  - `typescript/no-explicit-any`: error (no `any` types allowed)
+  - `typescript/no-extraneous-class`: off (allowed where needed)
+  - `typescript/no-unsafe-type-assertion`: off (type assertions permitted)
+  - `unicorn/consistent-function-scoping`: off (functions can be declared at module or function level)
+  - `curly`: error (braces required for all control structures)
+- Run `pnpm lint` to check; `pnpm lint:fix` to auto-fix
+- Custom lint checks: `pnpm lint:plugins:*`, `pnpm lint:auth:*`, `pnpm lint:tmp:*`
+
+## Import Organization
+
+**Order:**
+
+1. Node.js standard library imports (`import fs from "node:fs"`)
+2. Third-party packages (`import { describe, expect, it } from "vitest"`)
+3. Local module imports (`import { issuePairingChallenge } from "./pairing-challenge.js"`)
+4. Sibling and parent imports sorted alphabetically by relative path
+5. Type-only imports grouped and sorted alphabetically
+
+**Path Aliases:**
+
+- `openclaw/plugin-sdk`: mapped to `src/plugin-sdk/index.ts`
+- `openclaw/plugin-sdk/<subpath>`: mapped to `src/plugin-sdk/<subpath>.ts` (via vitest alias config)
+- No barrel file re-exports for plugin-sdk; direct subpath imports only
+- Relative imports used within same package; absolute aliases used for cross-package references
+
+**Example:**
+
+```typescript
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ChannelId } from "./types.js";
+import { ensureDir, normalizeE164 } from "./utils.js";
+```
+
+## Error Handling
+
+**Patterns:**
+
+- Use `try/catch (err)` with unknown type and narrow with type guard or assertion: `(err as { code?: string }).code`
+- For expected errors (file not found), check error code after narrowing: `if (code !== "ENOENT") throw`
+- For optional operations, use `.catch(() => {})` inline: `await fs.unlink(path).catch(() => {})`
+- Throw descriptive Error messages with context: `throw new Error("invalid pairing channel")`
+- No error classes; use Error with message strings
+- Callbacks accept error parameter without throwing immediately: `onReplyError?.(err)` (caller decides handling)
+- Never log sensitive data (API keys, tokens, passwords)
+
+## Logging
+
+**Framework:** `tslog` (imported as `logger` from `src/globals.js`)
+
+**Patterns:**
+
+- Use `logVerbose()` for debug output (guarded by `shouldLogVerbose()`)
+- Use `logger.info/warn/error()` for structured logging
+- Use `console.log()` only for CLI output (interactive flows)
+- All gateway/background operations use `logger`
+- Verbose output guarded by environment: `if (shouldLogVerbose()) logVerbose(...)`
+
+## Comments
+
+**When to Comment:**
+
+- Complex business logic that isn't obvious from variable/function names
+- Non-obvious algorithm choices or workarounds (with issue links where applicable)
+- Design decisions that differ from expected patterns
+- Tricky type casts or conditionals
+
+**JSDoc/TSDoc:**
+
+- Use JSDoc comments for exported functions and types
+- Document parameters with `@param`, return type with `@returns`
+- Document deprecation with `@deprecated` followed by migration path
+- Example: see `src/agents/command-poll-backoff.ts` and `src/agents/openai-ws-stream.ts`
+- Include `@see` links to related code or issues: `@see https://...`
+
+**Example JSDoc:**
+
+```typescript
+/**
+ * Shared pairing challenge issuance for DM pairing policy pathways.
+ * Ensures every channel follows the same create-if-missing + reply flow.
+ *
+ * @param params Configuration for pairing challenge issuance
+ * @returns Result object with created flag and optional code
+ * @deprecated Legacy bridge for older flows. See pairing-v2.ts for new implementation.
+ */
+export async function issuePairingChallenge(
+  params: PairingChallengeParams,
+): Promise<{ created: boolean; code?: string }> {
+  // ...
+}
+```
+
+## Function Design
+
+**Size:** Keep functions under ~200 lines; split larger functions into helpers
+
+- Large files (>500 LOC) should be broken into modules
+- Extract common logic into helper functions rather than duplicating
+
+**Parameters:**
+
+- Prefer parameter objects (destructured) over multiple positional params
+- Use type-safe parameter objects: `params: { foo: string; bar?: number }`
+- No variadic parameters; use arrays explicitly: `items: T[]` instead of `...items: T[]`
+
+**Return Values:**
+
+- Use Result/Option types for potentially-failing operations: `{ ok: boolean; value?: T; error?: string }`
+- Use discriminated unions for multi-outcome returns: `{ created: true; code: string } | { created: false }`
+- Never return `null`; use `undefined` or explicit optional types
+- Async functions always return `Promise<T>` (never a union with non-Promise)
+
+## Module Design
+
+**Exports:**
+
+- Default export only for entry points; use named exports elsewhere
+- Export types separately from values: `export type SomeType = ...` and `export function someFn() {}`
+- Group related exports together in source file
+- Use `export { Type1, Type2 } from "./types.js"` for re-exports
+
+**Barrel Files:**
+
+- Minimal barrel files; prefer direct imports
+- Plugin SDK has special barrel handling via `sync-plugin-sdk-exports.mjs` (auto-generated)
+- Don't manually maintain barrel files for plugin-sdk; rely on generation script
+
+**Module Boundaries:**
+
+- No prototype mutation or dynamic patching: use explicit inheritance/composition
+- Each module has a single responsibility
+- Avoid circular imports; use dependency injection or deferred imports if needed
+- Use `import type { ... } from "..."` for type-only imports to avoid circular deps
+
+## TypeScript Specifics
+
+- Strict mode enabled (no implicit `any`)
+- Use `unknown` for untyped error catches, then narrow with type guards
+- Avoid `as` casts; use type guards or constructors instead
+- Generic functions should have constrained type parameters
+- No `@ts-nocheck` or disabling of linting rules; fix root cause instead
+
+## Testing Patterns in Source
+
+- Test files co-located with source: `src/pairing/pairing-challenge.ts` + `src/pairing/pairing-challenge.test.ts`
+- Use vitest's `describe()` and `it()` structure
+- Mock calls: `vi.fn()`, `vi.spyOn()`, `vi.mock()`
+- Environment stubbing: `vi.stubEnv()` for per-test isolation
+- Faker/fixture data: use `captureEnv()`, `withEnvAsync()`, `withTempDir()` helpers
+
+---
+
+_Convention analysis: 2026-03-17_

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,321 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-17
+
+## APIs & External Services
+
+**LLM Providers (Core):**
+
+- OpenAI (GPT-4, GPT-4 Turbo, etc.)
+  - SDK/Client: `@mariozechner/pi-ai` (embedded)
+  - Auth: `OPENAI_API_KEY` environment variable
+  - Manifest: `extensions/openai/openclaw.plugin.json`
+  - Services: Chat completions, embeddings (text-embedding-3-small/large), image generation, audio transcription, TTS
+  - Config location: `src/providers/openai.ts` (via Pi framework)
+
+- Anthropic (Claude)
+  - SDK/Client: `@mariozechner/pi-ai` (embedded)
+  - Auth: `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` environment variables
+  - Manifest: `extensions/anthropic/openclaw.plugin.json`
+  - Setup token support: Claude setup-token paste flow
+  - Config location: via Pi framework
+
+- Google (Gemini)
+  - SDK/Client: `@mariozechner/pi-ai` (embedded)
+  - Auth: `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variables
+  - Manifest: `extensions/google/openclaw.plugin.json`
+  - OAuth support: Google Gemini CLI OAuth
+  - Services: Chat, embeddings, video understanding, image generation
+  - Config location: via Pi framework
+
+- AWS Bedrock
+  - SDK/Client: `@aws-sdk/client-bedrock` 3.1009.0
+  - Auth: AWS credentials (via SDK)
+  - Extension: `extensions/amazon-bedrock/`
+  - Models: Multiple foundation models through Bedrock
+
+**Additional LLM Providers:**
+
+- Mistral AI, Qwen, Minimax, Moonshot, ModelStudio, OpenRouter, GitHub Copilot, Ollama, NVIDIA, Hugging Face, Open Prose, Kimi, Kilocode, Byteplus, CloudFlare AI Gateway, OpenCode (Go and JS variants)
+- Location: Each has own extension in `extensions/`
+- Auth: Per-provider (API keys, OAuth, etc.)
+
+**Messaging Channels:**
+
+- **Discord** - `extensions/discord/`
+  - SDK/Client: discord-api-types, custom gateway integration
+  - Auth: Bot token via `DISCORD_BOT_TOKEN`
+  - Features: Message routing, voice, thread management, reactions, embeds
+  - Runtime: `src/plugins/runtime/runtime-discord*.ts`
+
+- **Telegram** - `extensions/telegram/`
+  - SDK/Client: grammy 1.41.1 + @grammyjs/runner
+  - Auth: Bot token via `TELEGRAM_BOT_TOKEN`
+  - Features: Message handling, inline keyboards, media uploads
+  - Runtime: `src/plugins/runtime/runtime-telegram*.ts`
+  - Throttling: @grammyjs/transformer-throttler
+
+- **Slack** - `extensions/slack/`
+  - SDK/Client: @slack/bolt 4.6.0, @slack/web-api 7.15.0
+  - Auth: Bot token, app-level token via environment
+  - Features: Message routing, file handling, slash commands
+
+- **WhatsApp** - `extensions/whatsapp/`
+  - SDK/Client: @whiskeysockets/baileys 7.0.0-rc.9
+  - Auth: WhatsApp Web session management
+  - Features: WhatsApp Web protocol bridging
+
+- **Signal** - `extensions/signal/`
+  - Integration for Signal messaging protocol
+
+- **Matrix** - `extensions/matrix/`
+  - SDK/Client: @matrix-org/matrix-sdk-crypto-nodejs
+  - Integration for Matrix protocol
+
+- **LINE** - `extensions/line/`
+  - SDK/Client: @line/bot-sdk 10.6.0
+  - Auth: LINE channel access token
+
+- **Feishu (Lark)** - `extensions/feishu/`
+  - SDK/Client: @larksuiteoapi/node-sdk 1.59.0
+  - Auth: Feishu app credentials
+
+- **Google Chat** - `extensions/googlechat/`
+
+- **Mattermost** - `extensions/mattermost/`
+
+- **Nextcloud Talk** - `extensions/nextcloud-talk/`
+
+- **Synology Chat** - `extensions/synology-chat/`
+
+- **IRC** - `extensions/irc/`
+
+- **Nostr** - `extensions/nostr/`
+
+- **Twitch** - `extensions/twitch/`
+
+- **Tlon (Urbit)** - `extensions/tlon/`
+
+- **Zalo** - `extensions/zalo/` (and zalouser)
+
+- **Blueubbles** - `extensions/bluebubbles/` (macOS Messages bridge)
+
+- **Device Pair** - `extensions/device-pair/` (multi-device support)
+
+- **Voice Call** - `extensions/voice-call/`
+
+- **ACPX** - `extensions/acpx/` (Assistant Control Protocol)
+
+- **Copilot Proxy** - `extensions/copilot-proxy/`
+
+- **Lobster** - `extensions/lobster/`
+
+- **LLM Task** - `extensions/llm-task/` (LLM task execution)
+
+## Data Storage
+
+**Databases:**
+
+- SQLite (Node.js built-in `node:sqlite`)
+  - Connection: Single-process file-based at `~/.openclaw/data/` (default)
+  - Client: `src/memory/sqlite.ts` (wrapper around Node's sqlite module)
+  - Purpose: Main application state, config, session storage
+  - Schema: `src/memory/memory-schema.ts` (vector storage tables)
+
+- LanceDB 0.26.2
+  - Connection: Vector database for embeddings
+  - Purpose: Semantic search, memory indexing
+  - Integration: `src/memory/manager.ts`, `@lancedb/lancedb`
+  - Schema: Vector table with embeddings managed by `MemoryIndexManager`
+
+- sqlite-vec 0.1.7-alpha.2
+  - SQLite extension for vector operations
+  - Used in conjunction with sqlite for vector search
+
+**File Storage:**
+
+- Local filesystem only
+  - Default: `~/.openclaw/` (configuration, credentials, sessions)
+  - Build output: `dist/` (local)
+  - Workspace: `~/.openclaw/workspace/` (per-agent)
+  - Media cache: Local temporary storage
+
+**Caching:**
+
+- In-memory caching via Node.js Maps (code-level caching)
+- No external cache service (Redis, Memcached)
+- File system caching for embeddings and memory indices
+
+## Authentication & Identity
+
+**Auth Providers:**
+
+**OpenAI OAuth:**
+
+- Method: Browser OAuth flow for Codex (`openai-codex` provider)
+- Implementation: `src/commands/openai-codex-oauth.ts`
+- Reference: `extensions/openai/openclaw.plugin.json`
+
+**Google OAuth:**
+
+- Method: Browser OAuth for Gemini
+- Implementation: `src/providers/google-shared.ts`
+- Reference: `extensions/google/openclaw.plugin.json`
+
+**Anthropic Setup Token:**
+
+- Method: setup-token paste flow (proprietary Anthropic auth)
+- Reference: `extensions/anthropic/openclaw.plugin.json`
+
+**Custom Authentication:**
+
+- Gateway auth: `src/gateway/auth.ts`
+- Rate limiting: `src/gateway/auth-rate-limit.ts`
+- Session management: `src/config/sessions/`
+- Authorization policies: `src/gateway/auth-mode-policy.ts`
+
+**API Key Management:**
+
+- Environment variable injection for provider credentials
+- Secure credential storage: `~/.openclaw/credentials/`
+- Secret runtime snapshot: `src/secrets/runtime.js`
+- Config-driven credential mapping via `src/plugins/bundled-provider-auth-env-vars.ts`
+
+## Monitoring & Observability
+
+**Error Tracking:**
+
+- None configured (custom error handling)
+- Error propagation via gateway protocol
+- Local logging via `src/logging/`
+
+**Logs:**
+
+- In-process logging via tslog 4.10.2
+- Subsystem loggers: `src/logging/subsystem.ts`
+- Structured logging with context
+- Diagnostic events: `src/infra/diagnostic-events.ts`
+- Unified logs (macOS): queried via `scripts/clawlog.sh`
+
+**Diagnostics:**
+
+- OpenTelemetry support: `extensions/diagnostics-otel/` (plugin SDK export)
+- Doctor command: `openclaw doctor` (health checks)
+- Health monitoring: `src/gateway/channel-health-monitor.ts`
+- Gateway readiness probes: `src/gateway/server/readiness.ts`
+
+**System Events:**
+
+- Heartbeat events: `src/infra/heartbeat-events.ts`
+- Agent events: `src/infra/agent-events.ts`
+- System event queue: `src/infra/system-events.ts`
+
+## CI/CD & Deployment
+
+**Hosting:**
+
+- Multi-platform:
+  - macOS app (distributed via Sparkle)
+  - iOS app (TestFlight via Xcode)
+  - Android app (Play Store)
+  - CLI npm package (npm registry)
+  - Docker images (Docker Hub via `docker-release.yml`)
+
+**CI Pipeline:**
+
+- GitHub Actions (`.github/workflows/`)
+  - `ci.yml` - Main test/build pipeline
+  - `docker-release.yml` - Docker image builds
+  - `openclaw-npm-release.yml` - npm publish (trusted publishing)
+  - `codeql.yml` - Security scanning
+  - `auto-response.yml` - GitHub issue/PR automation
+  - `stale.yml` - Stale issue management
+
+**npm Publishing:**
+
+- GitHub trusted publishing (no NPM_TOKEN required)
+- Separate flow for `@openclaw/*` scoped packages (maintainer-only auth)
+- npm dist-tag: `latest` (stable), `beta` (prerelease)
+
+**Deployment Targets:**
+
+- Self-hosted: macOS app, CLI, Docker
+- Cloud: Slack, Discord, Telegram, WhatsApp (message routing)
+- Mobile: iOS, Android (local agents)
+
+## Environment Configuration
+
+**Required env vars (provider-specific):**
+
+- `OPENAI_API_KEY` - OpenAI
+- `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` - Anthropic
+- `GEMINI_API_KEY` or `GOOGLE_API_KEY` - Google
+- `DISCORD_BOT_TOKEN` - Discord
+- `TELEGRAM_BOT_TOKEN` - Telegram
+- `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` - Slack
+- `LINE_CHANNEL_ACCESS_TOKEN` - LINE
+- AWS credentials (for Bedrock)
+- Per-channel provider tokens as needed
+
+**System env vars:**
+
+- `OPENCLAW_SKIP_CHANNELS` - Skip channel initialization
+- `OPENCLAW_PROFILE` - dev/production profile
+- `OPENCLAW_TEST_PROFILE` - Test execution profile
+- `NODE_ENV` - Node environment
+- `DEBUG` - Debug logging
+
+**Config location:**
+
+- `~/.openclaw/config.json` - Main config file
+- `.env` files - Supported but not recommended (use secure credential storage)
+- CLI flags - Override config
+
+**Secrets location:**
+
+- `~/.openclaw/credentials/` - Web provider credentials
+- Environment variables (for deploy)
+- Encrypted storage via operating system (macOS Keychain, etc.)
+- Not in version control (`.gitignore`)
+
+## Webhooks & Callbacks
+
+**Incoming Webhooks:**
+
+- Gateway HTTP endpoints: `src/gateway/server.impl.ts`
+- Webhook mode for channels: `src/gateway/channel-health-policy.ts`
+- Message handling: `src/gateway/server-channels.ts`
+- Protocol: ACP (Agent Control Protocol) over WebSocket + HTTP
+
+**Outgoing Webhooks:**
+
+- Cron-based jobs: `src/gateway/server-cron.ts`
+- SSRF-guarded outbound calls: `src/infra/outbound/`
+- Message action runner: `src/infra/outbound/message-action-runner.ts`
+- Tool invocation hooks: `src/gateway/tools-invoke-http.ts`
+
+**Hook System:**
+
+- Global hooks: `src/plugins/hook-runner-global.js`
+- Channel lifecycle hooks: `src/hooks/`
+- Plugin hook registration: `src/gateway/server-methods.js`
+
+## Plugin Extension Points
+
+**Plugin System:**
+
+- Plugin SDK: `src/plugin-sdk/` (exported to npm as `openclaw/plugin-sdk`)
+- Runtime: `src/plugins/runtime/index.js`
+- Registry: `src/plugins/registry.ts`
+- Hook runners: `src/plugins/hook-runner-*.ts`
+- Extensions directory: `extensions/` (bundled plugins)
+
+**Bundled Providers:**
+
+- Anthropic, Google, OpenAI, Amazon Bedrock core support
+- 50+ additional provider extensions
+- Channel plugins for all messaging platforms
+
+---
+
+_Integration audit: 2026-03-17_

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,181 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-17
+
+## Languages
+
+**Primary:**
+
+- TypeScript 5.9.3 - Source code, plugins, extensions
+- JavaScript (ES2023 target) - Runtime, built output
+
+**Secondary:**
+
+- Swift - macOS/iOS applications (`apps/macos`, `apps/ios`)
+- Kotlin - Android application (`apps/android`)
+- Bash/Shell - Build scripts and CLI wrappers
+
+## Runtime
+
+**Environment:**
+
+- Node.js 22.16.0+ (required - `engines.node` in `package.json`)
+- Supports Bun for TypeScript execution and package management
+
+**Package Manager:**
+
+- pnpm 10.23.0 (primary)
+- npm (fallback, supported for production installs)
+- Bun (supported for development and testing)
+- Lockfile: `pnpm-lock.yaml` (present, required)
+
+## Frameworks
+
+**Core Web/Server:**
+
+- Hono 4.12.7 - HTTP server framework (Web provider)
+- Express 5.2.1 - HTTP server support
+- ws 8.19.0 - WebSocket support
+
+**Testing:**
+
+- Vitest 4.1.0 - Unit and integration test runner
+  - V8 coverage with 70% threshold (`vitest.*.config.ts` configs)
+  - Multiple configs: `vitest.unit.config.ts`, `vitest.gateway.config.ts`, `vitest.e2e.config.ts`, `vitest.live.config.ts`
+- Playwright Core 1.58.2 - Browser automation
+
+**Build/Dev Tools:**
+
+- tsdown 0.21.2 - TypeScript bundler
+- oxlint 1.55.0 - Fast linter
+- oxfmt 0.40.0 - Code formatter
+- tsx 4.21.0 - TypeScript execution
+
+## Key Dependencies
+
+**Critical Infrastructure:**
+
+- @modelcontextprotocol/sdk 1.27.1 - MCP server support
+- @agentclientprotocol/sdk 0.16.1 - Agent communication
+- jiti 2.6.1 - Dynamic module loading (used for plugin-sdk aliases)
+
+**Database & Storage:**
+
+- node:sqlite (built-in, Node 22+) - Embedded database via `requireNodeSqlite()` in `src/memory/sqlite.ts`
+- @lancedb/lancedb 0.26.2 - Vector database for embeddings
+- sqlite-vec 0.1.7-alpha.2 - SQLite vector search extension
+- sharps 0.34.5 - Image processing
+
+**Messaging/Channels:**
+
+- grammy 1.41.1 + @grammyjs/runner, @grammyjs/transformer-throttler - Telegram bot framework
+- discord-api-types 0.38.42 - Discord API types
+- @discordjs/voice 0.19.1 - Discord voice support
+- @slack/bolt 4.6.0 + @slack/web-api 7.15.0 - Slack integration
+- @line/bot-sdk 10.6.0 - LINE messaging
+- @whiskeysockets/baileys 7.0.0-rc.9 - WhatsApp Web protocol
+- @larksuiteoapi/node-sdk 1.59.0 - Feishu integration
+- @matrix-org/matrix-sdk-crypto-nodejs - Matrix protocol support
+
+**AI/ML Provider SDKs:**
+
+- @aws-sdk/client-bedrock 3.1009.0 - AWS Bedrock (models)
+- @mariozechner/pi-ai, pi-agent-core, pi-coding-agent, pi-tui 0.58.0 - Embedded Pi framework for agents
+
+**Utilities:**
+
+- chalk 5.6.2 - Terminal colors
+- commander 14.0.3 - CLI argument parsing
+- zod 4.3.6 - Schema validation
+- ajv 8.18.0 - JSON schema validation
+- @sinclair/typebox 0.34.48 - TypeScript schema generation
+- yaml 2.8.2 - YAML parsing
+- markdown-it 14.1.1 - Markdown parsing
+- linkedom 0.18.12 - DOM parsing (headless)
+- jszip 3.10.1 - ZIP file handling
+- tar 7.5.11 - TAR archive handling
+- pdfjs-dist 5.5.207 - PDF reading
+- file-type 21.3.2 - File type detection
+- croner 10.0.1 - Cron scheduling
+- chokidar 5.0.0 - File watching
+- undici 7.24.1 - HTTP client (no external deps)
+- osc-progress 0.3.0 - CLI progress indicators
+
+**Speech/TTS:**
+
+- node-edge-tts 1.2.10 - Microsoft Edge TTS
+- opusscript 0.1.1 - Opus audio codec
+
+**Networking:**
+
+- @homebridge/ciao 1.3.5 - mDNS/Bonjour
+- https-proxy-agent 8.0.0 - HTTPS proxy support
+- ipaddr.js 2.3.0 - IP address utilities
+
+**Monitoring:**
+
+- tslog 4.10.2 - Structured logging
+- diagnostics-otel (internal plugin SDK export) - OpenTelemetry support
+
+## Configuration
+
+**Environment:**
+
+- Loaded from `~/.openclaw/config.json` (user home)
+- Overridable via CLI flags and environment variables
+- Config validation via Zod schemas (`src/config/`)
+- Secrets stored in `~/.openclaw/credentials/` (web provider) and environment
+
+**Build:**
+
+- `tsconfig.json` - TypeScript strict mode, ES2023 target, ESM output
+- `tsdown.config.ts` - Code bundling configuration
+- `pnpm` overrides in `package.json` for dependency version pinning
+- Workspace packages: `extensions/*` and `ui/`
+
+**Type Checking:**
+
+- TypeScript 5.9.3 in strict mode
+- Path aliases via `tsconfig.json` paths: `openclaw/plugin-sdk/*`
+- Native ESM with `"type": "module"` in package.json
+
+## Platform Requirements
+
+**Development:**
+
+- Node 22.16.0+
+- Bun (optional, preferred for dev scripts)
+- pnpm 10.23.0+
+- Git (for version info and configuration)
+
+**macOS-Specific:**
+
+- Xcode (for building apps/macos)
+- swiftformat 0.50+ (for Swift formatting)
+- swiftlint (for Swift linting)
+
+**iOS-Specific:**
+
+- Xcode 15+
+- SwiftUI (Observation framework preferred)
+- xcodegen (for project generation)
+
+**Android-Specific:**
+
+- Android SDK (gradle, SDK tools)
+- Kotlin support
+
+**Linux:**
+
+- Standard Linux development tools
+- Docker support for test environments
+
+**Production:**
+
+- Node 22+ runtime
+- Native SQLite support (built into Node)
+- Optional: Docker (for containerized deployment)
+
+---
+
+_Stack analysis: 2026-03-17_

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,355 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-17
+
+## Directory Layout
+
+```
+openclaw/
+├── src/                         # Core TypeScript source
+│   ├── entry.ts                 # CLI entry point
+│   ├── index.ts                 # Library exports
+│   ├── library.ts               # Re-export public APIs
+│   ├── runtime.ts               # Runtime environment setup
+│   ├── logger.ts                # Logging utilities
+│   ├── globals.ts               # Global state
+│   ├── agents/                  # Agent orchestration & AI execution
+│   ├── acp/                     # Agent Control Protocol (ACP) server/client
+│   ├── auto-reply/              # Message templating & reply generation
+│   ├── browser/                 # Browser CLI implementation
+│   ├── canvas-host/             # A2UI bundle hosting
+│   ├── channels/                # Channel transport abstraction
+│   ├── cli/                     # CLI command structure & options
+│   ├── commands/                # Top-level command implementations
+│   ├── config/                  # Configuration loading & validation
+│   ├── context-engine/          # Context/memory handling
+│   ├── cron/                    # Scheduled task execution
+│   ├── daemon/                  # Background process management
+│   ├── gateway/                 # WebSocket gateway server
+│   ├── hooks/                   # Extensible hook system
+│   ├── i18n/                    # Internationalization strings
+│   ├── image-generation/        # Image generation provider adapters
+│   ├── infra/                   # Infrastructure utilities (net, TLS, env, errors)
+│   ├── interactive/             # Interactive prompt handling
+│   ├── link-understanding/      # Link metadata extraction
+│   ├── logging/                 # Logging subsystem
+│   ├── markdown/                # Markdown parsing/formatting
+│   ├── media/                   # Media handling (upload, transcoding)
+│   ├── media-understanding/     # Image/video analysis providers
+│   ├── memory/                  # Conversation memory & context
+│   ├── node-host/               # Node.js child process hosting
+│   ├── pairing/                 # Device pairing logic
+│   ├── plugin-sdk/              # Plugin SDK types & utilities
+│   ├── plugins/                 # Plugin registry & loading
+│   ├── process/                 # Child process management
+│   ├── providers/               # Provider-specific adapters
+│   ├── routing/                 # Route resolution (channel → agent)
+│   ├── secrets/                 # Credential management
+│   ├── security/                # Security checks
+│   ├── sessions/                # Session state & overrides
+│   ├── shared/                  # Shared utilities (text, net)
+│   ├── terminal/                # Terminal UI (colors, prompts, tables)
+│   ├── test-helpers/            # Testing utilities
+│   ├── test-utils/              # Additional test tools
+│   ├── tts/                     # Text-to-speech providers
+│   ├── tui/                     # Terminal UI components
+│   ├── types/                   # Global type definitions
+│   ├── utils/                   # General utilities
+│   ├── web-search/              # Web search integration
+│   ├── whatsapp/                # WhatsApp Web integration
+│   └── wizard/                  # Setup/onboarding wizards
+├── extensions/                  # Plugin packages (channels, providers, integrations)
+│   ├── anthropic/               # Anthropic (Claude) provider
+│   ├── discord/                 # Discord channel
+│   ├── google/                  # Google services (Gemini, search)
+│   ├── openai/                  # OpenAI provider
+│   ├── telegram/                # Telegram channel
+│   ├── slack/                   # Slack channel
+│   ├── signal/                  # Signal channel
+│   ├── imessage/                # iMessage channel
+│   └── [70+ more]               # Other channels & providers
+├── ui/                          # React/Vue web UI
+│   ├── src/
+│   │   ├── main.ts              # UI entry point
+│   │   ├── local-storage.ts     # Browser storage management
+│   │   └── ui/                  # UI components
+│   └── vite.config.ts           # Vite build config
+├── apps/                        # Native mobile apps
+│   ├── ios/                     # iOS Swift/SwiftUI app
+│   ├── android/                 # Android Kotlin app
+│   ├── macos/                   # macOS Swift/SwiftUI app
+│   └── shared/                  # Cross-platform shared code
+├── dist/                        # Built JavaScript output
+├── docs/                        # Public documentation (Mintlify)
+├── test/                        # Integration & e2e tests
+│   ├── e2e/                     # End-to-end test suites
+│   └── fixtures/                # Test data
+├── test-fixtures/               # Shared test data
+├── scripts/                     # Build & utility scripts
+├── skills/                      # Agent skills definitions
+├── .github/                     # GitHub workflows & config
+├── package.json                 # Root workspace package
+├── pnpm-workspace.yaml          # pnpm monorepo config
+├── tsconfig.json                # TypeScript config
+├── vitest.config.ts             # Test runner config
+└── openclaw.mjs                 # CLI entrypoint wrapper
+```
+
+## Directory Purposes
+
+**src/**
+
+- Purpose: All core application TypeScript source code
+- Contains: Entry points, business logic, infrastructure
+- Key files: `entry.ts` (CLI), `index.ts` (library exports), `runtime.ts` (env setup)
+
+**src/agents/**
+
+- Purpose: Agent orchestration, model selection, auth profiles, spawned agents
+- Contains: Agent command handler (`agent-command.ts`), model catalog, auth store, PI agent integration
+- Key files: `agent-command.ts` (main handler), `model-selection.ts` (model picking), `auth-profiles.ts` (credential mgmt)
+
+**src/acp/**
+
+- Purpose: Agent Control Protocol server and client for inter-agent communication
+- Contains: WebSocket server, spawning policy, session management
+- Key files: `server.ts` (ACP server), `client.ts` (ACP client), `spawn.ts` (spawn logic)
+
+**src/channels/**
+
+- Purpose: Shared channel logic, message parsing, routing attributes
+- Contains: Channel config, allowlist rules, account snapshots, command gating
+- Key files: `allowlist-match.ts` (allowlist matching), `command-gating.ts` (command restrictions)
+
+**src/cli/**
+
+- Purpose: Command-line interface wiring and option definitions
+- Contains: Argument parsing, command registration, CLI deps injection
+- Key files: `argv.ts` (arg parsing), `run-main.ts` (CLI dispatcher)
+
+**src/commands/**
+
+- Purpose: Top-level command implementations (agent, gateway, channels, models, setup, onboard)
+- Contains: Each command as a subdirectory
+- Structure: One directory per command (e.g., `src/commands/agent/`, `src/commands/setup/`)
+
+**src/config/**
+
+- Purpose: Configuration loading, caching, validation, persistence
+- Contains: Config types, I/O, JSON5 parser, schema validation
+- Key files: `config.ts` (re-exports), `io.ts` (load/save), `types.ts` (TypeScript interfaces), `validation.ts` (schema checks)
+- Subdir `sessions/`: Session store file management
+
+**src/gateway/**
+
+- Purpose: WebSocket server, multi-channel aggregation, real-time routing
+- Contains: Server initialization, WebSocket connection handling, channel integration
+- Key files: `server/ws-connection.ts` (WebSocket handler), `server-channels.ts` (channel dispatch)
+
+**src/logging/**
+
+- Purpose: Structured logging with subsystem prefixes
+- Contains: Subsystem logger factory, test helpers
+- Key files: `subsystem.ts` (logger creation)
+
+**src/providers/**
+
+- Purpose: Provider-specific utilities and adapters
+- Contains: OAuth helpers, model listing utilities
+- Key files: Model and auth helpers for specific providers
+
+**src/routing/**
+
+- Purpose: Determine which agent should handle an inbound message
+- Contains: Route resolution engine, session key generation, binding logic
+- Key files: `resolve-route.ts` (main routing), `session-key.ts` (session ID generation), `bindings.ts` (binding rules)
+
+**src/sessions/**
+
+- Purpose: Session state management, transcripts, overrides
+- Contains: Session entry types, model/auth/verbose overrides, transcript events
+- Key files: Not in this dir directly; see `src/config/sessions/` for file storage
+
+**src/terminal/**
+
+- Purpose: Terminal UI components (colors, tables, prompts)
+- Contains: Color palette, table formatting, interactive prompts
+- Key files: `palette.ts` (color theme), `table.ts` (table formatting)
+
+**extensions/**
+
+- Purpose: Plugin packages (channels, LLM providers, integrations)
+- Contains: One directory per extension
+- Structure: Each extension is an npm package with `src/channel.ts` (channels) or provider-specific exports
+- Examples: `extensions/discord/` (Discord channel), `extensions/anthropic/` (Claude provider)
+
+**ui/**
+
+- Purpose: React/Vue web browser UI
+- Contains: React components, styles, i18n
+- Key files: `src/main.ts` (entry), `src/ui/` (components)
+
+**apps/**
+
+- Purpose: Native mobile and desktop applications
+- Contains: iOS (Swift/SwiftUI), Android (Kotlin), macOS (Swift/SwiftUI), shared logic
+- Structure: Separate Xcode + Android Studio projects
+
+**dist/**
+
+- Purpose: Built JavaScript output (generated)
+- Contains: Compiled TypeScript, bundled plugins
+- Generated: By `pnpm build`
+
+**test/**
+
+- Purpose: Integration and end-to-end tests
+- Contains: Test suites organized by feature area
+- Key files: Files matching `*.test.ts`, `*.e2e.test.ts`
+
+**scripts/**
+
+- Purpose: Build scripts, deployment utilities, development tools
+- Contains: Bash scripts for setup, bundling, releases
+
+**skills/**
+
+- Purpose: Agent skills definitions and implementations
+- Contains: JSON definitions of available agent capabilities
+
+## Key File Locations
+
+**Entry Points:**
+
+- `openclaw.mjs`: CLI entrypoint wrapper (Node version check, module cache, dist loader)
+- `src/entry.ts`: Main CLI entry point (runs CLI or daemon)
+- `src/index.ts`: Library exports (public API for `const openclaw = require('openclaw')`)
+
+**Configuration:**
+
+- `src/config/config.ts`: Re-export barrel for config module
+- `src/config/io.ts`: Config file loading/saving
+- `src/config/types.ts`: Config TypeScript interfaces
+- `src/config/validation.ts`: Config schema validation
+
+**Core Logic:**
+
+- `src/agents/agent-command.ts`: Main agent execution handler
+- `src/agents/model-selection.ts`: Model selection logic
+- `src/agents/auth-profiles.ts`: Auth credential management
+- `src/routing/resolve-route.ts`: Route resolution engine
+- `src/gateway/server/ws-connection.ts`: WebSocket message handler
+- `src/channels/allowlist-match.ts`: Allowlist validation
+
+**Testing:**
+
+- `vitest.config.ts`: Main test config
+- `vitest.unit.config.ts`: Unit test runner
+- `vitest.e2e.config.ts`: E2E test runner
+- `src/**/*.test.ts`: Unit tests (colocated with source)
+- `test/*.e2e.test.ts`: Integration/e2e tests
+
+## Naming Conventions
+
+**Files:**
+
+- Kebab-case: `model-selection.ts`, `auth-profiles.ts`, `agent-command.ts`
+- Suffixes: `.test.ts` (unit), `.e2e.test.ts` (integration), `.types.ts` (types-only)
+- Index files: `index.ts` in directories for re-exports (barrel pattern)
+
+**Directories:**
+
+- Kebab-case: `src/agents/`, `src/auth-profiles/`, `src/image-generation/`
+- Feature directories: Named by domain (channels, agents, config, routing, etc.)
+- Subdirs in large dirs: Organized by concern (e.g., `src/agents/auth-profiles/`, `src/gateway/server/`)
+
+**Functions/Types:**
+
+- camelCase: `resolveRoute()`, `loadConfig()`, `normalizeAgentId()`
+- Types: PascalCase: `ResolvedAgentRoute`, `RoutePeer`, `SessionEntry`
+- Constants: UPPER_SNAKE_CASE: `DEFAULT_AGENT_ID`, `MIN_NODE_VERSION`
+
+## Where to Add New Code
+
+**New Feature (e.g., new LLM provider):**
+
+- Primary code: `extensions/<provider-name>/src/` (new extension package)
+- Tests: `extensions/<provider-name>/src/**/*.test.ts` (colocated)
+- Config types: `src/config/types.ts` (add to config schema)
+- Exports: `package.json` under `.exports` (if it's part of plugin-sdk)
+
+**New Channel Integration:**
+
+- Primary code: `extensions/<channel-name>/src/channel.ts` (transport implementation)
+- Config: `src/channels/` (allowlist, command gating rules if shared)
+- Tests: `extensions/<channel-name>/src/**/*.test.ts`
+
+**New Command (e.g., `openclaw foo`):**
+
+- Implementation: `src/commands/foo/index.ts`
+- CLI registration: Edit `src/cli/` to register command with commander
+- Tests: `src/commands/foo/*.test.ts`
+
+**New Utility/Helper:**
+
+- Shared helpers: `src/utils/` (general-purpose utilities)
+- Subsystem helpers: `src/<subsystem>/test-helpers/` (domain-specific test utilities)
+- Shared text utils: `src/shared/text/`
+- Shared net utils: `src/shared/net/`
+
+**New Permission/Allowlist Rule:**
+
+- Implementation: `src/channels/allowlist-match.ts` or `src/channels/command-gating.ts`
+- Tests: Colocated `.test.ts`
+
+## Special Directories
+
+**node_modules/**
+
+- Purpose: Installed npm dependencies
+- Generated: By `pnpm install`
+- Committed: No (git-ignored)
+
+**dist/**
+
+- Purpose: Built JavaScript output
+- Generated: By `pnpm build`
+- Committed: No (git-ignored)
+
+**~/.openclaw/** (runtime, not in repo)
+
+- Purpose: User config and runtime state
+- Structure:
+  - `config.json5`: Main config file
+  - `sessions/`: Agent conversation state (one JSON file per session)
+  - `auth-profiles/`: LLM/channel provider credentials
+  - `agents/`: Agent-specific directories
+  - `plugins/`: User-installed plugin packages
+  - `credentials/`: Channel login tokens (web provider)
+
+**skills/** (committed)
+
+- Purpose: Agent skills definitions
+- Contents: JSON definitions of available agent capabilities
+- Used by: Agents during skill discovery
+
+**extensions/** (committed)
+
+- Purpose: Bundled plugins (channels, providers)
+- Structure: npm workspace packages
+- Used: Loaded at runtime via plugin registry
+
+**test-fixtures/** (committed)
+
+- Purpose: Shared test data (images, documents, JSON samples)
+- Used: Referenced in test files
+
+**.planning/codebase/** (planning only)
+
+- Purpose: GSD mapping documents
+- Contents: ARCHITECTURE.md, STRUCTURE.md, STACK.md, TESTING.md, CONVENTIONS.md, CONCERNS.md
+- Generated: By gsd-map-codebase command
+
+---
+
+_Structure analysis: 2026-03-17_

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,489 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-17
+
+## Test Framework
+
+**Runner:**
+
+- Vitest 4.1.0
+- Config: `vitest.config.ts` (base), `vitest.unit.config.ts` (unit tests only), `vitest.gateway.config.ts` (gateway tests), `vitest.e2e.config.ts` (end-to-end), `vitest.live.config.ts` (live tests with real credentials)
+- Pool strategy: `pool: "forks"` (default) with separate process pool per test file to prevent cross-file env pollution
+- Max workers: 4-16 local, 2-3 in CI (Windows uses 2, others use 3)
+- Timeouts: 120 seconds for tests, 120-180 seconds for hooks (higher on Windows)
+- Hook cleanup: `unstubEnvs: true` and `unstubGlobals: true` to ensure per-test isolation under vmForks
+
+**Assertion Library:**
+
+- Vitest's native assertions: `expect(value).toBe()`, `expect(fn).toHaveBeenCalled()`, etc.
+- No separate assertion library; vitest provides full assertion API
+- Custom matchers can be added via vitest's `expect.extend()`
+
+**Run Commands:**
+
+```bash
+pnpm test                    # Run all default tests (vitest.config.ts)
+pnpm test:coverage          # Run with V8 coverage reporter
+pnpm test:fast              # Unit tests only (vitest.unit.config.ts)
+pnpm test:watch             # Watch mode with rerun on file change
+pnpm test:gateway           # Gateway-specific tests (vitest.gateway.config.ts)
+pnpm test:e2e               # End-to-end tests (vitest.e2e.config.ts)
+pnpm test:live              # Live tests requiring real credentials (OPENCLAW_LIVE_TEST=1)
+pnpm test -- <path> -t "pattern"  # Run specific test file or pattern
+OPENCLAW_TEST_PROFILE=low pnpm test  # Low-profile mode for resource-constrained envs
+OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test  # Serial test execution (for memory pressure)
+```
+
+## Test File Organization
+
+**Location:**
+
+- **Co-located:** Unit tests live alongside source code: `src/pairing/pairing-challenge.ts` pairs with `src/pairing/pairing-challenge.test.ts`
+- **Extensions:** `extensions/**/src/**/*.test.ts` follow same co-located pattern
+- **E2E tests:** Located in `test/` directory for full-system flows
+- **Live tests:** Use `*.live.test.ts` suffix for tests requiring real external services/credentials
+
+**Naming:**
+
+- Unit test files: `*.test.ts`
+- E2E test files: `*.e2e.test.ts`
+- Live/integration tests: `*.live.test.ts`
+- Setup and utilities: `test/setup.ts`, `test/test-env.ts`, `test/helpers/`
+
+**Structure:**
+
+```
+src/
+├── pairing/
+│   ├── pairing-challenge.ts          # Source implementation
+│   ├── pairing-challenge.test.ts     # Co-located unit test
+│   ├── pairing-store.ts
+│   └── pairing-store.test.ts
+
+test/
+├── setup.ts                          # Global test setup (mock providers, plugin registry)
+├── test-env.ts                       # Environment isolation utilities
+├── helpers/                          # Shared test helpers
+└── fixtures/                         # Fixture data
+```
+
+## Test Structure
+
+**Suite Organization:**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { someFunction } from "./some-module.js";
+
+describe("someFunction", () => {
+  // Setup/teardown per-test
+  let resource: SomeResource;
+
+  beforeEach(() => {
+    resource = createResource();
+  });
+
+  afterEach(() => {
+    resource.cleanup?.();
+  });
+
+  // Grouped by behavior
+  describe("when condition X", () => {
+    it("returns Y", () => {
+      expect(someFunction(input)).toBe(expected);
+    });
+
+    it("calls callback Z", async () => {
+      const callback = vi.fn();
+      await someFunction(input, callback);
+      expect(callback).toHaveBeenCalledWith(expectedArg);
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws on invalid input", () => {
+      expect(() => someFunction(badInput)).toThrow("error message");
+    });
+  });
+});
+```
+
+**Patterns:**
+
+- Use `describe()` to group related tests; nest for sub-contexts
+- Use `it()` for individual test cases (descriptive second parameter)
+- Use `beforeEach()` / `afterEach()` for per-test setup and cleanup
+- Use `beforeAll()` / `afterAll()` only for expensive one-time setup (test registration, etc.)
+- Keep test names descriptive: "returns pairing code when request is newly created" not just "test 1"
+
+**Example from codebase:**
+
+```typescript
+describe("issuePairingChallenge", () => {
+  it("creates and sends a pairing reply when request is newly created", async () => {
+    const sent: string[] = [];
+
+    const result = await issuePairingChallenge({
+      channel: "telegram",
+      senderId: "123",
+      senderIdLine: "Your Telegram user id: 123",
+      upsertPairingRequest: async () => ({ code: "ABCD", created: true }),
+      sendPairingReply: async (text) => {
+        sent.push(text);
+      },
+    });
+
+    expect(result).toEqual({ created: true, code: "ABCD" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("ABCD");
+  });
+
+  it("does not send a reply when request already exists", async () => {
+    const sendPairingReply = vi.fn(async () => {});
+
+    const result = await issuePairingChallenge({
+      channel: "telegram",
+      senderId: "123",
+      senderIdLine: "Your Telegram user id: 123",
+      upsertPairingRequest: async () => ({ code: "ABCD", created: false }),
+      sendPairingReply,
+    });
+
+    expect(result).toEqual({ created: false });
+    expect(sendPairingReply).not.toHaveBeenCalled();
+  });
+});
+```
+
+## Mocking
+
+**Framework:** Vitest's built-in mocking API
+
+**Patterns:**
+
+Global mocks (in `test/setup.ts`):
+
+```typescript
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@mariozechner/pi-ai")>();
+  return {
+    ...original,
+    getOAuthApiKey: () => undefined,
+    getOAuthProviders: () => [],
+    loginOpenAICodex: vi.fn(),
+  };
+});
+```
+
+Function mocks (in test files):
+
+```typescript
+const sendPairingReply = vi.fn(async () => {});
+const onCreated = vi.fn();
+
+// Use mocks as arguments
+await issuePairingChallenge({
+  // ...
+  sendPairingReply,
+  onCreated,
+});
+
+// Verify calls
+expect(sendPairingReply).toHaveBeenCalledWith("reply text");
+expect(onCreated).toHaveBeenCalledTimes(1);
+expect(onCreated).not.toHaveBeenCalled();
+```
+
+Module mocks (inline in test):
+
+```typescript
+vi.mock("../infra/device-bootstrap.js", () => ({
+  issueDeviceBootstrapToken: vi.fn(async () => ({
+    token: "test-token",
+  })),
+}));
+```
+
+Spy on existing functions:
+
+```typescript
+const spy = vi.spyOn(fs, "readFile");
+spy.mockImplementation(async (path, opts) => {
+  if (path === expectedPath) {
+    return "mocked content";
+  }
+  return original(path, opts);
+});
+expect(spy).toHaveBeenCalledWith(expectedPath, expect.any(Object));
+spy.mockRestore();
+```
+
+Environment stubbing (per-test isolation):
+
+```typescript
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_PROFILE", "isolated");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+```
+
+**What to Mock:**
+
+- External service calls (HTTP, file system, crypto random operations)
+- Time-based operations: `vi.useFakeTimers()` for testing delays/intervals
+- Module-level side effects or expensive operations
+- Dependencies injected as parameters (preferred over mocking modules)
+
+**What NOT to Mock:**
+
+- Pure functions being tested (test them directly)
+- Core utilities like path, JSON operations
+- The system under test (test real implementation)
+- Helper libraries unless they have external dependencies
+- Standard library methods unless testing edge cases
+
+## Fixtures and Factories
+
+**Test Data:**
+
+```typescript
+// Factory functions for test objects
+export function createStubPlugin(params: {
+  id: ChannelId;
+  label?: string;
+  aliases?: string[];
+  deliveryMode?: ChannelOutboundAdapter["deliveryMode"];
+}): ChannelPlugin {
+  return {
+    id: params.id,
+    meta: {
+      id: params.id,
+      label: params.label ?? String(params.id),
+      // ...
+    },
+    // ...
+  };
+}
+
+// Usage in tests
+const testPlugin = createStubPlugin({ id: "discord", label: "Discord" });
+```
+
+**Location:**
+
+- Test utilities in `src/test-utils/`: `channel-plugins.js`, `env.js`, `temp-dir.js`, etc.
+- Shared test helpers in `test/helpers/`
+- Fixture data in `test/fixtures/`
+
+**Common Helpers:**
+
+- `captureEnv()`: Save/restore environment variables for test isolation
+- `withEnvAsync()`: Run test code with specific env vars set, auto-restore
+- `withTempDir()`: Create temp directory, run test code, auto-cleanup
+- `createTestRegistry()`: Create plugin registry with stub plugins
+- `createTrackedTempDirs()`: Manage multiple temp directories with cleanup
+
+## Coverage
+
+**Requirements:** V8 coverage with thresholds enforced
+
+**Thresholds:**
+
+- Lines: 70%
+- Functions: 70%
+- Branches: 55%
+- Statements: 70%
+
+**Exclusions:**
+
+- CLI entry points and wiring (`src/cli/`, `src/commands/`)
+- Large integration surfaces (gateway, channels, agents) validated via e2e/manual tests
+- Generated code and templates
+- Type definition files
+
+**View Coverage:**
+
+```bash
+pnpm test:coverage              # Generate coverage report
+open coverage/index.html        # View HTML report (macOS)
+```
+
+**Coverage is enforced by:**
+
+- Vitest config `coverage.thresholds` in `vitest.config.ts`
+- CI gates the coverage report; tests fail if thresholds not met
+- `all: false` means only files exercised by tests are counted (not whole src/)
+
+## Test Types
+
+**Unit Tests:**
+
+- **Scope:** Single function or small module
+- **Approach:** Test inputs and outputs in isolation; mock external dependencies
+- **Location:** `src/**/*.test.ts`
+- **Example:** `src/pairing/pairing-challenge.test.ts` tests `issuePairingChallenge()` in isolation with mock callbacks
+- **Run:** `pnpm test:fast` or `pnpm test` with `vitest.unit.config.ts`
+
+**Integration Tests:**
+
+- **Scope:** Multiple modules working together; may use real file system or in-memory state
+- **Approach:** Test workflows that span multiple layers (config, infra, channels)
+- **Location:** `src/**/*.test.ts` with setup from `test/setup.ts` (e.g., plugin registry)
+- **Example:** Tests in `src/infra/` that interact with real temp directories and store operations
+- **Run:** `pnpm test` or `pnpm test:contracts`
+
+**Contract Tests:**
+
+- **Scope:** Verify plugin/provider API contracts
+- **Approach:** Validate that implementations conform to expected interfaces
+- **Location:** `src/channels/plugins/contracts/`, `src/plugins/contracts/`
+- **Run:** `pnpm test:contracts:channels` and `pnpm test:contracts:plugins`
+
+**End-to-End Tests:**
+
+- **Scope:** Full system flows (CLI, gateway, multi-process)
+- **Approach:** Start gateway, CLI, or services; run commands; verify output
+- **Location:** `test/**/*.e2e.test.ts`
+- **Example:** `test/gateway.multi.e2e.test.ts`
+- **Run:** `pnpm test:e2e`
+
+**Live Tests:**
+
+- **Scope:** Real external service integration (Discord, Telegram, OpenAI API)
+- **Approach:** Use real credentials (from env vars) to test against live services
+- **Location:** `src/**/*.live.test.ts` or `test/**/*.live.test.ts`
+- **Example:** Android node capability tests, model fetch tests
+- **Run:** `OPENCLAW_LIVE_TEST=1 pnpm test:live` or `CLAWDBOT_LIVE_TEST=1 pnpm test:live`
+- **Skipped by default** unless `OPENCLAW_LIVE_TEST=1` or `CLAWDBOT_LIVE_TEST=1` is set
+
+## Common Patterns
+
+**Async Testing:**
+
+```typescript
+// vitest handles async naturally
+it("fetches data asynchronously", async () => {
+  const result = await someAsyncFunction();
+  expect(result).toEqual(expected);
+});
+
+// Or with promises and vi.advanceTimersByTime
+it("resolves after delay using fake timers", async () => {
+  vi.useFakeTimers();
+  const promise = sleep(1000);
+  vi.advanceTimersByTime(1000);
+  await expect(promise).resolves.toBeUndefined();
+  vi.useRealTimers();
+});
+```
+
+**Error Testing:**
+
+```typescript
+it("throws on invalid input", () => {
+  expect(() => functionThatThrows()).toThrow("error message");
+});
+
+it("rejects on async error", async () => {
+  await expect(asyncFunctionThatThrows()).rejects.toThrow("error");
+});
+
+// Capture error for inspection
+it("includes error details", async () => {
+  try {
+    await functionThatThrows();
+  } catch (err) {
+    expect((err as Error).message).toContain("expected text");
+  }
+});
+```
+
+**Testing with Real Files:**
+
+```typescript
+import { withTempDir } from "../test-utils/temp-dir.js";
+
+it("reads JSON5 object session stores", async () => {
+  await withTempDir("openclaw-session-store-", async (dir) => {
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{ main: { sessionId: 's1' } }", "utf-8");
+
+    const result = readSessionStoreJson5(storePath);
+    expect(result.ok).toBe(true);
+    expect(result.store.main?.sessionId).toBe("s1");
+    // temp dir auto-cleaned up after test
+  });
+});
+```
+
+**Data-Driven Tests:**
+
+```typescript
+const cases = [
+  { input: "a", expected: "A" },
+  { input: "b", expected: "B" },
+];
+
+for (const testCase of cases) {
+  it(`converts ${testCase.input}`, () => {
+    expect(convert(testCase.input)).toBe(testCase.expected);
+  });
+}
+```
+
+## Global Setup
+
+**File:** `test/setup.ts`
+
+**What happens:**
+
+1. Mock `@mariozechner/pi-ai` (OAuth providers)
+2. Set `VITEST=true` and plugin cache timeout (`OPENCLAW_PLUGIN_MANIFEST_CACHE_MS=60000`)
+3. Increase process listener limit to 128 (Vitest vm forks create many listeners)
+4. Create isolated test home directory (cleans up after all tests)
+5. Install process warning filter
+6. Create default plugin registry with stub Discord, Slack, Telegram, WhatsApp, Signal, iMessage
+7. Before each test: set active plugin registry to default
+8. After each test: restore plugin registry if modified, reset fake timers if active
+
+**Test Environment Isolation:**
+
+- HOME directory is isolated per test run (via `withIsolatedTestHome()`)
+- Environment variables are stubbed per-test via `vi.stubEnv()` and `unstubEnvs: true`
+- Fake timers are reset after each test to prevent leakage
+
+## Debugging Tests
+
+**Run specific test:**
+
+```bash
+pnpm test -- src/pairing/pairing-challenge.test.ts
+pnpm test -- src/pairing/pairing-challenge.test.ts -t "creates and sends"
+```
+
+**Watch mode:**
+
+```bash
+pnpm test:watch
+# Or with filter
+pnpm test -- src/pairing --watch
+```
+
+**Enable verbose logging:**
+
+```bash
+DEBUG=* pnpm test -- src/pairing/pairing-challenge.test.ts
+```
+
+**Inspect failures:**
+
+- Check test output for assertion diffs
+- Use `expect(actual).toEqual(expected)` for detailed object diffs
+- For async issues, check test timeout (120s default; override with `it(..., fn, timeout)`)
+
+---
+
+_Testing analysis: 2026-03-17_

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,14 @@
+{
+  "mode": "yolo",
+  "granularity": "coarse",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "quality",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": false,
+    "auto_advance": true
+  }
+}

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -2,7 +2,12 @@ import {
   getActivePluginRegistryVersion,
   requireActivePluginRegistry,
 } from "../../plugins/runtime.js";
-import { CHAT_CHANNEL_ORDER, type ChatChannelId, normalizeAnyChannelId } from "../registry.js";
+import {
+  CHAT_CHANNEL_ORDER,
+  type ChatChannelId,
+  normalizeAnyChannelId,
+  normalizeChatChannelId,
+} from "../registry.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
 function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
@@ -78,5 +83,9 @@ export function getChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
 }
 
 export function normalizeChannelId(raw?: string | null): ChannelId | null {
-  return normalizeAnyChannelId(raw);
+  // Try registry-based resolution first (handles external plugins and aliases).
+  // Fall back to the static built-in channel list so that well-known bundled
+  // channels (e.g. "discord") resolve without pre-loading the plugin registry,
+  // which is intentionally skipped for `channels add` and `onboard`.
+  return normalizeAnyChannelId(raw) ?? normalizeChatChannelId(raw);
 }

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -197,9 +197,10 @@ export async function channelsAddCommand(
       ...(pluginId ? { pluginId } : {}),
       workspaceDir: resolveWorkspaceDir(),
     });
+    // Prefer the setup plugin (has applyAccountConfig) over the runtime plugin.
     return (
-      snapshot.channels.find((entry) => entry.plugin.id === channelId)?.plugin ??
-      snapshot.channelSetups.find((entry) => entry.plugin.id === channelId)?.plugin
+      snapshot.channelSetups.find((entry) => entry.plugin.id === channelId)?.plugin ??
+      snapshot.channels.find((entry) => entry.plugin.id === channelId)?.plugin
     );
   };
 


### PR DESCRIPTION
## Summary

- `channels add --channel discord` (and other bundled channels) failed with **"Unknown channel: discord"** because the preaction hook intentionally skips plugin registry loading for `channels add`/`onboard`, leaving `normalizeChannelId` unable to resolve well-known channel names.
- After fixing that, a second error **"Channel discord does not support add"** surfaced because `loadScopedPlugin` returned the runtime plugin (no `setup.applyAccountConfig`) instead of the setup plugin.

## Changes

**`src/channels/plugins/registry.ts`** — `normalizeChannelId` now falls back to `normalizeChatChannelId` (static `CHAT_CHANNEL_ORDER` list) when the plugin registry is empty. This lets bundled channels like `discord`, `telegram`, etc. resolve correctly without requiring a full plugin pre-load, which is intentionally skipped for `channels add` and `onboard`.

**`src/commands/channels/add.ts`** — `loadScopedPlugin` now prefers `channelSetups` over `channels` when looking up the plugin for `channels add`. The setup plugin (e.g. `discordSetupPlugin`) carries `setup.applyAccountConfig`; the runtime plugin does not. The previous lookup order returned the runtime plugin first.

## Test plan

- [ ] `openclaw channels add --channel discord --token <token>` completes successfully without "Unknown channel" or "does not support add" errors
- [ ] `openclaw channels add --channel telegram --token <token>` still works (regression)
- [ ] `openclaw channels add` (wizard mode, no `--channel`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)