### PR TITLE
fix(sessions): preserve slack thread routing for A2A sessions

### DIFF
--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -33,4 +33,20 @@ describe("resolveGroupSessionKey", () => {
       chatType: "channel",
     });
   });
+
+  it("falls back to the provider hint when an agent-prefixed key does not encode a group surface", () => {
+    const resolution = resolveGroupSessionKey({
+      From: "agent:main:main",
+      Provider: "webchat",
+      Surface: "webchat",
+      ChatType: "channel",
+    } as never);
+
+    expect(resolution).toEqual({
+      key: "webchat:channel:agent:main:main",
+      channel: "webchat",
+      id: "agent:main:main",
+      chatType: "channel",
+    });
+  });
 });

--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { resolveGroupSessionKey } from "./group.js";
 
 describe("resolveGroupSessionKey", () => {
@@ -15,6 +14,22 @@ describe("resolveGroupSessionKey", () => {
       key: "slack:channel:c0aljbzc606:thread:1773810043.005839",
       channel: "slack",
       id: "c0aljbzc606:thread:1773810043.005839",
+      chatType: "channel",
+    });
+  });
+
+  it("still falls back to provider context for non-group agent-prefixed keys", () => {
+    const resolution = resolveGroupSessionKey({
+      From: "agent:main:main",
+      Provider: "slack",
+      Surface: "slack",
+      ChatType: "channel",
+    } as never);
+
+    expect(resolution).toEqual({
+      key: "slack:channel:agent:main:main",
+      channel: "slack",
+      id: "agent:main:main",
       chatType: "channel",
     });
   });

--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveGroupSessionKey } from "./group.js";
+
+describe("resolveGroupSessionKey", () => {
+  it("prefers the real provider encoded in agent-prefixed thread session keys", () => {
+    const resolution = resolveGroupSessionKey({
+      From: "agent:builder:slack:channel:C0ALJBZC606:thread:1773810043.005839",
+      Provider: "webchat",
+      Surface: "webchat",
+      ChatType: "channel",
+    } as never);
+
+    expect(resolution).toEqual({
+      key: "slack:channel:c0aljbzc606:thread:1773810043.005839",
+      channel: "slack",
+      id: "c0aljbzc606:thread:1773810043.005839",
+      chatType: "channel",
+    });
+  });
+});

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -72,6 +72,8 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
 
   const parts = from.split(":").filter(Boolean);
   const normalizedParts = parts.map((part) => part.trim().toLowerCase());
+  // Agent-prefixed session keys are encoded as agent:<agentId>:<provider>:...
+  // This assumes agent IDs themselves do not contain ':'.
   const startIndex = normalizedParts[0] === "agent" && normalizedParts.length >= 3 ? 2 : 0;
   const head = normalizedParts[startIndex] ?? "";
   const headIsSurface = head ? getGroupSurfaces().has(head) : false;

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -71,7 +71,9 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
   const providerHint = ctx.Provider?.trim().toLowerCase();
 
   const parts = from.split(":").filter(Boolean);
-  const head = parts[0]?.trim().toLowerCase() ?? "";
+  const normalizedParts = parts.map((part) => part.trim().toLowerCase());
+  const startIndex = normalizedParts[0] === "agent" && normalizedParts.length >= 3 ? 2 : 0;
+  const head = normalizedParts[startIndex] ?? "";
   const headIsSurface = head ? getGroupSurfaces().has(head) : false;
 
   const provider = headIsSurface
@@ -81,7 +83,7 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
     return null;
   }
 
-  const second = parts[1]?.trim().toLowerCase();
+  const second = normalizedParts[startIndex + 1];
   const secondIsKind = second === "group" || second === "channel";
   const kind = secondIsKind
     ? second
@@ -90,8 +92,8 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
       : "group";
   const id = headIsSurface
     ? secondIsKind
-      ? parts.slice(2).join(":")
-      : parts.slice(1).join(":")
+      ? parts.slice(startIndex + 2).join(":")
+      : parts.slice(startIndex + 1).join(":")
     : from;
   const finalId = id.trim().toLowerCase();
   if (!finalId) {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -222,4 +222,40 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     );
   });
+
+  it("falls back to a system event when baseSessionKey is null and the session route stays incomplete", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValueOnce({
+      payload: {
+        sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
+        deliveryContext: delivery({
+          channel: "slack",
+        }),
+      },
+    });
+    mocks.parseSessionThreadInfo.mockReturnValueOnce({
+      baseSessionKey: null,
+      threadId: "1773827207.576549",
+    });
+    mocks.loadSessionEntry.mockReturnValueOnce({
+      cfg: {},
+      entry: {
+        deliveryContext: delivery({
+          channel: "slack",
+        }),
+      },
+    });
+    mocks.deliveryContextFromSession.mockReturnValueOnce(
+      delivery({
+        channel: "slack",
+      }),
+    );
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.loadSessionEntry).toHaveBeenCalledTimes(1);
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
+      sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
+    });
+  });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -111,7 +111,7 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("falls back to base session delivery only when the current session route is incomplete", async () => {
+  it("prefers the parsed thread target over a stale base-session route", async () => {
     mocks.consumeRestartSentinel.mockResolvedValueOnce({
       payload: {
         sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
@@ -122,6 +122,11 @@ describe("scheduleRestartSentinelWake", () => {
     });
     mocks.parseSessionThreadInfo.mockReturnValueOnce({
       baseSessionKey: "agent:main:slack:channel:C0ALZAZ6ZBK",
+      threadId: "1773827207.576549",
+    });
+    mocks.resolveAnnounceTargetFromKey.mockReturnValueOnce({
+      channel: "slack",
+      to: "channel:C0AL50GP89M",
       threadId: "1773827207.576549",
     });
     mocks.loadSessionEntry
@@ -138,14 +143,14 @@ describe("scheduleRestartSentinelWake", () => {
         entry: {
           deliveryContext: {
             channel: "slack",
-            to: "channel:C0AL50GP89M",
+            to: "channel:C0ALZAZ6ZBK",
             accountId: "default",
           },
         },
       });
     mocks.deliveryContextFromSession.mockReturnValueOnce({ channel: "slack" }).mockReturnValueOnce({
       channel: "slack",
-      to: "channel:C0AL50GP89M",
+      to: "channel:C0ALZAZ6ZBK",
       accountId: "default",
     });
     mocks.resolveOutboundTarget.mockReturnValueOnce({
@@ -163,12 +168,13 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
-  it("keeps a partially populated current route when no base session is available", async () => {
+  it("preserves partial sentinel account hints while resolving the route from session data", async () => {
     mocks.consumeRestartSentinel.mockResolvedValueOnce({
       payload: {
         sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
         deliveryContext: {
           channel: "slack",
+          accountId: "acct-2",
         },
       },
     });
@@ -201,6 +207,7 @@ describe("scheduleRestartSentinelWake", () => {
       expect.objectContaining({
         channel: "slack",
         to: "channel:C0AL50GP89M",
+        accountId: "acct-2",
       }),
     );
   });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
@@ -78,6 +78,25 @@ vi.mock("../infra/system-events.js", () => ({
 
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.consumeRestartSentinel.mockResolvedValue({
+    payload: {
+      sessionKey: "agent:main:main",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "+15550002",
+        accountId: "acct-2",
+      },
+    },
+  });
+  mocks.parseSessionThreadInfo.mockReturnValue({ baseSessionKey: null, threadId: undefined });
+  mocks.loadSessionEntry.mockReturnValue({ cfg: {}, entry: {} });
+  mocks.resolveAnnounceTargetFromKey.mockReturnValue(null);
+  mocks.deliveryContextFromSession.mockReturnValue(undefined);
+  mocks.resolveOutboundTarget.mockReturnValue({ ok: true as const, to: "+15550002" });
+});
+
 describe("scheduleRestartSentinelWake", () => {
   it("forwards session context to outbound delivery", async () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
@@ -90,5 +109,56 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     );
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("falls back to base session delivery only when the current session route is incomplete", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValueOnce({
+      payload: {
+        sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
+        deliveryContext: {
+          channel: "slack",
+        },
+      },
+    });
+    mocks.parseSessionThreadInfo.mockReturnValueOnce({
+      baseSessionKey: "agent:main:slack:channel:C0ALZAZ6ZBK",
+      threadId: "1773827207.576549",
+    });
+    mocks.loadSessionEntry
+      .mockReturnValueOnce({
+        cfg: {},
+        entry: {
+          deliveryContext: {
+            channel: "slack",
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        cfg: {},
+        entry: {
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:C0AL50GP89M",
+            accountId: "default",
+          },
+        },
+      });
+    mocks.deliveryContextFromSession
+      .mockReturnValueOnce({ channel: "slack" })
+      .mockReturnValueOnce({
+        channel: "slack",
+        to: "channel:C0AL50GP89M",
+        accountId: "default",
+      });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({ ok: true as const, to: "channel:C0AL50GP89M" });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        to: "channel:C0AL50GP89M",
+      }),
+    );
   });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -143,17 +143,60 @@ describe("scheduleRestartSentinelWake", () => {
           },
         },
       });
-    mocks.deliveryContextFromSession
-      .mockReturnValueOnce({ channel: "slack" })
-      .mockReturnValueOnce({
-        channel: "slack",
-        to: "channel:C0AL50GP89M",
-        accountId: "default",
-      });
-    mocks.resolveOutboundTarget.mockReturnValueOnce({ ok: true as const, to: "channel:C0AL50GP89M" });
+    mocks.deliveryContextFromSession.mockReturnValueOnce({ channel: "slack" }).mockReturnValueOnce({
+      channel: "slack",
+      to: "channel:C0AL50GP89M",
+      accountId: "default",
+    });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: true as const,
+      to: "channel:C0AL50GP89M",
+    });
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        to: "channel:C0AL50GP89M",
+      }),
+    );
+  });
+
+  it("keeps a partially populated current route when no base session is available", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValueOnce({
+      payload: {
+        sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
+        deliveryContext: {
+          channel: "slack",
+        },
+      },
+    });
+    mocks.parseSessionThreadInfo.mockReturnValueOnce({
+      baseSessionKey: null,
+      threadId: "1773827207.576549",
+    });
+    mocks.loadSessionEntry.mockReturnValueOnce({
+      cfg: {},
+      entry: {
+        deliveryContext: {
+          channel: "slack",
+          to: "channel:C0AL50GP89M",
+        },
+      },
+    });
+    mocks.deliveryContextFromSession.mockReturnValueOnce({
+      channel: "slack",
+      to: "channel:C0AL50GP89M",
+    });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: true as const,
+      to: "channel:C0AL50GP89M",
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.loadSessionEntry).toHaveBeenCalledTimes(1);
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeliveryContext } from "../utils/delivery-context.js";
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
@@ -78,6 +79,8 @@ vi.mock("../infra/system-events.js", () => ({
 
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
 
+const delivery = (value: DeliveryContext) => value;
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.consumeRestartSentinel.mockResolvedValue({
@@ -115,44 +118,50 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.consumeRestartSentinel.mockResolvedValueOnce({
       payload: {
         sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
-        deliveryContext: {
+        deliveryContext: delivery({
           channel: "slack",
-        },
+        }),
       },
     });
     mocks.parseSessionThreadInfo.mockReturnValueOnce({
       baseSessionKey: "agent:main:slack:channel:C0ALZAZ6ZBK",
       threadId: "1773827207.576549",
     });
-    mocks.resolveAnnounceTargetFromKey.mockReturnValueOnce({
-      channel: "slack",
-      to: "channel:C0AL50GP89M",
-      threadId: "1773827207.576549",
-    });
+    mocks.resolveAnnounceTargetFromKey.mockReturnValueOnce(
+      delivery({
+        channel: "slack",
+        to: "channel:C0AL50GP89M",
+        threadId: "1773827207.576549",
+      }),
+    );
     mocks.loadSessionEntry
       .mockReturnValueOnce({
         cfg: {},
         entry: {
-          deliveryContext: {
+          deliveryContext: delivery({
             channel: "slack",
-          },
+          }),
         },
       })
       .mockReturnValueOnce({
         cfg: {},
         entry: {
-          deliveryContext: {
+          deliveryContext: delivery({
             channel: "slack",
             to: "channel:C0ALZAZ6ZBK",
             accountId: "default",
-          },
+          }),
         },
       });
-    mocks.deliveryContextFromSession.mockReturnValueOnce({ channel: "slack" }).mockReturnValueOnce({
-      channel: "slack",
-      to: "channel:C0ALZAZ6ZBK",
-      accountId: "default",
-    });
+    mocks.deliveryContextFromSession
+      .mockReturnValueOnce(delivery({ channel: "slack" }))
+      .mockReturnValueOnce(
+        delivery({
+          channel: "slack",
+          to: "channel:C0ALZAZ6ZBK",
+          accountId: "default",
+        }),
+      );
     mocks.resolveOutboundTarget.mockReturnValueOnce({
       ok: true as const,
       to: "channel:C0AL50GP89M",
@@ -172,10 +181,10 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.consumeRestartSentinel.mockResolvedValueOnce({
       payload: {
         sessionKey: "agent:main:slack:channel:C0AL50GP89M:thread:1773827207.576549",
-        deliveryContext: {
+        deliveryContext: delivery({
           channel: "slack",
           accountId: "acct-2",
-        },
+        }),
       },
     });
     mocks.parseSessionThreadInfo.mockReturnValueOnce({
@@ -185,16 +194,18 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.loadSessionEntry.mockReturnValueOnce({
       cfg: {},
       entry: {
-        deliveryContext: {
+        deliveryContext: delivery({
           channel: "slack",
           to: "channel:C0AL50GP89M",
-        },
+        }),
       },
     });
-    mocks.deliveryContextFromSession.mockReturnValueOnce({
-      channel: "slack",
-      to: "channel:C0AL50GP89M",
-    });
+    mocks.deliveryContextFromSession.mockReturnValueOnce(
+      delivery({
+        channel: "slack",
+        to: "channel:C0AL50GP89M",
+      }),
+    );
     mocks.resolveOutboundTarget.mockReturnValueOnce({
       ok: true as const,
       to: "channel:C0AL50GP89M",

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -40,6 +40,11 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   // Handles race condition where store wasn't flushed before restart
   const sentinelContext = payload.deliveryContext;
   const sessionDeliveryContext = deliveryContextFromSession(entry);
+  // If the current session entry only captured a partial route, consult the base
+  // session for missing fields. When there is no distinct base session to inspect
+  // (baseSessionKey is null or points back to the same session), we intentionally
+  // keep the partial context and fall back to system-event wakeups if routing still
+  // cannot be resolved.
   const shouldConsultBaseSession =
     (!sessionDeliveryContext || !sessionDeliveryContext.channel || !sessionDeliveryContext.to) &&
     baseSessionKey &&

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -39,22 +39,21 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   // Prefer delivery context from sentinel (captured at restart) over session store
   // Handles race condition where store wasn't flushed before restart
   const sentinelContext = payload.deliveryContext;
-  let sessionDeliveryContext = deliveryContextFromSession(entry);
-  if (
+  const sessionDeliveryContext = deliveryContextFromSession(entry);
+  const shouldConsultBaseSession =
     (!sessionDeliveryContext || !sessionDeliveryContext.channel || !sessionDeliveryContext.to) &&
     baseSessionKey &&
-    baseSessionKey !== sessionKey
-  ) {
-    const { entry: baseEntry } = loadSessionEntry(baseSessionKey);
-    const baseDeliveryContext = deliveryContextFromSession(baseEntry);
-    sessionDeliveryContext = mergeDeliveryContext(sessionDeliveryContext, baseDeliveryContext);
-  }
+    baseSessionKey !== sessionKey;
+  const baseDeliveryContext = shouldConsultBaseSession
+    ? deliveryContextFromSession(loadSessionEntry(baseSessionKey).entry)
+    : undefined;
 
-  const trustedSentinelContext =
-    sentinelContext?.channel && sentinelContext?.to ? sentinelContext : undefined;
+  // Keep explicit restart/session hints ahead of fallback routing derived from a
+  // parent/base session. The base session should only fill fields that are still
+  // missing after consulting the current session key/parsed target.
   const origin = mergeDeliveryContext(
-    trustedSentinelContext,
-    mergeDeliveryContext(sessionDeliveryContext, parsedTarget ?? undefined),
+    mergeDeliveryContext(sentinelContext, sessionDeliveryContext),
+    mergeDeliveryContext(parsedTarget ?? undefined, baseDeliveryContext),
   );
 
   const channelRaw = origin?.channel;

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -40,13 +40,20 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   // Handles race condition where store wasn't flushed before restart
   const sentinelContext = payload.deliveryContext;
   let sessionDeliveryContext = deliveryContextFromSession(entry);
-  if (!sessionDeliveryContext && baseSessionKey && baseSessionKey !== sessionKey) {
+  if (
+    (!sessionDeliveryContext || !sessionDeliveryContext.channel || !sessionDeliveryContext.to) &&
+    baseSessionKey &&
+    baseSessionKey !== sessionKey
+  ) {
     const { entry: baseEntry } = loadSessionEntry(baseSessionKey);
-    sessionDeliveryContext = deliveryContextFromSession(baseEntry);
+    const baseDeliveryContext = deliveryContextFromSession(baseEntry);
+    sessionDeliveryContext = mergeDeliveryContext(sessionDeliveryContext, baseDeliveryContext);
   }
 
+  const trustedSentinelContext =
+    sentinelContext?.channel && sentinelContext?.to ? sentinelContext : undefined;
   const origin = mergeDeliveryContext(
-    sentinelContext,
+    trustedSentinelContext,
     mergeDeliveryContext(sessionDeliveryContext, parsedTarget ?? undefined),
   );
 


### PR DESCRIPTION
## Summary

This PR fixes a related A2A routing regression for Slack thread sessions.

Two issues were contributing to the failure mode:

1. `resolveGroupSessionKey()` could normalize agent-prefixed Slack thread keys such as `agent:builder:slack:channel:C123:thread:...` as `webchat` because it only looked at the first segment of `ctx.From`.
2. Restart/announce fallback could still pull delivery routing back toward the base session when the current session route was only partially populated.

## Changes

- Teach `resolveGroupSessionKey()` to extract the real provider from `agent:<id>:<provider>:...` keys.
- Only trust restart sentinel `deliveryContext` when it is complete (`channel` + `to`).
- Use the base session only as a field-level fallback when the current session delivery context is incomplete.
- Add regression coverage for:
  - agent-prefixed Slack thread session keys
  - incomplete current delivery context + base-session fallback

## Why this matters

Without this fix, A2A Slack thread sessions can be persisted as `webchat`, and subsequent announce/restart delivery can drift back to the wrong thread/session.

## Related upstream context

- #44153
- #45929
- #44548

This PR addresses a related but distinct root cause that showed up in Slack-thread A2A routing.

## Tests

- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-restart-sentinel.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/config/sessions/group.test.ts`
