### PR TITLE
fix: support input_tokens/output_tokens fields for mlx-vlm and vLLM usage reporting

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -24,6 +24,7 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
+  createOpenAICompletionsUsageNormalizationWrapper,
   createOpenAIFastModeWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
@@ -210,6 +211,12 @@ export function applyExtraParamsToAgent(
         thinkingLevel,
       },
     }) ?? merged;
+
+  // Normalize usage field names (input_tokens/output_tokens →
+  // prompt_tokens/completion_tokens) for OpenAI-compatible servers like
+  // mlx-vlm and vLLM that use non-standard field names.  Applied first so
+  // the SSE data is normalized before pi-ai's parseChunkUsage reads it.
+  agent.streamFn = createOpenAICompletionsUsageNormalizationWrapper(agent.streamFn);
 
   const wrappedStreamFn = createStreamFnWithExtraParams(
     agent.streamFn,

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -411,3 +411,193 @@ export function createOpenAIAttributionHeadersWrapper(
     });
   };
 }
+
+/**
+ * Normalize usage field names in an SSE JSON data line.
+ *
+ * Some OpenAI-compatible servers (mlx-vlm, vLLM) return `input_tokens` /
+ * `output_tokens` instead of the standard `prompt_tokens` / `completion_tokens`.
+ * The upstream pi-ai `parseChunkUsage` only reads the standard field names, so
+ * usage ends up as zero.  This function adds the standard field names when they
+ * are absent but the alternatives are present, so pi-ai can read them.
+ */
+function normalizeUsageFieldsInSseJson(json: string): string {
+  // Fast-path: skip lines that don't contain a usage object.
+  if (!json.includes('"usage"')) {
+    return json;
+  }
+
+  try {
+    const obj = JSON.parse(json);
+    const usage = obj?.usage;
+    if (!usage || typeof usage !== "object") {
+      return json;
+    }
+
+    let patched = false;
+
+    // Add prompt_tokens from input_tokens when prompt_tokens is absent.
+    if (
+      usage.prompt_tokens === undefined &&
+      typeof usage.input_tokens === "number" &&
+      Number.isFinite(usage.input_tokens)
+    ) {
+      usage.prompt_tokens = usage.input_tokens;
+      patched = true;
+    }
+
+    // Add completion_tokens from output_tokens when completion_tokens is absent.
+    if (
+      usage.completion_tokens === undefined &&
+      typeof usage.output_tokens === "number" &&
+      Number.isFinite(usage.output_tokens)
+    ) {
+      usage.completion_tokens = usage.output_tokens;
+      patched = true;
+    }
+
+    if (!patched) {
+      return json;
+    }
+
+    return JSON.stringify(obj);
+  } catch {
+    // Not valid JSON — pass through unchanged.
+    return json;
+  }
+}
+
+/**
+ * Wrap a fetch Response so that SSE `data:` lines have their usage field names
+ * normalized before the OpenAI SDK parses them.
+ */
+function wrapSseResponse(original: Response): Response {
+  const body = original.body;
+  if (!body) {
+    return original;
+  }
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      const lines = buffer.split("\n");
+      // Keep the last (possibly incomplete) line in the buffer.
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (line.startsWith("data: ") && !line.startsWith("data: [DONE]")) {
+          const jsonPart = line.slice(6);
+          const normalized = normalizeUsageFieldsInSseJson(jsonPart);
+          controller.enqueue(encoder.encode(`data: ${normalized}\n`));
+        } else {
+          controller.enqueue(encoder.encode(`${line}\n`));
+        }
+      }
+    },
+    flush(controller) {
+      if (buffer.length > 0) {
+        if (buffer.startsWith("data: ") && !buffer.startsWith("data: [DONE]")) {
+          const jsonPart = buffer.slice(6);
+          const normalized = normalizeUsageFieldsInSseJson(jsonPart);
+          controller.enqueue(encoder.encode(`data: ${normalized}\n`));
+        } else {
+          controller.enqueue(encoder.encode(`${buffer}\n`));
+        }
+      }
+    },
+  });
+
+  const transformedBody = body.pipeThrough(transform);
+
+  return new Response(transformedBody, {
+    status: original.status,
+    statusText: original.statusText,
+    headers: original.headers,
+  });
+}
+
+/**
+ * Number of active callers that need the normalizing fetch wrapper installed.
+ * When it drops to zero, we restore the original fetch.
+ */
+let normalizingFetchRefCount = 0;
+let originalFetch: typeof globalThis.fetch | undefined;
+
+function installNormalizingFetch(): void {
+  normalizingFetchRefCount += 1;
+  if (normalizingFetchRefCount === 1) {
+    originalFetch = globalThis.fetch;
+    const savedFetch = originalFetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const response = await savedFetch(input, init);
+      const contentType = response.headers.get("content-type") ?? "";
+      // Only wrap SSE streaming responses from chat completion endpoints.
+      if (contentType.includes("text/event-stream")) {
+        return wrapSseResponse(response);
+      }
+      return response;
+    };
+  }
+}
+
+function uninstallNormalizingFetch(): void {
+  normalizingFetchRefCount -= 1;
+  if (normalizingFetchRefCount <= 0) {
+    normalizingFetchRefCount = 0;
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = undefined;
+    }
+  }
+}
+
+/**
+ * StreamFn wrapper that normalizes `input_tokens`/`output_tokens` →
+ * `prompt_tokens`/`completion_tokens` in SSE streaming responses from
+ * OpenAI-compatible servers (mlx-vlm, vLLM, etc.).
+ *
+ * The upstream pi-ai openai-completions provider only reads the standard
+ * OpenAI field names, so alternative servers that use Anthropic-style names
+ * report zero usage.  This wrapper intercepts the HTTP response via a scoped
+ * globalThis.fetch override and adds the missing standard field names before
+ * the OpenAI SDK and pi-ai parse the SSE data.
+ */
+export function createOpenAICompletionsUsageNormalizationWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    // Only apply to openai-completions API which uses the OpenAI SDK streaming.
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+
+    installNormalizingFetch();
+
+    const maybeStream = underlying(model, context, options);
+
+    // The underlying StreamFn may return a Promise or the stream directly.
+    // In either case, hook into the stream's result() to uninstall when done.
+    const hookCleanup = (stream: ReturnType<typeof streamSimple>) => {
+      const originalResult = stream.result.bind(stream);
+      stream.result = async () => {
+        try {
+          return await originalResult();
+        } finally {
+          uninstallNormalizingFetch();
+        }
+      };
+      return stream;
+    };
+
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) => hookCleanup(stream));
+    }
+
+    return hookCleanup(maybeStream);
+  };
+}

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.usage-normalization.test.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.usage-normalization.test.ts
@@ -1,0 +1,295 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOpenAICompletionsUsageNormalizationWrapper } from "./openai-stream-wrappers.js";
+
+describe("createOpenAICompletionsUsageNormalizationWrapper", () => {
+  const model: Model<"openai-completions"> = {
+    api: "openai-completions",
+    provider: "custom",
+    id: "test-model",
+    baseUrl: "http://127.0.0.1:8000/v1",
+  } as Model<"openai-completions">;
+
+  const context: Context = { messages: [] };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips wrapping for non-openai-completions APIs", () => {
+    const baseStreamFn: StreamFn = vi.fn((_m, _c, _o) => createAssistantMessageEventStream());
+    const wrapped = createOpenAICompletionsUsageNormalizationWrapper(baseStreamFn);
+
+    const responsesModel = {
+      ...model,
+      api: "openai-responses",
+    } as Model<"openai-responses">;
+
+    void wrapped(responsesModel, context, undefined);
+    expect(baseStreamFn).toHaveBeenCalledOnce();
+  });
+
+  it("installs and uninstalls fetch wrapper for openai-completions", async () => {
+    const savedFetch = globalThis.fetch;
+    const stream = createAssistantMessageEventStream();
+
+    const baseStreamFn: StreamFn = vi.fn((_m, _c, _o) => {
+      // Fetch should be wrapped at this point.
+      expect(globalThis.fetch).not.toBe(savedFetch);
+      // Push a done event so result() resolves.
+      stream.push({
+        type: "done",
+        message: {
+          role: "assistant",
+          content: [],
+          api: "openai-completions",
+          provider: "custom",
+          model: "test-model",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: Date.now(),
+        },
+      });
+      return stream;
+    });
+
+    const wrapped = createOpenAICompletionsUsageNormalizationWrapper(baseStreamFn);
+    const resultStream = wrapped(model, context, undefined);
+
+    // The stream should have been created with fetch wrapper in place.
+    expect(baseStreamFn).toHaveBeenCalledOnce();
+
+    // Wait for result to trigger cleanup.
+    const result = await (
+      resultStream as ReturnType<typeof createAssistantMessageEventStream>
+    ).result();
+    expect(result).toBeDefined();
+
+    // Fetch should be restored.
+    expect(globalThis.fetch).toBe(savedFetch);
+  });
+
+  it("normalizes input_tokens/output_tokens in SSE response body", async () => {
+    // Build a fake SSE response body with mlx-vlm-style usage fields.
+    const sseData = [
+      'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hi"}}]}\n\n',
+      'data: {"id":"chatcmpl-1","choices":[],"usage":{"input_tokens":11,"output_tokens":5,"total_tokens":16}}\n\n',
+      "data: [DONE]\n\n",
+    ].join("");
+
+    const sseBlob = new Blob([sseData], { type: "text/event-stream" });
+    const mockResponse = new Response(sseBlob.stream(), {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    // Capture what the wrapped fetch returns.
+    const realFetch = globalThis.fetch;
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    globalThis.fetch = mockFetch;
+
+    try {
+      const stream = createAssistantMessageEventStream();
+
+      const baseStreamFn: StreamFn = (_m, _c, _o) => {
+        // At this point, fetch is wrapped by our normalizer.
+        // Simulate what pi-ai does: call fetch and read SSE.
+        const wrappedFetch = globalThis.fetch;
+
+        // Fire off the fetch and read the response.
+        void (async () => {
+          const response = await wrappedFetch("http://127.0.0.1:8000/v1/chat/completions", {
+            method: "POST",
+          });
+
+          const reader = response.body!.getReader();
+          const decoder = new TextDecoder();
+          let text = "";
+          let done = false;
+          while (!done) {
+            const chunk = await reader.read();
+            done = chunk.done;
+            if (chunk.value) {
+              text += decoder.decode(chunk.value, { stream: true });
+            }
+          }
+
+          // Verify the SSE data was normalized: prompt_tokens/completion_tokens
+          // should have been added.
+          expect(text).toContain('"prompt_tokens":11');
+          expect(text).toContain('"completion_tokens":5');
+          // Original fields should still be present.
+          expect(text).toContain('"input_tokens":11');
+          expect(text).toContain('"output_tokens":5');
+
+          stream.push({
+            type: "done",
+            message: {
+              role: "assistant",
+              content: [],
+              api: "openai-completions",
+              provider: "custom",
+              model: "test-model",
+              usage: {
+                input: 11,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 16,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "stop",
+              timestamp: Date.now(),
+            },
+          });
+        })();
+
+        return stream;
+      };
+
+      const wrapped = createOpenAICompletionsUsageNormalizationWrapper(baseStreamFn);
+      const resultStream = wrapped(model, context, undefined);
+      await (resultStream as ReturnType<typeof createAssistantMessageEventStream>).result();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("does not modify SSE data when standard fields are already present", async () => {
+    const sseData =
+      'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":50,"completion_tokens":20,"total_tokens":70}}\n\n';
+
+    const sseBlob = new Blob([sseData], { type: "text/event-stream" });
+    const mockResponse = new Response(sseBlob.stream(), {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const realFetch = globalThis.fetch;
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    globalThis.fetch = mockFetch;
+
+    try {
+      const stream = createAssistantMessageEventStream();
+
+      const baseStreamFn: StreamFn = (_m, _c, _o) => {
+        const wrappedFetch = globalThis.fetch;
+
+        void (async () => {
+          const response = await wrappedFetch("http://localhost/v1/chat/completions", {
+            method: "POST",
+          });
+
+          const reader = response.body!.getReader();
+          const decoder = new TextDecoder();
+          let text = "";
+          let done = false;
+          while (!done) {
+            const chunk = await reader.read();
+            done = chunk.done;
+            if (chunk.value) {
+              text += decoder.decode(chunk.value, { stream: true });
+            }
+          }
+
+          // Standard fields should be unchanged.
+          expect(text).toContain('"prompt_tokens":50');
+          expect(text).toContain('"completion_tokens":20');
+          // No input_tokens/output_tokens should appear.
+          expect(text).not.toContain('"input_tokens"');
+          expect(text).not.toContain('"output_tokens"');
+
+          stream.push({
+            type: "done",
+            message: {
+              role: "assistant",
+              content: [],
+              api: "openai-completions",
+              provider: "openai",
+              model: "gpt-4o",
+              usage: {
+                input: 50,
+                output: 20,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 70,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "stop",
+              timestamp: Date.now(),
+            },
+          });
+        })();
+
+        return stream;
+      };
+
+      const wrapped = createOpenAICompletionsUsageNormalizationWrapper(baseStreamFn);
+      const resultStream = wrapped(model, context, undefined);
+      await (resultStream as ReturnType<typeof createAssistantMessageEventStream>).result();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("handles concurrent streams correctly with ref counting", async () => {
+    const savedFetch = globalThis.fetch;
+    const streams = [createAssistantMessageEventStream(), createAssistantMessageEventStream()];
+    let streamIndex = 0;
+
+    const baseStreamFn: StreamFn = vi.fn((_m, _c, _o) => {
+      const s = streams[streamIndex++];
+      s.push({
+        type: "done",
+        message: {
+          role: "assistant",
+          content: [],
+          api: "openai-completions",
+          provider: "custom",
+          model: "test-model",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: Date.now(),
+        },
+      });
+      return s;
+    });
+
+    const wrapped = createOpenAICompletionsUsageNormalizationWrapper(baseStreamFn);
+
+    // Start two concurrent streams.
+    const s1 = wrapped(model, context, undefined) as ReturnType<
+      typeof createAssistantMessageEventStream
+    >;
+    const s2 = wrapped(model, context, undefined) as ReturnType<
+      typeof createAssistantMessageEventStream
+    >;
+
+    // Fetch should be wrapped.
+    expect(globalThis.fetch).not.toBe(savedFetch);
+
+    // Complete first stream — fetch should still be wrapped.
+    await s1.result();
+    expect(globalThis.fetch).not.toBe(savedFetch);
+
+    // Complete second stream — fetch should be restored.
+    await s2.result();
+    expect(globalThis.fetch).toBe(savedFetch);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds SSE response normalization wrapper for `openai-completions` streaming that maps `input_tokens`/`output_tokens` to `prompt_tokens`/`completion_tokens` when the standard fields are absent
- Fixes 0% context usage display for mlx-vlm, vLLM, and other OpenAI-compatible servers that use non-standard usage field names
- The upstream pi-ai `parseChunkUsage` only reads `prompt_tokens`/`completion_tokens`; this wrapper normalizes the SSE data before the OpenAI SDK parses it

Fixes #49316

## Test plan
- [x] Unit tests for SSE normalization, fetch wrapper lifecycle, concurrent stream ref-counting, and no-op behavior for standard OpenAI responses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)