### PR TITLE
fix: add error recovery to UI lazy module loading

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -110,11 +110,17 @@ function createLazy<T>(loader: () => Promise<T>): () => T | null {
       return s.mod;
     }
     if (!s.promise) {
-      s.promise = loader().then((m) => {
-        s.mod = m;
-        _pendingUpdate?.();
-        return m;
-      });
+      s.promise = loader()
+        .then((m) => {
+          s.mod = m;
+          _pendingUpdate?.();
+          return m;
+        })
+        .catch((err) => {
+          console.error("Failed to load lazy module:", err);
+          s.promise = null; // allow retry
+          return null as unknown as T;
+        });
     }
     return null;
   };


### PR DESCRIPTION
## Problem

The `createLazy()` function in `ui/src/ui/app-render.ts` has no `.catch()` handler on the dynamic `import()`. When a lazy-loaded view module fails (e.g. runtime error during module evaluation), the promise rejects silently, `s.mod` stays null forever, and the page renders permanently blank with no error message.

All 9 lazy-loaded views share this vulnerability: lazyAgents, lazyChannels, lazyCron, lazyDebug, lazyInstances, lazyLogs, lazyNodes, lazySessions, lazySkills.

## Fix

Add a `.catch()` handler to `createLazy()` that:
- Logs the error to console for debugging
- Resets `s.promise = null` to allow retry on next render

## Testing

- Lint passes: `pnpm lint` (0 errors)
- Verified the catch handler correctly resets promise state for retry

Fixes #49665