### PR TITLE
fix(msteams): prevent EADDRINUSE crash on duplicate provider start

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -132,7 +132,7 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-import { monitorMSTeamsProvider } from "./monitor.js";
+import { monitorMSTeamsProvider, resetMSTeamsProviderInstance } from "./monitor.js";
 
 function createConfig(port: number): OpenClawConfig {
   return {
@@ -172,6 +172,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
   afterEach(() => {
     vi.clearAllMocks();
     expressControl.mode.value = "listening";
+    resetMSTeamsProviderInstance();
   });
 
   it("stays active until aborted", async () => {
@@ -210,5 +211,39 @@ describe("monitorMSTeamsProvider lifecycle", () => {
         pollStore: createStores().pollStore,
       }),
     ).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it("returns existing instance on duplicate start without crashing", async () => {
+    const abort = new AbortController();
+    const stores = createStores();
+    const cfg = createConfig(3978);
+    const runtime = createRuntime();
+
+    // Start the provider; it will block until abort.
+    const task1 = monitorMSTeamsProvider({
+      cfg,
+      runtime,
+      abortSignal: abort.signal,
+      conversationStore: stores.conversationStore,
+      pollStore: stores.pollStore,
+    });
+
+    // Second call while first is in-flight must return the same promise —
+    // not attempt a second expressApp.listen() which would throw EADDRINUSE.
+    const task2 = monitorMSTeamsProvider({
+      cfg,
+      runtime,
+      abortSignal: abort.signal,
+      conversationStore: stores.conversationStore,
+      pollStore: stores.pollStore,
+    });
+
+    // Both calls must share the same promise (same reference).
+    expect(task2).toBe(task1);
+
+    // Abort to unblock both tasks and verify they resolve cleanly.
+    abort.abort();
+    const [result1, result2] = await Promise.all([task1, task2]);
+    expect(result1.shutdown).toBe(result2.shutdown);
   });
 });

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -22,6 +22,15 @@ import { getMSTeamsRuntime } from "./runtime.js";
 import { createMSTeamsAdapter, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
+// Singleton guard: tracks the active server instance (or its in-flight startup
+// promise) to prevent EADDRINUSE crash loops when the gateway accidentally
+// starts the provider twice (race condition on double-start).
+let activeInstancePromise: Promise<MonitorMSTeamsResult> | null = null;
+
+export function resetMSTeamsProviderInstance(): void {
+  activeInstancePromise = null;
+}
+
 export type MonitorMSTeamsOpts = {
   cfg: OpenClawConfig;
   runtime?: RuntimeEnv;
@@ -62,9 +71,27 @@ export function applyMSTeamsWebhookTimeouts(
   httpServer.headersTimeout = headersTimeoutMs;
 }
 
-export async function monitorMSTeamsProvider(
-  opts: MonitorMSTeamsOpts,
-): Promise<MonitorMSTeamsResult> {
+export function monitorMSTeamsProvider(opts: MonitorMSTeamsOpts): Promise<MonitorMSTeamsResult> {
+  // Singleton guard: if a startup is already in flight or an instance is
+  // already running, return the same promise to prevent a second listen()
+  // which would throw EADDRINUSE and enter an infinite crash-restart loop.
+  if (activeInstancePromise) {
+    const core = getMSTeamsRuntime();
+    const log = core.logging.getChildLogger({ name: "msteams" });
+    log.warn?.(
+      "msteams provider already started; returning existing instance — incoming abortSignal ignored",
+    );
+    return activeInstancePromise;
+  }
+  activeInstancePromise = _startMSTeamsProvider(opts);
+  // Clear the singleton on failure so a future attempt can retry.
+  activeInstancePromise.catch(() => {
+    activeInstancePromise = null;
+  });
+  return activeInstancePromise;
+}
+
+async function _startMSTeamsProvider(opts: MonitorMSTeamsOpts): Promise<MonitorMSTeamsResult> {
   const core = getMSTeamsRuntime();
   const log = core.logging.getChildLogger({ name: "msteams" });
   let cfg = opts.cfg;
@@ -329,6 +356,9 @@ export async function monitorMSTeamsProvider(
         if (err) {
           log.debug?.("msteams server close error", { error: String(err) });
         }
+        // Clear singleton after the port is released so no race window exists
+        // where a new start() could fire before the old server is fully closed.
+        activeInstancePromise = null;
         resolve();
       });
     });


### PR DESCRIPTION
## Summary
- Adds singleton guard to prevent EADDRINUSE crash when msteams provider start is called twice during a race condition
- Properly clears the active instance promise after shutdown completes (not before), fixing a race window where a new start could fire before the old server fully releases the port

## Test plan
- [x] Unit tests pass (4 files, 10 tests including new singleton behavior test)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)