### PR TITLE
fix: constrain cron job entries within list boundary

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -783,6 +783,7 @@
 .cron-workspace-main {
   display: grid;
   gap: 16px;
+  min-width: 0;
 }
 
 .cron-workspace-form {
@@ -1498,6 +1499,8 @@
   font-weight: 600;
   font-size: 15px;
   letter-spacing: -0.015em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cron-job {
@@ -1549,6 +1552,8 @@
 .cron-job-detail-value {
   font-size: 13px;
   line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cron-job-state {
@@ -1575,6 +1580,8 @@
   color: var(--text);
   font-size: 12px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .cron-job-status-pill {


### PR DESCRIPTION
## Summary

Fixes #49228 -- cron job entries spill outside the list boundary and overlap the right-side "New Job" panel.

**Root cause:** `.cron-workspace-main` (the grid child holding the job list) lacks `min-width: 0`, so CSS grid's default `min-width: auto` prevents it from shrinking below its content width. Long job names, payloads, or state values push the column past its allocated grid fraction.

**Changes:**
- Add `min-width: 0` to `.cron-workspace-main` so it respects the grid column boundary
- Add `overflow-wrap: anywhere; word-break: break-word` to `.cron-job .list-title` and `.cron-job-detail-value` so long text wraps gracefully
- Add `overflow: hidden; text-overflow: ellipsis` to `.cron-job-state-value` (which uses `white-space: nowrap`) so it truncates instead of expanding

## Test plan

- [ ] Open Web UI Cron Jobs tab with a job that has a long name, payload, or state values
- [ ] Verify the job entry stays within the left list column and does not overlap the "New Job" panel
- [ ] Verify text wraps or truncates cleanly at narrow viewport widths
- [ ] Verify the responsive layout (container query < 560px) still works correctly

Generated with [Claude Code](https://claude.com/claude-code)