### PR TITLE
feat(gateway): include usage/cost metadata in agent.wait terminal response

### DIFF
--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -1,10 +1,29 @@
 import type { DedupeEntry } from "../server-shared.js";
 
+/** Per-run usage and cost metadata for external orchestrators. */
+export type AgentWaitUsageMeta = {
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  lastCallUsage?: {
+    input: number;
+    output: number;
+  };
+  costUsd?: number;
+  provider?: string;
+  model?: string;
+};
+
 export type AgentWaitTerminalSnapshot = {
   status: "ok" | "error" | "timeout";
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  /** Optional per-run usage/cost metadata for external orchestrators. */
+  meta?: AgentWaitUsageMeta;
 };
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
@@ -62,6 +81,63 @@ function notifyWaiters(runId: string): void {
   }
 }
 
+function extractUsageMeta(payload: Record<string, unknown> | undefined): AgentWaitUsageMeta | undefined {
+  if (!payload) {
+    return undefined;
+  }
+  const raw = payload.meta as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const meta: AgentWaitUsageMeta = {};
+  let hasAnyField = false;
+
+  const rawUsage = raw.usage as Record<string, unknown> | undefined;
+  if (rawUsage && typeof rawUsage === "object") {
+    const input = asFiniteNumber(rawUsage.input);
+    const output = asFiniteNumber(rawUsage.output);
+    if (input !== undefined || output !== undefined) {
+      meta.usage = {
+        input: input ?? 0,
+        output: output ?? 0,
+        cacheRead: asFiniteNumber(rawUsage.cacheRead),
+        cacheWrite: asFiniteNumber(rawUsage.cacheWrite),
+      };
+      hasAnyField = true;
+    }
+  }
+
+  const rawLastCall = raw.lastCallUsage as Record<string, unknown> | undefined;
+  if (rawLastCall && typeof rawLastCall === "object") {
+    const input = asFiniteNumber(rawLastCall.input);
+    const output = asFiniteNumber(rawLastCall.output);
+    if (input !== undefined || output !== undefined) {
+      meta.lastCallUsage = {
+        input: input ?? 0,
+        output: output ?? 0,
+      };
+      hasAnyField = true;
+    }
+  }
+
+  const costUsd = asFiniteNumber(raw.costUsd);
+  if (costUsd !== undefined) {
+    meta.costUsd = costUsd;
+    hasAnyField = true;
+  }
+
+  if (typeof raw.provider === "string" && raw.provider) {
+    meta.provider = raw.provider;
+    hasAnyField = true;
+  }
+  if (typeof raw.model === "string" && raw.model) {
+    meta.model = raw.model;
+    hasAnyField = true;
+  }
+
+  return hasAnyField ? meta : undefined;
+}
+
 export function readTerminalSnapshotFromDedupeEntry(
   entry: DedupeEntry,
 ): AgentWaitTerminalSnapshot | null {
@@ -72,6 +148,7 @@ export function readTerminalSnapshotFromDedupeEntry(
         endedAt?: unknown;
         error?: unknown;
         summary?: unknown;
+        meta?: unknown;
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -87,6 +164,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       : typeof payload?.summary === "string"
         ? payload.summary
         : entry.error?.message;
+  const meta = extractUsageMeta(payload as Record<string, unknown> | undefined);
 
   if (status === "ok" || status === "timeout") {
     return {
@@ -94,6 +172,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: status === "timeout" ? errorMessage : undefined,
+      meta,
     };
   }
   if (status === "error" || !entry.ok) {
@@ -102,6 +181,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: errorMessage,
+      meta,
     };
   }
   return null;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -59,9 +59,11 @@ import {
   readTerminalSnapshotFromGatewayDedupe,
   setGatewayDedupeEntry,
   type AgentWaitTerminalSnapshot,
+  type AgentWaitUsageMeta,
   waitForTerminalGatewayDedupe,
 } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
 const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
@@ -99,6 +101,72 @@ async function runSessionResetFromAgent(params: {
   };
 }
 
+function buildUsageMetaFromRunResult(result: {
+  meta?: {
+    agentMeta?: {
+      provider?: string;
+      model?: string;
+      usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+      lastCallUsage?: { input?: number; output?: number };
+    };
+  };
+}): AgentWaitUsageMeta | undefined {
+  const agentMeta = result.meta?.agentMeta;
+  if (!agentMeta) {
+    return undefined;
+  }
+
+  const meta: AgentWaitUsageMeta = {};
+  let hasAnyField = false;
+
+  if (agentMeta.usage) {
+    const input = agentMeta.usage.input ?? 0;
+    const output = agentMeta.usage.output ?? 0;
+    if (input > 0 || output > 0) {
+      meta.usage = {
+        input,
+        output,
+        cacheRead: agentMeta.usage.cacheRead,
+        cacheWrite: agentMeta.usage.cacheWrite,
+      };
+      hasAnyField = true;
+    }
+  }
+
+  if (agentMeta.lastCallUsage) {
+    const input = agentMeta.lastCallUsage.input ?? 0;
+    const output = agentMeta.lastCallUsage.output ?? 0;
+    if (input > 0 || output > 0) {
+      meta.lastCallUsage = { input, output };
+      hasAnyField = true;
+    }
+  }
+
+  if (agentMeta.provider) {
+    meta.provider = agentMeta.provider;
+    hasAnyField = true;
+  }
+  if (agentMeta.model) {
+    meta.model = agentMeta.model;
+    hasAnyField = true;
+  }
+
+  // Estimate cost from accumulated usage when provider/model cost config is available.
+  if (meta.usage && agentMeta.provider && agentMeta.model) {
+    const costConfig = resolveModelCostConfig({
+      provider: agentMeta.provider,
+      model: agentMeta.model,
+      config: loadConfig(),
+    });
+    const costUsd = estimateUsageCost({ usage: meta.usage, cost: costConfig });
+    if (costUsd !== undefined) {
+      meta.costUsd = costUsd;
+    }
+  }
+
+  return hasAnyField ? meta : undefined;
+}
+
 function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
@@ -108,11 +176,13 @@ function dispatchAgentRunFromGateway(params: {
 }) {
   void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
     .then((result) => {
+      const meta = buildUsageMetaFromRunResult(result);
       const payload = {
         runId: params.runId,
         status: "ok" as const,
         summary: "completed",
         result,
+        meta,
       };
       setGatewayDedupeEntry({
         dedupe: params.context.dedupe,
@@ -738,6 +808,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         startedAt: cachedGatewaySnapshot.startedAt,
         endedAt: cachedGatewaySnapshot.endedAt,
         error: cachedGatewaySnapshot.error,
+        meta: cachedGatewaySnapshot.meta,
       });
       return;
     }
@@ -792,6 +863,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      meta: "meta" in snapshot ? (snapshot as AgentWaitTerminalSnapshot).meta : undefined,
     });
   },
 };


### PR DESCRIPTION
## Summary

- Add optional `meta` field to `AgentWaitTerminalSnapshot` carrying per-run usage/cost metadata (token counts, last-call usage, estimated USD cost, provider, model)
- Extract usage from `EmbeddedPiAgentMeta` at run completion and estimate cost via existing `resolveModelCostConfig`/`estimateUsageCost` utilities
- Forward `meta` through both `agent.wait` response paths (cached snapshot and race-resolved snapshot)

Closes #49494

## Motivation

External orchestrators like Paperclip need per-run cost visibility to implement budget controls, usage dashboards, and cost attribution. Today they must parse JSONL transcripts after the fact. This change surfaces the data directly in the `agent.wait` WebSocket response, which is the natural integration point for synchronous orchestration flows.

## Design

The `meta` field is fully optional and backward-compatible -- it is omitted when no usage data is available (e.g., error runs that never reached the LLM). The shape mirrors existing `EmbeddedPiAgentMeta` fields:

```typescript
meta?: {
  usage?: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
  lastCallUsage?: { input: number; output: number };
  costUsd?: number;
  provider?: string;
  model?: string;
};
```

## Files changed

- `src/gateway/server-methods/agent-wait-dedupe.ts` -- New `AgentWaitUsageMeta` type, extended snapshot type, `extractUsageMeta()` parser
- `src/gateway/server-methods/agent.ts` -- `buildUsageMetaFromRunResult()` helper, meta injection in dispatch + both wait response paths

## Test plan

- [ ] Existing `agent-wait-dedupe.test.ts` tests continue to pass (snapshot shape is backward-compatible)
- [ ] Verify `meta` appears in `agent.wait` response when a run completes with usage data
- [ ] Verify `meta` is omitted when no agent meta is available (error paths)
- [ ] Verify `costUsd` is populated when model cost config exists, omitted otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)