### PR TITLE
docs: add NovaSpine Memory community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **NovaSpine Memory** — Local-first long-term memory for OpenClaw with recall, rollover capture, compression, provenance, and fact resolution.
+  npm: `novaspine-openclaw-memory`
+  repo: `https://github.com/maddwiz/Novaspine-Openclaw`
+  install: `openclaw plugins install novaspine-openclaw-memory`


### PR DESCRIPTION
Adds the NovaSpine Memory plugin to the community plugins page.

Details:
- npm: `novaspine-openclaw-memory`
- repo: https://github.com/maddwiz/Novaspine-Openclaw
- install: `openclaw plugins install novaspine-openclaw-memory`

The package is published on npm, the source is public on GitHub, and the repo includes setup/use documentation and issue tracking.