### PR TITLE
fix(heartbeat): suppress mixed ack output and preserve queued system events

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -260,6 +260,19 @@ describe("resolveHeartbeatReplyDisposition", () => {
     });
   });
 
+  it("treats short trailing text as ack when ackMaxChars allows it", () => {
+    expect(
+      resolveHeartbeatReplyDisposition({
+        text: "HEARTBEAT_OK all good",
+        ackMaxChars: 16,
+      }),
+    ).toEqual({
+      disposition: "ack",
+      text: "",
+      hadToken: true,
+    });
+  });
+
   it("classifies token plus reasoning as malformed", () => {
     expect(
       resolveHeartbeatReplyDisposition({
@@ -269,6 +282,19 @@ describe("resolveHeartbeatReplyDisposition", () => {
     ).toEqual({
       disposition: "malformedAck",
       text: "",
+      hadToken: true,
+    });
+  });
+
+  it("delivers exec-completion payloads even when they include the heartbeat token", () => {
+    expect(
+      resolveHeartbeatReplyDisposition({
+        text: "Backup finished successfully. HEARTBEAT_OK",
+        hasExecCompletion: true,
+      }),
+    ).toEqual({
+      disposition: "deliver",
+      text: "Backup finished successfully.",
       hadToken: true,
     });
   });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatReplyDisposition,
   stripHeartbeatToken,
 } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
@@ -235,5 +236,48 @@ Check the server logs
 ### Subsection
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+});
+
+describe("resolveHeartbeatReplyDisposition", () => {
+  it("classifies pure heartbeat tokens as ack", () => {
+    expect(resolveHeartbeatReplyDisposition({ text: "HEARTBEAT_OK" })).toEqual({
+      disposition: "ack",
+      text: "",
+      hadToken: true,
+    });
+  });
+
+  it("classifies mixed heartbeat text as malformed", () => {
+    expect(
+      resolveHeartbeatReplyDisposition({
+        text: "Checking queue/state before deciding. HEARTBEAT_OK",
+      }),
+    ).toEqual({
+      disposition: "malformedAck",
+      text: "Checking queue/state before deciding.",
+      hadToken: true,
+    });
+  });
+
+  it("classifies token plus reasoning as malformed", () => {
+    expect(
+      resolveHeartbeatReplyDisposition({
+        text: "HEARTBEAT_OK",
+        hasReasoning: true,
+      }),
+    ).toEqual({
+      disposition: "malformedAck",
+      text: "",
+      hadToken: true,
+    });
+  });
+
+  it("keeps non-token text deliverable", () => {
+    expect(resolveHeartbeatReplyDisposition({ text: "Disk usage crossed 95%" })).toEqual({
+      disposition: "deliver",
+      text: "Disk usage crossed 95%",
+      hadToken: false,
+    });
   });
 });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -4,9 +4,10 @@ import { HEARTBEAT_TOKEN } from "./tokens.js";
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
 export const HEARTBEAT_PROMPT =
-  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
+  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK. Final output must be either exact HEARTBEAT_OK or a user-visible conclusion, never both.";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+export type HeartbeatReplyDisposition = "ack" | "deliver" | "malformedAck";
 
 /**
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
@@ -58,6 +59,24 @@ export function resolveHeartbeatPrompt(raw?: string): string {
 }
 
 export type StripHeartbeatMode = "heartbeat" | "message";
+
+function stripLeadingHeartbeatResponsePrefix(
+  text: string,
+  responsePrefix: string | undefined,
+): string {
+  const normalizedPrefix = responsePrefix?.trim();
+  if (!normalizedPrefix) {
+    return text;
+  }
+
+  // Require a boundary after the configured prefix so short prefixes like "Hi"
+  // do not strip the beginning of normal words like "History".
+  const prefixPattern = new RegExp(
+    `^${escapeRegExp(normalizedPrefix)}(?=$|\\s|[\\p{P}\\p{S}])\\s*`,
+    "iu",
+  );
+  return text.replace(prefixPattern, "");
+}
 
 function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
   let text = raw.trim();
@@ -168,4 +187,63 @@ export function stripHeartbeatToken(
   }
 
   return { shouldSkip: false, text: rest, didStrip: true };
+}
+
+export function resolveHeartbeatReplyDisposition(params: {
+  text?: string;
+  responsePrefix?: string;
+  hasMedia?: boolean;
+  hasReasoning?: boolean;
+}): {
+  disposition: HeartbeatReplyDisposition;
+  text: string;
+  hadToken: boolean;
+} {
+  const rawText = typeof params.text === "string" ? params.text : "";
+  const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, params.responsePrefix);
+  const stripped = stripHeartbeatToken(textForStrip, { mode: "message" });
+  const normalized = textForStrip.trim();
+  const hasMedia = params.hasMedia === true;
+  const hasReasoning = params.hasReasoning === true;
+  const normalizedMarkup = normalized
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/^[*`~_]+/, "")
+    .replace(/[*`~_]+$/, "");
+  const hadToken =
+    normalized.includes(HEARTBEAT_TOKEN) || normalizedMarkup.includes(HEARTBEAT_TOKEN);
+  const strippedRemainder = stripped.text.trim();
+  const isSymbolOnlyRemainder =
+    Boolean(strippedRemainder) && !/[\p{L}\p{N}]/u.test(strippedRemainder);
+
+  if (!hadToken) {
+    return {
+      disposition: "deliver",
+      text: rawText.trim(),
+      hadToken: false,
+    };
+  }
+
+  if (
+    !hasMedia &&
+    !hasReasoning &&
+    stripped.didStrip &&
+    (!strippedRemainder || isSymbolOnlyRemainder)
+  ) {
+    return {
+      disposition: "ack",
+      text: "",
+      hadToken: true,
+    };
+  }
+
+  let finalText = stripped.didStrip ? stripped.text.trim() : rawText.trim();
+  if (params.responsePrefix && finalText && !finalText.startsWith(params.responsePrefix)) {
+    finalText = `${params.responsePrefix} ${finalText}`;
+  }
+  return {
+    disposition: "malformedAck",
+    text: finalText,
+    hadToken: true,
+  };
 }

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -194,6 +194,8 @@ export function resolveHeartbeatReplyDisposition(params: {
   responsePrefix?: string;
   hasMedia?: boolean;
   hasReasoning?: boolean;
+  hasExecCompletion?: boolean;
+  ackMaxChars?: number;
 }): {
   disposition: HeartbeatReplyDisposition;
   text: string;
@@ -202,9 +204,17 @@ export function resolveHeartbeatReplyDisposition(params: {
   const rawText = typeof params.text === "string" ? params.text : "";
   const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, params.responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, { mode: "message" });
+  const heartbeatAckStrip =
+    typeof params.ackMaxChars === "number"
+      ? stripHeartbeatToken(textForStrip, {
+          mode: "heartbeat",
+          maxAckChars: params.ackMaxChars,
+        })
+      : null;
   const normalized = textForStrip.trim();
   const hasMedia = params.hasMedia === true;
   const hasReasoning = params.hasReasoning === true;
+  const hasExecCompletion = params.hasExecCompletion === true;
   const normalizedMarkup = normalized
     .replace(/<[^>]*>/g, " ")
     .replace(/&nbsp;/gi, " ")
@@ -224,11 +234,27 @@ export function resolveHeartbeatReplyDisposition(params: {
     };
   }
 
+  let finalText = stripped.didStrip ? stripped.text.trim() : rawText.trim();
+  if (!finalText && hasExecCompletion) {
+    finalText = rawText.trim();
+  }
+  if (params.responsePrefix && finalText && !finalText.startsWith(params.responsePrefix)) {
+    finalText = `${params.responsePrefix} ${finalText}`;
+  }
+
+  if (hasExecCompletion) {
+    return {
+      disposition: "deliver",
+      text: finalText,
+      hadToken: true,
+    };
+  }
+
   if (
     !hasMedia &&
     !hasReasoning &&
-    stripped.didStrip &&
-    (!strippedRemainder || isSymbolOnlyRemainder)
+    ((stripped.didStrip && (!strippedRemainder || isSymbolOnlyRemainder)) ||
+      heartbeatAckStrip?.shouldSkip === true)
   ) {
     return {
       disposition: "ack",
@@ -237,10 +263,6 @@ export function resolveHeartbeatReplyDisposition(params: {
     };
   }
 
-  let finalText = stripped.didStrip ? stripped.text.trim() : rawText.trim();
-  if (params.responsePrefix && finalText && !finalText.startsWith(params.responsePrefix)) {
-    finalText = `${params.responsePrefix} ${finalText}`;
-  }
   return {
     disposition: "malformedAck",
     text: finalText,

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -154,7 +154,7 @@ describe("runHeartbeatOnce ack handling", () => {
     return cfg;
   }
 
-  it("respects ackMaxChars for heartbeat acks", async () => {
+  it("treats symbol-only heartbeat token variants as ack even when ackMaxChars is 0", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createWhatsAppHeartbeatConfig({
         tmpDir,
@@ -176,7 +176,7 @@ describe("runHeartbeatOnce ack handling", () => {
         deps: makeWhatsAppDeps({ sendWhatsApp }),
       });
 
-      expect(sendWhatsApp).toHaveBeenCalled();
+      expect(sendWhatsApp).not.toHaveBeenCalled();
     });
   });
 

--- a/src/infra/heartbeat-runner.strict-output.test.ts
+++ b/src/infra/heartbeat-runner.strict-output.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getLastHeartbeatEvent } from "./heartbeat-events.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import {
+  seedMainSessionStore,
+  setupTelegramHeartbeatPluginRuntimeForTests,
+  withTempTelegramHeartbeatSandbox,
+} from "./heartbeat-runner.test-utils.js";
+import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+const TELEGRAM_GROUP = "-1001234567890";
+
+beforeEach(() => {
+  setupTelegramHeartbeatPluginRuntimeForTests();
+  resetSystemEventsForTest();
+});
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});
+
+function createConfig(params: {
+  tmpDir: string;
+  storePath: string;
+  heartbeat?: Record<string, unknown>;
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace: params.tmpDir,
+        heartbeat: {
+          every: "5m",
+          target: "telegram",
+          ...params.heartbeat,
+        },
+      },
+    },
+    channels: {
+      telegram: {
+        allowFrom: ["*"],
+        heartbeat: { showOk: false },
+      },
+    },
+    session: { store: params.storePath },
+  } as OpenClawConfig;
+}
+
+describe("heartbeat strict output handling", () => {
+  it("suppresses mixed ack output, records skipped telemetry, and restores pending events", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      enqueueSystemEvent("Reminder: Check Base Scout results", {
+        sessionKey,
+        contextKey: "cron:base-scout",
+      });
+
+      replySpy.mockResolvedValue({
+        text: "Checking queue/state before deciding. Nothing needs attention.\n\nHEARTBEAT_OK",
+      });
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: TELEGRAM_GROUP,
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: { telegram: sendTelegram },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(peekSystemEvents(sessionKey)).toEqual(["Reminder: Check Base Scout results"]);
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "skipped",
+        reason: "mixed-ack-output",
+      });
+    });
+  });
+
+  it("restores events after malformed output and consumes them after a later successful send", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      enqueueSystemEvent("Reminder: Rotate API keys", {
+        sessionKey,
+        contextKey: "cron:rotate-keys",
+      });
+
+      replySpy
+        .mockResolvedValueOnce({
+          text: "I checked the reminder state and will stay quiet.\n\nHEARTBEAT_OK",
+        })
+        .mockResolvedValueOnce({
+          text: "Please rotate the API keys today.",
+        });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: TELEGRAM_GROUP,
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: { telegram: sendTelegram },
+      });
+      expect(peekSystemEvents(sessionKey)).toEqual(["Reminder: Rotate API keys"]);
+
+      await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: { telegram: sendTelegram },
+      });
+
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        TELEGRAM_GROUP,
+        "Please rotate the API keys today.",
+        expect.any(Object),
+      );
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
+  });
+
+  it("suppresses reasoning sidecars when the main heartbeat payload is token-only", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({
+        tmpDir,
+        storePath,
+        heartbeat: { includeReasoning: true },
+      });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+
+      replySpy.mockResolvedValue([
+        { text: "Reasoning:\nQueue looks clean." },
+        { text: "HEARTBEAT_OK" },
+      ]);
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: TELEGRAM_GROUP,
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: { telegram: sendTelegram },
+      });
+
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "skipped",
+        reason: "token-with-reasoning",
+      });
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.strict-output.test.ts
+++ b/src/infra/heartbeat-runner.strict-output.test.ts
@@ -13,6 +13,7 @@ import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "
 vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
 
 const TELEGRAM_GROUP = "-1001234567890";
+const LONG_MIXED_ACK_TEXT = `${"Checking queue/state before deciding. ".repeat(12)}HEARTBEAT_OK`;
 
 beforeEach(() => {
   setupTelegramHeartbeatPluginRuntimeForTests();
@@ -65,7 +66,7 @@ describe("heartbeat strict output handling", () => {
       });
 
       replySpy.mockResolvedValue({
-        text: "Checking queue/state before deciding. Nothing needs attention.\n\nHEARTBEAT_OK",
+        text: LONG_MIXED_ACK_TEXT,
       });
       const sendTelegram = vi.fn().mockResolvedValue({
         messageId: "m1",
@@ -103,7 +104,7 @@ describe("heartbeat strict output handling", () => {
 
       replySpy
         .mockResolvedValueOnce({
-          text: "I checked the reminder state and will stay quiet.\n\nHEARTBEAT_OK",
+          text: LONG_MIXED_ACK_TEXT,
         })
         .mockResolvedValueOnce({
           text: "Please rotate the API keys today.",
@@ -170,6 +171,43 @@ describe("heartbeat strict output handling", () => {
         status: "skipped",
         reason: "token-with-reasoning",
       });
+    });
+  });
+
+  it("delivers exec-completion payloads even when the reply also contains HEARTBEAT_OK", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      enqueueSystemEvent("exec finished: backup completed", {
+        sessionKey,
+        contextKey: "exec:backup",
+      });
+
+      replySpy.mockResolvedValue({
+        text: "Backup completed successfully. HEARTBEAT_OK",
+      });
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: TELEGRAM_GROUP,
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: { telegram: sendTelegram },
+      });
+
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        TELEGRAM_GROUP,
+        "Backup completed successfully.",
+        expect.any(Object),
+      );
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
     });
   });
 });

--- a/src/infra/heartbeat-runner.transcript-prune.test.ts
+++ b/src/infra/heartbeat-runner.transcript-prune.test.ts
@@ -100,6 +100,17 @@ describe("heartbeat transcript pruning", () => {
     });
   });
 
+  it("prunes transcript when heartbeat returns malformed mixed ack output", async () => {
+    await runTranscriptScenario({
+      sessionId: "test-session-malformed-prune",
+      reply: {
+        text: "Checking queue/state and nothing needs attention. HEARTBEAT_OK",
+        usage: { inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      },
+      expectPruned: true,
+    });
+  });
+
   it("does not prune transcript when heartbeat returns meaningful content", async () => {
     await runTranscriptScenario({
       sessionId: "test-session-no-prune",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -10,10 +10,9 @@ import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
-  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
-  stripHeartbeatToken,
+  resolveHeartbeatReplyDisposition,
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
@@ -43,7 +42,6 @@ import {
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
-import { escapeRegExp } from "../utils.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import {
@@ -76,7 +74,11 @@ import {
   resolveHeartbeatDeliveryTarget,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
-import { peekSystemEventEntries } from "./system-events.js";
+import {
+  consumeSystemEventSnapshot,
+  peekSystemEventEntries,
+  restoreSystemEventSnapshot,
+} from "./system-events.js";
 
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
@@ -153,15 +155,6 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
 
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
   return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
-}
-
-function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
-  return Math.max(
-    0,
-    heartbeat?.ackMaxChars ??
-      cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
-      DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  );
 }
 
 function resolveHeartbeatSession(
@@ -337,50 +330,6 @@ async function captureTranscriptState(params: {
     // Session or transcript doesn't exist yet - nothing to prune
     return {};
   }
-}
-
-function stripLeadingHeartbeatResponsePrefix(
-  text: string,
-  responsePrefix: string | undefined,
-): string {
-  const normalizedPrefix = responsePrefix?.trim();
-  if (!normalizedPrefix) {
-    return text;
-  }
-
-  // Require a boundary after the configured prefix so short prefixes like "Hi"
-  // do not strip the beginning of normal words like "History".
-  const prefixPattern = new RegExp(
-    `^${escapeRegExp(normalizedPrefix)}(?=$|\\s|[\\p{P}\\p{S}])\\s*`,
-    "iu",
-  );
-  return text.replace(prefixPattern, "");
-}
-
-function normalizeHeartbeatReply(
-  payload: ReplyPayload,
-  responsePrefix: string | undefined,
-  ackMaxChars: number,
-) {
-  const rawText = typeof payload.text === "string" ? payload.text : "";
-  const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
-  const stripped = stripHeartbeatToken(textForStrip, {
-    mode: "heartbeat",
-    maxAckChars: ackMaxChars,
-  });
-  const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0);
-  if (stripped.shouldSkip && !hasMedia) {
-    return {
-      shouldSkip: true,
-      text: "",
-      hasMedia,
-    };
-  }
-  let finalText = stripped.text;
-  if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
-    finalText = `${responsePrefix} ${finalText}`;
-  }
-  return { shouldSkip: false, text: finalText, hasMedia };
 }
 
 type HeartbeatReasonFlags = {
@@ -621,6 +570,10 @@ export async function runHeartbeatOnce(opts: {
     channel: delivery.channel !== "none" ? delivery.channel : undefined,
     accountId: delivery.accountId,
   }).responsePrefix;
+  const consumePendingEvents = () =>
+    consumeSystemEventSnapshot(sessionKey, preflight.pendingEventEntries);
+  const restorePendingEvents = () =>
+    restoreSystemEventSnapshot(sessionKey, preflight.pendingEventEntries);
 
   const canRelayToUser = Boolean(
     delivery.channel !== "none" && delivery.to && visibility.showAlerts,
@@ -732,6 +685,7 @@ export async function runHeartbeatOnce(opts: {
       // Prune the transcript to remove HEARTBEAT_OK turns
       await pruneHeartbeatTranscript(transcriptState);
       const okSent = await maybeSendHeartbeatOk();
+      consumePendingEvents();
       emitHeartbeatEvent({
         status: "ok-empty",
         reason: opts.reason,
@@ -744,22 +698,23 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
-    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
-    // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
-    // The model should be responding with exec results, not ack tokens.
-    // Also, if normalized.text is empty due to token stripping but we have exec completion,
-    // fall back to the original reply text.
-    const execFallbackText =
-      hasExecCompletion && !normalized.text.trim() && replyPayload.text?.trim()
+    const mediaUrls =
+      replyPayload.mediaUrls ?? (replyPayload.mediaUrl ? [replyPayload.mediaUrl] : []);
+    const replyDisposition = resolveHeartbeatReplyDisposition({
+      text: replyPayload.text,
+      responsePrefix,
+      hasMedia: mediaUrls.length > 0,
+      hasReasoning: reasoningPayloads.length > 0,
+    });
+    const previewFromRaw =
+      typeof replyPayload.text === "string" && replyPayload.text.trim()
         ? replyPayload.text.trim()
-        : null;
-    if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
-    }
-    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
-    if (shouldSkipMain && reasoningPayloads.length === 0) {
+        : reasoningPayloads
+            .map((payload) => payload.text?.trim())
+            .filter((text): text is string => Boolean(text))
+            .join("\n");
+
+    if (replyDisposition.disposition === "ack") {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
@@ -768,6 +723,7 @@ export async function runHeartbeatOnce(opts: {
       // Prune the transcript to remove HEARTBEAT_OK turns
       await pruneHeartbeatTranscript(transcriptState);
       const okSent = await maybeSendHeartbeatOk();
+      consumePendingEvents();
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
@@ -780,8 +736,35 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    const mediaUrls =
-      replyPayload.mediaUrls ?? (replyPayload.mediaUrl ? [replyPayload.mediaUrl] : []);
+    if (replyDisposition.disposition === "malformedAck") {
+      await restoreHeartbeatUpdatedAt({
+        storePath,
+        sessionKey,
+        updatedAt: previousUpdatedAt,
+      });
+      await pruneHeartbeatTranscript(transcriptState);
+      restorePendingEvents();
+      const malformedReason =
+        mediaUrls.length > 0
+          ? "token-with-media"
+          : reasoningPayloads.length > 0
+            ? "token-with-reasoning"
+            : "mixed-ack-output";
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: malformedReason,
+        preview: (replyDisposition.text || previewFromRaw).slice(0, 200),
+        durationMs: Date.now() - startedAt,
+        hasMedia: mediaUrls.length > 0,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+      });
+      log.warn("heartbeat: suppressed malformed mixed ack output", {
+        reason: malformedReason,
+        preview: (replyDisposition.text || previewFromRaw).slice(0, 200),
+      });
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
 
     // Suppress duplicate heartbeats (same payload) within a short window.
     // This prevents "nagging" when nothing changed but the model repeats the same items.
@@ -790,10 +773,9 @@ export async function runHeartbeatOnce(opts: {
     const prevHeartbeatAt =
       typeof entry?.lastHeartbeatSentAt === "number" ? entry.lastHeartbeatSentAt : undefined;
     const isDuplicateMain =
-      !shouldSkipMain &&
       !mediaUrls.length &&
       Boolean(prevHeartbeatText.trim()) &&
-      normalized.text.trim() === prevHeartbeatText.trim() &&
+      replyDisposition.text.trim() === prevHeartbeatText.trim() &&
       typeof prevHeartbeatAt === "number" &&
       startedAt - prevHeartbeatAt < 24 * 60 * 60 * 1000;
 
@@ -805,10 +787,11 @@ export async function runHeartbeatOnce(opts: {
       });
       // Prune the transcript to remove duplicate heartbeat turns
       await pruneHeartbeatTranscript(transcriptState);
+      consumePendingEvents();
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",
-        preview: normalized.text.slice(0, 200),
+        preview: replyDisposition.text.slice(0, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: false,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
@@ -818,14 +801,10 @@ export async function runHeartbeatOnce(opts: {
     }
 
     // Reasoning payloads are text-only; any attachments stay on the main reply.
-    const previewText = shouldSkipMain
-      ? reasoningPayloads
-          .map((payload) => payload.text)
-          .filter((text): text is string => Boolean(text?.trim()))
-          .join("\n")
-      : normalized.text;
+    const previewText = replyDisposition.text;
 
     if (delivery.channel === "none" || !delivery.to) {
+      consumePendingEvents();
       emitHeartbeatEvent({
         status: "skipped",
         reason: delivery.reason ?? "no-target",
@@ -843,6 +822,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      consumePendingEvents();
       emitHeartbeatEvent({
         status: "skipped",
         reason: "alerts-disabled",
@@ -891,26 +871,23 @@ export async function runHeartbeatOnce(opts: {
       threadId: delivery.threadId,
       payloads: [
         ...reasoningPayloads,
-        ...(shouldSkipMain
-          ? []
-          : [
-              {
-                text: normalized.text,
-                mediaUrls,
-              },
-            ]),
+        {
+          text: replyDisposition.text,
+          mediaUrls,
+        },
       ],
       deps: opts.deps,
     });
+    consumePendingEvents();
 
     // Record last delivered heartbeat payload for dedupe.
-    if (!shouldSkipMain && normalized.text.trim()) {
+    if (replyDisposition.text.trim()) {
       const store = loadSessionStore(storePath);
       const current = store[sessionKey];
       if (current) {
         store[sessionKey] = {
           ...current,
-          lastHeartbeatText: normalized.text,
+          lastHeartbeatText: replyDisposition.text,
           lastHeartbeatSentAt: startedAt,
         };
         await saveSessionStore(storePath, store);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -10,6 +10,7 @@ import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
   resolveHeartbeatReplyDisposition,
@@ -155,6 +156,15 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
 
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
   return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
+}
+
+function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
+  return Math.max(
+    0,
+    heartbeat?.ackMaxChars ??
+      cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
+      DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  );
 }
 
 function resolveHeartbeatSession(
@@ -700,11 +710,14 @@ export async function runHeartbeatOnce(opts: {
 
     const mediaUrls =
       replyPayload.mediaUrls ?? (replyPayload.mediaUrl ? [replyPayload.mediaUrl] : []);
+    const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const replyDisposition = resolveHeartbeatReplyDisposition({
       text: replyPayload.text,
       responsePrefix,
       hasMedia: mediaUrls.length > 0,
       hasReasoning: reasoningPayloads.length > 0,
+      hasExecCompletion,
+      ackMaxChars,
     });
     const previewFromRaw =
       typeof replyPayload.text === "string" && replyPayload.text.trim()

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -132,6 +132,28 @@ describe("system events (session routing)", () => {
       "Cron: second",
     ]);
     expect(peekSystemEvents(key)).toEqual(["Cron: first", "Cron: second", "Cron: third"]);
+  });
+
+  it("restores a snapshot even when a newer event matches the same text, ts, and context", () => {
+    const key = "agent:main:test-snapshot-restore-id-collision";
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100);
+    try {
+      enqueueSystemEvent("Cron: first", { sessionKey: key, contextKey: "cron:first" });
+      const snapshot = peekSystemEventEntries(key);
+
+      expect(drainSystemEventEntries(key).map((entry) => entry.text)).toEqual(["Cron: first"]);
+
+      enqueueSystemEvent("Cron: first", { sessionKey: key, contextKey: "cron:first" });
+
+      const restored = restoreSystemEventSnapshot(key, snapshot);
+      const queued = peekSystemEventEntries(key);
+      expect(restored.map((entry) => entry.text)).toEqual(["Cron: first"]);
+      expect(queued.map((entry) => entry.text)).toEqual(["Cron: first", "Cron: first"]);
+      expect(queued).toHaveLength(2);
+      expect(queued[0]?.id).not.toEqual(queued[1]?.id);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("keeps only the newest 20 queued events", () => {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import {
+  consumeSystemEventSnapshot,
   drainSystemEventEntries,
   enqueueSystemEvent,
   hasSystemEvents,
@@ -11,6 +12,7 @@ import {
   peekSystemEventEntries,
   peekSystemEvents,
   resetSystemEventsForTest,
+  restoreSystemEventSnapshot,
 } from "./system-events.js";
 
 const cfg = {} as unknown as OpenClawConfig;
@@ -95,6 +97,41 @@ describe("system events (session routing)", () => {
     expect(hasSystemEvents(key)).toBe(false);
 
     expect(enqueueSystemEvent("Node connected", { sessionKey: key })).toBe(true);
+  });
+
+  it("consumes only the peeked snapshot and preserves newer tail events", () => {
+    const key = "agent:main:test-snapshot-consume";
+    enqueueSystemEvent("Cron: first", { sessionKey: key, contextKey: "cron:first" });
+    enqueueSystemEvent("Cron: second", { sessionKey: key, contextKey: "cron:second" });
+
+    const snapshot = peekSystemEventEntries(key);
+    enqueueSystemEvent("Cron: third", { sessionKey: key, contextKey: "cron:third" });
+
+    expect(consumeSystemEventSnapshot(key, snapshot).map((entry) => entry.text)).toEqual([
+      "Cron: first",
+      "Cron: second",
+    ]);
+    expect(peekSystemEvents(key)).toEqual(["Cron: third"]);
+  });
+
+  it("restores a drained snapshot ahead of newer tail events", () => {
+    const key = "agent:main:test-snapshot-restore";
+    enqueueSystemEvent("Cron: first", { sessionKey: key, contextKey: "cron:first" });
+    enqueueSystemEvent("Cron: second", { sessionKey: key, contextKey: "cron:second" });
+
+    const snapshot = peekSystemEventEntries(key);
+    expect(drainSystemEventEntries(key).map((entry) => entry.text)).toEqual([
+      "Cron: first",
+      "Cron: second",
+    ]);
+
+    enqueueSystemEvent("Cron: third", { sessionKey: key, contextKey: "cron:third" });
+
+    expect(restoreSystemEventSnapshot(key, snapshot).map((entry) => entry.text)).toEqual([
+      "Cron: first",
+      "Cron: second",
+    ]);
+    expect(peekSystemEvents(key)).toEqual(["Cron: first", "Cron: second", "Cron: third"]);
   });
 
   it("keeps only the newest 20 queued events", () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -96,6 +96,93 @@ export function drainSystemEventEntries(sessionKey: string): SystemEvent[] {
   return out;
 }
 
+function isSameSystemEventEntry(a: SystemEvent, b: SystemEvent): boolean {
+  return a.text === b.text && a.ts === b.ts && (a.contextKey ?? null) === (b.contextKey ?? null);
+}
+
+/**
+ * Consume a previously peeked snapshot from the head of the session queue while
+ * preserving any events that arrived after the snapshot was taken.
+ */
+export function consumeSystemEventSnapshot(
+  sessionKey: string,
+  snapshot: SystemEvent[],
+): SystemEvent[] {
+  const key = requireSessionKey(sessionKey);
+  const entry = queues.get(key);
+  if (!entry || entry.queue.length === 0 || snapshot.length === 0) {
+    return [];
+  }
+
+  const consumed: SystemEvent[] = [];
+  for (const expected of snapshot) {
+    const head = entry.queue[0];
+    if (!head || !isSameSystemEventEntry(head, expected)) {
+      break;
+    }
+    const shifted = entry.queue.shift();
+    if (shifted) {
+      consumed.push(shifted);
+    }
+  }
+
+  if (entry.queue.length === 0) {
+    entry.lastText = null;
+    entry.lastContextKey = null;
+    queues.delete(key);
+  }
+
+  return consumed;
+}
+
+/**
+ * Restore a previously peeked snapshot at the head of the session queue while
+ * preserving any newer events that arrived after the snapshot was drained.
+ */
+export function restoreSystemEventSnapshot(
+  sessionKey: string,
+  snapshot: SystemEvent[],
+): SystemEvent[] {
+  const key = requireSessionKey(sessionKey);
+  if (snapshot.length === 0) {
+    return [];
+  }
+
+  const entry =
+    queues.get(key) ??
+    (() => {
+      const created: SessionQueue = {
+        queue: [],
+        lastText: null,
+        lastContextKey: null,
+      };
+      queues.set(key, created);
+      return created;
+    })();
+
+  let alreadyRestored = snapshot.length <= entry.queue.length;
+  if (alreadyRestored) {
+    for (let index = 0; index < snapshot.length; index += 1) {
+      if (!isSameSystemEventEntry(entry.queue[index], snapshot[index])) {
+        alreadyRestored = false;
+        break;
+      }
+    }
+  }
+  if (alreadyRestored) {
+    return [];
+  }
+
+  entry.queue = [...snapshot, ...entry.queue];
+  if (entry.queue.length > MAX_EVENTS) {
+    entry.queue.length = MAX_EVENTS;
+  }
+  const last = entry.queue.at(-1) ?? null;
+  entry.lastText = last?.text ?? null;
+  entry.lastContextKey = last?.contextKey ?? null;
+  return snapshot.map((event) => ({ ...event }));
+}
+
 export function drainSystemEvents(sessionKey: string): string[] {
   return drainSystemEventEntries(sessionKey).map((event) => event.text);
 }

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -2,9 +2,10 @@
 // prefixed to the next prompt. We intentionally avoid persistence to keep
 // events ephemeral. Events are session-scoped and require an explicit key.
 
-export type SystemEvent = { text: string; ts: number; contextKey?: string | null };
+export type SystemEvent = { id?: string; text: string; ts: number; contextKey?: string | null };
 
 const MAX_EVENTS = 20;
+let nextSystemEventId = 0;
 
 type SessionQueue = {
   queue: SystemEvent[];
@@ -36,6 +37,11 @@ function normalizeContextKey(key?: string | null): string | null {
     return null;
   }
   return trimmed.toLowerCase();
+}
+
+function createSystemEventId(): string {
+  nextSystemEventId += 1;
+  return `evt-${nextSystemEventId}`;
 }
 
 export function isSystemEventContextChanged(
@@ -72,6 +78,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   } // skip consecutive duplicates
   entry.lastText = cleaned;
   entry.queue.push({
+    id: createSystemEventId(),
     text: cleaned,
     ts: Date.now(),
     contextKey: normalizedContextKey,
@@ -97,6 +104,9 @@ export function drainSystemEventEntries(sessionKey: string): SystemEvent[] {
 }
 
 function isSameSystemEventEntry(a: SystemEvent, b: SystemEvent): boolean {
+  if (a.id && b.id) {
+    return a.id === b.id;
+  }
   return a.text === b.text && a.ts === b.ts && (a.contextKey ?? null) === (b.contextKey ?? null);
 }
 
@@ -203,4 +213,5 @@ export function hasSystemEvents(sessionKey: string) {
 
 export function resetSystemEventsForTest() {
   queues.clear();
+  nextSystemEventId = 0;
 }


### PR DESCRIPTION
## Summary
- suppress malformed mixed heartbeat ack output so `HEARTBEAT_OK` is never delivered alongside user-visible text, reasoning, or media
- preserve queued system events by consuming only the peeked snapshot on successful outcomes and restoring it when a malformed ack is suppressed
- add focused heartbeat and system-event regression tests for mixed ack suppression, transcript pruning, and snapshot consume/restore behavior

## Testing
- pnpm -C "/Users/Nan's document/workspace/temp/openclaw-upstream-heartbeat-minimal" exec vitest run src/auto-reply/heartbeat.test.ts src/infra/system-events.test.ts src/infra/heartbeat-runner.strict-output.test.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.transcript-prune.test.ts
- pnpm -C "/Users/Nan's document/workspace/temp/openclaw-upstream-heartbeat-minimal" exec vitest run src/plugins/loader.test.ts src/plugin-sdk/root-alias.test.ts
- openclaw gateway health