### PR TITLE
docs: add NemoSidecar community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,7 +45,7 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **NovaAdapt** — Curated NovaAdapt planning and orchestration tools for OpenClaw with guarded approvals and service-status surfaces.
+- **NemoSidecar** — Tiered NovaAdapt sidecar for OpenClaw with guarded planning in Core, browser and memory routes in Pro, and deeper operator surfaces at the top tier.
   npm: `novaspine-openclaw-adapt`
   repo: `https://github.com/maddwiz/Novaspine-Openclaw`
   install: `openclaw plugins install novaspine-openclaw-adapt`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **NovaAdapt** — Curated NovaAdapt planning and orchestration tools for OpenClaw with guarded approvals and service-status surfaces.
+  npm: `novaspine-openclaw-adapt`
+  repo: `https://github.com/maddwiz/Novaspine-Openclaw`
+  install: `openclaw plugins install novaspine-openclaw-adapt`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
Adds the NemoSidecar plugin to the community plugins page.

Details:
- npm: `novaspine-openclaw-adapt`
- repo: https://github.com/maddwiz/Novaspine-Openclaw
- install: `openclaw plugins install novaspine-openclaw-adapt`

NemoSidecar is the buyer-facing name for the tiered NovaAdapt sidecar product surface. The package is published on npm, the source is public on GitHub, and the repo includes setup/use documentation and issue tracking.