### PR TITLE
WhatsApp: add allowTo for outbound-only target gating

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -146,6 +146,28 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
 
     Multi-account override: `channels.whatsapp.accounts.<id>.dmPolicy` (and `allowFrom`) take precedence over channel-level defaults for that account.
 
+    **Outbound-only allowlist (`allowTo`)**
+
+    By default, outbound sends are gated by the same `allowFrom` list. To decouple inbound and outbound — for example, keeping the agent private to yourself while allowing it to message contacts — set `allowTo`:
+
+    ```json
+    {
+      "channels": {
+        "whatsapp": {
+          "dmPolicy": "allowlist",
+          "allowFrom": ["+15551234567"],
+          "allowTo": ["*"]
+        }
+      }
+    }
+    ```
+
+    - `allowTo: ["*"]` — agent can send to any number outbound; inbound stays restricted by `allowFrom`/`dmPolicy`
+    - `allowTo: ["+15559876543"]` — agent can only send outbound to that specific number
+    - omitting `allowTo` — outbound is gated by `allowFrom` as before (backward compatible)
+
+    `allowTo` applies to both message sends and action targets (e.g. reactions). Per-account override: `channels.whatsapp.accounts.<id>.allowTo`.
+
     Runtime behavior details:
 
     - pairings are persisted in channel allow-store and merged with configured `allowFrom`

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -23,6 +23,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowTo?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -142,6 +143,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
+    allowTo: accountCfg?.allowTo ?? rootCfg?.allowTo,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,

--- a/extensions/whatsapp/src/action-runtime-target-auth.ts
+++ b/extensions/whatsapp/src/action-runtime-target-auth.ts
@@ -18,11 +18,12 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   const resolution = resolveWhatsAppOutboundTarget({
     to: params.chatJid,
     allowFrom: account.allowFrom ?? [],
+    allowTo: account.allowTo,
     mode: "implicit",
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom/allowTo list for account "${account.accountId}".`,
     );
   }
   return { to: resolution.to, accountId: account.accountId };

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -161,8 +161,10 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       sendPollWhatsApp: async (...args) =>
         await getWhatsAppRuntime().channel.whatsapp.sendPollWhatsApp(...args),
       shouldLogVerbose: () => getWhatsAppRuntime().logging.shouldLogVerbose(),
-      resolveTarget: ({ to, allowFrom, mode }) =>
-        resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+      resolveTarget: ({ to, allowFrom, mode, cfg, accountId }) => {
+        const account = cfg ? resolveWhatsAppAccount({ cfg, accountId }) : null;
+        return resolveWhatsAppOutboundTarget({ to, allowFrom, allowTo: account?.allowTo, mode });
+      },
     }),
     normalizePayload: ({ payload }) => ({
       ...payload,

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -20,10 +20,12 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
     resolveWhatsAppOutboundTarget: ({
       to,
       allowFrom,
+      allowTo,
       mode,
     }: {
       to?: string;
       allowFrom: string[];
+      allowTo?: string[];
       mode: "explicit" | "implicit";
     }) => {
       const raw = typeof to === "string" ? to.trim() : "";
@@ -36,8 +38,10 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
       }
 
       if (mode === "implicit" && !normalized.endsWith("@g.us")) {
-        const allowAll = allowFrom.includes("*");
-        const allowExact = allowFrom.some((entry) => {
+        // Use allowTo for outbound gating when defined; otherwise fall back to allowFrom.
+        const outboundList = allowTo !== undefined ? allowTo : allowFrom;
+        const allowAll = outboundList.includes("*");
+        const allowExact = outboundList.some((entry) => {
           if (!entry) {
             return false;
           }
@@ -141,6 +145,47 @@ describe("whatsapp resolveTarget", () => {
       throw new Error("expected resolution to fail");
     }
     expect(result.error).toBeDefined();
+  });
+
+  it("should allow target not in allowFrom when allowTo contains wildcard", () => {
+    const result = resolveTarget({
+      to: "5511888888888",
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+      allowTo: ["*"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw result.error;
+    }
+    expect(result.to).toBe("5511888888888@s.whatsapp.net");
+  });
+
+  it("should allow target in allowTo even when not in allowFrom", () => {
+    const result = resolveTarget({
+      to: "5511888888888",
+      mode: "implicit",
+      allowFrom: ["5511999999999"],
+      allowTo: ["5511888888888"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw result.error;
+    }
+    expect(result.to).toBe("5511888888888@s.whatsapp.net");
+  });
+
+  it("should block target not in allowTo even if it is in allowFrom", () => {
+    const result = resolveTarget({
+      to: "5511888888888",
+      mode: "implicit",
+      allowFrom: ["5511888888888"],
+      allowTo: ["5511999999999"],
+    });
+
+    expect(result.ok).toBe(false);
   });
 
   installCommonResolveTargetErrorCases({

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -39,7 +39,7 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
 
       if (mode === "implicit" && !normalized.endsWith("@g.us")) {
         // Use allowTo for outbound gating when defined; otherwise fall back to allowFrom.
-        const outboundList = allowTo !== undefined ? allowTo : allowFrom;
+        const outboundList = allowTo != null ? allowTo : allowFrom;
         const allowAll = outboundList.includes("*");
         const allowExact = outboundList.some((entry) => {
           if (!entry) {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -160,6 +160,8 @@ export type ChannelOutboundAdapter = {
     cfg?: OpenClawConfig;
     to?: string;
     allowFrom?: string[];
+    /** Outbound-only allowlist; when set, used for target gating instead of allowFrom. */
+    allowTo?: string[];
     accountId?: string | null;
     mode?: ChannelOutboundTargetMode;
   }) => { ok: true; to: string } | { ok: false; error: Error };

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -47,6 +47,10 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Optional outbound-only allowlist (E.164). When set, used for outbound target gating instead of
+   * allowFrom — allowing sends to numbers not in allowFrom without granting them inbound access.
+   * Use ["*"] to allow sending to any number while keeping inbound restricted via allowFrom/dmPolicy. */
+  allowTo?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -45,6 +45,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowTo: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -181,6 +181,43 @@ describe("resolveDeliveryTarget", () => {
     expect(result.to).toBe("+15550000099");
   });
 
+  it("group JID passes through implicit check even when allowTo is set", async () => {
+    // Groups are always allowed by resolve-outbound-target; the prefilter must not redirect them.
+    const groupJid = "123456789012345678@g.us";
+    setLastSessionEntry({
+      sessionId: "sess-w5",
+      lastChannel: "whatsapp",
+      lastTo: groupJid,
+    });
+    setWhatsAppAllowFrom(["+15550000001"], ["+15550000099"]);
+    setStoredWhatsAppAllowFrom([]);
+
+    const cfg = makeCfg({ bindings: [] });
+    const result = await resolveLastTarget(cfg);
+
+    expect(result.channel).toBe("whatsapp");
+    expect(result.to).toBe(groupJid);
+  });
+
+  it("falls back to first allowTo entry when last target is not in allowTo", async () => {
+    // allowFrom=[owner], allowTo=[contactA]. Last DM was contactB (not in allowTo).
+    // Fallback should be contactA (first allowTo entry), not the owner — otherwise
+    // resolveOutboundTarget rejects the fallback because the owner is not in allowTo.
+    setLastSessionEntry({
+      sessionId: "sess-w6",
+      lastChannel: "whatsapp",
+      lastTo: "+15550000002",
+    });
+    setWhatsAppAllowFrom(["+15550000001"], ["+15550000099"]);
+    setStoredWhatsAppAllowFrom([]);
+
+    const cfg = makeCfg({ bindings: [] });
+    const result = await resolveLastTarget(cfg);
+
+    expect(result.channel).toBe("whatsapp");
+    expect(result.to).toBe("+15550000099");
+  });
+
   it("falls back to bound accountId when session has no lastAccountId", async () => {
     setMainSessionEntry(undefined);
     const cfg = makeTelegramBoundCfg();

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -81,9 +81,10 @@ function setLastSessionEntry(params: {
   });
 }
 
-function setWhatsAppAllowFrom(allowFrom: string[]) {
+function setWhatsAppAllowFrom(allowFrom: string[], allowTo?: string[]) {
   vi.mocked(resolveWhatsAppAccount).mockReturnValue({
     allowFrom,
+    ...(allowTo !== undefined ? { allowTo } : {}),
   } as unknown as ReturnType<typeof resolveWhatsAppAccount>);
 }
 
@@ -142,6 +143,41 @@ describe("resolveDeliveryTarget", () => {
       to: "+15550000099",
     });
 
+    expect(result.to).toBe("+15550000099");
+  });
+
+  it("uses allowTo for implicit target validation when configured", async () => {
+    // allowFrom is locked to the owner (+15550000001); allowTo opens a contact (+15550000099).
+    // Implicit delivery to the contact should not be rerouted back to the owner.
+    setLastSessionEntry({
+      sessionId: "sess-w3",
+      lastChannel: "whatsapp",
+      lastTo: "+15550000099",
+    });
+    setWhatsAppAllowFrom(["+15550000001"], ["+15550000099"]);
+    setStoredWhatsAppAllowFrom([]);
+
+    const cfg = makeCfg({ bindings: [] });
+    const result = await resolveLastTarget(cfg);
+
+    expect(result.channel).toBe("whatsapp");
+    expect(result.to).toBe("+15550000099");
+  });
+
+  it("allowTo wildcard skips implicit target redirect", async () => {
+    // allowTo: ["*"] means allow all — any implicit target should pass through unchanged.
+    setLastSessionEntry({
+      sessionId: "sess-w4",
+      lastChannel: "whatsapp",
+      lastTo: "+15550000099",
+    });
+    setWhatsAppAllowFrom(["+15550000001"], ["*"]);
+    setStoredWhatsAppAllowFrom([]);
+
+    const cfg = makeCfg({ bindings: [] });
+    const result = await resolveLastTarget(cfg);
+
+    expect(result.channel).toBe("whatsapp");
     expect(result.to).toBe("+15550000099");
   });
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -16,7 +16,7 @@ import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { resolveWhatsAppAccount } from "../../plugin-sdk/whatsapp.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
-import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
 export type DeliveryTargetResolution =
   | {
@@ -178,8 +178,16 @@ export async function resolveDeliveryTarget(
 
     if (toCandidate && mode === "implicit" && effectiveOutboundList.length > 0) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
-      if (!normalizedCurrentTarget || !effectiveOutboundList.includes(normalizedCurrentTarget)) {
-        toCandidate = allowFromOverride[0];
+      // Group JIDs are always allowed (mirrors resolve-outbound-target.ts:37-38).
+      const isGroup = normalizedCurrentTarget ? isWhatsAppGroupJid(normalizedCurrentTarget) : false;
+      if (
+        !isGroup &&
+        (!normalizedCurrentTarget || !effectiveOutboundList.includes(normalizedCurrentTarget))
+      ) {
+        // Fall back to the first allowed outbound recipient.
+        // When allowTo is configured, prefer its first entry so the fallback also
+        // passes the allowTo check in resolveOutboundTarget downstream.
+        toCandidate = configuredAllowTo != null ? effectiveOutboundList[0] : allowFromOverride[0];
       }
     }
   }

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -152,8 +152,8 @@ export async function resolveDeliveryTarget(
   let allowFromOverride: string[] | undefined;
   if (channel === "whatsapp") {
     const resolvedAccountId = normalizeAccountId(accountId);
-    const configuredAllowFromRaw =
-      resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId }).allowFrom ?? [];
+    const resolvedAccount = resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId });
+    const configuredAllowFromRaw = resolvedAccount.allowFrom ?? [];
     const configuredAllowFrom = configuredAllowFromRaw
       .map((entry) => String(entry).trim())
       .filter((entry) => entry && entry !== "*")
@@ -164,9 +164,21 @@ export async function resolveDeliveryTarget(
       .filter((entry): entry is string => Boolean(entry));
     allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
 
-    if (toCandidate && mode === "implicit" && allowFromOverride.length > 0) {
+    // When allowTo is configured, use it as the effective outbound list for implicit
+    // target validation so that scheduled delivery is decoupled from the inbound allowFrom.
+    const configuredAllowTo = resolvedAccount.allowTo;
+    const effectiveOutboundList =
+      configuredAllowTo != null
+        ? configuredAllowTo
+            .map((entry) => String(entry).trim())
+            .filter((entry) => entry !== "*")
+            .map((entry) => normalizeWhatsAppTarget(entry))
+            .filter((entry): entry is string => Boolean(entry))
+        : allowFromOverride;
+
+    if (toCandidate && mode === "implicit" && effectiveOutboundList.length > 0) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
-      if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
+      if (!normalizedCurrentTarget || !effectiveOutboundList.includes(normalizedCurrentTarget)) {
         toCandidate = allowFromOverride[0];
       }
     }

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -203,6 +203,74 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
   });
 
+  describe("allowTo overrides allowFrom for outbound gating", () => {
+    it("allows target not in allowFrom when allowTo contains wildcard", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        allowTo: ["*"],
+        mode: "implicit",
+      });
+      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+    });
+
+    it("allows target in allowTo even when not in allowFrom", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        allowTo: [PRIMARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+    });
+
+    it("blocks target not in allowTo even if it is in allowFrom", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [PRIMARY_TARGET],
+        allowTo: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("falls back to allowFrom when allowTo is undefined", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [PRIMARY_TARGET],
+        allowTo: undefined,
+        mode: "implicit",
+      });
+      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+    });
+
+    it("falls back to allowFrom when allowTo is null", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [PRIMARY_TARGET],
+        allowTo: null,
+        mode: "implicit",
+      });
+      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+    });
+
+    it("treats empty allowTo as unrestricted outbound (allow all)", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        allowTo: [],
+        mode: "implicit",
+      });
+      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+    });
+  });
+
   describe("whitespace handling", () => {
     it("trims whitespace from to parameter", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET);

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -248,15 +248,16 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
     });
 
-    it("falls back to allowFrom when allowTo is null", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+    it("falls back to allowFrom when allowTo is null, blocking unlisted target", () => {
+      // Target is NOT in allowFrom — if null incorrectly resolved to "allow all" this would pass.
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
       const result = resolveWhatsAppOutboundTarget({
         to: PRIMARY_TARGET,
-        allowFrom: [PRIMARY_TARGET],
+        allowFrom: [SECONDARY_TARGET],
         allowTo: null,
         mode: "implicit",
       });
-      expect(result).toEqual({ ok: true, to: PRIMARY_TARGET });
+      expect(result.ok).toBe(false);
     });
 
     it("treats empty allowTo as unrestricted outbound (allow all)", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -8,14 +8,19 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  /** When defined, used for outbound target gating instead of allowFrom.
+   * Set to ["*"] to allow sending to any number while keeping allowFrom restricted for inbound. */
+  allowTo?: Array<string | number> | null | undefined;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
-  const allowListRaw = (params.allowFrom ?? [])
+  // Use allowTo for outbound gating when explicitly configured; otherwise fall back to allowFrom.
+  const outboundListSource = params.allowTo !== undefined ? params.allowTo : params.allowFrom;
+  const outboundListRaw = (outboundListSource ?? [])
     .map((entry) => String(entry).trim())
     .filter(Boolean);
-  const hasWildcard = allowListRaw.includes("*");
-  const allowList = allowListRaw
+  const hasWildcard = outboundListRaw.includes("*");
+  const outboundList = outboundListRaw
     .filter((entry) => entry !== "*")
     .map((entry) => normalizeWhatsAppTarget(entry))
     .filter((entry): entry is string => Boolean(entry));
@@ -31,12 +36,12 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
+    // Enforce outbound allowlist for direct-message sends.
     // Group destinations are handled by group policy and are allowed above.
-    if (hasWildcard || allowList.length === 0) {
+    if (hasWildcard || outboundList.length === 0) {
       return { ok: true, to: normalizedTo };
     }
-    if (allowList.includes(normalizedTo)) {
+    if (outboundList.includes(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
     return {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -15,7 +15,8 @@ export function resolveWhatsAppOutboundTarget(params: {
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
   // Use allowTo for outbound gating when explicitly configured; otherwise fall back to allowFrom.
-  const outboundListSource = params.allowTo !== undefined ? params.allowTo : params.allowFrom;
+  // Use != null (not !== undefined) to treat both null and undefined as "not set".
+  const outboundListSource = params.allowTo != null ? params.allowTo : params.allowFrom;
   const outboundListRaw = (outboundListSource ?? [])
     .map((entry) => String(entry).trim())
     .filter(Boolean);


### PR DESCRIPTION
## Summary

- **Problem:** `allowFrom` is used for both inbound DM gating and outbound target validation, making it impossible to send messages to numbers outside the allowlist without also granting them inbound access to the agent.
- **Why it matters:** Users running OpenClaw on their personal WhatsApp number want to keep the agent private (only they can trigger it) while still having the agent send messages to contacts on their behalf. Tracked in #25513 (duplicate of #25039).
- **What changed:** Added an optional `allowTo` config field. When set, it is used for outbound target gating instead of `allowFrom`, fully decoupling inbound and outbound access control.
- **What did NOT change:** All existing behavior is backward compatible. If `allowTo` is not set, the function falls back to `allowFrom` exactly as before.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #25513
- Related #25039

## User-visible / Behavior Changes

New optional config field `channels.whatsapp.allowTo` (and per-account equivalent). When set, controls which numbers OpenClaw can send to outbound, independently of `allowFrom`.

Example — keep inbound locked to yourself, allow outbound to anyone:

```json
"channels": {
  "whatsapp": {
    "dmPolicy": "allowlist",
    "allowFrom": ["+14087028984"],
    "allowTo": ["*"]
  }
}
```

Example — allow outbound to a specific contact only:

```json
"allowFrom": ["+14087028984"],
"allowTo": ["+14087028984", "+19876543210"]
```

If `allowTo` is omitted entirely, behavior is identical to before this change.

## Security Impact (required)

- New permissions/capabilities? **Yes** — `allowTo: ["*"]` lets the agent send to any WhatsApp number outbound. This is opt-in and requires explicit config.
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk: a misconfigured `allowTo: ["*"]` with an open `dmPolicy` would allow anyone to both trigger the agent and be messaged by it. Mitigation: `allowTo` only affects outbound; inbound is still controlled by `dmPolicy`/`allowFrom` independently.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime: Node 22
- Integration/channel: WhatsApp (personal number / selfChatMode)
- Relevant config: `dmPolicy: "allowlist"`, `allowFrom: [<owner>]`, `allowTo: ["*"]`

### Steps

1. Set `allowFrom` to only your number and `allowTo: ["*"]`
2. Ask OpenClaw to send a WhatsApp message to a contact not in `allowFrom`
3. Message is delivered successfully
4. Verify the contact cannot trigger the agent (inbound still blocked by `allowFrom`)

### Expected

- Outbound send succeeds
- Inbound from unlisted number is blocked

### Actual

- Both work as expected

## Evidence

- [x] Failing test/log before + passing after

27 unit tests in `src/whatsapp/resolve-outbound-target.test.ts` (21 pre-existing + 6 new covering all `allowTo` scenarios). All passing.

## Human Verification (required)

- Verified scenarios: `allowTo: ["*"]` allows outbound while `allowFrom` still gates inbound; `allowTo: [specificNumber]` allows only that number outbound; omitting `allowTo` produces identical behavior to before.
- Edge cases checked: `allowTo: []` (treat as unrestricted, same as empty `allowFrom`); `allowTo: null` falls back to `allowFrom`; per-account `allowTo` overrides root config.
- What you did **not** verify: live WhatsApp send on a real connected session (no paired device available in this environment).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — `allowTo` is optional; existing configs with no `allowTo` behave identically.
- Config/env changes? Yes — new optional field `channels.whatsapp.allowTo` (and per-account).
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: remove `allowTo` from config; behavior reverts to `allowFrom`-only gating.
- Files/config to restore: `openclaw.json` — remove `allowTo` key.
- Known bad symptoms: outbound sends blocked unexpectedly → check that `allowTo` contains the target or `"*"`.

## Risks and Mitigations

- Risk: users set `allowTo: ["*"]` without realizing it only unlocks outbound, and separately set `dmPolicy: "open"` — fully open bot.
  - Mitigation: these are two separate, independent config fields with no surprising interaction. The combination is no more open than setting `allowFrom: ["*"]` today.