### PR TITLE
fix(zalo): resolve inbound images from photo_url field with fallback to photo

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -34,6 +34,7 @@ export type ZaloMessage = {
   date: number;
   text?: string;
   photo?: string;
+  photo_url?: string;
   caption?: string;
   sticker?: string;
 };

--- a/extensions/zalo/src/monitor.image-url.test.ts
+++ b/extensions/zalo/src/monitor.image-url.test.ts
@@ -28,4 +28,13 @@ describe("resolveZaloImageUrl", () => {
   it("returns undefined when neither field is present", () => {
     expect(resolveZaloImageUrl({})).toBeUndefined();
   });
+
+  it("falls back to photo when photo_url is an empty string", () => {
+    expect(
+      resolveZaloImageUrl({
+        photo: "https://example.com/img.jpg",
+        photo_url: "",
+      }),
+    ).toBe("https://example.com/img.jpg");
+  });
 });

--- a/extensions/zalo/src/monitor.image-url.test.ts
+++ b/extensions/zalo/src/monitor.image-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./monitor.js";
+
+const { resolveZaloImageUrl } = __testing;
+
+describe("resolveZaloImageUrl", () => {
+  it("prefers photo_url over photo when both are present", () => {
+    expect(
+      resolveZaloImageUrl({
+        photo: "https://old.example.com/img.jpg",
+        photo_url: "https://new.example.com/img.jpg",
+      }),
+    ).toBe("https://new.example.com/img.jpg");
+  });
+
+  it("falls back to photo when photo_url is absent", () => {
+    expect(resolveZaloImageUrl({ photo: "https://example.com/img.jpg" })).toBe(
+      "https://example.com/img.jpg",
+    );
+  });
+
+  it("uses photo_url when photo is absent", () => {
+    expect(resolveZaloImageUrl({ photo_url: "https://example.com/img.jpg" })).toBe(
+      "https://example.com/img.jpg",
+    );
+  });
+
+  it("returns undefined when neither field is present", () => {
+    expect(resolveZaloImageUrl({})).toBeUndefined();
+  });
+});

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -286,8 +286,8 @@ async function handleTextMessage(
 
 async function handleImageMessage(params: ZaloImageMessageParams): Promise<void> {
   const { message, mediaMaxMb, account, core, runtime } = params;
-  const { photo, photo_url, caption } = message;
-  const imageUrl = photo_url ?? photo;
+  const { caption } = message;
+  const imageUrl = resolveZaloImageUrl(message);
 
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
@@ -766,7 +766,8 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
 }
 
 function resolveZaloImageUrl(message: { photo?: string; photo_url?: string }): string | undefined {
-  return message.photo_url ?? message.photo;
+  // Use || so blank strings from webhook payloads fall through to the photo fallback
+  return message.photo_url || message.photo;
 }
 
 export const __testing = {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -286,15 +286,16 @@ async function handleTextMessage(
 
 async function handleImageMessage(params: ZaloImageMessageParams): Promise<void> {
   const { message, mediaMaxMb, account, core, runtime } = params;
-  const { photo, caption } = message;
+  const { photo, photo_url, caption } = message;
+  const imageUrl = photo_url ?? photo;
 
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
 
-  if (photo) {
+  if (imageUrl) {
     try {
       const maxBytes = mediaMaxMb * 1024 * 1024;
-      const fetched = await core.channel.media.fetchRemoteMedia({ url: photo, maxBytes });
+      const fetched = await core.channel.media.fetchRemoteMedia({ url: imageUrl, maxBytes });
       const saved = await core.channel.media.saveMediaBuffer(
         fetched.buffer,
         fetched.contentType,
@@ -764,7 +765,12 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   }
 }
 
+function resolveZaloImageUrl(message: { photo?: string; photo_url?: string }): string | undefined {
+  return message.photo_url ?? message.photo;
+}
+
 export const __testing = {
   evaluateZaloGroupAccess,
   resolveZaloRuntimeGroupPolicy,
+  resolveZaloImageUrl,
 };


### PR DESCRIPTION
## Summary
- Resolves inbound Zalo images from `photo_url` field with fallback to `photo`
- Adds test coverage for the image URL resolution logic

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)