### PR TITLE
fix: add openclaw workspace self-reference for extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -690,6 +690,7 @@
     "long": "^5.3.2",
     "markdown-it": "^14.1.1",
     "node-edge-tts": "^1.2.10",
+    "openclaw": "workspace:*",
     "opusscript": "^0.1.1",
     "osc-progress": "^0.3.0",
     "pdfjs-dist": "^5.5.207",


### PR DESCRIPTION
## Summary

iMessage extension fails to load with 'Cannot find package openclaw' error when using pnpm workspace.

## Fix

Add `workspace:*` self-reference to package.json to allow extensions to resolve the openclaw package.

## Related Issue

Fixes #49806