### PR TITLE
fix(telegram): prevent silent wrong-bot routing when accountId not in config

### DIFF
--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -188,6 +188,25 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("none");
   });
 
+  it("does not fall through to channel-level token when non-default accountId is not in config", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "wrong-bot-token",
+          accounts: {
+            knownBot: { botToken: "known-bot-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // accountId "unknownBot" is not in config — should NOT fall through to "wrong-bot-token"
+    const res = resolveTelegramToken(cfg, { accountId: "unknownBot" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+  });
+
   it("throws when botToken is an unresolved SecretRef object", () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -49,6 +49,9 @@ export function resolveTelegramToken(
   // return empty immediately — do NOT fall through to channel-level defaults,
   // which would silently route the message via the wrong bot's token.
   if (accountId !== DEFAULT_ACCOUNT_ID && !accountCfg) {
+    opts.logMissingFile?.(
+      `channels.telegram.accounts: unknown accountId "${accountId}" — not found in config, refusing channel-level fallback`,
+    );
     return { token: "", source: "none" };
   }
 

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -44,6 +44,14 @@ export function resolveTelegramToken(
   const accountCfg = resolveAccountCfg(
     accountId !== DEFAULT_ACCOUNT_ID ? accountId : DEFAULT_ACCOUNT_ID,
   );
+
+  // When a non-default accountId is explicitly specified but not found in config,
+  // return empty immediately — do NOT fall through to channel-level defaults,
+  // which would silently route the message via the wrong bot's token.
+  if (accountId !== DEFAULT_ACCOUNT_ID && !accountCfg) {
+    return { token: "", source: "none" };
+  }
+
   const accountTokenFile = accountCfg?.tokenFile?.trim();
   if (accountTokenFile) {
     const token = tryReadSecretFileSync(


### PR DESCRIPTION
lobster-biscuit

Closes #49383

## Problem

When message tool passes an `accountId` that doesn't match any configured account, `resolveTelegramToken()` silently falls through to the channel-level `botToken` — routing the message via the **wrong Telegram bot**. No error, no warning.

## Root cause

`extensions/telegram/src/token.ts:44-46` — `resolveAccountCfg()` returns `undefined` for unknown accountIds, but the code continues to channel-level fallbacks (lines 72-95) instead of stopping. Introduced in `e5bca0832f` when Telegram was moved to `extensions/`.

## User impact

Silent cross-bot message leak. Messages intended for Bot A (e.g. support bot) get sent via Bot B's token (e.g. internal bot). User discovers only when the wrong bot responds. Privacy/correctness issue.

## Fix

Return `{ token: "", source: "none" }` immediately when a non-default `accountId` is explicitly specified but not found in config. Existing behavior for known accounts (with or without per-account tokens) is preserved — they still fall through to channel-level defaults as designed.

## Changes

- `extensions/telegram/src/token.ts` — early return for unknown non-default accountId (+6 lines)
- `extensions/telegram/src/token.test.ts` — test: unknown accountId returns empty, not channel-level token (+15 lines)

## How to verify

1. Configure 2 Telegram bots with different accountIds
2. Call message tool with an accountId not in config
3. Before fix: message sent via wrong bot. After fix: token resolution returns empty, surfaces as error

## Tests

Added: "does not fall through to channel-level token when non-default accountId is not in config" (1/1 new test)
Existing: all 10 tests unaffected (verified — known accounts still fall through correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)