### PR TITLE
fix(macos): fix menu bar icon not appearing on macOS 26 (Tahoe)

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .executable(name: "openclaw-mac", targets: ["OpenClawMacCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.2.2"),
+        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.8.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -51,7 +51,6 @@ struct OpenClawApp: App {
                 animationsEnabled: self.state.iconAnimationsEnabled && !self.isGatewaySleeping,
                 iconState: self.effectiveIconState)
         }
-        .menuBarExtraStyle(.menu)
         .menuBarExtraAccess(isPresented: self.$isMenuPresented) { item in
             self.statusItem = item
             MenuSessionsInjector.shared.install(into: item)
@@ -59,6 +58,7 @@ struct OpenClawApp: App {
             self.installStatusItemMouseHandler(for: item)
             self.updateHoverHUDSuppression()
         }
+        .menuBarExtraStyle(.menu)
         .onChange(of: self.state.isPaused) { _, paused in
             self.applyStatusItemAppearance(paused: paused, sleeping: self.isGatewaySleeping)
             if self.state.connectionMode == .local {


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), the OpenClaw menu bar icon never appears after launch, even though the process is running. The app is invisible and unusable.

Root cause: two compounding issues with `MenuBarExtraAccess`:

1. **Wrong version** — `exact: "1.2.2"` predates the Tahoe-compatible fix. v1.2.2 added macOS 26 beta 4 support, but v1.3.0 (released 2026-02-25) contains a deeper fix: "Improved reliability of status item discovery upon `MenuBarExtra` scene initialization".

2. **Wrong modifier order** — v1.3.0 requires `.menuBarExtraAccess(...)` to be the **first** scene modifier. In the current code it comes after `.menuBarExtraStyle(.menu)`, which means SwiftUI finalizes the scene before the library can hook into the status item — triggering the `NSStatusItemView` reconnect loop visible in logs:
   ```
   NSStatusItemView ... Dropping transition context because the scene is reconnecting
   ```

## Fix

- `Package.swift`: bump `MenuBarExtraAccess` from `exact: "1.2.2"` → `from: "1.3.0"`
- `MenuBar.swift`: move `.menuBarExtraAccess(...)` before `.menuBarExtraStyle(.menu)`

## Testing

Tested on macOS 26.0.1 (25A362, arm64). Menu bar icon now appears on first launch.

Closes #29081