### PR TITLE
feat(openai-codex): add gpt-5.4-mini support for Codex OAuth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Browser/existing-session: support `browser.profiles.<name>.userDataDir` so Chrome DevTools MCP can attach to Brave, Edge, and other Chromium-based browsers through their own user data directories. (#48170) Thanks @velvet-shark.
 - Skills/prompt budget: preserve all registered skills via a compact catalog fallback before dropping entries when the full prompt format exceeds `maxSkillsPromptChars`. (#47553) Thanks @snese.
 - Models/OpenAI: add native forward-compat support for `gpt-5.4-mini` and `gpt-5.4-nano` in the OpenAI provider catalog, runtime resolution, and reasoning capability gates. Thanks @vincentkoc.
+- Models/OpenAI Codex: add `gpt-5.4-mini` support for the `openai-codex` OAuth provider — forward-compat resolution, catalog augmentation, xhigh thinking, and modern model filtering. (`gpt-5.4-nano` is API-only and not available via Codex OAuth.) Thanks @LittleMeHere.
 - Plugins/bundles: make enabled bundle MCP servers expose runnable tools in embedded Pi, and default relative bundle MCP launches to the bundle root so marketplace bundles like Context7 work through Pi instead of stopping at config import.
 - Scope message SecretRef resolution and harden doctor/status paths. (#48728) Thanks @joshavant.
 - Plugins/testing: add a public `openclaw/plugin-sdk/testing` surface for plugin-author test helpers, and move bundled-extension-only test bridges out of `extensions/` into private repo test helpers.

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -31,9 +31,11 @@ import {
 const PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
+const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS = 128_000;
@@ -42,6 +44,7 @@ const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 const OPENAI_CODEX_DEFAULT_MODEL = `${PROVIDER_ID}/${OPENAI_CODEX_GPT_54_MODEL_ID}`;
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   OPENAI_CODEX_GPT_53_MODEL_ID,
   OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
   "gpt-5.2-codex",
@@ -49,6 +52,7 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
 ] as const;
 const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   "gpt-5.2",
   "gpt-5.2-codex",
   OPENAI_CODEX_GPT_53_MODEL_ID,
@@ -99,6 +103,8 @@ function resolveCodexForwardCompatModel(
       contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
     };
+  } else if (lower === OPENAI_CODEX_GPT_54_MINI_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS;
   } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
     templateIds = [OPENAI_CODEX_GPT_53_MODEL_ID, ...OPENAI_CODEX_TEMPLATE_MODEL_IDS];
     patch = {
@@ -266,6 +272,11 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         providerId: PROVIDER_ID,
         templateIds: OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
       });
+      const gpt54MiniTemplate = findCatalogTemplate({
+        entries: ctx.entries,
+        providerId: PROVIDER_ID,
+        templateIds: OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS,
+      });
       const sparkTemplate = findCatalogTemplate({
         entries: ctx.entries,
         providerId: PROVIDER_ID,
@@ -277,6 +288,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
               ...gpt54Template,
               id: OPENAI_CODEX_GPT_54_MODEL_ID,
               name: OPENAI_CODEX_GPT_54_MODEL_ID,
+            }
+          : undefined,
+        gpt54MiniTemplate
+          ? {
+              ...gpt54MiniTemplate,
+              id: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+              name: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
             }
           : undefined,
         sparkTemplate

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -35,7 +35,6 @@ const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
-const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS = 128_000;
@@ -104,7 +103,7 @@ function resolveCodexForwardCompatModel(
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
     };
   } else if (lower === OPENAI_CODEX_GPT_54_MINI_MODEL_ID) {
-    templateIds = OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS;
+    templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
   } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
     templateIds = [OPENAI_CODEX_GPT_53_MODEL_ID, ...OPENAI_CODEX_TEMPLATE_MODEL_IDS];
     patch = {
@@ -272,11 +271,6 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         providerId: PROVIDER_ID,
         templateIds: OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
       });
-      const gpt54MiniTemplate = findCatalogTemplate({
-        entries: ctx.entries,
-        providerId: PROVIDER_ID,
-        templateIds: OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS,
-      });
       const sparkTemplate = findCatalogTemplate({
         entries: ctx.entries,
         providerId: PROVIDER_ID,
@@ -290,9 +284,9 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
               name: OPENAI_CODEX_GPT_54_MODEL_ID,
             }
           : undefined,
-        gpt54MiniTemplate
+        gpt54Template
           ? {
-              ...gpt54MiniTemplate,
+              ...gpt54Template,
               id: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
               name: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
             }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -244,6 +244,13 @@ describe("loadModelCatalog", () => {
         name: "gpt-5.4",
       }),
     );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai-codex",
+        id: "gpt-5.4-mini",
+        name: "gpt-5.4-mini",
+      }),
+    );
   });
 
   it("merges configured models for opted-in non-pi-native providers", async () => {

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -350,7 +350,7 @@ describe("isModernModelRef", () => {
       provider === "openai" &&
       ["gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"].includes(context.modelId)
         ? true
-        : provider === "openai-codex" && context.modelId === "gpt-5.4"
+        : provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-mini"].includes(context.modelId)
           ? true
           : provider === "opencode" && ["claude-opus-4-6", "gemini-3-pro"].includes(context.modelId)
             ? true
@@ -364,6 +364,7 @@ describe("isModernModelRef", () => {
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-nano" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "claude-opus-4-6" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "gemini-3-pro" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode-go", id: "kimi-k2.5" })).toBe(true);

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -666,6 +666,15 @@ describe("resolveModel", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("builds an openai-codex fallback for gpt-5.4-mini", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4-mini", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-mini"));
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex-spark", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
@@ -244,7 +244,7 @@ describe("directive behavior", () => {
 
       const unsupportedModelTexts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(unsupportedModelTexts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.4, openai/gpt-5.4-pro, openai/gpt-5.4-mini, openai/gpt-5.4-nano, openai/gpt-5.2, openai-codex/gpt-5.4, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.4, openai/gpt-5.4-pro, openai/gpt-5.4-mini, openai/gpt-5.4-nano, openai/gpt-5.2, openai-codex/gpt-5.4, openai-codex/gpt-5.4-mini, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });

--- a/src/plugins/contracts/runtime.contract.test.ts
+++ b/src/plugins/contracts/runtime.contract.test.ts
@@ -587,6 +587,31 @@ describe("provider runtime contract", () => {
       });
     });
 
+    it("owns openai-codex gpt-5.4 mini forward-compat resolution", () => {
+      const provider = requireProviderContractProvider("openai-codex");
+      const model = provider.resolveDynamicModel?.({
+        provider: "openai-codex",
+        modelId: "gpt-5.4-mini",
+        modelRegistry: {
+          find: (_provider: string, id: string) =>
+            id === "gpt-5.2-codex"
+              ? createModel({
+                  id,
+                  api: "openai-codex-responses",
+                  provider: "openai-codex",
+                  baseUrl: "https://chatgpt.com/backend-api",
+                })
+              : null,
+        } as never,
+      });
+
+      expect(model).toMatchObject({
+        id: "gpt-5.4-mini",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+      });
+    });
+
     it("owns codex transport defaults", () => {
       const provider = requireProviderContractProvider("openai-codex");
       expect(

--- a/src/plugins/provider-catalog-metadata.ts
+++ b/src/plugins/provider-catalog-metadata.ts
@@ -53,11 +53,6 @@ export function augmentBundledProviderCatalog(
     providerId: OPENAI_CODEX_PROVIDER_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
   });
-  const openAiCodexGpt54MiniTemplate = findCatalogTemplate({
-    entries: context.entries,
-    providerId: OPENAI_CODEX_PROVIDER_ID,
-    templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
-  });
   const openAiCodexSparkTemplate = findCatalogTemplate({
     entries: context.entries,
     providerId: OPENAI_CODEX_PROVIDER_ID,
@@ -100,9 +95,9 @@ export function augmentBundledProviderCatalog(
           name: "gpt-5.4",
         }
       : undefined,
-    openAiCodexGpt54MiniTemplate
+    openAiCodexGpt54Template
       ? {
-          ...openAiCodexGpt54MiniTemplate,
+          ...openAiCodexGpt54Template,
           id: "gpt-5.4-mini",
           name: "gpt-5.4-mini",
         }

--- a/src/plugins/provider-catalog-metadata.ts
+++ b/src/plugins/provider-catalog-metadata.ts
@@ -53,6 +53,11 @@ export function augmentBundledProviderCatalog(
     providerId: OPENAI_CODEX_PROVIDER_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
   });
+  const openAiCodexGpt54MiniTemplate = findCatalogTemplate({
+    entries: context.entries,
+    providerId: OPENAI_CODEX_PROVIDER_ID,
+    templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+  });
   const openAiCodexSparkTemplate = findCatalogTemplate({
     entries: context.entries,
     providerId: OPENAI_CODEX_PROVIDER_ID,
@@ -93,6 +98,13 @@ export function augmentBundledProviderCatalog(
           ...openAiCodexGpt54Template,
           id: "gpt-5.4",
           name: "gpt-5.4",
+        }
+      : undefined,
+    openAiCodexGpt54MiniTemplate
+      ? {
+          ...openAiCodexGpt54MiniTemplate,
+          id: "gpt-5.4-mini",
+          name: "gpt-5.4-mini",
         }
       : undefined,
     openAiCodexSparkTemplate

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -14,6 +14,7 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+  { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   {
     provider: "openai-codex",
     id: "gpt-5.3-codex-spark",

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -217,6 +217,7 @@ describe("provider-runtime", () => {
             { provider: "openai", id: "gpt-5.4", name: "gpt-5.4" },
             { provider: "openai", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
             { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+            { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
             {
               provider: "openai-codex",
               id: "gpt-5.3-codex-spark",
@@ -483,6 +484,7 @@ describe("provider-runtime", () => {
       { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
       { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+      { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       {
         provider: "openai-codex",
         id: "gpt-5.3-codex-spark",


### PR DESCRIPTION
## Summary

- **Problem:** `openai-codex/gpt-5.4-mini` is not recognized by the Codex OAuth provider — users get `Unknown model` / `missing` at runtime.
- **Why it matters:** GPT-5.4 mini launched March 17, 2026 and is [available in Codex](https://community.openai.com/t/introducing-gpt-5-4-mini-and-nano-our-most-capable-small-models-yet/1377015), but only the `openai` API key provider was updated (#49289). Most OpenClaw users authenticate via Codex OAuth.
- **What changed:** Forward-compat resolution, catalog augmentation, xhigh thinking, and modern model filtering for `gpt-5.4-mini` in the `openai-codex` provider.
- **What did NOT change (scope boundary):** `gpt-5.4-nano` is intentionally excluded — it is **API-only** per OpenAI and not available via Codex OAuth.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #37623 (openai-codex mini gap)
- Extends #49289 (which added `openai/gpt-5.4-mini` and `openai/gpt-5.4-nano`)

## User-visible / Behavior Changes

- `openai-codex/gpt-5.4-mini` resolves at runtime and appears in model listings for Codex OAuth users
- `/thinking xhigh` now works with `openai-codex/gpt-5.4-mini`
- The xhigh unsupported-model error message now includes `openai-codex/gpt-5.4-mini`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node v22.22.0
- Model/provider: openai-codex (OAuth)
- Relevant config: default openai-codex OAuth setup

### Steps

1. Configure `openai-codex/gpt-5.4-mini` as model
2. Run `openclaw models status`
3. Attempt to use the model in a session

### Expected

- Model resolves, shows as available, works at runtime

### Actual (before fix)

- Model shows `configured,missing`, fails with `Unknown model` at runtime

## Evidence

- [x] Test coverage: 7 test files updated with positive assertions for codex mini resolution, catalog augmentation, xhigh support, and modern model filtering
- `pnpm vitest run src/plugins/provider-runtime.test.ts` ✅
- `pnpm vitest run src/agents/model-compat.test.ts` ✅
- `pnpm vitest run extensions/openai/openai-provider.test.ts` ✅
- Lint passed (git hooks on commit)

## Human Verification (required)

- **Verified scenarios:** Reviewed `resolveCodexForwardCompatModel()` resolution path, catalog template cloning, xhigh/modern model id matching
- **Edge cases checked:** Confirmed `gpt-5.4-nano` is NOT in Codex per [OpenAI pricing](https://community.openai.com/t/introducing-gpt-5-4-mini-and-nano-our-most-capable-small-models-yet/1377015) (API-only: $0.20/$1.25 per 1M tokens) — intentionally excluded to avoid misinformation
- **What I did not verify:** Live end-to-end test against Codex OAuth backend (no access to a deployed instance with the patch applied)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit, gateway restart
- Files/config to restore: `extensions/openai/openai-codex-provider.ts`, `src/plugins/provider-catalog-metadata.ts`
- Known bad symptoms: `openai-codex/gpt-5.4-mini` showing as `missing` or `Unknown model` (same as current behavior — safe failure mode)

## Risks and Mitigations

- Risk: Template model (`gpt-5.3-codex` / `gpt-5.2-codex`) not found at catalog augmentation time → mini entry silently omitted
  - Mitigation: Same pattern used by existing `gpt-5.4` and `gpt-5.3-codex-spark` entries; graceful degradation via `.filter()`

## AI Disclosure

- [x] AI-assisted (OpenClaw/Claude — Havoc, local AI assistant)
- [x] Fully tested — 7 test files updated, 3 core test suites verified passing
- [x] I understand what the code does: forward-compat resolution clones existing codex template models to create runtime entries for gpt-5.4-mini, with matching catalog/xhigh/modern-model updates
- [x] Nano exclusion was a human catch — initially included, then removed after verifying OpenAI's announcement that nano is API-only