### PR TITLE
msteams: fix sender allowlist bypass when route allowlist is configured (GHSA-g7cr-9h7q-4qxq)

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -177,10 +177,17 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       channelName,
       allowNameMatching: isDangerousNameMatchingEnabled(msteamsCfg),
     });
-    const senderGroupPolicy = resolveSenderScopedGroupPolicy({
-      groupPolicy,
-      groupAllowFrom: effectiveGroupAllowFrom,
-    });
+    // When a route-level (team/channel) allowlist is configured but the sender allowlist is
+    // empty, resolveSenderScopedGroupPolicy would otherwise downgrade the policy to "open",
+    // allowing any sender. To close this bypass (GHSA-g7cr-9h7q-4qxq), treat an empty sender
+    // allowlist as deny-all whenever the route allowlist is active.
+    const senderGroupPolicy =
+      channelGate.allowlistConfigured && effectiveGroupAllowFrom.length === 0
+        ? groupPolicy
+        : resolveSenderScopedGroupPolicy({
+            groupPolicy,
+            groupAllowFrom: effectiveGroupAllowFrom,
+          });
     const access = resolveDmGroupAccessWithLists({
       isGroup: !isDirectMessage,
       dmPolicy,


### PR DESCRIPTION
## Summary

Fixes GHSA-g7cr-9h7q-4qxq — Sender allowlist bypass when a route allowlist (teams config) is configured but the sender allowlist is empty.

## What & Why

**Problem:** When a Teams route-level allowlist (per-team/per-channel config in `channels.msteams.teams`) is configured but the sender-level `groupAllowFrom` is empty or absent, the sender check is effectively bypassed — any Teams user can interact with the bot in that channel.

**Root cause:** `resolveSenderScopedGroupPolicy` in `group-access.ts` returns `"open"` when `groupAllowFrom` is empty (line 51: `params.groupAllowFrom.length > 0 ? "allowlist" : "open"`). When a route allowlist (teams config with channel gates) was active but sender allowlist was empty, this downgraded the effective policy from `"allowlist"` to `"open"`, allowing any Teams user to send messages.

**Fix:** In `extensions/msteams/src/monitor-handler/message-handler.ts`, when `channelGate.allowlistConfigured && effectiveGroupAllowFrom.length === 0`, preserve the configured `groupPolicy` instead of delegating to `resolveSenderScopedGroupPolicy`. This ensures an empty sender allowlist with a configured route allowlist defaults to "deny all senders" rather than "allow all senders".

**Files changed:** `extensions/msteams/src/monitor-handler/message-handler.ts`

## Screenshots

N/A — This is a server-side authorization logic fix. The change affects policy evaluation in the message handler's auth layer. Verification requires a running bot with a configured route allowlist and empty sender allowlist. The fix is validated via the existing regression test.

## Test Results

- Existing regression test `message-handler.authz.test.ts:106` ("does not widen sender auth when only a teams route allowlist is configured") passes
- **244 of 245 msteams tests pass** (1 pre-existing unrelated failure in `monitor.lifecycle.test.ts` — EADDRINUSE issue addressed in PR #49583)

## Security

- Advisory: GHSA-g7cr-9h7q-4qxq
- `SECURITY.md` reviewed before implementation
- Fix preserves all existing allowlist behavior when sender allowlist is non-empty

## AI Disclosure

- [x] AI-assisted (Claude Code with team orchestration)
- [x] Fully tested — existing regression test validates the fix
- [x] I understand what the code does: prevents policy downgrade from "allowlist" to "open" when route gates exist but sender allowlist is empty