### PR TITLE
fix: propagate agents.defaults.heartbeat to non-default agents

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -210,11 +210,31 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("enables all listed agents when agents.defaults.heartbeat is set and no explicit entries", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("falls back to default agent when no defaults.heartbeat and no explicit entries", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("enables only default agent when defaults.heartbeat set but no agent list", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { heartbeat: { every: "30m", target: "last" } },
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -147,6 +147,16 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       })
       .filter((entry) => entry.agentId);
   }
+  // When agents.defaults.heartbeat is configured, all listed agents inherit
+  // heartbeat enablement even without an explicit per-agent heartbeat block.
+  if (cfg.agents?.defaults?.heartbeat && list.length > 0) {
+    return list
+      .map((entry) => {
+        const id = normalizeAgentId(entry.id);
+        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
+      })
+      .filter((entry) => entry.agentId);
+  }
   const fallbackId = resolveDefaultAgentId(cfg);
   return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
 }

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -37,6 +37,14 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
+  // When agents.defaults.heartbeat is configured, all listed agents inherit
+  // heartbeat enablement even without an explicit per-agent heartbeat block.
+  if (cfg.agents?.defaults?.heartbeat) {
+    if (list.length === 0) {
+      return resolvedAgentId === resolveDefaultAgentId(cfg);
+    }
+    return list.some((entry) => normalizeAgentId(entry?.id) === resolvedAgentId);
+  }
   return resolvedAgentId === resolveDefaultAgentId(cfg);
 }
 


### PR DESCRIPTION
## Summary
- Fixes `isHeartbeatEnabledForAgent` and `resolveHeartbeatAgents` so that when `agents.defaults.heartbeat` is configured, all listed agents inherit heartbeat enablement -- not just the default agent or agents with explicit `heartbeat` blocks
- Previously, non-default agents silently skipped heartbeat runs unless they also defined `agents.list[].heartbeat`, even though value merging from `agents.defaults.heartbeat` already worked

Fixes #49613

## Test plan
- [x] Updated existing test to reflect correct behavior (non-default agents enabled via defaults)
- [x] Added test: falls back to default agent only when no `defaults.heartbeat` is set
- [x] Added test: defaults.heartbeat with empty agent list enables only default agent
- [x] `npx vitest run src/infra/heartbeat-runner.returns-default-unset.test.ts` -- 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)