### PR TITLE
docs/types: clarify that omitting accountId in bindings matches default account only, not all accounts

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -49,7 +49,13 @@ If you omit `accountId` (`--bind <channel>`), OpenClaw resolves it from channel 
 
 ### Binding scope behavior
 
-- A binding without `accountId` matches the channel default account only.
+> [!WARNING]
+> A binding **without `accountId`** matches the channel **default account
+> only** — it does **not** match all accounts. If you configure multiple
+> accounts for a channel (e.g. Feishu `default` + `ai-bot`), use
+> `--bind <channel>:*` or add `accountId: "*"` in JSON to match all of
+> them, or specify each account explicitly.
+
 - `accountId: "*"` is the channel-wide fallback (all accounts) and is less specific than an explicit account binding.
 - If the same agent already has a matching channel binding without `accountId`, and you later bind with an explicit or resolved `accountId`, OpenClaw upgrades that existing binding in place instead of adding a duplicate.
 

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -19,6 +19,7 @@ Related:
 ```bash
 openclaw agents list
 openclaw agents add work --workspace ~/.openclaw/workspace-work
+openclaw agents add work --workspace ~/.openclaw/workspace-work --bind telegram:*
 openclaw agents bindings
 openclaw agents bind --agent work --bind telegram:ops
 openclaw agents unbind --agent work --bind telegram:ops
@@ -45,7 +46,21 @@ Add bindings:
 openclaw agents bind --agent work --bind telegram:ops --bind discord:guild-a
 ```
 
+You can also add bindings at agent creation time with `--bind`:
+
+```bash
+openclaw agents add work --workspace ~/.openclaw/workspace-work --bind telegram:* --bind discord:*
+```
+
 If you omit `accountId` (`--bind <channel>`), OpenClaw resolves it from channel defaults and plugin setup hooks when available.
+
+### `--bind` format reference
+
+| Format | Meaning |
+|---|---|
+| `--bind <channel>:*` | Match **all** accounts on the channel |
+| `--bind <channel>:<account>` | Match a **specific** account only |
+| `--bind <channel>` | Match the **default** account only (see warning below) |
 
 ### Binding scope behavior
 
@@ -59,17 +74,23 @@ If you omit `accountId` (`--bind <channel>`), OpenClaw resolves it from channel 
 - `accountId: "*"` is the channel-wide fallback (all accounts) and is less specific than an explicit account binding.
 - If the same agent already has a matching channel binding without `accountId`, and you later bind with an explicit or resolved `accountId`, OpenClaw upgrades that existing binding in place instead of adding a duplicate.
 
-Example:
+Examples:
 
 ```bash
-# initial channel-only binding
+# match all accounts on the channel (recommended for multi-account setups)
+openclaw agents bind --agent work --bind feishu:*
+
+# match a specific account
+openclaw agents bind --agent work --bind feishu:ai-bot
+
+# initial channel-only binding (matches default account only)
 openclaw agents bind --agent work --bind telegram
 
 # later upgrade to account-scoped binding
 openclaw agents bind --agent work --bind telegram:ops
 ```
 
-After the upgrade, routing for that binding is scoped to `telegram:ops`. If you also want default-account routing, add it explicitly (for example `--bind telegram:default`).
+After an upgrade, routing for that binding is scoped to `telegram:ops`. If you also want default-account routing, add it explicitly (for example `--bind telegram:default`).
 
 Remove bindings:
 

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -67,7 +67,7 @@ If you omit `accountId` (`--bind <channel>`), OpenClaw resolves it from channel 
 > [!WARNING]
 > A binding **without `accountId`** matches the channel **default account
 > only** — it does **not** match all accounts. If you configure multiple
-> accounts for a channel (e.g. Feishu `default` + `ai-bot`), use
+> accounts for a channel (e.g. WhatsApp `personal` + `biz`), use
 > `--bind <channel>:*` or add `accountId: "*"` in JSON to match all of
 > them, or specify each account explicitly.
 
@@ -78,19 +78,19 @@ Examples:
 
 ```bash
 # match all accounts on the channel (recommended for multi-account setups)
-openclaw agents bind --agent work --bind feishu:*
+openclaw agents bind --agent work --bind telegram:*
 
 # match a specific account
-openclaw agents bind --agent work --bind feishu:ai-bot
+openclaw agents bind --agent work --bind telegram:ops
 
 # initial channel-only binding (matches default account only)
 openclaw agents bind --agent work --bind telegram
 
 # later upgrade to account-scoped binding
-openclaw agents bind --agent work --bind telegram:ops
+openclaw agents bind --agent work --bind telegram:alerts
 ```
 
-After an upgrade, routing for that binding is scoped to `telegram:ops`. If you also want default-account routing, add it explicitly (for example `--bind telegram:default`).
+After an upgrade, routing for that binding is scoped to `telegram:alerts`. If you also want default-account routing, add it explicitly (for example `--bind telegram:default`).
 
 Remove bindings:
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -185,10 +185,25 @@ Bindings are **deterministic** and **most-specific wins**:
 If multiple bindings match in the same tier, the first one in config order wins.
 If a binding sets multiple match fields (for example `peer` + `guildId`), all specified fields are required (`AND` semantics).
 
-Important account-scope detail:
+> [!WARNING]
+> **Account-scope pitfall (common source of silent routing failures)**
+>
+> A binding that **omits `accountId`** does **not** match all accounts — it
+> matches only the channel's **default account** (the one named `"default"`,
+> or the value of `channels.<ch>.defaultAccount`).
+>
+> If you have **multiple accounts** configured for a channel (e.g. Feishu
+> `default` + `ai-bot`, WhatsApp `personal` + `biz`), you **must** set
+> `accountId` explicitly in each binding:
+>
+> - `"accountId": "*"` — match **all** accounts (channel-wide).
+> - `"accountId": "<name>"` — match one specific account.
+>
+> Without this, messages from non-default accounts will silently fall
+> through to the default agent instead of matching the intended binding.
 
-- A binding that omits `accountId` matches the default account only.
-- Use `accountId: "*"` for a channel-wide fallback across all accounts.
+Additional account-scope notes:
+
 - If you later add the same binding for the same agent with an explicit account id, OpenClaw upgrades the existing channel-only binding to account-scoped instead of duplicating it.
 
 ## Multiple accounts / phone numbers
@@ -399,15 +414,20 @@ Split by channel: route WhatsApp to a fast everyday agent and Telegram to an Opu
     ],
   },
   bindings: [
-    { agentId: "chat", match: { channel: "whatsapp" } },
-    { agentId: "opus", match: { channel: "telegram" } },
+    { agentId: "chat", match: { channel: "whatsapp", accountId: "*" } },
+    { agentId: "opus", match: { channel: "telegram", accountId: "*" } },
   ],
 }
 ```
 
+> [!TIP]
+> These examples use `accountId: "*"` so the bindings work regardless of
+> which account receives the message. If you only have a single account
+> per channel you can safely omit it, but adding `"*"` is a good default
+> to avoid silent routing failures when accounts are added later.
+
 Notes:
 
-- If you have multiple accounts for a channel, add `accountId` to the binding (for example `{ channel: "whatsapp", accountId: "personal" }`).
 - To route a single DM/group to Opus while keeping the rest on chat, add a `match.peer` binding for that peer; peer matches always win over channel-wide rules.
 
 ## Example: same channel, one peer to Opus
@@ -435,9 +455,9 @@ Keep WhatsApp on the fast agent, but route one DM to Opus:
   bindings: [
     {
       agentId: "opus",
-      match: { channel: "whatsapp", peer: { kind: "direct", id: "+15551234567" } },
+      match: { channel: "whatsapp", accountId: "*", peer: { kind: "direct", id: "+15551234567" } },
     },
-    { agentId: "chat", match: { channel: "whatsapp" } },
+    { agentId: "chat", match: { channel: "whatsapp", accountId: "*" } },
   ],
 }
 ```

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -192,8 +192,8 @@ If a binding sets multiple match fields (for example `peer` + `guildId`), all sp
 > matches only the channel's **default account** (the one named `"default"`,
 > or the value of `channels.<ch>.defaultAccount`).
 >
-> If you have **multiple accounts** configured for a channel (e.g. Feishu
-> `default` + `ai-bot`, WhatsApp `personal` + `biz`), you **must** set
+> If you have **multiple accounts** configured for a channel (e.g. WhatsApp
+> `personal` + `biz`, Telegram `default` + `alerts`), you **must** set
 > `accountId` explicitly in each binding:
 >
 > - `"accountId": "*"` — match **all** accounts (channel-wide).

--- a/src/commands/agents.bindings.ts
+++ b/src/commands/agents.bindings.ts
@@ -258,6 +258,15 @@ function resolveBindingAccountId(params: {
     return resolveDefaultAccountId(params.config, params.channel);
   }
 
+  // When a channel has multiple accounts configured, default to "*" so the
+  // binding matches all accounts instead of silently matching only "default".
+  if (plugin) {
+    const accountIds = plugin.config.listAccountIds(params.config);
+    if (accountIds.length > 1) {
+      return "*";
+    }
+  }
+
   return undefined;
 }
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -27,6 +27,14 @@ export type AgentRuntimeConfig =
 
 export type AgentBindingMatch = {
   channel: string;
+  /**
+   * Channel account to match.
+   * - **Omitted / empty**: matches only the channel's **default** account
+   *   (`channels.<channel>.defaultAccount`, falling back to `"default"`).
+   *   It does **not** match all accounts.
+   * - `"*"`: wildcard — matches **every** account on the channel.
+   * - Any other string: matches that specific account id only.
+   */
   accountId?: string;
   peer?: { kind: ChatType; id: string };
   guildId?: string;


### PR DESCRIPTION
## Summary

- **Fix**: Auto-set `accountId: "*"` when a channel has multiple accounts configured and no explicit accountId is provided during `openclaw agents add` / `openclaw agents bind`
- **Docs**: Add JSDoc to `AgentBindingMatch.accountId` documenting the three behaviors (omitted → default only, `"*"` → all, string → specific)
- **Docs**: Replace easy-to-miss plain text note in `multi-agent.md` with a prominent `[!WARNING]` callout
- **Docs**: Add `--bind` format reference table and `agents add --bind` examples to CLI docs
- **Docs**: Update binding examples to include `accountId: "*"` as the safe default

## Problem

When configuring multi-agent routing with `bindings` in `openclaw.json`, omitting the `accountId` field silently matches **only the default account** rather than all accounts. This is counter-intuitive and causes hard-to-debug routing failures when multiple channel accounts are configured (e.g. WhatsApp `personal` + `biz`, Telegram `default` + `alerts`).

### Scenario

A user configures two accounts on a channel and sets up bindings to route specific groups to specific agents:

```json
{
  "channels": {
    "telegram": {
      "accounts": {
        "default": { "botToken": "123456:ABC..." },
        "alerts": { "botToken": "987654:XYZ..." }
      }
    }
  },
  "bindings": [
    {
      "match": {
        "channel": "telegram",
        "peer": { "kind": "group", "id": "-100123456789" }
      },
      "agentId": "work"
    }
  ]
}
```

**Expected**: The binding routes messages from the group to the `work` agent regardless of which account receives the message.

**Actual**:
- Messages via `telegram[default]` → ✅ correctly dispatched to `work` agent
- Messages via `telegram[alerts]` → ❌ silently falls back to `main` agent

### Root cause (in `src/routing/resolve-route.ts`)

`resolveAccountPatternKey()` converts an empty `accountPattern` (from an omitted `accountId`) to the literal string `"default"`:

```typescript
function resolveAccountPatternKey(accountPattern: string): string {
  if (!accountPattern.trim()) {
    return DEFAULT_ACCOUNT_ID;  // → "default"
  }
  return normalizeAccountId(accountPattern);
}
```

During `buildEvaluatedBindingsByChannel()`, bindings without `accountId` are indexed into the `byAccount.get("default")` bucket. Only bindings with `accountId: "*"` enter `byAnyAccount`.

At lookup time in `getEvaluatedBindingsForChannelAccount()`:

```typescript
const accountScoped = channelBindings?.byAccount.get(accountId) ?? [];
const anyAccount = channelBindings?.byAnyAccount ?? [];
```

When a message arrives from a non-default account, the system queries `byAccount.get("alerts")` — which is empty. `byAnyAccount` is also empty. No binding matches → fallback to default agent.

### Why this is confusing

1. Most users expect "field omitted" = "match any / don't care", not "match only default"
2. The `openclaw agents add` wizard does **not** prompt for `accountId` when creating bindings, even when multiple accounts are configured
3. Many doc examples showed bindings without `accountId`, implying this is the normal pattern
4. The TypeScript type `AgentBindingMatch.accountId` had no JSDoc explaining the default behavior
5. The CLI docs had no `--bind` format reference or examples showing the `:*` wildcard syntax

### Related issues

- #26066 — Feishu accountId binding not working
- #17817 — Telegram multi-account: accountId in bindings ignored
- #26421 — Feishu Channel Binding Routing Not Working
- #26199 — Channel agentId 配置未生效

## Changes

### 1. `src/commands/agents.bindings.ts` — CLI behavior fix (core fix)

In `resolveBindingAccountId()`, when a channel has **multiple accounts** configured and no explicit `accountId` is provided (by the user or plugin), the function now returns `"*"` instead of `undefined`. This ensures that `openclaw agents add` and `openclaw agents bind` automatically create bindings that match all accounts on multi-account channels.

The fix is safe and backward-compatible:
- If user explicitly specifies accountId (e.g. `--bind telegram:alerts`), that is used (no change)
- If plugin provides its own `resolveBindingAccountId` hook, that is used (no change)
- If plugin has `forceAccountBinding`, the default account is used (no change)
- **NEW**: If channel has >1 accounts, `"*"` is returned (fixes the issue)
- If channel has only 1 account, `undefined` is returned (no change)

### 2. `src/config/types.agents.ts` — Type annotation

Added JSDoc to `AgentBindingMatch.accountId` explicitly documenting all three behaviors (omitted → default only, `"*"` → wildcard, string → specific account).

### 3. `docs/concepts/multi-agent.md` — Core routing docs

- Replaced the easy-to-miss plain text "Important account-scope detail" with a prominent `> [!WARNING]` callout block
- Updated "WhatsApp daily chat + Telegram deep work" example bindings to include `accountId: "*"`
- Updated "same channel, one peer to Opus" example bindings to include `accountId: "*"`
- Added `> [!TIP]` explaining that `"*"` is always safe even for single-account setups

### 4. `docs/cli/agents.md` — CLI reference

- Added `> [!WARNING]` callout to the "Binding scope behavior" section
- Added `--bind` format reference table (`:*`, `:<account>`, bare channel)
- Added example showing `agents add --bind` at creation time
- Added wildcard and specific-account examples to the bind examples section

## Test plan

- [ ] Run `openclaw agents add` with a channel that has multiple accounts — verify the created binding includes `accountId: "*"`
- [ ] Run `openclaw agents bind --bind telegram` with multiple telegram accounts — verify `accountId: "*"` is set
- [ ] Run `openclaw agents bind --bind telegram:alerts` — verify explicit accountId is preserved (not overridden to `"*"`)
- [ ] Run `openclaw agents add` with a single-account channel — verify no `accountId` is added (same behavior as before)
- [ ] Verify JSDoc renders correctly in IDE hover tooltips
- [ ] Verify `[!WARNING]` / `[!TIP]` callouts render properly on docs.openclaw.ai