### PR TITLE
fix: preserve thinking/redacted_thinking blocks during context pruning

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -123,6 +123,94 @@ describe("pruneContextMessages", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("preserves assistant messages with thinking blocks unmodified during pruning", () => {
+    const thinkingBlock = {
+      type: "thinking",
+      thinking: "deep reasoning",
+      thinkingSignature: "opaque-sig-data",
+    } as unknown as AssistantContentBlock;
+    const redactedBlock = {
+      type: "thinking",
+      thinking: "[Reasoning redacted]",
+      thinkingSignature: "A".repeat(2000),
+      redacted: true,
+    } as unknown as AssistantContentBlock;
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeToolResult([{ type: "text", text: "X".repeat(5000) }]),
+      makeAssistant([thinkingBlock, { type: "text", text: "first answer" }]),
+      makeUser("followup"),
+      makeToolResult([{ type: "text", text: "Y".repeat(5000) }]),
+      makeAssistant([redactedBlock, { type: "text", text: "second answer" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        softTrim: { maxChars: 200, headChars: 100, tailChars: 50 },
+        hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 16,
+    });
+
+    // The assistant messages must remain identical (same reference).
+    const assistantMessages = result.filter((m) => m.role === "assistant");
+    expect(assistantMessages).toHaveLength(2);
+    expect(assistantMessages[0]).toBe(messages[2]);
+    expect(assistantMessages[1]).toBe(messages[5]);
+    // Thinking blocks must be fully intact.
+    const firstContent = (assistantMessages[0] as { content: unknown[] }).content;
+    expect(firstContent[0]).toBe(thinkingBlock);
+    const secondContent = (assistantMessages[1] as { content: unknown[] }).content;
+    expect(secondContent[0]).toBe(redactedBlock);
+  });
+
+  it("accounts for thinkingSignature in size estimates so pruning is triggered correctly", () => {
+    // A redacted thinking block with a large thinkingSignature should contribute to the
+    // estimated size, ensuring the pruner activates soft-trim when the context is tight.
+    const hugeSignature = "S".repeat(40_000);
+    const messages: AgentMessage[] = [
+      makeUser("go"),
+      makeToolResult([{ type: "text", text: "T".repeat(2000) }]),
+      makeAssistant([
+        {
+          type: "thinking",
+          thinking: "[Reasoning redacted]",
+          thinkingSignature: hugeSignature,
+          redacted: true,
+        } as unknown as AssistantContentBlock,
+        { type: "text", text: "done" },
+      ]),
+    ];
+
+    // With a tiny context window the large signature should push the ratio above softTrimRatio.
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0.5,
+        softTrim: { maxChars: 200, headChars: 100, tailChars: 50 },
+        hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+      },
+      ctx: { model: { contextWindow: 5_000 } } as unknown as ExtensionContext,
+      isToolPrunable: () => true,
+    });
+
+    // Pruning should have been triggered and toolResult soft-trimmed.
+    const toolResult = result.find((m) => m.role === "toolResult") as Extract<
+      AgentMessage,
+      { role: "toolResult" }
+    >;
+    const textBlock = toolResult.content[0] as { type: "text"; text: string };
+    expect(textBlock.text).toContain("[Tool result trimmed:");
+  });
+
   it("soft-trims image-containing tool results by replacing image blocks with placeholders", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -142,8 +142,16 @@ function estimateMessageChars(message: AgentMessage): number {
       if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
-      if (b.type === "thinking" && typeof b.thinking === "string") {
-        chars += b.thinking.length;
+      if (b.type === "thinking") {
+        if (typeof b.thinking === "string") {
+          chars += b.thinking.length;
+        }
+        // Account for thinkingSignature (opaque payload for redacted thinking blocks)
+        // which is included in the API request payload.
+        const sig = (b as { thinkingSignature?: string }).thinkingSignature;
+        if (typeof sig === "string") {
+          chars += sig.length;
+        }
       }
       if (b.type === "toolCall") {
         try {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -621,9 +621,8 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const isThinkingBlockError = /thinking.*(?:block|content|signature)|redacted_thinking/i.test(
-        message,
-      );
+      const isThinkingBlockError =
+        /\bthinking[_\s-]?(?:block|content|signature)\b|\bredacted_thinking\b/i.test(message);
       // Always sanitize error messages to avoid leaking raw API details to chat channels.
       const safeMessage = sanitizeUserFacingText(message, { errorContext: true });
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -621,9 +621,11 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
+      const isThinkingBlockError = /thinking.*(?:block|content|signature)|redacted_thinking/i.test(
+        message,
+      );
+      // Always sanitize error messages to avoid leaking raw API details to chat channels.
+      const safeMessage = sanitizeUserFacingText(message, { errorContext: true });
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling
         ? BILLING_ERROR_USER_MESSAGE
@@ -631,7 +633,9 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isThinkingBlockError
+              ? "⚠️ Session history contains stale reasoning data. Use /new to start a fresh session."
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1867,6 +1867,64 @@ describe("runReplyAgent transient HTTP retry", () => {
   });
 });
 
+async function runReplyAgentWithThrownError(errorMessage: string) {
+  runEmbeddedPiAgentMock.mockReset();
+  runEmbeddedPiAgentMock.mockRejectedValue(new Error(errorMessage));
+
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "telegram",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "telegram",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun,
+    queueKey: "main",
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing,
+    sessionCtx,
+    defaultModel: "anthropic/claude",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
 describe("runReplyAgent billing error classification", () => {
   // Regression guard for the runner-level catch block in runAgentTurnWithFallback.
   // Billing errors from providers like OpenRouter can contain token/size wording that
@@ -1933,5 +1991,44 @@ describe("runReplyAgent billing error classification", () => {
     const payload = Array.isArray(result) ? result[0] : result;
     expect(payload?.text).toContain("billing error");
     expect(payload?.text).not.toContain("Context overflow");
+  });
+});
+
+describe("runReplyAgent thinking block error classification", () => {
+  it("returns the stale reasoning fallback for explicit thinking signature failures", async () => {
+    const result = await runReplyAgentWithThrownError(
+      "400 redacted_thinking signature mismatch for previous assistant turn",
+    );
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toBe(
+      "⚠️ Session history contains stale reasoning data. Use /new to start a fresh session.",
+    );
+  });
+
+  it("keeps unrelated 'thinking about block' wording on the generic error fallback", async () => {
+    const result = await runReplyAgentWithThrownError(
+      "The model is thinking about block chain transactions right now",
+    );
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain(
+      "Agent failed before reply: The model is thinking about block chain transactions right now.",
+    );
+    expect(payload?.text).not.toContain("stale reasoning data");
+  });
+});
+
+describe("runReplyAgent pre-reply error sanitization", () => {
+  it("sanitizes raw API payload errors before surfacing them to the user", async () => {
+    const result = await runReplyAgentWithThrownError(
+      '500 {"error":{"type":"server_error","message":"Something exploded"}}',
+    );
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain(
+      "Agent failed before reply: HTTP 500 server_error: Something exploded.",
+    );
+    expect(payload?.text).not.toContain('{"error"');
   });
 });


### PR DESCRIPTION
## Summary
- Fix context pruning size estimator to account for thinkingSignature payloads on thinking blocks
- Add detection for thinking-block-related API errors with user-friendly fallback messages
- Sanitize all error messages before forwarding to chat channels, not just transient HTTP errors
- Includes 2 regression tests

## Test plan
- [ ] Long session with Anthropic model triggers context pruning without exposing thinking errors
- [ ] Context pruning correctly estimates size with thinking blocks present

Fixes #49573

🤖 Generated with [Claude Code](https://claude.com/claude-code)