### PR TITLE
fix(provider): fix Azure OpenAI custom provider onboarding

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -134,7 +134,7 @@ describe("promptCustomApiConfig", () => {
     expect(result.config.agents?.defaults?.models?.["custom/llama3"]?.alias).toBe("local");
   });
 
-  it("defaults custom setup to the native Ollama base URL", async () => {
+  it("defaults custom onboarding to the native Ollama base URL", async () => {
     const prompter = createTestPrompter({
       text: ["http://localhost:11434", "", "llama3", "custom", ""],
       select: ["plaintext", "openai"],
@@ -431,6 +431,94 @@ describe("applyCustomApiConfig", () => {
     },
   ])("rejects $name", ({ params, expectedMessage }) => {
     expect(() => applyCustomApiConfig(params)).toThrow(expectedMessage);
+  });
+
+  it("produces azure-specific config for Azure OpenAI URLs", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://kunalk16-resource.openai.azure.com",
+      modelId: "gpt-5.2-chat",
+      compatibility: "openai",
+      apiKey: "abcd1234",
+    });
+    const providerId = result.providerId!;
+    const provider = result.config.models?.providers?.[providerId];
+
+    expect(provider?.baseUrl).toBe("https://kunalk16-resource.openai.azure.com/openai/v1");
+    expect(provider?.api).toBe("openai-responses");
+    expect(provider?.authHeader).toBe(false);
+    expect(provider?.headers).toEqual({ "api-key": "abcd1234" });
+
+    const model = provider?.models?.find((m) => m.id === "gpt-5.2-chat");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.compat).toEqual({ supportsStore: false });
+
+    expect(result.config.agents?.defaults?.thinkingDefault).toBe("medium");
+  });
+
+  it("produces azure-specific config for Azure AI Foundry URLs", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://my-resource.services.ai.azure.com",
+      modelId: "gpt-4.1",
+      compatibility: "openai",
+      apiKey: "key123",
+    });
+    const providerId = result.providerId!;
+    const provider = result.config.models?.providers?.[providerId];
+
+    expect(provider?.baseUrl).toBe("https://my-resource.services.ai.azure.com/openai/v1");
+    expect(provider?.api).toBe("openai-responses");
+    expect(provider?.authHeader).toBe(false);
+    expect(provider?.headers).toEqual({ "api-key": "key123" });
+  });
+
+  it("strips pre-existing deployment path from Azure URL in stored config", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+      modelId: "gpt-4",
+      compatibility: "openai",
+      apiKey: "key456",
+    });
+    const providerId = result.providerId!;
+    const provider = result.config.models?.providers?.[providerId];
+
+    expect(provider?.baseUrl).toBe("https://my-resource.openai.azure.com/openai/v1");
+  });
+
+  it("does not add azure fields for non-azure URLs", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+      apiKey: "key123",
+      providerId: "custom",
+    });
+    const provider = result.config.models?.providers?.custom;
+
+    expect(provider?.api).toBe("openai-completions");
+    expect(provider?.authHeader).toBeUndefined();
+    expect(provider?.headers).toBeUndefined();
+    expect(provider?.models?.[0]?.reasoning).toBe(false);
+    expect(provider?.models?.[0]?.input).toEqual(["text"]);
+    expect(provider?.models?.[0]?.compat).toBeUndefined();
+    expect(result.config.agents?.defaults?.thinkingDefault).toBeUndefined();
+  });
+
+  it("preserves existing thinkingDefault when already set for azure", () => {
+    const result = applyCustomApiConfig({
+      config: {
+        agents: { defaults: { thinkingDefault: "high" } },
+      } as OpenClawConfig,
+      baseUrl: "https://my-resource.openai.azure.com",
+      modelId: "gpt-4.1",
+      compatibility: "openai",
+      apiKey: "key",
+    });
+    expect(result.config.agents?.defaults?.thinkingDefault).toBe("high");
   });
 });
 

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -61,6 +61,24 @@ function transformAzureUrl(baseUrl: string, modelId: string): string {
   return `${normalizedUrl}/openai/deployments/${modelId}`;
 }
 
+/**
+ * Transforms an Azure URL into the base URL stored in config.
+ *
+ * Example:
+ *   https://my-resource.openai.azure.com
+ *   => https://my-resource.openai.azure.com/openai/v1
+ */
+function transformAzureConfigUrl(baseUrl: string): string {
+  const normalizedUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  if (normalizedUrl.endsWith("/openai/v1")) {
+    return normalizedUrl;
+  }
+  // Strip a full deployment path back to the base origin
+  const deploymentIdx = normalizedUrl.indexOf("/openai/deployments/");
+  const base = deploymentIdx !== -1 ? normalizedUrl.slice(0, deploymentIdx) : normalizedUrl;
+  return `${base}/openai/v1`;
+}
+
 export type CustomApiCompatibility = "openai" | "anthropic";
 type CustomApiCompatibilityChoice = CustomApiCompatibility | "unknown";
 export type CustomApiResult = {
@@ -572,8 +590,9 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     throw new CustomApiError("invalid_model_id", "Custom provider model ID is required.");
   }
 
-  // Transform Azure URLs to include the deployment path for API calls
-  const resolvedBaseUrl = isAzureUrl(baseUrl) ? transformAzureUrl(baseUrl, modelId) : baseUrl;
+  const isAzure = isAzureUrl(baseUrl);
+  // Transform Azure URLs to use /openai/v1 base path for config storage
+  const resolvedBaseUrl = isAzure ? transformAzureConfigUrl(baseUrl) : baseUrl;
 
   const providerIdResult = resolveCustomProviderId({
     config: params.config,
@@ -597,19 +616,31 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const existingProvider = providers[providerId];
   const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   const hasModel = existingModels.some((model) => model.id === modelId);
-  const nextModel = {
-    id: modelId,
-    name: `${modelId} (Custom Provider)`,
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
-    input: ["text"] as ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    reasoning: false,
-  };
+  const nextModel = isAzure
+    ? {
+        id: modelId,
+        name: `${modelId} (Custom Provider)`,
+        contextWindow: DEFAULT_CONTEXT_WINDOW,
+        maxTokens: DEFAULT_MAX_TOKENS,
+        input: ["text", "image"] as Array<"text" | "image">,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        reasoning: true,
+        compat: { supportsStore: false },
+      }
+    : {
+        id: modelId,
+        name: `${modelId} (Custom Provider)`,
+        contextWindow: DEFAULT_CONTEXT_WINDOW,
+        maxTokens: DEFAULT_MAX_TOKENS,
+        input: ["text"] as ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        reasoning: false,
+      };
   const mergedModels = hasModel
     ? existingModels.map((model) =>
         model.id === modelId
           ? {
+              ...nextModel,
               ...model,
               contextWindow: normalizeContextWindowForCustomModel(model.contextWindow),
             }
@@ -621,6 +652,11 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     normalizeOptionalProviderApiKey(params.apiKey) ??
     normalizeOptionalProviderApiKey(existingApiKey);
 
+  const providerApi = isAzure
+    ? ("openai-responses" as const)
+    : resolveProviderApi(params.compatibility);
+  const azureHeaders = isAzure && normalizedApiKey ? { "api-key": normalizedApiKey } : undefined;
+
   let config: OpenClawConfig = {
     ...params.config,
     models: {
@@ -631,8 +667,10 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
         [providerId]: {
           ...existingProviderRest,
           baseUrl: resolvedBaseUrl,
-          api: resolveProviderApi(params.compatibility),
+          api: providerApi,
           ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+          ...(isAzure ? { authHeader: false } : {}),
+          ...(azureHeaders ? { headers: azureHeaders } : {}),
           models: mergedModels.length > 0 ? mergedModels : [nextModel],
         },
       },
@@ -640,6 +678,18 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   };
 
   config = applyPrimaryModel(config, modelRef);
+  if (isAzure) {
+    config = {
+      ...config,
+      agents: {
+        ...config.agents,
+        defaults: {
+          ...config.agents?.defaults,
+          thinkingDefault: config.agents?.defaults?.thinkingDefault ?? "medium",
+        },
+      },
+    };
+  }
   if (alias) {
     config = {
       ...config,


### PR DESCRIPTION
## Summary
- Fixes Azure OpenAI endpoints onboarded through the custom provider wizard
- Uses correct API path (`/openai/v1`) and `api-key` header for Azure endpoints
- Prevents 404 errors when using Azure OpenAI deployments

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)