### PR TITLE
fix(docker): copy src/ and apps/ to runtime image for WhatsApp extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,8 @@ COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
+COPY --from=runtime-assets --chown=node:node /app/src ./src
+COPY --from=runtime-assets --chown=node:node /app/apps ./apps
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 


### PR DESCRIPTION
## Summary
- Add `COPY` lines for `src/` and `apps/` directories in the Dockerfile runtime stage
- The WhatsApp extension (and potentially others) has runtime imports that reach into `src/` and `apps/` via relative paths (e.g. `../../../src/channels/plugins/account-helpers.js`, `../../apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json`)
- These directories were missing from the final Docker image, causing `Cannot find module` errors at runtime

## Test plan
- [ ] Build Docker image: `docker build .`
- [ ] Run container with WhatsApp extension enabled and verify no module-not-found errors for `src/` or `apps/` paths
- [ ] Verify other extensions that may reference `src/` or `apps/` also work correctly

Fixes #49498

🤖 Generated with [Claude Code](https://claude.com/claude-code)