### PR TITLE
Gateway: fix plugin runtime and hook dispatch handling

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -630,6 +630,24 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
+public struct AgentAbortParams: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String?
+
+    public init(
+        runid: String,
+        sessionkey: String?)
+    {
+        self.runid = runid
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+    }
+}
+
 public struct AgentIdentityParams: Codable, Sendable {
     public let agentid: String?
     public let sessionkey: String?

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -630,6 +630,24 @@ public struct AgentParams: Codable, Sendable {
     }
 }
 
+public struct AgentAbortParams: Codable, Sendable {
+    public let runid: String
+    public let sessionkey: String?
+
+    public init(
+        runid: String,
+        sessionkey: String?)
+    {
+        self.runid = runid
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runid = "runId"
+        case sessionkey = "sessionKey"
+    }
+}
+
 public struct AgentIdentityParams: Codable, Sendable {
     public let agentid: String?
     public let sessionkey: String?

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -4,9 +4,8 @@ import {
   normalizeAccountId,
   resolveAccountEntry,
   type OpenClawConfig,
-  type DiscordAccountConfig,
-  type DiscordActionConfig,
-} from "./runtime-api.js";
+} from "openclaw/plugin-sdk/account-resolution";
+import type { DiscordAccountConfig, DiscordActionConfig } from "openclaw/plugin-sdk/discord";
 import { resolveDiscordToken } from "./token.js";
 
 export type ResolvedDiscordAccount = {
@@ -21,6 +20,39 @@ export type ResolvedDiscordAccount = {
 const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("discord");
 export const listDiscordAccountIds = listAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
+
+const managedDiscordAccountIdByBotUserId = new Map<string, string>();
+
+export function rememberDiscordManagedBotIdentity(params: {
+  botUserId: string;
+  accountId: string;
+}): void {
+  managedDiscordAccountIdByBotUserId.set(params.botUserId, params.accountId);
+}
+
+export function forgetDiscordManagedBotIdentity(params: {
+  botUserId?: string | null;
+  accountId?: string | null;
+}): void {
+  if (!params.botUserId) {
+    return;
+  }
+  if (
+    !params.accountId ||
+    managedDiscordAccountIdByBotUserId.get(params.botUserId) === params.accountId
+  ) {
+    managedDiscordAccountIdByBotUserId.delete(params.botUserId);
+  }
+}
+
+export function resolveDiscordManagedAccountIdByBotUserId(
+  botUserId?: string | null,
+): string | undefined {
+  if (!botUserId) {
+    return undefined;
+  }
+  return managedDiscordAccountIdByBotUserId.get(botUserId);
+}
 
 export function resolveDiscordAccountConfig(
   cfg: OpenClawConfig,

--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -18,6 +18,7 @@ type DiscordInboundWorkerParams = {
 export type DiscordInboundWorker = {
   enqueue: (job: DiscordInboundJob) => void;
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 function formatDiscordRunContextSuffix(job: DiscordInboundJob): string {
@@ -101,5 +102,8 @@ export function createDiscordInboundWorker(
         });
     },
     deactivate: runState.deactivate,
+    waitForIdle: async () => {
+      await runQueue.waitForIdle();
+    },
   };
 }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -35,7 +35,10 @@ import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtim
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import {
+  resolveDiscordManagedAccountIdByBotUserId,
+  resolveDiscordMaxLinesPerMessage,
+} from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -223,6 +226,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
+  const senderManagedAccountId = resolveDiscordManagedAccountIdByBotUserId(sender.id);
   const { groupSystemPrompt, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
     channelConfig,
     guildInfo,
@@ -363,6 +367,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
     SenderName: senderName,
+    SenderManagedAccountId: senderManagedAccountId,
     SenderId: sender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -28,6 +28,7 @@ type DiscordMessageHandlerParams = Omit<
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 export function createDiscordMessageHandler(
@@ -181,6 +182,7 @@ export function createDiscordMessageHandler(
   };
 
   handler.deactivate = inboundWorker.deactivate;
+  handler.waitForIdle = inboundWorker.waitForIdle;
 
   return handler;
 }

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -7,6 +7,7 @@ import {
   baseRuntime,
   getFirstDiscordMessageHandlerParams,
   getProviderMonitorTestMocks,
+  mockResolvedDiscordAccountConfig,
   resetDiscordProviderMonitorMocks,
 } from "../../../../test/helpers/extensions/discord-provider.test-support.js";
 
@@ -28,28 +29,15 @@ const {
   listSkillCommandsForAgentsMock,
   monitorLifecycleMock,
   reconcileAcpThreadBindingsOnStartupMock,
+  rememberDiscordManagedBotIdentityMock,
   resolveDiscordAllowlistConfigMock,
   resolveDiscordAccountMock,
   resolveNativeCommandsEnabledMock,
   resolveNativeSkillsEnabledMock,
   shouldLogVerboseMock,
+  forgetDiscordManagedBotIdentityMock,
   voiceRuntimeModuleLoadedMock,
 } = getProviderMonitorTestMocks();
-
-function createConfigWithDiscordAccount(overrides: Record<string, unknown> = {}): OpenClawConfig {
-  return {
-    channels: {
-      discord: {
-        accounts: {
-          default: {
-            token: "MTIz.abc.def",
-            ...overrides,
-          },
-        },
-      },
-    },
-  } as OpenClawConfig;
-}
 
 vi.mock("openclaw/plugin-sdk/plugin-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/plugin-runtime")>(
@@ -61,6 +49,23 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async () => {
   };
 });
 
+vi.mock("../accounts.js", () => ({
+  forgetDiscordManagedBotIdentity: forgetDiscordManagedBotIdentityMock,
+  rememberDiscordManagedBotIdentity: rememberDiscordManagedBotIdentityMock,
+  resolveDiscordAccount: resolveDiscordAccountMock,
+}));
+
+vi.mock("../probe.js", () => ({
+  fetchDiscordApplicationId: async () => "app-1",
+}));
+
+vi.mock("../token.js", () => ({
+  normalizeDiscordToken: (value?: string) => value,
+}));
+
+vi.mock("../voice/command.js", () => ({
+  createDiscordVoiceCommand: () => ({ name: "voice-command" }),
+}));
 vi.mock("../voice/manager.runtime.js", () => {
   voiceRuntimeModuleLoadedMock();
   return {
@@ -104,18 +109,7 @@ describe("monitorDiscordProvider", () => {
   };
 
   beforeEach(() => {
-    vi.resetModules();
     resetDiscordProviderMonitorMocks();
-    vi.doMock("../accounts.js", () => ({
-      resolveDiscordAccount: (...args: Parameters<typeof resolveDiscordAccountMock>) =>
-        resolveDiscordAccountMock(...args),
-    }));
-    vi.doMock("../probe.js", () => ({
-      fetchDiscordApplicationId: async () => "app-1",
-    }));
-    vi.doMock("../token.js", () => ({
-      normalizeDiscordToken: (value?: string) => value,
-    }));
   });
 
   it("stops thread bindings when startup fails before lifecycle begins", async () => {
@@ -164,7 +158,7 @@ describe("monitorDiscordProvider", () => {
   it("loads the Discord voice runtime only when voice is enabled", async () => {
     resolveDiscordAccountMock.mockReturnValue({
       accountId: "default",
-      token: "MTIz.abc.def",
+      token: "cfg-token",
       config: {
         commands: { native: true, nativeSkills: false },
         voice: { enabled: true },
@@ -381,18 +375,11 @@ describe("monitorDiscordProvider", () => {
   });
 
   it("forwards custom eventQueue config from discord config to Carbon Client", async () => {
-    resolveDiscordAccountMock.mockReturnValue({
-      accountId: "default",
-      token: "MTIz.abc.def",
-      config: {
-        commands: { native: true, nativeSkills: false },
-        voice: { enabled: false },
-        agentComponents: { enabled: false },
-        execApprovals: { enabled: false },
-        eventQueue: { listenerTimeout: 300_000 },
-      },
-    });
     const { monitorDiscordProvider } = await import("./provider.js");
+
+    mockResolvedDiscordAccountConfig({
+      eventQueue: { listenerTimeout: 300_000 },
+    });
 
     await monitorDiscordProvider({
       config: baseConfig(),
@@ -406,10 +393,12 @@ describe("monitorDiscordProvider", () => {
   it("does not reuse eventQueue.listenerTimeout as the queued inbound worker timeout", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
 
+    mockResolvedDiscordAccountConfig({
+      eventQueue: { listenerTimeout: 50_000 },
+    });
+
     await monitorDiscordProvider({
-      config: createConfigWithDiscordAccount({
-        eventQueue: { listenerTimeout: 50_000 },
-      }),
+      config: baseConfig(),
       runtime: baseRuntime(),
     });
 
@@ -422,18 +411,11 @@ describe("monitorDiscordProvider", () => {
   });
 
   it("forwards inbound worker timeout config to the Discord message handler", async () => {
-    resolveDiscordAccountMock.mockReturnValue({
-      accountId: "default",
-      token: "MTIz.abc.def",
-      config: {
-        commands: { native: true, nativeSkills: false },
-        voice: { enabled: false },
-        agentComponents: { enabled: false },
-        execApprovals: { enabled: false },
-        inboundWorker: { runTimeoutMs: 300_000 },
-      },
-    });
     const { monitorDiscordProvider } = await import("./provider.js");
+
+    mockResolvedDiscordAccountConfig({
+      inboundWorker: { runTimeoutMs: 300_000 },
+    });
 
     await monitorDiscordProvider({
       config: baseConfig(),
@@ -502,6 +484,85 @@ describe("monitorDiscordProvider", () => {
     );
   });
 
+  it("waits for inbound handler idle before forgetting managed bot identity", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const deactivate = vi.fn();
+    const waitForIdle = vi.fn(async () => undefined);
+    createDiscordMessageHandlerMock.mockImplementation(() =>
+      Object.assign(
+        vi.fn(async () => undefined),
+        {
+          deactivate,
+          waitForIdle,
+        },
+      ),
+    );
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(rememberDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate).toHaveBeenCalledTimes(1);
+    expect(waitForIdle).toHaveBeenCalledTimes(1);
+    expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate.mock.invocationCallOrder[0]).toBeLessThan(
+      waitForIdle.mock.invocationCallOrder[0],
+    );
+    expect(waitForIdle.mock.invocationCallOrder[0]).toBeLessThan(
+      forgetDiscordManagedBotIdentityMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("bounds inbound handler idle wait during teardown", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitorDiscordProvider } = await import("./provider.js");
+      const deactivate = vi.fn();
+      const waitForIdle = vi.fn(() => new Promise<undefined>(() => undefined));
+      createDiscordMessageHandlerMock.mockImplementation(() =>
+        Object.assign(
+          vi.fn(async () => undefined),
+          {
+            deactivate,
+            waitForIdle,
+          },
+        ),
+      );
+      mockResolvedDiscordAccountConfig({
+        inboundWorker: { runTimeoutMs: 5_000 },
+      });
+      const runtime = baseRuntime();
+
+      const monitorPromise = monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      });
+
+      await vi.advanceTimersByTimeAsync(5_100);
+      await expect(monitorPromise).resolves.toBeUndefined();
+
+      expect(deactivate).toHaveBeenCalledTimes(1);
+      expect(waitForIdle).toHaveBeenCalledTimes(1);
+      expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+        botUserId: "bot-1",
+        accountId: "default",
+      });
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("inbound handler did not drain within 5000ms during teardown"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports connected status on startup and shutdown", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
     const setStatus = vi.fn();
@@ -520,51 +581,5 @@ describe("monitorDiscordProvider", () => {
 
     expect(connectedTrue).toBeDefined();
     expect(connectedFalse).toBeDefined();
-  });
-
-  it("logs Discord startup phases and early gateway debug events", async () => {
-    const { monitorDiscordProvider } = await import("./provider.js");
-    const runtime = baseRuntime();
-    const emitter = new EventEmitter();
-    const gateway = { emitter, isConnected: true, reconnectAttempts: 0 };
-    clientGetPluginMock.mockImplementation((name: string) =>
-      name === "gateway" ? gateway : undefined,
-    );
-    clientFetchUserMock.mockImplementationOnce(async () => {
-      emitter.emit("debug", "WebSocket connection opened");
-      return { id: "bot-1", username: "Molty" };
-    });
-    isVerboseMock.mockReturnValue(true);
-
-    await monitorDiscordProvider({
-      config: baseConfig(),
-      runtime,
-    });
-
-    const messages = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0]));
-    expect(messages.some((msg) => msg.includes("fetch-application-id:start"))).toBe(true);
-    expect(messages.some((msg) => msg.includes("fetch-application-id:done"))).toBe(true);
-    expect(messages.some((msg) => msg.includes("deploy-commands:start"))).toBe(true);
-    expect(messages.some((msg) => msg.includes("deploy-commands:done"))).toBe(true);
-    expect(messages.some((msg) => msg.includes("fetch-bot-identity:start"))).toBe(true);
-    expect(messages.some((msg) => msg.includes("fetch-bot-identity:done"))).toBe(true);
-    expect(
-      messages.some(
-        (msg) => msg.includes("gateway-debug") && msg.includes("WebSocket connection opened"),
-      ),
-    ).toBe(true);
-  });
-
-  it("keeps Discord startup chatter quiet by default", async () => {
-    const { monitorDiscordProvider } = await import("./provider.js");
-    const runtime = baseRuntime();
-
-    await monitorDiscordProvider({
-      config: baseConfig(),
-      runtime,
-    });
-
-    const messages = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0]));
-    expect(messages.some((msg) => msg.includes("discord startup ["))).toBe(false);
   });
 });

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -50,7 +50,21 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordAccount } from "../accounts.js";
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+import {
+  forgetDiscordManagedBotIdentity,
+  rememberDiscordManagedBotIdentity,
+  resolveDiscordAccount,
+} from "../accounts.js";
 import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
@@ -97,6 +111,7 @@ import {
   reconcileAcpThreadBindingsOnStartup,
 } from "./thread-bindings.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+import { normalizeDiscordInboundWorkerTimeoutMs } from "./timeouts.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -159,6 +174,15 @@ function appendPluginCommandSpecs(params: {
 
 const DISCORD_ACP_STATUS_PROBE_TIMEOUT_MS = 8_000;
 const DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS = 2 * 60 * 1000;
+const DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS = 15_000;
+
+function resolveDiscordMessageHandlerIdleTimeoutMs(raw: number | undefined): number {
+  const normalized = normalizeDiscordInboundWorkerTimeoutMs(raw);
+  if (!normalized) {
+    return DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS;
+  }
+  return Math.min(normalized, DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS);
+}
 
 function isLegacyMissingSessionError(message: string): boolean {
   return (
@@ -628,9 +652,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let lifecycleStarted = false;
   let releaseEarlyGatewayErrorGuard = () => {};
   let deactivateMessageHandler: (() => void) | undefined;
+  let waitForMessageHandlerIdle: (() => Promise<void>) | undefined;
   let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
   let earlyGatewayEmitter: ReturnType<typeof getDiscordGatewayEmitter> | undefined;
   let onEarlyGatewayDebug: ((msg: unknown) => void) | undefined;
+  let botUserId: string | undefined;
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -824,7 +850,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     const logger = createSubsystemLogger("discord/monitor");
     const guildHistories = new Map<string, HistoryEntry[]>();
-    let botUserId: string | undefined;
     let botUserName: string | undefined;
     let voiceManager: DiscordVoiceManager | null = null;
 
@@ -861,6 +886,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       const botUser = await client.fetchUser("@me");
       botUserId = botUser?.id;
       botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+      if (botUserId) {
+        rememberDiscordManagedBotIdentity({
+          botUserId,
+          accountId: account.accountId,
+        });
+      }
       logDiscordStartupPhase({
         runtime,
         accountId: account.accountId,
@@ -919,6 +950,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       discordRestFetch,
     });
     deactivateMessageHandler = messageHandler.deactivate;
+    waitForMessageHandlerIdle = messageHandler.waitForIdle;
     const trackInboundEvent = opts.setStatus
       ? () => {
           const at = Date.now();
@@ -993,6 +1025,24 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
   } finally {
     deactivateMessageHandler?.();
+    if (waitForMessageHandlerIdle) {
+      const idleTimeoutMs = resolveDiscordMessageHandlerIdleTimeoutMs(
+        discordCfg.inboundWorker?.runTimeoutMs,
+      );
+      try {
+        await withTimeout(waitForMessageHandlerIdle(), idleTimeoutMs);
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message === "timeout"
+            ? `discord: inbound handler did not drain within ${idleTimeoutMs}ms during teardown; continuing shutdown`
+            : `discord: inbound handler idle wait failed during teardown: ${formatErrorMessage(error)}`;
+        runtime.log?.(warn(message));
+      }
+    }
+    forgetDiscordManagedBotIdentity({
+      botUserId,
+      accountId: account.accountId,
+    });
     autoPresenceController?.stop();
     opts.setStatus?.({ connected: false });
     if (onEarlyGatewayDebug) {

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/loader.js", () => ({
+  loadOpenClawPlugins,
+}));
+
+import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
+
+afterEach(() => {
+  loadOpenClawPlugins.mockReset();
+});
+
+describe("ensureRuntimePluginsLoaded", () => {
+  test("opts into shared runtime inheritance", () => {
+    const config = { plugins: { enabled: true } };
+
+    ensureRuntimePluginsLoaded({
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config,
+        inheritSharedRuntimeOptions: true,
+      }),
+    );
+  });
+});

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -20,5 +20,6 @@ export function ensureRuntimePluginsLoaded(params: {
           allowGatewaySubagentBinding: true,
         }
       : undefined,
+    inheritSharedRuntimeOptions: true,
   });
 }

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -123,6 +123,8 @@ export type MsgContext = {
   /** Explicit owner allowlist overrides (trusted, configuration-derived). */
   OwnerAllowFrom?: Array<string | number>;
   SenderName?: string;
+  /** Provider-managed account id when the inbound sender is one of our configured bot accounts. */
+  SenderManagedAccountId?: string;
   SenderId?: string;
   SenderUsername?: string;
   SenderTag?: string;

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -2,7 +2,6 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
-import { buildPluginCompatibilityWarnings } from "../plugins/status.js";
 import { note } from "../terminal/note.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
@@ -62,17 +61,6 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
     }
 
     note(lines.join("\n"), "Plugins");
-  }
-  const compatibilityWarnings = buildPluginCompatibilityWarnings({
-    config: cfg,
-    workspaceDir,
-    report: {
-      workspaceDir,
-      ...pluginRegistry,
-    },
-  });
-  if (compatibilityWarnings.length > 0) {
-    note(compatibilityWarnings.map((line) => `- ${line}`).join("\n"), "Plugin compatibility");
   }
   if (pluginRegistry.diagnostics.length > 0) {
     const lines = pluginRegistry.diagnostics.map((diag) => {

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -14,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   probeGateway: vi.fn(),
   resolveGatewayProbeAuthResolution: vi.fn(),
   ensurePluginRegistryLoaded: vi.fn(),
-  buildPluginCompatibilityNotices: vi.fn(() => []),
 }));
 
 beforeEach(() => {
@@ -90,10 +89,6 @@ vi.mock("../process/exec.js", () => ({
 
 vi.mock("../cli/plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: mocks.ensurePluginRegistryLoaded,
-}));
-
-vi.mock("../plugins/status.js", () => ({
-  buildPluginCompatibilityNotices: mocks.buildPluginCompatibilityNotices,
 }));
 
 import { scanStatus } from "./status.scan.js";
@@ -355,14 +350,14 @@ describe("scanStatus", () => {
       session: {},
       plugins: { enabled: false },
       gateway: {},
-      channels: { telegram: { enabled: false } },
+      channels: { telegram: { enabled: false, botToken: "token" } },
     });
     mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
       resolvedConfig: {
         session: {},
         plugins: { enabled: false },
         gateway: {},
-        channels: { telegram: { enabled: false } },
+        channels: { telegram: { enabled: false, botToken: "token" } },
       },
       diagnostics: [],
     });

--- a/src/gateway/agent-abort.ts
+++ b/src/gateway/agent-abort.ts
@@ -1,0 +1,51 @@
+export type AgentAbortControllerEntry = {
+  controller: AbortController;
+  sessionKey?: string;
+  startedAtMs: number;
+  expiresAtMs: number;
+};
+
+export function resolveAgentRunExpiresAtMs(params: {
+  now: number;
+  timeoutMs?: number;
+  graceMs?: number;
+  minMs?: number;
+  maxMs?: number;
+}): number {
+  const {
+    now,
+    timeoutMs = 0,
+    graceMs = 60_000,
+    minMs = 2 * 60_000,
+    maxMs = 24 * 60 * 60_000,
+  } = params;
+  const boundedTimeoutMs = Math.max(0, timeoutMs);
+  // Preserve no-timeout semantics: if the caller explicitly requested a timeout
+  // longer than the default max (including timeout=0 → MAX_SAFE_TIMEOUT_MS),
+  // skip the 24h cap to avoid force-aborting long-running workflows.
+  if (boundedTimeoutMs > maxMs) {
+    return now + boundedTimeoutMs + graceMs;
+  }
+  const target = now + boundedTimeoutMs + graceMs;
+  const min = now + minMs;
+  const max = now + maxMs;
+  return Math.min(max, Math.max(min, target));
+}
+
+export function abortAgentRunById(params: {
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
+  runId: string;
+  sessionKey?: string;
+  reason?: unknown;
+}): { aborted: boolean } {
+  const active = params.agentAbortControllers.get(params.runId);
+  if (!active) {
+    return { aborted: false };
+  }
+  if (active.sessionKey && params.sessionKey !== active.sessionKey) {
+    return { aborted: false };
+  }
+  active.controller.abort(params.reason);
+  params.agentAbortControllers.delete(params.runId);
+  return { aborted: true };
+}

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -45,6 +45,16 @@ describe("operator scope authorization", () => {
     });
   });
 
+  it("requires admin for agent.abort", () => {
+    expect(authorizeOperatorScopesForMethod("agent.abort", ["operator.write"])).toEqual({
+      allowed: false,
+      missingScope: "operator.admin",
+    });
+    expect(authorizeOperatorScopesForMethod("agent.abort", ["operator.admin"])).toEqual({
+      allowed: true,
+    });
+  });
+
   it("requires approvals scope for approval methods", () => {
     expect(authorizeOperatorScopesForMethod("exec.approval.resolve", ["operator.write"])).toEqual({
       allowed: false,

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -91,6 +91,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "send",
     "poll",
     "agent",
+    "agent.enqueue",
     "agent.wait",
     "wake",
     "talk.mode",
@@ -107,6 +108,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "node.pending.enqueue",
   ],
   [ADMIN_SCOPE]: [
+    "agent.abort",
     "channels.logout",
     "agents.create",
     "agents.update",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -1,6 +1,8 @@
 import AjvPkg, { type ErrorObject } from "ajv";
 import type { SessionsPatchResult } from "../session-utils.types.js";
 import {
+  type AgentAbortParams,
+  AgentAbortParamsSchema,
   type AgentEvent,
   AgentEventSchema,
   type AgentIdentityParams,
@@ -263,6 +265,7 @@ export const validateEventFrame = ajv.compile<EventFrame>(EventFrameSchema);
 export const validateSendParams = ajv.compile(SendParamsSchema);
 export const validatePollParams = ajv.compile<PollParams>(PollParamsSchema);
 export const validateAgentParams = ajv.compile(AgentParamsSchema);
+export const validateAgentAbortParams = ajv.compile<AgentAbortParams>(AgentAbortParamsSchema);
 export const validateAgentIdentityParams =
   ajv.compile<AgentIdentityParams>(AgentIdentityParamsSchema);
 export const validateAgentWaitParams = ajv.compile<AgentWaitParams>(AgentWaitParamsSchema);
@@ -469,6 +472,7 @@ export {
   ErrorShapeSchema,
   StateVersionSchema,
   AgentEventSchema,
+  AgentAbortParamsSchema,
   ChatEventSchema,
   SendParamsSchema,
   PollParamsSchema,
@@ -575,6 +579,7 @@ export type {
   ErrorShape,
   StateVersion,
   AgentEvent,
+  AgentAbortParams,
   AgentIdentityParams,
   AgentIdentityResult,
   AgentWaitParams,

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -130,6 +130,14 @@ export const AgentWaitParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const AgentAbortParamsSchema = Type.Object(
+  {
+    runId: NonEmptyString,
+    sessionKey: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const WakeParamsSchema = Type.Object(
   {
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -1,5 +1,6 @@
 import type { TSchema } from "@sinclair/typebox";
 import {
+  AgentAbortParamsSchema,
   AgentEventSchema,
   AgentIdentityParamsSchema,
   AgentIdentityResultSchema,
@@ -174,6 +175,7 @@ export const ProtocolSchemas = {
   SendParams: SendParamsSchema,
   PollParams: PollParamsSchema,
   AgentParams: AgentParamsSchema,
+  AgentAbortParams: AgentAbortParamsSchema,
   AgentIdentityParams: AgentIdentityParamsSchema,
   AgentIdentityResult: AgentIdentityResultSchema,
   AgentWaitParams: AgentWaitParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -18,6 +18,7 @@ export type AgentEvent = SchemaType<"AgentEvent">;
 export type AgentIdentityParams = SchemaType<"AgentIdentityParams">;
 export type AgentIdentityResult = SchemaType<"AgentIdentityResult">;
 export type PollParams = SchemaType<"PollParams">;
+export type AgentAbortParams = SchemaType<"AgentAbortParams">;
 export type AgentWaitParams = SchemaType<"AgentWaitParams">;
 export type WakeParams = SchemaType<"WakeParams">;
 export type NodePairRequestParams = SchemaType<"NodePairRequestParams">;

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -22,6 +22,7 @@ function createMaintenanceTimerDeps() {
     refreshGatewayHealthSnapshot: async () => ({ ok: true }) as HealthSummary,
     logHealth: { error: () => {} },
     dedupe: new Map(),
+    agentAbortControllers: new Map(),
     chatAbortControllers: new Map(),
     chatRunState: { abortedRuns: new Map() },
     chatRunBuffers: new Map(),

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,5 +1,6 @@
 import type { HealthSummary } from "../commands/health.js";
 import { cleanOldMedia } from "../media/store.js";
+import { abortAgentRunById, type AgentAbortControllerEntry } from "./agent-abort.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
@@ -27,6 +28,7 @@ export function startGatewayMaintenanceTimers(params: {
   refreshGatewayHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   logHealth: { error: (msg: string) => void };
   dedupe: Map<string, DedupeEntry>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunState: { abortedRuns: Map<string, number> };
   chatRunBuffers: Map<string, string>;
@@ -100,6 +102,18 @@ export function startGatewayMaintenanceTimers(params: {
           break;
         }
       }
+    }
+
+    for (const [runId, entry] of params.agentAbortControllers) {
+      if (now <= entry.expiresAtMs) {
+        continue;
+      }
+      abortAgentRunById({
+        agentAbortControllers: params.agentAbortControllers,
+        runId,
+        sessionKey: entry.sessionKey,
+        reason: "timeout",
+      });
     }
 
     for (const [runId, entry] of params.chatAbortControllers) {

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -96,6 +96,8 @@ const BASE_METHODS = [
   "system-event",
   "send",
   "agent",
+  "agent.enqueue",
+  "agent.abort",
   "agent.identity.get",
   "agent.wait",
   "browser.request",

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../utils/delivery-context.js", async () => {
 
 const makeContext = (): GatewayRequestContext =>
   ({
+    agentAbortControllers: new Map(),
     dedupe: new Map(),
     addChatRun: vi.fn(),
     logGateway: { info: vi.fn(), error: vi.fn() },
@@ -618,6 +619,148 @@ describe("gateway agent handler", () => {
     // Should be undefined, not cause an error
     expect(capturedEntry?.cliSessionIds).toBeUndefined();
     expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("aborts active agent runs by run id", () => {
+    const respond = vi.fn();
+    const controller = new AbortController();
+    const context = makeContext();
+    context.agentAbortControllers.set("run-1", {
+      controller,
+      sessionKey: "agent:main:main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    void agentHandlers["agent.abort"]({
+      params: { runId: "run-1", sessionKey: "agent:main:main" },
+      respond: respond as never,
+      context,
+      req: { type: "req", id: "agent-abort-1", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(context.agentAbortControllers.has("run-1")).toBe(false);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, aborted: true, runId: "run-1" });
+    mocks.loadConfigReturn = {};
+  });
+
+  it("does not abort a session-bound run when sessionKey is omitted", async () => {
+    const respond = vi.fn();
+    const controller = new AbortController();
+    const context = makeContext();
+    context.agentAbortControllers.set("run-1", {
+      controller,
+      sessionKey: "agent:main:main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    await agentHandlers["agent.abort"]({
+      params: { runId: "run-1" },
+      respond: respond as never,
+      context,
+      req: { type: "req", id: "agent-abort-missing-session", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(context.agentAbortControllers.has("run-1")).toBe(true);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, aborted: false, runId: "run-1" });
+  });
+
+  it("canonicalizes alias session keys before aborting agent runs", async () => {
+    mocks.loadConfigReturn = { session: { mainKey: "work" } };
+    const respond = vi.fn();
+    const controller = new AbortController();
+    const context = makeContext();
+    context.agentAbortControllers.set("run-1", {
+      controller,
+      sessionKey: "agent:main:work",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    await agentHandlers["agent.abort"]({
+      params: { runId: "run-1", sessionKey: "main" },
+      respond: respond as never,
+      context,
+      req: { type: "req", id: "agent-abort-alias-session", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(context.agentAbortControllers.has("run-1")).toBe(false);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, aborted: true, runId: "run-1" });
+    mocks.loadConfigReturn = {};
+  });
+
+  it("keeps a newer abort controller entry when an older run with the same id finishes", async () => {
+    mockMainSessionEntry({ sessionId: "existing-session-id" });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+
+    let resolveOlderRun:
+      | ((value: { payloads: Array<{ text: string }>; meta: { durationMs: number } }) => void)
+      | undefined;
+    mocks.agentCommand.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOlderRun = resolve;
+        }),
+    );
+
+    const context = makeContext();
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "older run",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "shared-run-id",
+      },
+      { respond, reqId: "shared-run-id", context },
+    );
+
+    const olderEntry = context.agentAbortControllers.get("shared-run-id");
+    expect(olderEntry).toBeDefined();
+
+    const newerController = new AbortController();
+    context.agentAbortControllers.set("shared-run-id", {
+      controller: newerController,
+      sessionKey: "agent:main:main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    resolveOlderRun?.({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    await vi.waitFor(() => expect(respond).toHaveBeenCalledTimes(2));
+
+    expect(context.agentAbortControllers.get("shared-run-id")?.controller).toBe(newerController);
+
+    const abortRespond = vi.fn();
+    await agentHandlers["agent.abort"]({
+      params: { runId: "shared-run-id", sessionKey: "agent:main:main" },
+      respond: abortRespond as never,
+      context,
+      req: { type: "req", id: "agent-abort-shared", method: "agent.abort" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(newerController.signal.aborted).toBe(true);
+    expect(context.agentAbortControllers.has("shared-run-id")).toBe(false);
+    expect(abortRespond).toHaveBeenCalledWith(true, {
+      ok: true,
+      aborted: true,
+      runId: "shared-run-id",
+    });
   });
 
   it("prunes legacy main alias keys when writing a canonical session entry", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -5,6 +5,7 @@ import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
@@ -26,6 +27,7 @@ import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -33,6 +35,7 @@ import {
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { abortAgentRunById, resolveAgentRunExpiresAtMs } from "../agent-abort.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
@@ -42,6 +45,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validateAgentAbortParams,
   validateAgentIdentityParams,
   validateAgentParams,
   validateAgentWaitParams,
@@ -99,10 +103,55 @@ async function runSessionResetFromAgent(params: {
   };
 }
 
+function canonicalizeAbortSessionKey(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  activeSessionKey?: string;
+  requestedSessionKey?: string;
+}): string | undefined {
+  const raw = params.requestedSessionKey?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  if (lowered.startsWith("agent:")) {
+    const parsed = parseAgentSessionKey(lowered);
+    if (parsed) {
+      const canonicalMainKey = resolveAgentMainSessionKey({
+        cfg: params.cfg,
+        agentId: parsed.agentId,
+      }).toLowerCase();
+      const configuredMainAlias = canonicalMainKey.split(":").slice(2).join(":");
+      if (parsed.rest === "main" || parsed.rest === configuredMainAlias) {
+        return canonicalMainKey;
+      }
+    }
+    return lowered;
+  }
+  const activeAgentId =
+    (params.activeSessionKey ? resolveAgentIdFromSessionKey(params.activeSessionKey) : undefined) ??
+    resolveAgentIdFromSessionKey(lowered);
+  if (!activeAgentId) {
+    return lowered;
+  }
+  const canonicalMainKey = resolveAgentMainSessionKey({
+    cfg: params.cfg,
+    agentId: activeAgentId,
+  }).toLowerCase();
+  const configuredMainAlias = canonicalMainKey.split(":").slice(2).join(":");
+  if (lowered === "main" || lowered === configuredMainAlias) {
+    return canonicalMainKey;
+  }
+  return `agent:${normalizeAgentId(activeAgentId)}:${lowered}`;
+}
+
 function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
   idempotencyKey: string;
+  abortController: AbortController;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
 }) {
@@ -148,6 +197,12 @@ function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         error: formatForLog(err),
       });
+    })
+    .finally(() => {
+      const active = params.context.agentAbortControllers.get(params.runId);
+      if (active?.controller === params.abortController) {
+        params.context.agentAbortControllers.delete(params.runId);
+      }
     });
 }
 
@@ -584,11 +639,25 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
 
+    const acceptedAt = Date.now();
     const accepted = {
       runId,
       status: "accepted" as const,
-      acceptedAt: Date.now(),
+      acceptedAt,
     };
+    const agentAbortController = new AbortController();
+    context.agentAbortControllers.set(runId, {
+      controller: agentAbortController,
+      sessionKey: resolvedSessionKey,
+      startedAtMs: acceptedAt,
+      expiresAtMs: resolveAgentRunExpiresAtMs({
+        now: acceptedAt,
+        timeoutMs: resolveAgentTimeoutMs({
+          cfg: cfgForAgent ?? cfg,
+          overrideSeconds: request.timeout,
+        }),
+      }),
+    });
     // Store an in-flight ack so retries do not spawn a second run.
     setGatewayDedupeEntry({
       dedupe: context.dedupe,
@@ -638,6 +707,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         extraSystemPrompt: request.extraSystemPrompt,
         internalEvents: request.internalEvents,
         inputProvenance,
+        abortSignal: agentAbortController.signal,
         // Internal-only: allow workspace override for spawned subagent runs.
         workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
           spawnedBy: spawnedByValue,
@@ -648,9 +718,44 @@ export const agentHandlers: GatewayRequestHandlers = {
       },
       runId,
       idempotencyKey: idem,
+      abortController: agentAbortController,
       respond,
       context,
     });
+  },
+  "agent.enqueue": async ({ req, params, respond, context, client, isWebchatConnect }) => {
+    await agentHandlers.agent({ req, params, respond, context, client, isWebchatConnect });
+  },
+  "agent.abort": ({ params, respond, context }) => {
+    if (!validateAgentAbortParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid agent.abort params: ${formatValidationErrors(validateAgentAbortParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const request = params as { runId: string; sessionKey?: string };
+    const runId = request.runId.trim();
+    const activeSessionKey = context.agentAbortControllers.get(runId)?.sessionKey;
+    const sessionKey = canonicalizeAbortSessionKey({
+      cfg: loadConfig(),
+      activeSessionKey,
+      requestedSessionKey:
+        typeof request.sessionKey === "string" && request.sessionKey.trim()
+          ? request.sessionKey.trim()
+          : undefined,
+    });
+    const result = abortAgentRunById({
+      agentAbortControllers: context.agentAbortControllers,
+      runId,
+      sessionKey,
+      reason: "rpc",
+    });
+    respond(true, { ok: true, aborted: result.aborted, runId });
   },
   "agent.identity.get": ({ params, respond }) => {
     if (!validateAgentIdentityParams(params)) {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -252,6 +252,7 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
     runtimeOptions: {
       allowGatewaySubagentBinding: true,
     },
+    inheritSharedRuntimeOptions: true,
     logger: {
       info: () => {},
       warn: () => {},

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -4,6 +4,7 @@ import type { HealthSummary } from "../../commands/health.js";
 import type { CronService } from "../../cron/service.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
+import type { AgentAbortControllerEntry } from "../agent-abort.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { NodeRegistry } from "../node-registry.js";
@@ -57,6 +58,7 @@ export type GatewayRequestContext = {
   hasExecApprovalClients?: () => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  clearSharedPluginRuntimeOptions,
+  getSharedPluginRuntimeOptions,
+  setSharedPluginRuntimeOptions,
+} from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
@@ -84,6 +89,24 @@ function getLastDispatchedClientScopes(): string[] {
   return Array.isArray(scopes) ? scopes : [];
 }
 
+function getLastDispatchedRequest():
+  | { method: string; params?: Record<string, unknown> }
+  | undefined {
+  const call = handleGatewayRequest.mock.calls.at(-1)?.[0];
+  const req = call?.req;
+  if (!req) {
+    return undefined;
+  }
+  const params =
+    "params" in req && req.params != null && typeof req.params === "object"
+      ? (req.params as Record<string, unknown>)
+      : undefined;
+  return {
+    method: req.method,
+    params,
+  };
+}
+
 async function importServerPluginsModule(): Promise<ServerPluginsModule> {
   return import("./server-plugins.js");
 }
@@ -125,6 +148,7 @@ beforeEach(async () => {
   handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
     switch (opts.req.method) {
       case "agent":
+      case "agent.enqueue":
         opts.respond(true, { runId: "run-1" });
         return;
       case "agent.wait":
@@ -145,6 +169,7 @@ beforeEach(async () => {
 afterEach(async () => {
   const runtimeModule = await import("../plugins/runtime/index.js");
   runtimeModule.clearGatewaySubagentRuntime();
+  clearSharedPluginRuntimeOptions();
   vi.resetModules();
 });
 
@@ -296,27 +321,6 @@ describe("loadGatewayPlugins", () => {
       provider: "anthropic",
       model: "claude-haiku-4-5",
     });
-  });
-
-  test("includes docs guidance when a plugin fallback override is not trusted", async () => {
-    const serverPlugins = await importServerPluginsModule();
-    const runtime = await createSubagentRuntime(serverPlugins);
-    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-untrusted-plugin"));
-    const gatewayScopeModule = await import("../plugins/runtime/gateway-request-scope.js");
-
-    await expect(
-      gatewayScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
-        runtime.run({
-          sessionKey: "s-untrusted-override",
-          message: "use untrusted override",
-          provider: "anthropic",
-          model: "claude-haiku-4-5",
-          deliver: false,
-        }),
-      ),
-    ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
-    );
   });
 
   test("allows trusted fallback model-only overrides when the model ref is canonical", async () => {
@@ -524,6 +528,81 @@ describe("loadGatewayPlugins", () => {
     expect(log.error).not.toHaveBeenCalled();
     expect(log.info).not.toHaveBeenCalled();
   });
+
+  test("publishes shared runtime options for later plugin reloads", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+
+    expect(typeof getSharedPluginRuntimeOptions()?.subagent?.run).toBe("function");
+  });
+
+  test("rolls back shared runtime options when plugin loading fails", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("plugin load failed");
+    });
+
+    expect(() =>
+      loadGatewayPlugins({
+        cfg: {},
+        workspaceDir: "/tmp",
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        coreGatewayHandlers: {},
+        baseMethods: [],
+      }),
+    ).toThrow("plugin load failed");
+
+    expect(getSharedPluginRuntimeOptions()).toBeUndefined();
+  });
+
+  test("restores previous shared runtime options when plugin loading fails", async () => {
+    const { loadGatewayPlugins } = await importServerPluginsModule();
+    const previousRuntime = {
+      subagent: {
+        run: vi.fn(),
+      },
+    } as unknown as NonNullable<ReturnType<typeof getSharedPluginRuntimeOptions>>;
+    setSharedPluginRuntimeOptions(previousRuntime);
+    loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("plugin load failed");
+    });
+
+    expect(() =>
+      loadGatewayPlugins({
+        cfg: {},
+        workspaceDir: "/tmp",
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        coreGatewayHandlers: {},
+        baseMethods: [],
+      }),
+    ).toThrow("plugin load failed");
+
+    expect(getSharedPluginRuntimeOptions()).toBe(previousRuntime);
+  });
+
   test("shares fallback context across module reloads for existing runtimes", async () => {
     const first = await importServerPluginsModule();
     const runtime = await createSubagentRuntime(first);
@@ -572,5 +651,55 @@ describe("loadGatewayPlugins", () => {
       | (GatewayRequestContext & { marker: string })
       | undefined;
     expect(dispatched?.marker).toBe("after-mutation");
+  });
+
+  test("mints idempotency keys for plugin subagent requests when absent", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("idempotency-generated"));
+
+    await runtime.run({ sessionKey: "s-run", message: "hello" });
+    const runRequest = getLastDispatchedRequest();
+    expect(runRequest?.method).toBe("agent");
+    expect(runRequest?.params).toMatchObject({
+      sessionKey: "s-run",
+      message: "hello",
+      deliver: false,
+    });
+    expect(runRequest?.params?.idempotencyKey).toEqual(
+      expect.stringMatching(/^plugin-subagent:agent:s-run:/),
+    );
+
+    await runtime.enqueue({ sessionKey: "s-enqueue", message: "queued" });
+    const enqueueRequest = getLastDispatchedRequest();
+    expect(enqueueRequest?.method).toBe("agent.enqueue");
+    expect(enqueueRequest?.params).toMatchObject({
+      sessionKey: "s-enqueue",
+      message: "queued",
+      deliver: false,
+    });
+    expect(enqueueRequest?.params?.idempotencyKey).toEqual(
+      expect.stringMatching(/^plugin-subagent:agent\.enqueue:s-enqueue:/),
+    );
+  });
+
+  test("preserves caller-provided idempotency keys for plugin subagent requests", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("idempotency-preserved"));
+
+    await runtime.run({
+      sessionKey: "s-run",
+      message: "hello",
+      idempotencyKey: "plugin-run-idem",
+    });
+    expect(getLastDispatchedRequest()?.params?.idempotencyKey).toBe("plugin-run-idem");
+
+    await runtime.enqueue({
+      sessionKey: "s-enqueue",
+      message: "queued",
+      idempotencyKey: "plugin-enqueue-idem",
+    });
+    expect(getLastDispatchedRequest()?.params?.idempotencyKey).toBe("plugin-enqueue-idem");
   });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -6,6 +6,11 @@ import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
+import {
+  clearSharedPluginRuntimeOptions,
+  getSharedPluginRuntimeOptions,
+  setSharedPluginRuntimeOptions,
+} from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
@@ -155,10 +160,7 @@ function authorizeFallbackModelOverride(params: {
   if (!policy?.allowModelOverride) {
     return {
       allowed: false,
-      reason:
-        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
-        "plugins.entries.<id>.subagent.allowModelOverride",
+      reason: `plugin "${pluginId}" is not trusted for fallback provider/model override requests.`,
     };
   }
   if (policy.allowAnyModel) {
@@ -292,6 +294,18 @@ async function dispatchGatewayMethod<T>(
   return result.payload as T;
 }
 
+function resolvePluginSubagentIdempotencyKey(params: {
+  idempotencyKey?: string;
+  sessionKey: string;
+  method: "agent" | "agent.enqueue";
+}): string {
+  const provided = typeof params.idempotencyKey === "string" ? params.idempotencyKey.trim() : "";
+  if (provided) {
+    return provided;
+  }
+  return `plugin-subagent:${params.method}:${params.sessionKey}:${randomUUID()}`;
+}
+
 function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
   const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
     const payload = await dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
@@ -329,11 +343,15 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           sessionKey: params.sessionKey,
           message: params.message,
           deliver: params.deliver ?? false,
+          idempotencyKey: resolvePluginSubagentIdempotencyKey({
+            idempotencyKey: params.idempotencyKey,
+            sessionKey: params.sessionKey,
+            method: "agent",
+          }),
           ...(allowOverride && params.provider && { provider: params.provider }),
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
-          ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
         },
         {
           allowSyntheticModelOverride,
@@ -344,6 +362,68 @@ function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         throw new Error("Gateway agent method returned an invalid runId.");
       }
       return { runId };
+    },
+    async enqueue(params) {
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const overrideRequested = Boolean(params.provider || params.model);
+      const hasRequestScopeClient = Boolean(scope?.client);
+      let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
+      let allowSyntheticModelOverride = false;
+      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
+        const fallbackAuth = authorizeFallbackModelOverride({
+          pluginId: scope?.pluginId,
+          provider: params.provider,
+          model: params.model,
+        });
+        if (!fallbackAuth.allowed) {
+          throw new Error(fallbackAuth.reason);
+        }
+        allowOverride = true;
+        allowSyntheticModelOverride = true;
+      }
+      if (overrideRequested && !allowOverride) {
+        throw new Error(
+          "provider/model override is not authorized for this plugin subagent enqueue.",
+        );
+      }
+      const payload = await dispatchGatewayMethod<{ runId?: string }>(
+        "agent.enqueue",
+        {
+          sessionKey: params.sessionKey,
+          message: params.message,
+          deliver: params.deliver ?? false,
+          idempotencyKey: resolvePluginSubagentIdempotencyKey({
+            idempotencyKey: params.idempotencyKey,
+            sessionKey: params.sessionKey,
+            method: "agent.enqueue",
+          }),
+          ...(allowOverride && params.provider && { provider: params.provider }),
+          ...(allowOverride && params.model && { model: params.model }),
+          ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+          ...(params.lane && { lane: params.lane }),
+        },
+        {
+          allowSyntheticModelOverride,
+        },
+      );
+      const runId = payload?.runId;
+      if (typeof runId !== "string" || !runId) {
+        throw new Error("Gateway agent.enqueue method returned an invalid runId.");
+      }
+      return { runId };
+    },
+    async abort(params) {
+      const payload = await dispatchGatewayMethod<{ aborted?: boolean }>(
+        "agent.abort",
+        {
+          runId: params.runId,
+          ...(params.sessionKey && { sessionKey: params.sessionKey }),
+        },
+        {
+          syntheticScopes: [ADMIN_SCOPE],
+        },
+      );
+      return { aborted: payload?.aborted === true };
     },
     async waitForRun(params) {
       const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
@@ -398,29 +478,42 @@ export function loadGatewayPlugins(params: {
   logDiagnostics?: boolean;
 }) {
   setPluginSubagentOverridePolicies(params.cfg);
-  // Set the process-global gateway subagent runtime BEFORE loading plugins.
+  // Set the process-global gateway subagent runtime before loading plugins.
   // Gateway-owned registries may already exist from schema loads, so the
   // gateway path opts those runtimes into late binding rather than changing
   // the default subagent behavior for every plugin runtime in the process.
-  const gatewaySubagent = createGatewaySubagentRuntime();
-  setGatewaySubagentRuntime(gatewaySubagent);
-
-  const pluginRegistry = loadOpenClawPlugins({
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    logger: {
-      info: (msg) => params.log.info(msg),
-      warn: (msg) => params.log.warn(msg),
-      error: (msg) => params.log.error(msg),
-      debug: (msg) => params.log.debug(msg),
-    },
-    coreGatewayHandlers: params.coreGatewayHandlers,
-    runtimeOptions: {
-      allowGatewaySubagentBinding: true,
-    },
-    preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+  const gatewaySubagentRuntime = createGatewaySubagentRuntime();
+  setGatewaySubagentRuntime(gatewaySubagentRuntime);
+  const previousSharedRuntimeOptions = getSharedPluginRuntimeOptions();
+  setSharedPluginRuntimeOptions({
+    subagent: gatewaySubagentRuntime,
   });
   primeConfiguredBindingRegistry({ cfg: params.cfg });
+  let pluginRegistry;
+  try {
+    pluginRegistry = loadOpenClawPlugins({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      logger: {
+        info: (msg) => params.log.info(msg),
+        warn: (msg) => params.log.warn(msg),
+        error: (msg) => params.log.error(msg),
+        debug: (msg) => params.log.debug(msg),
+      },
+      coreGatewayHandlers: params.coreGatewayHandlers,
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+    });
+  } catch (error) {
+    if (previousSharedRuntimeOptions) {
+      setSharedPluginRuntimeOptions(previousSharedRuntimeOptions);
+    } else {
+      clearSharedPluginRuntimeOptions();
+    }
+    throw error;
+  }
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);
   const gatewayMethods = Array.from(new Set([...params.baseMethods, ...pluginMethods]));
   if ((params.logDiagnostics ?? true) && pluginRegistry.diagnostics.length > 0) {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -11,6 +11,7 @@ import {
   resolveActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { AgentAbortControllerEntry } from "./agent-abort.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
@@ -84,6 +85,7 @@ export async function createGatewayRuntimeState(params: {
   broadcast: GatewayBroadcastFn;
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   agentRunSeq: Map<string, number>;
+  agentAbortControllers: Map<string, AgentAbortControllerEntry>;
   dedupe: Map<string, DedupeEntry>;
   chatRunState: ReturnType<typeof createChatRunState>;
   chatRunBuffers: Map<string, string>;
@@ -216,6 +218,7 @@ export async function createGatewayRuntimeState(params: {
     }
 
     const agentRunSeq = new Map<string, number>();
+    const agentAbortControllers = new Map<string, AgentAbortControllerEntry>();
     const dedupe = new Map<string, DedupeEntry>();
     const chatRunState = createChatRunState();
     const chatRunRegistry = chatRunState.registry;
@@ -237,6 +240,7 @@ export async function createGatewayRuntimeState(params: {
       broadcast,
       broadcastToConnIds,
       agentRunSeq,
+      agentAbortControllers,
       dedupe,
       chatRunState,
       chatRunBuffers,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -50,6 +50,7 @@ import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-pl
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { clearSharedPluginRuntimeOptions } from "../plugins/runtime/shared-runtime-options.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -645,6 +646,7 @@ export async function startGatewayServer(
     broadcast,
     broadcastToConnIds,
     agentRunSeq,
+    agentAbortControllers,
     dedupe,
     chatRunState,
     chatRunBuffers,
@@ -768,6 +770,7 @@ export async function startGatewayServer(
       refreshGatewayHealthSnapshot,
       logHealth,
       dedupe,
+      agentAbortControllers,
       chatAbortControllers,
       chatRunState,
       chatRunBuffers,
@@ -907,6 +910,7 @@ export async function startGatewayServer(
     },
     nodeRegistry,
     agentRunSeq,
+    agentAbortControllers,
     chatAbortControllers,
     chatAbortedRuns: chatRunState.abortedRuns,
     chatRunBuffers: chatRunState.buffers,
@@ -1147,6 +1151,7 @@ export async function startGatewayServer(
       authRateLimiter?.dispose();
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
+      clearSharedPluginRuntimeOptions();
       clearSecretsRuntimeSnapshot();
       await close(opts);
     },

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -171,6 +171,9 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       messageId: "out-1",
+      threadId: "thread-1",
+      sessionKey: "agent:agent-1:telegram:chat:456",
+      agentId: "agent-1",
       isGroup: true,
       groupId: "telegram:chat:456",
     });
@@ -185,6 +188,17 @@ describe("message hook mappers", () => {
       content: "reply",
       success: false,
       error: "network error",
+      metadata: {
+        channel: "telegram",
+        accountId: "acc-1",
+        conversationId: "telegram:chat:456",
+        messageId: "out-1",
+        threadId: "thread-1",
+        sessionKey: "agent:agent-1:telegram:chat:456",
+        agentId: "agent-1",
+        isGroup: true,
+        groupId: "telegram:chat:456",
+      },
     });
     expect(toInternalMessageSentContext(canonical)).toEqual({
       to: "telegram:chat:456",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -28,6 +28,7 @@ export type CanonicalInboundMessageHookContext = {
   messageId?: string;
   senderId?: string;
   senderName?: string;
+  senderManagedAccountId?: string;
   senderUsername?: string;
   senderE164?: string;
   provider?: string;
@@ -52,6 +53,9 @@ export type CanonicalSentMessageHookContext = {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 };
@@ -97,6 +101,7 @@ export function deriveInboundMessageHookContext(
       ctx.MessageSidLast,
     senderId: ctx.SenderId,
     senderName: ctx.SenderName,
+    senderManagedAccountId: ctx.SenderManagedAccountId,
     senderUsername: ctx.SenderUsername,
     senderE164: ctx.SenderE164,
     provider: ctx.Provider,
@@ -122,6 +127,9 @@ export function buildCanonicalSentMessageHookContext(params: {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 }): CanonicalSentMessageHookContext {
@@ -134,6 +142,9 @@ export function buildCanonicalSentMessageHookContext(params: {
     accountId: params.accountId,
     conversationId: params.conversationId ?? params.to,
     messageId: params.messageId,
+    threadId: params.threadId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     isGroup: params.isGroup,
     groupId: params.groupId,
   };
@@ -296,6 +307,7 @@ export function toPluginMessageReceivedEvent(
       messageId: canonical.messageId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
@@ -312,6 +324,17 @@ export function toPluginMessageSentEvent(
     content: canonical.content,
     success: canonical.success,
     ...(canonical.error ? { error: canonical.error } : {}),
+    metadata: {
+      channel: canonical.channelId,
+      accountId: canonical.accountId,
+      conversationId: canonical.conversationId,
+      messageId: canonical.messageId,
+      threadId: canonical.threadId,
+      sessionKey: canonical.sessionKey,
+      agentId: canonical.agentId,
+      isGroup: canonical.isGroup,
+      groupId: canonical.groupId,
+    },
   };
 }
 
@@ -333,6 +356,7 @@ export function toInternalMessageReceivedContext(
       threadId: canonical.threadId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -126,6 +126,7 @@ describe("outbound channel resolution", () => {
       runtimeOptions: {
         allowGatewaySubagentBinding: true,
       },
+      inheritSharedRuntimeOptions: true,
     });
 
     getChannelPluginMock.mockReturnValue(undefined);
@@ -140,6 +141,7 @@ describe("outbound channel resolution", () => {
       runtimeOptions: {
         allowGatewaySubagentBinding: true,
       },
+      inheritSharedRuntimeOptions: true,
     });
   });
 

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -57,6 +57,7 @@ function maybeBootstrapChannelPlugin(params: {
       runtimeOptions: {
         allowGatewaySubagentBinding: true,
       },
+      inheritSharedRuntimeOptions: true,
     });
   } catch {
     // Allow a follow-up resolution attempt if bootstrap failed transiently.

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -20,7 +20,8 @@ const mocks = vi.hoisted(() => ({
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => false),
+    hasHooks: vi.fn<(name: string) => boolean>((_name) => false),
+    runMessageSending: vi.fn(async () => undefined),
     runMessageSent: vi.fn(async () => {}),
   },
 }));
@@ -208,6 +209,8 @@ describe("deliverOutboundPayloads", () => {
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
     hookMocks.runner.hasHooks.mockClear();
     hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSending.mockClear();
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
     hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
     internalHookMocks.createInternalHookEvent.mockClear();
@@ -981,6 +984,167 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("uses the same resolved sessionKey in message_sending and message_sent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello" }],
+      replyToId: "1741719181.247349",
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses payload-level replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-2" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello", replyToId: "1741719181.999999" }],
+      replyToId: undefined,
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to mirror metadata for message_sending when session is absent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+      skipQueue: true,
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
@@ -1195,6 +1359,47 @@ describe("deliverOutboundPayloads", () => {
         error: "downstream failed",
       }),
       expect.objectContaining({ channelId: "whatsapp" }),
+    );
+  });
+
+  it("emits payload-level threadId in message_sent failure metadata for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi.fn().mockRejectedValue(new Error("downstream failed"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "slack",
+        to: "C123",
+        payloads: [{ text: "hi", replyToId: "1741719181.424242" }],
+        threadId: null,
+        session: { key: "agent:sender:session", agentId: "sender-agent" },
+      }),
+    ).rejects.toThrow("downstream failed");
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.424242",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+        success: false,
+        error: "downstream failed",
+      }),
+      expect.anything(),
     );
   });
 });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -349,13 +349,23 @@ function createMessageSentEmitter(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  conversationId?: string;
+  agentId?: string;
+  sessionKey?: string;
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
-}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+}): {
+  emitMessageSent: (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => void;
+  hasMessageSentHooks: boolean;
+} {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
-  const emitMessageSent = (event: MessageSentEvent) => {
+  const emitMessageSent = (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => {
     if (!hasMessageSentHooks && !canEmitInternalHook) {
       return;
     }
@@ -366,8 +376,11 @@ function createMessageSentEmitter(params: {
       error: event.error,
       channelId: params.channel,
       accountId: params.accountId ?? undefined,
-      conversationId: params.to,
+      conversationId: event.conversationId ?? params.conversationId ?? params.to,
       messageId: event.messageId,
+      threadId: event.threadId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -404,6 +417,31 @@ function createMessageSentEmitter(params: {
   return { emitMessageSent, hasMessageSentHooks };
 }
 
+function resolveOutboundHookMetadata(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  conversationId?: string;
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  session?: OutboundSessionContext;
+  mirror?: DeliverOutboundPayloadsCoreParams["mirror"];
+}): {
+  conversationId: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
+} {
+  const resolvedThreadId =
+    params.threadId ??
+    (params.channel === "slack" && params.replyToId ? params.replyToId : undefined);
+  return {
+    conversationId: params.conversationId ?? params.to,
+    threadId: resolvedThreadId,
+    sessionKey: params.mirror?.sessionKey ?? params.session?.key,
+    agentId: params.mirror?.agentId ?? params.session?.agentId,
+  };
+}
+
 async function applyMessageSendingHook(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
@@ -412,6 +450,10 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  conversationId?: string;
+  threadId?: string | number | null;
+  sessionKey?: string;
+  agentId?: string;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
@@ -432,12 +474,17 @@ async function applyMessageSendingHook(params: {
         metadata: {
           channel: params.channel,
           accountId: params.accountId,
+          conversationId: params.conversationId ?? params.to,
+          threadId: params.threadId ?? undefined,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
           mediaUrls: params.payloadSummary.mediaUrls,
         },
       },
       {
         channelId: params.channel,
         accountId: params.accountId ?? undefined,
+        conversationId: params.conversationId ?? params.to,
       },
     );
     if (sendingResult?.cancel) {
@@ -613,7 +660,16 @@ async function deliverOutboundPayloadsCore(
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
+  const hookMetadata = resolveOutboundHookMetadata({
+    channel,
+    to,
+    conversationId: to,
+    replyToId: params.replyToId,
+    threadId: params.threadId,
+    session: params.session,
+    mirror: params.mirror,
+  });
+  const sessionKeyForInternalHooks = hookMetadata.sessionKey;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
@@ -621,23 +677,35 @@ async function deliverOutboundPayloadsCore(
     channel,
     to,
     accountId,
+    conversationId: hookMetadata.conversationId,
+    agentId: hookMetadata.agentId,
+    sessionKey: hookMetadata.sessionKey,
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
+  if (hasMessageSentHooks && hookMetadata.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
         channel,
         to,
-        agentId: params.session.agentId,
+        agentId: hookMetadata.agentId,
       },
     );
   }
   for (const payload of normalizedPayloads) {
     let payloadSummary = buildPayloadSummary(payload);
+    let payloadHookMetadata = resolveOutboundHookMetadata({
+      channel,
+      to,
+      conversationId: to,
+      replyToId: payload.replyToId ?? params.replyToId,
+      threadId: params.threadId,
+      session: params.session,
+      mirror: params.mirror,
+    });
     try {
       throwIfAborted(abortSignal);
 
@@ -650,6 +718,10 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
+        sessionKey: payloadHookMetadata.sessionKey,
+        agentId: payloadHookMetadata.agentId,
       });
       if (hookResult.cancelled) {
         continue;
@@ -663,6 +735,15 @@ async function deliverOutboundPayloadsCore(
         threadId: params.threadId ?? undefined,
         forceDocument: params.forceDocument,
       };
+      payloadHookMetadata = resolveOutboundHookMetadata({
+        channel,
+        to,
+        conversationId: to,
+        replyToId: sendOverrides.replyToId,
+        threadId: sendOverrides.threadId,
+        session: params.session,
+        mirror: params.mirror,
+      });
       if (
         handler.sendPayload &&
         (effectivePayload.channelData ||
@@ -676,6 +757,8 @@ async function deliverOutboundPayloadsCore(
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -691,6 +774,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -717,6 +802,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -741,12 +828,16 @@ async function deliverOutboundPayloadsCore(
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
     } catch (err) {
       emitMessageSent({
         success: false,
         content: payloadSummary.text,
         error: err instanceof Error ? err.message : String(err),
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
       if (!params.bestEffort) {
         throw err;

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -34,7 +34,12 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
   await fs.utimes(pluginSdkAliasPath, baselineTime, baselineTime);
 }
 
-function expectedBuildSpawn() {
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf-8"));
+}
+
+function expectedBuildSpawn(platform: NodeJS.Platform = process.platform) {
+  void platform;
   return [process.execPath, "scripts/tsdown-build.mjs", "--no-clean"];
 }
 
@@ -153,10 +158,11 @@ describe("run-node script", () => {
         fs.readFile(path.join(tmp, "dist", "plugin-sdk", "root-alias.cjs"), "utf-8"),
       ).resolves.toContain("module.exports = {};");
       await expect(
-        fs
-          .readFile(path.join(tmp, "dist", "extensions", "demo", "openclaw.plugin.json"), "utf-8")
-          .then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({ id: "demo" });
+        readJsonFile(path.join(tmp, "dist", "extensions", "demo", "openclaw.plugin.json")),
+      ).resolves.toMatchObject({
+        id: "demo",
+        configSchema: { type: "object" },
+      });
       await expect(
         fs.readFile(path.join(tmp, "dist", "extensions", "demo", "package.json"), "utf-8"),
       ).resolves.toContain(
@@ -499,10 +505,9 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
-      await expect(
-        fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({
+      await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
         id: "demo",
+        configSchema: { type: "object" },
       });
     });
   });
@@ -568,10 +573,9 @@ describe("run-node script", () => {
 
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([[process.execPath, "openclaw.mjs", "status"]]);
-      await expect(
-        fs.readFile(distManifestPath, "utf-8").then((raw) => JSON.parse(raw)),
-      ).resolves.toMatchObject({
+      await expect(readJsonFile(distManifestPath)).resolves.toMatchObject({
         id: "demo",
+        configSchema: { type: "object" },
       });
     });
   });

--- a/src/plugin-sdk/keyed-async-queue.test.ts
+++ b/src/plugin-sdk/keyed-async-queue.test.ts
@@ -105,4 +105,42 @@ describe("KeyedAsyncQueue", () => {
     await Promise.resolve();
     expect(queue.getTailMapForTesting().has("actor")).toBe(false);
   });
+
+  it("waits for tasks enqueued while draining", async () => {
+    const queue = new KeyedAsyncQueue();
+    const firstGate = deferred<void>();
+    const secondGate = deferred<void>();
+    let secondStarted = false;
+
+    void queue.enqueue("actor", async () => {
+      await firstGate.promise;
+    });
+
+    const idlePromise = queue.waitForIdle();
+
+    await vi.waitFor(() => {
+      expect(queue.getTailMapForTesting().has("actor")).toBe(true);
+    });
+
+    void queue.enqueue("actor", async () => {
+      secondStarted = true;
+      await secondGate.promise;
+    });
+
+    firstGate.resolve();
+    await vi.waitFor(() => {
+      expect(secondStarted).toBe(true);
+    });
+
+    let idleResolved = false;
+    void idlePromise.then(() => {
+      idleResolved = true;
+    });
+    await Promise.resolve();
+    expect(idleResolved).toBe(false);
+
+    secondGate.resolve();
+    await idlePromise;
+    expect(queue.getTailMapForTesting().size).toBe(0);
+  });
 });

--- a/src/plugin-sdk/keyed-async-queue.ts
+++ b/src/plugin-sdk/keyed-async-queue.ts
@@ -46,4 +46,14 @@ export class KeyedAsyncQueue {
       ...(hooks ? { hooks } : {}),
     });
   }
+
+  async waitForIdle(): Promise<void> {
+    while (this.tails.size > 0) {
+      const tails = [...this.tails.values()];
+      if (tails.length === 0) {
+        return;
+      }
+      await Promise.allSettled(tails);
+    }
+  }
 }

--- a/src/plugins/contracts/catalog.contract.test.ts
+++ b/src/plugins/contracts/catalog.contract.test.ts
@@ -27,6 +27,14 @@ const resolveNonBundledProviderPluginIdsMock = vi.hoisted(() =>
   vi.fn<ResolveNonBundledProviderPluginIds>((_) => [] as string[]),
 );
 
+vi.mock("../providers.js", () => ({
+  resolvePluginProviders: (params: unknown) => resolvePluginProvidersMock(params as never),
+  resolveOwningPluginIdsForProvider: (params: unknown) =>
+    resolveOwningPluginIdsForProviderMock(params as never),
+  resolveNonBundledProviderPluginIds: (params: unknown) =>
+    resolveNonBundledProviderPluginIdsMock(params as never),
+}));
+
 let augmentModelCatalogWithProviderPlugins: typeof import("../provider-runtime.js").augmentModelCatalogWithProviderPlugins;
 let buildProviderMissingAuthMessageWithPlugin: typeof import("../provider-runtime.js").buildProviderMissingAuthMessageWithPlugin;
 let resetProviderRuntimeHookCacheForTest: typeof import("../provider-runtime.js").resetProviderRuntimeHookCacheForTest;
@@ -35,12 +43,18 @@ let resolveProviderBuiltInModelSuppression: typeof import("../provider-runtime.j
 describe("provider catalog contract", () => {
   beforeEach(async () => {
     vi.resetModules();
-    vi.doUnmock("../providers.js");
     ({
       resolveProviderContractPluginIdsForProvider,
       resolveProviderContractProvidersForPluginIds,
       uniqueProviderContractProviders,
     } = await import("./registry.js"));
+    ({
+      augmentModelCatalogWithProviderPlugins,
+      buildProviderMissingAuthMessageWithPlugin,
+      resetProviderRuntimeHookCacheForTest,
+      resolveProviderBuiltInModelSuppression,
+    } = await import("../provider-runtime.js"));
+    resetProviderRuntimeHookCacheForTest();
 
     resolveOwningPluginIdsForProviderMock.mockReset();
     resolveOwningPluginIdsForProviderMock.mockImplementation((params) =>
@@ -58,25 +72,13 @@ describe("provider catalog contract", () => {
       }
       return resolveProviderContractProvidersForPluginIds(onlyPluginIds);
     });
-
-    vi.doMock("../providers.js", () => ({
-      resolvePluginProviders: (params: unknown) => resolvePluginProvidersMock(params as never),
-      resolveOwningPluginIdsForProvider: (params: unknown) =>
-        resolveOwningPluginIdsForProviderMock(params as never),
-      resolveNonBundledProviderPluginIds: (params: unknown) =>
-        resolveNonBundledProviderPluginIdsMock(params as never),
-    }));
-
-    ({
-      augmentModelCatalogWithProviderPlugins,
-      buildProviderMissingAuthMessageWithPlugin,
-      resetProviderRuntimeHookCacheForTest,
-      resolveProviderBuiltInModelSuppression,
-    } = await import("../provider-runtime.js"));
-    resetProviderRuntimeHookCacheForTest();
   });
 
   it("keeps codex-only missing-auth hints wired through the provider runtime", () => {
+    resolveOwningPluginIdsForProviderMock.mockReturnValue(["openai"]);
+    resolvePluginProvidersMock.mockReturnValue(
+      resolveProviderContractProvidersForPluginIds(["openai"]),
+    );
     expectCodexMissingAuthHint(buildProviderMissingAuthMessageWithPlugin);
   });
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -14,19 +14,24 @@ async function importFreshPluginTestModules() {
   vi.doUnmock("./hooks.js");
   vi.doUnmock("./loader.js");
   vi.doUnmock("jiti");
-  const [loader, hookRunnerGlobal, hooks, runtime, registry] = await Promise.all([
-    import("./loader.js"),
-    import("./hook-runner-global.js"),
-    import("./hooks.js"),
-    import("./runtime.js"),
-    import("./registry.js"),
-  ]);
+  const [loader, hookRunnerGlobal, hooks, runtime, registry, sharedRuntimeOptions, tools] =
+    await Promise.all([
+      import("./loader.js"),
+      import("./hook-runner-global.js"),
+      import("./hooks.js"),
+      import("./runtime.js"),
+      import("./registry.js"),
+      import("./runtime/shared-runtime-options.js"),
+      import("./tools.js"),
+    ]);
   return {
     ...loader,
     ...hookRunnerGlobal,
     ...hooks,
     ...runtime,
     ...registry,
+    ...sharedRuntimeOptions,
+    ...tools,
   };
 }
 
@@ -35,12 +40,15 @@ const {
   clearPluginLoaderCache,
   createHookRunner,
   createEmptyPluginRegistry,
+  clearSharedPluginRuntimeOptions,
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   getGlobalHookRunner,
   loadOpenClawPlugins,
   resetGlobalHookRunner,
+  resolvePluginTools,
   setActivePluginRegistry,
+  setSharedPluginRuntimeOptions,
 } = await importFreshPluginTestModules();
 
 type TempPlugin = { dir: string; file: string; id: string };
@@ -641,6 +649,8 @@ function resolvePluginRuntimeModule(params: {
 
 afterEach(() => {
   clearPluginLoaderCache();
+  clearSharedPluginRuntimeOptions();
+  resetGlobalHookRunner();
   if (prevBundledDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -1179,6 +1189,281 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("does not reuse cached registries across runtime capability changes", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "runtime-capability-cache",
+      filename: "runtime-capability-cache.cjs",
+      body: `module.exports = {
+        id: "runtime-capability-cache",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "runtime-capability", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["runtime-capability-cache"],
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-1" })),
+      enqueue: vi.fn(async () => ({ runId: "run-1" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const second = loadOpenClawPlugins({
+      ...options,
+      runtimeOptions: { subagent },
+    });
+
+    expect(second).not.toBe(first);
+    expect(second.plugins.map((entry) => entry.id)).toEqual(first.plugins.map((entry) => entry.id));
+
+    const third = loadOpenClawPlugins({
+      ...options,
+      runtimeOptions: { subagent },
+    });
+
+    expect(third).toBe(second);
+  });
+
+  it("does not inherit shared runtime options without explicit opt-in", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options-no-inherit",
+      filename: "shared-runtime-options-no-inherit.cjs",
+      body: `module.exports = {
+        id: "shared-runtime-options-no-inherit",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "shared-runtime-no-inherit", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    setSharedPluginRuntimeOptions({ subagent });
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-inherit"],
+        },
+      },
+    });
+
+    const inherited = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      inheritSharedRuntimeOptions: true,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-inherit"],
+        },
+      },
+    });
+
+    expect(inherited).not.toBe(registry);
+    expect(
+      loadOpenClawPlugins({
+        workspaceDir: plugin.dir,
+        config: {
+          plugins: {
+            load: { paths: [plugin.file] },
+            allow: ["shared-runtime-options-no-inherit"],
+          },
+        },
+      }),
+    ).toBe(registry);
+  });
+
+  it("does not replace the global hook runner when activation is disabled", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options-no-global-replace",
+      filename: "shared-runtime-options-no-global-replace.cjs",
+      body: `module.exports = { id: "shared-runtime-options-no-global-replace", register() {} };`,
+    });
+    const activeRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-global-replace"],
+        },
+      },
+    });
+    const globalHookRunner = getGlobalHookRunner();
+    expect(globalHookRunner).not.toBeNull();
+
+    const previewRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      inheritSharedRuntimeOptions: true,
+      activate: false,
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options-no-global-replace"],
+        },
+      },
+    });
+
+    expect(getGlobalHookRunner()).toBe(globalHookRunner);
+    expect(activeRegistry).not.toBe(previewRegistry);
+    expect(previewRegistry).not.toBe(activeRegistry);
+  });
+
+  it("keeps the global hook runner stable while resolving plugin tools", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "tool-resolution-preserves-hook-runner",
+      filename: "tool-resolution-preserves-hook-runner.cjs",
+      body: `module.exports = {
+        id: "tool-resolution-preserves-hook-runner",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "tool-resolution-preserved", message: "hello" });
+          });
+          api.registerTool({
+            name: "echo",
+            description: "echo",
+            parameters: { type: "object", properties: {} },
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const activeRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      runtimeOptions: { subagent },
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["tool-resolution-preserves-hook-runner"],
+        },
+      },
+    });
+    const globalHookRunner = getGlobalHookRunner();
+
+    expect(globalHookRunner).not.toBeNull();
+
+    const tools = resolvePluginTools({
+      context: {
+        config: {
+          plugins: {
+            enabled: true,
+            load: { paths: [plugin.file] },
+            allow: ["tool-resolution-preserves-hook-runner"],
+          },
+        },
+        workspaceDir: plugin.dir,
+      } as never,
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(getGlobalHookRunner()).toBe(globalHookRunner);
+    expect(activeRegistry).not.toBeNull();
+  });
+
+  it("uses shared runtime options when explicit runtime options are absent and inheritance is enabled", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-runtime-options",
+      filename: "shared-runtime-options.cjs",
+      body: `module.exports = {
+        id: "shared-runtime-options",
+        register(api) {
+          api.on("agent_end", async () => {
+            await api.runtime.subagent.run({ sessionKey: "shared-runtime", message: "hello" });
+          });
+        },
+      };`,
+    });
+
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-shared" })),
+      enqueue: vi.fn(async () => ({ runId: "run-shared" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    setSharedPluginRuntimeOptions({ subagent });
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      inheritSharedRuntimeOptions: true,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options"],
+        },
+      },
+    });
+
+    const inheritedAgain = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      inheritSharedRuntimeOptions: true,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options"],
+        },
+      },
+    });
+    const plain = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-runtime-options"],
+        },
+      },
+    });
+
+    expect(inheritedAgain).toBe(registry);
+    expect(plain).not.toBe(registry);
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -29,6 +29,10 @@ import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./
 import { resolvePluginCacheInputs } from "./roots.js";
 import { setActivePluginRegistry } from "./runtime.js";
 import type { CreatePluginRuntimeOptions } from "./runtime/index.js";
+import {
+  getPluginRuntimeCapabilityKey,
+  getSharedPluginRuntimeOptions,
+} from "./runtime/shared-runtime-options.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
 import type {
@@ -51,6 +55,7 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   runtimeOptions?: CreatePluginRuntimeOptions;
+  inheritSharedRuntimeOptions?: boolean;
   cache?: boolean;
   mode?: "full" | "validate";
   onlyPluginIds?: string[];
@@ -331,7 +336,7 @@ function buildCacheKey(params: {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
-  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  runtimeOptions?: CreatePluginRuntimeOptions;
 }): string {
   const { roots, loadPaths } = resolvePluginCacheInputs({
     workspaceDir: params.workspaceDir,
@@ -362,7 +367,8 @@ function buildCacheKey(params: {
     ...params.plugins,
     installs,
     loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}`;
+    runtimeCapabilities: getPluginRuntimeCapabilityKey(params.runtimeOptions),
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -811,6 +817,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
   const shouldActivate = options.activate !== false;
+  const effectiveRuntimeOptions =
+    options.runtimeOptions ??
+    (options.inheritSharedRuntimeOptions ? getSharedPluginRuntimeOptions() : undefined);
   // NOTE: `activate` is intentionally excluded from the cache key. All non-activating
   // (snapshot) callers pass `cache: false` via loadOnboardingPluginRegistry(), so they
   // never read from or write to the cache. Including `activate` here would be misleading
@@ -823,12 +832,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    runtimeSubagentMode:
-      options.runtimeOptions?.allowGatewaySubagentBinding === true
-        ? "gateway-bindable"
-        : options.runtimeOptions?.subagent
-          ? "explicit"
-          : "default",
+    runtimeOptions: effectiveRuntimeOptions,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -889,7 +893,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   // not eagerly load every channel/runtime dependency tree.
   let resolvedRuntime: PluginRuntime | null = null;
   const resolveRuntime = (): PluginRuntime => {
-    resolvedRuntime ??= resolveCreatePluginRuntime()(options.runtimeOptions);
+    resolvedRuntime ??= resolveCreatePluginRuntime()(effectiveRuntimeOptions);
     return resolvedRuntime;
   };
   const lazyRuntimeReflectionKeySet = new Set<PropertyKey>(LAZY_RUNTIME_REFLECTION_KEYS);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -14,7 +14,6 @@ import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import { registerPluginInteractiveHandler } from "./interactive.js";
 import { normalizeRegisteredProvider } from "./provider-validation.js";
-import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { withPluginRuntimePluginIdScope } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { defaultSlotIdForKey } from "./slots.js";
@@ -241,7 +240,28 @@ const constrainLegacyPromptInjectionHook = (
   };
 };
 
-export { createEmptyPluginRegistry } from "./registry-empty.js";
+export function createEmptyPluginRegistry(): PluginRegistry {
+  return {
+    plugins: [],
+    tools: [],
+    hooks: [],
+    typedHooks: [],
+    channels: [],
+    channelSetups: [],
+    providers: [],
+    speechProviders: [],
+    mediaUnderstandingProviders: [],
+    imageGenerationProviders: [],
+    webSearchProviders: [],
+    gatewayHandlers: {},
+    httpRoutes: [],
+    cliRegistrars: [],
+    services: [],
+    commands: [],
+    conversationBindingResolvedHandlers: [],
+    diagnostics: [],
+  };
+}
 
 export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const registry = createEmptyPluginRegistry();
@@ -857,6 +877,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         const subagent = Reflect.get(target, prop, receiver);
         return {
           run: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.run(params)),
+          enqueue: (params) =>
+            withPluginRuntimePluginIdScope(pluginId, () => subagent.enqueue(params)),
+          abort: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.abort(params)),
           waitForRun: (params) =>
             withPluginRuntimePluginIdScope(pluginId, () => subagent.waitForRun(params)),
           getSessionMessages: (params) =>

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -113,6 +113,8 @@ describe("plugin runtime command execution", () => {
     const runtime = createPluginRuntime();
     setGatewaySubagentRuntime({
       run: vi.fn(),
+      enqueue: vi.fn(),
+      abort: vi.fn(),
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       getSession: vi.fn(),
@@ -130,6 +132,8 @@ describe("plugin runtime command execution", () => {
 
     setGatewaySubagentRuntime({
       run,
+      enqueue: vi.fn(),
+      abort: vi.fn(),
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       getSession: vi.fn(),
@@ -140,5 +144,31 @@ describe("plugin runtime command execution", () => {
       runId: "run-1",
     });
     expect(run).toHaveBeenCalledWith({ sessionKey: "s-2", message: "hello" });
+  });
+
+  it("uses the provided subagent runtime when available", async () => {
+    const subagent = {
+      run: vi.fn(async () => ({ runId: "run-1" })),
+      enqueue: vi.fn(async () => ({ runId: "run-1" })),
+      abort: vi.fn(async () => ({ aborted: true })),
+      waitForRun: vi.fn(async () => ({ status: "ok" as const })),
+      getSessionMessages: vi.fn(async () => ({ messages: [] })),
+      getSession: vi.fn(async () => ({ messages: [] })),
+      deleteSession: vi.fn(async () => undefined),
+    };
+
+    const runtime = createPluginRuntime({ subagent });
+    await expect(runtime.subagent.run({ sessionKey: "s", message: "hi" })).resolves.toEqual({
+      runId: "run-1",
+    });
+    await expect(runtime.subagent.enqueue({ sessionKey: "s", message: "hi" })).resolves.toEqual({
+      runId: "run-1",
+    });
+    await expect(runtime.subagent.abort({ runId: "run-1" })).resolves.toEqual({
+      aborted: true,
+    });
+    expect(subagent.run).toHaveBeenCalledWith({ sessionKey: "s", message: "hi" });
+    expect(subagent.enqueue).toHaveBeenCalledWith({ sessionKey: "s", message: "hi" });
+    expect(subagent.abort).toHaveBeenCalledWith({ runId: "run-1" });
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -50,6 +50,8 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   };
   return {
     run: unavailable,
+    enqueue: unavailable,
+    abort: unavailable,
     waitForRun: unavailable,
     getSessionMessages: unavailable,
     getSession: unavailable,

--- a/src/plugins/runtime/shared-runtime-options.ts
+++ b/src/plugins/runtime/shared-runtime-options.ts
@@ -1,0 +1,43 @@
+import type { CreatePluginRuntimeOptions } from "./index.js";
+
+const SHARED_PLUGIN_RUNTIME_OPTIONS_KEY: unique symbol = Symbol.for(
+  "openclaw.sharedPluginRuntimeOptions",
+);
+
+type SharedPluginRuntimeOptionsState = {
+  options?: CreatePluginRuntimeOptions;
+};
+
+function getSharedPluginRuntimeOptionsState(): SharedPluginRuntimeOptionsState {
+  const globalState = globalThis as typeof globalThis & {
+    [SHARED_PLUGIN_RUNTIME_OPTIONS_KEY]?: SharedPluginRuntimeOptionsState;
+  };
+  const existing = globalState[SHARED_PLUGIN_RUNTIME_OPTIONS_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created: SharedPluginRuntimeOptionsState = {};
+  globalState[SHARED_PLUGIN_RUNTIME_OPTIONS_KEY] = created;
+  return created;
+}
+
+export function setSharedPluginRuntimeOptions(options: CreatePluginRuntimeOptions): void {
+  getSharedPluginRuntimeOptionsState().options = options;
+}
+
+export function getSharedPluginRuntimeOptions(): CreatePluginRuntimeOptions | undefined {
+  return getSharedPluginRuntimeOptionsState().options;
+}
+
+export function clearSharedPluginRuntimeOptions(): void {
+  getSharedPluginRuntimeOptionsState().options = undefined;
+}
+
+export function getPluginRuntimeCapabilityKey(
+  options?: CreatePluginRuntimeOptions,
+): Record<string, boolean> {
+  return {
+    subagent: Boolean(options?.subagent),
+    gatewaySubagentBinding: options?.allowGatewaySubagentBinding === true,
+  };
+}

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -20,6 +20,10 @@ export type SubagentRunResult = {
   runId: string;
 };
 
+export type SubagentEnqueueParams = SubagentRunParams;
+
+export type SubagentEnqueueResult = SubagentRunResult;
+
 export type SubagentWaitParams = {
   runId: string;
   timeoutMs?: number;
@@ -28,6 +32,15 @@ export type SubagentWaitParams = {
 export type SubagentWaitResult = {
   status: "ok" | "error" | "timeout";
   error?: string;
+};
+
+export type SubagentAbortParams = {
+  runId: string;
+  sessionKey?: string;
+};
+
+export type SubagentAbortResult = {
+  aborted: boolean;
 };
 
 export type SubagentGetSessionMessagesParams = {
@@ -53,6 +66,8 @@ export type SubagentDeleteSessionParams = {
 export type PluginRuntime = PluginRuntimeCore & {
   subagent: {
     run: (params: SubagentRunParams) => Promise<SubagentRunResult>;
+    enqueue: (params: SubagentEnqueueParams) => Promise<SubagentEnqueueResult>;
+    abort: (params: SubagentAbortParams) => Promise<SubagentAbortResult>;
     waitForRun: (params: SubagentWaitParams) => Promise<SubagentWaitResult>;
     getSessionMessages: (
       params: SubagentGetSessionMessagesParams,

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -79,7 +79,6 @@ export type PluginInspectReport = {
     hasAllowedModelsConfig: boolean;
   };
   usesLegacyBeforeAgentStart: boolean;
-  compatibility: PluginCompatibilityNotice[];
 };
 
 function buildCompatibilityNoticesForInspect(
@@ -106,6 +105,7 @@ function buildCompatibilityNoticesForInspect(
   }
   return warnings;
 }
+
 
 const log = createSubsystemLogger("plugins");
 
@@ -220,17 +220,6 @@ export function buildPluginInspectReport(params: {
   const diagnostics = report.diagnostics.filter((entry) => entry.pluginId === plugin.id);
   const policyEntry = normalizePluginsConfig(config.plugins).entries[plugin.id];
   const capabilityCount = capabilities.length;
-  const shape = deriveInspectShape({
-    capabilityCount,
-    typedHookCount: typedHooks.length,
-    customHookCount: customHooks.length,
-    toolCount: tools.length,
-    commandCount: plugin.commands.length,
-    cliCount: plugin.cliCommands.length,
-    serviceCount: plugin.services.length,
-    gatewayMethodCount: plugin.gatewayMethods.length,
-    httpRouteCount: plugin.httpRoutes,
-  });
 
   // Populate MCP server info for bundle-format plugins with a known rootDir.
   let mcpServers: PluginInspectReport["mcpServers"] = [];
@@ -263,7 +252,17 @@ export function buildPluginInspectReport(params: {
   return {
     workspaceDir: report.workspaceDir,
     plugin,
-    shape,
+    shape: deriveInspectShape({
+      capabilityCount,
+      typedHookCount: typedHooks.length,
+      customHookCount: customHooks.length,
+      toolCount: tools.length,
+      commandCount: plugin.commands.length,
+      cliCount: plugin.cliCommands.length,
+      serviceCount: plugin.services.length,
+      gatewayMethodCount: plugin.gatewayMethods.length,
+      httpRouteCount: plugin.httpRoutes,
+    }),
     capabilityMode: capabilityCount === 0 ? "none" : capabilityCount === 1 ? "plain" : "hybrid",
     capabilityCount,
     capabilities,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -157,6 +157,20 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics).toHaveLength(0);
   });
 
+  it("loads plugin tools without re-initializing the global hook runner", () => {
+    setOptionalDemoRegistry();
+
+    resolvePluginTools({
+      context: createContext() as never,
+      toolAllowlist: ["optional_tool"],
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inheritSharedRuntimeOptions: true,
+      }),
+    );
+  });
   it("forwards an explicit env to plugin loading", () => {
     setOptionalDemoRegistry();
     const env = { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv;

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -68,6 +68,7 @@ export function resolvePluginTools(params: {
         }
       : undefined,
     env,
+    inheritSharedRuntimeOptions: true,
     logger: createPluginLoaderLogger(log),
   });
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -866,19 +866,6 @@ export type WebSearchProviderContext = {
   runtimeMetadata?: RuntimeWebSearchMetadata;
 };
 
-export type WebSearchCredentialResolutionSource = "config" | "secretRef" | "env" | "missing";
-
-export type WebSearchRuntimeMetadataContext = {
-  config?: OpenClawConfig;
-  searchConfig?: Record<string, unknown>;
-  runtimeMetadata?: RuntimeWebSearchMetadata;
-  resolvedCredential?: {
-    value?: string;
-    source: WebSearchCredentialResolutionSource;
-    fallbackEnvVar?: string;
-  };
-};
-
 export type WebSearchProviderPlugin = {
   id: WebSearchProviderId;
   label: string;
@@ -888,16 +875,8 @@ export type WebSearchProviderPlugin = {
   signupUrl: string;
   docsUrl?: string;
   autoDetectOrder?: number;
-  credentialPath: string;
-  inactiveSecretPaths?: string[];
   getCredentialValue: (searchConfig?: Record<string, unknown>) => unknown;
   setCredentialValue: (searchConfigTarget: Record<string, unknown>, value: unknown) => void;
-  getConfiguredCredentialValue?: (config?: OpenClawConfig) => unknown;
-  setConfiguredCredentialValue?: (configTarget: OpenClawConfig, value: unknown) => void;
-  applySelectionConfig?: (config: OpenClawConfig) => OpenClawConfig;
-  resolveRuntimeMetadata?: (
-    ctx: WebSearchRuntimeMetadataContext,
-  ) => Partial<RuntimeWebSearchMetadata> | Promise<Partial<RuntimeWebSearchMetadata>>;
   createTool: (ctx: WebSearchProviderContext) => WebSearchProviderToolDefinition | null;
 };
 
@@ -1664,6 +1643,7 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  metadata?: Record<string, unknown>;
 };
 
 // Tool context

--- a/test/helpers/extensions/discord-provider.test-support.ts
+++ b/test/helpers/extensions/discord-provider.test-support.ts
@@ -38,8 +38,10 @@ type ProviderMonitorTestMocks = {
   listNativeCommandSpecsForConfigMock: Mock<() => NativeCommandSpecMock[]>;
   listSkillCommandsForAgentsMock: Mock<() => unknown[]>;
   monitorLifecycleMock: Mock<(params: { threadBindings: { stop: () => void } }) => Promise<void>>;
+  rememberDiscordManagedBotIdentityMock: Mock<() => void>;
   resolveDiscordAccountMock: Mock<() => unknown>;
   resolveDiscordAllowlistConfigMock: Mock<() => Promise<unknown>>;
+  forgetDiscordManagedBotIdentityMock: Mock<() => void>;
   resolveNativeCommandsEnabledMock: Mock<() => boolean>;
   resolveNativeSkillsEnabledMock: Mock<() => boolean>;
   isVerboseMock: Mock<() => boolean>;
@@ -81,6 +83,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
         vi.fn(async () => undefined),
         {
           deactivate: vi.fn(),
+          waitForIdle: vi.fn(async () => undefined),
         },
       ),
     ),
@@ -113,6 +116,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
     monitorLifecycleMock: vi.fn(async (params: { threadBindings: { stop: () => void } }) => {
       params.threadBindings.stop();
     }),
+    rememberDiscordManagedBotIdentityMock: vi.fn(),
     resolveDiscordAccountMock: vi.fn(() => ({
       accountId: "default",
       token: "cfg-token",
@@ -122,6 +126,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
       guildEntries: undefined,
       allowFrom: undefined,
     })),
+    forgetDiscordManagedBotIdentityMock: vi.fn(),
     resolveNativeCommandsEnabledMock: vi.fn(() => true),
     resolveNativeSkillsEnabledMock: vi.fn(() => false),
     isVerboseMock,
@@ -147,8 +152,10 @@ const {
   listNativeCommandSpecsForConfigMock,
   listSkillCommandsForAgentsMock,
   monitorLifecycleMock,
+  rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccountMock,
   resolveDiscordAllowlistConfigMock,
+  forgetDiscordManagedBotIdentityMock,
   resolveNativeCommandsEnabledMock,
   resolveNativeSkillsEnabledMock,
   isVerboseMock,
@@ -199,6 +206,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
       vi.fn(async () => undefined),
       {
         deactivate: vi.fn(),
+        waitForIdle: vi.fn(async () => undefined),
       },
     ),
   );
@@ -221,6 +229,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
   monitorLifecycleMock.mockClear().mockImplementation(async (monitorParams) => {
     monitorParams.threadBindings.stop();
   });
+  rememberDiscordManagedBotIdentityMock.mockClear();
   resolveDiscordAccountMock.mockClear().mockReturnValue({
     accountId: "default",
     token: "cfg-token",
@@ -230,6 +239,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
     guildEntries: undefined,
     allowFrom: undefined,
   });
+  forgetDiscordManagedBotIdentityMock.mockClear();
   resolveNativeCommandsEnabledMock.mockClear().mockReturnValue(true);
   resolveNativeSkillsEnabledMock.mockClear().mockReturnValue(false);
   isVerboseMock.mockClear().mockReturnValue(false);
@@ -248,16 +258,34 @@ export const baseConfig = (): OpenClawConfig =>
     channels: {
       discord: {
         accounts: {
-          default: {
-            token: "MTIz.abc.def",
-          },
+          default: {},
         },
       },
     },
   }) as OpenClawConfig;
 
-vi.mock("@buape/carbon", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@buape/carbon")>();
+vi.mock("@buape/carbon", () => {
+  class Button {}
+  class ChannelSelectMenu {}
+  class Command {}
+  class CommandWithSubcommands {}
+  class Container {
+    constructor(
+      _components?: unknown,
+      _options?: {
+        accentColor?: string;
+        spoiler?: boolean;
+      },
+    ) {}
+  }
+  class MentionableSelectMenu {}
+  class Message {}
+  class MessageCreateListener {}
+  class MessageReactionAddListener {}
+  class MessageReactionRemoveListener {}
+  class Modal {}
+  class PresenceUpdateListener {}
+  class ReadyListener {}
   class RateLimitError extends Error {
     status = 429;
     discordCode?: number;
@@ -294,16 +322,91 @@ vi.mock("@buape/carbon", async (importOriginal) => {
       return clientGetPluginMock(name);
     }
   }
-  return { ...actual, Client, RateLimitError };
+  class RequestClient {}
+  class Row {}
+  class RoleSelectMenu {}
+  class Separator {}
+  class StringSelectMenu {}
+  class TextDisplay {}
+  class ThreadUpdateListener {}
+  class UserSelectMenu {}
+  class Embed {}
+  const ChannelType = {
+    GuildText: 0,
+    DM: 1,
+    GuildVoice: 2,
+    GroupDM: 3,
+    GuildCategory: 4,
+    GuildAnnouncement: 5,
+    AnnouncementThread: 10,
+    PublicThread: 11,
+    PrivateThread: 12,
+  };
+  const MessageType = {
+    Default: 0,
+    Reply: 19,
+  };
+  return {
+    Client,
+    Button,
+    ChannelSelectMenu,
+    ChannelType,
+    Command,
+    CommandWithSubcommands,
+    Container,
+    Embed,
+    MentionableSelectMenu,
+    Message,
+    MessageCreateListener,
+    MessageType,
+    MessageReactionAddListener,
+    MessageReactionRemoveListener,
+    Modal,
+    PresenceUpdateListener,
+    RateLimitError,
+    ReadyListener,
+    RequestClient,
+    Row,
+    RoleSelectMenu,
+    Separator,
+    serializePayload: (payload: unknown) => payload,
+    StringSelectMenu,
+    TextDisplay,
+    ThreadUpdateListener,
+    UserSelectMenu,
+  };
 });
 
-vi.mock("@buape/carbon/gateway", () => ({
-  GatewayCloseCodes: { DisallowedIntents: 4014 },
-}));
+vi.mock("@buape/carbon/gateway", () => {
+  class GatewayPlugin {
+    gatewayInfo?: unknown;
+    constructor(_options?: unknown) {}
+    async registerClient(_client: unknown) {
+      return undefined;
+    }
+  }
+  return {
+    GatewayCloseCodes: { DisallowedIntents: 4014 },
+    GatewayIntents: {
+      Guilds: 1 << 0,
+      GuildMessages: 1 << 9,
+      MessageContent: 1 << 15,
+      DirectMessages: 1 << 12,
+      GuildMessageReactions: 1 << 10,
+      DirectMessageReactions: 1 << 13,
+      GuildVoiceStates: 1 << 7,
+      GuildPresences: 1 << 8,
+      GuildMembers: 1 << 1,
+    },
+    GatewayPlugin,
+  };
+});
 
-vi.mock("@buape/carbon/voice", () => ({
-  VoicePlugin: class VoicePlugin {},
-}));
+vi.mock("@buape/carbon/voice", () => {
+  return {
+    VoicePlugin: class VoicePlugin {},
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/acp-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/acp-runtime")>(
@@ -380,6 +483,8 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
 });
 
 vi.mock("../../../extensions/discord/src/accounts.js", () => ({
+  forgetDiscordManagedBotIdentity: forgetDiscordManagedBotIdentityMock,
+  rememberDiscordManagedBotIdentity: rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccount: resolveDiscordAccountMock,
 }));
 
@@ -464,9 +569,7 @@ vi.mock("../../../extensions/discord/src/monitor/provider.lifecycle.js", () => (
 }));
 
 vi.mock("../../../extensions/discord/src/monitor/rest-fetch.js", () => ({
-  resolveDiscordRestFetch: () => async () => {
-    throw new Error("offline");
-  },
+  resolveDiscordRestFetch: () => async () => undefined,
 }));
 
 vi.mock("../../../extensions/discord/src/monitor/thread-bindings.js", () => ({

--- a/test/helpers/extensions/plugin-runtime-mock.ts
+++ b/test/helpers/extensions/plugin-runtime-mock.ts
@@ -326,6 +326,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     subagent: {
       run: vi.fn(),
+      enqueue: vi.fn(),
+      abort: vi.fn(),
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       getSession: vi.fn(),


### PR DESCRIPTION
## Summary

- Forward `provider`/`model` overrides in `subagent.enqueue` (parity with `subagent.run`)
- Use `ADMIN_SCOPE` for `subagent.abort` fallback dispatch so plugin runtime abort works without request-scope client
- Add `enqueue`/`abort` to plugin registry subagent proxy
- Canonicalize agent-prefixed main aliases before abort session match
- Enforce exact session match and admin scope for `agent.abort`
- Add agent abort controller tracking with configurable expiry, preserving no-timeout semantics
- `KeyedAsyncQueue.waitForIdle()` drains until queue stays empty (not just snapshot)
- Discord provider teardown: bounded idle wait before identity cleanup
- Inherit shared runtime options in lazy outbound channel bootstrap

Recreated from #48230 with a clean single commit on upstream/main to avoid merge noise.

## Test plan

- [x] `src/gateway/server-plugins.test.ts` — subagent enqueue/abort parameter forwarding
- [x] `src/gateway/method-scopes.test.ts` — agent.abort admin scope boundary
- [x] `src/gateway/server-methods/agent.test.ts` — abort session canonicalization
- [x] `src/plugin-sdk/keyed-async-queue.test.ts` — idle drain behavior
- [x] `extensions/discord/src/monitor/provider.test.ts` — teardown idle wait and identity cleanup