### PR TITLE
Agents: enable Codex parallel tool calls

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -584,32 +584,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.parallel_tool_calls).toBe(true);
   });
 
-  it("injects parallel_tool_calls for openai-codex-responses payloads when configured", () => {
-    const payload = runParallelToolCallsPayloadMutationCase({
-      applyProvider: "openai-codex",
-      applyModelId: "gpt-5.3-codex",
-      cfg: {
-        agents: {
-          defaults: {
-            models: {
-              "openai-codex/gpt-5.3-codex": {
-                params: {
-                  parallelToolCalls: false,
-                },
-              },
-            },
-          },
-        },
-      },
-      model: {
-        api: "openai-codex-responses",
-        provider: "openai-codex",
-        id: "gpt-5.3-codex",
-      } as unknown as Model<"openai-codex-responses">,
-    });
-
-    expect(payload.parallel_tool_calls).toBe(false);
-  });
+  it("respects camelCase parallelToolCalls: false config to disable default for openai-codex", () => {
 
   it("defaults parallel_tool_calls on for openai-codex responses", () => {
     const payload = runParallelToolCallsPayloadMutationCase({

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -339,7 +339,11 @@ describe("applyExtraParamsToAgent", () => {
   function runParallelToolCallsPayloadMutationCase(params: {
     applyProvider: string;
     applyModelId: string;
-    model: Model<"openai-completions"> | Model<"openai-responses"> | Model<"anthropic-messages">;
+    model:
+      | Model<"openai-completions">
+      | Model<"openai-responses">
+      | Model<"openai-codex-responses">
+      | Model<"anthropic-messages">;
     cfg?: Record<string, unknown>;
     extraParamsOverride?: Record<string, unknown>;
     payload?: Record<string, unknown>;
@@ -577,6 +581,47 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.parallel_tool_calls).toBe(true);
   });
 
+  it("injects parallel_tool_calls for openai-codex-responses payloads when configured", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.3-codex",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.3-codex": {
+                params: {
+                  parallelToolCalls: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-codex-responses">,
+    });
+
+    expect(payload.parallel_tool_calls).toBe(false);
+  });
+
+  it("defaults parallel_tool_calls on for openai-codex responses", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-codex-responses">,
+    });
+
+    expect(payload.parallel_tool_calls).toBe(true);
+  });
+
   it("does not inject parallel_tool_calls for unsupported APIs", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "anthropic",
@@ -629,6 +674,33 @@ describe("applyExtraParamsToAgent", () => {
         provider: "nvidia-nim",
         id: "moonshotai/kimi-k2.5",
       } as Model<"openai-completions">,
+    });
+
+    expect(payload.parallel_tool_calls).toBe(false);
+  });
+
+  it("lets explicit false config disable default openai-codex parallel_tool_calls", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.3-codex",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.3-codex": {
+                params: {
+                  parallel_tool_calls: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-codex-responses">,
     });
 
     expect(payload.parallel_tool_calls).toBe(false);

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -585,6 +585,31 @@ describe("applyExtraParamsToAgent", () => {
   });
 
   it("respects camelCase parallelToolCalls: false config to disable default for openai-codex", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.3-codex",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.3-codex": {
+                params: {
+                  parallelToolCalls: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-codex-responses">,
+    });
+
+    expect(payload.parallel_tool_calls).toBe(false);
+  });
 
   it("defaults parallel_tool_calls on for openai-codex responses", () => {
     const payload = runParallelToolCallsPayloadMutationCase({

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -305,6 +305,9 @@ describe("applyExtraParamsToAgent", () => {
       params.applyProvider,
       params.applyModelId,
       params.extraParamsOverride,
+      undefined,
+      undefined,
+      params.model.api,
     );
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, params.options ?? {});
@@ -620,6 +623,20 @@ describe("applyExtraParamsToAgent", () => {
     });
 
     expect(payload.parallel_tool_calls).toBe(true);
+  });
+
+  it("does not default parallel_tool_calls on for openai-codex openai-completions", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.4",
+      model: {
+        api: "openai-completions",
+        provider: "openai-codex",
+        id: "gpt-5.4",
+      } as unknown as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("parallel_tool_calls");
   });
 
   it("does not inject parallel_tool_calls for unsupported APIs", () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -363,6 +363,9 @@ describe("applyExtraParamsToAgent", () => {
       params.applyProvider,
       params.applyModelId,
       params.extraParamsOverride,
+      undefined,
+      undefined,
+      params.model.api,
     );
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, {});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -182,7 +182,11 @@ function createParallelToolCallsWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (model.api !== "openai-completions" && model.api !== "openai-responses") {
+    if (
+      model.api !== "openai-completions" &&
+      model.api !== "openai-responses" &&
+      model.api !== "openai-codex-responses"
+    ) {
       return underlying(model, context, options);
     }
     log.debug(
@@ -199,6 +203,13 @@ function createParallelToolCallsWrapper(
       },
     });
   };
+}
+
+function resolveDefaultParallelToolCalls(provider: string): boolean | undefined {
+  // Codex workloads are dominated by tool-heavy coding loops. Defaulting
+  // parallel_tool_calls on reduces serialized read/exec round-trips unless the
+  // user explicitly overrides it for a model or agent.
+  return provider === "openai-codex" ? true : undefined;
 }
 
 /**
@@ -358,16 +369,20 @@ export function applyExtraParamsToAgent(
     "parallel_tool_calls",
     "parallelToolCalls",
   );
-  if (rawParallelToolCalls !== undefined) {
-    if (typeof rawParallelToolCalls === "boolean") {
-      agent.streamFn = createParallelToolCallsWrapper(agent.streamFn, rawParallelToolCalls);
-    } else if (rawParallelToolCalls === null) {
+  const resolvedParallelToolCalls =
+    rawParallelToolCalls === undefined
+      ? resolveDefaultParallelToolCalls(provider)
+      : rawParallelToolCalls;
+  if (resolvedParallelToolCalls !== undefined) {
+    if (typeof resolvedParallelToolCalls === "boolean") {
+      agent.streamFn = createParallelToolCallsWrapper(agent.streamFn, resolvedParallelToolCalls);
+    } else if (resolvedParallelToolCalls === null) {
       log.debug("parallel_tool_calls suppressed by null override, skipping injection");
     } else {
       const summary =
-        typeof rawParallelToolCalls === "string"
-          ? rawParallelToolCalls
-          : typeof rawParallelToolCalls;
+        typeof resolvedParallelToolCalls === "string"
+          ? resolvedParallelToolCalls
+          : typeof resolvedParallelToolCalls;
       log.warn(`ignoring invalid parallel_tool_calls param: ${summary}`);
     }
   }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -205,11 +205,11 @@ function createParallelToolCallsWrapper(
   };
 }
 
-function resolveDefaultParallelToolCalls(provider: string): boolean | undefined {
+function resolveDefaultParallelToolCalls(provider: string, modelApi?: string): boolean | undefined {
   // Codex workloads are dominated by tool-heavy coding loops. Defaulting
   // parallel_tool_calls on reduces serialized read/exec round-trips unless the
   // user explicitly overrides it for a model or agent.
-  return provider === "openai-codex" ? true : undefined;
+  return provider === "openai-codex" && modelApi === "openai-codex-responses" ? true : undefined;
 }
 
 /**
@@ -227,6 +227,7 @@ export function applyExtraParamsToAgent(
   thinkingLevel?: ThinkLevel,
   agentId?: string,
   workspaceDir?: string,
+  modelApi?: string,
 ): void {
   const resolvedExtraParams = resolveExtraParams({
     cfg,
@@ -371,7 +372,7 @@ export function applyExtraParamsToAgent(
   );
   const resolvedParallelToolCalls =
     rawParallelToolCalls === undefined
-      ? resolveDefaultParallelToolCalls(provider)
+      ? resolveDefaultParallelToolCalls(provider, modelApi)
       : rawParallelToolCalls;
   if (resolvedParallelToolCalls !== undefined) {
     if (typeof resolvedParallelToolCalls === "boolean") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2299,6 +2299,7 @@ export async function runEmbeddedAttempt(
         params.thinkLevel,
         sessionAgentId,
         effectiveWorkspace,
+        params.model.api,
       );
 
       if (cacheTrace) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/agents/pi-embedded-runner/extra-params.ts` applied `parallel_tool_calls` to `openai-completions` and `openai-responses`, but not `openai-codex-responses`.
- Why it matters: `openai-codex/gpt-5.3-codex` sessions could serialize tool work by default, leading to extra assistant/tool rounds and unnecessary prompt replay costs.
- What changed: the runner now applies `parallel_tool_calls` to `openai-codex-responses` and defaults `openai-codex` to `parallel_tool_calls: true` unless explicitly overridden.
- What did NOT change (scope boundary): no other providers were changed, no tool policies changed, and explicit `parallel_tool_calls: false` / `null` overrides still win.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`openai-codex` embedded runs now default to parallel tool calls on the responses API path unless explicitly disabled. This should reduce serialized tool loops and prompt replay cost for Codex workflows.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/tsx run from clean worktrees
- Model/provider: `openai-codex/gpt-5.3-codex`
- Integration/channel (if any): none
- Relevant config (redacted): isolated temp state dir with only `openai-codex:default` auth + model store; minimal config pinned to `openai-codex/gpt-5.3-codex`; plugins disabled

### Steps

1. Run the same real embedded Codex workflow from a clean `origin/main` worktree with isolated state.
2. Run the same workflow from this branch with the same prompt, auth profile, and isolated state.
3. Compare settled transcript files for assistant turns, `toolUse` turns, and summed assistant token usage.

### Expected

- The patched branch should complete the same workflow with fewer serialized assistant/tool rounds and lower total token usage.

### Actual

- Settled transcript comparison:
  - `origin/main`: `19` assistant turns, `17` `toolUse` turns, `1,414,601` assistant tokens
  - this branch: `13` assistant turns, `12` `toolUse` turns, `961,260` assistant tokens
  - delta: `-31.6%` assistant turns, `-29.4%` `toolUse` turns, `-32.0%` assistant tokens

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed `origin/main` excluded `openai-codex-responses` from `parallel_tool_calls` handling in `src/agents/pi-embedded-runner/extra-params.ts`.
  - Ran `pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts` after adding Codex regression coverage.
  - Ran one real isolated `openai-codex/gpt-5.3-codex` workflow on `origin/main` and on this branch, then recomputed metrics from the settled transcript files.
- Edge cases checked:
  - Explicit `parallel_tool_calls` values for Codex responses.
  - Default-on behavior for `openai-codex`.
  - Explicit `false` still disables the default.
- What you did **not** verify:
  - More than one live end-to-end Codex scenario.
  - Behavior of every ordering-sensitive tool sequence under parallel execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `parallel_tool_calls: false` for the affected Codex model/provider config, or revert this commit
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms reviewers should watch for: ordering-sensitive Codex workflows behaving differently because tool calls are no longer serialized by default

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some Codex workflows may implicitly rely on serialized tool execution order.
  - Mitigation: explicit `parallel_tool_calls: false` still disables the new default, and the patch scope is limited to `openai-codex` responses.
- Risk: the live improvement can vary by prompt/workflow.
  - Mitigation: unit coverage verifies the config behavior directly, and this PR includes one real before/after Codex comparison with transcript-backed numbers.
