### PR TITLE
fix: use agent workspace instead of process.cwd() for transcript headers

### DIFF
--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -67,6 +67,8 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  /** Explicit workspace directory; avoids process.cwd() race under multi-agent workloads. */
+  cwd?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
@@ -77,7 +79,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: params.cwd ?? process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -138,6 +140,8 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   idempotencyKey?: string;
   /** Optional override for store path (mostly for tests). */
   storePath?: string;
+  /** Explicit workspace directory for the transcript header; avoids process.cwd() race. */
+  cwd?: string;
 }): Promise<{ ok: true; sessionFile: string } | { ok: false; reason: string }> {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
@@ -178,7 +182,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, cwd: params.cwd });
 
   if (
     params.idempotencyKey &&

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,3 +1,4 @@
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   chunkByParagraph,
   chunkMarkdownTextWithMode,
@@ -760,11 +761,13 @@ async function deliverOutboundPayloadsCore(
       mediaUrls: params.mirror.mediaUrls,
     });
     if (mirrorText) {
+      const mirrorAgentId = params.mirror.agentId;
       await appendAssistantMessageToSessionTranscript({
-        agentId: params.mirror.agentId,
+        agentId: mirrorAgentId,
         sessionKey: params.mirror.sessionKey,
         text: mirrorText,
         idempotencyKey: params.mirror.idempotencyKey,
+        cwd: mirrorAgentId ? resolveAgentWorkspaceDir(cfg, mirrorAgentId) : undefined,
       });
     }
   }

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -107,12 +108,14 @@ export async function executeSendAction(params: {
         params.ctx.mirror.mediaUrls ??
         params.mediaUrls ??
         (params.mediaUrl ? [params.mediaUrl] : undefined);
+      const mirrorAgentId = params.ctx.mirror.agentId;
       await appendAssistantMessageToSessionTranscript({
-        agentId: params.ctx.mirror.agentId,
+        agentId: mirrorAgentId,
         sessionKey: params.ctx.mirror.sessionKey,
         text: mirrorText,
         mediaUrls: mirrorMediaUrls,
         idempotencyKey: params.ctx.mirror.idempotencyKey,
+        cwd: mirrorAgentId ? resolveAgentWorkspaceDir(params.ctx.cfg, mirrorAgentId) : undefined,
       });
     },
   });


### PR DESCRIPTION
## Summary

- `ensureSessionHeader()` in `src/config/sessions/transcript.ts` used `process.cwd()` to record the workspace directory in transcript file headers. Under concurrent multi-agent workloads, other embedded agents temporarily call `process.chdir()`, so the transcript could record the wrong workspace.
- Added an explicit `cwd` parameter to `ensureSessionHeader()` and `appendAssistantMessageToSessionTranscript()`, falling back to `process.cwd()` when not provided.
- Updated callers in `deliver.ts` and `outbound-send-service.ts` to resolve the workspace from agent config via `resolveAgentWorkspaceDir()` and pass it explicitly.

Fixes #49523

## Test plan

- [x] Existing session transcript tests pass (`src/config/sessions/sessions.test.ts` -- 19/19)
- [x] Deliver tests pass (`src/infra/outbound/deliver.test.ts`)
- [x] Outbound send service tests pass (`src/infra/outbound/outbound-send-service.test.ts` -- 9/9)
- [x] TypeScript check passes (no new errors)
- [ ] Manual: verify transcript headers record correct workspace under multi-agent load

🤖 Generated with [Claude Code](https://claude.com/claude-code)