### PR TITLE
fix(cron): auto-infer accountId from agentId when not set

### DIFF
--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -120,6 +120,13 @@ export async function resolveDeliveryTarget(
     }
   }
 
+  // When no accountId was resolved from session or bindings, fall back to
+  // the agentId so cron jobs with a specific agent identity send from the
+  // correct account rather than the default one (see #49507).
+  if (!accountId && agentId) {
+    accountId = agentId;
+  }
+
   // job.delivery.accountId takes highest precedence — explicitly set by the job author.
   if (jobPayload.accountId) {
     accountId = jobPayload.accountId;


### PR DESCRIPTION
## Summary
- When a cron job specifies `agentId` but not `accountId`, now uses the agentId value as the accountId
- Prevents sending messages from the wrong account identity (e.g., wrong Feishu account)

## Test plan
- [ ] Create cron job with agentId but no accountId, verify correct account is used
- [ ] Verify explicit accountId still takes precedence

Fixes #49507

🤖 Generated with [Claude Code](https://claude.com/claude-code)