### PR TITLE
fix(sessions_spawn): ignore ACP-only params for subagent runtime

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -185,7 +185,7 @@ describe("sessions_spawn tool", () => {
     );
   });
 
-  it("rejects resumeSessionId without runtime=acp", async () => {
+  it("ignores resumeSessionId without runtime=acp", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -195,8 +195,17 @@ describe("sessions_spawn tool", () => {
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
+    });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "resume prior work",
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
@@ -224,7 +233,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('ignores streamTo when runtime is not "acp"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -236,12 +245,17 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze file",
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -97,7 +97,7 @@ export function createSessionsSpawnTool(
       const label = typeof params.label === "string" ? params.label.trim() : "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
-      const resumeSessionId = readStringParam(params, "resumeSessionId");
+      const resumeSessionIdRaw = readStringParam(params, "resumeSessionId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");
@@ -105,7 +105,9 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamToRaw = params.streamTo === "parent" ? "parent" : undefined;
+      const resumeSessionId = runtime === "acp" ? resumeSessionIdRaw : undefined;
+      const streamTo = runtime === "acp" ? streamToRaw : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -126,20 +128,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (runtime === "acp") {
         if (Array.isArray(attachments) && attachments.length > 0) {


### PR DESCRIPTION
﻿## Summary
- ignore `streamTo` when `runtime` is not `acp` instead of returning an error
- ignore `resumeSessionId` when `runtime` is not `acp` instead of returning an error
- keep ACP behavior unchanged (`streamTo`/`resumeSessionId` still forwarded for ACP runs)
- update unit tests to validate subagent calls succeed when ACP-only params are present

## Why
Some tool-callers may include optional fields from the schema even when spawning subagents. Treating ACP-only fields as hard errors for subagent runtime makes `sessions_spawn` brittle and breaks otherwise valid requests.

## Error examples seen in real usage
When spawning subagents, callers may still pass ACP-only fields (for example due to generic tool-call serialization):

```json
{
  "runtime": "subagent",
  "streamTo": "parent",
  "task": "..."
}
```

Current behavior before this fix:

```json
{
  "status": "error",
  "error": "streamTo is only supported for runtime=acp; got runtime=subagent"
}
```

A similar failure happens for `resumeSessionId` when `runtime` is `subagent`.

This PR makes those ACP-only fields no-ops for subagent runtime, so valid subagent requests can still proceed.

## Validation
- `corepack pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts`
  - passed (9/9)
