### PR TITLE
fix: generalize api_error detection for fallback model triggering

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -97,6 +97,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("context length exceeded") ||
     lower.includes("maximum context length") ||
     lower.includes("prompt is too long") ||
+    lower.includes("prompt too long") ||
     lower.includes("exceeds model context window") ||
     lower.includes("model token limit") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
@@ -211,11 +212,12 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
   return undefined;
 }
 
+// Allow provider-wrapped API payloads such as "Ollama API error 400: {...}".
 const ERROR_PAYLOAD_PREFIX_RE =
-  /^(?:error|api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)[:\s-]+/i;
+  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)(?:\s+\d{3})?[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 const ERROR_PREFIX_RE =
-  /^(?:error|api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)[:\s-]+/i;
+  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
@@ -851,9 +853,12 @@ function isJsonApiInternalServerError(raw: string): boolean {
     return false;
   }
   const value = raw.toLowerCase();
-  // Anthropic often wraps transient 500s in JSON payloads like:
+  // Providers wrap transient 5xx errors in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  // Non-standard providers (e.g. MiniMax) may use different message text:
+  // {"type":"api_error","message":"unknown error, 520 (1000)"}
+  // Any api_error type indicates a provider-side failure regardless of message text.
+  return value.includes('"type":"api_error"');
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary

`isJsonApiInternalServerError()` previously required both `"type":"api_error"` **and** the text `"internal server error"` to classify an error as retryable/fallback-eligible. This caused fallback models to **never trigger** for providers that use non-standard error messages.

## Problem

MiniMax (and potentially other non-Anthropic providers) returns api_error with different message text:
```json
{"type":"api_error","message":"unknown error, 520 (1000)"}
```

The old check required `"internal server error"` in the message, so this was **not** classified as a retryable error, and the configured fallback model was never used.

## Fix

Remove the message text requirement. Any response with `"type":"api_error"` is by definition a provider-side failure — the specific message text is irrelevant to the fallback decision.

**Before:**
```typescript
return value.includes(type:api_error) && value.includes("internal server error");
```

**After:**
```typescript
return value.includes(type:api_error);
```

## Risk

Low. The `api_error` type is defined as a provider-side transient failure. Triggering fallback on all such errors (rather than just those with a specific English message) is the correct, provider-agnostic behavior.

Fixes #49440