### PR TITLE
fix: preserve qualified provider prefix in Control UI model selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 
 - Sandbox/security: block credential-path binds even when sandbox home paths resolve through canonical aliases, so agent containers cannot mount user secret stores through alternate home-directory paths. (#59157) Thanks @eleqtrizit.
 - Gateway/Windows scheduled tasks: preserve Task Scheduler settings on reinstall, fail loud when Scheduled Task `/Run` does not start, and report fast failed restarts with the actual elapsed time instead of a fake 60s timeout. (#59335) Thanks @tmimmanuel.
+- Control UI/model picker: preserve already-qualified `provider/model` refs from the server so models whose ids already contain slashes stop being double-prefixed and remapped to the wrong provider. (#49874) Thanks @ShionEria.
 
 ## 2026.4.1-beta.1
 

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -29,6 +29,12 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
+  it("preserves already-qualified model refs without prepending provider", () => {
+    expect(resolveServerChatModelValue("ollama/qwen3:30b", "openai-codex")).toBe(
+      "ollama/qwen3:30b",
+    );
+  });
+
   it("normalizes raw overrides when the catalog match is unique", () => {
     expect(normalizeChatModelOverrideValue(createChatModelOverride("gpt-5-mini"), catalog)).toBe(
       "openai/gpt-5-mini",

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -25,6 +25,11 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
   if (!trimmedModel) {
     return "";
   }
+  // Preserve already-qualified model refs (provider/model) as-is.
+  // This avoids prepending an unrelated/default provider.
+  if (trimmedModel.includes("/")) {
+    return trimmedModel;
+  }
   const trimmedProvider = provider?.trim();
   return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
 }


### PR DESCRIPTION
## Problem
Control UI model selector re-qualified already-qualified model refs using session/default provider.

Example:
- Expected: \
- Actual: \

This happened when \ received a model string that already contained a provider prefix, but still passed through provider qualification logic.

## Fix
- Preserve already-qualified model refs (strings containing \) as-is in \
- Only prepend provider for unqualified model ids

## Tests
- Added test: preserves qualified model refs without prepending provider
- Verified UI chat tests pass:
  - \
  - \

Fixes #49839