### PR TITLE
fix(discord): return null from readDiscordComponentSpec for empty specs

### DIFF
--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -71,6 +71,15 @@ describe("discord components", () => {
       }),
     ).toThrow("filename");
   });
+
+  it("returns null for an empty spec so callers fall back to the regular send path", () => {
+    // Empty blocks array — the most common case when LLM passes {"blocks":[]} as placeholder
+    expect(readDiscordComponentSpec({ blocks: [] })).toBeNull();
+    // Completely empty object
+    expect(readDiscordComponentSpec({})).toBeNull();
+    // All fields present but all empty/falsy
+    expect(readDiscordComponentSpec({ blocks: [], text: "", container: undefined, modal: undefined })).toBeNull();
+  });
 });
 
 describe("discord component registry", () => {

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -597,7 +597,7 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
       fields,
     };
   }
-  return {
+  const spec = {
     text: readOptionalString(obj.text),
     reusable,
     container:
@@ -616,6 +616,21 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
     blocks,
     modal,
   };
+
+  // Treat an empty spec (no text, no non-empty blocks, no modal, no container) as null so
+  // callers fall back to the regular send path instead of routing through the v2 Components
+  // path where media attachments are silently dropped. An empty `{"blocks":[]}` is the most
+  // common case: the LLM passes it as a placeholder but intends a plain message send.
+  const hasContent =
+    spec.text ||
+    (spec.blocks && spec.blocks.length > 0) ||
+    spec.modal ||
+    spec.container;
+  if (!hasContent) {
+    return null;
+  }
+
+  return spec;
 }
 
 export function buildDiscordComponentCustomId(params: {


### PR DESCRIPTION
## Problem

When the LLM calls the `message` tool with `components: {"blocks":[]}` (an empty placeholder), the Discord send handler routes the message through `sendDiscordComponentMessage` (the v2 Components path) instead of the regular `sendMessageDiscord` path.

In the v2 path, any `mediaUrl` attachment is silently dropped because no `file`-type block exists in the empty spec. The tool returns `{ok: true, components: true}` but no image is visible to the user.

## Root cause

`readDiscordComponentSpec` treated any non-null, non-array object as a valid spec — including `{}` and `{"blocks":[]}`. The caller's truthy check `if (componentSpec)` then routes to the v2 path unconditionally.

## Fix

After building the parsed spec, check whether it contains any actual content (non-empty text, non-empty blocks array, modal, or container). Return `null` if the spec is empty so callers fall back to the standard send path.

```ts
const hasContent =
  spec.text ||
  (spec.blocks && spec.blocks.length > 0) ||
  spec.modal ||
  spec.container;
if (!hasContent) {
  return null;
}
```

## Changes

- `extensions/discord/src/components.ts`: convert the terminal `return { ... }` to an assignment, add empty-spec guard  
- `extensions/discord/src/components.test.ts`: add test case for `{"blocks":[]}`, `{}`, and all-falsy specs  

## Testing

All 5 existing + new tests pass:

```
✓ discord components > builds v2 containers with modal trigger
✓ discord components > requires options for modal select fields
✓ discord components > requires attachment references for file blocks
✓ discord components > returns null for an empty spec so callers fall back to the regular send path
✓ discord component registry > registers and consumes component entries
```

Fixes #49703