### PR TITLE
fix: resolve web UI chat model dropdown desync and wrong provider prefix

### DIFF
--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -1,6 +1,6 @@
+import { createAccountListHelpers } from "openclaw/plugin-sdk/account-helpers";
 import {
   createAccountActionGate,
-  createAccountListHelpers,
   normalizeAccountId,
   resolveAccountEntry,
   type OpenClawConfig,

--- a/extensions/discord/src/audit.test.ts
+++ b/extensions/discord/src/audit.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("./send.js", () => ({
-  fetchChannelPermissionsDiscord: vi.fn(),
-}));
+vi.mock("./send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send.js")>();
+  return {
+    ...actual,
+    fetchChannelPermissionsDiscord: vi.fn(),
+  };
+});
 
 describe("discord audit", () => {
   it("collects numeric channel ids and counts unresolved keys", async () => {

--- a/extensions/discord/src/monitor.tool-result.test-harness.ts
+++ b/extensions/discord/src/monitor.tool-result.test-harness.ts
@@ -8,12 +8,16 @@ export const dispatchMock: MockFn = vi.fn();
 export const readAllowFromStoreMock: MockFn = vi.fn();
 export const upsertPairingRequestMock: MockFn = vi.fn();
 
-vi.mock("./send.js", () => ({
-  sendMessageDiscord: (...args: unknown[]) => sendMock(...args),
-  reactMessageDiscord: async (...args: unknown[]) => {
-    reactMock(...args);
-  },
-}));
+vi.mock("./send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send.js")>();
+  return {
+    ...actual,
+    sendMessageDiscord: (...args: unknown[]) => sendMock(...args),
+    reactMessageDiscord: async (...args: unknown[]) => {
+      reactMock(...args);
+    },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -67,10 +67,14 @@ const configSessionsMocks = vi.hoisted(() => ({
 const readSessionUpdatedAt = configSessionsMocks.readSessionUpdatedAt;
 const resolveStorePath = configSessionsMocks.resolveStorePath;
 
-vi.mock("../send.js", () => ({
-  reactMessageDiscord: sendMocks.reactMessageDiscord,
-  removeReactionDiscord: sendMocks.removeReactionDiscord,
-}));
+vi.mock("../send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../send.js")>();
+  return {
+    ...actual,
+    reactMessageDiscord: sendMocks.reactMessageDiscord,
+    removeReactionDiscord: sendMocks.removeReactionDiscord,
+  };
+});
 
 vi.mock("../send.messages.js", () => ({
   editMessageDiscord: deliveryMocks.editMessageDiscord,

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -9,9 +9,13 @@ vi.mock("../../../../src/media/fetch.js", () => ({
   fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
 }));
 
-vi.mock("../../../../src/media/store.js", () => ({
-  saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
-}));
+vi.mock("../../../../src/media/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../src/media/store.js")>();
+  return {
+    ...actual,
+    saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
+  };
+});
 
 vi.mock("../../../../src/globals.js", () => ({
   logVerbose: () => {},

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -12,11 +12,15 @@ const sendVoiceMessageDiscordMock = vi.hoisted(() => vi.fn());
 const sendWebhookMessageDiscordMock = vi.hoisted(() => vi.fn());
 const sendDiscordTextMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../send.js", () => ({
-  sendMessageDiscord: (...args: unknown[]) => sendMessageDiscordMock(...args),
-  sendVoiceMessageDiscord: (...args: unknown[]) => sendVoiceMessageDiscordMock(...args),
-  sendWebhookMessageDiscord: (...args: unknown[]) => sendWebhookMessageDiscordMock(...args),
-}));
+vi.mock("../send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../send.js")>();
+  return {
+    ...actual,
+    sendMessageDiscord: (...args: unknown[]) => sendMessageDiscordMock(...args),
+    sendVoiceMessageDiscord: (...args: unknown[]) => sendVoiceMessageDiscordMock(...args),
+    sendWebhookMessageDiscord: (...args: unknown[]) => sendWebhookMessageDiscordMock(...args),
+  };
+});
 
 vi.mock("../send.shared.js", () => ({
   sendDiscordText: (...args: unknown[]) => sendDiscordTextMock(...args),

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -24,10 +24,14 @@ vi.mock("../client.js", () => ({
   createDiscordRestClient: hoisted.createDiscordRestClient,
 }));
 
-vi.mock("../send.js", () => ({
-  sendMessageDiscord: (...args: unknown[]) => hoisted.sendMessageDiscord(...args),
-  sendWebhookMessageDiscord: (...args: unknown[]) => hoisted.sendWebhookMessageDiscord(...args),
-}));
+vi.mock("../send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../send.js")>();
+  return {
+    ...actual,
+    sendMessageDiscord: (...args: unknown[]) => hoisted.sendMessageDiscord(...args),
+    sendWebhookMessageDiscord: (...args: unknown[]) => hoisted.sendWebhookMessageDiscord(...args),
+  };
+});
 
 const { maybeSendBindingMessage, resolveChannelIdForBinding } =
   await import("./thread-bindings.discord-api.js");

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -41,10 +41,14 @@ const hoisted = vi.hoisted(() => {
   };
 });
 
-vi.mock("../send.js", () => ({
-  sendMessageDiscord: hoisted.sendMessageDiscord,
-  sendWebhookMessageDiscord: hoisted.sendWebhookMessageDiscord,
-}));
+vi.mock("../send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../send.js")>();
+  return {
+    ...actual,
+    sendMessageDiscord: hoisted.sendMessageDiscord,
+    sendWebhookMessageDiscord: hoisted.sendWebhookMessageDiscord,
+  };
+});
 
 vi.mock("../send.messages.js", () => ({
   createThreadDiscord: hoisted.createThreadDiscord,

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -76,9 +76,13 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
-  getReplyFromConfig: (...args: unknown[]) => replyMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    getReplyFromConfig: (...args: unknown[]) => replyMock(...args),
+  };
+});
 
 vi.mock("./send.js", () => ({
   sendMessageSignal: (...args: unknown[]) => sendMock(...args),
@@ -116,9 +120,13 @@ vi.mock("./daemon.js", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
-  waitForTransportReady: (...args: unknown[]) => waitForTransportReadyMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    waitForTransportReady: (...args: unknown[]) => waitForTransportReadyMock(...args),
+  };
+});
 
 export function installSignalToolResultTestHooks() {
   beforeEach(() => {

--- a/extensions/slack/src/blocks.test-helpers.ts
+++ b/extensions/slack/src/blocks.test-helpers.ts
@@ -17,9 +17,13 @@ export type SlackSendTestClient = WebClient & {
 };
 
 export function installSlackBlockTestMocks() {
-  vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
-    loadConfig: () => ({}),
-  }));
+  vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+    return {
+      ...actual,
+      loadConfig: () => ({}),
+    };
+  });
 
   vi.mock("./accounts.js", () => ({
     resolveSlackAccount: () => ({

--- a/extensions/whatsapp/src/outbound-adapter.poll.test.ts
+++ b/extensions/whatsapp/src/outbound-adapter.poll.test.ts
@@ -9,9 +9,13 @@ vi.mock("../../../src/globals.js", () => ({
   shouldLogVerbose: () => false,
 }));
 
-vi.mock("./send.js", () => ({
-  sendPollWhatsApp: hoisted.sendPollWhatsApp,
-}));
+vi.mock("./send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send.js")>();
+  return {
+    ...actual,
+    sendPollWhatsApp: hoisted.sendPollWhatsApp,
+  };
+});
 
 import { whatsappOutbound } from "./outbound-adapter.js";
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveTelegramAccount } from "../../extensions/telegram/src/accounts.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
@@ -22,7 +23,6 @@ import {
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
-import { resolveTelegramAccount } from "../plugin-sdk/account-resolution.js";
 import {
   fetchTelegramChatId,
   inspectTelegramAccount,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -835,9 +835,9 @@ export function resolveSessionModelIdentityRef(
       if (parsedRuntime) {
         return { provider: parsedRuntime.provider, model: parsedRuntime.model };
       }
-      return { model: runtimeModel };
     }
-    return { model: runtimeModel };
+    // Provider inference failed; fall through to resolveSessionModelRef which
+    // has override fields and defaults and always returns a provider.
   }
   const resolved = resolveSessionModelRef(cfg, entry, agentId);
   return { provider: resolved.provider, model: resolved.model };

--- a/src/plugin-sdk/account-resolution.ts
+++ b/src/plugin-sdk/account-resolution.ts
@@ -10,16 +10,6 @@ export {
   normalizeOptionalAccountId,
 } from "../routing/session-key.js";
 export { normalizeE164, pathExists, resolveUserPath } from "../utils.js";
-export {
-  resolveDiscordAccount,
-  type ResolvedDiscordAccount,
-} from "../../extensions/discord/api.js";
-export { resolveSlackAccount, type ResolvedSlackAccount } from "../../extensions/slack/api.js";
-export {
-  resolveTelegramAccount,
-  type ResolvedTelegramAccount,
-} from "../../extensions/telegram/api.js";
-export { resolveSignalAccount, type ResolvedSignalAccount } from "../../extensions/signal/api.js";
 
 /** Resolve an account by id, then fall back to the default account when the primary lacks credentials. */
 export function resolveAccountWithDefaultFallback<TAccount>(params: {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -19,7 +19,7 @@ import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
-import type { ModelCatalogEntry, SessionsListResult } from "./types.ts";
+import type { ModelCatalogEntry, SessionsListResult, SessionsPatchResult } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -539,7 +539,16 @@ function resolveModelOverrideValue(state: AppViewState): string {
   // Include provider prefix so the value matches option keys (provider/model).
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
-    return resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
+    const serverValue = resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
+    // When server data lacks a provider, normalize against the catalog
+    // so the value matches a "provider/model" dropdown option.
+    if (serverValue && !serverValue.includes("/")) {
+      return normalizeChatModelOverrideValue(
+        { kind: "raw", value: serverValue },
+        state.chatModelCatalog ?? [],
+      );
+    }
+    return serverValue;
   }
   return "";
 }
@@ -575,10 +584,16 @@ function buildChatModelOptions(
   }
 
   if (currentOverride) {
-    addOption(currentOverride);
+    const normalizedCurrent = currentOverride.includes("/")
+      ? currentOverride
+      : normalizeChatModelOverrideValue({ kind: "raw", value: currentOverride }, catalog);
+    addOption(normalizedCurrent || currentOverride);
   }
   if (defaultModel) {
-    addOption(defaultModel);
+    const normalizedDefault = defaultModel.includes("/")
+      ? defaultModel
+      : normalizeChatModelOverrideValue({ kind: "raw", value: defaultModel }, catalog);
+    addOption(normalizedDefault || defaultModel);
   }
   return options;
 }
@@ -639,10 +654,23 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
     [targetSessionKey]: createChatModelOverride(nextModel),
   };
   try {
-    await state.client.request("sessions.patch", {
+    const patched = await state.client.request<SessionsPatchResult>("sessions.patch", {
       key: targetSessionKey,
       model: nextModel || null,
     });
+    // Update the local cache with the server's authoritative resolved value.
+    if (patched?.resolved) {
+      const resolvedValue = resolveServerChatModelValue(
+        patched.resolved.model,
+        patched.resolved.modelProvider,
+      );
+      if (resolvedValue) {
+        state.chatModelOverrides = {
+          ...state.chatModelOverrides,
+          [targetSessionKey]: createChatModelOverride(resolvedValue),
+        };
+      }
+    }
     await refreshSessionOptions(state);
   } catch (err) {
     // Roll back so the picker reflects the actual server model.

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -876,6 +876,120 @@ describe("chat view", () => {
     expect(labels).not.toContain("Subagent:");
   });
 
+  it("resolves bare server model against catalog when modelProvider is missing", () => {
+    const { state } = createChatHeaderState();
+    // Simulate server returning model without provider (e.g. set via /model in another channel)
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+          modelProvider: undefined,
+          model: "gpt-5-mini",
+        },
+      ],
+    };
+    state.chatModelOverrides = {};
+
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+    // Should resolve to "openai/gpt-5-mini" via catalog, not fall through to default
+    expect(modelSelect?.value).toBe("openai/gpt-5-mini");
+
+    const optionValues = Array.from(modelSelect?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    // Bare value must not appear as its own option
+    expect(optionValues).not.toContain("gpt-5-mini");
+  });
+
+  it("updates chatModelOverrides cache from sessions.patch resolved response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false } satisfies Partial<Response>));
+    const catalog: ModelCatalogEntry[] = [
+      { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro", provider: "google" },
+    ];
+    const { state, request } = createChatHeaderState({ models: catalog });
+    // Override request to return a resolved block
+    request.mockImplementation(async (method: string, _params: Record<string, unknown>) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: "main",
+          resolved: { modelProvider: "google", model: "gemini-3.1-pro" },
+        };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [
+            {
+              key: "main",
+              kind: "direct",
+              updatedAt: null,
+              modelProvider: "google",
+              model: "gemini-3.1-pro",
+            },
+          ],
+        };
+      }
+      if (method === "chat.history") {
+        return { messages: [], thinkingLevel: null };
+      }
+      if (method === "models.list") {
+        return { models: catalog };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    modelSelect!.value = "google/gemini-3.1-pro";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    // Cache should now reflect the server's authoritative resolved value
+    const override = state.chatModelOverrides["main"];
+    expect(override).not.toBeNull();
+    expect(override?.value).toBe("google/gemini-3.1-pro");
+    vi.unstubAllGlobals();
+  });
+
+  it("does not add bare-only option when catalog resolves the model", () => {
+    const { state } = createChatHeaderState();
+    // Current override is a bare model name (e.g. loaded from old state)
+    state.chatModelOverrides = { main: { kind: "raw", value: "gpt-5-mini" } };
+
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    const optionValues = Array.from(modelSelect?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    // Bare name must not appear; only the qualified form should be present
+    expect(optionValues).not.toContain("gpt-5-mini");
+    expect(optionValues).toContain("openai/gpt-5-mini");
+  });
+
   it("disambiguates duplicate grouped labels with the scoped key suffix", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";


### PR DESCRIPTION
## Summary

- **Problem:** When a session's model is changed via `/model` in another channel (e.g. Feishu), the Web UI Chat model dropdown shows the global default instead of the session's actual model, and selecting a model manually sends the wrong provider prefix (e.g. `aliyun-coding/gemini-3.1-pro-preview` instead of `google/gemini-3.1-pro-preview`).
- **Why it matters:** Users lose track of the active model after cross-channel `/model` changes, and manual picker changes produce invalid model refs that fail backend validation.
- **What changed:** Three coordinated frontend fixes (normalize bare server values, use `sessions.patch` resolved response to update cache, normalize bare fallback dropdown options) plus a backend defense-in-depth fix when runtime model lacks a provider.
- **What did NOT change:** No API/contract surface changes; no behavioral changes for sessions that already have `modelProvider` set.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #48096

## User-visible / Behavior Changes

The Web UI Chat model dropdown now correctly reflects the session's model when it was set via `/model` in another channel, and manual model selection sends the correct `provider/model` ref.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: Any (reproduced with Gemini models via Aliyun/Google providers)
- Integration/channel: Feishu → Web UI Chat

### Steps

1. Set model via `/model gemini-3.1-pro-preview` in Feishu channel (no provider stored in `modelProvider`).
2. Open Web UI Chat for the same session.
3. Observe dropdown — before fix it showed "Default (qwen3.5-plus)"; after fix it shows "gemini-3.1-pro-preview · google".
4. Select a model from the picker — before fix `sessions.patch` received `aliyun-coding/gemini-3.1-pro-preview`; after fix it receives `google/gemini-3.1-pro-preview`.

### Expected

- Dropdown reflects the session's actual model after cross-channel `/model` change.
- Picker sends qualified `provider/model` that passes backend validation.

### Actual (before fix)

- Dropdown fell through to "Default (qwen3.5-plus)" when server returned bare model name.
- Patch sent wrong provider prefix from global default.

## Evidence

- [x] Failing test/log before + passing after — 3 regression tests added in `ui/src/ui/views/chat.test.ts`; all 29 tests pass.

## Human Verification (required)

- Verified scenarios: Catalog lookup normalization, `sessions.patch` resolved cache update, no bare option in dropdown.
- Edge cases checked: Model already has provider (unchanged path), null/undefined override cleared to default.
- What you did **not** verify: Live end-to-end with real Feishu → Web UI session (tested via unit tests only).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit c3bfb492a6.
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`, `src/gateway/session-utils.ts`.
- Known bad symptoms reviewers should watch for: Dropdown regressing to show default model when session has a model set.

## Risks and Mitigations

- Risk: `resolveSessionModelRef` fallthrough in backend may return a different default provider than before for sessions where runtime model was set but provider inference failed.
  - Mitigation: This only affects sessions where provider inference already failed (returning no provider); fallthrough to `resolveSessionModelRef` gives a more accurate result with full context (overrides + configured defaults).