### PR TITLE
fix: normalize same-provider embedded model refs

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -435,6 +435,43 @@ describe("resolveModel", () => {
     });
   });
 
+  it("normalizes same-provider qualified refs before provider fallback matching", () => {
+    const cfg = {
+      models: {
+        providers: {
+          polza: {
+            baseUrl: "https://proxy.example/v1",
+            api: "openai-completions",
+            headers: { "X-Provider": "provider" },
+            models: [
+              {
+                ...makeModel("gpt-4o-mini"),
+                reasoning: true,
+                contextWindow: 123456,
+                maxTokens: 4096,
+                headers: { "X-Model": "special" },
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("polza", "polza/gpt-4o-mini", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "polza",
+      id: "gpt-4o-mini",
+      reasoning: true,
+      contextWindow: 123456,
+      maxTokens: 4096,
+    });
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+      "X-Provider": "provider",
+      "X-Model": "special",
+    });
+  });
   it("uses OpenRouter API capabilities for unknown models when cache is populated", () => {
     mockGetOpenRouterModelCapabilities.mockReturnValue({
       name: "Healer Alpha",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -232,6 +232,16 @@ function resolveExplicitModelWithRegistry(params: {
   return undefined;
 }
 
+function stripSameProviderPrefix(params: { provider: string; modelId: string }): string {
+  const providerId = normalizeProviderId(params.provider);
+  const modelId = params.modelId.trim();
+  if (!providerId || !modelId) {
+    return modelId;
+  }
+  const prefix = `${providerId}/`;
+  return modelId.toLowerCase().startsWith(prefix) ? modelId.slice(prefix.length) : modelId;
+}
+
 export function resolveModelWithRegistry(params: {
   provider: string;
   modelId: string;
@@ -245,6 +255,23 @@ export function resolveModelWithRegistry(params: {
   }
   if (explicitModel?.kind === "resolved") {
     return explicitModel.model;
+  }
+
+  const alternateModelId = stripSameProviderPrefix({
+    provider: params.provider,
+    modelId: params.modelId,
+  });
+  if (alternateModelId !== params.modelId) {
+    const alternateExplicitModel = resolveExplicitModelWithRegistry({
+      ...params,
+      modelId: alternateModelId,
+    });
+    if (alternateExplicitModel?.kind === "suppressed") {
+      return undefined;
+    }
+    if (alternateExplicitModel?.kind === "resolved") {
+      return alternateExplicitModel.model;
+    }
   }
 
   const { provider, modelId, cfg, modelRegistry, agentDir } = params;
@@ -270,21 +297,22 @@ export function resolveModelWithRegistry(params: {
     });
   }
 
-  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
+  const fallbackModelId = alternateModelId !== modelId ? alternateModelId : modelId;
+  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === fallbackModelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
-  if (providerConfig || modelId.startsWith("mock-")) {
+  if (providerConfig || fallbackModelId.startsWith("mock-")) {
     return normalizeResolvedModel({
       provider,
       cfg,
       agentDir,
       model: {
-        id: modelId,
-        name: modelId,
+        id: fallbackModelId,
+        name: fallbackModelId,
         api: providerConfig?.api ?? "openai-responses",
         provider,
         baseUrl: providerConfig?.baseUrl,


### PR DESCRIPTION
## Summary

- Problem: embedded runs could pass `provider/model` through to OpenAI-compatible proxies instead of the resolved model ID when the selected ref repeated the same provider prefix.
- Why it matters: proxies such as `polza.ai` reject `polza/gpt-4o-mini` and expect `gpt-4o-mini`, so `/model`-selected embedded runs fail even though the configured model is valid.
- What changed: retry embedded model resolution with the same-provider prefix stripped before provider fallback matching, and use the normalized ID for the fallback model payload.
- What did NOT change (scope boundary): exact model resolution still runs first, and provider-qualified refs for other providers (for example OpenRouter dynamic models) are left intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48876
- Related #

## User-visible / Behavior Changes

Embedded runs now normalize same-provider-qualified model refs like `polza/gpt-4o-mini` to `gpt-4o-mini` before provider fallback, so OpenAI-compatible proxy backends receive the configured model ID instead of the menu/display ref.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 24.14.0 for targeted harness validation
- Model/provider: `polza/gpt-4o-mini` and `openrouter/healer-alpha`
- Integration/channel (if any): embedded runner model resolution
- Relevant config (redacted): custom OpenAI-compatible provider with configured model `gpt-4o-mini`, provider headers, and model-specific overrides

### Steps

1. Configure a custom OpenAI-compatible provider with model `gpt-4o-mini`.
2. Select `polza/gpt-4o-mini` in an embedded run.
3. Resolve the embedded model configuration.

### Expected

- The resolved model sent to the proxy uses `gpt-4o-mini`.
- Provider-level and model-level overrides still apply.

### Actual

- Before this change, embedded fallback resolution kept `polza/gpt-4o-mini`, and model-specific overrides keyed by `gpt-4o-mini` were skipped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before fix (targeted harness): `id = "polza/gpt-4o-mini"`, `reasoning = false`, headers only included the provider-level header.

After fix (same harness): `id = "gpt-4o-mini"`, `reasoning = true`, headers include both provider-level and model-level overrides. The same harness also confirms `openrouter/healer-alpha` stays unchanged.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failing fallback path in a targeted local harness built from the current source, then reran the same harness after the fix and confirmed the normalized ID plus restored model-specific overrides.
- Edge cases checked: exact-match resolution still wins; OpenRouter-style provider-qualified refs continue to pass through unchanged.
- What you did **not** verify: `pnpm exec vitest` for this file hangs in my current Windows environment, so I could not get the repo test runner to complete locally for this case.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous embedded fallback behavior.
- Files/config to restore: `src/agents/pi-embedded-runner/model.ts`, `src/agents/pi-embedded-runner/model.test.ts`
- Known bad symptoms reviewers should watch for: embedded runs stripping prefixes for provider-qualified refs that should remain untouched.

## Risks and Mitigations

- Risk: over-normalizing a provider-qualified ref that should stay qualified.
  - Mitigation: exact resolution still runs first, and the fallback strip only applies when the prefix matches the already selected provider.