### PR TITLE
fix: strip prompt_cache_key for providers that reject unknown fields

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -30,6 +30,25 @@ import {
   resolveOpenAIFastMode,
   resolveOpenAIServiceTier,
 } from "./openai-stream-wrappers.js";
+import { streamWithPayloadPatch } from "./stream-payload-utils.js";
+
+/** Providers whose APIs accept `prompt_cache_key` / `prompt_cache_retention`. */
+const PROMPT_CACHE_KEY_PROVIDERS = new Set([
+  "openai",
+  "openai-codex",
+  "opencode",
+  "azure-openai-responses",
+  "github-copilot",
+]);
+
+function createStripPromptCacheFieldsWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    streamWithPayloadPatch(underlying, model, context, options, (payload) => {
+      delete payload.prompt_cache_key;
+      delete payload.prompt_cache_retention;
+    });
+}
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -220,6 +239,14 @@ export function applyExtraParamsToAgent(
   if (wrappedStreamFn) {
     log.debug(`applying extraParams to agent streamFn for ${provider}/${modelId}`);
     agent.streamFn = wrappedStreamFn;
+  }
+
+  // Strip prompt_cache_key/prompt_cache_retention for providers that don't
+  // support OpenAI-style prompt caching. The pi-ai library injects these
+  // fields unconditionally for openai-responses streams, but non-OpenAI
+  // endpoints (e.g. Volcano Engine) reject unknown fields with HTTP 400.
+  if (!PROMPT_CACHE_KEY_PROVIDERS.has(provider)) {
+    agent.streamFn = createStripPromptCacheFieldsWrapper(agent.streamFn);
   }
 
   const anthropicBetas = resolveAnthropicBetas(effectiveExtraParams, provider, modelId);


### PR DESCRIPTION
## Summary

- Problem: Volcano Engine DeepSeek (and other non-OpenAI providers using the `openai-responses` API) returns HTTP 400 `unknown field "prompt_cache_key"` because the pi-ai library unconditionally injects `prompt_cache_key` and `prompt_cache_retention` into OpenAI Responses request bodies.
- Why it matters: users configuring Volcano Engine models cannot use them at all — every request fails with a 400.
- What changed: added an `onPayload` wrapper that strips `prompt_cache_key` and `prompt_cache_retention` from the request body for providers not in the known-supported set (`openai`, `openai-codex`, `opencode`, `azure-openai-responses`, `github-copilot`).
- What did NOT change: prompt caching behavior for OpenAI, Codex, Azure, and GitHub Copilot providers. Anthropic caching uses a different mechanism (`cacheRetention` option) and is unaffected. The existing `createBedrockNoCacheWrapper` for non-Anthropic Bedrock models is also unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Fixes #48155

## User-visible / Behavior Changes

Volcano Engine DeepSeek (and other non-OpenAI providers using `openai-responses` API) will no longer fail with HTTP 400 on unknown `prompt_cache_key` field.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Code inspection: traced `prompt_cache_key` injection from pi-ai `openai-responses.js:140` through to the HTTP request body; confirmed the field is only meaningful for OpenAI's own API

## Human Verification (required)

- Verified scenarios: traced the full code path from `applyExtraParamsToAgent` through `streamWithPayloadPatch` to confirm the wrapper correctly strips the fields before the request is sent
- Edge cases checked: OpenAI/Codex/Azure providers are in the allowlist and keep prompt caching; Anthropic uses a separate caching mechanism; existing Bedrock no-cache wrapper is preserved
- What I did **not** verify: live Volcano Engine API call (no credentials available); full `pnpm check` currently fails on existing main typing debt unrelated to this PR

## AI Disclosure

- [x] AI-assisted (Kiro CLI)
- [x] I understand what the code does

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms: if a provider that actually needs `prompt_cache_key` is missing from `PROMPT_CACHE_KEY_PROVIDERS`, prompt caching would silently stop working for that provider

## Risks and Mitigations

- Risk: a new provider that supports `prompt_cache_key` would need to be added to the allowlist.
  - Mitigation: the set is explicit and easy to extend; prompt caching is an optimization, not a correctness requirement, so missing it degrades performance but doesn't break functionality.
