### PR TITLE
fix(cron): auto-infer accountId from agentId when not set

### DIFF
--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -120,6 +120,13 @@ export async function resolveDeliveryTarget(
     }
   }
 
+  // When no accountId was resolved from session or bindings, fall back to
+  // the agentId so cron jobs with a specific agent identity send from the
+  // correct account rather than the default one (see #49507).
+  if (!accountId && agentId) {
+    accountId = agentId;
+  }
+
   // job.delivery.accountId takes highest precedence — explicitly set by the job author.
   if (jobPayload.accountId) {
     accountId = jobPayload.accountId;


### PR DESCRIPTION
## Summary

- When a cron job has `agentId` set but no `accountId`, the system previously used the wrong (default) account to send messages via Feishu/Lark and other channels.
- Added a fallback in `resolveDeliveryTarget` that infers `accountId` from `agentId` when no explicit accountId, session-derived accountId, or binding-derived accountId is available.
- The explicit `jobPayload.accountId` override still takes highest precedence, so existing behavior for jobs with an explicit account is unchanged.

Fixes #49507

## Test plan

- [ ] Verify that a cron job with `agentId` set but no `accountId` now sends messages using the agent's identity rather than the default account.
- [ ] Verify that cron jobs with an explicit `accountId` still use that explicit value.
- [ ] Verify that session-derived and binding-derived accountIds still take precedence over the agentId fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)