### PR TITLE
fix(sessions): updateLastRoute must not bump updatedAt

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -243,7 +243,8 @@ describe("sessions", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[mainSessionKey]?.sessionId).toBe("sess-1");
-    expect(store[mainSessionKey]?.updatedAt).toBeGreaterThanOrEqual(123);
+    // updateLastRoute must preserve existing updatedAt (activity timestamp)
+    expect(store[mainSessionKey]?.updatedAt).toBe(123);
     expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
     expect(store[mainSessionKey]?.lastTo).toBe("12345");
     expect(store[mainSessionKey]?.deliveryContext).toEqual({
@@ -353,6 +354,36 @@ describe("sessions", () => {
     expect(store[sessionKey]?.origin?.label).toBe("Family id:123@g.us");
     expect(store[sessionKey]?.origin?.provider).toBe("whatsapp");
     expect(store[sessionKey]?.origin?.chatType).toBe("group");
+  });
+
+  it("updateLastRoute does not bump updatedAt on existing sessions (#49515)", async () => {
+    const mainSessionKey = "agent:main:main";
+    const frozenUpdatedAt = 1000;
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateLastRoute-preserve-activity",
+      entries: {
+        [mainSessionKey]: buildMainSessionEntry({
+          updatedAt: frozenUpdatedAt,
+        }),
+      },
+    });
+
+    await updateLastRoute({
+      storePath,
+      sessionKey: mainSessionKey,
+      deliveryContext: {
+        channel: "telegram",
+        to: "99999",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    // Route updates must not refresh activity timestamps; idle/daily reset
+    // evaluation relies on updatedAt from actual session turns.
+    expect(store[mainSessionKey]?.updatedAt).toBe(frozenUpdatedAt);
+    // Routing fields should still be updated
+    expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
+    expect(store[mainSessionKey]?.lastTo).toBe("99999");
   });
 
   it("updateSessionStoreEntry preserves existing fields when patching", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -886,7 +886,6 @@ export async function updateLastRoute(params: {
     const store = loadSessionStore(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
-    const now = Date.now();
     const explicitContext = normalizeDeliveryContext(params.deliveryContext);
     const inlineContext = normalizeDeliveryContext({
       channel,
@@ -932,14 +931,15 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    // Route updates must not refresh activity timestamps; idle/daily reset
+    // evaluation relies on updatedAt from actual session turns (#49515).
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );


### PR DESCRIPTION
## Summary
- Removes `updatedAt` from route-only updates so idle/daily reset timers are not inadvertently refreshed
- Switches to `mergeSessionEntryPreserveActivity` which already exists for this purpose
- Removes unused `now` variable left over after the `updatedAt` removal

Fixes #49515

## Test plan
- [x] Existing test assertion tightened: `toBeGreaterThanOrEqual(123)` -> `toBe(123)`
- [x] New dedicated test: `updateLastRoute does not bump updatedAt on existing sessions (#49515)`
- [x] All 73 session tests pass (11 test files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)