### PR TITLE
Plugins: consistent conversationId and accountId across hook contexts

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -333,6 +333,7 @@ export async function runEmbeddedPiAgent(
         messageProvider: params.messageProvider ?? undefined,
         trigger: params.trigger,
         channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+        conversationId: params.messageTo ?? undefined,
       };
       if (hookRunner?.hasHooks("before_model_resolve")) {
         try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -334,6 +334,7 @@ export async function runEmbeddedPiAgent(
         trigger: params.trigger,
         channelId: params.messageChannel ?? params.messageProvider ?? undefined,
         conversationId: params.messageTo ?? undefined,
+        accountId: params.agentAccountId ?? undefined,
       };
       if (hookRunner?.hasHooks("before_model_resolve")) {
         try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2430,6 +2430,7 @@ export async function runEmbeddedAttempt(
           trigger: params.trigger,
           channelId: params.messageChannel ?? params.messageProvider ?? undefined,
           conversationId: params.messageTo ?? undefined,
+          accountId: params.agentAccountId ?? undefined,
         };
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2429,6 +2429,7 @@ export async function runEmbeddedAttempt(
           messageProvider: params.messageProvider ?? undefined,
           trigger: params.trigger,
           channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+          conversationId: params.messageTo ?? undefined,
         };
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2811,6 +2811,7 @@ export async function runEmbeddedAttempt(
                 messageProvider: params.messageProvider ?? undefined,
                 trigger: params.trigger,
                 channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                conversationId: params.messageTo ?? undefined,
               },
             )
             .catch((err) => {

--- a/src/auto-reply/reply/agent-runner-hooks.ts
+++ b/src/auto-reply/reply/agent-runner-hooks.ts
@@ -1,0 +1,112 @@
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { AgentRunLoopResult } from "./agent-runner-execution.js";
+import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
+
+/** Hard safety cap against infinite loops from buggy plugins. */
+const HOOK_REINJECT_SAFETY_CAP = 5;
+
+type RunAgentTurnParams = Parameters<typeof runAgentTurnWithFallback>[0];
+
+export type AfterAgentCompleteHookContext = {
+  /** Channel type, e.g. "slack", "discord". */
+  channelId: string;
+  /** Account-scoped channel key. */
+  channelKey: string;
+  /** Conversation target (e.g. group ID, DM address). */
+  conversationId?: string;
+  /** Account id for multi-account channels (e.g. "conor", "default"). */
+  accountId?: string;
+  agentId: string;
+  /** Factory to recreate the block reply pipeline on reinject iterations. */
+  recreateBlockPipeline?: () => RunAgentTurnParams["blockReplyPipeline"];
+};
+
+/**
+ * Wrap runAgentTurnWithFallback with the after_agent_complete hook loop.
+ *
+ * After each successful agent run, fires the after_agent_complete hook.
+ * Plugins can return `reinject: true` with `injectContext` to re-run
+ * the agent with updated context, or `suppress: true` to drop the response.
+ * The plugin owns retry budgeting; core only enforces HOOK_REINJECT_SAFETY_CAP.
+ */
+export async function runAgentTurnWithHooks(
+  params: RunAgentTurnParams,
+  hookCtx: AfterAgentCompleteHookContext,
+): Promise<AgentRunLoopResult> {
+  const hookRunner = getGlobalHookRunner();
+
+  // Fast path: no hooks registered, skip the loop overhead.
+  if (!hookRunner?.hasHooks("after_agent_complete")) {
+    return runAgentTurnWithFallback(params);
+  }
+
+  let effectiveCommandBody = params.commandBody;
+  let blockReplyPipeline = params.blockReplyPipeline;
+  const processingStartedAt = Date.now();
+
+  for (let attempt = 0; attempt <= HOOK_REINJECT_SAFETY_CAP; attempt++) {
+    const outcome = await runAgentTurnWithFallback({
+      ...params,
+      commandBody: effectiveCommandBody,
+      blockReplyPipeline,
+    });
+
+    // Early terminations (errors, session resets) bypass the hook.
+    if (outcome.kind === "final") {
+      return outcome;
+    }
+
+    const responseText =
+      outcome.runResult.payloads
+        ?.map((p) => p.text)
+        .filter(Boolean)
+        .join("\n") ?? "";
+
+    const hookResult = await hookRunner.runAfterAgentComplete(
+      {
+        sessionKey: params.sessionKey ?? "",
+        channelId: hookCtx.channelId,
+        channelKey: hookCtx.channelKey,
+        conversationId: hookCtx.conversationId,
+        agentId: hookCtx.agentId,
+        response: responseText,
+        processingStartedAt,
+      },
+      {
+        agentId: hookCtx.agentId,
+        sessionKey: params.sessionKey,
+        channelId: hookCtx.channelId,
+        conversationId: hookCtx.conversationId,
+        accountId: hookCtx.accountId,
+      },
+    );
+
+    // No hook result or no reinject/suppress: return normally.
+    if (!hookResult?.reinject && !hookResult?.suppress) {
+      return outcome;
+    }
+
+    if (hookResult.suppress) {
+      return { kind: "final", payload: { text: undefined } };
+    }
+
+    // Last attempt: return whatever we have rather than looping again.
+    if (attempt === HOOK_REINJECT_SAFETY_CAP) {
+      return outcome;
+    }
+
+    // Reinject: update context and loop.
+    if (hookResult.injectContext) {
+      effectiveCommandBody = `${effectiveCommandBody}\n\n${hookResult.injectContext}`;
+    }
+
+    // Recreate block reply pipeline for the next iteration if available.
+    if (hookCtx.recreateBlockPipeline) {
+      blockReplyPipeline?.stop();
+      blockReplyPipeline = hookCtx.recreateBlockPipeline();
+    }
+  }
+
+  // Unreachable, but satisfies the type checker.
+  return runAgentTurnWithFallback(params);
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -29,7 +29,6 @@ import {
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
   createShouldEmitToolOutput,
   createShouldEmitToolResult,
@@ -37,6 +36,7 @@ import {
   isAudioPayload,
   signalTypingIfNeeded,
 } from "./agent-runner-helpers.js";
+import { runAgentTurnWithHooks } from "./agent-runner-hooks.js";
 import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import {
@@ -344,29 +344,56 @@ export async function runReplyAgent(params: {
     });
   try {
     const runStartedAt = Date.now();
-    const runOutcome = await runAgentTurnWithFallback({
-      commandBody,
-      followupRun,
-      sessionCtx,
-      opts,
-      typingSignals,
-      blockReplyPipeline,
-      blockStreamingEnabled,
-      blockReplyChunking,
-      resolvedBlockStreamingBreak,
-      applyReplyToMode,
-      shouldEmitToolResult,
-      shouldEmitToolOutput,
-      pendingToolTasks,
-      resetSessionAfterCompactionFailure,
-      resetSessionAfterRoleOrderingConflict,
-      isHeartbeat,
-      sessionKey,
-      getActiveSessionEntry: () => activeSessionEntry,
-      activeSessionStore,
-      storePath,
-      resolvedVerboseLevel,
-    });
+    const hookChannelId = (
+      replyToChannel ??
+      followupRun.run.messageProvider ??
+      "unknown"
+    ).toLowerCase();
+    const hookChannelKey = [hookChannelId, sessionCtx.AccountId, sessionCtx.To]
+      .filter(Boolean)
+      .join(":");
+    const runOutcome = await runAgentTurnWithHooks(
+      {
+        commandBody,
+        followupRun,
+        sessionCtx,
+        opts,
+        typingSignals,
+        blockReplyPipeline,
+        blockStreamingEnabled,
+        blockReplyChunking,
+        resolvedBlockStreamingBreak,
+        applyReplyToMode,
+        shouldEmitToolResult,
+        shouldEmitToolOutput,
+        pendingToolTasks,
+        resetSessionAfterCompactionFailure,
+        resetSessionAfterRoleOrderingConflict,
+        isHeartbeat,
+        sessionKey,
+        getActiveSessionEntry: () => activeSessionEntry,
+        activeSessionStore,
+        storePath,
+        resolvedVerboseLevel,
+      },
+      {
+        channelId: hookChannelId,
+        channelKey: hookChannelKey,
+        conversationId: sessionCtx.To ?? undefined,
+        accountId: sessionCtx.AccountId ?? undefined,
+        agentId: followupRun.run.agentId ?? "",
+        recreateBlockPipeline:
+          blockStreamingEnabled && opts?.onBlockReply
+            ? () =>
+                createBlockReplyPipeline({
+                  onBlockReply: opts.onBlockReply!,
+                  timeoutMs: blockReplyTimeoutMs,
+                  coalescing: blockReplyCoalescing,
+                  buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
+                })
+            : undefined,
+      },
+    );
 
     if (runOutcome.kind === "final") {
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -123,7 +123,7 @@ describe("message hook mappers", () => {
     });
   });
 
-  it("normalizes Discord DM targets for inbound claim contexts", () => {
+  it("passes through raw conversationId for inbound claim contexts", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({
         Provider: "discord",
@@ -137,10 +137,12 @@ describe("message hook mappers", () => {
       }),
     );
 
+    // inbound_claim context uses canonical.conversationId directly
+    // (consistent with toPluginMessageContext and agent hook contexts)
     expect(toPluginInboundClaimContext(canonical)).toEqual({
       channelId: "discord",
       accountId: "acc-1",
-      conversationId: "user:1177378744822943744",
+      conversationId: "channel:1480574946919846079",
       parentConversationId: undefined,
       senderId: "sender-1",
       messageId: "msg-1",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -178,58 +178,19 @@ function deriveParentConversationId(
   );
 }
 
-function deriveConversationId(canonical: CanonicalInboundMessageHookContext): string | undefined {
-  if (canonical.channelId === "discord") {
-    const rawTarget = canonical.to ?? canonical.originatingTo ?? canonical.conversationId;
-    const rawSender = canonical.from;
-    const senderUserId = rawSender?.startsWith("discord:user:")
-      ? rawSender.slice("discord:user:".length)
-      : rawSender?.startsWith("discord:")
-        ? rawSender.slice("discord:".length)
-        : undefined;
-    if (!canonical.isGroup && senderUserId) {
-      return `user:${senderUserId}`;
-    }
-    if (!rawTarget) {
-      return undefined;
-    }
-    if (rawTarget.startsWith("discord:channel:")) {
-      return `channel:${rawTarget.slice("discord:channel:".length)}`;
-    }
-    if (rawTarget.startsWith("discord:user:")) {
-      return `user:${rawTarget.slice("discord:user:".length)}`;
-    }
-    if (rawTarget.startsWith("discord:")) {
-      return `user:${rawTarget.slice("discord:".length)}`;
-    }
-    if (rawTarget.startsWith("channel:") || rawTarget.startsWith("user:")) {
-      return rawTarget;
-    }
-  }
-  const baseConversationId = stripChannelPrefix(
-    canonical.to ?? canonical.originatingTo ?? canonical.conversationId,
-    canonical.channelId,
-  );
-  if (canonical.channelId === "telegram" && baseConversationId) {
-    const threadId =
-      typeof canonical.threadId === "number" || typeof canonical.threadId === "string"
-        ? String(canonical.threadId).trim()
-        : "";
-    if (threadId) {
-      return `${baseConversationId}:topic:${threadId}`;
-    }
-  }
-  return baseConversationId;
-}
+// deriveConversationId was removed: it did per-channel transformations
+// (Discord DM rerouting, Telegram thread suffixes, Slack prefix stripping)
+// that produced conversationId values inconsistent with toPluginMessageContext
+// and agent hook contexts. Per-channel normalization should live in channel
+// adapters, not in generic hook mappers. See toPluginInboundClaimContext.
 
 export function toPluginInboundClaimContext(
   canonical: CanonicalInboundMessageHookContext,
 ): PluginHookInboundClaimContext {
-  const conversationId = deriveConversationId(canonical);
   return {
     channelId: canonical.channelId,
     accountId: canonical.accountId,
-    conversationId,
+    conversationId: canonical.conversationId,
     parentConversationId: deriveParentConversationId(canonical),
     senderId: canonical.senderId,
     messageId: canonical.messageId,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1365,6 +1365,7 @@ export type PluginHookName =
   | "before_model_resolve"
   | "before_prompt_build"
   | "before_agent_start"
+  | "after_agent_complete"
   | "llm_input"
   | "llm_output"
   | "agent_end"
@@ -1392,6 +1393,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
   "before_prompt_build",
   "before_agent_start",
+  "after_agent_complete",
   "llm_input",
   "llm_output",
   "agent_end",
@@ -1449,6 +1451,10 @@ export type PluginHookAgentContext = {
   trigger?: string;
   /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
   channelId?: string;
+  /** Conversation target (e.g. group ID, DM address). */
+  conversationId?: string;
+  /** Account id for multi-account channels (e.g. "conor", "default"). */
+  accountId?: string;
 };
 
 // before_model_resolve hook
@@ -1530,6 +1536,24 @@ export const stripPromptMutationFieldsFromLegacyHookResult = (
   return Object.keys(remaining).length > 0
     ? (remaining as PluginHookBeforeAgentStartOverrideResult)
     : undefined;
+};
+
+// after_agent_complete hook — fires after agent produces a response, before delivery
+export type PluginHookAfterAgentCompleteEvent = {
+  sessionKey: string;
+  channelId: string;
+  channelKey: string;
+  /** Conversation target (e.g. group ID, DM address). */
+  conversationId?: string;
+  agentId: string;
+  response: string;
+  processingStartedAt: number;
+};
+
+export type PluginHookAfterAgentCompleteResult = {
+  reinject?: boolean;
+  injectContext?: string;
+  suppress?: boolean;
 };
 
 // llm_input hook
@@ -1876,6 +1900,13 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
+  after_agent_complete: (
+    event: PluginHookAfterAgentCompleteEvent,
+    ctx: PluginHookAgentContext,
+  ) =>
+    | Promise<PluginHookAfterAgentCompleteResult | void>
+    | PluginHookAfterAgentCompleteResult
+    | void;
   llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,


### PR DESCRIPTION
## Summary

- Pass `conversationId` through directly in `toPluginInboundClaimContext` instead of running it through `deriveConversationId()`, consistent with `toPluginMessageContext` and agent hook contexts
- Add `conversationId` to `PluginHookAgentContext` and wire it through agent runner hook call sites
- Add `accountId` to `PluginHookAgentContext` and `AfterAgentCompleteHookContext`, wire from `params.agentAccountId` and `sessionCtx.AccountId`
- Remove `deriveConversationId` (per-channel normalization should live in channel adapters, not generic hook mappers)

Fixes #49746

## Motivation

Plugin hook contexts produced different `conversationId` values for the same message across hook phases. `inbound_claim` ran the value through `deriveConversationId()` (stripping prefixes, rerouting Discord DMs) while `message_received` and agent hooks passed it through directly. Plugins building channel-scoped state across hook phases (e.g. speedtrap) could never match keys.

Additionally, `accountId` was missing from agent hook contexts entirely, making it impossible for plugins to distinguish per-agent conversations (e.g. DMs to different bot accounts from the same human user).

## Changes

1. **`src/hooks/message-hook-mappers.ts`**: Use `canonical.conversationId` directly in `toPluginInboundClaimContext`. Remove `deriveConversationId`.
2. **`src/plugins/types.ts`**: Add `conversationId` and `accountId` to `PluginHookAgentContext`.
3. **`src/agents/pi-embedded-runner/run.ts`**: Wire `conversationId` and `accountId` into hookCtx.
4. **`src/agents/pi-embedded-runner/run/attempt.ts`**: Wire `conversationId` and `accountId` into hookCtx.
5. **`src/auto-reply/reply/agent-runner-hooks.ts`**: Add `accountId` to `AfterAgentCompleteHookContext`, pass through to hook context.
6. **`src/auto-reply/reply/agent-runner.ts`**: Supply `accountId` from `sessionCtx.AccountId`.

## Test plan

- [x] `src/hooks/message-hook-mappers.test.ts` updated and passing (7/7)
- [ ] Verify Discord DM routing is not affected by `deriveConversationId` removal (the old derivation converted raw Discord targets to `user:` prefixed form for DMs)
- [ ] Manual testing with multi-agent Slack channels confirms consistent keys across all hook phases

## Note on Discord

The removed `deriveConversationId` did per-channel transformations including Discord DM target rerouting. The test was updated to expect the raw `conversationId` passthrough. Discord DM routing should be verified to ensure no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)