### PR TITLE
feat(cli): support custom HTTP headers on gateway WebSocket connections

### DIFF
--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -12,13 +12,75 @@ export type GatewayRpcOpts = {
   timeout?: string;
   expectFinal?: boolean;
   json?: boolean;
+  header?: string[];
 };
+
+/**
+ * Parse repeatable `--header "Name: Value"` flags into a headers record.
+ * Also merges headers from the `OPENCLAW_GATEWAY_HEADERS` env var
+ * (comma-separated `Name: Value` pairs) and from the config file
+ * (`gateway.remote.headers`). Precedence: CLI > env > config.
+ */
+function resolveGatewayHeaders(opts: GatewayRpcOpts): Record<string, string> | undefined {
+  const merged: Record<string, string> = {};
+  let hasHeaders = false;
+
+  // Lowest precedence: config file gateway.remote.headers
+  const configHeaders = opts.config?.gateway?.remote?.headers;
+  if (configHeaders && typeof configHeaders === "object") {
+    for (const [key, value] of Object.entries(configHeaders)) {
+      if (typeof key === "string" && key.trim().length > 0 && typeof value === "string") {
+        merged[key.trim()] = value;
+        hasHeaders = true;
+      }
+    }
+  }
+
+  // Middle precedence: OPENCLAW_GATEWAY_HEADERS env var (comma-separated "Name: Value" pairs)
+  const envHeaders = process.env.OPENCLAW_GATEWAY_HEADERS;
+  if (typeof envHeaders === "string" && envHeaders.trim().length > 0) {
+    for (const entry of envHeaders.split(",")) {
+      const colonIdx = entry.indexOf(":");
+      if (colonIdx > 0) {
+        const key = entry.slice(0, colonIdx).trim();
+        const value = entry.slice(colonIdx + 1).trim();
+        if (key.length > 0) {
+          merged[key] = value;
+          hasHeaders = true;
+        }
+      }
+    }
+  }
+
+  // Highest precedence: CLI --header flags
+  if (Array.isArray(opts.header)) {
+    for (const entry of opts.header) {
+      const colonIdx = entry.indexOf(":");
+      if (colonIdx > 0) {
+        const key = entry.slice(0, colonIdx).trim();
+        const value = entry.slice(colonIdx + 1).trim();
+        if (key.length > 0) {
+          merged[key] = value;
+          hasHeaders = true;
+        }
+      }
+    }
+  }
+
+  return hasHeaders ? merged : undefined;
+}
 
 export const gatewayCallOpts = (cmd: Command) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
+    .option(
+      "--header <header>",
+      "Custom HTTP header for WebSocket upgrade (repeatable, format: Name: Value)",
+      (value: string, previous: string[]) => [...previous, value],
+      [] as string[],
+    )
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--expect-final", "Wait for final response (agent)", false)
     .option("--json", "Output JSON", false);
@@ -36,6 +98,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
         url: opts.url,
         token: opts.token,
         password: opts.password,
+        headers: resolveGatewayHeaders(opts),
         method,
         params,
         expectFinal: Boolean(opts.expectFinal),

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -198,6 +198,11 @@ export type GatewayRemoteConfig = {
   password?: SecretInput;
   /** Expected TLS certificate fingerprint (sha256) for remote gateways. */
   tlsFingerprint?: string;
+  /**
+   * Custom HTTP headers to send on the WebSocket upgrade request.
+   * Useful for authenticating reverse proxies (Cloudflare Access, etc.).
+   */
+  headers?: Record<string, string>;
   /** SSH target for tunneling remote Gateway (user@host). */
   sshTarget?: string;
   /** SSH identity file path for tunneling remote Gateway. */

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -59,6 +59,8 @@ type CallGatewayBaseOptions = {
    * Does not affect config loading; callers still control auth via opts.token/password/env/config.
    */
   configPath?: string;
+  /** Custom HTTP headers to include in the WebSocket upgrade request. */
+  headers?: Record<string, string>;
 };
 
 export type CallGatewayScopedOptions = CallGatewayBaseOptions & {
@@ -116,6 +118,8 @@ export function ensureExplicitGatewayAuth(params: {
   resolvedAuth?: ExplicitGatewayAuth;
   errorHint: string;
   configPath?: string;
+  /** Custom HTTP headers to include in the WebSocket upgrade request. */
+  headers?: Record<string, string>;
 }): void {
   if (!params.urlOverride) {
     return;
@@ -152,6 +156,8 @@ export function buildGatewayConnectionDetails(
     config?: OpenClawConfig;
     url?: string;
     configPath?: string;
+    /** Custom HTTP headers to include in the WebSocket upgrade request. */
+    headers?: Record<string, string>;
     urlSource?: "cli" | "env";
   } = {},
 ): GatewayConnectionDetails {
@@ -820,6 +826,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       token,
       password,
       tlsFingerprint,
+      headers: opts.headers,
       instanceId: opts.instanceId ?? randomUUID(),
       clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
       clientDisplayName: opts.clientDisplayName,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -101,6 +101,8 @@ export type GatewayClientOptions = {
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
+  /** Custom HTTP headers to include in the WebSocket upgrade request. */
+  headers?: Record<string, string>;
   onEvent?: (evt: EventFrame) => void;
   onHelloOk?: (hello: HelloOk) => void;
   onConnectError?: (err: Error) => void;
@@ -224,6 +226,10 @@ export class GatewayClient {
         return undefined;
         // oxlint-disable-next-line typescript/no-explicit-any
       }) as any;
+    }
+    // Merge custom HTTP headers into the WebSocket upgrade request.
+    if (this.opts.headers && Object.keys(this.opts.headers).length > 0) {
+      wsOptions.headers = { ...wsOptions.headers, ...this.opts.headers };
     }
     const ws = new WebSocket(url, wsOptions);
     this.ws = ws;


### PR DESCRIPTION
## Summary

- Add repeatable `--header "Name: Value"` CLI flag to gateway CLI commands for passing custom HTTP headers on WebSocket upgrade requests
- Add `OPENCLAW_GATEWAY_HEADERS` environment variable support (comma-separated `Name: Value` pairs)
- Add `gateway.remote.headers` config file support (`Record<string, string>`)
- Thread headers through `CallGatewayBaseOptions` -> `GatewayClientOptions` -> `wsOptions` before `new WebSocket(url, wsOptions)`
- Precedence: CLI flags > env var > config file (higher sources override lower)

Enables CLI access through authenticating reverse proxies (Cloudflare Access, OAuth2 Proxy, etc.).

Fixes #49599

## Test plan

- [ ] Verify `--header "X-Custom: value"` flag is accepted and repeatable on gateway CLI commands
- [ ] Verify `OPENCLAW_GATEWAY_HEADERS="X-Foo: bar,X-Baz: qux"` env var is parsed correctly
- [ ] Verify `gateway.remote.headers` config values are read and passed through
- [ ] Verify precedence: CLI flag overrides env var overrides config
- [ ] Verify headers appear in WebSocket upgrade request (tcpdump or proxy inspection)
- [ ] Verify existing gateway CLI commands still work without `--header`

🤖 Generated with [Claude Code](https://claude.com/claude-code)