### PR TITLE
Slack: fix missing directory helper import

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -171,6 +171,28 @@ describe("slackPlugin outbound", () => {
   });
 });
 
+describe("slackPlugin directory", () => {
+  it("lists configured peers without throwing a ReferenceError", async () => {
+    const listPeers = slackPlugin.directory?.listPeers;
+    expect(listPeers).toBeDefined();
+
+    await expect(
+      listPeers!({
+        cfg: {
+          channels: {
+            slack: {
+              dms: {
+                U123: {},
+              },
+            },
+          },
+        },
+        runtime: undefined,
+      }),
+    ).resolves.toEqual([{ id: "user:u123", kind: "user" }]);
+  });
+});
+
 describe("slackPlugin agentPrompt", () => {
   it("tells agents interactive replies are disabled by default", () => {
     const hints = slackPlugin.agentPrompt?.messageToolHints?.({

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -21,6 +21,10 @@ import type { SlackActionContext } from "./action-runtime.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { createSlackActions } from "./channel-actions.js";
 import { createSlackWebClient } from "./client.js";
+import {
+  listSlackDirectoryGroupsFromConfig,
+  listSlackDirectoryPeersFromConfig,
+} from "./directory-config.js";
 import { resolveSlackGroupRequireMention, resolveSlackGroupToolPolicy } from "./group-policy.js";
 import { isSlackInteractiveRepliesEnabled } from "./interactive-replies.js";
 import { normalizeAllowListLower } from "./monitor/allow-list.js";


### PR DESCRIPTION
## Summary
- import the Slack directory config helpers into the channel plugin so `directory.listPeers` and `directory.listGroups` do not throw at runtime
- add a regression test that exercises `slackPlugin.directory.listPeers` against configured Slack DMs

## Validation
- `pnpm test -- extensions/slack/src/channel.test.ts`

## Notes
- This addresses a real runtime failure: the directory methods referenced bare identifiers that were never imported.
