### PR TITLE
fix: restore main build

### DIFF
--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -4,7 +4,7 @@ import {
   resolveAccountEntry,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-resolution";
-import type { SignalAccountConfig } from "../runtime-api.js";
+import type { SignalAccountConfig } from "../../../src/config/types.signal.js";
 
 export type ResolvedSignalAccount = {
   accountId: string;

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -14,6 +14,7 @@ import {
   wrapWebContent,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
+import type { WebSearchProviderPlugin } from "../../src/plugins/types.js";
 
 const XAI_WEB_SEARCH_ENDPOINT = "https://api.x.ai/v1/responses";
 const XAI_DEFAULT_WEB_SEARCH_MODEL = "grok-4-1-fast";
@@ -200,7 +201,7 @@ async function runXaiWebSearch(params: {
   return payload;
 }
 
-export function createXaiWebSearchProvider() {
+export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
   return {
     id: "grok",
     label: "Grok (xAI)",
@@ -210,8 +211,8 @@ export function createXaiWebSearchProvider() {
     signupUrl: "https://console.x.ai/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 30,
-    credentialPath: "tools.web.search.grok.apiKey",
-    inactiveSecretPaths: ["tools.web.search.grok.apiKey"],
+    credentialPath: "plugins.entries.xai.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.xai.config.webSearch.apiKey"],
     getCredentialValue: (searchConfig?: Record<string, unknown>) =>
       getScopedCredentialValue(searchConfig, "grok"),
     setCredentialValue: (searchConfigTarget: Record<string, unknown>, value: unknown) =>

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -14,7 +14,21 @@ export const MODEL_APIS = [
 
 export type ModelApi = (typeof MODEL_APIS)[number];
 
-export type ModelCompatConfig = OpenAICompletionsCompat & {
+type SupportedOpenAICompatFields = Pick<
+  OpenAICompletionsCompat,
+  | "supportsStore"
+  | "supportsDeveloperRole"
+  | "supportsReasoningEffort"
+  | "supportsUsageInStreaming"
+  | "supportsStrictMode"
+  | "maxTokensField"
+  | "thinkingFormat"
+  | "requiresToolResultName"
+  | "requiresAssistantAfterToolResult"
+  | "requiresThinkingAsText"
+>;
+
+export type ModelCompatConfig = SupportedOpenAICompatFields & {
   supportsTools?: boolean;
   toolSchemaProfile?: "xai";
   nativeWebSearchTool?: boolean;

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -1,3 +1,4 @@
+import type { OpenAICompletionsCompat } from "@mariozechner/pi-ai";
 import type { SecretInput } from "./types.secrets.js";
 
 export const MODEL_APIS = [
@@ -13,21 +14,11 @@ export const MODEL_APIS = [
 
 export type ModelApi = (typeof MODEL_APIS)[number];
 
-export type ModelCompatConfig = {
-  supportsStore?: boolean;
-  supportsDeveloperRole?: boolean;
-  supportsReasoningEffort?: boolean;
-  supportsUsageInStreaming?: boolean;
+export type ModelCompatConfig = OpenAICompletionsCompat & {
   supportsTools?: boolean;
-  supportsStrictMode?: boolean;
   toolSchemaProfile?: "xai";
   nativeWebSearchTool?: boolean;
   toolCallArgumentsEncoding?: "html-entities";
-  maxTokensField?: "max_completion_tokens" | "max_tokens";
-  thinkingFormat?: "openai" | "zai" | "qwen";
-  requiresToolResultName?: boolean;
-  requiresAssistantAfterToolResult?: boolean;
-  requiresThinkingAsText?: boolean;
   requiresMistralToolIds?: boolean;
   requiresOpenAiAnthropicToolPayload?: boolean;
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -191,7 +191,14 @@ export const ModelCompatSchema = z
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
-    thinkingFormat: z.union([z.literal("openai"), z.literal("zai"), z.literal("qwen")]).optional(),
+    thinkingFormat: z
+      .union([
+        z.literal("openai"),
+        z.literal("zai"),
+        z.literal("qwen"),
+        z.literal("qwen-chat-template"),
+      ])
+      .optional(),
     requiresToolResultName: z.boolean().optional(),
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -6,6 +6,7 @@ import {
   isValidExecSecretRefId,
   isValidFileSecretRefId,
 } from "../secrets/ref-contract.js";
+import type { ModelCompatConfig } from "./types.models.js";
 import { MODEL_APIS } from "./types.models.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -202,11 +203,24 @@ export const ModelCompatSchema = z
     requiresToolResultName: z.boolean().optional(),
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
+    toolSchemaProfile: z.literal("xai").optional(),
+    nativeWebSearchTool: z.boolean().optional(),
+    toolCallArgumentsEncoding: z.literal("html-entities").optional(),
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();
+
+type AssertAssignable<_T extends U, U> = true;
+type _ModelCompatSchemaAssignableToType = AssertAssignable<
+  z.infer<typeof ModelCompatSchema>,
+  ModelCompatConfig | undefined
+>;
+type _ModelCompatTypeAssignableToSchema = AssertAssignable<
+  ModelCompatConfig | undefined,
+  z.infer<typeof ModelCompatSchema>
+>;
 
 export const ModelDefinitionSchema = z
   .object({


### PR DESCRIPTION
## What
This PR restores a green `pnpm build` on `main` by fixing a stale Slack runtime import and aligning a few extension/config type surfaces with the current plugin and `pi-ai` contracts.

## Why
`pnpm build` was failing on `main` with an unresolved import in the Slack extension, and once that was corrected the build exposed a small set of TypeScript contract mismatches in Signal, xAI web search provider registration, and model compat typing. Keeping `main` buildable matters for both local development and release confidence.

## Changes
- Fix Slack runtime directory-config import path
- Import Signal account config from source type module
- Align model compat config with current `pi-ai` compat shape
- Accept `qwen-chat-template` in config schema
- Add required xAI web-search provider credential metadata

## Testing
- `pnpm build`
- Expected outcome: build completes successfully from the current branch without the prior unresolved import or TypeScript contract failures
