### PR TITLE
fix: allow plugin apiKey and env in gateway config validator

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -162,6 +162,8 @@ const PluginEntrySchema = z
       })
       .strict()
       .optional(),
+    apiKey: SecretInputSchema.optional().register(sensitive),
+    env: z.record(z.string(), z.string()).optional(),
     config: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();


### PR DESCRIPTION
## Summary
- Added `apiKey` and `env` properties to `PluginEntrySchema` in `src/config/zod-schema.ts`, matching the fields already present in `SkillEntrySchema`
- The gateway config validator (Zod `.strict()` mode) rejected `plugins.entries.*.apiKey` and `plugins.entries.*.env` as unrecognized keys, even though the help system and labels already documented them
- Plugin entries now accept `apiKey` (SecretInput), `env` (string record), and `config` (already present) without validation errors

## Test plan
- [x] Verified `OpenClawSchema.safeParse()` now accepts `apiKey`, `env`, and `config` on plugin entries
- [x] Verified generated JSON schema includes all three properties
- [x] All existing schema tests pass (schema.help.quality, config.plugin-validation, plugins-runtime-boundary, schema, schema.hints, redact-snapshot)

Fixes #49495

🤖 Generated with [Claude Code](https://claude.com/claude-code)