### PR TITLE
[codex] add openai-codex gpt-5.4-mini support

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -36,7 +36,28 @@ describe("buildOpenAICodexProviderPlugin", () => {
       api: "openai-codex-responses",
       baseUrl: "https://chatgpt.com/backend-api",
       contextWindow: 128_000,
-      maxTokens: 64_000,
+      maxTokens: 128_000,
+    });
+  });
+
+  it("uses explicit gpt-5.4-mini limits on the no-template fallback path", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const mini = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-mini",
+      modelRegistry: {
+        find: () => null,
+      } as never,
+    });
+
+    expect(mini).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4-mini",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      contextWindow: 128_000,
+      maxTokens: 128_000,
     });
   });
 

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenAICodexProviderPlugin } from "./openai-codex-provider.js";
+
+describe("buildOpenAICodexProviderPlugin", () => {
+  it("resolves gpt-5.4-mini from the codex mini template", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const registry = {
+      find(providerId: string, id: string) {
+        if (providerId !== "openai-codex" || id !== "gpt-5.1-codex-mini") {
+          return null;
+        }
+        return {
+          id,
+          name: "GPT-5.1 Codex Mini",
+          provider: "openai-codex",
+          api: "openai-codex-responses",
+          baseUrl: "https://chatgpt.com/backend-api",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 64_000,
+        };
+      },
+    };
+
+    const mini = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-mini",
+      modelRegistry: registry as never,
+    });
+
+    expect(mini).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4-mini",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      contextWindow: 128_000,
+      maxTokens: 64_000,
+    });
+  });
+
+  it("surfaces gpt-5.4-mini in codex augmented catalog metadata", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const entries = provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [{ provider: "openai-codex", id: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini" }],
+    } as never);
+
+    expect(entries).toContainEqual({
+      provider: "openai-codex",
+      id: "gpt-5.4-mini",
+      name: "gpt-5.4-mini",
+    });
+    expect(
+      provider.isModernModelRef?.({
+        provider: "openai-codex",
+        modelId: "gpt-5.4-mini",
+      } as never),
+    ).toBe(true);
+  });
+});

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -18,7 +18,7 @@ describe("buildOpenAICodexProviderPlugin", () => {
           reasoning: true,
           input: ["text", "image"],
           cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 128_000,
+          contextWindow: 272_000,
           maxTokens: 64_000,
         };
       },

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -34,6 +34,8 @@ const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
+const OPENAI_CODEX_GPT_54_MINI_CONTEXT_TOKENS = 128_000;
+const OPENAI_CODEX_GPT_54_MINI_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = ["gpt-5.1-codex-mini"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
@@ -110,6 +112,8 @@ function resolveCodexForwardCompatModel(
       baseUrl: OPENAI_CODEX_BASE_URL,
       reasoning: true,
       input: ["text", "image"],
+      contextWindow: OPENAI_CODEX_GPT_54_MINI_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MINI_MAX_TOKENS,
     };
   } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
     templateIds = [OPENAI_CODEX_GPT_53_MODEL_ID, ...OPENAI_CODEX_TEMPLATE_MODEL_IDS];

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -31,9 +31,11 @@ import {
 const PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
+const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = ["gpt-5.1-codex-mini"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS = 128_000;
@@ -49,6 +51,7 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
 ] as const;
 const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   "gpt-5.2",
   "gpt-5.2-codex",
   OPENAI_CODEX_GPT_53_MODEL_ID,
@@ -98,6 +101,15 @@ function resolveCodexForwardCompatModel(
     patch = {
       contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+    };
+  } else if (lower === OPENAI_CODEX_GPT_54_MINI_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS;
+    patch = {
+      api: "openai-codex-responses",
+      provider: PROVIDER_ID,
+      baseUrl: OPENAI_CODEX_BASE_URL,
+      reasoning: true,
+      input: ["text", "image"],
     };
   } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
     templateIds = [OPENAI_CODEX_GPT_53_MODEL_ID, ...OPENAI_CODEX_TEMPLATE_MODEL_IDS];
@@ -266,6 +278,11 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         providerId: PROVIDER_ID,
         templateIds: OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
       });
+      const gpt54MiniTemplate = findCatalogTemplate({
+        entries: ctx.entries,
+        providerId: PROVIDER_ID,
+        templateIds: OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS,
+      });
       const sparkTemplate = findCatalogTemplate({
         entries: ctx.entries,
         providerId: PROVIDER_ID,
@@ -277,6 +294,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
               ...gpt54Template,
               id: OPENAI_CODEX_GPT_54_MODEL_ID,
               name: OPENAI_CODEX_GPT_54_MODEL_ID,
+            }
+          : undefined,
+        gpt54MiniTemplate
+          ? {
+              ...gpt54MiniTemplate,
+              id: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+              name: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
             }
           : undefined,
         sparkTemplate

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -205,6 +205,14 @@ describe("loadModelCatalog", () => {
         contextWindow: 272000,
         input: ["text", "image"],
       },
+      {
+        id: "gpt-5.1-codex-mini",
+        provider: "openai-codex",
+        name: "GPT-5.1 Codex Mini",
+        reasoning: true,
+        contextWindow: 272000,
+        input: ["text", "image"],
+      },
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
@@ -242,6 +250,13 @@ describe("loadModelCatalog", () => {
         provider: "openai-codex",
         id: "gpt-5.4",
         name: "gpt-5.4",
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai-codex",
+        id: "gpt-5.4-mini",
+        name: "gpt-5.4-mini",
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -46,6 +46,7 @@ export function buildOpenAICodexForwardCompatExpectation(
   baseUrl: string;
 } {
   const isGpt54 = id === "gpt-5.4";
+  const isGpt54Mini = id === "gpt-5.4-mini";
   const isSpark = id === "gpt-5.3-codex-spark";
   return {
     provider: "openai-codex",
@@ -57,7 +58,7 @@ export function buildOpenAICodexForwardCompatExpectation(
     cost: isSpark
       ? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
       : OPENAI_CODEX_TEMPLATE_MODEL.cost,
-    contextWindow: isGpt54 ? 1_050_000 : isSpark ? 128_000 : 272000,
+    contextWindow: isGpt54 ? 1_050_000 : isGpt54Mini || isSpark ? 128_000 : 272000,
     maxTokens: 128000,
   };
 }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -666,6 +666,24 @@ describe("resolveModel", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("builds an openai-codex fallback for gpt-5.4-mini", () => {
+    mockDiscoveredModel({
+      provider: "openai-codex",
+      modelId: "gpt-5.1-codex-mini",
+      templateModel: {
+        ...buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"),
+        id: "gpt-5.1-codex-mini",
+        name: "GPT-5.1 Codex Mini",
+        contextWindow: 128_000,
+      },
+    });
+
+    const result = resolveModel("openai-codex", "gpt-5.4-mini", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-mini"));
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex-spark", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -18,6 +18,13 @@ const OPENAI_CODEX_53_MODEL = {
   name: "GPT-5.3 Codex",
 };
 
+const OPENAI_CODEX_54_MINI_MODEL = {
+  ...OPENAI_CODEX_MODEL,
+  id: "gpt-5.4-mini",
+  name: "GPT-5.4 Mini",
+  contextWindow: 128000,
+};
+
 const mocks = vi.hoisted(() => {
   const sourceConfig = {
     agents: { defaults: { model: { primary: "openai-codex/gpt-5.4" } } },
@@ -321,6 +328,55 @@ describe("modelsListCommand forward-compat", () => {
         }),
         expect.objectContaining({
           key: "openai-codex/gpt-5.4",
+          available: true,
+        }),
+      ]);
+    });
+
+    it("includes synthetic codex gpt-5.4-mini in --all output when catalog supports it", async () => {
+      mockDiscoveredCodex53Registry();
+      mocks.loadModelCatalog.mockResolvedValueOnce([
+        {
+          provider: "openai-codex",
+          id: "gpt-5.1-codex-mini",
+          name: "GPT-5.1 Codex Mini",
+          input: ["text"],
+          contextWindow: 128000,
+        },
+        {
+          provider: "openai-codex",
+          id: "gpt-5.4-mini",
+          name: "GPT-5.4 Mini",
+          input: ["text"],
+          contextWindow: 128000,
+        },
+      ]);
+      mocks.listProfilesForProvider.mockImplementation((_: unknown, provider: string) =>
+        provider === "openai-codex"
+          ? ([{ id: "profile-1" }] as Array<Record<string, unknown>>)
+          : [],
+      );
+      mocks.resolveModelWithRegistry.mockImplementation(
+        ({ provider, modelId }: { provider: string; modelId: string }) => {
+          if (provider !== "openai-codex") {
+            return undefined;
+          }
+          if (modelId === "gpt-5.3-codex") {
+            return { ...OPENAI_CODEX_53_MODEL };
+          }
+          if (modelId === "gpt-5.4-mini") {
+            return { ...OPENAI_CODEX_54_MINI_MODEL };
+          }
+          return undefined;
+        },
+      );
+      await runAllOpenAiCodexCommand();
+      expect(lastPrintedRows<{ key: string; available: boolean }>()).toEqual([
+        expect.objectContaining({
+          key: "openai-codex/gpt-5.3-codex",
+        }),
+        expect.objectContaining({
+          key: "openai-codex/gpt-5.4-mini",
           available: true,
         }),
       ]);

--- a/src/plugins/contracts/runtime.contract.test.ts
+++ b/src/plugins/contracts/runtime.contract.test.ts
@@ -429,6 +429,40 @@ describe("provider runtime contract", () => {
     });
   });
 
+  describe("openai-codex", () => {
+    it("owns openai-codex gpt-5.4 mini forward-compat resolution", () => {
+      const provider = requireProviderContractProvider("openai-codex");
+      const model = provider.resolveDynamicModel?.({
+        provider: "openai-codex",
+        modelId: "gpt-5.4-mini",
+        modelRegistry: {
+          find: (_provider: string, id: string) =>
+            id === "gpt-5.1-codex-mini"
+              ? createModel({
+                  id,
+                  provider: "openai-codex",
+                  api: "openai-codex-responses",
+                  baseUrl: "https://chatgpt.com/backend-api",
+                  input: ["text", "image"],
+                  reasoning: true,
+                  contextWindow: 272_000,
+                  maxTokens: 128_000,
+                })
+              : null,
+        } as never,
+      });
+
+      expect(model).toMatchObject({
+        id: "gpt-5.4-mini",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        contextWindow: 272_000,
+        maxTokens: 128_000,
+      });
+    });
+  });
+
   describe("xai", () => {
     it("owns Grok forward-compat resolution for newer fast models", () => {
       const provider = requireProviderContractProvider("xai");

--- a/src/plugins/provider-catalog-metadata.ts
+++ b/src/plugins/provider-catalog-metadata.ts
@@ -53,6 +53,11 @@ export function augmentBundledProviderCatalog(
     providerId: OPENAI_CODEX_PROVIDER_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
   });
+  const openAiCodexGpt54MiniTemplate = findCatalogTemplate({
+    entries: context.entries,
+    providerId: OPENAI_CODEX_PROVIDER_ID,
+    templateIds: ["gpt-5.1-codex-mini"],
+  });
   const openAiCodexSparkTemplate = findCatalogTemplate({
     entries: context.entries,
     providerId: OPENAI_CODEX_PROVIDER_ID,
@@ -93,6 +98,13 @@ export function augmentBundledProviderCatalog(
           ...openAiCodexGpt54Template,
           id: "gpt-5.4",
           name: "gpt-5.4",
+        }
+      : undefined,
+    openAiCodexGpt54MiniTemplate
+      ? {
+          ...openAiCodexGpt54MiniTemplate,
+          id: "gpt-5.4-mini",
+          name: "gpt-5.4-mini",
         }
       : undefined,
     openAiCodexSparkTemplate

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -6,6 +6,7 @@ export const openaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5-mini", name: "GPT-5 mini" },
   { provider: "openai", id: "gpt-5-nano", name: "GPT-5 nano" },
   { provider: "openai-codex", id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+  { provider: "openai-codex", id: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini" },
 ];
 
 export const expectedAugmentedOpenaiCodexCatalogEntries = [
@@ -14,6 +15,7 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+  { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   {
     provider: "openai-codex",
     id: "gpt-5.3-codex-spark",

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -474,6 +474,11 @@ describe("provider-runtime", () => {
             { provider: "openai", id: "gpt-5-mini", name: "GPT-5 mini" },
             { provider: "openai", id: "gpt-5-nano", name: "GPT-5 nano" },
             { provider: "openai-codex", id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+            {
+              provider: "openai-codex",
+              id: "gpt-5.1-codex-mini",
+              name: "GPT-5.1 Codex Mini",
+            },
           ],
         },
       }),
@@ -483,6 +488,7 @@ describe("provider-runtime", () => {
       { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
       { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+      { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       {
         provider: "openai-codex",
         id: "gpt-5.3-codex-spark",


### PR DESCRIPTION
Reviewer summary:
- Adds forward-compatible `openai-codex/gpt-5.4-mini` support.
- Mirrors the existing `openai-codex/gpt-5.4` path in both dynamic resolution and bundled catalog augmentation.
- Covers the change with provider, catalog, runtime-contract, embedded-runner, and models-list tests.

This change adds forward-compatible `openai-codex/gpt-5.4-mini` support to OpenClaw.

Today `origin/main` already knows about `openai/gpt-5.4-mini`, but the Codex provider path still stops at `openai-codex/gpt-5.4`. In practice that means a Codex-authenticated runtime can list and select `openai-codex/gpt-5.4`, but not the matching mini variant, even when the Codex catalog already has enough neighboring templates to synthesize it. Users end up with an inconsistent model surface between `openai` and `openai-codex`, and downstream integrations that try to default Codex traffic onto `gpt-5.4-mini` cannot rely on the model catalog to expose it.

The root cause is that the Codex provider only taught dynamic resolution and bundled catalog augmentation about `gpt-5.4`, plus the spark variant. The bundled provider metadata path also never emitted a synthetic `openai-codex/gpt-5.4-mini` entry, so even consumers that load the augmented catalog instead of the provider plugin directly could not discover it.

This patch extends the Codex provider in both places. `extensions/openai/openai-codex-provider.ts` now treats `gpt-5.4-mini` as a modern Codex model, resolves it dynamically from the `gpt-5.1-codex-mini` template lineage, and emits it from the provider-side catalog augmentation. `src/plugins/provider-catalog-metadata.ts` mirrors that behavior for the bundled metadata augmentation path so the synthetic model shows up wherever OpenClaw assembles its built-in provider catalog. The accompanying tests cover provider resolution, runtime contract ownership, catalog loading, forward-compatible model listing, and the embedded runner fallback path.

I verified the change with targeted checks:

- `pnpm exec oxlint --type-aware extensions/openai/openai-codex-provider.ts extensions/openai/openai-codex-provider.test.ts src/plugins/provider-catalog-metadata.ts src/plugins/provider-runtime.test-support.ts src/plugins/provider-runtime.test.ts src/plugins/contracts/runtime.contract.test.ts src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.test-harness.ts src/agents/pi-embedded-runner/model.test.ts src/commands/models/list.list-command.forward-compat.test.ts`
- `node dist/index.js models list --all --json` now includes `openai-codex/gpt-5.4-mini`

Repository-wide CI is currently also surfacing unrelated failures outside this diff, including formatting drift in other extension files and existing unresolved imports in `extensions/acpx` and `extensions/google` during full builds.

This should make Codex-authenticated runtimes expose the mini model consistently without changing any existing `openai-codex/gpt-5.4` behavior.
