### PR TITLE
fix(heartbeat): non-default agents now inherit agents.defaults.heartbeat

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -138,9 +138,12 @@ function resolveHeartbeatConfig(
 
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   const list = cfg.agents?.list ?? [];
-  if (hasExplicitHeartbeatAgents(cfg)) {
+  const hasDefaults = Boolean(cfg.agents?.defaults?.heartbeat);
+  if (hasExplicitHeartbeatAgents(cfg) || hasDefaults) {
+    // Include any agent that has an explicit heartbeat config OR inherits from defaults.
+    // Without this, agents that rely solely on agents.defaults.heartbeat are silently excluded.
     return list
-      .filter((entry) => entry?.heartbeat)
+      .filter((entry) => entry?.heartbeat || hasDefaults)
       .map((entry) => {
         const id = normalizeAgentId(entry.id);
         return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };


### PR DESCRIPTION
## Problem

When `agents.defaults.heartbeat` was configured but individual agents in `agents.list[]` did not define their own `heartbeat` block, heartbeat silently never ran for those non-default agents.

### Config that reproduces the bug

```json
{
  "agents": {
    "defaults": {
      "heartbeat": { "every": "30m", "target": "last" }
    },
    "list": [
      { "id": "main", "default": true },
      { "id": "ops" }
    ]
  }
}
```

With this config, heartbeat ran for `main` but not for `ops`, even though `agents.defaults.heartbeat` should have applied to both.

## Root cause

Two independent guards in `resolveHeartbeatAgents()` both required `entry?.heartbeat` to be truthy:

1. `hasExplicitHeartbeatAgents()` — returned `false` when only `defaults.heartbeat` was set (no agent in the list had its own `heartbeat` block)
2. The `.filter((entry) => entry?.heartbeat)` — dropped agents without an explicit heartbeat, even when defaults covered them

When `hasExplicitHeartbeatAgents()` returned `false`, execution fell through to the default-agent-only fallback — so only the default agent got heartbeat regardless of defaults config.

## Fix

Track `hasDefaults = Boolean(cfg.agents?.defaults?.heartbeat)` and:
- Include it in the branch condition: `if (hasExplicitHeartbeatAgents(cfg) || hasDefaults)`
- Broaden the filter: `.filter((entry) => entry?.heartbeat || hasDefaults)`

Individual agents with an explicit `heartbeat` block still win via `resolveHeartbeatConfig()`'s `{ ...defaults, ...overrides }` merge.

Fixes #49613