### PR TITLE
fix: preserve thinking/redacted_thinking blocks during context pruning

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -123,6 +123,94 @@ describe("pruneContextMessages", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("preserves assistant messages with thinking blocks unmodified during pruning", () => {
+    const thinkingBlock = {
+      type: "thinking",
+      thinking: "deep reasoning",
+      thinkingSignature: "opaque-sig-data",
+    } as unknown as AssistantContentBlock;
+    const redactedBlock = {
+      type: "thinking",
+      thinking: "[Reasoning redacted]",
+      thinkingSignature: "A".repeat(2000),
+      redacted: true,
+    } as unknown as AssistantContentBlock;
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeToolResult([{ type: "text", text: "X".repeat(5000) }]),
+      makeAssistant([thinkingBlock, { type: "text", text: "first answer" }]),
+      makeUser("followup"),
+      makeToolResult([{ type: "text", text: "Y".repeat(5000) }]),
+      makeAssistant([redactedBlock, { type: "text", text: "second answer" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        softTrim: { maxChars: 200, headChars: 100, tailChars: 50 },
+        hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 16,
+    });
+
+    // The assistant messages must remain identical (same reference).
+    const assistantMessages = result.filter((m) => m.role === "assistant");
+    expect(assistantMessages).toHaveLength(2);
+    expect(assistantMessages[0]).toBe(messages[2]);
+    expect(assistantMessages[1]).toBe(messages[5]);
+    // Thinking blocks must be fully intact.
+    const firstContent = (assistantMessages[0] as { content: unknown[] }).content;
+    expect(firstContent[0]).toBe(thinkingBlock);
+    const secondContent = (assistantMessages[1] as { content: unknown[] }).content;
+    expect(secondContent[0]).toBe(redactedBlock);
+  });
+
+  it("accounts for thinkingSignature in size estimates so pruning is triggered correctly", () => {
+    // A redacted thinking block with a large thinkingSignature should contribute to the
+    // estimated size, ensuring the pruner activates soft-trim when the context is tight.
+    const hugeSignature = "S".repeat(40_000);
+    const messages: AgentMessage[] = [
+      makeUser("go"),
+      makeToolResult([{ type: "text", text: "T".repeat(2000) }]),
+      makeAssistant([
+        {
+          type: "thinking",
+          thinking: "[Reasoning redacted]",
+          thinkingSignature: hugeSignature,
+          redacted: true,
+        } as unknown as AssistantContentBlock,
+        { type: "text", text: "done" },
+      ]),
+    ];
+
+    // With a tiny context window the large signature should push the ratio above softTrimRatio.
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0.5,
+        softTrim: { maxChars: 200, headChars: 100, tailChars: 50 },
+        hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+      },
+      ctx: { model: { contextWindow: 5_000 } } as unknown as ExtensionContext,
+      isToolPrunable: () => true,
+    });
+
+    // Pruning should have been triggered and toolResult soft-trimmed.
+    const toolResult = result.find((m) => m.role === "toolResult") as Extract<
+      AgentMessage,
+      { role: "toolResult" }
+    >;
+    const textBlock = toolResult.content[0] as { type: "text"; text: string };
+    expect(textBlock.text).toContain("[Tool result trimmed:");
+  });
+
   it("soft-trims image-containing tool results by replacing image blocks with placeholders", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -142,8 +142,16 @@ function estimateMessageChars(message: AgentMessage): number {
       if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
-      if (b.type === "thinking" && typeof b.thinking === "string") {
-        chars += b.thinking.length;
+      if (b.type === "thinking") {
+        if (typeof b.thinking === "string") {
+          chars += b.thinking.length;
+        }
+        // Account for thinkingSignature (opaque payload for redacted thinking blocks)
+        // which is included in the API request payload.
+        const sig = (b as { thinkingSignature?: string }).thinkingSignature;
+        if (typeof sig === "string") {
+          chars += sig.length;
+        }
       }
       if (b.type === "toolCall") {
         try {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -621,9 +621,11 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
+      const isThinkingBlockError = /thinking.*(?:block|content|signature)|redacted_thinking/i.test(
+        message,
+      );
+      // Always sanitize error messages to avoid leaking raw API details to chat channels.
+      const safeMessage = sanitizeUserFacingText(message, { errorContext: true });
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling
         ? BILLING_ERROR_USER_MESSAGE
@@ -631,7 +633,9 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isThinkingBlockError
+              ? "⚠️ Session history contains stale reasoning data. Use /new to start a fresh session."
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",


### PR DESCRIPTION
## Summary

- Fix context pruning size estimation to include `thinkingSignature` payload from redacted thinking blocks, ensuring the pruner triggers correctly when large opaque signatures are present
- Add thinking-block-related API error detection with a user-friendly fallback message instead of forwarding raw API errors to chat channels
- Always sanitize error messages through `sanitizeUserFacingText` before displaying to users (previously only transient HTTP errors were sanitized)

## Test plan

- [x] Added test: assistant messages with thinking/redacted_thinking blocks remain unmodified (same reference) after pruning
- [x] Added test: large `thinkingSignature` on redacted thinking blocks is accounted for in size estimates, triggering soft-trim correctly
- [x] All 9 pruner tests pass

Fixes #49573

🤖 Generated with [Claude Code](https://claude.com/claude-code)