### PR TITLE
fix(docker): include source runtime assets for bundled plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,8 @@ COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
+COPY --from=runtime-assets --chown=node:node /app/src ./src
+COPY --from=runtime-assets --chown=node:node /app/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json ./apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -44,6 +44,10 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       "COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules",
     );
+    expect(dockerfile).toContain("COPY --from=runtime-assets --chown=node:node /app/src ./src");
+    expect(dockerfile).toContain(
+      "COPY --from=runtime-assets --chown=node:node /app/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json ./apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json",
+    );
   });
 
   it("normalizes plugin and agent paths permissions in image layers", async () => {


### PR DESCRIPTION
## Summary\n- fix the Docker runtime image to keep bundled source plugins working by copying /app/src into the final image\n- copy the shared 	ool-display.json resource needed by src/agents/tool-display.ts without pulling in the full pps/ tree\n- add regression coverage in src/dockerfile.test.ts for both runtime asset copies\n\nFixes #49498.\n\n## Why\nSome bundled source plugins still import OpenClaw internals at runtime. In the current tree that includes paths like:\n- extensions/llm-task/src/llm-task-tool.ts -> ../../../src/agents/pi-embedded-runner.js\n- extensions/zalo/src/monitor.webhook.ts -> ../../../src/gateway/net.js\n\nThose source paths were missing from the runtime image. src/agents/tool-display.ts also loads the shared pps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json asset, so the runtime image needs that file as well.\n\n## Testing\n- corepack pnpm exec vitest run src/dockerfile.test.ts\n- corepack pnpm exec vitest run src/agents/tool-display.test.ts\n\nAI-assisted: Codex