### PR TITLE
plugins: dist node_modules symlink + config raw-toggle UI fix

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -97,8 +97,15 @@ function linkPluginNodeModules(params) {
   // resolves bare-specifier dependencies relative to the dist plugin directory.
   // copy-bundled-plugin-metadata removes dist node_modules; restore the link here.
   if (params.distPluginDir) {
+    removePathIfExists(path.join(params.distPluginDir, "node_modules"));
+  }
+  if (!fs.existsSync(params.sourcePluginNodeModulesDir)) {
+    return;
+  }
+  fs.symlinkSync(params.sourcePluginNodeModulesDir, runtimeNodeModulesDir, symlinkType());
+
+  if (params.distPluginDir) {
     const distNodeModulesDir = path.join(params.distPluginDir, "node_modules");
-    removePathIfExists(distNodeModulesDir);
     fs.symlinkSync(params.sourcePluginNodeModulesDir, distNodeModulesDir, symlinkType());
   }
 }

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -88,6 +88,9 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
 function linkPluginNodeModules(params) {
   const runtimeNodeModulesDir = path.join(params.runtimePluginDir, "node_modules");
   removePathIfExists(runtimeNodeModulesDir);
+  if (params.distPluginDir) {
+    removePathIfExists(path.join(params.distPluginDir, "node_modules"));
+  }
   if (!fs.existsSync(params.sourcePluginNodeModulesDir)) {
     return;
   }

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -92,6 +92,15 @@ function linkPluginNodeModules(params) {
     return;
   }
   fs.symlinkSync(params.sourcePluginNodeModulesDir, runtimeNodeModulesDir, symlinkType());
+
+  // Runtime wrappers re-export from dist/extensions/<plugin>/index.js, so Node
+  // resolves bare-specifier dependencies relative to the dist plugin directory.
+  // copy-bundled-plugin-metadata removes dist node_modules; restore the link here.
+  if (params.distPluginDir) {
+    const distNodeModulesDir = path.join(params.distPluginDir, "node_modules");
+    removePathIfExists(distNodeModulesDir);
+    fs.symlinkSync(params.sourcePluginNodeModulesDir, distNodeModulesDir, symlinkType());
+  }
 }
 
 export function stageBundledPluginRuntime(params = {}) {
@@ -121,6 +130,7 @@ export function stageBundledPluginRuntime(params = {}) {
     stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir);
     linkPluginNodeModules({
       runtimePluginDir,
+      distPluginDir,
       sourcePluginNodeModulesDir,
     });
   }

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -49,6 +49,12 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.realpathSync(path.join(runtimePluginDir, "node_modules"))).toBe(
       fs.realpathSync(sourcePluginNodeModulesDir),
     );
+
+    // dist/ also gets a node_modules symlink so bare-specifier resolution works
+    // from the actual code location that the runtime wrapper re-exports into
+    const distNodeModules = path.join(distPluginDir, "node_modules");
+    expect(fs.lstatSync(distNodeModules).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(distNodeModules)).toBe(fs.realpathSync(sourcePluginNodeModulesDir));
   });
 
   it("writes wrappers that forward plugin entry imports into canonical dist files", async () => {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -715,10 +715,10 @@
   line-height: 1.55;
 }
 
-.config-raw-toggle {
+.config-raw-field .config-raw-toggle {
   width: 32px;
   height: 32px;
-  padding: 6px !important;
+  padding: 6px;
   min-width: 32px;
 }
 

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -715,6 +715,13 @@
   line-height: 1.55;
 }
 
+.config-raw-toggle {
+  width: 32px;
+  height: 32px;
+  padding: 6px !important;
+  min-width: 32px;
+}
+
 /* Loading State */
 .config-loading {
   display: flex;

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1060,7 +1060,7 @@ export function renderConfig(props: ConfigProps) {
                           `
                         : nothing
                     }
-                    <label class="field config-raw-field">
+                    <div class="field config-raw-field">
                       <span style="display:flex;align-items:center;gap:8px;">
                         Raw JSON5
                         ${
@@ -1068,8 +1068,7 @@ export function renderConfig(props: ConfigProps) {
                             ? html`
                               <span class="pill pill--sm">${sensitiveCount} secret${sensitiveCount === 1 ? "" : "s"} ${blurred ? "redacted" : "visible"}</span>
                               <button
-                                class="btn btn--icon ${blurred ? "" : "active"}"
-                                style="width:28px;height:28px;padding:0;"
+                                class="btn btn--icon config-raw-toggle ${blurred ? "" : "active"}"
                                 title=${
                                   blurred ? "Reveal sensitive values" : "Hide sensitive values"
                                 }
@@ -1098,7 +1097,7 @@ export function renderConfig(props: ConfigProps) {
                           props.onRawChange((e.target as HTMLTextAreaElement).value);
                         }}
                       ></textarea>
-                    </label>
+                    </div>
                   `;
                   })()
           }


### PR DESCRIPTION
## Summary

- **Plugin runtime staging:** also symlink `node_modules` into the `dist/extensions/<plugin>/` directory so bare-specifier resolution works from the actual code location that runtime wrappers re-export into. Previously only the runtime overlay directory got the link, but Node resolves dependencies relative to the file doing the `require`/`import`, which lives under `dist/`. Adds matching test coverage.
- **Config UI:** extract the raw-toggle button sizing into a dedicated `.config-raw-toggle` CSS class instead of inline styles, and change the wrapping `<label>` to a `<div>` since the container holds interactive controls (buttons + textarea), not a single labeled input.

## Test plan

- [x] `stage-bundled-plugin-runtime.test.ts` updated and passes
- [x] Visual check of config raw-toggle button in web UI


Made with [Cursor](https://cursor.com)