### PR TITLE
fix(token): tokens usage statistics show "?" when provider returns zero-valued usage

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -271,7 +271,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
   const recordAssistantUsage = (usageLike: unknown) => {
     const usage = normalizeUsage((usageLike ?? undefined) as UsageLike | undefined);
-    if (!hasNonzeroUsage(usage)) {
+    if (!usage) {
       return;
     }
     usageTotals.input += usage.input ?? 0;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -19,7 +19,7 @@ import type {
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
-import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
+import { normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

Fixed an issue where tokens usage statistics consistently showed "?" instead of actual values when providers return usage data with all fields set to zero (e.g., Qwen free trial tier).


- Problem:
The `/status` command displayed tokens `?/128k` instead of actual token counts, even when the provider returned valid usage data. This affected Qwen and other providers that may return zero-valued usage for free trial accounts or certain configurations.

- Why it matters:

- What changed:
- 
Root cause: In src/agents/pi-embedded-subscribe.ts, the recordAssistantUsage function used hasNonzeroUsage(usage) to check if usage should be recorded. This caused the function to skip recording when all usage fields were zero, resulting in:

1. usageTotals remaining at initial values
2. getUsageTotals() returning undefined
3. persistSessionUsageUpdate receiving no valid usage
4. totalTokensFresh being set to false
5. Display layer showing "tokens ?" instead of the actual count

- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #49442

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) NO
- Secrets/tokens handling changed? (`Yes/No`) NO
- New/changed network calls? (`Yes/No`) NO 
- Command/tool execution surface changed? (`Yes/No`) NO
- Data access scope changed? (`Yes/No`) NO
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macos 15.6 
- Runtime/container:  docker runtimer
- Model/provider:  Qwen2.5
- Integration/channel (if any):  nil
- Relevant config (redacted): nil

### Steps

1.
2.
3.

### Expected

```
if (!hasNonzeroUsage(usage)) {
  return;
}
````

### Actual

```

if (!usage) {
  return;
}

```

## Fix Effect
* When the Provider returns usage with a value of 0, totalTokensFresh is correctly set to true.
* The display layer will show "tokens 0/128k" instead of "tokens ?/128k".
* Users can now distinguish between no usage data and usage equal to 0.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
