### PR TITLE
fix: normalize same-provider embedded model refs

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -20,6 +20,7 @@ vi.mock("./openrouter-model-capabilities.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import * as providerRuntime from "../../plugins/provider-runtime.js";
 import { buildInlineProviderModels, resolveModel, resolveModelAsync } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
@@ -433,6 +434,138 @@ describe("resolveModel", () => {
       contextWindow: 262144,
       maxTokens: 65536,
     });
+  });
+
+  it("normalizes same-provider qualified refs before provider fallback matching", () => {
+    const cfg = {
+      models: {
+        providers: {
+          polza: {
+            baseUrl: "https://proxy.example/v1",
+            api: "openai-completions",
+            headers: { "X-Provider": "provider" },
+            models: [
+              {
+                ...makeModel("gpt-4o-mini"),
+                reasoning: true,
+                contextWindow: 123456,
+                maxTokens: 4096,
+                headers: { "X-Model": "special" },
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("polza", "polza/gpt-4o-mini", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "polza",
+      id: "gpt-4o-mini",
+      reasoning: true,
+      contextWindow: 123456,
+      maxTokens: 4096,
+    });
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+      "X-Provider": "provider",
+      "X-Model": "special",
+    });
+
+    const uppercasePrefixResult = resolveModel("polza", "POLZA/gpt-4o-mini", "/tmp/agent", cfg);
+
+    expect(uppercasePrefixResult.error).toBeUndefined();
+    expect(uppercasePrefixResult.model).toMatchObject({
+      provider: "polza",
+      id: "gpt-4o-mini",
+      reasoning: true,
+      contextWindow: 123456,
+      maxTokens: 4096,
+    });
+  });
+
+  it("keeps OpenRouter native ids qualified when fallback config uses bare ids", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("healer-alpha"),
+                reasoning: true,
+                input: ["text", "image"],
+                contextWindow: 262144,
+                maxTokens: 65536,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("openrouter", "openrouter/healer-alpha", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openrouter",
+      id: "openrouter/healer-alpha",
+      reasoning: true,
+      contextWindow: 262144,
+      maxTokens: 65536,
+    });
+  });
+
+  it("normalizes same-provider qualified ids before dynamic model hooks", async () => {
+    const resolvePluginSpy = vi
+      .spyOn(providerRuntime, "resolveProviderRuntimePlugin")
+      .mockReturnValue({ id: "polza-plugin", prepareDynamicModel: async () => {} } as never);
+    const prepareSpy = vi
+      .spyOn(providerRuntime, "prepareProviderDynamicModel")
+      .mockResolvedValue(undefined);
+    const runSpy = vi.spyOn(providerRuntime, "runProviderDynamicModel").mockReturnValue(undefined);
+    try {
+      const cfg = {
+        models: {
+          providers: {
+            polza: {
+              baseUrl: "https://proxy.example/v1",
+              api: "openai-completions",
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await resolveModelAsync("polza", "polza/gpt-4o-mini", "/tmp/agent", cfg);
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "polza",
+          context: expect.objectContaining({
+            modelId: "gpt-4o-mini",
+          }),
+        }),
+      );
+      expect(runSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "polza",
+          context: expect.objectContaining({
+            modelId: "gpt-4o-mini",
+          }),
+        }),
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.model).toMatchObject({
+        provider: "polza",
+        id: "gpt-4o-mini",
+      });
+    } finally {
+      runSpy.mockRestore();
+      prepareSpy.mockRestore();
+      resolvePluginSpy.mockRestore();
+    }
   });
 
   it("uses OpenRouter API capabilities for unknown models when cache is populated", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -232,6 +232,34 @@ function resolveExplicitModelWithRegistry(params: {
   return undefined;
 }
 
+function stripSameProviderPrefix(params: { provider: string; modelId: string }): string {
+  const providerId = normalizeProviderId(params.provider);
+  const modelId = params.modelId.trim();
+  if (!providerId || !modelId) {
+    return modelId;
+  }
+  const prefix = `${providerId}/`;
+  const separatorIndex = modelId.indexOf("/");
+  if (separatorIndex < 0) {
+    return modelId;
+  }
+  return modelId.slice(0, separatorIndex + 1).toLowerCase() === prefix
+    ? modelId.slice(separatorIndex + 1)
+    : modelId;
+}
+
+function resolveSameProviderModelIds(params: { provider: string; modelId: string }) {
+  const alternateModelId = stripSameProviderPrefix(params);
+  const preserveQualifiedModelId =
+    normalizeProviderId(params.provider) === "openrouter" && alternateModelId !== params.modelId;
+  return {
+    alternateModelId,
+    fallbackLookupModelId: alternateModelId,
+    runtimeModelId: preserveQualifiedModelId ? params.modelId : alternateModelId,
+    shouldTryAlternateExplicit: !preserveQualifiedModelId && alternateModelId !== params.modelId,
+  };
+}
+
 export function resolveModelWithRegistry(params: {
   provider: string;
   modelId: string;
@@ -247,16 +275,34 @@ export function resolveModelWithRegistry(params: {
     return explicitModel.model;
   }
 
-  const { provider, modelId, cfg, modelRegistry, agentDir } = params;
+  const { alternateModelId, fallbackLookupModelId, runtimeModelId, shouldTryAlternateExplicit } =
+    resolveSameProviderModelIds({
+      provider: params.provider,
+      modelId: params.modelId,
+    });
+  if (shouldTryAlternateExplicit) {
+    const alternateExplicitModel = resolveExplicitModelWithRegistry({
+      ...params,
+      modelId: alternateModelId,
+    });
+    if (alternateExplicitModel?.kind === "suppressed") {
+      return undefined;
+    }
+    if (alternateExplicitModel?.kind === "resolved") {
+      return alternateExplicitModel.model;
+    }
+  }
+
+  const { provider, cfg, modelRegistry, agentDir } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const pluginDynamicModel = runProviderDynamicModel({
-    provider,
+    provider: params.provider,
     config: cfg,
     context: {
       config: cfg,
       agentDir,
       provider,
-      modelId,
+      modelId: runtimeModelId,
       modelRegistry,
       providerConfig,
     },
@@ -270,21 +316,24 @@ export function resolveModelWithRegistry(params: {
     });
   }
 
-  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
+  const fallbackModelId = fallbackLookupModelId;
+  const configuredModel = providerConfig?.models?.find(
+    (candidate) => candidate.id === fallbackModelId,
+  );
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
-  if (providerConfig || modelId.startsWith("mock-")) {
+  if (providerConfig || fallbackModelId.startsWith("mock-")) {
     return normalizeResolvedModel({
       provider,
       cfg,
       agentDir,
       model: {
-        id: modelId,
-        name: modelId,
+        id: runtimeModelId,
+        name: runtimeModelId,
         api: providerConfig?.api ?? "openai-responses",
         provider,
         baseUrl: providerConfig?.baseUrl,
@@ -354,6 +403,11 @@ export async function resolveModelAsync(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const { alternateModelId, runtimeModelId, shouldTryAlternateExplicit } =
+    resolveSameProviderModelIds({
+      provider,
+      modelId,
+    });
   const explicitModel = resolveExplicitModelWithRegistry({
     provider,
     modelId,
@@ -368,6 +422,30 @@ export async function resolveModelAsync(
       modelRegistry,
     };
   }
+  if (explicitModel?.kind === "resolved") {
+    return { model: explicitModel.model, authStorage, modelRegistry };
+  }
+
+  if (shouldTryAlternateExplicit) {
+    const alternateExplicitModel = resolveExplicitModelWithRegistry({
+      provider,
+      modelId: alternateModelId,
+      modelRegistry,
+      cfg,
+      agentDir: resolvedAgentDir,
+    });
+    if (alternateExplicitModel?.kind === "suppressed") {
+      return {
+        error: buildUnknownModelError(provider, modelId),
+        authStorage,
+        modelRegistry,
+      };
+    }
+    if (alternateExplicitModel?.kind === "resolved") {
+      return { model: alternateExplicitModel.model, authStorage, modelRegistry };
+    }
+  }
+
   if (!explicitModel) {
     const providerPlugin = resolveProviderRuntimePlugin({
       provider,
@@ -381,23 +459,20 @@ export async function resolveModelAsync(
           config: cfg,
           agentDir: resolvedAgentDir,
           provider,
-          modelId,
+          modelId: runtimeModelId,
           modelRegistry,
           providerConfig: resolveConfiguredProviderConfig(cfg, provider),
         },
       });
     }
   }
-  const model =
-    explicitModel?.kind === "resolved"
-      ? explicitModel.model
-      : resolveModelWithRegistry({
-          provider,
-          modelId,
-          modelRegistry,
-          cfg,
-          agentDir: resolvedAgentDir,
-        });
+  const model = resolveModelWithRegistry({
+    provider,
+    modelId,
+    modelRegistry,
+    cfg,
+    agentDir: resolvedAgentDir,
+  });
   if (model) {
     return { model, authStorage, modelRegistry };
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1994,7 +1994,7 @@ export async function runEmbeddedAttempt(
         activeSession.agent,
         params.config,
         params.provider,
-        params.modelId,
+        params.model.id,
         {
           ...params.streamParams,
           fastMode: params.fastMode,


### PR DESCRIPTION
## Summary
- Normalizes embedded model references when the provider prefix matches the current provider
- Prevents duplicate model resolution for same-provider refs
- Uses `params.model.id` (normalized) instead of `params.modelId` (raw) in attempt extra-params

## Test plan
- [x] Unit tests pass (3 new tests: same-provider normalization, OpenRouter qualified ID preservation, dynamic model hook normalization)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)