### PR TITLE
fix: reject unrecognized accountId in message tool routing

### DIFF
--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -673,4 +673,96 @@ describe("runMessageAction plugin dispatch", () => {
       expect(ctx.params.accountId).toBe(expectedAccountId);
     });
   });
+
+  describe("accountId exact-match validation", () => {
+    const handleAction = vi.fn(async () => jsonResult({ ok: true }));
+
+    const multiAccountPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram multi-account test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["8510324544", "8401457831"],
+        resolveAccount: () => ({}),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        handleAction,
+      },
+    };
+
+    beforeEach(() => {
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "telegram",
+            source: "test",
+            plugin: multiAccountPlugin,
+          },
+        ]),
+      );
+      handleAction.mockClear();
+    });
+
+    afterEach(() => {
+      setActivePluginRegistry(createTestRegistry([]));
+      vi.clearAllMocks();
+    });
+
+    it("rejects an accountId that does not exactly match any configured account", async () => {
+      await expect(
+        runMessageAction({
+          cfg: {} as OpenClawConfig,
+          action: "send",
+          params: {
+            channel: "telegram",
+            target: "channel:123",
+            message: "hi",
+            accountId: "851032",
+          },
+        }),
+      ).rejects.toThrow(/not configured for channel/);
+    });
+
+    it("accepts an accountId that exactly matches a configured account", async () => {
+      await runMessageAction({
+        cfg: {} as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "telegram",
+          target: "channel:123",
+          message: "hi",
+          accountId: "8510324544",
+        },
+      });
+
+      expect(handleAction).toHaveBeenCalled();
+      const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+        | { accountId?: string | null }
+        | undefined;
+      expect(ctx?.accountId).toBe("8510324544");
+    });
+
+    it("does not reject a defaultAccountId that comes from bindings (not tool params)", async () => {
+      await runMessageAction({
+        cfg: {} as OpenClawConfig,
+        action: "send",
+        defaultAccountId: "8510324544",
+        params: {
+          channel: "telegram",
+          target: "channel:123",
+          message: "hi",
+        },
+      });
+
+      expect(handleAction).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -19,7 +19,7 @@ import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { hasPollCreationParams, resolveTelegramPollVisibility } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
 import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
@@ -759,6 +759,26 @@ export async function runMessageAction(
     const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));
     if (boundAccountIds && boundAccountIds.length > 0) {
       accountId = boundAccountIds[0];
+    }
+  }
+  // Validate that an explicitly-provided accountId (from tool params) exists
+  // among the channel's configured accounts.  Without this check a partial or
+  // wrong accountId could silently fall through to the default account and
+  // route messages to the wrong bot.
+  // See: https://github.com/openclaw/openclaw/issues/49383
+  const explicitParamAccountId = readStringParam(params, "accountId");
+  if (explicitParamAccountId) {
+    const plugin = getChannelPlugin(channel);
+    if (plugin?.config.listAccountIds) {
+      const configuredIds = plugin.config.listAccountIds(cfg);
+      const normalizedRequested = normalizeAccountId(explicitParamAccountId);
+      const normalizedConfigured = new Set(configuredIds.map((id) => normalizeAccountId(id)));
+      if (normalizedConfigured.size > 0 && !normalizedConfigured.has(normalizedRequested)) {
+        throw new Error(
+          `Account "${explicitParamAccountId}" is not configured for channel "${channel}". ` +
+            `Configured accounts: ${configuredIds.join(", ")}`,
+        );
+      }
     }
   }
   if (accountId) {


### PR DESCRIPTION
## Summary
- Adds explicit validation in `runMessageAction` that rejects accountIds not found among the channel plugin's configured accounts
- Prevents messages from being silently routed to the wrong bot when the message tool receives a partial or incorrect accountId
- Only validates accountIds explicitly provided in tool params (not those derived from agent bindings or defaults)

Fixes #49383

## Test plan
- [x] Added test: rejects partial accountId that does not match any configured account
- [x] Added test: accepts exact accountId match
- [x] Added test: does not reject defaultAccountId from bindings (non-tool-param path)
- [x] Existing tests pass (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)