### PR TITLE
fix(discord): return null for empty component specs to prevent media loss

### DIFF
--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -71,6 +71,34 @@ describe("discord components", () => {
       }),
     ).toThrow("filename");
   });
+
+  it("returns null for empty components to avoid dropping media", () => {
+    // Empty blocks array — should fall back to regular message path
+    expect(readDiscordComponentSpec({ blocks: [] })).toBeNull();
+    // No blocks, no modal, no text — trivially empty
+    expect(readDiscordComponentSpec({})).toBeNull();
+    // Only reusable flag, no actual content
+    expect(readDiscordComponentSpec({ reusable: true })).toBeNull();
+    // Only container, no content
+    expect(readDiscordComponentSpec({ container: { accentColor: "#ff0000" } })).toBeNull();
+  });
+
+  it("returns spec when text-only components are provided", () => {
+    const spec = readDiscordComponentSpec({ text: "Hello world" });
+    expect(spec).not.toBeNull();
+    expect(spec?.text).toBe("Hello world");
+  });
+
+  it("returns spec when modal-only components are provided", () => {
+    const spec = readDiscordComponentSpec({
+      modal: {
+        title: "Test",
+        fields: [{ type: "text", label: "Name" }],
+      },
+    });
+    expect(spec).not.toBeNull();
+    expect(spec?.modal).toBeDefined();
+  });
 });
 
 describe("discord component registry", () => {

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -597,8 +597,19 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
       fields,
     };
   }
+  const text = readOptionalString(obj.text);
+  const hasBlocks = blocks !== undefined && blocks.length > 0;
+
+  // If the spec carries no meaningful content (no blocks, no modal, no text),
+  // return null so the caller falls back to the regular message path.
+  // This prevents an empty `components: { blocks: [] }` from silently
+  // swallowing media attachments by routing through the v2 components path.
+  if (!hasBlocks && !modal && !text) {
+    return null;
+  }
+
   return {
-    text: readOptionalString(obj.text),
+    text,
     reusable,
     container:
       typeof obj.container === "object" && obj.container && !Array.isArray(obj.container)


### PR DESCRIPTION
## Summary

When `components` is passed as an empty object (`{}`) or with an empty blocks array (`{ blocks: [] }`), `readDiscordComponentSpec` previously returned a valid (but content-less) spec. This caused the message to be routed through the v2 Components path (`sendDiscordComponentMessage`), which silently dropped media attachments.

## Fix

Added an early-return check in `readDiscordComponentSpec`: if the parsed spec has no meaningful content (no blocks, no modal, no text), return `null` instead. This allows the caller to fall back to the regular `sendMessageDiscord` path, which correctly handles media attachments.

## Tests

Added test cases in `components.test.ts`:
- Empty blocks array → returns `null`
- Empty object → returns `null`
- Only `reusable` flag → returns `null`
- Only `container` → returns `null`
- Text-only → returns valid spec ✅
- Modal-only → returns valid spec ✅

All existing tests pass.

Fixes #49703