### PR TITLE
fix: retry same auth profile on transient overloaded errors before failover

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -66,6 +66,9 @@ export const mockedEnsureRuntimePluginsLoaded = vi.fn<(params?: unknown) => void
 export const mockedPrepareProviderRuntimeAuth = vi.fn(async () => undefined);
 export const mockedRunEmbeddedAttempt =
   vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
+export const mockedMarkAuthProfileFailure = vi.fn(async () => {});
+export const mockedMarkAuthProfileGood = vi.fn(async () => {});
+export const mockedMarkAuthProfileUsed = vi.fn(async () => {});
 export const mockedSessionLikelyHasOversizedToolResults = vi.fn(() => false);
 export const mockedTruncateOversizedToolResultsInSession = vi.fn<
   () => Promise<MockTruncateOversizedToolResultsResult>
@@ -120,6 +123,7 @@ export const mockedLog: {
 };
 
 export const mockedClassifyFailoverReason = vi.fn(() => null);
+export const mockedIsFailoverAssistantError = vi.fn(() => false);
 export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;
@@ -173,6 +177,12 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedPrepareProviderRuntimeAuth.mockReset();
   mockedPrepareProviderRuntimeAuth.mockResolvedValue(undefined);
   mockedRunEmbeddedAttempt.mockReset();
+  mockedMarkAuthProfileFailure.mockReset();
+  mockedMarkAuthProfileFailure.mockResolvedValue(undefined);
+  mockedMarkAuthProfileGood.mockReset();
+  mockedMarkAuthProfileGood.mockResolvedValue(undefined);
+  mockedMarkAuthProfileUsed.mockReset();
+  mockedMarkAuthProfileUsed.mockResolvedValue(undefined);
   mockedSessionLikelyHasOversizedToolResults.mockReset();
   mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
   mockedTruncateOversizedToolResultsInSession.mockReset();
@@ -205,6 +215,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
 
   mockedClassifyFailoverReason.mockReset();
   mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedIsFailoverAssistantError.mockReset();
+  mockedIsFailoverAssistantError.mockReturnValue(false);
   mockedExtractObservedOverflowTokenCount.mockReset();
   mockedExtractObservedOverflowTokenCount.mockImplementation((msg?: string) => {
     const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
@@ -250,9 +262,9 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../auth-profiles.js", () => ({
     isProfileInCooldown: vi.fn(() => false),
-    markAuthProfileFailure: vi.fn(async () => {}),
-    markAuthProfileGood: vi.fn(async () => {}),
-    markAuthProfileUsed: vi.fn(async () => {}),
+    markAuthProfileFailure: mockedMarkAuthProfileFailure,
+    markAuthProfileGood: mockedMarkAuthProfileGood,
+    markAuthProfileUsed: mockedMarkAuthProfileUsed,
     resolveProfilesUnavailableReason: vi.fn(() => undefined),
   }));
 
@@ -290,7 +302,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isBillingAssistantError: vi.fn(() => false),
     isCompactionFailureError: mockedIsCompactionFailureError,
     isLikelyContextOverflowError: mockedIsLikelyContextOverflowError,
-    isFailoverAssistantError: vi.fn(() => false),
+    isFailoverAssistantError: mockedIsFailoverAssistantError,
     isFailoverErrorMessage: vi.fn(() => false),
     parseImageSizeError: vi.fn(() => null),
     parseImageDimensionError: vi.fn(() => null),

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -122,8 +122,12 @@ export const mockedLog: {
   isEnabled: vi.fn(() => false),
 };
 
-export const mockedClassifyFailoverReason = vi.fn(() => null);
-export const mockedIsFailoverAssistantError = vi.fn(() => false);
+export const mockedClassifyFailoverReason = vi.fn<(message?: string) => "overloaded" | null>(
+  () => null,
+);
+export const mockedIsFailoverAssistantError = vi.fn<
+  (assistant?: { errorMessage?: string }) => boolean
+>(() => false);
 export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;

--- a/src/agents/pi-embedded-runner/run.overloaded-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.overloaded-retry.test.ts
@@ -30,7 +30,7 @@ function makeSuccessfulAssistant(): EmbeddedRunAttemptResult["lastAssistant"] {
       cacheWrite: 0,
       total: 300,
     },
-  } as EmbeddedRunAttemptResult["lastAssistant"];
+  } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
 }
 
 describe("same-profile overloaded retry loop", () => {

--- a/src/agents/pi-embedded-runner/run.overloaded-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.overloaded-retry.test.ts
@@ -1,0 +1,96 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverReason,
+  mockedIsFailoverAssistantError,
+  mockedLog,
+  mockedMarkAuthProfileGood,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams as baseParams,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+function makeOverloadedAssistant(): EmbeddedRunAttemptResult["lastAssistant"] {
+  return {
+    stopReason: "error",
+    errorMessage:
+      '{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}',
+  } as EmbeddedRunAttemptResult["lastAssistant"];
+}
+
+function makeSuccessfulAssistant(): EmbeddedRunAttemptResult["lastAssistant"] {
+  return {
+    stopReason: "end_turn",
+    usage: {
+      input: 100,
+      cacheRead: 200,
+      cacheWrite: 0,
+      total: 300,
+    },
+  } as EmbeddedRunAttemptResult["lastAssistant"];
+}
+
+describe("same-profile overloaded retry loop", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    mockedRunEmbeddedAttempt.mockReset();
+    mockedClassifyFailoverReason.mockReset();
+    mockedClassifyFailoverReason.mockImplementation((message?: string) =>
+      String(message ?? "").includes("overloaded_error") ? "overloaded" : null,
+    );
+    mockedIsFailoverAssistantError.mockReset();
+    mockedIsFailoverAssistantError.mockImplementation((assistant?: { errorMessage?: string }) =>
+      String(assistant?.errorMessage ?? "").includes("overloaded_error"),
+    );
+    mockedMarkAuthProfileGood.mockReset();
+    mockedMarkAuthProfileGood.mockResolvedValue(undefined);
+    mockedLog.warn.mockReset();
+    mockedLog.info.mockReset();
+    mockedLog.debug.mockReset();
+    mockedLog.error.mockReset();
+  });
+
+  it("retries twice on overloaded assistant errors and succeeds on the third attempt", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          lastAssistant: makeOverloadedAssistant(),
+          assistantTexts: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          lastAssistant: makeOverloadedAssistant(),
+          assistantTexts: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          lastAssistant: makeSuccessfulAssistant(),
+          assistantTexts: ["ok"],
+        }),
+      );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(mockedMarkAuthProfileGood).toHaveBeenCalledTimes(3);
+    expect(
+      mockedLog.warn.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("retrying same profile for anthropic/test-model"),
+      ),
+    ).toHaveLength(2);
+    expect(result.meta.error).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -106,6 +106,15 @@ const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
 // Retry the *same* profile on transient overloaded errors before rotating or
 // surfacing the failure.  The delays are deliberately longer than the failover
 // backoff because a 529 usually resolves within seconds/minutes.
+//
+// Worst-case added latency before surfacing an error:
+//   attempt 1: ~2s, attempt 2: ~4s, attempt 3: ~8s → total ~14s (plus jitter).
+// This is a meaningful but acceptable delay — users previously had to manually
+// retry, which took longer.
+//
+// Complementary to PR #49807 which prevents overloaded errors from triggering
+// auth profile cooldown escalation.  Together they form a coherent response:
+// don't penalize the profile (49807) and do retry it with backoff (this).
 const OVERLOAD_SAME_PROFILE_RETRY_POLICY: BackoffPolicy = {
   initialMs: 2_000,
   maxMs: 30_000,
@@ -888,6 +897,44 @@ export async function runEmbeddedPiAgent(
           throw err;
         }
       };
+      const maybeRetrySameProfileOnOverload = async (options: {
+        stage: "prompt" | "assistant";
+        reason: FailoverReason | null;
+        profileId?: string;
+        logDecision: (decision: "retry_same_profile") => void;
+      }): Promise<boolean> => {
+        const { stage, reason, profileId, logDecision } = options;
+        if (
+          reason !== "overloaded" ||
+          overloadSameProfileRetries >= MAX_OVERLOAD_SAME_PROFILE_RETRIES
+        ) {
+          return false;
+        }
+        overloadSameProfileRetries += 1;
+        const delayMs = computeBackoff(
+          OVERLOAD_SAME_PROFILE_RETRY_POLICY,
+          overloadSameProfileRetries,
+        );
+        log.warn(
+          `${stage === "prompt" ? "overloaded (prompt)" : "overloaded"} — retrying same profile for ${provider}/${modelId}: ` +
+            `attempt=${overloadSameProfileRetries}/${MAX_OVERLOAD_SAME_PROFILE_RETRIES} ` +
+            `delayMs=${delayMs}`,
+        );
+        logDecision("retry_same_profile");
+        // Compatibility note: before PR #49807, overloaded errors could still
+        // mark the profile as failed. Clearing the state here keeps same-profile
+        // retry working both before and after that companion fix lands.
+        if (profileId) {
+          await markAuthProfileGood({
+            store: authStore,
+            provider,
+            profileId,
+            agentDir,
+          });
+        }
+        await sleepWithAbort(delayMs, params.abortSignal);
+        return true;
+      };
       // Resolve the context engine once and reuse across retries to avoid
       // repeated initialization/connection overhead per attempt.
       ensureContextEnginesInitialized();
@@ -1421,31 +1468,14 @@ export async function runEmbeddedPiAgent(
               overloadSameProfileRetries = 0;
               continue;
             }
-            // No other profile — retry the same profile on overloaded errors.
             if (
-              promptFailoverReason === "overloaded" &&
-              overloadSameProfileRetries < MAX_OVERLOAD_SAME_PROFILE_RETRIES
+              await maybeRetrySameProfileOnOverload({
+                stage: "prompt",
+                reason: promptFailoverReason,
+                profileId: lastProfileId,
+                logDecision: logPromptFailoverDecision,
+              })
             ) {
-              overloadSameProfileRetries += 1;
-              const delayMs = computeBackoff(
-                OVERLOAD_SAME_PROFILE_RETRY_POLICY,
-                overloadSameProfileRetries,
-              );
-              log.warn(
-                `overloaded (prompt) — retrying same profile for ${provider}/${modelId}: ` +
-                  `attempt=${overloadSameProfileRetries}/${MAX_OVERLOAD_SAME_PROFILE_RETRIES} ` +
-                  `delayMs=${delayMs}`,
-              );
-              logPromptFailoverDecision("retry_same_profile");
-              if (lastProfileId) {
-                await markAuthProfileGood({
-                  store: authStore,
-                  provider,
-                  profileId: lastProfileId,
-                  agentDir,
-                });
-              }
-              await sleepWithAbort(delayMs, params.abortSignal);
               continue;
             }
             const fallbackThinking = pickFallbackThinkingLevel({
@@ -1463,6 +1493,9 @@ export async function runEmbeddedPiAgent(
             // are configured so outer model fallback can continue on overload,
             // rate-limit, auth, or billing failures.
             if (fallbackConfigured && promptFailoverFailure) {
+              // Reset the same-profile retry budget before handing control to a
+              // fallback model so the next candidate gets the same treatment.
+              overloadSameProfileRetries = 0;
               const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
               logPromptFailoverDecision("fallback_model", { status });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
@@ -1582,37 +1615,21 @@ export async function runEmbeddedPiAgent(
               continue;
             }
 
-            // No other profile available — retry the *same* profile on
-            // transient overloaded errors before giving up or falling back.
             if (
-              assistantFailoverReason === "overloaded" &&
-              overloadSameProfileRetries < MAX_OVERLOAD_SAME_PROFILE_RETRIES
+              await maybeRetrySameProfileOnOverload({
+                stage: "assistant",
+                reason: assistantFailoverReason,
+                profileId: lastProfileId,
+                logDecision: logAssistantFailoverDecision,
+              })
             ) {
-              overloadSameProfileRetries += 1;
-              const delayMs = computeBackoff(
-                OVERLOAD_SAME_PROFILE_RETRY_POLICY,
-                overloadSameProfileRetries,
-              );
-              log.warn(
-                `overloaded — retrying same profile for ${provider}/${modelId}: ` +
-                  `attempt=${overloadSameProfileRetries}/${MAX_OVERLOAD_SAME_PROFILE_RETRIES} ` +
-                  `delayMs=${delayMs}`,
-              );
-              logAssistantFailoverDecision("retry_same_profile");
-              // Un-mark the profile failure so the same profile is used on retry.
-              if (lastProfileId) {
-                await markAuthProfileGood({
-                  store: authStore,
-                  provider,
-                  profileId: lastProfileId,
-                  agentDir,
-                });
-              }
-              await sleepWithAbort(delayMs, params.abortSignal);
               continue;
             }
 
             if (fallbackConfigured) {
+              // Reset the same-profile retry budget before handing control to a
+              // fallback model so the next candidate gets the same treatment.
+              overloadSameProfileRetries = 0;
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               // Prefer formatted error message (user-friendly) over raw errorMessage
               const message =

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1722,7 +1722,8 @@ export async function runEmbeddedPiAgent(
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
-          // Reset overload retry counter on success.
+          // Reset overload retry counter after each successful LLM response.
+          // This gives each attempt within the run loop its full retry budget.
           overloadSameProfileRetries = 0;
           if (lastProfileId) {
             await markAuthProfileGood({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -103,6 +103,17 @@ const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
   jitter: 0.2,
 };
 
+// Retry the *same* profile on transient overloaded errors before rotating or
+// surfacing the failure.  The delays are deliberately longer than the failover
+// backoff because a 529 usually resolves within seconds/minutes.
+const OVERLOAD_SAME_PROFILE_RETRY_POLICY: BackoffPolicy = {
+  initialMs: 2_000,
+  maxMs: 30_000,
+  factor: 2,
+  jitter: 0.25,
+};
+const MAX_OVERLOAD_SAME_PROFILE_RETRIES = 3;
+
 // Avoid Anthropic's refusal test token poisoning session transcripts.
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
@@ -827,6 +838,7 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      let overloadSameProfileRetries = 0;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -1406,6 +1418,34 @@ export async function runEmbeddedPiAgent(
             ) {
               logPromptFailoverDecision("rotate_profile");
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+              overloadSameProfileRetries = 0;
+              continue;
+            }
+            // No other profile — retry the same profile on overloaded errors.
+            if (
+              promptFailoverReason === "overloaded" &&
+              overloadSameProfileRetries < MAX_OVERLOAD_SAME_PROFILE_RETRIES
+            ) {
+              overloadSameProfileRetries += 1;
+              const delayMs = computeBackoff(
+                OVERLOAD_SAME_PROFILE_RETRY_POLICY,
+                overloadSameProfileRetries,
+              );
+              log.warn(
+                `overloaded (prompt) — retrying same profile for ${provider}/${modelId}: ` +
+                  `attempt=${overloadSameProfileRetries}/${MAX_OVERLOAD_SAME_PROFILE_RETRIES} ` +
+                  `delayMs=${delayMs}`,
+              );
+              logPromptFailoverDecision("retry_same_profile");
+              if (lastProfileId) {
+                await markAuthProfileGood({
+                  store: authStore,
+                  provider,
+                  profileId: lastProfileId,
+                  agentDir,
+                });
+              }
+              await sleepWithAbort(delayMs, params.abortSignal);
               continue;
             }
             const fallbackThinking = pickFallbackThinkingLevel({
@@ -1538,6 +1578,37 @@ export async function runEmbeddedPiAgent(
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
+              overloadSameProfileRetries = 0;
+              continue;
+            }
+
+            // No other profile available — retry the *same* profile on
+            // transient overloaded errors before giving up or falling back.
+            if (
+              assistantFailoverReason === "overloaded" &&
+              overloadSameProfileRetries < MAX_OVERLOAD_SAME_PROFILE_RETRIES
+            ) {
+              overloadSameProfileRetries += 1;
+              const delayMs = computeBackoff(
+                OVERLOAD_SAME_PROFILE_RETRY_POLICY,
+                overloadSameProfileRetries,
+              );
+              log.warn(
+                `overloaded — retrying same profile for ${provider}/${modelId}: ` +
+                  `attempt=${overloadSameProfileRetries}/${MAX_OVERLOAD_SAME_PROFILE_RETRIES} ` +
+                  `delayMs=${delayMs}`,
+              );
+              logAssistantFailoverDecision("retry_same_profile");
+              // Un-mark the profile failure so the same profile is used on retry.
+              if (lastProfileId) {
+                await markAuthProfileGood({
+                  store: authStore,
+                  provider,
+                  profileId: lastProfileId,
+                  agentDir,
+                });
+              }
+              await sleepWithAbort(delayMs, params.abortSignal);
               continue;
             }
 
@@ -1651,6 +1722,8 @@ export async function runEmbeddedPiAgent(
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
+          // Reset overload retry counter on success.
+          overloadSameProfileRetries = 0;
           if (lastProfileId) {
             await markAuthProfileGood({
               store: authStore,

--- a/src/agents/pi-embedded-runner/run/failover-observation.ts
+++ b/src/agents/pi-embedded-runner/run/failover-observation.ts
@@ -9,7 +9,7 @@ import { log } from "../logger.js";
 
 export type FailoverDecisionLoggerInput = {
   stage: "prompt" | "assistant";
-  decision: "rotate_profile" | "fallback_model" | "surface_error";
+  decision: "rotate_profile" | "retry_same_profile" | "fallback_model" | "surface_error";
   runId?: string;
   rawError?: string;
   failoverReason: FailoverReason | null;


### PR DESCRIPTION
## Summary

- **Problem:** When the LLM API returns a transient `overloaded` error (HTTP 529 / `overloaded_error`), OpenClaw tries to rotate to the next auth profile. If only one profile is configured for the provider, the error is surfaced immediately with "The AI service is temporarily overloaded. Please try again in a moment." — no retry.
- **Why it matters:** During Anthropic capacity spikes (frequent in March 2026), agents with a single API key become unresponsive. Users must manually resend messages. The cron subsystem already has configurable retry (`cron.retry`), but the main LLM request path does not.
- **What changed:** Added a same-profile retry loop (up to 3 attempts, exponential backoff 2s→4s→8s, jitter 25%, capped at 30s) for `overloaded` errors when no other profile is available. Applies to both prompt-side and assistant-side error paths.
- **What did NOT change (scope boundary):** Existing profile rotation, fallback model logic, and backoff-before-failover behavior are untouched. Rate-limit, auth, billing, and format errors are NOT retried. The retry counter resets on success. No new config surface (hardcoded constants — a follow-up could expose these via `agents.defaults.llmRetry`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49376
- Closes #48913
- Related #49696
- Related #24321

## User-visible / Behavior Changes

- When a single-profile provider returns `overloaded` (529), the agent now silently retries up to 3 times with exponential backoff (2s, 4s, 8s) before surfacing the error.
- Log messages at `warn` level: `overloaded — retrying same profile for <provider>/<model>: attempt=N/3 delayMs=X`.
- Failover observation logs a new decision value: `retry_same_profile`.
- If all 3 retries are exhausted, behavior is identical to before (fallback model or surface error).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same LLM API call, just retried)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node 24
- Model/provider: Anthropic Claude Opus 4.6 (single API key profile)
- Channel: Telegram

### Steps

1. Configure an agent with a single Anthropic auth profile (no fallbacks).
2. Send a message when Anthropic API is overloaded (returns 529).
3. **Before fix:** Error surfaced immediately.
4. **After fix:** Agent retries up to 3 times with backoff, then surfaces error only if still overloaded.

### Expected

Agent retries transparently and recovers when the API comes back within ~15s.

### Actual

Agent retries (visible in warn logs) and succeeds on retry, or surfaces error after 3 failed attempts.

## Evidence

- `tsgo` type check: 0 errors ✅
- `oxlint` on changed files: 0 warnings, 0 errors ✅
- `vitest run` on `failover-observation.test.ts`: 2/2 passed ✅
- `vitest run` on `runs.test.ts`: 6/6 passed ✅

## Human Verification (required)

- Verified: TypeScript compiles, lint passes, existing tests pass.
- Verified: Code review of both prompt-side and assistant-side paths — retry only triggers for `overloaded` reason, counter resets on success and on profile rotation.
- Edge cases checked: abort signal interrupts retry sleep; counter does not interfere with existing `overloadFailoverAttempts`; `markAuthProfileGood` is called before retry to clear cooldown state.
- What I did **not** verify: Live 529 error from Anthropic (cannot reproduce on demand).

## Review Conversations

- [x] N/A (new PR)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit to restore previous behavior (immediate surface on overloaded).
- The retry is bounded (3 attempts, ~15s max wall-clock) and respects abort signals, so it cannot cause infinite loops.
- Watch for: warn-level log spam if overload is persistent (3 log lines per failed request vs 0 before).

## Risks and Mitigations

- Risk: Retry adds up to ~15s latency before surfacing a persistent overload error.
  - Mitigation: 3 retries with 2s/4s/8s backoff is a reasonable tradeoff. Users previously had to manually retry anyway. A future config option could let users tune this.
- Risk: `markAuthProfileGood` call before retry could mask a genuinely bad profile.
  - Mitigation: Only called for `overloaded` reason (transient), not for auth/billing/format errors. The profile was working before the overload.