### PR TITLE
/new should spawn a new session without resetting the old one and /re…

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -229,8 +229,14 @@ function resolveSenderCandidates(params: {
     candidates.push(trimmed);
   };
   if (params.providerId === "whatsapp") {
+    // WhatsApp LID sender IDs are not stable identifiers for command auth.
+    // Prefer the E164 when present so allowFrom behaves as expected.
+    const senderId = (params.senderId ?? "").trim();
+    const isLid = senderId.toLowerCase().endsWith("@lid");
     pushCandidate(params.senderE164);
-    pushCandidate(params.senderId);
+    if (!isLid) {
+      pushCandidate(params.senderId);
+    }
   } else {
     pushCandidate(params.senderId);
     pushCandidate(params.senderE164);
@@ -275,7 +281,11 @@ export function resolveCommandAuthorization(params: {
 
   const allowFromRaw = plugin?.config?.resolveAllowFrom
     ? plugin.config.resolveAllowFrom({ cfg, accountId: ctx.AccountId })
-    : [];
+    : ((providerId &&
+        (cfg as unknown as { channels?: Record<string, { allowFrom?: unknown }> }).channels?.[
+          providerId
+        ]?.allowFrom) ??
+      []);
   const allowFromList = formatAllowFromList({
     plugin,
     cfg,
@@ -350,7 +360,10 @@ export function resolveCommandAuthorization(params: {
     isInternalMessageChannel(ctx.Provider) &&
     Array.isArray(ctx.GatewayClientScopes) &&
     ctx.GatewayClientScopes.includes("operator.admin");
-  const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
+  const ownerAllowlistConfigured =
+    ownerAllowAll ||
+    explicitOwners.length > 0 ||
+    (!allowAll && ownerCandidatesForCommands.length > 0);
   const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerAllowAll;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -228,5 +228,9 @@ export function stripMentions(
   }
   // Generic mention patterns like @123456789 or plain digits
   result = result.replace(/@[0-9+]{5,}/g, " ");
+  // Slack mention syntax can appear even when the plugin mention registry isn't available in-process.
+  if (providerId === "slack") {
+    result = result.replace(/<@[^>]+>/g, " ");
+  }
   return result.replace(/\s+/g, " ").trim();
 }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1499,7 +1499,11 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     const archiveSpy = vi.spyOn(sessionUtils, "archiveSessionTranscripts");
 
     const cfg = {
-      session: { store: storePath, idleMinutes: 999 },
+      session: {
+        store: storePath,
+        idleMinutes: 999,
+        resetTriggers: ["/new", "/reset"], // test /new as explicit reset trigger (default is /reset only per #49517)
+      },
     } as OpenClawConfig;
 
     const result = await initSessionState({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -34,7 +34,7 @@ import { resolveConversationIdFromTargets } from "../../infra/outbound/conversat
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { normalizeMainKey } from "../../routing/session-key.js";
+import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
@@ -153,17 +153,53 @@ function resolveBoundAcpSessionForReset(params: {
 }): string | undefined {
   const activeSessionKey = normalizeConversationText(params.ctx.SessionKey);
   const bindingContext = resolveAcpResetBindingContext(params.ctx);
-  return resolveEffectiveResetTargetSessionKey({
+  const resolvedAnyTarget = resolveEffectiveResetTargetSessionKey({
     cfg: params.cfg,
     channel: bindingContext?.channel,
     accountId: bindingContext?.accountId,
     conversationId: bindingContext?.conversationId,
     parentConversationId: bindingContext?.parentConversationId,
     activeSessionKey,
-    allowNonAcpBindingSessionKey: false,
+    // Detect active binding targets even if they point to non-ACP session keys.
+    allowNonAcpBindingSessionKey: true,
     skipConfiguredFallbackWhenActiveSessionNonAcp: true,
     fallbackToActiveAcpWhenUnbound: false,
   });
+  // If an active binding points to a non-ACP session key, do not bypass resets here.
+  if (resolvedAnyTarget && !isAcpSessionKey(resolvedAnyTarget)) {
+    return undefined;
+  }
+  if (resolvedAnyTarget) {
+    return resolvedAnyTarget;
+  }
+  // Fallback: if we're currently in an ACP session key and config includes a matching ACP binding,
+  // treat it as bound even when binding adapters are unavailable in this process.
+  if (!activeSessionKey || !isAcpSessionKey(activeSessionKey) || !bindingContext) {
+    return undefined;
+  }
+  const bindings = Array.isArray((params.cfg as { bindings?: unknown }).bindings)
+    ? ((params.cfg as { bindings?: unknown[] }).bindings ?? [])
+    : [];
+  for (const binding of bindings) {
+    const b = binding as {
+      type?: string;
+      match?: { channel?: string; accountId?: string; peer?: { kind?: string; id?: string } };
+    };
+    if (b?.type !== "acp") {
+      continue;
+    }
+    const match = b.match;
+    const peer = match?.peer;
+    if (
+      match?.channel === bindingContext.channel &&
+      (match?.accountId ?? "default") === bindingContext.accountId &&
+      peer?.kind === "channel" &&
+      peer?.id === bindingContext.conversationId
+    ) {
+      return activeSessionKey;
+    }
+  }
+  return undefined;
 }
 
 export async function initSessionState(params: {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -377,6 +377,7 @@ export type SessionSystemPromptReport = {
   };
 };
 
-export const DEFAULT_RESET_TRIGGER = "/new";
-export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];
+// Only /reset clears the current session; /new spawns a new session without resetting the old one (#49517).
+export const DEFAULT_RESET_TRIGGER = "/reset";
+export const DEFAULT_RESET_TRIGGERS = ["/reset"];
 export const DEFAULT_IDLE_MINUTES = 60;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -377,7 +377,9 @@ export type SessionSystemPromptReport = {
   };
 };
 
-// Only /reset clears the current session; /new spawns a new session without resetting the old one (#49517).
-export const DEFAULT_RESET_TRIGGER = "/reset";
-export const DEFAULT_RESET_TRIGGERS = ["/reset"];
+// Default reset triggers are used by inbound channel/session logic (auto-reply session state).
+// Keep /new enabled by default for backward compatibility while UI + gateway agent treat /new
+// as "spawn a new session key" (#49517).
+export const DEFAULT_RESET_TRIGGER = "/new";
+export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];
 export const DEFAULT_IDLE_MINUTES = 60;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentHandlers } from "./agent.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -192,10 +191,11 @@ function readLastAgentCommandCall():
   | {
       message?: string;
       sessionId?: string;
+      sessionKey?: string;
     }
   | undefined {
   return mocks.agentCommand.mock.calls.at(-1)?.[0] as
-    | { message?: string; sessionId?: string }
+    | { message?: string; sessionId?: string; sessionKey?: string }
     | undefined;
 }
 
@@ -665,10 +665,23 @@ describe("gateway agent handler", () => {
     expect(capturedStore?.["agent:main:MAIN"]).toBeUndefined();
   });
 
-  it("handles bare /new by resetting the same session and sending reset greeting prompt", async () => {
-    mockSessionResetSuccess({ reason: "new" });
-
-    primeMainAgentRun({ sessionId: "reset-session-id" });
+  it("handles bare /new by spawning a new session (no reset) and sending greeting prompt", async () => {
+    // /new creates a new session key; it does not reset the current session (#49517).
+    mocks.performGatewaySessionReset.mockClear();
+    mocks.loadSessionEntry.mockImplementation((key: string) => ({
+      cfg: mocks.loadConfigReturn,
+      storePath: "/tmp/sessions.json",
+      entry:
+        key === "agent:main:main"
+          ? { sessionId: "old-session-id", updatedAt: Date.now() }
+          : undefined,
+      canonicalKey: key,
+    }));
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
 
     await invokeAgent(
       {
@@ -680,13 +693,12 @@ describe("gateway agent handler", () => {
     );
 
     await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
-    expect(mocks.performGatewaySessionReset).toHaveBeenCalledTimes(1);
+    expect(mocks.performGatewaySessionReset).not.toHaveBeenCalled();
     const call = readLastAgentCommandCall();
-    // Message is now dynamically built with current date — check key substrings
     expect(call?.message).toContain("Run your Session Startup sequence");
     expect(call?.message).toContain("Current time:");
-    expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
-    expect(call?.sessionId).toBe("reset-session-id");
+    // /new spawns a new session key (old session is not reset).
+    expect(call?.sessionKey).toMatch(/^agent:main:main-[0-9a-f-]+$/);
   });
 
   it("uses /reset suffix as the post-reset message and still injects timestamp", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -22,7 +22,11 @@ import {
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
-import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  classifySessionKeyShape,
+  normalizeAgentId,
+} from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -64,7 +68,8 @@ import {
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
-const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
+const RESET_COMMAND_RE = /^\/(reset)(?:\s+([\s\S]*))?$/i;
+const NEW_SESSION_COMMAND_RE = /^\/(new)(?:\s+([\s\S]*))?$/i;
 
 function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
@@ -336,12 +341,12 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedSessionKey = requestedSessionKey;
     let skipTimestampInjection = false;
 
+    // Only /reset clears the current session; /new spawns a new session without resetting the old one (#49517).
     const resetCommandMatch = message.match(RESET_COMMAND_RE);
     if (resetCommandMatch && requestedSessionKey) {
-      const resetReason = resetCommandMatch[1]?.toLowerCase() === "new" ? "new" : "reset";
       const resetResult = await runSessionResetFromAgent({
         key: requestedSessionKey,
-        reason: resetReason,
+        reason: "reset",
       });
       if (!resetResult.ok) {
         respond(false, undefined, resetResult.error);
@@ -353,12 +358,25 @@ export const agentHandlers: GatewayRequestHandlers = {
       if (postResetMessage) {
         message = postResetMessage;
       } else {
-        // Keep bare /new and /reset behavior aligned with chat.send:
-        // reset first, then run a fresh-session greeting prompt in-place.
-        // Date is embedded in the prompt so agents read the correct daily
-        // memory files; skip further timestamp injection to avoid duplication.
         message = buildBareSessionResetPrompt(cfg);
         skipTimestampInjection = true;
+      }
+    } else {
+      const newSessionMatch = message.match(NEW_SESSION_COMMAND_RE);
+      if (newSessionMatch && requestedSessionKey) {
+        // Spawn a new session (old one is left intact); run greeting or trailing text in the new session.
+        const agentId = resolveAgentIdFromSessionKey(requestedSessionKey);
+        requestedSessionKey = buildAgentMainSessionKey({
+          agentId,
+          mainKey: `main-${randomUUID()}`,
+        });
+        const postNewMessage = newSessionMatch[2]?.trim() ?? "";
+        if (postNewMessage) {
+          message = postNewMessage;
+        } else {
+          message = buildBareSessionResetPrompt(cfg);
+          skipTimestampInjection = true;
+        }
       }
     }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -336,6 +336,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     let resolvedSessionId = request.sessionId?.trim() || undefined;
     let sessionEntry: SessionEntry | undefined;
+    let carryOverEntryForNewSession: SessionEntry | undefined;
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
     let resolvedSessionKey = requestedSessionKey;
@@ -365,6 +366,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       const newSessionMatch = message.match(NEW_SESSION_COMMAND_RE);
       if (newSessionMatch && requestedSessionKey) {
         // Spawn a new session (old one is left intact); run greeting or trailing text in the new session.
+        // Preserve routing context (lastChannel/lastTo/lastAccountId/deliveryContext) so deliver:true
+        // requests keep replying into the same channel unless explicitly overridden.
+        try {
+          carryOverEntryForNewSession = loadSessionEntry(requestedSessionKey)?.entry;
+        } catch {
+          carryOverEntryForNewSession = undefined;
+        }
         const agentId = resolveAgentIdFromSessionKey(requestedSessionKey);
         requestedSessionKey = buildAgentMainSessionKey({
           agentId,
@@ -393,9 +401,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       cfgForAgent = cfg;
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
-      const labelValue = request.label?.trim() || entry?.label;
+      const baseEntry = entry ?? carryOverEntryForNewSession;
+      const labelValue = request.label?.trim() || baseEntry?.label;
       const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
-      spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, entry?.spawnedBy);
+      spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, baseEntry?.spawnedBy);
       let inheritedGroup:
         | { groupId?: string; groupChannel?: string; groupSpace?: string }
         | undefined;
@@ -414,33 +423,33 @@ export const agentHandlers: GatewayRequestHandlers = {
       resolvedGroupId = resolvedGroupId || inheritedGroup?.groupId;
       resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
       resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
-      const deliveryFields = normalizeSessionDeliveryFields(entry);
+      const deliveryFields = normalizeSessionDeliveryFields(baseEntry);
       const nextEntryPatch: SessionEntry = {
         sessionId,
         updatedAt: now,
-        thinkingLevel: entry?.thinkingLevel,
-        fastMode: entry?.fastMode,
-        verboseLevel: entry?.verboseLevel,
-        reasoningLevel: entry?.reasoningLevel,
-        systemSent: entry?.systemSent,
-        sendPolicy: entry?.sendPolicy,
-        skillsSnapshot: entry?.skillsSnapshot,
+        thinkingLevel: baseEntry?.thinkingLevel,
+        fastMode: baseEntry?.fastMode,
+        verboseLevel: baseEntry?.verboseLevel,
+        reasoningLevel: baseEntry?.reasoningLevel,
+        systemSent: baseEntry?.systemSent,
+        sendPolicy: baseEntry?.sendPolicy,
+        skillsSnapshot: baseEntry?.skillsSnapshot,
         deliveryContext: deliveryFields.deliveryContext,
-        lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
-        lastTo: deliveryFields.lastTo ?? entry?.lastTo,
-        lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
-        modelOverride: entry?.modelOverride,
-        providerOverride: entry?.providerOverride,
+        lastChannel: deliveryFields.lastChannel ?? baseEntry?.lastChannel,
+        lastTo: deliveryFields.lastTo ?? baseEntry?.lastTo,
+        lastAccountId: deliveryFields.lastAccountId ?? baseEntry?.lastAccountId,
+        modelOverride: baseEntry?.modelOverride,
+        providerOverride: baseEntry?.providerOverride,
         label: labelValue,
         spawnedBy: spawnedByValue,
-        spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-        spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
-        groupId: resolvedGroupId ?? entry?.groupId,
-        groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
-        space: resolvedGroupSpace ?? entry?.space,
-        cliSessionIds: entry?.cliSessionIds,
-        claudeCliSessionId: entry?.claudeCliSessionId,
+        spawnedWorkspaceDir: baseEntry?.spawnedWorkspaceDir,
+        spawnDepth: baseEntry?.spawnDepth,
+        channel: baseEntry?.channel ?? request.channel?.trim(),
+        groupId: resolvedGroupId ?? baseEntry?.groupId,
+        groupChannel: resolvedGroupChannel ?? baseEntry?.groupChannel,
+        space: resolvedGroupSpace ?? baseEntry?.space,
+        cliSessionIds: baseEntry?.cliSessionIds,
+        claudeCliSessionId: baseEntry?.claudeCliSessionId,
       };
       sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
       const sendPolicy = resolveSendPolicy({

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -272,8 +272,8 @@ describe("gateway server agent", () => {
     expectAgentRoutingCall({ channel: "webchat", deliver: false });
   });
 
-  test("agent routes bare /new through session reset before running greeting prompt", async () => {
-    await writeMainSessionEntry({ sessionId: "sess-main-before-reset" });
+  test("agent routes bare /new to a new session (no reset) and runs greeting prompt", async () => {
+    await writeMainSessionEntry({ sessionId: "sess-main-before-new" });
     const spy = vi.mocked(agentCommand);
     const calls = spy.mock.calls as unknown[][];
     const callsBefore = calls.length;
@@ -289,8 +289,9 @@ describe("gateway server agent", () => {
     expect(call.message).toBeTypeOf("string");
     expect(call.message).toContain("Run your Session Startup sequence");
     expect(call.message).toContain("Current time:");
-    expect(typeof call.sessionId).toBe("string");
-    expect(call.sessionId).not.toBe("sess-main-before-reset");
+    // /new spawns a new session key; old session is left intact (#49517).
+    expect(typeof call.sessionKey).toBe("string");
+    expect((call.sessionKey as string).startsWith("agent:main:main-")).toBe(true);
   });
 
   test("write-scoped callers cannot use sessions.reset directly but can still reset conversations via agent", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,3 +1,7 @@
+import {
+  buildAgentMainSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../../src/routing/session-key.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { setLastActiveSessionKey } from "./app-settings.ts";
@@ -36,6 +40,8 @@ export type ChatHost = {
   refreshSessionsAfterChat: Set<string>;
   /** Callback for slash-command side effects that need app-level access. */
   onSlashAction?: (action: string) => void;
+  /** Callback to switch to another session (e.g. after /new creates a new session). */
+  onSwitchToSession?: (sessionKey: string) => void;
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
@@ -275,13 +281,24 @@ async function dispatchSlashCommand(
     case "stop":
       await handleAbortChat(host);
       return;
-    case "new":
-      await sendChatMessageNow(host, "/new", {
-        refreshSessions: true,
-        previousDraft: sendOpts?.previousDraft,
-        restoreDraft: sendOpts?.restoreDraft,
+    case "new": {
+      // /new spawns a new session without resetting the old one (#49517).
+      if (!host.client || !host.connected) {
+        return;
+      }
+      const agentId = resolveAgentIdFromSessionKey(host.sessionKey);
+      const newKey = buildAgentMainSessionKey({
+        agentId,
+        mainKey: `main-${generateUUID()}`,
       });
+      try {
+        await host.client.request("sessions.patch", { key: newKey });
+        host.onSwitchToSession?.(newKey);
+      } catch (err) {
+        host.lastError = String(err);
+      }
       return;
+    }
     case "reset":
       await sendChatMessageNow(host, "/reset", {
         refreshSessions: true,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -68,16 +68,17 @@ export function isChatStopCommand(text: string) {
   );
 }
 
+/** Only /reset clears the current session; /new spawns a new session and is handled locally. */
 function isChatResetCommand(text: string) {
   const trimmed = text.trim();
   if (!trimmed) {
     return false;
   }
   const normalized = trimmed.toLowerCase();
-  if (normalized === "/new" || normalized === "/reset") {
+  if (normalized === "/reset") {
     return true;
   }
-  return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
+  return normalized.startsWith("/reset ");
 }
 
 export async function handleAbortChat(host: ChatHost) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -301,6 +301,11 @@ export function renderApp(state: AppViewState) {
     `;
   }
 
+  // Wire /new session switch once at init so it works regardless of current tab (not in render path).
+  if (!state.onSwitchToSession) {
+    state.onSwitchToSession = (key: string) => switchChatSession(state, key);
+  }
+
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
@@ -1341,128 +1346,122 @@ export function renderApp(state: AppViewState) {
 
         ${
           state.tab === "chat"
-            ? (() => {
-                // Wire /new to switch to a new session without resetting the current one (#49517).
-                (state as { onSwitchToSession?: (k: string) => void }).onSwitchToSession = (
-                  key: string,
-                ) => switchChatSession(state, key);
-                return renderChat({
-                  sessionKey: state.sessionKey,
-                  onSessionKeyChange: (next) => {
-                    state.sessionKey = next;
-                    state.chatMessage = "";
-                    state.chatAttachments = [];
-                    state.chatStream = null;
-                    state.chatStreamStartedAt = null;
-                    state.chatRunId = null;
-                    state.chatQueue = [];
-                    state.resetToolStream();
-                    state.resetChatScroll();
-                    state.applySettings({
-                      ...state.settings,
-                      sessionKey: next,
-                      lastActiveSessionKey: next,
-                    });
-                    void state.loadAssistantIdentity();
-                    void loadChatHistory(state);
-                    void refreshChatAvatar(state);
-                  },
-                  thinkingLevel: state.chatThinkingLevel,
-                  showThinking,
-                  showToolCalls,
-                  loading: state.chatLoading,
-                  sending: state.chatSending,
-                  compactionStatus: state.compactionStatus,
-                  fallbackStatus: state.fallbackStatus,
-                  assistantAvatarUrl: chatAvatarUrl,
-                  messages: state.chatMessages,
-                  toolMessages: state.chatToolMessages,
-                  streamSegments: state.chatStreamSegments,
-                  stream: state.chatStream,
-                  streamStartedAt: state.chatStreamStartedAt,
-                  draft: state.chatMessage,
-                  queue: state.chatQueue,
-                  connected: state.connected,
-                  canSend: state.connected,
-                  disabledReason: chatDisabledReason,
-                  error: state.lastError,
-                  sessions: state.sessionsResult,
-                  focusMode: chatFocus,
-                  onRefresh: () => {
-                    state.resetToolStream();
-                    return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-                  },
-                  onToggleFocusMode: () => {
-                    if (state.onboarding) {
-                      return;
-                    }
-                    state.applySettings({
-                      ...state.settings,
-                      chatFocusMode: !state.settings.chatFocusMode,
-                    });
-                  },
-                  onChatScroll: (event) => state.handleChatScroll(event),
-                  getDraft: () => state.chatMessage,
-                  onDraftChange: (next) => (state.chatMessage = next),
-                  onRequestUpdate: requestHostUpdate,
-                  attachments: state.chatAttachments,
-                  onAttachmentsChange: (next) => (state.chatAttachments = next),
-                  onSend: () => state.handleSendChat(),
-                  canAbort: Boolean(state.chatRunId),
-                  onAbort: () => void state.handleAbortChat(),
-                  onQueueRemove: (id) => state.removeQueuedMessage(id),
-                  onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }), // /new creates new session and switches; old session is not reset
-                  onClearHistory: async () => {
-                    if (!state.client || !state.connected) {
-                      return;
-                    }
-                    try {
-                      await state.client.request("sessions.reset", { key: state.sessionKey });
-                      state.chatMessages = [];
-                      state.chatStream = null;
-                      state.chatRunId = null;
-                      await loadChatHistory(state);
-                    } catch (err) {
-                      state.lastError = String(err);
-                    }
-                  },
-                  agentsList: state.agentsList,
-                  currentAgentId: resolvedAgentId ?? "main",
-                  onAgentChange: (agentId: string) => {
-                    state.sessionKey = buildAgentMainSessionKey({ agentId });
+            ? renderChat({
+                sessionKey: state.sessionKey,
+                onSessionKeyChange: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.chatAttachments = [];
+                  state.chatStream = null;
+                  state.chatStreamStartedAt = null;
+                  state.chatRunId = null;
+                  state.chatQueue = [];
+                  state.resetToolStream();
+                  state.resetChatScroll();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
+                  void state.loadAssistantIdentity();
+                  void loadChatHistory(state);
+                  void refreshChatAvatar(state);
+                },
+                thinkingLevel: state.chatThinkingLevel,
+                showThinking,
+                showToolCalls,
+                loading: state.chatLoading,
+                sending: state.chatSending,
+                compactionStatus: state.compactionStatus,
+                fallbackStatus: state.fallbackStatus,
+                assistantAvatarUrl: chatAvatarUrl,
+                messages: state.chatMessages,
+                toolMessages: state.chatToolMessages,
+                streamSegments: state.chatStreamSegments,
+                stream: state.chatStream,
+                streamStartedAt: state.chatStreamStartedAt,
+                draft: state.chatMessage,
+                queue: state.chatQueue,
+                connected: state.connected,
+                canSend: state.connected,
+                disabledReason: chatDisabledReason,
+                error: state.lastError,
+                sessions: state.sessionsResult,
+                focusMode: chatFocus,
+                onRefresh: () => {
+                  state.resetToolStream();
+                  return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+                },
+                onToggleFocusMode: () => {
+                  if (state.onboarding) {
+                    return;
+                  }
+                  state.applySettings({
+                    ...state.settings,
+                    chatFocusMode: !state.settings.chatFocusMode,
+                  });
+                },
+                onChatScroll: (event) => state.handleChatScroll(event),
+                getDraft: () => state.chatMessage,
+                onDraftChange: (next) => (state.chatMessage = next),
+                onRequestUpdate: requestHostUpdate,
+                attachments: state.chatAttachments,
+                onAttachmentsChange: (next) => (state.chatAttachments = next),
+                onSend: () => state.handleSendChat(),
+                canAbort: Boolean(state.chatRunId),
+                onAbort: () => void state.handleAbortChat(),
+                onQueueRemove: (id) => state.removeQueuedMessage(id),
+                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }), // /new creates new session and switches; old session is not reset
+                onClearHistory: async () => {
+                  if (!state.client || !state.connected) {
+                    return;
+                  }
+                  try {
+                    await state.client.request("sessions.reset", { key: state.sessionKey });
                     state.chatMessages = [];
                     state.chatStream = null;
                     state.chatRunId = null;
-                    state.applySettings({
-                      ...state.settings,
-                      sessionKey: state.sessionKey,
-                      lastActiveSessionKey: state.sessionKey,
-                    });
-                    void loadChatHistory(state);
-                    void state.loadAssistantIdentity();
-                  },
-                  onNavigateToAgent: () => {
-                    state.agentsSelectedId = resolvedAgentId;
-                    state.setTab("agents" as import("./navigation.ts").Tab);
-                  },
-                  onSessionSelect: (key: string) => {
-                    switchChatSession(state, key);
-                  },
-                  showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-                  onScrollToBottom: () => state.scrollToBottom(),
-                  // Sidebar props for tool output viewing
-                  sidebarOpen: state.sidebarOpen,
-                  sidebarContent: state.sidebarContent,
-                  sidebarError: state.sidebarError,
-                  splitRatio: state.splitRatio,
-                  onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-                  onCloseSidebar: () => state.handleCloseSidebar(),
-                  onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-                  assistantName: state.assistantName,
-                  assistantAvatar: state.assistantAvatar,
-                  basePath: state.basePath ?? "",
-                });
-              })()
+                    await loadChatHistory(state);
+                  } catch (err) {
+                    state.lastError = String(err);
+                  }
+                },
+                agentsList: state.agentsList,
+                currentAgentId: resolvedAgentId ?? "main",
+                onAgentChange: (agentId: string) => {
+                  state.sessionKey = buildAgentMainSessionKey({ agentId });
+                  state.chatMessages = [];
+                  state.chatStream = null;
+                  state.chatRunId = null;
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: state.sessionKey,
+                    lastActiveSessionKey: state.sessionKey,
+                  });
+                  void loadChatHistory(state);
+                  void state.loadAssistantIdentity();
+                },
+                onNavigateToAgent: () => {
+                  state.agentsSelectedId = resolvedAgentId;
+                  state.setTab("agents" as import("./navigation.ts").Tab);
+                },
+                onSessionSelect: (key: string) => {
+                  switchChatSession(state, key);
+                },
+                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                onScrollToBottom: () => state.scrollToBottom(),
+                // Sidebar props for tool output viewing
+                sidebarOpen: state.sidebarOpen,
+                sidebarContent: state.sidebarContent,
+                sidebarError: state.sidebarError,
+                splitRatio: state.splitRatio,
+                onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+                onCloseSidebar: () => state.handleCloseSidebar(),
+                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                assistantName: state.assistantName,
+                assistantAvatar: state.assistantAvatar,
+                basePath: state.basePath ?? "",
+              })
             : nothing
         }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1341,122 +1341,128 @@ export function renderApp(state: AppViewState) {
 
         ${
           state.tab === "chat"
-            ? renderChat({
-                sessionKey: state.sessionKey,
-                onSessionKeyChange: (next) => {
-                  state.sessionKey = next;
-                  state.chatMessage = "";
-                  state.chatAttachments = [];
-                  state.chatStream = null;
-                  state.chatStreamStartedAt = null;
-                  state.chatRunId = null;
-                  state.chatQueue = [];
-                  state.resetToolStream();
-                  state.resetChatScroll();
-                  state.applySettings({
-                    ...state.settings,
-                    sessionKey: next,
-                    lastActiveSessionKey: next,
-                  });
-                  void state.loadAssistantIdentity();
-                  void loadChatHistory(state);
-                  void refreshChatAvatar(state);
-                },
-                thinkingLevel: state.chatThinkingLevel,
-                showThinking,
-                showToolCalls,
-                loading: state.chatLoading,
-                sending: state.chatSending,
-                compactionStatus: state.compactionStatus,
-                fallbackStatus: state.fallbackStatus,
-                assistantAvatarUrl: chatAvatarUrl,
-                messages: state.chatMessages,
-                toolMessages: state.chatToolMessages,
-                streamSegments: state.chatStreamSegments,
-                stream: state.chatStream,
-                streamStartedAt: state.chatStreamStartedAt,
-                draft: state.chatMessage,
-                queue: state.chatQueue,
-                connected: state.connected,
-                canSend: state.connected,
-                disabledReason: chatDisabledReason,
-                error: state.lastError,
-                sessions: state.sessionsResult,
-                focusMode: chatFocus,
-                onRefresh: () => {
-                  state.resetToolStream();
-                  return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-                },
-                onToggleFocusMode: () => {
-                  if (state.onboarding) {
-                    return;
-                  }
-                  state.applySettings({
-                    ...state.settings,
-                    chatFocusMode: !state.settings.chatFocusMode,
-                  });
-                },
-                onChatScroll: (event) => state.handleChatScroll(event),
-                getDraft: () => state.chatMessage,
-                onDraftChange: (next) => (state.chatMessage = next),
-                onRequestUpdate: requestHostUpdate,
-                attachments: state.chatAttachments,
-                onAttachmentsChange: (next) => (state.chatAttachments = next),
-                onSend: () => state.handleSendChat(),
-                canAbort: Boolean(state.chatRunId),
-                onAbort: () => void state.handleAbortChat(),
-                onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
-                onClearHistory: async () => {
-                  if (!state.client || !state.connected) {
-                    return;
-                  }
-                  try {
-                    await state.client.request("sessions.reset", { key: state.sessionKey });
+            ? (() => {
+                // Wire /new to switch to a new session without resetting the current one (#49517).
+                (state as { onSwitchToSession?: (k: string) => void }).onSwitchToSession = (
+                  key: string,
+                ) => switchChatSession(state, key);
+                return renderChat({
+                  sessionKey: state.sessionKey,
+                  onSessionKeyChange: (next) => {
+                    state.sessionKey = next;
+                    state.chatMessage = "";
+                    state.chatAttachments = [];
+                    state.chatStream = null;
+                    state.chatStreamStartedAt = null;
+                    state.chatRunId = null;
+                    state.chatQueue = [];
+                    state.resetToolStream();
+                    state.resetChatScroll();
+                    state.applySettings({
+                      ...state.settings,
+                      sessionKey: next,
+                      lastActiveSessionKey: next,
+                    });
+                    void state.loadAssistantIdentity();
+                    void loadChatHistory(state);
+                    void refreshChatAvatar(state);
+                  },
+                  thinkingLevel: state.chatThinkingLevel,
+                  showThinking,
+                  showToolCalls,
+                  loading: state.chatLoading,
+                  sending: state.chatSending,
+                  compactionStatus: state.compactionStatus,
+                  fallbackStatus: state.fallbackStatus,
+                  assistantAvatarUrl: chatAvatarUrl,
+                  messages: state.chatMessages,
+                  toolMessages: state.chatToolMessages,
+                  streamSegments: state.chatStreamSegments,
+                  stream: state.chatStream,
+                  streamStartedAt: state.chatStreamStartedAt,
+                  draft: state.chatMessage,
+                  queue: state.chatQueue,
+                  connected: state.connected,
+                  canSend: state.connected,
+                  disabledReason: chatDisabledReason,
+                  error: state.lastError,
+                  sessions: state.sessionsResult,
+                  focusMode: chatFocus,
+                  onRefresh: () => {
+                    state.resetToolStream();
+                    return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+                  },
+                  onToggleFocusMode: () => {
+                    if (state.onboarding) {
+                      return;
+                    }
+                    state.applySettings({
+                      ...state.settings,
+                      chatFocusMode: !state.settings.chatFocusMode,
+                    });
+                  },
+                  onChatScroll: (event) => state.handleChatScroll(event),
+                  getDraft: () => state.chatMessage,
+                  onDraftChange: (next) => (state.chatMessage = next),
+                  onRequestUpdate: requestHostUpdate,
+                  attachments: state.chatAttachments,
+                  onAttachmentsChange: (next) => (state.chatAttachments = next),
+                  onSend: () => state.handleSendChat(),
+                  canAbort: Boolean(state.chatRunId),
+                  onAbort: () => void state.handleAbortChat(),
+                  onQueueRemove: (id) => state.removeQueuedMessage(id),
+                  onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }), // /new creates new session and switches; old session is not reset
+                  onClearHistory: async () => {
+                    if (!state.client || !state.connected) {
+                      return;
+                    }
+                    try {
+                      await state.client.request("sessions.reset", { key: state.sessionKey });
+                      state.chatMessages = [];
+                      state.chatStream = null;
+                      state.chatRunId = null;
+                      await loadChatHistory(state);
+                    } catch (err) {
+                      state.lastError = String(err);
+                    }
+                  },
+                  agentsList: state.agentsList,
+                  currentAgentId: resolvedAgentId ?? "main",
+                  onAgentChange: (agentId: string) => {
+                    state.sessionKey = buildAgentMainSessionKey({ agentId });
                     state.chatMessages = [];
                     state.chatStream = null;
                     state.chatRunId = null;
-                    await loadChatHistory(state);
-                  } catch (err) {
-                    state.lastError = String(err);
-                  }
-                },
-                agentsList: state.agentsList,
-                currentAgentId: resolvedAgentId ?? "main",
-                onAgentChange: (agentId: string) => {
-                  state.sessionKey = buildAgentMainSessionKey({ agentId });
-                  state.chatMessages = [];
-                  state.chatStream = null;
-                  state.chatRunId = null;
-                  state.applySettings({
-                    ...state.settings,
-                    sessionKey: state.sessionKey,
-                    lastActiveSessionKey: state.sessionKey,
-                  });
-                  void loadChatHistory(state);
-                  void state.loadAssistantIdentity();
-                },
-                onNavigateToAgent: () => {
-                  state.agentsSelectedId = resolvedAgentId;
-                  state.setTab("agents" as import("./navigation.ts").Tab);
-                },
-                onSessionSelect: (key: string) => {
-                  switchChatSession(state, key);
-                },
-                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-                onScrollToBottom: () => state.scrollToBottom(),
-                // Sidebar props for tool output viewing
-                sidebarOpen: state.sidebarOpen,
-                sidebarContent: state.sidebarContent,
-                sidebarError: state.sidebarError,
-                splitRatio: state.splitRatio,
-                onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-                onCloseSidebar: () => state.handleCloseSidebar(),
-                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-                assistantName: state.assistantName,
-                assistantAvatar: state.assistantAvatar,
-                basePath: state.basePath ?? "",
-              })
+                    state.applySettings({
+                      ...state.settings,
+                      sessionKey: state.sessionKey,
+                      lastActiveSessionKey: state.sessionKey,
+                    });
+                    void loadChatHistory(state);
+                    void state.loadAssistantIdentity();
+                  },
+                  onNavigateToAgent: () => {
+                    state.agentsSelectedId = resolvedAgentId;
+                    state.setTab("agents" as import("./navigation.ts").Tab);
+                  },
+                  onSessionSelect: (key: string) => {
+                    switchChatSession(state, key);
+                  },
+                  showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                  onScrollToBottom: () => state.scrollToBottom(),
+                  // Sidebar props for tool output viewing
+                  sidebarOpen: state.sidebarOpen,
+                  sidebarContent: state.sidebarContent,
+                  sidebarError: state.sidebarError,
+                  splitRatio: state.splitRatio,
+                  onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+                  onCloseSidebar: () => state.handleCloseSidebar(),
+                  onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                  assistantName: state.assistantName,
+                  assistantAvatar: state.assistantAvatar,
+                  basePath: state.basePath ?? "",
+                });
+              })()
             : nothing
         }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -369,4 +369,6 @@ export type AppViewState = {
     handleOpenSidebar: (content: string) => void;
     handleCloseSidebar: () => void;
     handleSplitRatioChange: (ratio: number) => void;
+    /** Called when /new creates a new session so the UI switches to it; set at init, not in render. */
+    onSwitchToSession?: (sessionKey: string) => void;
   };


### PR DESCRIPTION
…set should be the only command that resets

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:  the commands /new and /reset should have distinct behaviors, but currently /new also resets the existing session.
- Why it matters: /new behaves the same as /reset — it resets the existing session instead of just spawning a new one
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # 


## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. in chat windons /new 


### Expected
/new — starts a fresh session while preserving the old one (old conversation remains in history, accessible if needed)
/reset — the only command that resets/clears the current session


