### PR TITLE
fix: add circuit breaker to proxy fetch to prevent CPU exhaustion

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -122,7 +122,7 @@ const CONTEXT_WINDOW_TOO_SMALL_RE = /context window.*(too small|minimum is)/i;
 const CONTEXT_OVERFLOW_HINT_RE =
   /context.*overflow|context window.*(too (?:large|long)|exceed|over|limit|max(?:imum)?|requested|sent|tokens)|prompt.*(too (?:large|long)|exceed|over|limit|max(?:imum)?)|(?:request|input).*(?:context|window|length|token).*(too (?:large|long)|exceed|over|limit|max(?:imum)?)/i;
 const RATE_LIMIT_HINT_RE =
-  /rate limit|too many requests|requests per (?:minute|hour|day)|quota|throttl|429\b|tokens per day/i;
+  /rate limit|too many requests|requests per (?:minute|hour|day)|quota|throttl|429\b|too many tokens per|tokens per day/i;
 
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -14,6 +14,7 @@ const ERROR_PATTERNS = {
     "usage limit",
     /\btpm\b/i,
     "tokens per minute",
+    "too many tokens per",
     "tokens per day",
   ],
   overloaded: [

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -133,7 +133,7 @@ const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
 
 const TRANSIENT_PATTERNS: Record<string, RegExp> = {
   rate_limit:
-    /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
+    /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|too many tokens per|tokens per day)/i,
   overloaded:
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network: /(network|econnreset|econnrefused|fetch failed|socket)/i,

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -5,6 +5,12 @@ import { ProxyAgent, fetch as undiciFetch } from "undici";
 import WebSocket from "ws";
 import type { DiscordAccountConfig } from "../../config/types.js";
 import { danger } from "../../globals.js";
+import {
+  isProxyCircuitOpen,
+  isProxyConnectError,
+  recordProxyFailure,
+  recordProxySuccess,
+} from "../../infra/net/proxy-probe.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 export function resolveDiscordGatewayIntents(
@@ -34,7 +40,7 @@ export function createDiscordGatewayPlugin(params: {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = params.discordConfig?.proxy?.trim();
   const options = {
-    reconnect: { maxAttempts: 50 },
+    reconnect: { maxAttempts: 10 },
     intents,
     autoInteractions: true,
   };
@@ -57,14 +63,21 @@ export function createDiscordGatewayPlugin(params: {
       override async registerClient(client: Parameters<GatewayPlugin["registerClient"]>[0]) {
         if (!this.gatewayInfo) {
           try {
+            const useProxy = !isProxyCircuitOpen(proxy);
             const response = await undiciFetch("https://discord.com/api/v10/gateway/bot", {
               headers: {
                 Authorization: `Bot ${client.options.token}`,
               },
-              dispatcher: fetchAgent,
+              ...(useProxy ? { dispatcher: fetchAgent } : {}),
             } as Record<string, unknown>);
             this.gatewayInfo = (await response.json()) as APIGatewayBotInfo;
+            if (useProxy) {
+              recordProxySuccess(proxy);
+            }
           } catch (error) {
+            if (isProxyConnectError(error)) {
+              recordProxyFailure(proxy);
+            }
             throw new Error(
               `Failed to get gateway information from Discord: ${error instanceof Error ? error.message : String(error)}`,
               { cause: error },
@@ -75,6 +88,9 @@ export function createDiscordGatewayPlugin(params: {
       }
 
       override createWebSocket(url: string) {
+        if (isProxyCircuitOpen(proxy)) {
+          return new WebSocket(url);
+        }
         return new WebSocket(url, { agent: wsAgent });
       }
     }

--- a/src/discord/monitor/rest-fetch.ts
+++ b/src/discord/monitor/rest-fetch.ts
@@ -1,6 +1,12 @@
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { danger } from "../../globals.js";
 import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
+import {
+  isProxyCircuitOpen,
+  isProxyConnectError,
+  recordProxyFailure,
+  recordProxySuccess,
+} from "../../infra/net/proxy-probe.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 export function resolveDiscordRestFetch(
@@ -13,11 +19,25 @@ export function resolveDiscordRestFetch(
   }
   try {
     const agent = new ProxyAgent(proxy);
-    const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
-        dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (isProxyCircuitOpen(proxy)) {
+        return fetch(input, init);
+      }
+      try {
+        const response = await undiciFetch(input as string | URL, {
+          ...(init as Record<string, unknown>),
+          dispatcher: agent,
+        });
+        recordProxySuccess(proxy);
+        return response as unknown as Response;
+      } catch (err) {
+        if (isProxyConnectError(err)) {
+          recordProxyFailure(proxy);
+          return fetch(input, init);
+        }
+        throw err;
+      }
+    }) as typeof fetch;
     runtime.log?.("discord: rest proxy enabled");
     return wrapFetchWithAbortSignal(fetcher);
   } catch (err) {

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -39,9 +39,13 @@ vi.mock("undici", () => ({
 }));
 
 import { makeProxyFetch, resolveProxyFetchFromEnv } from "./proxy-fetch.js";
+import { resetProxyCircuits } from "./proxy-probe.js";
 
 describe("makeProxyFetch", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProxyCircuits();
+  });
 
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
     const proxyUrl = "http://proxy.test:8080";
@@ -135,5 +139,85 @@ describe("resolveProxyFetchFromEnv", () => {
 
     const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeUndefined();
+  });
+});
+
+describe("circuit breaker integration", () => {
+  const directFetchResult = { ok: true, direct: true } as unknown as Response;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProxyCircuits();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(directFetchResult);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("falls back to direct fetch on proxy connection error", async () => {
+    const connError = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    undiciFetch.mockRejectedValueOnce(connError);
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+    const result = await proxyFetch("https://api.example.com");
+
+    expect(result).toBe(directFetchResult);
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://api.example.com", undefined);
+  });
+
+  it("rethrows non-connection errors without fallback", async () => {
+    const apiError = new Error("500 Internal Server Error");
+    undiciFetch.mockRejectedValueOnce(apiError);
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:9090");
+    await expect(proxyFetch("https://api.example.com")).rejects.toThrow("500 Internal Server Error");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("skips proxy after circuit opens", async () => {
+    const connError = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    undiciFetch.mockRejectedValueOnce(connError);
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:7070");
+
+    // First call: proxy fails, falls back to direct
+    await proxyFetch("https://api.example.com/1");
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    // Second call: circuit open, goes direct immediately (no proxy attempt)
+    await proxyFetch("https://api.example.com/2");
+    expect(undiciFetch).toHaveBeenCalledTimes(1); // still 1 — proxy skipped
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("resumes proxy after circuit closes on success", async () => {
+    vi.useFakeTimers();
+    const connError = Object.assign(new Error("ETIMEDOUT"), { code: "ETIMEDOUT" });
+    undiciFetch.mockRejectedValueOnce(connError);
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:6060");
+
+    // First call: proxy fails
+    await proxyFetch("https://api.example.com/1");
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+
+    // Wait for cooldown to expire
+    vi.advanceTimersByTime(11_000);
+
+    // Next call: half_open, tries proxy again — this time it succeeds
+    undiciFetch.mockResolvedValueOnce({ ok: true, proxy: true });
+    const result = await proxyFetch("https://api.example.com/2");
+    expect(undiciFetch).toHaveBeenCalledTimes(2); // proxy was tried again
+    expect((result as unknown as { proxy: boolean }).proxy).toBe(true);
+
+    vi.useRealTimers();
   });
 });

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,19 +1,53 @@
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
+import {
+  isProxyCircuitOpen,
+  isProxyConnectError,
+  recordProxyFailure,
+  recordProxySuccess,
+} from "./proxy-probe.js";
+
+/**
+ * Wrap a proxy-backed fetch with circuit breaker logic.
+ * When the proxy is unreachable, falls back to direct fetch and records
+ * the failure so subsequent calls skip the proxy during the cooldown window.
+ */
+function wrapWithCircuitBreaker(proxyUrl: string, proxyFetch: typeof fetch): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (isProxyCircuitOpen(proxyUrl)) {
+      return fetch(input, init);
+    }
+    try {
+      const response = await proxyFetch(input, init);
+      recordProxySuccess(proxyUrl);
+      return response;
+    } catch (err) {
+      if (isProxyConnectError(err)) {
+        recordProxyFailure(proxyUrl);
+        // Fall back to direct fetch for this request.
+        return fetch(input, init);
+      }
+      throw err;
+    }
+  }) as typeof fetch;
+}
 
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
  * Uses undici's ProxyAgent under the hood.
+ *
+ * Includes a circuit breaker: when the proxy is unreachable, automatically
+ * falls back to direct fetch and suppresses further proxy attempts during
+ * a cooldown window (exponential backoff up to 5 minutes).
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  return ((input: RequestInfo | URL, init?: RequestInit) =>
+  const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),
       dispatcher: agent,
     }) as unknown as Promise<Response>) as typeof fetch;
+  return wrapWithCircuitBreaker(proxyUrl, proxyFetch);
 }
 
 /**
@@ -34,11 +68,12 @@ export function resolveProxyFetchFromEnv(): typeof fetch | undefined {
   }
   try {
     const agent = new EnvHttpProxyAgent();
-    return ((input: RequestInfo | URL, init?: RequestInit) =>
+    const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
         ...(init as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>) as typeof fetch;
+    return wrapWithCircuitBreaker(proxyUrl, proxyFetch);
   } catch (err) {
     logWarn(
       `Proxy env var set but agent creation failed — falling back to direct fetch: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/infra/net/proxy-probe.test.ts
+++ b/src/infra/net/proxy-probe.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isProxyCircuitOpen,
+  isProxyConnectError,
+  recordProxyFailure,
+  recordProxySuccess,
+  resetProxyCircuits,
+} from "./proxy-probe.js";
+
+afterEach(() => {
+  resetProxyCircuits();
+  vi.restoreAllMocks();
+});
+
+describe("proxy circuit breaker", () => {
+  const proxy = "http://proxy.test:8080";
+
+  it("starts with circuit closed (proxy usable)", () => {
+    expect(isProxyCircuitOpen(proxy)).toBe(false);
+  });
+
+  it("opens circuit after failure", () => {
+    recordProxyFailure(proxy);
+    expect(isProxyCircuitOpen(proxy)).toBe(true);
+  });
+
+  it("closes circuit after success", () => {
+    recordProxyFailure(proxy);
+    expect(isProxyCircuitOpen(proxy)).toBe(true);
+    recordProxySuccess(proxy);
+    expect(isProxyCircuitOpen(proxy)).toBe(false);
+  });
+
+  it("re-probes after cooldown expires", () => {
+    vi.useFakeTimers();
+    recordProxyFailure(proxy);
+    expect(isProxyCircuitOpen(proxy)).toBe(true);
+
+    // Advance past the initial cooldown (10s)
+    vi.advanceTimersByTime(11_000);
+    expect(isProxyCircuitOpen(proxy)).toBe(false); // half_open: allows probe
+
+    vi.useRealTimers();
+  });
+
+  it("increases cooldown with consecutive failures", () => {
+    vi.useFakeTimers();
+
+    // First failure: 10s cooldown
+    recordProxyFailure(proxy);
+    vi.advanceTimersByTime(11_000);
+    expect(isProxyCircuitOpen(proxy)).toBe(false); // half_open
+
+    // Second failure: 20s cooldown (10s * 2^1 = 20s)
+    recordProxyFailure(proxy);
+    vi.advanceTimersByTime(11_000);
+    expect(isProxyCircuitOpen(proxy)).toBe(true); // still in cooldown
+    vi.advanceTimersByTime(10_000);
+    expect(isProxyCircuitOpen(proxy)).toBe(false); // 21s > 20s cooldown
+
+    vi.useRealTimers();
+  });
+
+  it("caps cooldown at 5 minutes", () => {
+    vi.useFakeTimers();
+
+    // Simulate many failures
+    for (let i = 0; i < 20; i++) {
+      recordProxyFailure(proxy);
+    }
+
+    // Should not exceed 5 minutes
+    vi.advanceTimersByTime(5 * 60_000 + 1000);
+    expect(isProxyCircuitOpen(proxy)).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("resets cooldown after success", () => {
+    vi.useFakeTimers();
+
+    // Build up consecutive failures for a long cooldown
+    for (let i = 0; i < 5; i++) {
+      recordProxyFailure(proxy);
+    }
+
+    // Success resets everything
+    recordProxySuccess(proxy);
+    expect(isProxyCircuitOpen(proxy)).toBe(false);
+
+    // Next failure should use initial cooldown again
+    recordProxyFailure(proxy);
+    vi.advanceTimersByTime(11_000);
+    expect(isProxyCircuitOpen(proxy)).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("normalizes proxy URLs to same circuit", () => {
+    recordProxyFailure("http://proxy.test:8080");
+    expect(isProxyCircuitOpen("http://proxy.test:8080/")).toBe(true);
+  });
+});
+
+describe("isProxyConnectError", () => {
+  it("detects ECONNREFUSED", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("detects ETIMEDOUT", () => {
+    const err = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("detects UND_ERR_CONNECT_TIMEOUT", () => {
+    const err = Object.assign(new Error("timeout"), { code: "UND_ERR_CONNECT_TIMEOUT" });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("detects ENOTFOUND", () => {
+    const err = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("detects EAI_AGAIN", () => {
+    const err = Object.assign(new Error("getaddrinfo EAI_AGAIN"), { code: "EAI_AGAIN" });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("detects connection error in cause", () => {
+    const cause = Object.assign(new Error("inner"), { code: "ECONNREFUSED" });
+    const err = new Error("fetch failed", { cause });
+    expect(isProxyConnectError(err)).toBe(true);
+  });
+
+  it("returns false for non-connection errors", () => {
+    expect(isProxyConnectError(new Error("404 Not Found"))).toBe(false);
+    expect(isProxyConnectError(new Error("401 Unauthorized"))).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isProxyConnectError(null)).toBe(false);
+    expect(isProxyConnectError(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object errors", () => {
+    expect(isProxyConnectError("string error")).toBe(false);
+    expect(isProxyConnectError(42)).toBe(false);
+  });
+});

--- a/src/infra/net/proxy-probe.ts
+++ b/src/infra/net/proxy-probe.ts
@@ -1,0 +1,141 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("proxy-probe");
+
+/**
+ * Circuit breaker for HTTP proxy connectivity.
+ *
+ * Tracks proxy reachability based on actual fetch outcomes. When a proxy
+ * fetch fails with a connection error, the circuit opens and subsequent
+ * requests fall back to direct fetch during a cooldown window.
+ *
+ * State transitions:
+ *   CLOSED  → fetch succeeds   → stay CLOSED (proxy usable)
+ *   CLOSED  → fetch conn error → OPEN (proxy bypassed)
+ *   OPEN    → cooldown expires  → HALF_OPEN (next fetch tries proxy)
+ *   HALF_OPEN → fetch succeeds  → CLOSED
+ *   HALF_OPEN → fetch fails     → OPEN (reset cooldown)
+ */
+
+type CircuitState = "closed" | "open" | "half_open";
+
+const INITIAL_COOLDOWN_MS = 10_000;
+const MAX_COOLDOWN_MS = 5 * 60_000;
+const COOLDOWN_FACTOR = 2;
+
+type ProxyCircuit = {
+  state: CircuitState;
+  lastFailAt: number;
+  cooldownMs: number;
+  consecutiveFailures: number;
+};
+
+const circuits = new Map<string, ProxyCircuit>();
+
+function normalizeKey(proxyUrl: string): string {
+  try {
+    const url = new URL(proxyUrl);
+    return `${url.hostname}:${url.port || (url.protocol === "https:" ? "443" : "80")}`;
+  } catch {
+    return proxyUrl;
+  }
+}
+
+function getCircuit(proxyUrl: string): ProxyCircuit {
+  const key = normalizeKey(proxyUrl);
+  let circuit = circuits.get(key);
+  if (!circuit) {
+    circuit = {
+      state: "closed",
+      lastFailAt: 0,
+      cooldownMs: INITIAL_COOLDOWN_MS,
+      consecutiveFailures: 0,
+    };
+    circuits.set(key, circuit);
+  }
+  return circuit;
+}
+
+/**
+ * Returns true if the proxy circuit is currently open (proxy known-bad)
+ * and the cooldown has not yet expired. When the cooldown expires, returns
+ * false so the next fetch attempt can re-probe the proxy.
+ */
+export function isProxyCircuitOpen(proxyUrl: string): boolean {
+  const circuit = getCircuit(proxyUrl);
+  if (circuit.state === "closed") {
+    return false;
+  }
+  const elapsed = Date.now() - circuit.lastFailAt;
+  if (elapsed >= circuit.cooldownMs) {
+    // Cooldown expired — allow one probe attempt.
+    circuit.state = "half_open";
+    return false;
+  }
+  return true;
+}
+
+/** Record a successful proxy fetch — close the circuit. */
+export function recordProxySuccess(proxyUrl: string): void {
+  const circuit = getCircuit(proxyUrl);
+  if (circuit.state === "closed") {
+    return;
+  }
+  const key = normalizeKey(proxyUrl);
+  log.info?.(`proxy ${key} is reachable again`);
+  circuit.state = "closed";
+  circuit.consecutiveFailures = 0;
+  circuit.cooldownMs = INITIAL_COOLDOWN_MS;
+}
+
+/** Record a proxy connection failure — open the circuit. */
+export function recordProxyFailure(proxyUrl: string): void {
+  const circuit = getCircuit(proxyUrl);
+  const key = normalizeKey(proxyUrl);
+  if (circuit.state === "closed") {
+    log.warn?.(`proxy ${key} is unreachable — falling back to direct connection`);
+  }
+  circuit.state = "open";
+  circuit.consecutiveFailures += 1;
+  circuit.cooldownMs = Math.min(
+    INITIAL_COOLDOWN_MS * COOLDOWN_FACTOR ** (circuit.consecutiveFailures - 1),
+    MAX_COOLDOWN_MS,
+  );
+  circuit.lastFailAt = Date.now();
+}
+
+const PROXY_CONNECT_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/** Check if an error is a proxy connection failure (vs. an application-level error). */
+export function isProxyConnectError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const code = (err as { code?: string }).code;
+  if (typeof code === "string" && PROXY_CONNECT_ERROR_CODES.has(code)) {
+    return true;
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && typeof cause === "object") {
+    const causeCode = (cause as { code?: string }).code;
+    if (typeof causeCode === "string" && PROXY_CONNECT_ERROR_CODES.has(causeCode)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Reset all circuit state (for tests). */
+export function resetProxyCircuits(): void {
+  circuits.clear();
+}

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -532,7 +532,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private isRetryableEmbeddingError(message: string): boolean {
-    return /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i.test(
+    return /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|too many tokens per|tokens per day)/i.test(
       message,
     );
   }


### PR DESCRIPTION
## Summary
- Adds a circuit breaker (`proxy-probe.ts`) that opens on proxy connection errors (ECONNREFUSED, ETIMEDOUT, etc.) and falls back to direct fetch
- Exponential backoff cooldown (10s → 5min) before re-probing; auto-resumes when proxy recovers
- Wraps `makeProxyFetch`, `resolveProxyFetchFromEnv`, Discord REST fetch, and Discord gateway (WS + fetch) with the circuit breaker
- Reduces Discord gateway `maxAttempts` from 50 to 10

## Problem
When `HTTP_PROXY` points to an unavailable proxy, every channel (Discord, Telegram, etc.) independently retries connections through the dead proxy. The cumulative effect of rapid connection failures across multiple channels causes excessive CPU usage.

## Test plan
- [x] 17 unit tests for circuit breaker state machine + `isProxyConnectError`
- [x] 4 integration tests for fetch circuit breaker (fallback, rethrow, skip-after-open, resume-after-cooldown)
- [x] All 84 affected tests pass (net infra + Discord monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)