### PR TITLE
Tests: cover Twitch runtime barrel

### DIFF
--- a/extensions/twitch/src/runtime-api.test.ts
+++ b/extensions/twitch/src/runtime-api.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+describe("twitch runtime-api", () => {
+  it("re-exports the runtime helpers used by Twitch internals", async () => {
+    const runtimeApi = await import("../runtime-api.js");
+
+    expect(runtimeApi.DEFAULT_ACCOUNT_ID).toBe("default");
+    expect(runtimeApi.MarkdownConfigSchema).toBeDefined();
+    expect(typeof runtimeApi.buildChannelConfigSchema).toBe("function");
+    expect(typeof runtimeApi.createReplyPrefixOptions).toBe("function");
+    expect(typeof runtimeApi.normalizeAccountId).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused Twitch runtime-barrel test
- verify the private `extensions/twitch/runtime-api.ts` surface keeps the core helpers used by Twitch internals available

## Test plan
- [x] `pnpm test -- extensions/twitch/src/runtime-api.test.ts` *(fails in the current workspace because `src/plugin-sdk/twitch.ts` transitively imports `zod`, which is not resolving in this checkout)*

Made with [Cursor](https://cursor.com)