### PR TITLE
ui: preserve Discord id strings in form coercion

### DIFF
--- a/ui/src/ui/controllers/config/form-coerce.ts
+++ b/ui/src/ui/controllers/config/form-coerce.ts
@@ -57,6 +57,7 @@ export function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
     const variants = (schema.anyOf ?? schema.oneOf ?? []).filter(
       (v) => !(v.type === "null" || (Array.isArray(v.type) && v.type.includes("null"))),
     );
+    const hasStringVariant = variants.some((variant) => schemaType(variant) === "string");
 
     if (variants.length === 1) {
       return coerceFormValues(value, variants[0]);
@@ -64,6 +65,9 @@ export function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
 
     // Try number/boolean coercion for string values
     if (typeof value === "string") {
+      if (hasStringVariant) {
+        return value;
+      }
       for (const variant of variants) {
         const variantType = schemaType(variant);
         if (variantType === "number" || variantType === "integer") {

--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -287,7 +287,7 @@ describe("coerceFormValues", () => {
     expect(coerceFormValues(undefined, topLevelSchema)).toBeUndefined();
   });
 
-  it("handles anyOf schemas with number variant", () => {
+  it("preserves string values when anyOf also allows strings", () => {
     const schema: JsonSchema = {
       type: "object",
       properties: {
@@ -298,8 +298,24 @@ describe("coerceFormValues", () => {
     };
     const form = { timeout: "30" };
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
-    expect(typeof coerced.timeout).toBe("number");
-    expect(coerced.timeout).toBe(30);
+    expect(coerced.timeout).toBe("30");
+  });
+
+  it("preserves large Discord-style ids for string-or-number unions", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        ids: {
+          type: "array",
+          items: {
+            anyOf: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      },
+    };
+    const form = { ids: ["1234567890123456789"] };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    expect(coerced.ids).toEqual(["1234567890123456789"]);
   });
 
   it("handles integer schema type", () => {
@@ -477,7 +493,21 @@ describe("coerceFormValues", () => {
     expect(values).toEqual([1, 3]);
   });
 
-  it("coerces boolean in anyOf union", () => {
+  it("coerces boolean in anyOf union when string is not allowed", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        flag: {
+          anyOf: [{ type: "boolean" }, { type: "null" }],
+        },
+      },
+    };
+    const form = { flag: "true" };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    expect(coerced.flag).toBe(true);
+  });
+
+  it("preserves string values in boolean-or-string union", () => {
     const schema: JsonSchema = {
       type: "object",
       properties: {
@@ -488,6 +518,6 @@ describe("coerceFormValues", () => {
     };
     const form = { flag: "true" };
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
-    expect(coerced.flag).toBe(true);
+    expect(coerced.flag).toBe("true");
   });
 });


### PR DESCRIPTION
## Summary
- Fixes form coercion to preserve string values when a schema variant allows strings (anyOf/oneOf)
- Prevents silent truncation of large Discord snowflake IDs that exceed JS Number precision

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)