### PR TITLE
fix: handle MiniMax HTTP 520 and api_error body without internal server error

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyFailoverReason,
+  classifyFailoverReasonFromHttpStatus,
+  isTransientHttpError,
+} from "./errors.js";
+
+describe("MiniMax HTTP 520 failover (#49440)", () => {
+  describe("isTransientHttpError", () => {
+    it("treats HTTP 520 as transient", () => {
+      expect(
+        isTransientHttpError(
+          '520 {"type":"error","error":{"type":"api_error","message":"unknown error, 520 (1000)"}}',
+        ),
+      ).toBe(true);
+    });
+
+    it("still treats HTTP 500 as transient", () => {
+      expect(isTransientHttpError("500 Internal Server Error")).toBe(true);
+    });
+
+    it("does not treat HTTP 404 as transient", () => {
+      expect(isTransientHttpError("404 Not Found")).toBe(false);
+    });
+  });
+
+  describe("classifyFailoverReasonFromHttpStatus", () => {
+    it("classifies 520 as timeout", () => {
+      expect(classifyFailoverReasonFromHttpStatus(520)).toBe("timeout");
+    });
+
+    it("classifies 520 with body as timeout", () => {
+      expect(classifyFailoverReasonFromHttpStatus(520, "unknown error, 520 (1000)")).toBe(
+        "timeout",
+      );
+    });
+
+    it("still classifies 529 as overloaded", () => {
+      expect(classifyFailoverReasonFromHttpStatus(529)).toBe("overloaded");
+    });
+
+    it("still classifies 429 as rate_limit", () => {
+      expect(classifyFailoverReasonFromHttpStatus(429)).toBe("rate_limit");
+    });
+  });
+
+  describe("classifyFailoverReason — JSON api_error body without status prefix", () => {
+    it("classifies MiniMax unknown error as timeout", () => {
+      const raw =
+        '{"type":"error","error":{"type":"api_error","message":"unknown error, 520 (1000)"}}';
+      expect(classifyFailoverReason(raw)).toBe("timeout");
+    });
+
+    it("classifies Anthropic internal server error as timeout (backward compat)", () => {
+      const raw = '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}';
+      expect(classifyFailoverReason(raw)).toBe("timeout");
+    });
+
+    it("does not misclassify billing error as api_error timeout", () => {
+      const raw =
+        '{"type":"error","error":{"type":"billing_error","message":"insufficient credits"}}';
+      expect(classifyFailoverReason(raw)).toBe("billing");
+    });
+
+    it("does not misclassify auth error as api_error timeout", () => {
+      const raw =
+        '{"type":"error","error":{"type":"auth_error","message":"invalid api key provided"}}';
+      expect(classifyFailoverReason(raw)).toBe("auth");
+    });
+  });
+
+  describe("classifyFailoverReason — prefixed with HTTP 520", () => {
+    it("classifies 520-prefixed MiniMax error as timeout", () => {
+      const raw =
+        '520 {"type":"error","error":{"type":"api_error","message":"unknown error, 520 (1000)"}}';
+      expect(classifyFailoverReason(raw)).toBe("timeout");
+    });
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -224,7 +224,7 @@ const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
-const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529]);
 const HTTP_ERROR_HINTS = [
   "error",
   "bad request",
@@ -428,6 +428,10 @@ export function classifyFailoverReasonFromHttpStatus(
     return "timeout";
   }
   if (status === 502 || status === 504) {
+    return "timeout";
+  }
+  if (status === 520) {
+    // Cloudflare "Web server returns unknown error" / MiniMax transient API errors (#49440)
     return "timeout";
   }
   if (status === 529) {
@@ -853,9 +857,11 @@ function isJsonApiInternalServerError(raw: string): boolean {
     return false;
   }
   const value = raw.toLowerCase();
-  // Anthropic often wraps transient 500s in JSON payloads like:
-  // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  // Anthropic-compatible providers wrap transient server errors as:
+  // {"type":"error","error":{"type":"api_error","message":"..."}}
+  // Some providers (e.g. MiniMax) use non-standard messages like "unknown error, 520 (1000)"
+  // instead of "internal server error", so we match on the error type alone. (#49440)
+  return value.includes('"type":"api_error"');
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary
- Handles MiniMax HTTP 520 errors as transient/retryable
- Recognizes api_error responses that lack the 'internal server error' substring

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)