### PR TITLE
fix: add docs hint for plugin override trust error

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -298,6 +298,27 @@ describe("loadGatewayPlugins", () => {
     });
   });
 
+  test("includes docs guidance when a plugin fallback override is not trusted", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-untrusted-plugin"));
+    const gatewayScopeModule = await import("../plugins/runtime/gateway-request-scope.js");
+
+    await expect(
+      gatewayScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+        runtime.run({
+          sessionKey: "s-untrusted-override",
+          message: "use untrusted override",
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          deliver: false,
+        }),
+      ),
+    ).rejects.toThrow(
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
+    );
+  });
+
   test("allows trusted fallback model-only overrides when the model ref is canonical", async () => {
     const serverPlugins = await importServerPluginsModule();
     const runtime = await createSubagentRuntime(serverPlugins, {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -155,7 +155,10 @@ function authorizeFallbackModelOverride(params: {
   if (!policy?.allowModelOverride) {
     return {
       allowed: false,
-      reason: `plugin "${pluginId}" is not trusted for fallback provider/model override requests.`,
+      reason:
+        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
+        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
+        "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }
   if (policy.allowAnyModel) {


### PR DESCRIPTION
## What
Update the fallback plugin provider/model override trust error so it points users at the plugin runtime docs and tells them exactly which config key to search for. Add a focused regression test for the untrusted-plugin branch.

## Why
The previous error explained that the plugin was untrusted, but it did not tell operators where to find the relevant documentation or which config setting unlocks the behavior. That made the fix harder to discover from the runtime failure alone.

## Changes
- Link trust error to docs
- Add search hint for config key
- Cover untrusted plugin branch

## Testing
- `git diff --check`
  - Expected: no whitespace or merge issues
- `pnpm test -- src/gateway/server-plugins.test.ts -t "includes docs guidance when a plugin fallback override is not trusted"`
  - Result: Vitest started, then hung in this worktree without producing a completion result
