### PR TITLE
fix(minimax): add MiniMax-M2.5-Lightning to provider catalog

### DIFF
--- a/extensions/minimax/provider-catalog.test.ts
+++ b/extensions/minimax/provider-catalog.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { buildMinimaxPortalProvider } from "./provider-catalog.js";
+
+describe("buildMinimaxPortalProvider", () => {
+  it("includes MiniMax-M2.5-Lightning in the provider catalog", () => {
+    const provider = buildMinimaxPortalProvider();
+    const modelIds = provider.models.map((model) => model.id);
+
+    expect(modelIds).toContain("MiniMax-M2.5-Lightning");
+  });
+});

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -68,6 +68,11 @@ function buildMinimaxCatalog(): ModelDefinitionConfig[] {
       name: "MiniMax M2.5 Highspeed",
       reasoning: true,
     }),
+    buildMinimaxTextModel({
+      id: "MiniMax-M2.5-Lightning",
+      name: "MiniMax M2.5 Lightning",
+      reasoning: true,
+    }),
   ];
 }
 


### PR DESCRIPTION
## Summary

Adds `MiniMax-M2.5-Lightning` to the bundled MiniMax provider catalog so the model exposed in the MiniMax plugin aliases is also available in the actual provider model list.

## Why this PR changed shape

The original `MiniMax-M2.7` work is already present on `main`, so this PR has been cleaned up to keep only the remaining minimax-specific delta that is still missing from `upstream/main`.

## Changes

- Added `MiniMax-M2.5-Lightning` to `extensions/minimax/provider-catalog.ts`
- Added a focused vitest to ensure the portal provider catalog includes `MiniMax-M2.5-Lightning`
- Removed unrelated merge noise from the PR branch

## Test plan

- [x] `npx pnpm@10.23.0 exec vitest run extensions/minimax/provider-catalog.test.ts extensions/minimax/model-definitions.test.ts`
