### PR TITLE
fix(model-compat): enable streaming usage by default for OpenAI-compatible endpoints

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -46,11 +46,11 @@ function expectSupportsDeveloperRoleForcedOff(overrides?: Partial<Model<Api>>): 
   expect(supportsDeveloperRole(normalized)).toBe(false);
 }
 
-function expectSupportsUsageInStreamingForcedOff(overrides?: Partial<Model<Api>>): void {
+function expectSupportsUsageInStreamingForcedOn(overrides?: Partial<Model<Api>>): void {
   const model = { ...baseModel(), ...overrides };
   delete (model as { compat?: unknown }).compat;
   const normalized = normalizeModelCompat(model as Model<Api>);
-  expect(supportsUsageInStreaming(normalized)).toBe(false);
+  expect(supportsUsageInStreaming(normalized)).toBe(true);
 }
 
 function expectSupportsStrictModeForcedOff(overrides?: Partial<Model<Api>>): void {
@@ -181,8 +181,8 @@ describe("normalizeModelCompat", () => {
     });
   });
 
-  it("forces supportsUsageInStreaming off for generic custom openai-completions provider", () => {
-    expectSupportsUsageInStreamingForcedOff({
+  it("forces supportsUsageInStreaming on for generic custom openai-completions provider", () => {
+    expectSupportsUsageInStreamingForcedOn({
       provider: "custom-cpa",
       baseUrl: "https://cpa.example.com/v1",
     });
@@ -257,7 +257,7 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(normalized)).toBe(false);
   });
 
-  it("still forces flags off when not explicitly set by user", () => {
+  it("forces supportsUsageInStreaming on when not explicitly set by user", () => {
     const model = {
       ...baseModel(),
       provider: "custom-cpa",
@@ -266,7 +266,7 @@ describe("normalizeModelCompat", () => {
     delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);
     expect(supportsDeveloperRole(normalized)).toBe(false);
-    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
     expect(supportsStrictMode(normalized)).toBe(false);
   });
 
@@ -294,7 +294,7 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(model)).toBeUndefined();
     expect(supportsStrictMode(model)).toBeUndefined();
     expect(supportsDeveloperRole(normalized)).toBe(false);
-    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
     expect(supportsStrictMode(normalized)).toBe(false);
   });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -145,12 +145,12 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
       ? {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
-          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: false }),
+          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: true }),
           supportsStrictMode: targetStrictMode,
         }
       : {
           supportsDeveloperRole: false,
-          supportsUsageInStreaming: false,
+          supportsUsageInStreaming: true,
           supportsStrictMode: false,
         },
   } as typeof model;


### PR DESCRIPTION
## Summary

Change the default value of `supportsUsageInStreaming` from `false` to `true` for non-native OpenAI endpoints in `normalizeModelCompat()`.

## Root Cause

In `src/agents/model-compat.ts`, the compat layer defaulted `supportsUsageInStreaming` to `false` for OpenAI-compatible backends (Qwen, DeepSeek, GLM, vllm, groq, etc.). This caused streaming requests to omit `stream_options: { include_usage: true }`, resulting in streaming responses not including usage data. The downstream effect is that `session.totalTokens` is always 0.

## Impact

- **Affected versions**: v2026.3.8+
- **Affected models**: All OpenAI-compatible backends that rely on streaming for usage data
- **Symptom**: `tokens ?/128k` in /status shows `?`, usage dashboard shows 0 tokens

## Fix

- Default `supportsUsageInStreaming` to `true` instead of `false`
- Backends that cannot handle this can explicitly opt out via `compat.supportsUsageInStreaming: false`

## Testing

- Updated `src/agents/model-compat.test.ts` with 32 passing tests
- Test coverage for the new default behavior

## Transparency

[AI-ASSISTED] Root cause identified via investigation of Issue #49590; fix inspired by PR #49672 (closed due to active PR limit).