### PR TITLE
fix(ui): use selected model's provider prefix in webchat model switcher

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -119,9 +119,10 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
+    // Bare model name is now qualified with the catalog provider before sending.
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(host.chatModelOverrides.main).toEqual({
       kind: "qualified",

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -267,6 +267,11 @@ describe("executeSlashCommand directives", () => {
 
   it("mirrors resolved provider-qualified model refs after /model changes", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "models.list") {
+        return {
+          models: [{ id: "gpt-5-mini", provider: "openai", name: "GPT-5 Mini" }],
+        };
+      }
       if (method === "sessions.patch") {
         return {
           ok: true,
@@ -287,13 +292,55 @@ describe("executeSlashCommand directives", () => {
       "gpt-5-mini",
     );
 
+    // Bare model name is qualified with the catalog provider before sending.
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
       value: "openai/gpt-5-mini",
+    });
+  });
+
+  it("uses the selected model's own provider when switching between providers", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "models.list") {
+        return {
+          models: [
+            { id: "claude-opus-4-6", provider: "anthropic", name: "Claude Opus" },
+            { id: "gemini-2.5-pro", provider: "google", name: "Gemini 2.5 Pro" },
+          ],
+        };
+      }
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: "main",
+          resolved: {
+            modelProvider: "google",
+            model: "gemini-2.5-pro",
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "gemini-2.5-pro",
+    );
+
+    // Must send "google/gemini-2.5-pro", NOT "anthropic/gemini-2.5-pro".
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "google/gemini-2.5-pro",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "google/gemini-2.5-pro",
     });
   });
 

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -16,7 +16,11 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolveServerChatModelValue } from "../chat-model-ref.ts";
+import {
+  buildQualifiedChatModelValue,
+  createChatModelOverride,
+  resolveServerChatModelValue,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -151,16 +155,35 @@ async function executeModel(
   }
 
   try {
+    // Qualify bare model names with their catalog provider so the server
+    // does not fall back to the session's current provider (which may
+    // belong to a completely different provider).
+    const modelArg = args.trim();
+    let qualifiedModel = modelArg;
+    if (!modelArg.includes("/")) {
+      try {
+        const catalog = await client.request<{ models: ModelCatalogEntry[] }>("models.list", {});
+        const match = catalog?.models?.find(
+          (m: ModelCatalogEntry) => m.id.toLowerCase() === modelArg.toLowerCase(),
+        );
+        if (match?.provider) {
+          qualifiedModel = buildQualifiedChatModelValue(match.id, match.provider);
+        }
+      } catch {
+        // Catalog unavailable — send the bare name and let the server resolve.
+      }
+    }
+
     const patched = await client.request<SessionsPatchResult>("sessions.patch", {
       key: sessionKey,
-      model: args.trim(),
+      model: qualifiedModel,
     });
     const resolvedValue = resolveServerChatModelValue(
-      patched.resolved?.model ?? args.trim(),
+      patched.resolved?.model ?? modelArg,
       patched.resolved?.modelProvider,
     );
     return {
-      content: `Model set to \`${args.trim()}\`.`,
+      content: `Model set to \`${modelArg}\`.`,
       action: "refresh",
       sessionPatch: { modelOverride: createChatModelOverride(resolvedValue) },
     };


### PR DESCRIPTION
## Summary

- When switching models via the webchat `/model` command with a bare model name (e.g., `/model gemini-2.5-pro`), the UI now looks up the model in the catalog and qualifies it with the correct provider prefix before sending to the server.
- Previously, bare model names were sent as-is to the server, which would fall back to the session's default provider (e.g., `anthropic`) instead of the selected model's actual provider (e.g., `google`), producing invalid refs like `anthropic/gemini-2.5-pro`.
- Already-qualified model names (e.g., `google/gemini-2.5-pro`) and the dropdown model switcher (which always sends qualified values) are unaffected.

Fixes #49544

## Test plan

- [x] Updated existing test "mirrors resolved provider-qualified model refs after /model changes" to verify catalog lookup
- [x] Added new test "uses the selected model's own provider when switching between providers" covering the cross-provider scenario
- [x] Updated `app-chat.test.ts` to expect the qualified model name in the `sessions.patch` call
- [x] All existing chat/model tests pass (`ui/src/ui/views/chat.test.ts`, `ui/src/ui/app-chat.test.ts`, `ui/src/ui/chat/slash-command-executor.node.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)