### PR TITLE
fix: resolve ANTHROPIC_MODEL_ALIASES initialization order crash (#49519)

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -262,6 +262,22 @@ describe("model-selection", () => {
     it.each(["", "  ", "/", "anthropic/", "/model"])("returns null for invalid ref %j", (raw) => {
       expect(parseModelRef(raw, "anthropic")).toBeNull();
     });
+
+    it("does not crash when parsing non-Anthropic provider model refs (#49519)", () => {
+      // Regression: normalizeAnthropicModelId previously referenced a module-level
+      // ANTHROPIC_MODEL_ALIASES constant that could trigger a TDZ ReferenceError
+      // when the bundled module initialization order differed from source order.
+      // The call path: parseModelRef -> normalizeModelRef -> normalizeProviderModelId
+      // must be safe for every provider, including openai-codex-responses models.
+      expect(parseModelRef("azure-foundry-codex/gpt-5.3-codex", "anthropic")).toEqual({
+        provider: "azure-foundry-codex",
+        model: "gpt-5.3-codex",
+      });
+      expect(parseModelRef("openai/gpt-5.3-codex", "openai")).toEqual({
+        provider: "openai",
+        model: "gpt-5.3-codex",
+      });
+    });
   });
 
   describe("inferUniqueProviderFromConfiguredModels", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -92,7 +92,7 @@ function normalizeAnthropicModelId(model: string): string {
   }
   const lower = trimmed.toLowerCase();
   // Keep alias resolution local so bundled startup paths cannot trip a TDZ on
-  // a module-level alias table while config parsing is still initializing.
+  // a module-level alias table while config parsing is still initializing (#45520, #49519).
   switch (lower) {
     case "opus-4.6":
       return "claude-opus-4-6";


### PR DESCRIPTION
## Summary

- Adds a regression test covering the exact crash path from #49519: `parseModelRef` called with non-Anthropic providers (e.g. `azure-foundry-codex/gpt-5.3-codex`) going through `normalizeModelRef` -> `normalizeProviderModelId`
- Cross-references #49519 in the existing TDZ-avoidance comment in `normalizeAnthropicModelId`

The root cause (module-level `const ANTHROPIC_MODEL_ALIASES` replaced with an inline `switch` statement) was already addressed in #45520. The reporter in #49519 is on version `2026.3.12` which predates that fix. This PR adds the regression test to prevent future reintroduction of the TDZ-vulnerable pattern.

## Test plan

- [x] New test `"does not crash when parsing non-Anthropic provider model refs (#49519)"` passes
- [x] Existing `model-selection.test.ts` suite passes (62 tests)

Fixes #49519

🤖 Generated with [Claude Code](https://claude.com/claude-code)