### PR TITLE
fix(cron): announce delivery for Telegram forum topics

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -284,10 +284,15 @@ the topic/thread into the `to` field:
 - `-1001234567890` (chat id only)
 - `-1001234567890:topic:123` (preferred: explicit topic marker)
 - `-1001234567890:123` (shorthand: numeric suffix)
+- `-1001234567890/123` (legacy slash form — also accepted)
 
 Prefixed targets like `telegram:...` / `telegram:group:...` are also accepted:
 
 - `telegram:group:-1001234567890:topic:123`
+
+> **Note:** Prior to this fix, `announce` delivery to Telegram forum topics silently produced
+> `deliveryStatus: "not-delivered"` because the channel plugin was not bootstrapped during
+> target resolution. All formats above now work correctly for cron `announce` delivery.
 
 ## JSON schema for tool calls
 

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -48,6 +48,14 @@ describe("parseTelegramTarget", () => {
     });
   });
 
+  it("parses legacy chatId/topicId format", () => {
+    expect(parseTelegramTarget("-1001234567890/123")).toEqual({
+      chatId: "-1001234567890",
+      messageThreadId: 123,
+      chatType: "group",
+    });
+  });
+
   it("parses chatId:topic:topicId format", () => {
     expect(parseTelegramTarget("-1001234567890:topic:456")).toEqual({
       chatId: "-1001234567890",
@@ -73,6 +81,14 @@ describe("parseTelegramTarget", () => {
 
   it("strips internal prefixes before parsing", () => {
     expect(parseTelegramTarget("telegram:group:-1001234567890:topic:456")).toEqual({
+      chatId: "-1001234567890",
+      messageThreadId: 456,
+      chatType: "group",
+    });
+  });
+
+  it("parses slash targets after stripping telegram prefixes", () => {
+    expect(parseTelegramTarget("telegram:-1001234567890/456")).toEqual({
       chatId: "-1001234567890",
       messageThreadId: 456,
       chatType: "group",

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -74,6 +74,7 @@ export function normalizeTelegramLookupTarget(raw: string): string | undefined {
  *
  * Supported formats:
  * - `chatId` (plain chat ID, t.me link, @username, or internal prefixes like `telegram:...`)
+ * - `chatId/topicId` (legacy slash topic/thread ID)
  * - `chatId:topicId` (numeric topic/thread ID)
  * - `chatId:topic:topicId` (explicit topic marker; preferred)
  */
@@ -97,6 +98,16 @@ export function parseTelegramTarget(to: string): TelegramTarget {
       chatId: topicMatch[1],
       messageThreadId: Number.parseInt(topicMatch[2], 10),
       chatType: resolveTelegramChatType(topicMatch[1]),
+    };
+  }
+
+  // Legacy slash format: -1001234567890/123
+  const slashMatch = /^(-?\d+)\/(\d+)$/.exec(normalized);
+  if (slashMatch) {
+    return {
+      chatId: slashMatch[1],
+      messageThreadId: Number.parseInt(slashMatch[2], 10),
+      chatType: resolveTelegramChatType(slashMatch[1]),
     };
   }
 

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -61,4 +61,27 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
     });
   });
+
+  it("routes slash-encoded telegram forum-topic targets through the correct delivery path", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "forum message" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "-1001234567890/42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(true);
+      expectDirectTelegramDelivery(deps, {
+        chatId: "-1001234567890",
+        text: "forum message",
+        messageThreadId: 42,
+      });
+    });
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -106,6 +106,7 @@ export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
   delivered: boolean;
   deliveryAttempted: boolean;
+  deliveryError?: string;
   summary?: string;
   outputText?: string;
   synthesizedText?: string;
@@ -293,10 +294,12 @@ export async function dispatchCronDelivery(
   // remains the only source of delivered state.
   let delivered = skipMessagingToolDelivery;
   let deliveryAttempted = skipMessagingToolDelivery;
+  let deliveryError: string | undefined;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
       status: "error",
       error,
+      deliveryError: error,
       errorKind: "delivery-target",
       summary,
       outputText,
@@ -376,16 +379,19 @@ export async function dispatchCronDelivery(
       }
       return null;
     } catch (err) {
+      const errorMessage = summarizeDirectCronDeliveryError(err);
       if (!params.deliveryBestEffort) {
         return params.withRunSession({
           status: "error",
           summary,
           outputText,
-          error: String(err),
+          error: errorMessage,
+          deliveryError: errorMessage,
           deliveryAttempted,
           ...params.telemetry,
         });
       }
+      deliveryError = errorMessage;
       return null;
     }
   };
@@ -522,6 +528,7 @@ export async function dispatchCronDelivery(
           result: failDeliveryTarget(params.resolvedDelivery.error.message),
           delivered,
           deliveryAttempted,
+          deliveryError,
           summary,
           outputText,
           synthesizedText,
@@ -534,11 +541,13 @@ export async function dispatchCronDelivery(
           status: "ok",
           summary,
           outputText,
+          deliveryError,
           deliveryAttempted,
           ...params.telemetry,
         }),
         delivered,
         deliveryAttempted,
+        deliveryError,
         summary,
         outputText,
         synthesizedText,
@@ -558,6 +567,7 @@ export async function dispatchCronDelivery(
           result: directResult,
           delivered,
           deliveryAttempted,
+          deliveryError,
           summary,
           outputText,
           synthesizedText,
@@ -571,6 +581,7 @@ export async function dispatchCronDelivery(
           result: finalizedTextResult,
           delivered,
           deliveryAttempted,
+          deliveryError,
           summary,
           outputText,
           synthesizedText,
@@ -583,6 +594,7 @@ export async function dispatchCronDelivery(
   return {
     delivered,
     deliveryAttempted,
+    deliveryError,
     summary,
     outputText,
     synthesizedText,

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -265,6 +265,32 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBe("thread-2");
   });
 
+  it("parses telegram slash topic targets into chatId + threadId", async () => {
+    setMainSessionEntry(undefined);
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "-1001234567890/77",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("-1001234567890");
+    expect(result.threadId).toBe(77);
+  });
+
+  it("parses prefixed telegram topic targets into chatId + threadId", async () => {
+    setMainSessionEntry(undefined);
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "telegram:group:-1001234567890:topic:77",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("-1001234567890");
+    expect(result.threadId).toBe(77);
+  });
+
   it("uses single configured channel when neither explicit nor session channel exists", async () => {
     setMainSessionEntry(undefined);
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -1,5 +1,33 @@
 import type { ChannelId } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+
+/**
+ * Pre-parse well-known forum/topic target formats from a delivery `to` string.
+ * Returns the base chatId and extracted threadId when a topic format is detected.
+ *
+ * Handles these Telegram forum topic formats before plugin bootstrapping:
+ *   - `-1001234567890/77`                       (legacy slash)
+ *   - `-1001234567890:topic:77`                 (explicit topic marker)
+ *   - `telegram:-1001234567890/77`              (prefixed slash)
+ *   - `telegram:group:-1001234567890:topic:77`  (fully-qualified)
+ */
+function extractForumTopicFromTarget(to: string): { to: string; threadId: number } | null {
+  const stripped = to.replace(/^telegram:group:/, "").replace(/^telegram:/, "");
+
+  // chatId:topic:topicId
+  const topicMatch = /^(-?\d+):topic:(\d+)$/.exec(stripped);
+  if (topicMatch) {
+    return { to: topicMatch[1], threadId: parseInt(topicMatch[2], 10) };
+  }
+
+  // chatId/topicId (legacy slash)
+  const slashMatch = /^(-?\d+)\/(\d+)$/.exec(stripped);
+  if (slashMatch) {
+    return { to: slashMatch[1], threadId: parseInt(slashMatch[2], 10) };
+  }
+
+  return null;
+}
 import {
   loadSessionStore,
   resolveAgentMainSessionKey,
@@ -49,7 +77,12 @@ export async function resolveDeliveryTarget(
   },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
-  const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
+  const rawTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
+  // Pre-parse forum/topic formats (e.g. telegram:-GROUP/TOPIC, telegram:group:-GROUP:topic:TOPIC)
+  // before plugin bootstrapping so threadId is always extracted regardless of plugin load state.
+  const preParseResult = rawTo ? extractForumTopicFromTarget(rawTo) : null;
+  const explicitTo = preParseResult ? preParseResult.to : rawTo;
+  const preExtractedThreadId = preParseResult?.threadId;
   const allowMismatchedLastTo = requestedChannel === "last";
 
   const sessionCfg = cfg.session;
@@ -67,7 +100,9 @@ export async function resolveDeliveryTarget(
     entry: main,
     requestedChannel,
     explicitTo,
+    explicitThreadId: preExtractedThreadId,
     allowMismatchedLastTo,
+    cfg,
   });
 
   let fallbackChannel: Exclude<OutboundChannel, "none"> | undefined;
@@ -93,9 +128,11 @@ export async function resolveDeliveryTarget(
         entry: main,
         requestedChannel,
         explicitTo,
+        explicitThreadId: preExtractedThreadId,
         fallbackChannel,
         allowMismatchedLastTo,
         mode: preliminary.mode,
+        cfg,
       })
     : preliminary;
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -833,7 +833,11 @@ export async function runCronIsolatedAgentTurn(params: {
   const embeddedRunError = hasFatalErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
-  const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
+  const resolveRunOutcome = (params?: {
+    delivered?: boolean;
+    deliveryAttempted?: boolean;
+    deliveryError?: string;
+  }) =>
     withRunSession({
       status: hasFatalErrorPayload ? "error" : "ok",
       ...(hasFatalErrorPayload
@@ -843,6 +847,7 @@ export async function runCronIsolatedAgentTurn(params: {
       outputText,
       delivered: params?.delivered,
       deliveryAttempted: params?.deliveryAttempted,
+      deliveryError: params?.deliveryError,
       ...telemetry,
     });
 
@@ -892,6 +897,7 @@ export async function runCronIsolatedAgentTurn(params: {
       ...deliveryResult.result,
       deliveryAttempted:
         deliveryResult.result.deliveryAttempted ?? deliveryResult.deliveryAttempted,
+      deliveryError: deliveryResult.result.deliveryError ?? deliveryResult.deliveryError,
     };
     if (!hasFatalErrorPayload || deliveryResult.result.status !== "ok") {
       return resultWithDeliveryMeta;
@@ -899,6 +905,7 @@ export async function runCronIsolatedAgentTurn(params: {
     return resolveRunOutcome({
       delivered: deliveryResult.result.delivered,
       deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
+      deliveryError: resultWithDeliveryMeta.deliveryError,
     });
   }
   const delivered = deliveryResult.delivered;
@@ -906,5 +913,9 @@ export async function runCronIsolatedAgentTurn(params: {
   summary = deliveryResult.summary;
   outputText = deliveryResult.outputText;
 
-  return resolveRunOutcome({ delivered, deliveryAttempted });
+  return resolveRunOutcome({
+    delivered,
+    deliveryAttempted,
+    deliveryError: deliveryResult.deliveryError,
+  });
 }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -297,16 +297,14 @@ describe("applyJobPatch", () => {
     expect(job.delivery?.failureDestination?.to).toBe("https://example.invalid/failure");
   });
 
-  it("rejects Telegram delivery with invalid target (chatId/topicId format)", () => {
+  it("accepts Telegram delivery with legacy slash topic targets", () => {
     const job = createIsolatedAgentTurnJob("job-telegram-invalid", {
       mode: "announce",
       channel: "telegram",
       to: "-10012345/6789",
     });
 
-    expect(() => applyJobPatch(job, { enabled: true })).toThrow(
-      'Invalid Telegram delivery target "-10012345/6789". Use colon (:) as delimiter for topics, not slash. Valid formats: -1001234567890, -1001234567890:123, -1001234567890:topic:123, @username, https://t.me/username',
-    );
+    expect(() => applyJobPatch(job, { enabled: true })).not.toThrow();
   });
 
   it("accepts Telegram delivery with t.me URL", () => {

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -40,6 +40,7 @@ function buildMainSessionSystemEventJob(name: string): CronAddInput {
 function createIsolatedCronWithFinishedBarrier(params: {
   storePath: string;
   delivered?: boolean;
+  deliveryError?: string;
   onFinished?: (evt: { jobId: string; delivered?: boolean; deliveryStatus?: string }) => void;
 }) {
   const finished = createFinishedBarrier();
@@ -53,6 +54,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
       status: "ok" as const,
       summary: "done",
       ...(params.delivered === undefined ? {} : { delivered: params.delivered }),
+      ...(params.deliveryError === undefined ? {} : { deliveryError: params.deliveryError }),
     })),
     onEvent: (evt) => {
       if (evt.action === "finished") {
@@ -117,12 +119,14 @@ function expectDeliveryNotRequested(
 async function runIsolatedJobAndReadState(params: {
   job: CronAddInput;
   delivered?: boolean;
+  deliveryError?: string;
   onFinished?: (evt: { jobId: string; delivered?: boolean; deliveryStatus?: string }) => void;
 }) {
   const store = await makeStorePath();
   const { cron, finished } = createIsolatedCronWithFinishedBarrier({
     storePath: store.storePath,
     ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
+    ...(params.deliveryError !== undefined ? { deliveryError: params.deliveryError } : {}),
     ...(params.onFinished ? { onFinished: params.onFinished } : {}),
   });
 
@@ -160,6 +164,18 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastDelivered).toBe(false);
     expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
+  });
+
+  it("persists delivery-specific error text when announce delivery reports not delivered", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: buildIsolatedAgentTurnJob("delivery-error"),
+      delivered: false,
+      deliveryError: "Telegram recipient must be a numeric chat ID",
+    });
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryError).toBe("Telegram recipient must be a numeric chat ID");
   });
 
   it("persists not-requested delivery state when delivery is not configured", async () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -175,7 +175,7 @@ function validateTelegramDeliveryTarget(to: string | undefined): string | undefi
     return undefined;
   }
   if (TELEGRAM_SLASH_TOPIC_REGEX.test(trimmed)) {
-    return `Invalid Telegram delivery target "${to}". Use colon (:) as delimiter for topics, not slash. Valid formats: -1001234567890, -1001234567890:123, -1001234567890:topic:123, @username, https://t.me/username`;
+    return undefined;
   }
   return undefined;
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -298,6 +298,7 @@ export function applyJobResult(
   result: {
     status: CronRunStatus;
     error?: string;
+    deliveryError?: string;
     delivered?: boolean;
     startedAt: number;
     endedAt: number;
@@ -331,7 +332,7 @@ export function applyJobResult(
   const deliveryStatus = resolveDeliveryStatus({ job, delivered: result.delivered });
   job.state.lastDeliveryStatus = deliveryStatus;
   job.state.lastDeliveryError =
-    deliveryStatus === "not-delivered" && result.error ? result.error : undefined;
+    deliveryStatus === "not-delivered" ? (result.deliveryError ?? result.error) : undefined;
   job.updatedAtMs = result.endedAt;
 
   // Track consecutive errors for backoff / auto-disable.
@@ -491,6 +492,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   const shouldDelete = applyJobResult(state, job, {
     status: result.status,
     error: result.error,
+    deliveryError: result.deliveryError,
     delivered: result.delivered,
     startedAt: result.startedAt,
     endedAt: result.endedAt,
@@ -933,6 +935,7 @@ async function runStartupCatchupCandidate(
       jobId: candidate.jobId,
       status: result.status,
       error: result.error,
+      deliveryError: result.deliveryError,
       summary: result.summary,
       delivered: result.delivered,
       sessionId: result.sessionId,
@@ -1143,6 +1146,7 @@ export async function executeJobCore(
   return {
     status: res.status,
     error: res.error,
+    deliveryError: res.deliveryError,
     summary: res.summary,
     delivered: res.delivered,
     deliveryAttempted: res.deliveryAttempted,
@@ -1187,6 +1191,7 @@ export async function executeJob(
   const shouldDelete = applyJobResult(state, job, {
     status: coreResult.status,
     error: coreResult.error,
+    deliveryError: coreResult.deliveryError,
     delivered: coreResult.delivered,
     startedAt,
     endedAt,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -60,6 +60,7 @@ export type CronRunTelemetry = {
 export type CronRunOutcome = {
   status: CronRunStatus;
   error?: string;
+  deliveryError?: string;
   /** Optional classifier for execution errors to guide fallback behavior. */
   errorKind?: "delivery-target";
   summary?: string;

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -62,6 +62,7 @@ function parseExplicitTargetWithPlugin(params: {
   channel?: DeliverableMessageChannel;
   fallbackChannel?: DeliverableMessageChannel;
   raw?: string;
+  cfg?: OpenClawConfig;
 }) {
   const raw = params.raw?.trim();
   if (!raw) {
@@ -72,7 +73,10 @@ function parseExplicitTargetWithPlugin(params: {
     return null;
   }
   return (
-    resolveOutboundChannelPlugin({ channel: provider })?.messaging?.parseExplicitTarget?.({
+    resolveOutboundChannelPlugin({
+      channel: provider,
+      cfg: params.cfg,
+    })?.messaging?.parseExplicitTarget?.({
       raw,
     }) ?? null
   );
@@ -105,6 +109,8 @@ export function resolveSessionDeliveryTarget(params: {
   turnSourceAccountId?: string;
   /** Turn-source `threadId` — paired with `turnSourceChannel`. */
   turnSourceThreadId?: string | number;
+  /** Config object — used to bootstrap channel plugins for explicit target parsing (e.g. forum topic formats). */
+  cfg?: OpenClawConfig;
 }): SessionDeliveryTarget {
   const context = deliveryContextFromSession(params.entry);
   const sessionLastChannel =
@@ -142,6 +148,7 @@ export function resolveSessionDeliveryTarget(params: {
     channel,
     fallbackChannel: !channel ? lastChannel : undefined,
     raw: rawExplicitTo,
+    cfg: params.cfg,
   });
   if (parsedExplicitTarget?.to) {
     explicitTo = parsedExplicitTarget.to;


### PR DESCRIPTION
## Problem
Cron jobs with `delivery.mode = "announce"` silently fail to deliver to Telegram forum topics. The `deliveryStatus` shows `"not-delivered"` with no surfaced error, even with valid targets like `telegram:-GROUP/TOPIC` or `telegram:group:-GROUP:topic:TOPIC`.

Root cause: `resolveDeliveryTarget` in `delivery-target.ts` relies on `parseExplicitTargetWithPlugin` to extract the threadId from forum topic target strings. But this function calls `resolveOutboundChannelPlugin`, which requires the Telegram plugin to be bootstrapped — and bootstrap only happens when the gateway config includes a Telegram account. In isolated cron sessions (no full gateway config), the plugin is never loaded, so `parseExplicitTarget` is never called, and the threadId is silently dropped.

Additionally, `parseTelegramTarget` did not handle the legacy slash format (`chatId/topicId`), causing it to pass the full string as chatId.

## Fix
1. **Pre-parse forum topic formats** in `delivery-target.ts` using a lightweight regex parser (`extractForumTopicFromTarget`) that doesn't depend on plugin loading. This runs before `resolveSessionDeliveryTarget` and injects the extracted threadId as `explicitThreadId`.
2. **Add slash format** to `parseTelegramTarget` so `-GROUP/TOPIC` is parsed correctly everywhere.
3. **Pass `cfg` through** `resolveSessionDeliveryTarget` → `parseExplicitTargetWithPlugin` as a fallback for environments where plugin bootstrap is possible.
4. **Propagate `deliveryError`** from dispatch through to the run result so failures surface in `lastDeliveryError` instead of silent `not-delivered`.

## Files changed
- `src/cron/isolated-agent/delivery-target.ts` — core fix
- `extensions/telegram/src/targets.ts` — slash format support
- `src/infra/outbound/targets.ts` — cfg passthrough
- `src/cron/isolated-agent/delivery-dispatch.ts` + `run.ts` — deliveryError propagation
- `docs/automation/cron-jobs.md` — document all supported formats
- Tests added for all new behaviour

## Testing
All new tests pass. No regressions in existing test suite.
