### PR TITLE
Agents: wait for rate-limit retry lifecycle before ending embedded run

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -94,6 +94,9 @@ vi.mock("../../pi-embedded-subscribe.js", () => ({
 
 vi.mock("../../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: hoisted.getGlobalHookRunnerMock,
+  initializeGlobalHookRunner: () => {},
+  getGlobalPluginRegistry: () => null,
+  resetGlobalHookRunner: () => {},
 }));
 
 vi.mock("../../../infra/machine-name.js", () => ({
@@ -210,6 +213,13 @@ vi.mock("../../openai-ws-stream.js", () => ({
 
 vi.mock("../../anthropic-payload-log.js", () => ({
   createAnthropicPayloadLogger: () => undefined,
+}));
+
+vi.mock("../../../image-generation/runtime.js", () => ({
+  listRuntimeImageGenerationProviders: () => [],
+  generateImage: async () => {
+    throw new Error("generateImage not implemented in this test");
+  },
 }));
 
 vi.mock("../../cache-trace.js", () => ({
@@ -634,6 +644,98 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
         timestamp: expect.any(Number),
       }),
     );
+  });
+});
+
+describe("runEmbeddedAttempt rate-limit retry lifecycle", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness({
+      subscribeImpl: () => {
+        const unsubscribe = vi.fn();
+        return { ...createSubscriptionMock(), unsubscribe };
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("waits for SDK waitForRetry() before unsubscribing on final 429", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rl-workspace-"));
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rl-agent-dir-"));
+    const sessionFile = path.join(workspaceDir, "session.jsonl");
+    tempPaths.push(workspaceDir, agentDir);
+    await fs.writeFile(sessionFile, "", "utf8");
+
+    let resolveRetry: (() => void) | null = null;
+    const retryPromise = new Promise<void>((resolve) => {
+      resolveRetry = resolve;
+    });
+
+    hoisted.createAgentSessionMock.mockImplementation(async () => {
+      const session = createDefaultEmbeddedSession({
+        prompt: async (s) => {
+          s.messages = [
+            ...s.messages,
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "" }],
+              stopReason: "error",
+              errorMessage: "429 qpm exceeded",
+              provider: "openai",
+              model: "gpt-test",
+              usage: { input: 1, output: 0, total: 1 },
+            },
+          ];
+        },
+      });
+      (session.agent as unknown as { waitForRetry?: () => Promise<void> }).waitForRetry = () =>
+        retryPromise;
+      return { session };
+    });
+
+    const runPromise = runEmbeddedAttempt({
+      sessionId: "embedded-session",
+      sessionKey: "agent:main:main",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      config: {},
+      prompt: "hello",
+      timeoutMs: 10_000,
+      runId: "run-rate-limit",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: testModel,
+      authStorage: {} as AuthStorage,
+      modelRegistry: {} as ModelRegistry,
+      thinkLevel: "off",
+      senderIsOwner: true,
+      disableMessageTool: true,
+    });
+
+    // Let the attempt set up the embedded subscription + reach the retry wait.
+    // If it unsubscribed early, we'd see it here.
+    for (let i = 0; i < 10; i += 1) {
+      if (hoisted.subscribeEmbeddedPiSessionMock.mock.calls.length > 0) {
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    const firstSubscription = hoisted.subscribeEmbeddedPiSessionMock.mock.results[0]?.value as
+      | { unsubscribe?: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(firstSubscription?.unsubscribe).toBeDefined();
+    expect(firstSubscription?.unsubscribe).not.toHaveBeenCalled();
+
+    resolveRetry?.();
+    const result = await runPromise;
+    expect(result.promptError).toBeNull();
+    expect(firstSubscription?.unsubscribe).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -66,6 +66,7 @@ import { createBundleMcpToolRuntime } from "../../pi-bundle-mcp-tools.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
+  isRateLimitAssistantError,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
@@ -161,6 +162,40 @@ type PromptBuildHookRunner = {
 
 const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
 const SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE = "openclaw.sessions_yield";
+
+type RetryAwareAgent = {
+  waitForRetry?: (() => Promise<void>) | undefined;
+};
+
+const DEFAULT_WAIT_FOR_RETRY_TIMEOUT_MS = 30_000;
+
+async function waitForAgentRetryBestEffort(
+  agent: RetryAwareAgent | null | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  const waitForRetry = agent?.waitForRetry;
+  if (typeof waitForRetry !== "function") {
+    return;
+  }
+  const resolved = Symbol("resolved");
+  const timedOut = Symbol("timeout");
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      waitForRetry.call(agent).then(() => resolved),
+      new Promise<symbol>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve(timedOut), timeoutMs);
+        timeoutHandle.unref?.();
+      }),
+    ]);
+  } catch {
+    // Best-effort during cleanup.
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
 
 // Persist a hidden context reminder so the next turn knows why the runner stopped.
 function buildSessionsYieldContextMessage(message: string): string {
@@ -2711,6 +2746,34 @@ export async function runEmbeddedAttempt(
         }
         messagesSnapshot = snapshotSelection.messagesSnapshot;
         sessionIdUsed = snapshotSelection.sessionIdUsed;
+
+        // pi-agent-core can schedule rate-limit retries that fire after the initial
+        // prompt call resolves (especially on the final model call). If we tear down
+        // the embedded subscription/run handle immediately, the eventual successful
+        // retry response has no live reply pipeline and is silently dropped (#49645).
+        //
+        // Best-effort: when the last assistant message is a rate-limit error, wait
+        // briefly for the SDK's retry lifecycle to settle (if available), then
+        // refresh the snapshot so delivery/subscribers observe the final result.
+        const lastAssistantPreRetry = messagesSnapshot
+          .slice()
+          .toReversed()
+          .find(
+            (m) => m && typeof m === "object" && (m as { role?: unknown }).role === "assistant",
+          );
+        const shouldWaitForRateLimitRetry =
+          !aborted &&
+          !promptError &&
+          lastAssistantPreRetry &&
+          isRateLimitAssistantError(lastAssistantPreRetry as never);
+        if (shouldWaitForRateLimitRetry) {
+          await waitForAgentRetryBestEffort(
+            activeSession.agent as unknown as RetryAwareAgent,
+            DEFAULT_WAIT_FOR_RETRY_TIMEOUT_MS,
+          );
+          messagesSnapshot = activeSession.messages.slice();
+          sessionIdUsed = activeSession.sessionId;
+        }
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {


### PR DESCRIPTION
## Summary

Fixes a case where an embedded agent run could end its session/lane lifecycle too early when a **429 rate-limit** happens on the **final model call**. In that scenario, the provider SDK may perform a delayed retry, but the reply context was already torn down, causing the eventual successful response to be silently dropped.

This change keeps the embedded run alive long enough (best-effort, bounded) to let the SDK’s retry lifecycle settle, then refreshes the message snapshot so the final assistant response is delivered through the normal session path.

Refs: https://github.com/openclaw/openclaw/issues/49645

## Behavior Changes

- **Embedded runner lifecycle**: when the last assistant message indicates a rate-limit error, the runner **waits best-effort for the SDK retry lifecycle** (if available) before finalizing/unsubscribing.
- **Snapshot refresh**: after the wait, the runner refreshes the message snapshot so downstream delivery/subscribers observe the final state.

## Existing Functionality Check

- [x] Searched for existing “rate-limit retry / unsubscribe / snapshot” handling in the embedded runner
- [x] Verified behavior is scoped to rate-limit terminal cases and remains best-effort + time-bounded

## What Changed

- **Modified `src/agents/pi-embedded-runner/run/attempt.ts`**
  - Detects “last assistant message is a rate-limit error”
  - Waits for retry lifecycle best-effort (bounded timeout) before final snapshot + teardown

- **Updated/added tests in `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts`**
  - Adds coverage that the runner waits for the retry hook before unsubscribing when the final turn is a 429/rate-limit error

## Tests

Run locally:

- `pnpm test -- src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts -t "rate-limit retry"`
- `pnpm test -- src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts`
- `pnpm lint src/agents/pi-embedded-runner/run/attempt.ts`

## Manual Testing

- Reproduced the “final 429 then delayed retry” sequence by simulating a rate-limit error on the last call and validating the run does not unsubscribe early, and the eventual successful response is observable via the normal embedded session lifecycle.

## Files Changed

- `src/agents/pi-embedded-runner/run/attempt.ts`
- `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts`

## Checklist

- [x] PR scoped to one bugfix
- [x] Tests added/updated for the regression
- [x] Lint/format/typecheck compatible with repo conventions
