### PR TITLE
fix: inherit agents.defaults.heartbeat for non-default agents

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -183,10 +183,9 @@ describe("resolveHeartbeatPrompt", () => {
 });
 
 describe("isHeartbeatEnabledForAgent", () => {
-  it("enables only explicit heartbeat agents when configured", () => {
+  it("enables only explicit heartbeat agents when no defaults heartbeat", () => {
     const cfg: OpenClawConfig = {
       agents: {
-        defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };
@@ -194,7 +193,18 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("inherits defaults.heartbeat for all agents in the list", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("inherits defaults.heartbeat for agents without explicit heartbeat block", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -202,7 +212,27 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("falls back to default agent when no explicit heartbeat entries and no defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("returns false for unknown agent even with defaults.heartbeat", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "unknown-agent")).toBe(false);
   });
 });
 
@@ -484,7 +514,6 @@ describe("runHeartbeatOnce", () => {
   it("skips when agent heartbeat is not enabled", async () => {
     const cfg: OpenClawConfig = {
       agents: {
-        defaults: { heartbeat: { every: "30m" } },
         list: [{ id: "main" }, { id: "ops", heartbeat: { every: "1h" } }],
       },
     };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -140,8 +140,28 @@ function resolveHeartbeatConfig(
   return { ...defaults, ...overrides };
 }
 
+function hasDefaultsHeartbeat(cfg: OpenClawConfig) {
+  return Boolean(cfg.agents?.defaults?.heartbeat);
+}
+
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   const list = cfg.agents?.list ?? [];
+
+  // When agents.defaults.heartbeat is configured, every agent in the list
+  // inherits heartbeat enablement (merged with any per-agent overrides).
+  if (hasDefaultsHeartbeat(cfg)) {
+    if (list.length > 0) {
+      return list
+        .map((entry) => {
+          const id = normalizeAgentId(entry.id);
+          return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
+        })
+        .filter((entry) => entry.agentId);
+    }
+    const fallbackId = resolveDefaultAgentId(cfg);
+    return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  }
+
   if (hasExplicitHeartbeatAgents(cfg)) {
     return list
       .filter((entry) => entry?.heartbeat)

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -59,6 +59,8 @@ import {
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
 import { resolveHeartbeatReasonKind } from "./heartbeat-reason.js";
 import {
+  hasDefaultsHeartbeat,
+  hasExplicitHeartbeatAgents,
   isHeartbeatEnabledForAgent,
   resolveHeartbeatIntervalMs,
   resolveHeartbeatSummaryForAgent,
@@ -120,11 +122,6 @@ export type HeartbeatRunner = {
   updateConfig: (cfg: OpenClawConfig) => void;
 };
 
-function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
-  const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
-}
-
 function resolveHeartbeatConfig(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -138,10 +135,6 @@ function resolveHeartbeatConfig(
     return overrides;
   }
   return { ...defaults, ...overrides };
-}
-
-function hasDefaultsHeartbeat(cfg: OpenClawConfig) {
-  return Boolean(cfg.agents?.defaults?.heartbeat);
 }
 
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -28,9 +28,23 @@ function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   return list.some((entry) => Boolean(entry?.heartbeat));
 }
 
+function hasDefaultsHeartbeat(cfg: OpenClawConfig) {
+  return Boolean(cfg.agents?.defaults?.heartbeat);
+}
+
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
   const list = cfg.agents?.list ?? [];
+
+  // When agents.defaults.heartbeat is configured, every known agent inherits
+  // heartbeat enablement (there is no per-agent opt-out field today).
+  if (hasDefaultsHeartbeat(cfg)) {
+    if (list.length > 0) {
+      return list.some((entry) => normalizeAgentId(entry?.id) === resolvedAgentId);
+    }
+    return resolvedAgentId === resolveDefaultAgentId(cfg);
+  }
+
   const hasExplicit = hasExplicitHeartbeatAgents(cfg);
   if (hasExplicit) {
     return list.some(

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -23,12 +23,12 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
 
-function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
+export function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
   return list.some((entry) => Boolean(entry?.heartbeat));
 }
 
-function hasDefaultsHeartbeat(cfg: OpenClawConfig) {
+export function hasDefaultsHeartbeat(cfg: OpenClawConfig) {
   return Boolean(cfg.agents?.defaults?.heartbeat);
 }
 


### PR DESCRIPTION
## Summary

- Non-default agents now correctly inherit heartbeat configuration from `agents.defaults.heartbeat` without requiring an explicit `heartbeat` block in their agent list entry.
- Previously, `isHeartbeatEnabledForAgent` and `resolveHeartbeatAgents` only considered agents with explicit `heartbeat` config in their list entry, ignoring `agents.defaults.heartbeat` for non-default agents.
- Added `hasDefaultsHeartbeat` check that, when `agents.defaults.heartbeat` is set, enables heartbeat for all agents in the list (not just those with explicit overrides).

Fixes #49613

## Test plan

- [x] Updated existing `isHeartbeatEnabledForAgent` tests to reflect correct inheritance behavior
- [x] Added new test: agents without explicit heartbeat block inherit from defaults
- [x] Added new test: unknown agents remain disabled even with defaults
- [x] Updated `runHeartbeatOnce` test to correctly test the explicit-only path (no defaults)
- [x] All 28 tests in `heartbeat-runner.returns-default-unset.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)