### PR TITLE
fix(docker): copy src/ and apps/ to runtime image for WhatsApp extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,8 @@ COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
+COPY --from=runtime-assets --chown=node:node /app/src ./src
+COPY --from=runtime-assets --chown=node:node /app/apps ./apps
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 


### PR DESCRIPTION
## Summary
- Add COPY lines for `src/` and `apps/` directories in the Dockerfile runtime stage
- The WhatsApp extension has runtime imports reaching into `src/` and `apps/` via relative paths
- These directories were missing from the final Docker stage, causing module not found errors

## Test plan
- [ ] Build Docker image and verify WhatsApp extension starts successfully
- [ ] Verify src/channels/plugins/account-helpers.js and tool-display.json are accessible

Fixes #49498

🤖 Generated with [Claude Code](https://claude.com/claude-code)