### PR TITLE
feat: update default context window to 1M tokens for Claude Opus/Sonnet 4.6

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -2,5 +2,7 @@
 // Model id uses pi-ai's built-in Anthropic catalog.
 export const DEFAULT_PROVIDER = "anthropic";
 export const DEFAULT_MODEL = "claude-opus-4-6";
-// Conservative fallback used when model metadata is unavailable.
-export const DEFAULT_CONTEXT_TOKENS = 200_000;
+// Fallback used when model metadata is unavailable.
+// Updated to 1M to match Anthropic's March 2026 GA announcement for
+// Claude Opus 4.6 and Sonnet 4.6 (https://claude.com/blog/1m-context-ga).
+export const DEFAULT_CONTEXT_TOKENS = 1_000_000;


### PR DESCRIPTION
## Summary

Update `DEFAULT_CONTEXT_TOKENS` from 200K to 1M to match Anthropic's March 13, 2026 GA announcement that the 1M token context window is now generally available for Claude Opus 4.6 and Sonnet 4.6 at standard pricing.

## Changes

- `src/agents/defaults.ts`: `DEFAULT_CONTEXT_TOKENS` from `200_000` → `1_000_000`

## Context

- Announcement: https://claude.com/blog/1m-context-ga
- Currently all Anthropic sessions are capped at 200K regardless of actual model capability
- Venice provider already has Claude models at 1M (`src/agents/venice-models.ts`)

## Note

This changes the **fallback** default. Models that already specify their own `contextWindow` in their registry entry are not affected. This only impacts models where `contextWindow` is not explicitly set (which includes the default Anthropic provider).

Closes #49939