### PR TITLE
fix: classify HTTP 404 as model_not_found in failover error handler

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -557,6 +557,13 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
       ),
     ).toBe("overloaded");
   });
+
+  it("treats HTTP 404 as model_not_found so fallback loop continues", () => {
+    expect(classifyFailoverReasonFromHttpStatus(404)).toBe("model_not_found");
+    expect(classifyFailoverReasonFromHttpStatus(404, "404 status code (no body)")).toBe(
+      "model_not_found",
+    );
+  });
 });
 
 describe("isFailoverErrorMessage", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -433,6 +433,12 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 529) {
     return "overloaded";
   }
+  if (status === 404) {
+    // A 404 from a fallback candidate means the endpoint or model was not
+    // found on that provider. Treat it as model_not_found so the fallback
+    // loop continues to the next candidate instead of silently succeeding.
+    return "model_not_found";
+  }
   if (status === 400 || status === 422) {
     // Some providers return quota/balance errors under HTTP 400, so do not
     // let the generic format fallback mask an explicit billing signal.


### PR DESCRIPTION
## Summary

- **Problem:** `classifyFailoverReasonFromHttpStatus()` has no case for HTTP 404, so it returns `null`. This causes `coerceToFailoverError()` to produce no `FailoverError`, and the fallback loop incorrectly marks the attempt as `candidate_succeeded`, silently stopping all further fallback.
- **Why it matters:** When a fallback candidate returns 404 (wrong endpoint, model not found, etc.), OpenClaw goes completely silent — no further fallback to Sonnet/Opus/etc. is attempted, and the user sees `404 status code (no body)` as the final response.
- **What changed:** Added `if (status === 404) { return "model_not_found"; }` to `classifyFailoverReasonFromHttpStatus()` in `errors.ts`. Added 2 test cases.
- **What did NOT change:** No behavior change for any other status code. No config, API, or schema changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes # (none — discovered in production)
- Related # (none)

## User-visible / Behavior Changes

When a fallback candidate returns HTTP 404, OpenClaw will now continue to the next fallback candidate instead of stopping and surfacing the 404 to the user. Previously the bot would go silent.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 14.6 (Darwin arm64)
- Runtime/container: Node v22.22.0, OpenClaw 2026.3.13
- Model/provider: openai-codex/gpt-5.4 (primary), custom proxy as fallback (api: openai-completions)
- Integration/channel: Discord
- Relevant config: `agents.defaults.model.primary = "openai-codex/gpt-5.4"`, fallback = custom proxy on port 11435

### Steps

1. Configure OpenClaw with openai-codex as primary and a custom openai-completions proxy as fallback
2. Trigger a Codex 429 rate limit (or let it expire)
3. OpenClaw falls back to the proxy; proxy returns 404 on the request

### Expected

- Fallback loop continues to next candidate (Sonnet/Opus)

### Actual

- Gateway logs `decision=candidate_succeeded` despite 404 response
- All subsequent requests return `404 status code (no body)`
- Bot goes completely silent; no further fallback attempted

## Evidence

- [x] Trace/log snippets

**Gateway log (before fix):**
```
[model-fallback/decision] decision=candidate_failed  candidate=openai-codex  reason=rate_limit  next=clawdio-proxy
[agent/embedded] error=404 status code (no body)
[model-fallback/decision] decision=candidate_succeeded  candidate=clawdio-proxy   ← BUG
```

**Source pointer:** `src/agents/pi-embedded-helpers/errors.ts` — `classifyFailoverReasonFromHttpStatus()` handles 401, 402, 403, 408, 422, 429, 499, 502, 503, 504, 529 but has no `case 404`.

## Human Verification (required)

- Verified scenarios: Confirmed via source code inspection that 404 returns `null` from `classifyFailoverReasonFromHttpStatus()`, confirmed the fallback loop path that reaches `candidate_succeeded` when no `FailoverError` is produced, confirmed `"model_not_found"` is an existing valid `FailoverReason` that triggers continuation
- Edge cases checked: 404 with message body, 404 with no body — both now return `model_not_found`
- What I did **not** verify: End-to-end test with a live Codex 429 + proxy 404 scenario post-fix (rate limit cooldown prevents immediate retest)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to revert: `git revert` the single commit; the 6-line addition is self-contained
- Files to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms: None expected; 404 was previously unhandled (returned null), not explicitly handled differently

## Risks and Mitigations

- Risk: A legitimate 404 from a provider that means "permanent endpoint not found" (not retryable) would now trigger fallback continuation instead of failing fast
  - Mitigation: `model_not_found` is already treated as non-retryable in cooldown logic (see `shouldPreserveTransientProbeSlot` in `model-fallback.ts`); the fallback loop will still exhaust candidates and fail with a summary if none succeed
