### PR TITLE
fix(telegram): retry setMyCommands on 429 rate-limit with retry_after backoff

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -248,6 +248,7 @@ describe("bot-native-command-menu", () => {
     const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 5"), {
       error_code: 429,
       description: "Too Many Requests: retry after 5",
+      parameters: { retry_after: 5 },
     });
     const setMyCommands = vi
       .fn()
@@ -283,6 +284,7 @@ describe("bot-native-command-menu", () => {
     const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 2"), {
       error_code: 429,
       description: "Too Many Requests: retry after 2",
+      parameters: { retry_after: 2 },
     });
     const setMyCommands = vi.fn().mockRejectedValue(rateLimitError);
     const runtimeLog = vi.fn();

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -242,6 +242,74 @@ describe("bot-native-command-menu", () => {
     await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
   });
 
+  it("retries setMyCommands after a 429 rate-limit using the retry_after delay", async () => {
+    vi.useFakeTimers();
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 5"), {
+      error_code: 429,
+      description: "Too Many Requests: retry after 5",
+    });
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      runtimeError,
+      commandsToRegister: [{ command: "help", description: "Help" }],
+      accountId: `test-ratelimit-${Date.now()}`,
+      botIdentity: "bot-ratelimit",
+    });
+
+    // Advance past the 5-second retry_after delay.
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("rate-limited (retry after 5s)"),
+    );
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
+
+  it("gives up setMyCommands after exhausting 429 rate-limit retries", async () => {
+    vi.useFakeTimers();
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 2"), {
+      error_code: 429,
+      description: "Too Many Requests: retry after 2",
+    });
+    const setMyCommands = vi.fn().mockRejectedValue(rateLimitError);
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      runtimeError,
+      commandsToRegister: [{ command: "help", description: "Help" }],
+      accountId: `test-ratelimit-exhaust-${Date.now()}`,
+      botIdentity: "bot-exhaust",
+    });
+
+    // Each retry schedules a new timer; drain multiple rounds to exhaust all retries.
+    for (let i = 0; i < 4; i++) {
+      await vi.runAllTimersAsync();
+    }
+    vi.useRealTimers();
+
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("rate-limited after 3 retries"),
+    );
+  });
+
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -14,6 +14,8 @@ import { withTelegramApiErrorLogging } from "./api-logging.js";
 
 export const TELEGRAM_MAX_COMMANDS = 100;
 const TELEGRAM_COMMAND_RETRY_RATIO = 0.8;
+/** Maximum number of times to retry a rate-limited command sync operation. */
+const TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES = 3;
 
 export type TelegramMenuCommand = {
   command: string;
@@ -24,6 +26,20 @@ type TelegramPluginCommandSpec = {
   name: unknown;
   description: unknown;
 };
+
+/**
+ * Extract the retry-after delay in seconds from a Telegram 429 rate-limit error.
+ * Returns undefined if the error is not a 429 or the delay cannot be parsed.
+ */
+function extractRateLimitRetryAfterSeconds(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const maybe = err as { error_code?: unknown; description?: unknown };
+  if (maybe.error_code !== 429) return undefined;
+  const desc = typeof maybe.description === "string" ? maybe.description : "";
+  const match = /retry after (\d+)/i.exec(desc);
+  if (match?.[1]) return parseInt(match[1], 10);
+  return undefined;
+}
 
 function isBotCommandsTooMuchError(err: unknown): boolean {
   if (!err) {
@@ -209,12 +225,15 @@ export function syncTelegramMenuCommands(params: {
 
     let retryCommands = commandsToRegister;
     const initialCommandCount = commandsToRegister.length;
+    // Track 429 retry attempts separately from BOT_COMMANDS_TOO_MUCH shrink retries.
+    let rateLimitRetries = 0;
     while (retryCommands.length > 0) {
       try {
         await withTelegramApiErrorLogging({
           operation: "setMyCommands",
           runtime,
-          shouldLog: (err) => !isBotCommandsTooMuchError(err),
+          shouldLog: (err) =>
+            !isBotCommandsTooMuchError(err) && extractRateLimitRetryAfterSeconds(err) === undefined,
           fn: () => bot.api.setMyCommands(retryCommands),
         });
         if (retryCommands.length < initialCommandCount) {
@@ -228,6 +247,25 @@ export function syncTelegramMenuCommands(params: {
         await writeCachedCommandHash(accountId, botIdentity, currentHash);
         return;
       } catch (err) {
+        // Handle 429 rate-limit: wait for the server-specified delay then retry.
+        const rateLimitDelaySecs = extractRateLimitRetryAfterSeconds(err);
+        if (rateLimitDelaySecs !== undefined) {
+          if (rateLimitRetries >= TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES) {
+            runtime.error?.(
+              `Telegram setMyCommands rate-limited after ${rateLimitRetries} retries; giving up. ` +
+                "The command menu will be synced on the next gateway restart.",
+            );
+            return;
+          }
+          rateLimitRetries++;
+          runtime.log?.(
+            `Telegram setMyCommands rate-limited (retry after ${rateLimitDelaySecs}s); ` +
+              `will retry in ${rateLimitDelaySecs}s (attempt ${rateLimitRetries}/${TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES}).`,
+          );
+          await new Promise<void>((resolve) => setTimeout(resolve, rateLimitDelaySecs * 1000));
+          continue;
+        }
+
         if (!isBotCommandsTooMuchError(err)) {
           throw err;
         }

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -33,8 +33,17 @@ type TelegramPluginCommandSpec = {
  */
 function extractRateLimitRetryAfterSeconds(err: unknown): number | undefined {
   if (!err || typeof err !== "object") return undefined;
-  const maybe = err as { error_code?: unknown; description?: unknown };
+  const maybe = err as {
+    error_code?: unknown;
+    parameters?: { retry_after?: unknown };
+    description?: unknown;
+  };
   if (maybe.error_code !== 429) return undefined;
+  // Prefer the structured retry_after from GrammyError.parameters
+  if (typeof maybe.parameters?.retry_after === "number" && maybe.parameters.retry_after > 0) {
+    return maybe.parameters.retry_after;
+  }
+  // Fallback to parsing the description string
   const desc = typeof maybe.description === "string" ? maybe.description : "";
   const match = /retry after (\d+)/i.exec(desc);
   if (match?.[1]) return parseInt(match[1], 10);


### PR DESCRIPTION
## Problem

When the gateway restarts, `syncTelegramMenuCommands` calls `setMyCommands` / `deleteMyCommands` on each bot. Under rapid restarts (e.g., config changes during debugging), Telegram rate-limits these calls with `429 Too Many Requests: retry after N`. The current code catches this error, logs it, and silently drops the sync — but the **command hash is never written**, so every subsequent restart retries the call, hitting 429 again and again in a compounding loop.

The existing hash-caching defence (see #32017) prevents redundant syncs when commands are unchanged, but it only writes the hash after a **successful** `setMyCommands`. A 429 breaks this invariant.

## Root cause

`extensions/telegram/src/bot-native-command-menu.ts` — inside `syncTelegramMenuCommands`, a 429 error is not a `BOT_COMMANDS_TOO_MUCH` error, so it falls through to `throw err`, which propagates to the outer `.catch` that only logs. No retry-after handling means the hash never gets cached, causing an infinite 429 loop on next restart.

## Fix

Add `extractRateLimitRetryAfterSeconds` that parses the `retry_after` value from a GrammyError with `error_code === 429`. When detected:

1. Log a message including the delay.
2. `await` the specified delay via `setTimeout`.
3. Re-enter the loop (`continue`).
4. Give up after `TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES` (3) attempts with an explanatory error log.

This mirrors the correct pattern: **wait the server-specified time, then retry**; never immediately re-throw and let systemd restart do it (that would call setMyCommands again immediately, re-triggering the 429).

## Changes

- `extensions/telegram/src/bot-native-command-menu.ts` — adds `extractRateLimitRetryAfterSeconds` helper and 429-aware retry loop inside `syncTelegramMenuCommands`
- `extensions/telegram/src/bot-native-command-menu.test.ts` — two new test cases:
  - successful retry after a single 429
  - exhaustion of all retries with error log

## Tests

```
✓ retries setMyCommands after a 429 rate-limit using the retry_after delay
✓ gives up setMyCommands after exhausting 429 rate-limit retries
13 tests passed (0 failed)
```

## Summary
- Adds 429 rate-limit retry with server-specified backoff to Telegram command menu sync
- Prevents compounding 429 loop on rapid gateway restarts

## Test plan
- [x] All 13 existing + new tests pass locally
- [ ] Verify CI passes on rebased `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)