### PR TITLE
fix(auto-reply): suppress routine WhatsApp gateway banners

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -38,6 +38,15 @@ export async function drainFormattedSystemEvents(params: {
     if (lower.includes("heartbeat poll") || lower.includes("heartbeat wake")) {
       return null;
     }
+    // Keep routine transport flaps out of normal prompt assembly; higher-signal
+    // channel-health issues (logged out, relink required, max-attempts, etc.)
+    // can still surface via their own system events.
+    if (
+      lower.startsWith("whatsapp gateway connected") ||
+      lower.startsWith("whatsapp gateway disconnected")
+    ) {
+      return null;
+    }
     if (trimmed.startsWith("Node:")) {
       return trimmed.replace(/ · last input [^·]+/i, "").trim();
     }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1640,6 +1640,64 @@ describe("drainFormattedSystemEvents", () => {
       vi.useRealTimers();
     }
   });
+
+  it("suppresses routine WhatsApp gateway connect and disconnect banners", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-17T07:32:00Z"));
+
+      enqueueSystemEvent("WhatsApp gateway connected as +15551234567.", {
+        sessionKey: "agent:main:main",
+      });
+      enqueueSystemEvent("WhatsApp gateway disconnected (status 428)", {
+        sessionKey: "agent:main:main",
+      });
+
+      const result = await drainFormattedSystemEvents({
+        cfg: {} as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: false,
+        isNewSession: false,
+      });
+
+      expect(result).toBeUndefined();
+    } finally {
+      resetSystemEventsForTest();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps non-routine WhatsApp system events while filtering routine gateway flaps", async () => {
+    vi.useFakeTimers();
+    try {
+      const timestamp = new Date("2026-03-17T07:32:00Z");
+      const expectedTimestamp = formatZonedTimestamp(timestamp, { displaySeconds: true });
+      vi.setSystemTime(timestamp);
+
+      enqueueSystemEvent("WhatsApp gateway connected as +15551234567.", {
+        sessionKey: "agent:main:main",
+      });
+      enqueueSystemEvent("WhatsApp session logged out. Run relink.", {
+        sessionKey: "agent:main:main",
+      });
+
+      const result = await drainFormattedSystemEvents({
+        cfg: {} as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: false,
+        isNewSession: false,
+      });
+
+      expect(expectedTimestamp).toBeDefined();
+      expect(result).toContain(
+        `System: [${expectedTimestamp}] WhatsApp session logged out. Run relink.`,
+      );
+      expect(result).not.toContain("WhatsApp gateway connected");
+    } finally {
+      resetSystemEventsForTest();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("persistSessionUsageUpdate", () => {


### PR DESCRIPTION
## Summary
- Filters out routine WhatsApp "gateway connected"/"gateway disconnected" system events from auto-reply prompt assembly
- Saves tokens and prevents model confusion from noise events
- Still passes through important events like "logged out" and "relink required"

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)