### PR TITLE
fix: preserve logical symlinked session paths

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -161,6 +161,50 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
   });
 
+  it("does not flag live transcripts as orphaned when ~/.openclaw is a symlink", async () => {
+    const cfg: OpenClawConfig = {};
+    const logicalStateDir = path.join(tempHome, ".openclaw");
+    const realStateDir = path.join(tempHome, "real-state");
+    fs.rmSync(logicalStateDir, { recursive: true, force: true });
+    fs.mkdirSync(realStateDir, { recursive: true });
+    fs.symlinkSync(realStateDir, logicalStateDir, "dir");
+    delete process.env.OPENCLAW_STATE_DIR;
+
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    const logicalTranscript = path.join(sessionsDir, "sess-1.jsonl");
+    fs.writeFileSync(logicalTranscript, '{"type":"session"}\n');
+    const realTranscript = fs.realpathSync(logicalTranscript);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:main": {
+            sessionId: "sess-1",
+            updatedAt: Date.now(),
+            sessionFile: realTranscript,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const confirmSkipInNonInteractive = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive });
+
+    expect(stateIntegrityText()).not.toContain("orphan transcript file");
+    expect(stateIntegrityText()).not.toContain(
+      "These .jsonl files are no longer referenced by sessions.json",
+    );
+    expect(confirmSkipInNonInteractive).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Archive"),
+      }),
+    );
+  });
+
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {
     const cfg: OpenClawConfig = {};
     writeSessionStore(cfg, {

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -168,6 +168,8 @@ describe("doctor state integrity oauth dir checks", () => {
     fs.rmSync(logicalStateDir, { recursive: true, force: true });
     fs.mkdirSync(realStateDir, { recursive: true });
     fs.symlinkSync(realStateDir, logicalStateDir, "dir");
+    // Let state-dir resolution go through HOME so the test exercises the logical
+    // ~/.openclaw symlink path instead of pinning everything to a real dir override.
     delete process.env.OPENCLAW_STATE_DIR;
 
     setupSessionState(cfg, process.env, process.env.HOME ?? "");

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -79,14 +79,15 @@ function resolvePathFromAgentSessionsDir(
   agentSessionsDir: string,
   candidateAbsPath: string,
 ): string | undefined {
-  const agentBase =
-    safeRealpathSync(path.resolve(agentSessionsDir)) ?? path.resolve(agentSessionsDir);
-  const realCandidate = safeRealpathSync(candidateAbsPath) ?? candidateAbsPath;
+  const resolvedAgentBase = path.resolve(agentSessionsDir);
+  const agentBase = safeRealpathSync(resolvedAgentBase) ?? resolvedAgentBase;
+  const resolvedCandidate = path.resolve(candidateAbsPath);
+  const realCandidate = safeRealpathSync(resolvedCandidate) ?? resolvedCandidate;
   const relative = path.relative(agentBase, realCandidate);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
     return undefined;
   }
-  return path.resolve(agentBase, relative);
+  return path.resolve(resolvedAgentBase, relative);
 }
 
 function resolveSiblingAgentSessionsDir(
@@ -189,7 +190,7 @@ function resolvePathWithinSessionsDir(
   if (normalized.startsWith("..") && path.isAbsolute(realTrimmed)) {
     const tryAgentFallback = (agentId: string): string | undefined => {
       const normalizedAgentId = normalizeAgentId(agentId);
-      const siblingSessionsDir = resolveSiblingAgentSessionsDir(realBase, normalizedAgentId);
+      const siblingSessionsDir = resolveSiblingAgentSessionsDir(resolvedBase, normalizedAgentId);
       if (siblingSessionsDir) {
         const siblingResolved = resolvePathFromAgentSessionsDir(siblingSessionsDir, realTrimmed);
         if (siblingResolved) {
@@ -229,7 +230,9 @@ function resolvePathWithinSessionsDir(
   if (!normalized || normalized.startsWith("..") || path.isAbsolute(normalized)) {
     throw new Error("Session file path must be within sessions directory");
   }
-  return path.resolve(realBase, normalized);
+  // Preserve the caller-visible sessions dir so symlinked ~/.openclaw paths
+  // stay stable in sessions.json and other diagnostics compare the same namespace.
+  return path.resolve(resolvedBase, normalized);
 }
 
 export function resolveSessionTranscriptPathInDir(

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -159,6 +159,36 @@ describe("session path safety", () => {
     }
   });
 
+  it("maps sibling fallback paths back to the logical symlinked sessions dir", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-sibling-session-"));
+    const realRoot = path.join(tmpDir, "real-state");
+    const aliasRoot = path.join(tmpDir, "alias-state");
+    try {
+      fs.mkdirSync(realRoot, { recursive: true });
+      fs.symlinkSync(realRoot, aliasRoot, "dir");
+      const logicalMainSessionsDir = path.join(aliasRoot, "agents", "main", "sessions");
+      const logicalWorkerSessionsDir = path.join(aliasRoot, "agents", "worker", "sessions");
+      fs.mkdirSync(logicalMainSessionsDir, { recursive: true });
+      fs.mkdirSync(logicalWorkerSessionsDir, { recursive: true });
+      const logicalWorkerTranscript = path.join(logicalWorkerSessionsDir, "sess-1.jsonl");
+      fs.writeFileSync(logicalWorkerTranscript, "");
+      const storedRealTranscript = fs.realpathSync(logicalWorkerTranscript);
+
+      const resolved = resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: storedRealTranscript },
+        { sessionsDir: logicalMainSessionsDir, agentId: "worker" },
+      );
+
+      expect(resolved).toBe(logicalWorkerTranscript);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back when sessionFile is a symlink that escapes sessions dir", () => {
     if (process.platform === "win32") {
       return;

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -101,6 +101,64 @@ describe("session path safety", () => {
     }
   });
 
+  it("preserves logical session paths when the sessions dir is a symlink", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-logical-session-"));
+    const realRoot = path.join(tmpDir, "real-state");
+    const aliasRoot = path.join(tmpDir, "alias-state");
+    try {
+      fs.mkdirSync(realRoot, { recursive: true });
+      fs.symlinkSync(realRoot, aliasRoot, "dir");
+      const logicalSessionsDir = path.join(aliasRoot, "agents", "main", "sessions");
+      fs.mkdirSync(logicalSessionsDir, { recursive: true });
+      const logicalTranscript = path.join(logicalSessionsDir, "sess-1.jsonl");
+      fs.writeFileSync(logicalTranscript, "");
+
+      const resolved = resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: logicalTranscript },
+        { sessionsDir: logicalSessionsDir },
+      );
+
+      expect(resolved).toBe(logicalTranscript);
+      expect(fs.realpathSync(resolved)).toBe(
+        fs.realpathSync(path.join(realRoot, "agents", "main", "sessions", "sess-1.jsonl")),
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("maps stored real session paths back to the logical symlinked sessions dir", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-symlink-real-session-"));
+    const realRoot = path.join(tmpDir, "real-state");
+    const aliasRoot = path.join(tmpDir, "alias-state");
+    try {
+      fs.mkdirSync(realRoot, { recursive: true });
+      fs.symlinkSync(realRoot, aliasRoot, "dir");
+      const logicalSessionsDir = path.join(aliasRoot, "agents", "main", "sessions");
+      fs.mkdirSync(logicalSessionsDir, { recursive: true });
+      const logicalTranscript = path.join(logicalSessionsDir, "sess-1.jsonl");
+      fs.writeFileSync(logicalTranscript, "");
+      const storedRealTranscript = fs.realpathSync(logicalTranscript);
+
+      const resolved = resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: storedRealTranscript },
+        { sessionsDir: logicalSessionsDir },
+      );
+
+      expect(resolved).toBe(logicalTranscript);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back when sessionFile is a symlink that escapes sessions dir", () => {
     if (process.platform === "win32") {
       return;


### PR DESCRIPTION
## Summary
- keep realpath-based safety checks for session files, but return and persist logical session paths under the caller-visible sessions directory
- normalize legacy stored real paths back to the logical symlinked path so `openclaw doctor` does not report false orphan transcripts
- add regression coverage for symlinked session dirs, sibling fallback handling, and doctor orphan detection

## Reproduction
Before this change, a symlinked `~/.openclaw` caused `resolveSessionFilePath()` to canonicalize `sessionFile` values into the symlink target. `openclaw doctor` scans the logical sessions directory, so those stored real paths were misclassified as orphaned transcripts.

## Validation
- reproduced the mismatch with a temporary symlinked state dir before the fix
- reran the same harness after the fix and verified both logical and legacy stored real paths resolve back to the logical transcript path
- added regression coverage in `src/config/sessions/sessions.test.ts` and `src/commands/doctor-state-integrity.test.ts`

## AI Assistance
- AI-assisted: yes (implemented with Codex plus manual verification and follow-up fixes)
- Testing degree: targeted/source-level validation plus focused regression tests in the changed modules; full local `pnpm build && pnpm check && pnpm test` was not available in the initial sandbox, so broader validation is currently delegated to repository CI

Fixes #49708
