### PR TITLE
fix(cron): do not mark job as error when agent task succeeded but delivery failed

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -110,6 +110,9 @@ export type DispatchCronDeliveryState = {
   deliveryAttempted: boolean;
   /** True when all payloads were intentionally cancelled by a `message_sending` hook. */
   hookCancelled?: boolean;
+  /** True when deliverOutboundPayloads returned an empty array without error — e.g. because
+   * the channel sanitizer stripped an HTML-only payload. This is not a failure. */
+  noOpDelivery?: boolean;
   summary?: string;
   outputText?: string;
   synthesizedText?: string;
@@ -359,6 +362,7 @@ export async function dispatchCronDelivery(
   let delivered = skipMessagingToolDelivery;
   let deliveryAttempted = skipMessagingToolDelivery;
   let hookCancelled = false;
+  let noOpDelivery = false;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
       status: "error",
@@ -499,6 +503,11 @@ export async function dispatchCronDelivery(
       }
       if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
+      } else {
+        // deliverOutboundPayloads returned an empty array without throwing — the
+        // channel sanitizer stripped all payloads (e.g. HTML-only message on a
+        // plain-text channel). This is intentional, not a delivery failure.
+        noOpDelivery = true;
       }
       return null;
     } catch (err) {
@@ -670,6 +679,7 @@ export async function dispatchCronDelivery(
         }),
         delivered,
         deliveryAttempted,
+        noOpDelivery,
         hookCancelled,
         summary,
         outputText,
@@ -690,6 +700,7 @@ export async function dispatchCronDelivery(
           result: directResult,
           delivered,
           deliveryAttempted,
+          noOpDelivery,
           summary,
           outputText,
           synthesizedText,
@@ -704,6 +715,7 @@ export async function dispatchCronDelivery(
           result: finalizedTextResult,
           delivered,
           deliveryAttempted,
+          noOpDelivery,
           summary,
           outputText,
           synthesizedText,
@@ -717,6 +729,7 @@ export async function dispatchCronDelivery(
   return {
     delivered,
     deliveryAttempted,
+    noOpDelivery,
     hookCancelled,
     summary,
     outputText,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -108,6 +108,8 @@ export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
   delivered: boolean;
   deliveryAttempted: boolean;
+  /** True when all payloads were intentionally cancelled by a `message_sending` hook. */
+  hookCancelled?: boolean;
   summary?: string;
   outputText?: string;
   synthesizedText?: string;
@@ -356,6 +358,7 @@ export async function dispatchCronDelivery(
   // remains the only source of delivered state.
   let delivered = skipMessagingToolDelivery;
   let deliveryAttempted = skipMessagingToolDelivery;
+  let hookCancelled = false;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
       status: "error",
@@ -462,6 +465,9 @@ export async function dispatchCronDelivery(
           deps: createOutboundSendDeps(params.deps),
           abortSignal: params.abortSignal,
           onError,
+          onHookCancelled: () => {
+            hookCancelled = true;
+          },
           // Isolated cron direct delivery uses its own transient retry loop.
           // Keep all attempts out of the write-ahead delivery queue so a
           // late-successful first send cannot leave behind a failed queue
@@ -650,6 +656,7 @@ export async function dispatchCronDelivery(
           outputText,
           synthesizedText,
           deliveryPayloads,
+          hookCancelled,
         };
       }
       logWarn(`[cron:${params.job.id}] ${params.resolvedDelivery.error.message}`);
@@ -663,6 +670,7 @@ export async function dispatchCronDelivery(
         }),
         delivered,
         deliveryAttempted,
+        hookCancelled,
         summary,
         outputText,
         synthesizedText,
@@ -686,6 +694,7 @@ export async function dispatchCronDelivery(
           outputText,
           synthesizedText,
           deliveryPayloads,
+          hookCancelled,
         };
       }
     } else {
@@ -699,6 +708,7 @@ export async function dispatchCronDelivery(
           outputText,
           synthesizedText,
           deliveryPayloads,
+          hookCancelled,
         };
       }
     }
@@ -707,6 +717,7 @@ export async function dispatchCronDelivery(
   return {
     delivered,
     deliveryAttempted,
+    hookCancelled,
     summary,
     outputText,
     synthesizedText,

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -52,7 +52,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status ok when agent task succeeded but best-effort delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -76,7 +76,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status error when agent task succeeded but strict delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -106,7 +106,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
       provider: "openai",
       model: "gpt-4",
     });
-    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -49,7 +49,31 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
     });
   }
 
-  it("returns status ok when agent task succeeded but delivery threw", async () => {
+  it("returns status ok when agent task succeeded but best-effort delivery threw", async () => {
+    mockRunCronFallbackPassthrough();
+    setupDeliveryRequested();
+    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: {
+            mode: "announce",
+            channel: "feishu",
+            to: "group-123",
+            bestEffort: true,
+          },
+        }),
+      }),
+    );
+
+    // The agent task itself succeeded and delivery is best-effort — status
+    // must reflect the task outcome, not the transient delivery failure.
+    // Fixes #49826.
+    expect(result.status).toBe("ok");
+  });
+
+  it("returns status error when agent task succeeded but strict delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
     deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
@@ -62,9 +86,8 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
       }),
     );
 
-    // The agent task itself succeeded — status must reflect that, not the
-    // transient delivery failure.
-    expect(result.status).toBe("ok");
+    // Delivery is NOT best-effort — strict delivery failure must surface.
+    expect(result.status).toBe("error");
   });
 
   it("returns status error when agent task itself had a fatal error payload", async () => {
@@ -130,12 +153,17 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   });
 
   it("returns status error when delivery was aborted even with best-effort", async () => {
+    // Abort the signal *during delivery* (not before the agent run) so the
+    // run reaches the delivery-phase isAborted() guard in run.ts rather than
+    // exiting early from the runPrompt abort check.  Fixes P2 review thread.
+    const ac = new AbortController();
+
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockRejectedValueOnce(new Error("aborted: timeout"));
-
-    const ac = new AbortController();
-    ac.abort("timeout");
+    deliverOutboundPayloads.mockImplementationOnce(async () => {
+      ac.abort("timeout");
+      throw new Error("aborted: timeout");
+    });
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -45,7 +45,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status ok when agent task succeeded but best-effort delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("permanent delivery failure"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -69,7 +69,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status error when agent task succeeded but strict delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("permanent delivery failure"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -99,7 +99,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
       provider: "openai",
       model: "gpt-4",
     });
-    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("permanent delivery failure"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression test for #49826: cron job status should not be "error" when the
+ * agent task succeeded but delivery failed (transient network error, etc.).
+ *
+ * The fix ensures that the run outcome is derived from the agent task result
+ * (hasFatalErrorPayload) rather than the delivery result when the task itself
+ * completed successfully.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  resolveCronDeliveryPlanMock,
+  resolveDeliveryTargetMock,
+} from "./run.test-harness.js";
+
+// Access the mocked deliverOutboundPayloads from the same mock scope as the
+// test harness.  The harness already calls vi.mock() on this module so we can
+// just import and cast.
+const { deliverOutboundPayloads } =
+  (await import("../../infra/outbound/deliver.js")) as unknown as {
+    deliverOutboundPayloads: ReturnType<typeof vi.fn>;
+  };
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn — delivery failure does not mark job as error (#49826)", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  function setupDeliveryRequested(): void {
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "feishu",
+      to: "group-123",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "feishu",
+      to: "group-123",
+      accountId: undefined,
+      error: undefined,
+    });
+  }
+
+  it("returns status ok when agent task succeeded but delivery threw", async () => {
+    mockRunCronFallbackPassthrough();
+    setupDeliveryRequested();
+    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123" },
+        }),
+      }),
+    );
+
+    // The agent task itself succeeded — status must reflect that, not the
+    // transient delivery failure.
+    expect(result.status).toBe("ok");
+  });
+
+  it("returns status error when agent task itself had a fatal error payload", async () => {
+    setupDeliveryRequested();
+
+    // Simulate the agent returning an error payload.
+    const { runWithModelFallback } =
+      (await import("../../agents/model-fallback.js")) as unknown as {
+        runWithModelFallback: ReturnType<typeof vi.fn>;
+      };
+    runWithModelFallback.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "something went wrong", isError: true }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+    deliverOutboundPayloads.mockRejectedValueOnce(new Error("network timeout"));
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123" },
+        }),
+      }),
+    );
+
+    // Both agent task AND delivery failed — status should be error.
+    expect(result.status).toBe("error");
+  });
+
+  it("returns status error when delivery was aborted even with best-effort", async () => {
+    mockRunCronFallbackPassthrough();
+    setupDeliveryRequested();
+    deliverOutboundPayloads.mockRejectedValueOnce(new Error("aborted: timeout"));
+
+    const ac = new AbortController();
+    ac.abort("timeout");
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        abortSignal: ac.signal,
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123", bestEffort: true },
+        }),
+      }),
+    );
+
+    // Even though delivery is best-effort, an abort/timeout must always surface
+    // as an error — the run was killed mid-flight.
+    expect(result.status).toBe("error");
+  });
+
+  it("returns status ok and delivered=true when delivery succeeds", async () => {
+    mockRunCronFallbackPassthrough();
+    setupDeliveryRequested();
+    deliverOutboundPayloads.mockResolvedValueOnce([{ ok: true }]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.delivered).toBe(true);
+  });
+});

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -97,6 +97,38 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
     expect(result.status).toBe("error");
   });
 
+  it("returns status error when agent task had fatal error but delivery succeeded", async () => {
+    setupDeliveryRequested();
+
+    // Agent returns a fatal error payload, but delivery succeeds.
+    const { runWithModelFallback } =
+      (await import("../../agents/model-fallback.js")) as unknown as {
+        runWithModelFallback: ReturnType<typeof vi.fn>;
+      };
+    runWithModelFallback.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "context window exceeded", isError: true }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+    deliverOutboundPayloads.mockResolvedValueOnce([{ ok: true }]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123" },
+        }),
+      }),
+    );
+
+    // Agent task failed — status must remain "error" even though delivery
+    // succeeded.  Fixes P1: fatal payloads must not be rewritten to success.
+    expect(result.status).toBe("error");
+    expect(result.error).toBeDefined();
+  });
+
   it("returns status error when delivery was aborted even with best-effort", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -14,19 +14,12 @@ import {
   setupRunCronIsolatedAgentTurnSuite,
 } from "./run.suite-helpers.js";
 import {
+  deliverOutboundPayloadsMock,
   loadRunCronIsolatedAgentTurn,
   mockRunCronFallbackPassthrough,
   resolveCronDeliveryPlanMock,
   resolveDeliveryTargetMock,
 } from "./run.test-harness.js";
-
-// Access the mocked deliverOutboundPayloads from the same mock scope as the
-// test harness.  The harness already calls vi.mock() on this module so we can
-// just import and cast.
-const { deliverOutboundPayloads } =
-  (await import("../../infra/outbound/deliver.js")) as unknown as {
-    deliverOutboundPayloads: ReturnType<typeof vi.fn>;
-  };
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
@@ -52,7 +45,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status ok when agent task succeeded but best-effort delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -76,7 +69,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status error when agent task succeeded but strict delivery threw", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -106,7 +99,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
       provider: "openai",
       model: "gpt-4",
     });
-    deliverOutboundPayloads.mockRejectedValue(new Error("network timeout"));
+    deliverOutboundPayloadsMock.mockRejectedValue(new Error("network timeout"));
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -136,7 +129,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
       provider: "openai",
       model: "gpt-4",
     });
-    deliverOutboundPayloads.mockResolvedValueOnce([{ ok: true }]);
+    deliverOutboundPayloadsMock.mockResolvedValueOnce([{ ok: true }]);
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -160,7 +153,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
 
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockImplementationOnce(async () => {
+    deliverOutboundPayloadsMock.mockImplementationOnce(async () => {
       ac.abort("timeout");
       throw new Error("aborted: timeout");
     });
@@ -186,7 +179,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
     // Simulate what happens when a message_sending hook cancels every payload:
     // deliverOutboundPayloads returns an empty array (no sends) and calls
     // the onHookCancelled callback for each cancelled payload.
-    deliverOutboundPayloads.mockImplementationOnce(
+    deliverOutboundPayloadsMock.mockImplementationOnce(
       async (params: { onHookCancelled?: (p: unknown) => void }) => {
         params.onHookCancelled?.({ text: "cancelled payload" });
         return [];
@@ -210,7 +203,7 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
   it("returns status ok and delivered=true when delivery succeeds", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();
-    deliverOutboundPayloads.mockResolvedValueOnce([{ ok: true }]);
+    deliverOutboundPayloadsMock.mockResolvedValueOnce([{ ok: true }]);
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({

--- a/src/cron/isolated-agent/run.delivery-failure-status.test.ts
+++ b/src/cron/isolated-agent/run.delivery-failure-status.test.ts
@@ -179,6 +179,34 @@ describe("runCronIsolatedAgentTurn — delivery failure does not mark job as err
     expect(result.status).toBe("error");
   });
 
+  it("returns status ok when message_sending hook cancelled all payloads (not a failure)", async () => {
+    mockRunCronFallbackPassthrough();
+    setupDeliveryRequested();
+
+    // Simulate what happens when a message_sending hook cancels every payload:
+    // deliverOutboundPayloads returns an empty array (no sends) and calls
+    // the onHookCancelled callback for each cancelled payload.
+    deliverOutboundPayloads.mockImplementationOnce(
+      async (params: { onHookCancelled?: (p: unknown) => void }) => {
+        params.onHookCancelled?.({ text: "cancelled payload" });
+        return [];
+      },
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "announce", channel: "feishu", to: "group-123" },
+        }),
+      }),
+    );
+
+    // The hook intentionally cancelled the delivery — this is NOT a failure.
+    // The run should be marked as "ok" (not "error").
+    // Fixes: skip synthetic failures for intentionally cancelled deliveries.
+    expect(result.status).toBe("ok");
+  });
+
   it("returns status ok and delivered=true when delivery succeeds", async () => {
     mockRunCronFallbackPassthrough();
     setupDeliveryRequested();

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -433,7 +433,7 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
 
   deliverOutboundPayloadsMock.mockReset();
-  deliverOutboundPayloadsMock.mockResolvedValue(undefined);
+  deliverOutboundPayloadsMock.mockResolvedValue([]);
 
   logWarnMock.mockReset();
 }

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -47,6 +47,7 @@ export const resolveCronPayloadOutcomeMock = createMock();
 export const resolveCronDeliveryPlanMock = createMock();
 export const resolveDeliveryTargetMock = createMock();
 export const resolveSessionAuthProfileOverrideMock = createMock();
+export const deliverOutboundPayloadsMock = createMock();
 
 vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../agents/agent-scope.js")>();
@@ -251,7 +252,7 @@ vi.mock("../../infra/outbound/deliver.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../infra/outbound/deliver.js")>();
   return {
     ...actual,
-    deliverOutboundPayloads: vi.fn().mockResolvedValue(undefined),
+    deliverOutboundPayloads: deliverOutboundPayloadsMock,
   };
 });
 
@@ -430,6 +431,9 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   });
   resolveSessionAuthProfileOverrideMock.mockReset();
   resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+
+  deliverOutboundPayloadsMock.mockReset();
+  deliverOutboundPayloadsMock.mockResolvedValue(undefined);
 
   logWarnMock.mockReset();
 }

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -316,7 +316,7 @@ vi.mock("../../agents/defaults.js", async (importOriginal) => {
 
 export function makeCronSessionEntry(overrides?: Record<string, unknown>): CronSessionEntry {
   return {
-    sessionId: "test-session-id",
+    sessionId: `test-session-id-${Math.random().toString(36).slice(2)}`,
     updatedAt: 0,
     systemSent: false,
     skillsSnapshot: undefined,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -858,7 +858,12 @@ export async function runCronIsolatedAgentTurn(params: {
   // (strict delivery failures normally return an enriched result), but guard
   // it defensively: if delivery was attempted and not best-effort, surface
   // the failure.
-  if (deliveryAttempted && !deliveryBestEffort && !delivered) {
+  //
+  // Exception: when a `message_sending` plugin hook intentionally cancelled
+  // all payloads, deliverOutboundPayloads legitimately returns no results
+  // without any delivery error.  This is not a failure — the hook decided
+  // the message should not be sent.  Fixes review thread on #49880.
+  if (deliveryAttempted && !deliveryBestEffort && !delivered && !deliveryResult.hookCancelled) {
     return withRunSession({
       status: "error",
       error: "delivery failed without enriched result",

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -819,5 +819,21 @@ export async function runCronIsolatedAgentTurn(params: {
   summary = deliveryResult.summary;
   outputText = deliveryResult.outputText;
 
+  // When the run was aborted/timed-out but dispatchCronDelivery() swallowed
+  // the error (e.g. best-effort delivery catch block returns null), the run
+  // must still surface the abort — otherwise one-shot jobs are deleted and
+  // recurring jobs skip back-off.  Fixes P1 review on #49880.
+  if (isAborted() && !hasFatalErrorPayload) {
+    return withRunSession({
+      status: "error",
+      error: abortReason() ?? "cron run aborted",
+      summary,
+      outputText,
+      delivered,
+      deliveryAttempted,
+      ...telemetry,
+    });
+  }
+
   return resolveRunOutcome({ delivered, deliveryAttempted });
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -772,13 +772,36 @@ export async function runCronIsolatedAgentTurn(params: {
       deliveryAttempted:
         deliveryResult.result.deliveryAttempted ?? deliveryResult.deliveryAttempted,
     };
-    if (!hasFatalErrorPayload || deliveryResult.result.status !== "ok") {
+    // When the agent task itself had a fatal error AND delivery also returned a
+    // non-ok result, prefer the delivery-level error details (e.g. permanent
+    // target misconfiguration).  In all other cases derive the run status from
+    // the agent task outcome so that a successful task is never marked "error"
+    // due to a *best-effort* delivery failure.  Fixes #49826.
+    //
+    // However, when delivery is NOT best-effort and delivery failed, the run
+    // must still report "error" — the caller explicitly opted into strict
+    // delivery semantics.
+    if (hasFatalErrorPayload && deliveryResult.result.status !== "ok") {
       return resultWithDeliveryMeta;
     }
-    return resolveRunOutcome({
-      delivered: deliveryResult.result.delivered,
-      deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
-    });
+    if (!hasFatalErrorPayload && deliveryResult.result.status !== "ok" && !deliveryBestEffort) {
+      return resultWithDeliveryMeta;
+    }
+    // Abort/timeout errors must always surface even for best-effort delivery:
+    // the run was killed mid-flight, so treating it as "ok" would let one-shot
+    // jobs be deleted and suppress back-off for recurring jobs.  Fixes P1
+    // review thread on #49880.
+    if (isAborted() && deliveryResult.result.status !== "ok") {
+      return resultWithDeliveryMeta;
+    }
+    // Agent task succeeded — return the delivery result which preserves
+    // enriched summary/outputText from dispatchCronDelivery (e.g.
+    // sub-agent synthesis), overriding status to reflect the agent outcome.
+    return {
+      ...resultWithDeliveryMeta,
+      status: "ok" as const,
+      error: undefined,
+    };
   }
   const delivered = deliveryResult.delivered;
   const deliveryAttempted = deliveryResult.deliveryAttempted;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -794,6 +794,17 @@ export async function runCronIsolatedAgentTurn(params: {
     if (isAborted() && deliveryResult.result.status !== "ok") {
       return resultWithDeliveryMeta;
     }
+    // When the agent task itself returned a fatal error payload, always
+    // surface that error — even when delivery succeeded.  Without this
+    // guard the status override below would rewrite the run to "ok",
+    // clearing consecutiveErrors and potentially deleting one-shot jobs
+    // despite the agent task having failed.  Fixes P1 review on #49880.
+    if (hasFatalErrorPayload) {
+      return resolveRunOutcome({
+        delivered: resultWithDeliveryMeta.delivered,
+        deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
+      });
+    }
     // Agent task succeeded — return the delivery result which preserves
     // enriched summary/outputText from dispatchCronDelivery (e.g.
     // sub-agent synthesis), overriding status to reflect the agent outcome.

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -805,6 +805,21 @@ export async function runCronIsolatedAgentTurn(params: {
         deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
       });
     }
+    // Abort/timeout during delivery must surface even when
+    // dispatchCronDelivery returned a result with status "ok" (e.g.
+    // best-effort delivery swallowed the error but enriched the result).
+    // Without this guard, the status override below rewrites the abort to
+    // "ok", causing one-shot jobs to be deleted and recurring jobs to skip
+    // back-off.  Fixes P2 review thread on #49880.
+    if (isAborted()) {
+      return withRunSession({
+        status: "error",
+        error: abortReason() ?? "cron run aborted",
+        delivered: resultWithDeliveryMeta.delivered,
+        deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
+        ...telemetry,
+      });
+    }
     // Agent task succeeded — return the delivery result which preserves
     // enriched summary/outputText from dispatchCronDelivery (e.g.
     // sub-agent synthesis), overriding status to reflect the agent outcome.

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -834,14 +834,34 @@ export async function runCronIsolatedAgentTurn(params: {
   summary = deliveryResult.summary;
   outputText = deliveryResult.outputText;
 
-  // When the run was aborted/timed-out but dispatchCronDelivery() swallowed
-  // the error (e.g. best-effort delivery catch block returns null), the run
-  // must still surface the abort — otherwise one-shot jobs are deleted and
-  // recurring jobs skip back-off.  Fixes P1 review on #49880.
-  if (isAborted() && !hasFatalErrorPayload) {
+  // dispatchCronDelivery() returned no enriched result — this is the common
+  // path when best-effort delivery is swallowed (deliverOutboundPayloads threw
+  // and the catch block returned null).  The guards below mirror the ones in
+  // the `if (deliveryResult.result)` block above.  Fixes P2 review on #49880.
+
+  // Abort/timeout must always surface — even when best-effort delivery
+  // swallowed the error — so one-shot jobs are not deleted and recurring
+  // jobs trigger back-off.
+  if (isAborted()) {
     return withRunSession({
       status: "error",
       error: abortReason() ?? "cron run aborted",
+      summary,
+      outputText,
+      delivered,
+      deliveryAttempted,
+      ...telemetry,
+    });
+  }
+
+  // Non-best-effort delivery that returned no result is an unexpected state
+  // (strict delivery failures normally return an enriched result), but guard
+  // it defensively: if delivery was attempted and not best-effort, surface
+  // the failure.
+  if (deliveryAttempted && !deliveryBestEffort && !delivered) {
+    return withRunSession({
+      status: "error",
+      error: "delivery failed without enriched result",
       summary,
       outputText,
       delivered,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -862,8 +862,17 @@ export async function runCronIsolatedAgentTurn(params: {
   // Exception: when a `message_sending` plugin hook intentionally cancelled
   // all payloads, deliverOutboundPayloads legitimately returns no results
   // without any delivery error.  This is not a failure — the hook decided
-  // the message should not be sent.  Fixes review thread on #49880.
-  if (deliveryAttempted && !deliveryBestEffort && !delivered && !deliveryResult.hookCancelled) {
+  // the message should not be sent.  Similarly, when the channel sanitizer
+  // strips all payloads (e.g. HTML-only on WhatsApp), deliverOutboundPayloads
+  // returns [] without throwing — this is also not a failure (noOpDelivery).
+  // Fixes review thread on #49880.
+  if (
+    deliveryAttempted &&
+    !deliveryBestEffort &&
+    !delivered &&
+    !deliveryResult.hookCancelled &&
+    !deliveryResult.noOpDelivery
+  ) {
     return withRunSession({
       status: "error",
       error: "delivery failed without enriched result",

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -273,6 +273,8 @@ type DeliverOutboundPayloadsCoreParams = {
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
+  /** Invoked when a `message_sending` plugin hook cancels a payload before send. */
+  onHookCancelled?: (payload: NormalizedOutboundPayload) => void;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
   mirror?: DeliveryMirror;
@@ -674,6 +676,7 @@ async function deliverOutboundPayloadsCore(
         accountId,
       });
       if (hookResult.cancelled) {
+        params.onHookCancelled?.(payloadSummary);
         continue;
       }
       const effectivePayload = hookResult.payload;


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs show status "error" even when the agent task succeeded and messages were delivered, because a transient delivery failure overrides the run status.
- **Why it matters:** False-positive errors trigger consecutive-error backoff and confuse users ("⚠️ ✉️ Message failed" when it actually worked).
- **What changed:** Inverted the condition in `run.ts` so that delivery-level errors only propagate when the agent task itself also failed (`hasFatalErrorPayload`). When the agent task succeeded, `resolveRunOutcome` now always derives status from the task outcome ("ok").
- **What did NOT change (scope boundary):** Permanent delivery target errors (`errorKind: "delivery-target"`) still surface when the agent task itself fails. Delivery metadata (`delivered`, `deliveryAttempted`) is still tracked.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49826

## User-visible / Behavior Changes

Cron jobs whose agent task succeeds will now show status "ok" even if delivery encountered a transient error. Previously they would show "error" — a false positive.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node.js
- Model/provider: any
- Integration/channel: Feishu (reported), any channel
- Relevant config: cron job with delivery configured

### Steps

1. Configure a cron job with delivery to a channel
2. Agent task succeeds but delivery encounters a transient error (e.g. ECONNRESET)
3. Check cron job status

### Expected

- Status: "ok" (agent task succeeded)

### Actual

- Status: "error" (false positive from delivery failure)

## Evidence

- [x] Failing test/log before + passing after

New test `run.delivery-false-positive.test.ts` verifies:
1. Status is "ok" when agent task succeeded but delivery threw
2. Status is "error" when agent task itself failed

## Human Verification (required)

- Verified scenarios: test suite passes, both positive and negative cases
- Edge cases checked: agent task failure still correctly returns "error"
- What you did **not** verify: live Feishu delivery (no access)

> **AI-assisted:** This PR was created with AI assistance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single condition change in `run.ts` line ~896
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: if reverted, false-positive errors return

## Risks and Mitigations

- Risk: Permanent delivery target errors (e.g. "chat not found") may no longer surface as job "error" when agent task succeeds.
  - Mitigation: These are configuration errors that should be caught during job setup. The `delivered` and `deliveryAttempted` fields still track delivery outcome separately.