### PR TITLE
fix(feishu): convert absolute paths to file:// URLs for ESM imports on Windows

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -49,7 +49,7 @@ const meta: ChannelMeta = {
 };
 
 const loadFeishuChannelRuntime = createLazyRuntimeNamedExport(
-  () => import("./channel.runtime.js"),
+  () => import(/* @vite-ignore */ new URL("./channel.runtime.js", import.meta.url).href),
   "feishuChannelRuntime",
 );
 
@@ -934,7 +934,9 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   },
   gateway: {
     startAccount: async (ctx) => {
-      const { monitorFeishuProvider } = await import("./monitor.js");
+      const { monitorFeishuProvider } = await import(
+        /* @vite-ignore */ new URL("./monitor.js", import.meta.url).href
+      );
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
       ctx.setStatus({ accountId: ctx.accountId, port });


### PR DESCRIPTION
## Summary

- Convert dynamic `import()` calls in the Feishu extension to use `new URL(specifier, import.meta.url).href`, ensuring the resolved import URL always uses the `file://` scheme on Windows.
- On Windows, Node.js ESM loader rejects absolute paths (e.g. `g:\...`) passed to `import()` because the drive letter is interpreted as a URL scheme. Resolving relative specifiers against `import.meta.url` produces proper `file://` URLs that work cross-platform.
- Affects two dynamic imports in `extensions/feishu/src/channel.ts`: the lazy channel runtime loader and the gateway `startAccount` monitor import.

Fixes #49489

## Note

Other extensions (matrix, msteams, telegram, zalouser, bluebubbles, googlechat, tlon, zalo, imessage) have the same `import("./...")` pattern in their `channel.ts` files. Those should be updated in a follow-up for consistency, though this PR focuses on the Feishu extension as reported in the issue.

## Test plan

- [x] All 43 Feishu test files pass (461 tests)
- [ ] Verify on Windows that the Feishu channel starts without ESM loader errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)