### PR TITLE
fix: exclude overloaded errors from auth profile cooldown escalation

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -73,6 +73,7 @@ import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
+import { resolveAuthProfileFailureReason } from "./run/resolve-profile-failure-reason.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
@@ -835,6 +836,9 @@ export async function runEmbeddedPiAgent(
       }) => {
         const { profileId, reason } = failure;
         if (!profileId || !reason || reason === "timeout" || reason === "overloaded") {
+          if (reason === "overloaded") {
+            log.warn(`auth profile ${profileId} overloaded — skipping cooldown (transient 529)`);
+          }
           return;
         }
         await markAuthProfileFailure({
@@ -846,20 +850,10 @@ export async function runEmbeddedPiAgent(
           runId: params.runId,
         });
       };
-      const resolveAuthProfileFailureReason = (
-        failoverReason: FailoverReason | null,
-      ): AuthProfileFailureReason | null => {
-        // Timeouts are transport/model-path failures, not auth health signals,
-        // so they should not persist auth-profile failure state.
-        // Overloaded errors (529) are transient server-side capacity issues —
-        // the auth profile itself is healthy.  Marking it as failed causes an
-        // exponential cooldown (60s → 5min → 25min → 1h) that makes the
-        // profile unusable long after the provider has recovered.
-        if (!failoverReason || failoverReason === "timeout" || failoverReason === "overloaded") {
-          return null;
-        }
-        return failoverReason;
-      };
+      // resolveAuthProfileFailureReason is imported from
+      // ./run/resolve-profile-failure-reason.ts — see that module for the
+      // rationale on which failover reasons are excluded from profile failure
+      // tracking (timeout, overloaded).
       const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
         if (reason !== "overloaded") {
           return;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -834,7 +834,7 @@ export async function runEmbeddedPiAgent(
         agentDir?: RunEmbeddedPiAgentParams["agentDir"];
       }) => {
         const { profileId, reason } = failure;
-        if (!profileId || !reason || reason === "timeout") {
+        if (!profileId || !reason || reason === "timeout" || reason === "overloaded") {
           return;
         }
         await markAuthProfileFailure({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -851,7 +851,11 @@ export async function runEmbeddedPiAgent(
       ): AuthProfileFailureReason | null => {
         // Timeouts are transport/model-path failures, not auth health signals,
         // so they should not persist auth-profile failure state.
-        if (!failoverReason || failoverReason === "timeout") {
+        // Overloaded errors (529) are transient server-side capacity issues —
+        // the auth profile itself is healthy.  Marking it as failed causes an
+        // exponential cooldown (60s → 5min → 25min → 1h) that makes the
+        // profile unusable long after the provider has recovered.
+        if (!failoverReason || failoverReason === "timeout" || failoverReason === "overloaded") {
           return null;
         }
         return failoverReason;

--- a/src/agents/pi-embedded-runner/run/resolve-profile-failure-reason.test.ts
+++ b/src/agents/pi-embedded-runner/run/resolve-profile-failure-reason.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveAuthProfileFailureReason } from "./resolve-profile-failure-reason.js";
+
+describe("resolveAuthProfileFailureReason", () => {
+  it("returns null for null input", () => {
+    expect(resolveAuthProfileFailureReason(null)).toBeNull();
+  });
+
+  it("returns null for timeout (transport failure, not auth issue)", () => {
+    expect(resolveAuthProfileFailureReason("timeout")).toBeNull();
+  });
+
+  it("returns null for overloaded (transient 529, not auth issue)", () => {
+    expect(resolveAuthProfileFailureReason("overloaded")).toBeNull();
+  });
+
+  it("passes through rate_limit as a valid failure reason", () => {
+    expect(resolveAuthProfileFailureReason("rate_limit")).toBe("rate_limit");
+  });
+
+  it("passes through billing as a valid failure reason", () => {
+    expect(resolveAuthProfileFailureReason("billing")).toBe("billing");
+  });
+
+  it("passes through auth as a valid failure reason", () => {
+    expect(resolveAuthProfileFailureReason("auth")).toBe("auth");
+  });
+
+  it("passes through auth_permanent as a valid failure reason", () => {
+    expect(resolveAuthProfileFailureReason("auth_permanent")).toBe("auth_permanent");
+  });
+
+  it("passes through unknown reasons", () => {
+    expect(resolveAuthProfileFailureReason("unknown")).toBe("unknown");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/resolve-profile-failure-reason.ts
+++ b/src/agents/pi-embedded-runner/run/resolve-profile-failure-reason.ts
@@ -1,0 +1,21 @@
+import type { AuthProfileFailureReason } from "../../auth-profiles.js";
+import type { FailoverReason } from "../../pi-embedded-helpers.js";
+
+/**
+ * Map a failover reason to an auth-profile failure reason.
+ *
+ * Returns `null` for reasons that should NOT mark the auth profile as failed:
+ * - `null` / missing: no failure to record.
+ * - `"timeout"`: transport/model-path failure, not an auth health signal.
+ * - `"overloaded"`: transient server-side capacity issue (HTTP 529). The
+ *   profile itself is healthy; marking it as failed causes exponential
+ *   cooldown escalation that outlasts the provider recovery.
+ */
+export function resolveAuthProfileFailureReason(
+  failoverReason: FailoverReason | null,
+): AuthProfileFailureReason | null {
+  if (!failoverReason || failoverReason === "timeout" || failoverReason === "overloaded") {
+    return null;
+  }
+  return failoverReason;
+}


### PR DESCRIPTION
## Summary

- **Problem:** Transient `overloaded` errors (HTTP 529) are persisted to auth profile failure stats, triggering exponential cooldown escalation (`60s × 5^(n-1)`, up to 1 hour). This causes a cascading failure where the profile becomes unusable long after the provider recovers.
- **Why it matters:** Two agents sharing the same Anthropic API key and model — one works fine, the other is stuck in cooldown for 25+ minutes after a brief 529 spike. The agent that first hit the 529 enters a death spiral: retry → 529 or cooldown → error count ↑ → longer cooldown → repeat.
- **What changed:** `resolveAuthProfileFailureReason()` now returns `null` for `"overloaded"` (same treatment as `"timeout"`), so overloaded errors do not persist to usage stats or trigger cooldown escalation. The profile stays healthy for immediate retry.
- **What did NOT change:** Rate-limit, billing, auth, and format errors still trigger cooldown as before. The `maybeBackoffBeforeOverloadFailover()` backoff between profile rotations is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49696
- Related #49376
- Related #48913
- Related #24321
- Related #49800

## User-visible / Behavior Changes

- `overloaded` (529) errors no longer cause auth profile cooldown escalation.
- After a 529 spike, the agent can immediately retry instead of waiting out an exponentially growing cooldown window.
- Two agents sharing the same API key will no longer have divergent availability after one hits a transient 529.
- Log change: `auth_profile_failure_state_updated` events will no longer appear for `reason: "overloaded"`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin arm64
- Runtime: Node 24
- Model/provider: Anthropic Claude Opus 4.6 (single API key, no fallbacks)
- Channel: Telegram

### Steps

1. Configure two agents (A and B) with the same Anthropic API key, same model, no fallbacks.
2. During an Anthropic 529 spike, agent A gets overloaded errors.
3. Anthropic recovers after ~1 minute.
4. **Before fix:** Agent A is stuck in 5-25min cooldown. Agent B (which never hit 529) works fine. Same key, same model, different availability.
5. **After fix:** Agent A can immediately retry after the 529 clears. No cooldown escalation.

### Expected

Both agents recover as soon as Anthropic's 529 clears.

### Actual (before fix)

Agent A stuck in exponential cooldown (observed: 16 consecutive overloaded errors over 28 minutes, cooldown escalating from 60s to 25min+).

## Evidence

- Gateway logs showing cascading cooldown: `cooldownUntil` values increasing from `1773837921711` → `1773838086435` → `1773838284549` (3+ minute jumps between each)
- `tsgo` type check: 0 errors ✅
- `oxlint`: 0 warnings, 0 errors ✅
- `vitest run` failover-observation + runs tests: 8/8 passed ✅

## Human Verification (required)

- Verified: Reproduced the cascading cooldown in gateway logs with real Anthropic 529 errors.
- Verified: After the fix, `resolveAuthProfileFailureReason("overloaded")` returns `null`, preventing `markAuthProfileFailure()` from being called.
- Edge cases: `overloaded` still triggers `maybeBackoffBeforeOverloadFailover()` for inter-profile rotation backoff (unchanged). Rate-limit errors still escalate cooldown correctly.
- What I did **not** verify: Live test with intentional 529 triggering (cannot reproduce on demand).

## Review Conversations

- [x] N/A (new PR)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit.
- Watch for: If overloaded errors are persistent (not transient), the profile will no longer be cooled down. But the existing `maybeBackoffBeforeOverloadFailover()` backoff still provides pacing between failover attempts.

## Risks and Mitigations

- Risk: Without cooldown, a truly overloaded provider gets hammered with retries.
  - Mitigation: The run loop already has `MAX_RUN_LOOP_ITERATIONS` to cap total retries. The related PR #49800 adds same-profile retry with exponential backoff (2s→4s→8s) which provides proper pacing.