### PR TITLE
feat(plugin-sdk): expose agent steer/abort APIs for channel plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,10 @@
       "types": "./dist/plugin-sdk/agent-runtime.d.ts",
       "default": "./dist/plugin-sdk/agent-runtime.js"
     },
+    "./plugin-sdk/agent-steer": {
+      "types": "./dist/plugin-sdk/agent-steer.d.ts",
+      "default": "./dist/plugin-sdk/agent-steer.js"
+    },
     "./plugin-sdk/speech-runtime": {
       "types": "./dist/plugin-sdk/speech-runtime.d.ts",
       "default": "./dist/plugin-sdk/speech-runtime.js"

--- a/src/plugin-sdk/agent-steer.ts
+++ b/src/plugin-sdk/agent-steer.ts
@@ -1,0 +1,7 @@
+export {
+  queueEmbeddedPiMessage,
+  abortEmbeddedPiRun,
+  isEmbeddedPiRunActive,
+  isEmbeddedPiRunStreaming,
+  waitForEmbeddedPiRunEnd,
+} from "../agents/pi-embedded-runner/runs.js";


### PR DESCRIPTION
## Summary
- Add `src/plugin-sdk/agent-steer.ts` barrel that re-exports `queueEmbeddedPiMessage`, `abortEmbeddedPiRun`, `isEmbeddedPiRunActive`, `isEmbeddedPiRunStreaming`, and `waitForEmbeddedPiRunEnd` from `src/agents/pi-embedded-runner/runs.ts`
- Add `./plugin-sdk/agent-steer` entry to `package.json` exports map so channel plugins can `import { ... } from "openclaw/plugin-sdk/agent-steer"`

Fixes #49624

## Test plan
- [ ] `pnpm build` succeeds and `dist/plugin-sdk/agent-steer.js` + `dist/plugin-sdk/agent-steer.d.ts` are emitted
- [ ] Existing tests pass (`pnpm test`)
- [ ] Importing from `openclaw/plugin-sdk/agent-steer` in an extension resolves the five exported functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)