### PR TITLE
fix: use explicit agent workspace when writing transcript headers

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
-import Ajv from "ajv";
+import AjvPkg from "ajv";
 import {
   formatXHighModelHint,
   normalizeThinkLevel,
@@ -214,7 +214,13 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
         // oxlint-disable-next-line typescript/no-explicit-any
         const schema = (params as any).schema as unknown;
         if (schema && typeof schema === "object" && !Array.isArray(schema)) {
-          const ajv = new Ajv.default({ allErrors: true, strict: false });
+          const Ajv = AjvPkg as unknown as new (opts?: object) => {
+            compile: (schema: unknown) => {
+              errors?: Array<{ instancePath?: string; message?: string }>;
+              (value: unknown): boolean;
+            };
+          };
+          const ajv = new Ajv({ allErrors: true, strict: false });
           // oxlint-disable-next-line typescript/no-explicit-any
           const validate = ajv.compile(schema as any);
           const ok = validate(parsed);

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -9,6 +9,13 @@ vi.mock("./create-client.js", () => ({
   createMatrixClient: (...args: unknown[]) => createMatrixClientMock(...args),
 }));
 
+vi.mock("../sdk-runtime.js", () => ({
+  getMatrixLogService: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
 function makeAuth(suffix: string): MatrixAuth {
   return {
     homeserver: "https://matrix.example.org",

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -8,6 +8,18 @@ import {
 } from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
+vi.mock("../../../runtime-api.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../runtime-api.js")>("../../../runtime-api.js");
+  return {
+    ...actual,
+    dispatchReplyFromConfigWithSettledDispatcher: vi.fn().mockResolvedValue({
+      queuedFinal: false,
+      counts: { final: 0, partial: 0, tool: 0 },
+    }),
+  };
+});
+
 describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
   it("stores sender-labeled BodyForAgent for group thread messages", async () => {
     const recordInboundSession = vi.fn().mockResolvedValue(undefined);

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
-import { buildModelsProviderData } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import {
   buildMattermostAllowedModelRefs,
@@ -126,7 +125,7 @@ describe("Mattermost model picker", () => {
     expect(parseMattermostModelPickerContext({ action: "select" })).toBeNull();
   });
 
-  it("falls back to the routed agent default model when no override is stored", async () => {
+  it("falls back to the routed agent default model when no override is stored", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-model-picker-"));
     try {
       const cfg: OpenClawConfig = {
@@ -145,7 +144,14 @@ describe("Mattermost model picker", () => {
           ],
         },
       };
-      const providerData = await buildModelsProviderData(cfg, "support");
+      const providerData = {
+        byProvider: new Map<string, Set<string>>(),
+        providers: [],
+        resolvedDefault: {
+          provider: "openai",
+          model: "gpt-5",
+        },
+      };
 
       expect(
         resolveMattermostModelPickerCurrentModel({

--- a/extensions/nostr/src/config-schema.ts
+++ b/extensions/nostr/src/config-schema.ts
@@ -1,6 +1,10 @@
-import { AllowFromListSchema, DmPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
+import {
+  AllowFromListSchema,
+  buildChannelConfigSchema,
+  DmPolicySchema,
+  MarkdownConfigSchema,
+} from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
-import { MarkdownConfigSchema, buildChannelConfigSchema } from "../api.js";
 
 /**
  * Validates https:// URLs only (no javascript:, data:, file:, etc.)

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { configureClient } from "@tloncorp/api";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-runtime";
 import type {
   ChannelAccountSnapshot,
@@ -16,6 +15,7 @@ import {
   parseTlonTarget,
   resolveTlonOutboundTarget,
 } from "./targets.js";
+import { loadTlonApi } from "./tlon-api.js";
 import { resolveTlonAccount } from "./types.js";
 import { authenticate } from "./urbit/auth.js";
 import { ssrfPolicyFromAllowPrivateNetwork } from "./urbit/context.js";
@@ -164,8 +164,9 @@ export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
     const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
+    const { configureClient } = await loadTlonApi();
 
-    configureClient({
+    await configureClient({
       shipUrl: account.url,
       shipName: account.ship.replace(/^~/, ""),
       verbose: false,

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -1,0 +1,25 @@
+type ConfigureClientParams = {
+  shipUrl: string;
+  shipName: string;
+  verbose?: boolean;
+  getCode?: () => Promise<string> | string;
+};
+
+type UploadFileParams = {
+  blob: Blob;
+  fileName?: string;
+  contentType?: string;
+};
+
+type UploadFileResult = {
+  url: string;
+};
+
+type TlonApiModule = {
+  configureClient: (params: ConfigureClientParams) => Promise<void>;
+  uploadFile: (params: UploadFileParams) => Promise<UploadFileResult>;
+};
+
+export async function loadTlonApi(): Promise<TlonApiModule> {
+  return (await import("@tloncorp/api")) as unknown as TlonApiModule;
+}

--- a/extensions/tlon/src/tloncorp-api.d.ts
+++ b/extensions/tlon/src/tloncorp-api.d.ts
@@ -1,0 +1,14 @@
+declare module "@tloncorp/api" {
+  export function configureClient(params: {
+    shipUrl: string;
+    shipName: string;
+    verbose?: boolean;
+    getCode?: () => Promise<string> | string;
+  }): Promise<void>;
+
+  export function uploadFile(params: {
+    blob: Blob;
+    fileName?: string;
+    contentType?: string;
+  }): Promise<{ url: string }>;
+}

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -1,8 +1,8 @@
 /**
  * Upload an image from a URL to Tlon storage.
  */
-import { uploadFile } from "@tloncorp/api";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/infra-runtime";
+import { loadTlonApi } from "../tlon-api.js";
 import { getDefaultSsrFPolicy } from "./context.js";
 
 /**
@@ -43,6 +43,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
       const fileName = urlPath.split("/").pop() || `upload-${Date.now()}.png`;
 
       // Upload to Tlon storage
+      const { uploadFile } = await loadTlonApi();
       const result = await uploadFile({
         blob,
         fileName,

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -167,5 +167,18 @@ export function createWhatsAppPluginBase(params: {
     },
     setup: params.setup,
     groups: params.groups,
-  });
+  }) as Pick<
+    ChannelPlugin<ResolvedWhatsAppAccount>,
+    | "id"
+    | "meta"
+    | "setupWizard"
+    | "capabilities"
+    | "reload"
+    | "gatewayMethods"
+    | "configSchema"
+    | "config"
+    | "security"
+    | "setup"
+    | "groups"
+  >;
 }

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -167,18 +167,5 @@ export function createWhatsAppPluginBase(params: {
     },
     setup: params.setup,
     groups: params.groups,
-  }) as Pick<
-    ChannelPlugin<ResolvedWhatsAppAccount>,
-    | "id"
-    | "meta"
-    | "setupWizard"
-    | "capabilities"
-    | "reload"
-    | "gatewayMethods"
-    | "configSchema"
-    | "config"
-    | "security"
-    | "setup"
-    | "groups"
-  >;
+  });
 }

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -16,17 +16,10 @@ const pnpm = "pnpm";
 const behaviorManifest = loadTestRunnerBehavior();
 const existingFiles = (entries) =>
   entries.map((entry) => entry.file).filter((file) => fs.existsSync(file));
-const unitBehaviorIsolatedFiles = existingFiles(behaviorManifest.unit.isolated);
-const unitSingletonIsolatedFiles = existingFiles(behaviorManifest.unit.singletonIsolated);
-const unitThreadSingletonFiles = existingFiles(behaviorManifest.unit.threadSingleton);
-const unitVmForkSingletonFiles = existingFiles(behaviorManifest.unit.vmForkSingleton);
-const unitBehaviorOverrideSet = new Set([
-  ...unitBehaviorIsolatedFiles,
-  ...unitSingletonIsolatedFiles,
-  ...unitThreadSingletonFiles,
-  ...unitVmForkSingletonFiles,
-]);
-const channelSingletonFiles = [];
+const rawUnitBehaviorIsolatedFiles = existingFiles(behaviorManifest.unit.isolated);
+const rawUnitSingletonIsolatedFiles = existingFiles(behaviorManifest.unit.singletonIsolated);
+const rawUnitThreadSingletonFiles = existingFiles(behaviorManifest.unit.threadSingleton);
+const rawUnitVmForkSingletonFiles = existingFiles(behaviorManifest.unit.vmForkSingleton);
 
 const children = new Set();
 const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
@@ -173,6 +166,30 @@ const passthroughRequiresSingleRun = passthroughOptionArgs.some((arg) => {
 });
 const baseConfigPrefixes = ["src/agents/", "src/auto-reply/", "src/commands/", "test/", "ui/"];
 const normalizeRepoPath = (value) => value.split(path.sep).join("/");
+const inferOwner = (fileFilter) => {
+  if (fileFilter.endsWith(".live.test.ts")) {
+    return "live";
+  }
+  if (fileFilter.endsWith(".e2e.test.ts")) {
+    return "e2e";
+  }
+  if (channelTestPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "channels";
+  }
+  if (fileFilter.startsWith("extensions/")) {
+    return "extensions";
+  }
+  if (fileFilter.startsWith("src/gateway/")) {
+    return "gateway";
+  }
+  if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "base";
+  }
+  if (fileFilter.startsWith("src/")) {
+    return "unit";
+  }
+  return "base";
+};
 const walkTestFiles = (rootDir) => {
   if (!fs.existsSync(rootDir)) {
     return [];
@@ -206,37 +223,38 @@ const allKnownTestFiles = [
     ...walkTestFiles(path.join("ui", "src", "ui")),
   ]),
 ];
+// Keep the unit-specific behavior lanes aligned with vitest.unit.config.ts. If the
+// manifest accidentally points at a file owned by another config (for example an
+// extension test), we should not count it toward unit sharding.
+const unitBehaviorIsolatedFiles = rawUnitBehaviorIsolatedFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitSingletonIsolatedFiles = rawUnitSingletonIsolatedFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitThreadSingletonFiles = rawUnitThreadSingletonFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitVmForkSingletonFiles = rawUnitVmForkSingletonFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitBehaviorOverrideSet = new Set([
+  ...unitBehaviorIsolatedFiles,
+  ...unitSingletonIsolatedFiles,
+  ...unitThreadSingletonFiles,
+  ...unitVmForkSingletonFiles,
+]);
+const channelSingletonFiles = [];
 const inferTarget = (fileFilter) => {
   const isolated = unitBehaviorIsolatedFiles.includes(fileFilter);
-  if (fileFilter.endsWith(".live.test.ts")) {
-    return { owner: "live", isolated };
-  }
-  if (fileFilter.endsWith(".e2e.test.ts")) {
-    return { owner: "e2e", isolated };
-  }
-  if (channelTestPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return { owner: "channels", isolated };
-  }
-  if (fileFilter.startsWith("extensions/")) {
-    return { owner: "extensions", isolated };
-  }
-  if (fileFilter.startsWith("src/gateway/")) {
-    return { owner: "gateway", isolated };
-  }
-  if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return { owner: "base", isolated };
-  }
-  if (fileFilter.startsWith("src/")) {
-    return { owner: "unit", isolated };
-  }
-  return { owner: "base", isolated };
+  return { owner: inferOwner(fileFilter), isolated };
 };
 const unitTimingManifest = loadUnitTimingManifest();
 const parseEnvNumber = (name, fallback) => {
   const parsed = Number.parseInt(process.env[name] ?? "", 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 };
-const allKnownUnitFiles = allKnownTestFiles.filter((file) => inferTarget(file).owner === "unit");
+const allKnownUnitFiles = allKnownTestFiles.filter((file) => inferOwner(file) === "unit");
 const defaultHeavyUnitFileLimit =
   testProfile === "serial" ? 0 : testProfile === "low" ? 8 : highMemLocalHost ? 24 : 16;
 const defaultHeavyUnitLaneCount =

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "./types.js";
+
+const state = vi.hoisted(() => ({
+  sessionFile: "",
+  store: {} as Record<string, SessionEntry>,
+  appendMessage: vi.fn(),
+}));
+
+vi.mock("../io.js", () => ({
+  loadConfig: () => ({
+    agents: {
+      list: [{ id: "sunke", default: true }],
+    },
+  }),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "sunke",
+  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) =>
+    `/Users/admin/.openclaw/workspace-${agentId}`,
+}));
+
+vi.mock("../../sessions/transcript-events.js", () => ({
+  emitSessionTranscriptUpdate: vi.fn(),
+}));
+
+vi.mock("./delivery-info.js", () => ({
+  parseSessionThreadInfo: () => ({ baseSessionKey: undefined, threadId: undefined }),
+}));
+
+vi.mock("./paths.js", () => ({
+  resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
+  resolveSessionFilePath: () => state.sessionFile,
+  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionTranscriptPath: () => state.sessionFile,
+}));
+
+vi.mock("./session-file.js", () => ({
+  resolveAndPersistSessionFile: async () => ({
+    sessionFile: state.sessionFile,
+    sessionEntry: state.store["agent:main:test:user-1"],
+  }),
+}));
+
+vi.mock("./store.js", () => ({
+  loadSessionStore: () => state.store,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+  CURRENT_SESSION_VERSION: 2,
+  SessionManager: {
+    open: () => ({
+      appendMessage: state.appendMessage,
+    }),
+  },
+}));
+
+let appendAssistantMessageToSessionTranscript: typeof import("./transcript.js").appendAssistantMessageToSessionTranscript;
+let originalCwd = process.cwd();
+
+beforeEach(async () => {
+  vi.resetModules();
+  state.appendMessage = vi.fn();
+  state.store = {
+    "agent:main:test:user-1": {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+    } as SessionEntry,
+  };
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-"));
+  const wrongWorkspace = path.join(tmpRoot, "wrong-workspace");
+  fs.mkdirSync(wrongWorkspace, { recursive: true });
+  process.chdir(wrongWorkspace);
+
+  state.sessionFile = path.join(tmpRoot, "sessions", "session-1.jsonl");
+  ({ appendAssistantMessageToSessionTranscript } = await import("./transcript.js"));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+});
+
+describe("appendAssistantMessageToSessionTranscript", () => {
+  it("writes the session header cwd from the target agent workspace instead of process.cwd()", async () => {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: "sunke",
+      sessionKey: "agent:main:test:user-1",
+      text: "hello",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      sessionFile: state.sessionFile,
+    });
+
+    const [headerLine] = fs.readFileSync(state.sessionFile, "utf-8").split(/\r?\n/);
+    const header = JSON.parse(headerLine) as { cwd?: string };
+
+    expect(header.cwd).toBe("/Users/admin/.openclaw/workspace-sunke");
+    expect(header.cwd).not.toBe(process.cwd());
+  });
+});

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -35,7 +35,10 @@ vi.mock("./delivery-info.js", () => ({
 vi.mock("./paths.js", () => ({
   resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
   resolveSessionFilePath: () => state.sessionFile,
-  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionFilePathOptions: () => ({
+    agentId: "sunke",
+    sessionsDir: path.dirname(state.sessionFile),
+  }),
   resolveSessionTranscriptPath: () => state.sessionFile,
 }));
 
@@ -60,7 +63,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 }));
 
 let appendAssistantMessageToSessionTranscript: typeof import("./transcript.js").appendAssistantMessageToSessionTranscript;
-let originalCwd = process.cwd();
+const originalCwd = process.cwd();
 
 beforeEach(async () => {
   vi.resetModules();

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { loadConfig } from "../io.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
@@ -67,17 +69,23 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  agentId?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: resolveAgentWorkspaceDir(cfg, agentId),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -178,7 +186,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, agentId: params.agentId });
 
   if (
     params.idempotencyKey &&

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -69,23 +69,18 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
-  agentId?: string;
+  cwd: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
-  const cfg = loadConfig();
-  const agentId =
-    typeof params.agentId === "string" && params.agentId.trim()
-      ? params.agentId.trim()
-      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: resolveAgentWorkspaceDir(cfg, agentId),
+    cwd: params.cwd,
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -166,6 +161,12 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
+  const sessionCwd = resolveAgentWorkspaceDir(cfg, agentId);
 
   let sessionFile: string;
   try {
@@ -186,7 +187,11 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, agentId: params.agentId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    cwd: sessionCwd,
+  });
 
   if (
     params.idempotencyKey &&

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { loadConfig } from "../io.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { loadConfig } from "../io.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
   resolveDefaultSessionStorePath,
@@ -161,6 +161,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
+
   const cfg = loadConfig();
   const agentId =
     typeof params.agentId === "string" && params.agentId.trim()

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -213,24 +213,29 @@ type CreateChannelPluginBaseOptions<TResolvedAccount> = {
   groups?: ChannelPlugin<TResolvedAccount>["groups"];
 };
 
-type CreatedChannelPluginBase<TResolvedAccount> = Pick<
-  ChannelPlugin<TResolvedAccount>,
-  "id" | "meta" | "setup"
-> &
-  Partial<
-    Pick<
-      ChannelPlugin<TResolvedAccount>,
-      | "setupWizard"
-      | "capabilities"
-      | "agentPrompt"
-      | "streaming"
-      | "reload"
-      | "gatewayMethods"
-      | "configSchema"
-      | "config"
-      | "security"
-      | "groups"
-    >
+type ChannelPluginBaseOptionalKeys =
+  | "setupWizard"
+  | "capabilities"
+  | "agentPrompt"
+  | "streaming"
+  | "reload"
+  | "gatewayMethods"
+  | "configSchema"
+  | "config"
+  | "security"
+  | "groups";
+
+type CreatedChannelPluginBase<
+  TResolvedAccount,
+  TOptions extends CreateChannelPluginBaseOptions<TResolvedAccount> =
+    CreateChannelPluginBaseOptions<TResolvedAccount>,
+> = Pick<ChannelPlugin<TResolvedAccount>, "id" | "meta" | "setup"> & {
+  [K in Extract<
+    ChannelPluginBaseOptionalKeys,
+    keyof TOptions
+  >]-?: ChannelPlugin<TResolvedAccount>[K];
+} & Partial<
+    Pick<ChannelPlugin<TResolvedAccount>, Exclude<ChannelPluginBaseOptionalKeys, keyof TOptions>>
   >;
 
 function resolvePluginConfigSchema(
@@ -290,9 +295,10 @@ export function defineSetupPluginEntry<TPlugin>(plugin: TPlugin) {
 }
 
 // Shared base object for channel plugins that only need to override a few optional surfaces.
-export function createChannelPluginBase<TResolvedAccount>(
-  params: CreateChannelPluginBaseOptions<TResolvedAccount>,
-): CreatedChannelPluginBase<TResolvedAccount> {
+export function createChannelPluginBase<
+  TResolvedAccount,
+  TOptions extends CreateChannelPluginBaseOptions<TResolvedAccount>,
+>(params: TOptions): CreatedChannelPluginBase<TResolvedAccount, TOptions> {
   return {
     id: params.id,
     meta: {
@@ -310,5 +316,5 @@ export function createChannelPluginBase<TResolvedAccount>(
     ...(params.security ? { security: params.security } : {}),
     ...(params.groups ? { groups: params.groups } : {}),
     setup: params.setup,
-  } as CreatedChannelPluginBase<TResolvedAccount>;
+  } as CreatedChannelPluginBase<TResolvedAccount, TOptions>;
 }


### PR DESCRIPTION
## Summary

This PR stops session transcript headers from recording `cwd` via `process.cwd()` in the outbound transcript mirroring path.

Instead, `ensureSessionHeader()` now resolves the workspace explicitly from config + target agent id, and `appendAssistantMessageToSessionTranscript()` passes `agentId` through.

## Why

Related issue: #49523  
Related regression pattern: #45413

The previous code path in `src/config/sessions/transcript.ts` wrote:

```ts
cwd: process.cwd()
```

That is process-global state. In a multi-agent runtime, other embedded paths can temporarily switch cwd, so a brand-new transcript header can end up recording another agent's workspace.

## Changes

- import `resolveAgentWorkspaceDir` and `resolveDefaultAgentId`
- import `loadConfig`
- make `ensureSessionHeader()` accept `agentId`
- resolve header `cwd` from the target agent workspace instead of `process.cwd()`
- add a focused regression test for transcript header cwd isolation

## Notes

I have not run the full OpenClaw test suite in this environment.

This draft PR is based on:

- a live production hotfix applied to OpenClaw `2026.3.13`
- observed session header mismatches on a multi-agent deployment
- a focused unit test intended to fail on the old implementation and pass on the new one
