### PR TITLE
fix(mattermost): tighten sanitizeActionId to alphanumeric-only, add empty-id and collision guards

### DIFF
--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -433,6 +433,119 @@ describe("buildButtonAttachments", () => {
   });
 });
 
+describe("sanitizeActionId (via buildButtonAttachments)", () => {
+  beforeEach(() => {
+    setInteractionSecret("test-bot-token");
+  });
+
+  it("strips colons from action ID", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "softgate:approve:0001", name: "Approve" }],
+    });
+    const action = result[0].actions![0];
+    expect(action.id).toBe("softgateapprove0001");
+    expect(action.integration.context.action_id).toBe("softgateapprove0001");
+  });
+
+  it("strips hyphens and underscores (legacy behaviour preserved)", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "my-action_id", name: "Do It" }],
+    });
+    const action = result[0].actions![0];
+    expect(action.id).toBe("myactionid");
+  });
+
+  it("is a no-op on alphanumeric-only IDs", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "alreadySafe123", name: "Go" }],
+    });
+    const action = result[0].actions![0];
+    expect(action.id).toBe("alreadySafe123");
+  });
+
+  it("sanitizes unicode/non-ascii characters", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "héllo", name: "Hello" }],
+    });
+    const action = result[0].actions![0];
+    // "h", "l", "l", "o" remain; "é" is stripped
+    expect(action.id).toBe("hllo");
+  });
+
+  it("generates deterministic fallback for all-punctuation ID", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: ":::", name: "Broken" }],
+    });
+    const action = result[0].actions![0];
+    // safeId would be "" → fallback = "action" + shortHash(":::")
+    expect(action.id).toMatch(/^action[0-9a-f]{8}$/);
+    expect(action.integration.context.action_id).toBe(action.id);
+  });
+
+  it("generates deterministic fallback for empty ID", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [{ id: "", name: "Empty" }],
+    });
+    const action = result[0].actions![0];
+    expect(action.id).toMatch(/^action[0-9a-f]{8}$/);
+    expect(action.integration.context.action_id).toBe(action.id);
+  });
+
+  it("all produced action IDs match /^[a-zA-Z0-9]+$/", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [
+        { id: "normal", name: "N" },
+        { id: "colon:test", name: "C" },
+        { id: "---", name: "D" },
+        { id: "softgate:approve:0001-watchdog", name: "A" },
+      ],
+    });
+    for (const action of result[0].actions!) {
+      expect(action.id).toMatch(/^[a-zA-Z0-9]+$/);
+    }
+  });
+
+  it("actions[].id equals integration.context.action_id for all buttons", () => {
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [
+        { id: "approve:softgate", name: "Approve" },
+        { id: "reject_all", name: "Reject" },
+      ],
+    });
+    for (const action of result[0].actions!) {
+      expect(action.id).toBe(action.integration.context.action_id);
+    }
+  });
+
+  it("collision case: two IDs that sanitize to same value produce unique action IDs", () => {
+    // "a:b" and "ab" both sanitize to "ab"
+    const result = buildButtonAttachments({
+      callbackUrl: "http://localhost/cb",
+      buttons: [
+        { id: "a:b", name: "First" },
+        { id: "ab", name: "Second" },
+      ],
+    });
+    const ids = result[0].actions!.map((a) => a.id);
+    // Both must be unique
+    expect(new Set(ids).size).toBe(2);
+    // Both must be alphanumeric-only
+    for (const id of ids) {
+      expect(id).toMatch(/^[a-zA-Z0-9]+$/);
+    }
+    // First must be "ab" (no collision yet when processed)
+    expect(ids[0]).toBe("ab");
+  });
+});
+
 describe("createMattermostInteractionHandler", () => {
   beforeEach(() => {
     setMattermostRuntime({

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { isTrustedProxyAddress, resolveClientIp, type OpenClawConfig } from "../runtime-api.js";
 import { getMattermostRuntime } from "../runtime.js";
@@ -256,13 +256,20 @@ export type MattermostAttachment = {
  * button click (Mattermost's recommended security pattern).
  */
 /**
- * Sanitize a button ID so Mattermost's action router can match it.
- * Mattermost uses the action ID in the URL path `/api/v4/posts/{id}/actions/{actionId}`
- * and IDs containing hyphens or underscores break the server-side routing.
+ * Sanitize a button ID to alphanumeric-only for use as a Mattermost URL path segment.
+ * Mattermost uses the action ID in `/api/v4/posts/{id}/actions/{actionId}`.
+ * Colons, hyphens, underscores, and other non-alphanumeric characters break routing.
  * See: https://github.com/mattermost/mattermost/issues/25747
+ *
+ * @returns alphanumeric-only string (may be empty if input is all non-alphanumeric)
  */
 function sanitizeActionId(id: string): string {
-  return id.replace(/[-_]/g, "");
+  return id.replace(/[^a-zA-Z0-9]/g, "");
+}
+
+/** Return the first 8 hex characters of SHA-256(input). */
+function shortHash(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 8);
 }
 
 export function buildButtonAttachments(params: {
@@ -276,8 +283,32 @@ export function buildButtonAttachments(params: {
   }>;
   text?: string;
 }): MattermostAttachment[] {
+  const seenIds = new Set<string>();
+
   const actions: MattermostButton[] = params.buttons.map((btn) => {
-    const safeId = sanitizeActionId(btn.id);
+    let safeId = sanitizeActionId(btn.id);
+
+    // Guard: empty after sanitization → deterministic fallback
+    if (safeId === "") {
+      safeId = "action" + shortHash(btn.id);
+    }
+
+    // Guard: within-message collision → append hash suffix (and counter if needed)
+    if (seenIds.has(safeId)) {
+      const candidate = safeId + shortHash(btn.id);
+      if (!seenIds.has(candidate)) {
+        safeId = candidate;
+      } else {
+        // Pathological: same hash collision, use counter
+        let counter = 2;
+        while (seenIds.has(safeId + String(counter))) {
+          counter++;
+        }
+        safeId = safeId + String(counter);
+      }
+    }
+    seenIds.add(safeId);
+
     const context: Record<string, unknown> = {
       action_id: safeId,
       ...btn.context,


### PR DESCRIPTION
## Summary

Fixes Mattermost interactive button 404s caused by action IDs containing  (and other non-alphanumeric chars) used as URL path segments.

**Spec:** `/home/ubuntu/workspace/metalab/specs/mattermost-actionid-sanitization/SPEC.md`

## Changes

### `interactions.ts`
- `sanitizeActionId()`: regex tightened from `/[-_]/g` to `/[^a-zA-Z0-9]/g` — strips colons, unicode, and all non-alphanumeric chars
- Added `shortHash()` helper: first 8 hex chars of SHA-256 for deterministic fallback IDs
- `buildButtonAttachments()`: empty-id fallback (`"action" + shortHash(originalId)`) when sanitization yields empty string
- `buildButtonAttachments()`: within-message collision dedup via `seenIds` Set

### `interactions.test.ts`
9 new test cases (57 total):
- Strips colons: `softgate:approve:0001` → `softgateapprove0001`
- Strips hyphens/underscores (legacy preserved)
- No-op on alphanumeric-only IDs
- Unicode stripped: `héllo` → `hllo`
- All-punct fallback: `:::` → `action{hash}`
- Empty ID fallback: `""` → `action{hash}`
- All produced IDs match `/^[a-zA-Z0-9]+$/`
- `actions[].id === integration.context.action_id` invariant
- Collision case: unique IDs produced for `"a:b"` and `"ab"`

## Testing

All 57 tests pass. HMAC verification model unaffected (both send and receive paths use the sanitized `safeId`).

## Rollout Note

After merge + deploy, Lucius owns #approval remediation: audit pending broken posts and re-post.