### PR TITLE
feat: add 21 missing tools to tool-display registry

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -28,69 +28,147 @@
     "bash": {
       "emoji": "🛠️",
       "title": "Bash",
-      "detailKeys": ["command"]
+      "detailKeys": [
+        "command"
+      ]
     },
     "process": {
       "emoji": "🧰",
       "title": "Process",
-      "detailKeys": ["sessionId"]
+      "detailKeys": [
+        "sessionId"
+      ]
     },
     "read": {
       "emoji": "📖",
       "title": "Read",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "write": {
       "emoji": "✍️",
       "title": "Write",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "edit": {
       "emoji": "📝",
       "title": "Edit",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "attach": {
       "emoji": "📎",
       "title": "Attach",
-      "detailKeys": ["path", "url", "fileName"]
+      "detailKeys": [
+        "path",
+        "url",
+        "fileName"
+      ]
     },
     "browser": {
       "emoji": "🌐",
       "title": "Browser",
       "actions": {
-        "status": { "label": "status" },
-        "start": { "label": "start" },
-        "stop": { "label": "stop" },
-        "tabs": { "label": "tabs" },
-        "open": { "label": "open", "detailKeys": ["targetUrl"] },
-        "focus": { "label": "focus", "detailKeys": ["targetId"] },
-        "close": { "label": "close", "detailKeys": ["targetId"] },
+        "status": {
+          "label": "status"
+        },
+        "start": {
+          "label": "start"
+        },
+        "stop": {
+          "label": "stop"
+        },
+        "tabs": {
+          "label": "tabs"
+        },
+        "open": {
+          "label": "open",
+          "detailKeys": [
+            "targetUrl"
+          ]
+        },
+        "focus": {
+          "label": "focus",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
+        "close": {
+          "label": "close",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
         "snapshot": {
           "label": "snapshot",
-          "detailKeys": ["targetUrl", "targetId", "ref", "element", "format"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId",
+            "ref",
+            "element",
+            "format"
+          ]
         },
         "screenshot": {
           "label": "screenshot",
-          "detailKeys": ["targetUrl", "targetId", "ref", "element"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId",
+            "ref",
+            "element"
+          ]
         },
         "navigate": {
           "label": "navigate",
-          "detailKeys": ["targetUrl", "targetId"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId"
+          ]
         },
-        "console": { "label": "console", "detailKeys": ["level", "targetId"] },
-        "pdf": { "label": "pdf", "detailKeys": ["targetId"] },
+        "console": {
+          "label": "console",
+          "detailKeys": [
+            "level",
+            "targetId"
+          ]
+        },
+        "pdf": {
+          "label": "pdf",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
         "upload": {
           "label": "upload",
-          "detailKeys": ["paths", "ref", "inputRef", "element", "targetId"]
+          "detailKeys": [
+            "paths",
+            "ref",
+            "inputRef",
+            "element",
+            "targetId"
+          ]
         },
         "dialog": {
           "label": "dialog",
-          "detailKeys": ["accept", "promptText", "targetId"]
+          "detailKeys": [
+            "accept",
+            "promptText",
+            "targetId"
+          ]
         },
         "act": {
           "label": "act",
-          "detailKeys": ["request.kind", "request.ref", "request.selector", "request.text", "request.value"]
+          "detailKeys": [
+            "request.kind",
+            "request.ref",
+            "request.selector",
+            "request.text",
+            "request.value"
+          ]
         }
       }
     },
@@ -98,31 +176,136 @@
       "emoji": "🖼️",
       "title": "Canvas",
       "actions": {
-        "present": { "label": "present", "detailKeys": ["target", "node", "nodeId"] },
-        "hide": { "label": "hide", "detailKeys": ["node", "nodeId"] },
-        "navigate": { "label": "navigate", "detailKeys": ["url", "node", "nodeId"] },
-        "eval": { "label": "eval", "detailKeys": ["javaScript", "node", "nodeId"] },
-        "snapshot": { "label": "snapshot", "detailKeys": ["format", "node", "nodeId"] },
-        "a2ui_push": { "label": "A2UI push", "detailKeys": ["jsonlPath", "node", "nodeId"] },
-        "a2ui_reset": { "label": "A2UI reset", "detailKeys": ["node", "nodeId"] }
+        "present": {
+          "label": "present",
+          "detailKeys": [
+            "target",
+            "node",
+            "nodeId"
+          ]
+        },
+        "hide": {
+          "label": "hide",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
+        "navigate": {
+          "label": "navigate",
+          "detailKeys": [
+            "url",
+            "node",
+            "nodeId"
+          ]
+        },
+        "eval": {
+          "label": "eval",
+          "detailKeys": [
+            "javaScript",
+            "node",
+            "nodeId"
+          ]
+        },
+        "snapshot": {
+          "label": "snapshot",
+          "detailKeys": [
+            "format",
+            "node",
+            "nodeId"
+          ]
+        },
+        "a2ui_push": {
+          "label": "A2UI push",
+          "detailKeys": [
+            "jsonlPath",
+            "node",
+            "nodeId"
+          ]
+        },
+        "a2ui_reset": {
+          "label": "A2UI reset",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        }
       }
     },
     "nodes": {
       "emoji": "📱",
       "title": "Nodes",
       "actions": {
-        "status": { "label": "status" },
-        "describe": { "label": "describe", "detailKeys": ["node", "nodeId"] },
-        "pending": { "label": "pending" },
-        "approve": { "label": "approve", "detailKeys": ["requestId"] },
-        "reject": { "label": "reject", "detailKeys": ["requestId"] },
-        "notify": { "label": "notify", "detailKeys": ["node", "nodeId", "title", "body"] },
-        "camera_snap": { "label": "camera snap", "detailKeys": ["node", "nodeId", "facing", "deviceId"] },
-        "camera_list": { "label": "camera list", "detailKeys": ["node", "nodeId"] },
-        "camera_clip": { "label": "camera clip", "detailKeys": ["node", "nodeId", "facing", "duration", "durationMs"] },
+        "status": {
+          "label": "status"
+        },
+        "describe": {
+          "label": "describe",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
+        "pending": {
+          "label": "pending"
+        },
+        "approve": {
+          "label": "approve",
+          "detailKeys": [
+            "requestId"
+          ]
+        },
+        "reject": {
+          "label": "reject",
+          "detailKeys": [
+            "requestId"
+          ]
+        },
+        "notify": {
+          "label": "notify",
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "title",
+            "body"
+          ]
+        },
+        "camera_snap": {
+          "label": "camera snap",
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "facing",
+            "deviceId"
+          ]
+        },
+        "camera_list": {
+          "label": "camera list",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
+        "camera_clip": {
+          "label": "camera clip",
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "facing",
+            "duration",
+            "durationMs"
+          ]
+        },
         "screen_record": {
           "label": "screen record",
-          "detailKeys": ["node", "nodeId", "duration", "durationMs", "fps", "screenIndex"]
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "duration",
+            "durationMs",
+            "fps",
+            "screenIndex"
+          ]
         }
       }
     },
@@ -130,68 +313,520 @@
       "emoji": "⏰",
       "title": "Cron",
       "actions": {
-        "status": { "label": "status" },
-        "list": { "label": "list" },
+        "status": {
+          "label": "status"
+        },
+        "list": {
+          "label": "list"
+        },
         "add": {
           "label": "add",
-          "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
+          "detailKeys": [
+            "job.name",
+            "job.id",
+            "job.schedule",
+            "job.cron"
+          ]
         },
-        "update": { "label": "update", "detailKeys": ["id"] },
-        "remove": { "label": "remove", "detailKeys": ["id"] },
-        "run": { "label": "run", "detailKeys": ["id"] },
-        "runs": { "label": "runs", "detailKeys": ["id"] },
-        "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
+        "update": {
+          "label": "update",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "remove": {
+          "label": "remove",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "run": {
+          "label": "run",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "runs": {
+          "label": "runs",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "wake": {
+          "label": "wake",
+          "detailKeys": [
+            "text",
+            "mode"
+          ]
+        }
       }
     },
     "gateway": {
       "emoji": "🔌",
       "title": "Gateway",
       "actions": {
-        "restart": { "label": "restart", "detailKeys": ["reason", "delayMs"] }
+        "restart": {
+          "label": "restart",
+          "detailKeys": [
+            "reason",
+            "delayMs"
+          ]
+        }
       }
     },
     "whatsapp_login": {
       "emoji": "🟢",
       "title": "WhatsApp Login",
       "actions": {
-        "start": { "label": "start" },
-        "wait": { "label": "wait" }
+        "start": {
+          "label": "start"
+        },
+        "wait": {
+          "label": "wait"
+        }
       }
     },
     "discord": {
       "emoji": "💬",
       "title": "Discord",
       "actions": {
-        "react": { "label": "react", "detailKeys": ["channelId", "messageId", "emoji"] },
-        "reactions": { "label": "reactions", "detailKeys": ["channelId", "messageId"] },
-        "sticker": { "label": "sticker", "detailKeys": ["to", "stickerIds"] },
-        "poll": { "label": "poll", "detailKeys": ["question", "to"] },
-        "permissions": { "label": "permissions", "detailKeys": ["channelId"] },
-        "readMessages": { "label": "read messages", "detailKeys": ["channelId", "limit"] },
-        "sendMessage": { "label": "send", "detailKeys": ["to", "content"] },
-        "editMessage": { "label": "edit", "detailKeys": ["channelId", "messageId"] },
-        "deleteMessage": { "label": "delete", "detailKeys": ["channelId", "messageId"] },
-        "threadCreate": { "label": "thread create", "detailKeys": ["channelId", "name"] },
-        "threadList": { "label": "thread list", "detailKeys": ["guildId", "channelId"] },
-        "threadReply": { "label": "thread reply", "detailKeys": ["channelId", "content"] },
-        "pinMessage": { "label": "pin", "detailKeys": ["channelId", "messageId"] },
-        "unpinMessage": { "label": "unpin", "detailKeys": ["channelId", "messageId"] },
-        "listPins": { "label": "list pins", "detailKeys": ["channelId"] },
-        "searchMessages": { "label": "search", "detailKeys": ["guildId", "content"] },
-        "memberInfo": { "label": "member", "detailKeys": ["guildId", "userId"] },
-        "roleInfo": { "label": "roles", "detailKeys": ["guildId"] },
-        "emojiList": { "label": "emoji list", "detailKeys": ["guildId"] },
-        "roleAdd": { "label": "role add", "detailKeys": ["guildId", "userId", "roleId"] },
-        "roleRemove": { "label": "role remove", "detailKeys": ["guildId", "userId", "roleId"] },
-        "channelInfo": { "label": "channel", "detailKeys": ["channelId"] },
-        "channelList": { "label": "channels", "detailKeys": ["guildId"] },
-        "voiceStatus": { "label": "voice", "detailKeys": ["guildId", "userId"] },
-        "eventList": { "label": "events", "detailKeys": ["guildId"] },
-        "eventCreate": { "label": "event create", "detailKeys": ["guildId", "name"] },
-        "timeout": { "label": "timeout", "detailKeys": ["guildId", "userId"] },
-        "kick": { "label": "kick", "detailKeys": ["guildId", "userId"] },
-        "ban": { "label": "ban", "detailKeys": ["guildId", "userId"] }
+        "react": {
+          "label": "react",
+          "detailKeys": [
+            "channelId",
+            "messageId",
+            "emoji"
+          ]
+        },
+        "reactions": {
+          "label": "reactions",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "sticker": {
+          "label": "sticker",
+          "detailKeys": [
+            "to",
+            "stickerIds"
+          ]
+        },
+        "poll": {
+          "label": "poll",
+          "detailKeys": [
+            "question",
+            "to"
+          ]
+        },
+        "permissions": {
+          "label": "permissions",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "readMessages": {
+          "label": "read messages",
+          "detailKeys": [
+            "channelId",
+            "limit"
+          ]
+        },
+        "sendMessage": {
+          "label": "send",
+          "detailKeys": [
+            "to",
+            "content"
+          ]
+        },
+        "editMessage": {
+          "label": "edit",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "deleteMessage": {
+          "label": "delete",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "threadCreate": {
+          "label": "thread create",
+          "detailKeys": [
+            "channelId",
+            "name"
+          ]
+        },
+        "threadList": {
+          "label": "thread list",
+          "detailKeys": [
+            "guildId",
+            "channelId"
+          ]
+        },
+        "threadReply": {
+          "label": "thread reply",
+          "detailKeys": [
+            "channelId",
+            "content"
+          ]
+        },
+        "pinMessage": {
+          "label": "pin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "unpinMessage": {
+          "label": "unpin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "listPins": {
+          "label": "list pins",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "searchMessages": {
+          "label": "search",
+          "detailKeys": [
+            "guildId",
+            "content"
+          ]
+        },
+        "memberInfo": {
+          "label": "member",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "roleInfo": {
+          "label": "roles",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "emojiList": {
+          "label": "emoji list",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "roleAdd": {
+          "label": "role add",
+          "detailKeys": [
+            "guildId",
+            "userId",
+            "roleId"
+          ]
+        },
+        "roleRemove": {
+          "label": "role remove",
+          "detailKeys": [
+            "guildId",
+            "userId",
+            "roleId"
+          ]
+        },
+        "channelInfo": {
+          "label": "channel",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "channelList": {
+          "label": "channels",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "voiceStatus": {
+          "label": "voice",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "eventList": {
+          "label": "events",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "eventCreate": {
+          "label": "event create",
+          "detailKeys": [
+            "guildId",
+            "name"
+          ]
+        },
+        "timeout": {
+          "label": "timeout",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "kick": {
+          "label": "kick",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "ban": {
+          "label": "ban",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        }
       }
+    },
+    "exec": {
+      "emoji": "🛠️",
+      "title": "Exec",
+      "detailKeys": [
+        "command"
+      ]
+    },
+    "apply_patch": {
+      "emoji": "📝",
+      "title": "Apply Patch",
+      "detailKeys": [
+        "path"
+      ]
+    },
+    "web_search": {
+      "emoji": "🔍",
+      "title": "Web Search",
+      "detailKeys": [
+        "query"
+      ]
+    },
+    "web_fetch": {
+      "emoji": "🌐",
+      "title": "Web Fetch",
+      "detailKeys": [
+        "url"
+      ]
+    },
+    "message": {
+      "emoji": "💬",
+      "title": "Message",
+      "actions": {
+        "send": {
+          "label": "send",
+          "detailKeys": [
+            "to",
+            "message",
+            "channel"
+          ]
+        },
+        "poll": {
+          "label": "poll",
+          "detailKeys": [
+            "channel",
+            "limit"
+          ]
+        },
+        "react": {
+          "label": "react",
+          "detailKeys": [
+            "emoji",
+            "messageId"
+          ]
+        },
+        "delete": {
+          "label": "delete",
+          "detailKeys": [
+            "messageId"
+          ]
+        },
+        "edit": {
+          "label": "edit",
+          "detailKeys": [
+            "messageId"
+          ]
+        },
+        "topic-create": {
+          "label": "topic",
+          "detailKeys": [
+            "name",
+            "channel"
+          ]
+        }
+      }
+    },
+    "image": {
+      "emoji": "🖼️",
+      "title": "Image",
+      "detailKeys": [
+        "image",
+        "prompt"
+      ]
+    },
+    "image_generate": {
+      "emoji": "🎨",
+      "title": "Image Generate",
+      "actions": {
+        "generate": {
+          "label": "generate",
+          "detailKeys": [
+            "prompt",
+            "size"
+          ]
+        },
+        "list": {
+          "label": "list"
+        }
+      }
+    },
+    "pdf": {
+      "emoji": "📄",
+      "title": "PDF",
+      "detailKeys": [
+        "pdf",
+        "prompt",
+        "pages"
+      ]
+    },
+    "sessions_spawn": {
+      "emoji": "🚀",
+      "title": "Spawn Agent",
+      "detailKeys": [
+        "task",
+        "label",
+        "agentId",
+        "runtime",
+        "mode"
+      ]
+    },
+    "sessions_list": {
+      "emoji": "📋",
+      "title": "Sessions",
+      "detailKeys": [
+        "kinds",
+        "limit"
+      ]
+    },
+    "sessions_history": {
+      "emoji": "📜",
+      "title": "Session History",
+      "detailKeys": [
+        "sessionKey",
+        "limit"
+      ]
+    },
+    "sessions_send": {
+      "emoji": "📨",
+      "title": "Session Send",
+      "detailKeys": [
+        "sessionKey",
+        "label",
+        "message"
+      ]
+    },
+    "sessions_yield": {
+      "emoji": "⏸️",
+      "title": "Yield",
+      "detailKeys": [
+        "message"
+      ]
+    },
+    "session_status": {
+      "emoji": "📊",
+      "title": "Status",
+      "detailKeys": [
+        "sessionKey",
+        "model"
+      ]
+    },
+    "subagents": {
+      "emoji": "🤖",
+      "title": "Sub-agents",
+      "actions": {
+        "list": {
+          "label": "list"
+        },
+        "kill": {
+          "label": "kill",
+          "detailKeys": [
+            "target"
+          ]
+        },
+        "steer": {
+          "label": "steer",
+          "detailKeys": [
+            "target",
+            "message"
+          ]
+        }
+      }
+    },
+    "agents_list": {
+      "emoji": "📇",
+      "title": "Agents List"
+    },
+    "diffs": {
+      "emoji": "📊",
+      "title": "Diffs",
+      "detailKeys": [
+        "path",
+        "mode",
+        "title"
+      ]
+    },
+    "lobster": {
+      "emoji": "🦞",
+      "title": "Lobster",
+      "actions": {
+        "run": {
+          "label": "run",
+          "detailKeys": [
+            "pipeline"
+          ]
+        },
+        "resume": {
+          "label": "resume",
+          "detailKeys": [
+            "token",
+            "approve"
+          ]
+        }
+      }
+    },
+    "llm-task": {
+      "emoji": "🧠",
+      "title": "LLM Task",
+      "detailKeys": [
+        "prompt",
+        "model",
+        "provider"
+      ]
+    },
+    "memory_search": {
+      "emoji": "🔎",
+      "title": "Memory Search",
+      "detailKeys": [
+        "query"
+      ]
+    },
+    "memory_get": {
+      "emoji": "🧠",
+      "title": "Memory Get",
+      "detailKeys": [
+        "id",
+        "key"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Add display metadata (emoji, title, detailKeys, actions) for 21 tools that currently fall through to the generic fallback in the Control UI dashboard, showing only "Tool output" instead of meaningful labels and detail previews.

## Changes

Single file change: `apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json`

### Tools added

**Core tools:**
- `exec` — shows command being run
- `apply_patch` — shows target path
- `web_search` — shows search query
- `web_fetch` — shows URL being fetched
- `message` — shows action (send/poll/react/delete/edit) with relevant details
- `image` — shows image path and prompt
- `image_generate` — shows generate/list action with prompt and size
- `pdf` — shows PDF path, prompt, and pages

**Session tools:**
- `sessions_spawn` — shows task, label, agentId, runtime, mode
- `sessions_list` — shows filter params
- `sessions_history` — shows sessionKey and limit
- `sessions_send` — shows target and message
- `sessions_yield` — shows message
- `session_status` — shows sessionKey and model
- `subagents` — shows list/kill/steer actions
- `agents_list`

**Plugin tools:**
- `diffs` — shows path, mode, title
- `lobster` — shows run/resume actions with pipeline detail
- `llm-task` — shows prompt, model, provider

**Memory tools:**
- `memory_search` — shows query
- `memory_get` — shows id/key

## Before/After

**Before:** Tool calls show as generic "Tool output" with no context about what's being executed.

**After:** Each tool shows its name, emoji icon, and relevant detail (e.g., `Exec: ls -la`, `Web Search: "openclaw skills"`, `Spawn Agent: fix-ci-task`).

## Testing

- Follows the existing `ToolDisplaySpec` contract (`emoji`, `title`, `detailKeys`, `actions`)
- Existing tests in `tool-display.test.ts` already reference `sessions_spawn`, `message`, and `sessions_history` — this change provides the registry entries those tests expect
- No breaking changes: only additive entries to the JSON registry