### PR TITLE
fix(tlon): use crypto.randomBytes for approval IDs

### DIFF
--- a/extensions/tlon/src/monitor/approval.ts
+++ b/extensions/tlon/src/monitor/approval.ts
@@ -5,6 +5,7 @@
  * a notification and can approve or deny the request.
  */
 
+import { randomBytes } from "node:crypto";
 import type { PendingApproval } from "../settings.js";
 
 export type { PendingApproval };
@@ -32,7 +33,7 @@ export type CreateApprovalParams = {
  */
 export function generateApprovalId(type: ApprovalType): string {
   const timestamp = Date.now();
-  const randomPart = Math.random().toString(36).substring(2, 6);
+  const randomPart = randomBytes(4).toString("hex");
   return `${type}-${timestamp}-${randomPart}`;
 }
 


### PR DESCRIPTION
## Problem

`generateApprovalId()` in the Tlon approval system uses `Math.random()` to generate the random component of approval IDs. These IDs gate security-sensitive actions (approve, deny, block) for DM requests, channel mentions, and group invites. `Math.random()` is not cryptographically secure and its output can be predicted if an attacker can observe a few prior values.

## Fix

Replace `Math.random().toString(36).substring(2, 6)` with `crypto.randomBytes(4).toString(hex)`, producing 8 hex characters (32 bits) of cryptographic randomness. This matches the pattern used elsewhere in the codebase (e.g. `external-content.ts` marker IDs use `randomBytes(8)`).

## Testing

- All existing Tlon extension tests pass (`pnpm test:extension tlon`)
- The change is a drop-in replacement; the ID format stays `{type}-{timestamp}-{random}` with the random segment slightly longer (8 hex chars vs 4 base36 chars), providing more entropy