### PR TITLE
fix: clear self-owned lock files on gateway boot

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -18,6 +18,7 @@ import {
   __testing,
   acquireSessionWriteLock,
   cleanStaleLockFiles,
+  clearSelfOwnedLockFiles,
   resolveSessionLockMaxHoldFromTimeout,
 } from "./session-write-lock.js";
 
@@ -396,5 +397,71 @@ describe("acquireSessionWriteLock", () => {
 
     expect(process.listeners("SIGINT")).toContain(keepAlive);
     process.off("SIGINT", keepAlive);
+  });
+});
+
+describe("clearSelfOwnedLockFiles", () => {
+  it("removes lock files owned by current PID that are not held in memory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-self-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    try {
+      const lockPath = path.join(sessionsDir, "test-session.jsonl.lock");
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
+        "utf8",
+      );
+
+      const removed = await clearSelfOwnedLockFiles({ sessionsDir });
+      expect(removed).toBe(1);
+      await expect(fs.access(lockPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not remove lock files owned by a different PID", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-self-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    try {
+      const lockPath = path.join(sessionsDir, "other.jsonl.lock");
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: 999999, createdAt: new Date().toISOString() }),
+        "utf8",
+      );
+
+      const removed = await clearSelfOwnedLockFiles({ sessionsDir });
+      expect(removed).toBe(0);
+      await expect(fs.access(lockPath)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not remove lock files that are actively held in memory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-self-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    try {
+      const sessionFile = path.join(sessionsDir, "active.jsonl");
+      // Acquire a real lock so it's tracked in HELD_LOCKS
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+      const removed = await clearSelfOwnedLockFiles({ sessionsDir });
+      expect(removed).toBe(0);
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 0 for non-existent sessions directory", async () => {
+    const removed = await clearSelfOwnedLockFiles({
+      sessionsDir: "/tmp/openclaw-nonexistent-dir-" + Date.now(),
+    });
+    expect(removed).toBe(0);
   });
 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -384,6 +384,71 @@ function shouldTreatAsOrphanSelfLock(params: {
   return !HELD_LOCKS.has(params.normalizedSessionFile);
 }
 
+/**
+ * Remove lock files owned by the current PID that are not tracked in HELD_LOCKS.
+ *
+ * On gateway boot the process has no in-memory lock state, but lock files from
+ * a previous incarnation of the same PID may still exist on disk. Because the
+ * PID is alive, `cleanStaleLockFiles` will not treat them as stale, causing
+ * every subsequent session acquire to spin until timeout. Calling this function
+ * early in startup sweeps those orphans before the lock manager is initialised.
+ */
+export async function clearSelfOwnedLockFiles(params: {
+  sessionsDir: string;
+  log?: { warn?: (message: string) => void };
+}): Promise<number> {
+  const sessionsDir = path.resolve(params.sessionsDir);
+
+  let entries: fsSync.Dirent[] = [];
+  try {
+    entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return 0;
+    }
+    throw err;
+  }
+
+  const lockEntries = entries.filter((entry) => entry.name.endsWith(".jsonl.lock"));
+  let removed = 0;
+
+  for (const entry of lockEntries) {
+    const lockPath = path.join(sessionsDir, entry.name);
+    const payload = await readLockPayload(lockPath);
+    const pid = isValidLockNumber(payload?.pid) && payload.pid > 0 ? payload.pid : null;
+    if (pid !== process.pid) {
+      continue;
+    }
+
+    // The lock references our PID but we have no in-memory record of it,
+    // so it must be left over from a previous run of this process.
+    // Resolve through realpath to match the key used by acquireSessionWriteLock.
+    const sessionFileName = entry.name.replace(/\.lock$/, "");
+    let normalizedSessionFile = path.join(sessionsDir, sessionFileName);
+    try {
+      const realDir = await fs.realpath(path.dirname(normalizedSessionFile));
+      normalizedSessionFile = path.join(realDir, path.basename(normalizedSessionFile));
+    } catch {
+      // Fall back to resolved path if realpath fails.
+    }
+    if (HELD_LOCKS.has(normalizedSessionFile)) {
+      continue;
+    }
+
+    try {
+      await fs.rm(lockPath, { force: true });
+      removed += 1;
+      params.log?.warn?.(`removed self-owned orphan lock on boot: ${lockPath}`);
+    } catch {
+      // Best-effort removal; if it fails the normal stale-lock path may
+      // still reclaim it later.
+    }
+  }
+
+  return removed;
+}
+
 export async function cleanStaleLockFiles(params: {
   sessionsDir: string;
   staleMs?: number;

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -8,7 +8,7 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
-import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
+import { cleanStaleLockFiles, clearSelfOwnedLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -50,6 +50,14 @@ export async function startGatewaySidecars(params: {
     const stateDir = resolveStateDir(process.env);
     const sessionDirs = await resolveAgentSessionDirs(stateDir);
     for (const sessionsDir of sessionDirs) {
+      // First, remove any lock files that reference our own PID but are not
+      // tracked in memory. These are orphans from a previous incarnation of
+      // this process (same PID reused) that cleanStaleLockFiles would skip
+      // because isPidAlive(process.pid) is always true. See #49603.
+      await clearSelfOwnedLockFiles({
+        sessionsDir,
+        log: { warn: (message) => params.log.warn(message) },
+      });
       await cleanStaleLockFiles({
         sessionsDir,
         staleMs: SESSION_LOCK_STALE_MS,


### PR DESCRIPTION
## Summary
- On startup, sweep lock files owned by the current PID before initializing lock manager
- Prevents deadlocks when gateway survives API failure but loses in-memory lock state  
- Includes 4 tests covering orphan cleanup, other-PID preservation, and active lock safety

Fixes #49603

🤖 Generated with [Claude Code](https://claude.com/claude-code)