### PR TITLE
fix: restore token counting for OpenAI-compatible providers

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -46,11 +46,11 @@ function expectSupportsDeveloperRoleForcedOff(overrides?: Partial<Model<Api>>): 
   expect(supportsDeveloperRole(normalized)).toBe(false);
 }
 
-function expectSupportsUsageInStreamingForcedOff(overrides?: Partial<Model<Api>>): void {
+function expectSupportsUsageInStreamingDefaultsTrue(overrides?: Partial<Model<Api>>): void {
   const model = { ...baseModel(), ...overrides };
   delete (model as { compat?: unknown }).compat;
   const normalized = normalizeModelCompat(model as Model<Api>);
-  expect(supportsUsageInStreaming(normalized)).toBe(false);
+  expect(supportsUsageInStreaming(normalized)).toBe(true);
 }
 
 function expectSupportsStrictModeForcedOff(overrides?: Partial<Model<Api>>): void {
@@ -181,8 +181,8 @@ describe("normalizeModelCompat", () => {
     });
   });
 
-  it("forces supportsUsageInStreaming off for generic custom openai-completions provider", () => {
-    expectSupportsUsageInStreamingForcedOff({
+  it("defaults supportsUsageInStreaming to true for generic custom openai-completions provider", () => {
+    expectSupportsUsageInStreamingDefaultsTrue({
       provider: "custom-cpa",
       baseUrl: "https://cpa.example.com/v1",
     });
@@ -257,7 +257,7 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(normalized)).toBe(false);
   });
 
-  it("still forces flags off when not explicitly set by user", () => {
+  it("forces developer role and strict mode off but leaves usage streaming on when not explicitly set", () => {
     const model = {
       ...baseModel(),
       provider: "custom-cpa",
@@ -266,7 +266,7 @@ describe("normalizeModelCompat", () => {
     delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);
     expect(supportsDeveloperRole(normalized)).toBe(false);
-    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
     expect(supportsStrictMode(normalized)).toBe(false);
   });
 
@@ -294,7 +294,7 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(model)).toBeUndefined();
     expect(supportsStrictMode(model)).toBeUndefined();
     expect(supportsDeveloperRole(normalized)).toBe(false);
-    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
     expect(supportsStrictMode(normalized)).toBe(false);
   });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -114,12 +114,17 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
 
-  // The `developer` role and stream usage chunks are OpenAI-native behaviors.
-  // Many OpenAI-compatible backends reject `developer` and/or emit usage-only
-  // chunks that break strict parsers expecting choices[0]. Additionally, the
-  // `strict` boolean inside tools validation is rejected by several providers
-  // causing tool calls to be ignored. For non-native openai-completions endpoints,
-  // default these compat flags off unless explicitly opted in.
+  // The `developer` role is an OpenAI-native behavior that most compatible
+  // backends reject. The `strict` boolean in tool definitions is also rejected
+  // by several providers. For non-native openai-completions endpoints, force
+  // both flags off unless explicitly opted in.
+  //
+  // `supportsUsageInStreaming` defaults to true because most OpenAI-compatible
+  // backends (vllm, qwen, deepseek, groq, together, etc.) handle
+  // `stream_options: { include_usage: true }` correctly, and disabling it
+  // silently breaks usage/token tracking for all non-native providers.
+  // Backends that reject the parameter can opt out with
+  // `compat.supportsUsageInStreaming: false` in their model config.
   const compat = model.compat ?? undefined;
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let default native behavior apply.
@@ -145,12 +150,12 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
       ? {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
-          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: false }),
+          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: true }),
           supportsStrictMode: targetStrictMode,
         }
       : {
           supportsDeveloperRole: false,
-          supportsUsageInStreaming: false,
+          supportsUsageInStreaming: true,
           supportsStrictMode: false,
         },
   } as typeof model;


### PR DESCRIPTION
## Summary

- Token usage statistics showed 0 for all OpenAI-compatible providers (vllm, qwen, deepseek, groq, together, etc.) since v2026.3.8
- Root cause: `normalizeModelCompat()` in `src/agents/model-compat.ts` was defaulting `supportsUsageInStreaming` to `false` for all non-native OpenAI endpoints, preventing `stream_options: { include_usage: true }` from being sent in streaming requests
- Changed the default to `true` since most OpenAI-compatible backends handle `stream_options` correctly; backends that reject it can opt out via `compat.supportsUsageInStreaming: false`

Fixes #49527
Fixes #49590

## Test plan

- [x] Updated `model-compat.test.ts` to verify new default (32 tests pass)
- [x] Verified `usage.test.ts` and `usage.normalization.test.ts` still pass (26 tests)
- [x] Verified `usage-reporting.test.ts` still passes
- [ ] Manual verification with vllm/qwen OpenAI-compatible endpoint to confirm tokens are reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)