### PR TITLE
feat(gateway): include usage/cost metadata in agent.wait terminal response

### DIFF
--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -2,6 +2,7 @@ import type { DedupeEntry } from "../server-shared.js";
 
 /** Per-run usage and cost metadata for external orchestrators. */
 export type AgentWaitUsageMeta = {
+  sessionId?: string;
   usage?: {
     input: number;
     output: number;
@@ -128,6 +129,10 @@ function extractUsageMeta(payload: Record<string, unknown> | undefined): AgentWa
     hasAnyField = true;
   }
 
+  if (typeof raw.sessionId === "string" && raw.sessionId) {
+    meta.sessionId = raw.sessionId;
+    hasAnyField = true;
+  }
   if (typeof raw.provider === "string" && raw.provider) {
     meta.provider = raw.provider;
     hasAnyField = true;

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -1,10 +1,29 @@
 import type { DedupeEntry } from "../server-shared.js";
 
+/** Per-run usage and cost metadata for external orchestrators. */
+export type AgentWaitUsageMeta = {
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  lastCallUsage?: {
+    input: number;
+    output: number;
+  };
+  costUsd?: number;
+  provider?: string;
+  model?: string;
+};
+
 export type AgentWaitTerminalSnapshot = {
   status: "ok" | "error" | "timeout";
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  /** Optional per-run usage/cost metadata for external orchestrators. */
+  meta?: AgentWaitUsageMeta;
 };
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
@@ -62,6 +81,63 @@ function notifyWaiters(runId: string): void {
   }
 }
 
+function extractUsageMeta(payload: Record<string, unknown> | undefined): AgentWaitUsageMeta | undefined {
+  if (!payload) {
+    return undefined;
+  }
+  const raw = payload.meta as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const meta: AgentWaitUsageMeta = {};
+  let hasAnyField = false;
+
+  const rawUsage = raw.usage as Record<string, unknown> | undefined;
+  if (rawUsage && typeof rawUsage === "object") {
+    const input = asFiniteNumber(rawUsage.input);
+    const output = asFiniteNumber(rawUsage.output);
+    if (input !== undefined || output !== undefined) {
+      meta.usage = {
+        input: input ?? 0,
+        output: output ?? 0,
+        cacheRead: asFiniteNumber(rawUsage.cacheRead),
+        cacheWrite: asFiniteNumber(rawUsage.cacheWrite),
+      };
+      hasAnyField = true;
+    }
+  }
+
+  const rawLastCall = raw.lastCallUsage as Record<string, unknown> | undefined;
+  if (rawLastCall && typeof rawLastCall === "object") {
+    const input = asFiniteNumber(rawLastCall.input);
+    const output = asFiniteNumber(rawLastCall.output);
+    if (input !== undefined || output !== undefined) {
+      meta.lastCallUsage = {
+        input: input ?? 0,
+        output: output ?? 0,
+      };
+      hasAnyField = true;
+    }
+  }
+
+  const costUsd = asFiniteNumber(raw.costUsd);
+  if (costUsd !== undefined) {
+    meta.costUsd = costUsd;
+    hasAnyField = true;
+  }
+
+  if (typeof raw.provider === "string" && raw.provider) {
+    meta.provider = raw.provider;
+    hasAnyField = true;
+  }
+  if (typeof raw.model === "string" && raw.model) {
+    meta.model = raw.model;
+    hasAnyField = true;
+  }
+
+  return hasAnyField ? meta : undefined;
+}
+
 export function readTerminalSnapshotFromDedupeEntry(
   entry: DedupeEntry,
 ): AgentWaitTerminalSnapshot | null {
@@ -72,6 +148,7 @@ export function readTerminalSnapshotFromDedupeEntry(
         endedAt?: unknown;
         error?: unknown;
         summary?: unknown;
+        meta?: unknown;
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -87,6 +164,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       : typeof payload?.summary === "string"
         ? payload.summary
         : entry.error?.message;
+  const meta = extractUsageMeta(payload as Record<string, unknown> | undefined);
 
   if (status === "ok" || status === "timeout") {
     return {
@@ -94,6 +172,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: status === "timeout" ? errorMessage : undefined,
+      meta,
     };
   }
   if (status === "error" || !entry.ok) {
@@ -102,6 +181,7 @@ export function readTerminalSnapshotFromDedupeEntry(
       startedAt,
       endedAt,
       error: errorMessage,
+      meta,
     };
   }
   return null;

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -96,12 +96,14 @@ function extractUsageMeta(payload: Record<string, unknown> | undefined): AgentWa
   if (rawUsage && typeof rawUsage === "object") {
     const input = asFiniteNumber(rawUsage.input);
     const output = asFiniteNumber(rawUsage.output);
-    if (input !== undefined || output !== undefined) {
+    const cacheRead = asFiniteNumber(rawUsage.cacheRead);
+    const cacheWrite = asFiniteNumber(rawUsage.cacheWrite);
+    if (input !== undefined || output !== undefined || cacheRead !== undefined || cacheWrite !== undefined) {
       meta.usage = {
         input: input ?? 0,
         output: output ?? 0,
-        cacheRead: asFiniteNumber(rawUsage.cacheRead),
-        cacheWrite: asFiniteNumber(rawUsage.cacheWrite),
+        ...(cacheRead !== undefined ? { cacheRead } : {}),
+        ...(cacheWrite !== undefined ? { cacheWrite } : {}),
       };
       hasAnyField = true;
     }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -182,12 +182,13 @@ function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
   idempotencyKey: string;
+  sessionId?: string;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
 }) {
   void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
     .then((result) => {
-      const meta = buildUsageMetaFromRunResult(result, result.entry?.sessionId);
+      const meta = buildUsageMetaFromRunResult(result, params.sessionId);
       const payload = {
         runId: params.runId,
         status: "ok" as const,
@@ -685,6 +686,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
     dispatchAgentRunFromGateway({
+      sessionId: resolvedSessionId,
       ingressOpts: {
         message,
         images,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -864,11 +864,11 @@ export const agentHandlers: GatewayRequestHandlers = {
     // When lifecycle wins the race, it may not carry meta (usage/cost).
     // Fall back to the dedupe entry which has meta from dispatchAgentRunFromGateway.
     let meta: AgentWaitUsageMeta | undefined =
-      "meta" in snapshot ? snapshot.meta : undefined;
+      "meta" in snapshot ? (snapshot as AgentWaitTerminalSnapshot).meta ?? undefined : undefined;
     if (!meta && first.source === "lifecycle") {
       const dedupeSnapshot = await dedupePromise.catch(() => null);
       if (dedupeSnapshot && "meta" in dedupeSnapshot) {
-        meta = dedupeSnapshot.meta;
+        meta = (dedupeSnapshot as AgentWaitTerminalSnapshot).meta ?? undefined;
       }
     }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -122,12 +122,14 @@ function buildUsageMetaFromRunResult(result: {
   if (agentMeta.usage) {
     const input = agentMeta.usage.input ?? 0;
     const output = agentMeta.usage.output ?? 0;
-    if (input > 0 || output > 0) {
+    const cacheRead = agentMeta.usage.cacheRead ?? 0;
+    const cacheWrite = agentMeta.usage.cacheWrite ?? 0;
+    if (input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0) {
       meta.usage = {
         input,
         output,
-        cacheRead: agentMeta.usage.cacheRead,
-        cacheWrite: agentMeta.usage.cacheWrite,
+        ...(cacheRead > 0 ? { cacheRead } : {}),
+        ...(cacheWrite > 0 ? { cacheWrite } : {}),
       };
       hasAnyField = true;
     }
@@ -161,6 +163,7 @@ function buildUsageMetaFromRunResult(result: {
     const costUsd = estimateUsageCost({ usage: meta.usage, cost: costConfig });
     if (costUsd !== undefined) {
       meta.costUsd = costUsd;
+      hasAnyField = true;
     }
   }
 
@@ -857,13 +860,25 @@ export const agentHandlers: GatewayRequestHandlers = {
       });
       return;
     }
+
+    // When lifecycle wins the race, it may not carry meta (usage/cost).
+    // Fall back to the dedupe entry which has meta from dispatchAgentRunFromGateway.
+    let meta: AgentWaitUsageMeta | undefined =
+      "meta" in snapshot ? snapshot.meta : undefined;
+    if (!meta && first.source === "lifecycle") {
+      const dedupeSnapshot = await dedupePromise.catch(() => null);
+      if (dedupeSnapshot && "meta" in dedupeSnapshot) {
+        meta = dedupeSnapshot.meta;
+      }
+    }
+
     respond(true, {
       runId,
       status: snapshot.status,
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
-      meta: "meta" in snapshot ? (snapshot as AgentWaitTerminalSnapshot).meta : undefined,
+      meta,
     });
   },
 };

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -59,9 +59,11 @@ import {
   readTerminalSnapshotFromGatewayDedupe,
   setGatewayDedupeEntry,
   type AgentWaitTerminalSnapshot,
+  type AgentWaitUsageMeta,
   waitForTerminalGatewayDedupe,
 } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
 const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
@@ -99,6 +101,72 @@ async function runSessionResetFromAgent(params: {
   };
 }
 
+function buildUsageMetaFromRunResult(result: {
+  meta?: {
+    agentMeta?: {
+      provider?: string;
+      model?: string;
+      usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+      lastCallUsage?: { input?: number; output?: number };
+    };
+  };
+}): AgentWaitUsageMeta | undefined {
+  const agentMeta = result.meta?.agentMeta;
+  if (!agentMeta) {
+    return undefined;
+  }
+
+  const meta: AgentWaitUsageMeta = {};
+  let hasAnyField = false;
+
+  if (agentMeta.usage) {
+    const input = agentMeta.usage.input ?? 0;
+    const output = agentMeta.usage.output ?? 0;
+    if (input > 0 || output > 0) {
+      meta.usage = {
+        input,
+        output,
+        cacheRead: agentMeta.usage.cacheRead,
+        cacheWrite: agentMeta.usage.cacheWrite,
+      };
+      hasAnyField = true;
+    }
+  }
+
+  if (agentMeta.lastCallUsage) {
+    const input = agentMeta.lastCallUsage.input ?? 0;
+    const output = agentMeta.lastCallUsage.output ?? 0;
+    if (input > 0 || output > 0) {
+      meta.lastCallUsage = { input, output };
+      hasAnyField = true;
+    }
+  }
+
+  if (agentMeta.provider) {
+    meta.provider = agentMeta.provider;
+    hasAnyField = true;
+  }
+  if (agentMeta.model) {
+    meta.model = agentMeta.model;
+    hasAnyField = true;
+  }
+
+  // Estimate cost from accumulated usage when provider/model cost config is available.
+  if (meta.usage && agentMeta.provider && agentMeta.model) {
+    const costConfig = resolveModelCostConfig({
+      provider: agentMeta.provider,
+      model: agentMeta.model,
+      config: loadConfig(),
+    });
+    const costUsd = estimateUsageCost({ usage: meta.usage, cost: costConfig });
+    if (costUsd !== undefined) {
+      meta.costUsd = costUsd;
+    }
+  }
+
+  return hasAnyField ? meta : undefined;
+}
+
 function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
   runId: string;
@@ -108,11 +176,13 @@ function dispatchAgentRunFromGateway(params: {
 }) {
   void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
     .then((result) => {
+      const meta = buildUsageMetaFromRunResult(result);
       const payload = {
         runId: params.runId,
         status: "ok" as const,
         summary: "completed",
         result,
+        meta,
       };
       setGatewayDedupeEntry({
         dedupe: params.context.dedupe,
@@ -738,6 +808,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         startedAt: cachedGatewaySnapshot.startedAt,
         endedAt: cachedGatewaySnapshot.endedAt,
         error: cachedGatewaySnapshot.error,
+        meta: cachedGatewaySnapshot.meta,
       });
       return;
     }
@@ -792,6 +863,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      meta: "meta" in snapshot ? (snapshot as AgentWaitTerminalSnapshot).meta : undefined,
     });
   },
 };

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -101,25 +101,33 @@ async function runSessionResetFromAgent(params: {
   };
 }
 
-function buildUsageMetaFromRunResult(result: {
-  meta?: {
-    agentMeta?: {
-      provider?: string;
-      model?: string;
-      usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
-      lastCallUsage?: { input?: number; output?: number };
+function buildUsageMetaFromRunResult(
+  result: {
+    meta?: {
+      agentMeta?: {
+        provider?: string;
+        model?: string;
+        usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+        lastCallUsage?: { input?: number; output?: number };
+      };
     };
-  };
-}): AgentWaitUsageMeta | undefined {
+  },
+  sessionId?: string,
+): AgentWaitUsageMeta | undefined {
   const agentMeta = result.meta?.agentMeta;
-  if (!agentMeta) {
+  if (!agentMeta && !sessionId) {
     return undefined;
   }
 
   const meta: AgentWaitUsageMeta = {};
   let hasAnyField = false;
 
-  if (agentMeta.usage) {
+  if (sessionId) {
+    meta.sessionId = sessionId;
+    hasAnyField = true;
+  }
+
+  if (agentMeta?.usage) {
     const input = agentMeta.usage.input ?? 0;
     const output = agentMeta.usage.output ?? 0;
     const cacheRead = agentMeta.usage.cacheRead ?? 0;
@@ -135,7 +143,7 @@ function buildUsageMetaFromRunResult(result: {
     }
   }
 
-  if (agentMeta.lastCallUsage) {
+  if (agentMeta?.lastCallUsage) {
     const input = agentMeta.lastCallUsage.input ?? 0;
     const output = agentMeta.lastCallUsage.output ?? 0;
     if (input > 0 || output > 0) {
@@ -144,17 +152,17 @@ function buildUsageMetaFromRunResult(result: {
     }
   }
 
-  if (agentMeta.provider) {
+  if (agentMeta?.provider) {
     meta.provider = agentMeta.provider;
     hasAnyField = true;
   }
-  if (agentMeta.model) {
+  if (agentMeta?.model) {
     meta.model = agentMeta.model;
     hasAnyField = true;
   }
 
   // Estimate cost from accumulated usage when provider/model cost config is available.
-  if (meta.usage && agentMeta.provider && agentMeta.model) {
+  if (meta.usage && agentMeta?.provider && agentMeta?.model) {
     const costConfig = resolveModelCostConfig({
       provider: agentMeta.provider,
       model: agentMeta.model,
@@ -179,7 +187,7 @@ function dispatchAgentRunFromGateway(params: {
 }) {
   void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
     .then((result) => {
-      const meta = buildUsageMetaFromRunResult(result);
+      const meta = buildUsageMetaFromRunResult(result, result.entry?.sessionId);
       const payload = {
         runId: params.runId,
         status: "ok" as const,


### PR DESCRIPTION
## Summary

- Add optional `meta` field to `AgentWaitTerminalSnapshot` carrying per-run usage/cost metadata (token counts, last-call usage, estimated USD cost, provider, model)
- Extract usage from `EmbeddedPiAgentMeta` at run completion and estimate cost via existing `resolveModelCostConfig`/`estimateUsageCost` utilities
- Forward `meta` through both `agent.wait` response paths (cached snapshot and race-resolved snapshot)

Closes #49494
Supersedes #49499 (closed due to fork visibility change)

## Motivation

External orchestrators like Paperclip need per-run cost visibility to implement budget controls, usage dashboards, and cost attribution. Today they must parse JSONL transcripts after the fact. This change surfaces the data directly in the `agent.wait` WebSocket response, which is the natural integration point for synchronous orchestration flows.

Paperclip's adapter (`@paperclipai/adapter-openclaw-gateway`) already has `parseUsage()` ready to consume `usage`, `costUsd`, `provider`, and `model` from response metadata — it just gets `undefined` today. See Paperclip PR [#884](https://github.com/paperclipai/paperclip/pull/884).

## Design

The `meta` field is fully optional and backward-compatible — it is omitted when no usage data is available (e.g., error runs that never reached the LLM).

```typescript
meta?: {
  usage?: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
  lastCallUsage?: { input: number; output: number };
  costUsd?: number;
  provider?: string;
  model?: string;
};
```

## Files changed

- `src/gateway/server-methods/agent-wait-dedupe.ts` — New `AgentWaitUsageMeta` type, extended snapshot type, `extractUsageMeta()` parser
- `src/gateway/server-methods/agent.ts` — `buildUsageMetaFromRunResult()` helper, meta injection in dispatch + both wait response paths

## Security

This change does not alter any trust boundary. The `meta` field is only included in `agent.wait` responses to authenticated gateway callers (trusted operators per the security policy). No secrets, credentials, or sensitive data are exposed — only token counts and estimated cost.

## Test plan

- [ ] Existing `agent-wait-dedupe.test.ts` tests pass (backward-compatible)
- [ ] `meta` appears in `agent.wait` response when a run completes with usage data
- [ ] `meta` is omitted when no agent meta is available (error paths)
- [ ] `costUsd` is populated when model cost config exists, omitted otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)