### PR TITLE
fix(memory): use qmd query tool for mcporter query mode (AI-assisted)

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1608,7 +1608,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("uses the qmd.query mcporter tool when searchMode=query", async () => {
+  it("uses qmd.query with structured searches when searchMode=query", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1633,7 +1633,7 @@ describe("QmdMemoryManager", () => {
       return child;
     });
 
-    const { manager } = await createManager();
+    const { manager, resolved } = await createManager();
     await expect(
       manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
     ).resolves.toEqual([]);
@@ -1642,7 +1642,18 @@ describe("QmdMemoryManager", () => {
       (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
     );
     expect(mcporterCall).toBeDefined();
-    expect((mcporterCall?.[1] as string[])[1]).toBe("qmd.query");
+    const mcporterArgs = mcporterCall?.[1] as string[];
+    expect(mcporterArgs[1]).toBe("qmd.query");
+    const parsedArgs = JSON.parse(mcporterArgs[3] ?? "{}");
+    expect(parsedArgs).toEqual({
+      searches: [
+        { type: "lex", query: "hello" },
+        { type: "vec", query: "hello" },
+      ],
+      limit: resolved.qmd?.limits.maxResults,
+      minScore: 0,
+      collections: [resolved.qmd?.collections[0]?.name],
+    });
 
     await manager.close();
   });

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1608,6 +1608,45 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses the qmd.query mcporter tool when searchMode=query", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await expect(
+      manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([]);
+
+    const mcporterCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])[0] === "call",
+    );
+    expect(mcporterCall).toBeDefined();
+    expect((mcporterCall?.[1] as string[])[1]).toBe("qmd.query");
+
+    await manager.close();
+  });
+
   it("resolves mcporter to a direct Windows entrypoint without enabling shell mode", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const previousPath = process.env.PATH;

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -749,12 +749,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     ): Promise<QmdQueryResult[]> => {
       try {
         if (mcporterEnabled) {
-          const tool: "search" | "vector_search" | "deep_search" =
+          const tool: "search" | "vector_search" | "query" =
             qmdSearchCommand === "search"
               ? "search"
               : qmdSearchCommand === "vsearch"
                 ? "vector_search"
-                : "deep_search";
+                : "query";
           const minScore = opts?.minScore ?? 0;
           if (collectionNames.length > 1) {
             return await this.runMcporterAcrossCollections({
@@ -1263,7 +1263,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private async runQmdSearchViaMcporter(params: {
     mcporter: ResolvedQmdMcporterConfig;
-    tool: "search" | "vector_search" | "deep_search";
+    tool: "search" | "vector_search" | "query";
     query: string;
     limit: number;
     minScore: number;
@@ -1997,7 +1997,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async runMcporterAcrossCollections(params: {
-    tool: "search" | "vector_search" | "deep_search";
+    tool: "search" | "vector_search" | "query";
     query: string;
     limit: number;
     minScore: number;

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1261,6 +1261,39 @@ export class QmdMemoryManager implements MemorySearchManager {
     });
   }
 
+  private buildMcporterSearchCallArgs(params: {
+    tool: "search" | "vector_search" | "query";
+    query: string;
+    limit: number;
+    minScore: number;
+    collection?: string;
+  }): Record<string, unknown> {
+    if (params.tool === "query") {
+      const callArgs: Record<string, unknown> = {
+        searches: [
+          { type: "lex", query: params.query },
+          { type: "vec", query: params.query },
+        ],
+        limit: params.limit,
+        minScore: params.minScore,
+      };
+      if (params.collection) {
+        callArgs.collections = [params.collection];
+      }
+      return callArgs;
+    }
+
+    const callArgs: Record<string, unknown> = {
+      query: params.query,
+      limit: params.limit,
+      minScore: params.minScore,
+    };
+    if (params.collection) {
+      callArgs.collection = params.collection;
+    }
+    return callArgs;
+  }
+
   private async runQmdSearchViaMcporter(params: {
     mcporter: ResolvedQmdMcporterConfig;
     tool: "search" | "vector_search" | "query";
@@ -1273,14 +1306,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     await this.ensureMcporterDaemonStarted(params.mcporter);
 
     const selector = `${params.mcporter.serverName}.${params.tool}`;
-    const callArgs: Record<string, unknown> = {
-      query: params.query,
-      limit: params.limit,
-      minScore: params.minScore,
-    };
-    if (params.collection) {
-      callArgs.collection = params.collection;
-    }
+    const callArgs = this.buildMcporterSearchCallArgs(params);
 
     const result = await this.runMcporter(
       [


### PR DESCRIPTION
## Summary
- use the mcporter `query` tool when `memory.qmd.searchMode=query`
- replace the stale `deep_search` mapping used by the mcporter bridge
- **Updated:** adapt the mcporter payload to the structured `searches` and `collections` schema required by QMD v2 (addressing Codex review P1)
- add a regression test covering the `qmd.query` selector and payload schema

## Testing
- `corepack pnpm vitest run src/memory/qmd-manager.test.ts` (All 58 tests passed, including the new regression test)
- Local `pnpm build` and `pnpm check` attempted; encountered existing baseline dependency/type issues on main branch unrelated to this change.

## AI Assistance
This PR was prepared with the assistance of an OpenClaw agent to automate issue triage and implementation. Fixes were verified against upstream QMD source code.