### PR TITLE
Plugin SDK: restore read-only directory inspection seam

### DIFF
--- a/extensions/discord/src/directory-config.ts
+++ b/extensions/discord/src/directory-config.ts
@@ -1,23 +1,18 @@
 import {
   applyDirectoryQueryAndLimit,
   collectNormalizedDirectoryIds,
+  inspectReadOnlyChannelAccount,
   toDirectoryEntries,
   type DirectoryConfigParams,
 } from "openclaw/plugin-sdk/directory-runtime";
-import { inspectDiscordAccount } from "../api.js";
 import type { InspectedDiscordAccount } from "../api.js";
 
-function inspectDiscordDirectoryAccount(
-  params: DirectoryConfigParams,
-): InspectedDiscordAccount | null {
-  return inspectDiscordAccount({
+export async function listDiscordDirectoryPeersFromConfig(params: DirectoryConfigParams) {
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "discord",
     cfg: params.cfg,
     accountId: params.accountId,
-  });
-}
-
-export async function listDiscordDirectoryPeersFromConfig(params: DirectoryConfigParams) {
-  const account = inspectDiscordDirectoryAccount(params);
+  })) as InspectedDiscordAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }
@@ -39,7 +34,11 @@ export async function listDiscordDirectoryPeersFromConfig(params: DirectoryConfi
 }
 
 export async function listDiscordDirectoryGroupsFromConfig(params: DirectoryConfigParams) {
-  const account = inspectDiscordDirectoryAccount(params);
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "discord",
+    cfg: params.cfg,
+    accountId: params.accountId,
+  })) as InspectedDiscordAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }

--- a/extensions/slack/src/directory-config.ts
+++ b/extensions/slack/src/directory-config.ts
@@ -1,23 +1,20 @@
-import { normalizeSlackMessagingTarget } from "openclaw/plugin-sdk/channel-runtime";
 import {
   applyDirectoryQueryAndLimit,
   collectNormalizedDirectoryIds,
+  inspectReadOnlyChannelAccount,
   listDirectoryGroupEntriesFromMapKeys,
   toDirectoryEntries,
   type DirectoryConfigParams,
 } from "openclaw/plugin-sdk/directory-runtime";
-import { inspectSlackAccount } from "../api.js";
 import type { InspectedSlackAccount } from "../api.js";
-
-function inspectSlackDirectoryAccount(params: DirectoryConfigParams): InspectedSlackAccount | null {
-  return inspectSlackAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
-}
+import { parseSlackTarget } from "./targets.js";
 
 export async function listSlackDirectoryPeersFromConfig(params: DirectoryConfigParams) {
-  const account = inspectSlackDirectoryAccount(params);
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "slack",
+    cfg: params.cfg,
+    accountId: params.accountId,
+  })) as InspectedSlackAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }
@@ -35,15 +32,19 @@ export async function listSlackDirectoryPeersFromConfig(params: DirectoryConfigP
         return null;
       }
       const target = `user:${normalizedUserId}`;
-      const normalized = normalizeSlackMessagingTarget(target) ?? target.toLowerCase();
-      return normalized.startsWith("user:") ? normalized : null;
+      const normalized = parseSlackTarget(target, { defaultKind: "user" });
+      return normalized?.kind === "user" ? `user:${normalized.id.toLowerCase()}` : null;
     },
   });
   return toDirectoryEntries("user", applyDirectoryQueryAndLimit(ids, params));
 }
 
 export async function listSlackDirectoryGroupsFromConfig(params: DirectoryConfigParams) {
-  const account = inspectSlackDirectoryAccount(params);
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "slack",
+    cfg: params.cfg,
+    accountId: params.accountId,
+  })) as InspectedSlackAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }
@@ -52,8 +53,8 @@ export async function listSlackDirectoryGroupsFromConfig(params: DirectoryConfig
     query: params.query,
     limit: params.limit,
     normalizeId: (raw) => {
-      const normalized = normalizeSlackMessagingTarget(raw) ?? raw.toLowerCase();
-      return normalized.startsWith("channel:") ? normalized : null;
+      const normalized = parseSlackTarget(raw, { defaultKind: "channel" });
+      return normalized?.kind === "channel" ? `channel:${normalized.id.toLowerCase()}` : null;
     },
   });
 }

--- a/extensions/telegram/src/directory-config.ts
+++ b/extensions/telegram/src/directory-config.ts
@@ -2,24 +2,19 @@ import { mapAllowFromEntries } from "openclaw/plugin-sdk/channel-config-helpers"
 import {
   applyDirectoryQueryAndLimit,
   collectNormalizedDirectoryIds,
+  inspectReadOnlyChannelAccount,
   listDirectoryGroupEntriesFromMapKeys,
   toDirectoryEntries,
   type DirectoryConfigParams,
 } from "openclaw/plugin-sdk/directory-runtime";
-import { inspectTelegramAccount } from "../api.js";
 import type { InspectedTelegramAccount } from "../api.js";
 
-async function inspectTelegramDirectoryAccount(
-  params: DirectoryConfigParams,
-): Promise<InspectedTelegramAccount | null> {
-  return inspectTelegramAccount({
+export async function listTelegramDirectoryPeersFromConfig(params: DirectoryConfigParams) {
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "telegram",
     cfg: params.cfg,
     accountId: params.accountId,
-  });
-}
-
-export async function listTelegramDirectoryPeersFromConfig(params: DirectoryConfigParams) {
-  const account = await inspectTelegramDirectoryAccount(params);
+  })) as InspectedTelegramAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }
@@ -41,7 +36,11 @@ export async function listTelegramDirectoryPeersFromConfig(params: DirectoryConf
 }
 
 export async function listTelegramDirectoryGroupsFromConfig(params: DirectoryConfigParams) {
-  const account = await inspectTelegramDirectoryAccount(params);
+  const account = (await inspectReadOnlyChannelAccount({
+    channelId: "telegram",
+    cfg: params.cfg,
+    accountId: params.accountId,
+  })) as InspectedTelegramAccount | null;
   if (!account || !("config" in account)) {
     return [];
   }

--- a/src/plugin-sdk/directory-runtime.ts
+++ b/src/plugin-sdk/directory-runtime.ts
@@ -1,5 +1,6 @@
 /** Shared directory listing helpers for plugins that derive users/groups from config maps. */
 export type { DirectoryConfigParams } from "../channels/plugins/directory-types.js";
+export type { ReadOnlyInspectedAccount } from "../channels/read-only-account-inspect.js";
 export {
   applyDirectoryQueryAndLimit,
   collectNormalizedDirectoryIds,
@@ -9,3 +10,4 @@ export {
   listDirectoryUserEntriesFromAllowFromAndMapKeys,
   toDirectoryEntries,
 } from "../channels/plugins/directory-config-helpers.js";
+export { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";


### PR DESCRIPTION
## Summary

- Problem: the previous cleanup replaced `inspectReadOnlyChannelAccount({ channelId: ... })` in Discord/Slack/Telegram directory helpers with direct extension account-inspect calls.
- Why it matters: that dropped the lazy read-only inspection seam and tightened these helpers to eager local extension imports.
- What changed: restored the directory helpers to use `inspectReadOnlyChannelAccount` with explicit `channelId`, and re-exported that read-only inspection seam through `openclaw/plugin-sdk/directory-runtime` so extensions do not need direct core `src/*` imports.
- What did NOT change (scope boundary): no new runtime-api cleanup, no new package exports, no config/account resolution changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #49542
- Related #49553

## User-visible / Behavior Changes

None intended.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): Discord, Slack, Telegram directory config helpers
- Relevant config (redacted): none

### Steps

1. Run `pnpm test -- src/channels/plugins/plugins-core.test.ts -t "directory"`.
2. Run `pnpm test -- src/plugin-sdk/channel-import-guardrails.test.ts src/plugin-sdk/package-contract-guardrails.test.ts src/plugin-sdk/subpaths.test.ts`.

### Expected

- Directory helpers keep the lazy read-only inspection seam.
- Extension code stays off direct core `src/*` imports.

### Actual

- Both targeted test runs pass after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the two targeted test commands above locally.
- Edge cases checked: Slack directory IDs stay lowercase; Discord/Slack/Telegram directory helpers all route through the shared read-only inspection seam again.
- What you did **not** verify: full repo test suite and full build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `24a5e9cfbe2733f7e04efcdb8f3b97d431770ed9`.
- Files/config to restore: `src/plugin-sdk/directory-runtime.ts`, `extensions/discord/src/directory-config.ts`, `extensions/slack/src/directory-config.ts`, `extensions/telegram/src/directory-config.ts`
- Known bad symptoms reviewers should watch for: directory helpers losing lazy inspection again, or Slack directory IDs changing case.

## Risks and Mitigations

- Risk: `directory-runtime` now exposes one more helper from core.
  - Mitigation: it is a narrow additive export that preserves the existing lazy inspection path instead of introducing a new direct extension/core dependency.
