### PR TITLE
fix(compact): show 'skipped' instead of 'failed' for safeguard cancellations

### DIFF
--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -44,6 +44,46 @@ function extractCompactInstructions(params: {
   return rest.length ? rest : undefined;
 }
 
+/**
+ * Returns true when the compaction result reason indicates a safeguard
+ * cancellation (i.e. the compaction was deliberately skipped, not actually
+ * failed). Used to distinguish user-facing label: "skipped" vs "failed".
+ */
+function isCompactionCancellation(reason: string | undefined): boolean {
+  if (!reason) {
+    return false;
+  }
+  const lower = reason.trim().toLowerCase();
+  return lower.includes("cancelled") || lower.includes("canceled");
+}
+
+/**
+ * Returns the reason string to show to the user, or undefined when the reason
+ * is a generic cancellation notice already implied by the label.
+ *
+ * Specifically, when the label is "Compaction skipped" and the reason is the
+ * bare "Compaction cancelled" / "Compaction canceled" string from the SDK, we
+ * suppress it — the context-usage summary that follows already tells the user
+ * enough, and repeating "cancelled" after "skipped" is confusing.
+ */
+function resolveDisplayReason(reason: string | undefined, label: string): string | undefined {
+  if (!reason) {
+    return undefined;
+  }
+  const trimmed = reason.trim();
+  const lower = trimmed.toLowerCase();
+  // Strip the generic SDK-level cancellation notice when the label already
+  // conveys "skipped", to avoid the redundant "Compaction skipped: Compaction
+  // cancelled" phrasing that prompted issue #49664.
+  if (
+    label === "Compaction skipped" &&
+    (lower === "compaction cancelled" || lower === "compaction canceled")
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export const handleCompactCommand: CommandHandler = async (params) => {
   const compactRequested =
     params.command.commandBodyNormalized === "/compact" ||
@@ -118,7 +158,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
           ? `Compacted (${formatTokenCount(result.result.tokensBefore)} before)`
           : "Compacted"
       : "Compaction skipped"
-    : "Compaction failed";
+    : isCompactionCancellation(result.reason)
+      ? "Compaction skipped"
+      : "Compaction failed";
   if (result.ok && result.compacted) {
     await incrementCompactionCount({
       sessionEntry: params.sessionEntry,
@@ -136,9 +178,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     typeof totalTokens === "number" && totalTokens > 0 ? totalTokens : null,
     params.contextTokens ?? params.sessionEntry.contextTokens ?? null,
   );
-  const reason = result.reason?.trim();
-  const line = reason
-    ? `${compactLabel}: ${reason} • ${contextSummary}`
+  const displayReason = resolveDisplayReason(result.reason?.trim(), compactLabel);
+  const line = displayReason
+    ? `${compactLabel}: ${displayReason} • ${contextSummary}`
     : `${compactLabel} • ${contextSummary}`;
   enqueueSystemEvent(line, { sessionKey: params.sessionKey });
   return { shouldContinue: false, reply: { text: `⚙️ ${line}` } };


### PR DESCRIPTION
## Problem

Closes #49664

When the compaction safeguard cancels a `/compact` request (e.g. context usage is below the threshold), users see:

```
⚙️ Compaction failed: Compaction cancelled • Context 31k/200k (15%)
```

Two issues:
1. **"Compaction failed"** implies something broke, but this is a deliberate safeguard decision
2. **"Compaction cancelled"** adds no information on top of the "failed" label — it just repeats the same idea in different words

Users end up asking the AI _why_ it failed, wasting an LLM API call to diagnose a non-issue.

## Solution

Add two small helper functions to `commands-compact.ts`:

- **`isCompactionCancellation(reason)`** — detects SDK-level cancel reasons (`reason` contains `cancelled`/`canceled`). When a cancellation is detected, use **"Compaction skipped"** instead of **"Compaction failed"** so the message reads like a deliberate decision.

- **`resolveDisplayReason(reason, label)`** — strips the bare "Compaction cancelled" string when the label already says "skipped", avoiding the tautology _"Compaction skipped: Compaction cancelled"_.

Real failures (API errors, timeouts, model-resolution errors) continue to show **"Compaction failed"** unchanged.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Safeguard cancellation (low context) | `⚙️ Compaction failed: Compaction cancelled • Context 31k/200k (15%)` | `⚙️ Compaction skipped • Context 31k/200k (15%)` |
| Real failure (API error) | `⚙️ Compaction failed: 429 rate limit • Context 190k/200k (95%)` | _unchanged_ |
| Already-skipped path (`ok=true, compacted=false`) | `⚙️ Compaction skipped • ...` | _unchanged_ |

## Changes

- `src/auto-reply/reply/commands-compact.ts`
  - Add `isCompactionCancellation()` helper
  - Add `resolveDisplayReason()` helper
  - Update `compactLabel` assignment to use `"Compaction skipped"` for cancellations
  - Replace inline `reason` variable with `resolveDisplayReason()`