### PR TITLE
Slack: remove duplicate directory imports

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -38,8 +38,6 @@ import { resolveSlackUserAllowlist } from "./resolve-users.js";
 import {
   buildComputedAccountStatusSnapshot,
   DEFAULT_ACCOUNT_ID,
-  listSlackDirectoryGroupsFromConfig,
-  listSlackDirectoryPeersFromConfig,
   looksLikeSlackTargetId,
   normalizeSlackMessagingTarget,
   PAIRING_APPROVED_MESSAGE,


### PR DESCRIPTION
## Summary
- remove the duplicate Slack directory helper imports from `./runtime-api.js`
- keep the direct `./directory-config.js` import path that the merged fix already uses

## Validation
- `pnpm test -- extensions/slack/src/channel.test.ts`

## Context
Pulling latest `main` after #49930 showed `extensions/slack/src/channel.ts` importing `listSlackDirectoryPeersFromConfig` and `listSlackDirectoryGroupsFromConfig` twice, which caused a parse failure before the Slack tests could run.
