### PR TITLE
refactor(line): use setup Setup-safe config adapter

### DIFF
--- a/extensions/line/src/channel.setup.ts
+++ b/extensions/line/src/channel.setup.ts
@@ -6,7 +6,6 @@ import {
 } from "../api.js";
 import {
   listLineAccountIds,
-  normalizeAccountId,
   resolveDefaultLineAccountId,
   resolveLineAccount,
 } from "../runtime-api.js";

--- a/extensions/line/src/channel.setup.ts
+++ b/extensions/line/src/channel.setup.ts
@@ -4,9 +4,16 @@ import {
   type ChannelPlugin,
   type ResolvedLineAccount,
 } from "../api.js";
-import { lineConfigAdapter } from "./config-adapter.js";
+import {
+  listLineAccountIds,
+  normalizeAccountId,
+  resolveDefaultLineAccountId,
+  resolveLineAccount,
+} from "../runtime-api.js";
+import { normalizeLineAllowFrom } from "./config-adapter.js";
 import { lineSetupAdapter } from "./setup-core.js";
 import { lineSetupWizard } from "./setup-surface.js";
+import { createScopedChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
 
 const meta = {
   id: "line",
@@ -18,6 +25,29 @@ const meta = {
   blurb: "LINE Messaging API bot for Japan/Taiwan/Thailand markets.",
   systemImage: "message.fill",
 } as const;
+
+/**
+ * Setup-safe config adapter that uses pure core functions instead of
+ * getLineRuntime(), which is unavailable during setup-only registration.
+ */
+const lineSetupConfigAdapter = createScopedChannelConfigAdapter<
+  ResolvedLineAccount,
+  ResolvedLineAccount,
+  import("../api.js").OpenClawConfig
+>({
+  sectionKey: "line",
+  listAccountIds: (cfg) => listLineAccountIds(cfg),
+  resolveAccount: (cfg, accountId) =>
+    resolveLineAccount({ cfg, accountId: accountId ?? undefined }),
+  defaultAccountId: (cfg) => resolveDefaultLineAccountId(cfg),
+  clearBaseFields: ["channelSecret", "tokenFile", "secretFile"],
+  resolveAllowFrom: (account) => account.config.allowFrom,
+  formatAllowFrom: (allowFrom) =>
+    allowFrom
+      .map((entry) => String(entry).trim())
+      .filter(Boolean)
+      .map(normalizeLineAllowFrom),
+});
 
 export const lineSetupPlugin: ChannelPlugin<ResolvedLineAccount> = {
   id: "line",
@@ -36,7 +66,7 @@ export const lineSetupPlugin: ChannelPlugin<ResolvedLineAccount> = {
   reload: { configPrefixes: ["channels.line"] },
   configSchema: buildChannelConfigSchema(LineConfigSchema),
   config: {
-    ...lineConfigAdapter,
+    ...lineSetupConfigAdapter,
     isConfigured: (account) =>
       Boolean(account.channelAccessToken?.trim() && account.channelSecret?.trim()),
     describeAccount: (account) => ({


### PR DESCRIPTION


Here's the completed PR description:

---

## Summary

When running `openclaw onboard --install-daemon`, the CLI crashes with `Error: LINE runtime not initialized - plugin not registered` at the channel selection step.

- **Problem:** `lineSetupPlugin` in `channel.setup.ts` spreads `lineConfigAdapter` into its `config` field. The callbacks in `lineConfigAdapter` (`listAccountIds`, `resolveAccount`, `defaultAccountId`) all call `getLineRuntime()`. During onboard, setup plugins are loaded via `defineSetupPluginEntry` in setup-only registration mode, which never calls `setLineRuntime()`. When the wizard renders the channel list, it invokes these callbacks, triggering `getLineRuntime()` on an uninitialized runtime — causing the crash.
- **Why it matters:** This issue blocks the entire `onboard` command, preventing new users from completing initial setup.
- **What changed:** Replaced the runtime-dependent `lineConfigAdapter` in `lineSetupPlugin` with a standalone `lineSetupConfigAdapter` that uses pure core functions (`listLineAccountIds`, `resolveLineAccount`, `resolveDefaultLineAccountId` from `runtime-api.ts`) directly, without going through `getLineRuntime()`. This aligns LINE with all other bundled channel setup plugins (Telegram, WhatsApp, Discord, Slack, Signal, iMessage, IRC, Google Chat), none of which depend on their respective runtimes in setup mode.
- **What did NOT change (scope boundary):** Any files other than `extensions/line/src/channel.setup.ts`. The full `lineConfigAdapter` in `config-adapter.ts` remains unchanged and is still used by the main channel plugin entry during normal operation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
https://github.com/openclaw/openclaw/issues/49922

## User-visible / Behavior Changes

The onboard wizard now correctly displays LINE as "needs token + secret" instead of crashing. No behavioral change for LINE during normal (non-setup) operation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu

Using the current main branch, commit number 3d8afb96bd903d308e4e6132b77f8f33a994ba22 caused the OpenClaw to crash during the onboard-channel stage.
The error message is as follows:

### Steps

```bash
git clone https://github.com/openclaw/openclaw.git
pnpm install
pnpm ui:build # auto-installs UI deps on first run
pnpm build
pnpm openclaw onboard --install-daemon
# set up your config step by step
# after finishing model setup, proceed to channel setup — crash happens
```

### Actual

```
Error: LINE runtime not initialized - plugin not registered
 ELIFECYCLE  Command failed with exit code 1.
```

### Expected

The channel selection list displays all channels including LINE with status hints (e.g., "needs token + secret") without crashing, allowing the user to select and configure a channel.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
    - Ran `openclaw onboard --install-daemon` end-to-end; channel selection step now renders LINE correctly without crashing
    - Selected LINE channel in the wizard; configuration prompt appears as expected
- Edge cases checked:
    - Audited all 8 other bundled setup plugins (Telegram, WhatsApp, Discord, Slack, Signal, iMessage, IRC, Google Chat) — none have the same runtime dependency issue; LINE was the only outlier
    - Verified that importing `normalizeLineAllowFrom` from `config-adapter.ts` does not trigger `getLineRuntime()` at module load time (it only appears inside callback bodies, not at top-level)
- What you did **not** verify:
    - Full LINE channel messaging flow after configuration (requires actual LINE bot credentials)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `extensions/line/src/channel.setup.ts` to use `lineConfigAdapter` spread (single file change)
- Files/config to restore: `extensions/line/src/channel.setup.ts`
- Known bad symptoms reviewers should watch for: LINE channel not appearing in the onboard wizard, or LINE channel configuration wizard failing to list/resolve accounts

## Risks and Mitigations

- Risk: The new `lineSetupConfigAdapter` could diverge from `lineConfigAdapter` if future changes are made to one but not the other.
  - Mitigation: Both adapters use the same underlying pure functions (`listLineAccountIds`, `resolveLineAccount`, `resolveDefaultLineAccountId`) from the shared core module. A code comment in `channel.setup.ts` documents why a separate adapter is needed. Long-term, `lineConfigAdapter` in `config-adapter.ts` could also be refactored to use the pure functions directly, eliminating the divergence risk entirely.