### PR TITLE
fix: groupPolicy "open" no longer silently drops group messages

### DIFF
--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./config.js";
-import { resolveChannelGroupPolicy, resolveToolsBySender } from "./group-policy.js";
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupRequireMention,
+  resolveToolsBySender,
+} from "./group-policy.js";
 
 describe("resolveChannelGroupPolicy", () => {
   it("fails closed when groupPolicy=allowlist and groups are missing", () => {
@@ -128,6 +132,65 @@ describe("resolveChannelGroupPolicy", () => {
 
     expect(policy.allowlistEnabled).toBe(true);
     expect(policy.allowed).toBe(false);
+  });
+});
+
+describe("resolveChannelGroupRequireMention", () => {
+  it("defaults to false when groupPolicy is open and no requireMention is configured", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "open",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("defaults to true when groupPolicy is allowlist and no requireMention is configured", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("respects explicit requireMention even when groupPolicy is open", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "open",
+          groups: {
+            "*": { requireMention: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe(true);
   });
 });
 

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -385,6 +385,14 @@ export function resolveChannelGroupRequireMention(params: {
   if (overrideOrder !== "before-config" && typeof requireMentionOverride === "boolean") {
     return requireMentionOverride;
   }
+
+  // When groupPolicy is "open" and no explicit requireMention is configured,
+  // default to false so messages are not silently dropped by mention gating.
+  const groupPolicy = resolveChannelGroupPolicyMode(params.cfg, params.channel, params.accountId);
+  if (groupPolicy === "open") {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

- When `groupPolicy: "open"` is configured without explicit `requireMention` settings, `resolveChannelGroupRequireMention` now defaults to `false` instead of `true`, so group messages are not silently dropped by mention gating.
- Previously, all group messages were received but then dropped at the mention gate because `requireMention` always defaulted to `true` regardless of the group policy mode.
- Adds regression tests for the `resolveChannelGroupRequireMention` function covering the `"open"`, `"allowlist"`, and explicit `requireMention` override cases.

Closes #49343

## Test plan

- [x] Existing `group-policy.test.ts` tests continue to pass (16 tests)
- [x] Existing `web-auto-reply-monitor.test.ts` tests continue to pass (13 tests)
- [x] New tests verify: `groupPolicy: "open"` defaults `requireMention` to `false`; `groupPolicy: "allowlist"` still defaults to `true`; explicit `requireMention: true` in groups config is respected even with `groupPolicy: "open"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)