### PR TITLE
fix(sessions): preserve updatedAt in updateLastRoute to allow idle/daily resets

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -869,7 +869,7 @@ export async function updateLastRoute(params: {
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );

--- a/src/config/sessions/store.update-last-route.test.ts
+++ b/src/config/sessions/store.update-last-route.test.ts
@@ -1,0 +1,75 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore, updateLastRoute } from "./store.js";
+import type { SessionEntry } from "./types.js";
+
+// Prevent reads of a real openclaw.json during tests.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+let testDir = "";
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ulr-test-"));
+});
+
+afterEach(async () => {
+  clearSessionStoreCacheForTest();
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+function makeEntry(updatedAt: number): SessionEntry {
+  return { sessionId: crypto.randomUUID(), updatedAt };
+}
+
+describe("updateLastRoute", () => {
+  it("does not bump updatedAt for an existing session", async () => {
+    // Verifies fix for issue #49515: updateLastRoute was calling mergeSessionEntry
+    // which reset updatedAt to Date.now() on every inbound message, preventing
+    // idle/daily session resets from firing.
+    const storePath = path.join(testDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:dm:user-1";
+    const originalUpdatedAt = Date.now() - 60_000; // 1 minute ago
+
+    const initial: Record<string, SessionEntry> = {
+      [sessionKey]: makeEntry(originalUpdatedAt),
+    };
+    await saveSessionStore(storePath, initial);
+
+    await updateLastRoute({
+      storePath,
+      sessionKey,
+      deliveryContext: { channel: "telegram", to: "telegram:user-1" },
+    });
+
+    const store = loadSessionStore(storePath);
+    const entry = store[sessionKey];
+    expect(entry).toBeDefined();
+    // updatedAt must not be bumped to wall-clock time — it should stay at originalUpdatedAt
+    // so that evaluateSessionFreshness can correctly detect idle sessions.
+    expect(entry!.updatedAt).toBe(originalUpdatedAt);
+  });
+
+  it("sets updatedAt to now for a new (non-existing) session", async () => {
+    const storePath = path.join(testDir, "sessions.json");
+    await saveSessionStore(storePath, {});
+
+    const before = Date.now();
+    await updateLastRoute({
+      storePath,
+      sessionKey: "agent:main:telegram:dm:user-2",
+      deliveryContext: { channel: "telegram", to: "telegram:user-2" },
+    });
+    const after = Date.now();
+
+    const store = loadSessionStore(storePath);
+    const entry = store["agent:main:telegram:dm:user-2"];
+    expect(entry).toBeDefined();
+    expect(entry!.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(entry!.updatedAt).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
Fixes #49515.

## What was happening

`updateLastRoute` is called on every inbound message via `recordInboundSession`. It builds a `basePatch` that includes `updatedAt: Math.max(existing?.updatedAt ?? 0, now)`, then called `mergeSessionEntry` to persist. `mergeSessionEntry` applies another `Math.max(..., Date.now())` pass, so the session `updatedAt` was bumped to wall-clock time on every received message.

This meant `evaluateSessionFreshness` always saw a fresh session — `idleMinutes` and `atHour` resets never fired. Issue #49515 documents a concrete case: a session ran 2.5 days, 1084 entries, through 16 idle gaps with zero resets.

## The fix

`recordSessionMetaFromInbound` was already patched in #32379 to use `mergeSessionEntryPreserveActivity` for the same reason — inbound metadata should not count as session activity. `updateLastRoute` was a missed call site with the same bug.

Changed one call in `updateLastRoute`:

```diff
- const next = mergeSessionEntry(
+ const next = mergeSessionEntryPreserveActivity(
    existing,
    metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
  );
```

`mergeSessionEntryPreserveActivity` preserves `existing.updatedAt` for existing sessions (the preserve-activity policy in `resolveMergedUpdatedAt`). New sessions (no existing entry) still get a fresh timestamp via the normal fallback — correct behavior.

The `basePatch.updatedAt` field is left intact; it is dead computation for existing sessions under the preserve-activity policy, but removing it would widen scope beyond this fix.

## Test

Added `store.update-last-route.test.ts` with two cases: existing session keeps its original `updatedAt`, new session gets a fresh timestamp.