### PR TITLE
test(status): cover authenticated loopback probe regression in status scan

### DIFF
--- a/src/commands/status.scan.shared.integration.test.ts
+++ b/src/commands/status.scan.shared.integration.test.ts
@@ -4,16 +4,14 @@ import { withTempConfig } from "../gateway/test-temp-config.js";
 
 installGatewayTestHooks();
 
+// Load the module under test after the gateway harness installs its hooks.
 const { resolveGatewayProbeSnapshot } = await import("./status.scan.shared.js");
-const { readBestEffortConfig } = await import("../config/config.js");
 
 describe("resolveGatewayProbeSnapshot integration", () => {
   it("keeps local authenticated status probes out of scope-limited mode", async () => {
-    const token =
-      typeof (testState.gatewayAuth as { token?: unknown } | undefined)?.token === "string"
-        ? ((testState.gatewayAuth as { token?: string }).token ?? "")
-        : "";
-    expect(token).toBeTruthy();
+    const rawToken = (testState.gatewayAuth as { token?: string } | undefined)?.token;
+    expect(rawToken).toBeTruthy();
+    const token = rawToken!;
 
     await withGatewayServer(async ({ port }) => {
       await withTempConfig({
@@ -30,6 +28,7 @@ describe("resolveGatewayProbeSnapshot integration", () => {
           },
         },
         run: async () => {
+          const { readBestEffortConfig } = await import("../config/config.js");
           const cfg = await readBestEffortConfig();
           const snapshot = await resolveGatewayProbeSnapshot({
             cfg,
@@ -42,10 +41,11 @@ describe("resolveGatewayProbeSnapshot integration", () => {
           expect(snapshot.gatewayMode).toBe("local");
           expect(snapshot.gatewayProbeAuth.token).toBe(token);
           expect(snapshot.gatewayProbeAuthWarning).toBeUndefined();
-          expect(snapshot.gatewayProbe).not.toBeNull();
-          expect(snapshot.gatewayProbe?.ok).toBe(true);
-          expect(snapshot.gatewayProbe?.error).toBeNull();
-          expect(snapshot.gatewayProbe?.presence).not.toBeNull();
+          const gatewayProbe = snapshot.gatewayProbe;
+          expect(gatewayProbe).not.toBeNull();
+          expect(gatewayProbe!.ok).toBe(true);
+          expect(gatewayProbe!.error).toBeNull();
+          expect(gatewayProbe!.presence).not.toBeNull();
         },
       });
     });

--- a/src/commands/status.scan.shared.integration.test.ts
+++ b/src/commands/status.scan.shared.integration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { installGatewayTestHooks, testState, withGatewayServer } from "../gateway/test-helpers.js";
+import { withTempConfig } from "../gateway/test-temp-config.js";
+
+installGatewayTestHooks();
+
+const { resolveGatewayProbeSnapshot } = await import("./status.scan.shared.js");
+const { readBestEffortConfig } = await import("../config/config.js");
+
+describe("resolveGatewayProbeSnapshot integration", () => {
+  it("keeps local authenticated status probes out of scope-limited mode", async () => {
+    const token =
+      typeof (testState.gatewayAuth as { token?: unknown } | undefined)?.token === "string"
+        ? ((testState.gatewayAuth as { token?: string }).token ?? "")
+        : "";
+    expect(token).toBeTruthy();
+
+    await withGatewayServer(async ({ port }) => {
+      await withTempConfig({
+        prefix: "openclaw-status-scan-shared-integration-",
+        cfg: {
+          gateway: {
+            mode: "local",
+            bind: "loopback",
+            port,
+            auth: {
+              mode: "token",
+              token,
+            },
+          },
+        },
+        run: async () => {
+          const cfg = await readBestEffortConfig();
+          const snapshot = await resolveGatewayProbeSnapshot({
+            cfg,
+            opts: {
+              all: true,
+              timeoutMs: 5_000,
+            },
+          });
+
+          expect(snapshot.gatewayMode).toBe("local");
+          expect(snapshot.gatewayProbeAuth.token).toBe(token);
+          expect(snapshot.gatewayProbeAuthWarning).toBeUndefined();
+          expect(snapshot.gatewayProbe).not.toBeNull();
+          expect(snapshot.gatewayProbe?.ok).toBe(true);
+          expect(snapshot.gatewayProbe?.error).toBeNull();
+          expect(snapshot.gatewayProbe?.presence).not.toBeNull();
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Related #49730
- `main` already contains the loopback probe fix in `src/gateway/probe.ts`, but stable `v2026.3.13-1` still reproduces the false `missing scope: operator.read` diagnostic because it predates that fix.
- This PR does **not** reapply the probe fix itself. Instead, it adds command-path regression coverage for the `status --json` probe snapshot flow so this user-visible symptom is harder to reintroduce.

## Why this PR exists if `main` already has the fix

- The original fix path was already discussed in closed PR #48617 and is present on `main` via upstream commit `4ab016a9bd`.
- The missing piece here is higher-level coverage around the status scan path that users actually hit when they see the degraded diagnostic.
- This keeps the PR non-duplicative while still improving protection against regressions.

## What changed

- Added `src/commands/status.scan.shared.integration.test.ts`
- The new test starts a real gateway test server, uses local loopback token auth, and verifies that `resolveGatewayProbeSnapshot()` keeps the authenticated loopback status probe out of scope-limited mode.

## Verification

- `pnpm test -- src/gateway/probe.auth.integration.test.ts src/commands/status.scan.shared.integration.test.ts`

## Notes

- This PR intentionally leaves `.nova/` and `.aicoding/` out of the commit; only the repo test file is included.
