### PR TITLE
TUI: restore hook-visible /new resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Docs: https://docs.openclaw.ai
 - xAI/web search: add missing Grok credential metadata so the bundled provider registration type-checks again. (#49472) thanks @scoootscooob.
 - Signal/runtime API: re-export `SignalAccountConfig` so Signal account resolution type-checks again. (#49470) Thanks @scoootscooob.
 - Google Chat/runtime API: thin the private runtime barrel onto the curated public SDK surface while keeping public Google Chat exports intact. (#49504) Thanks @scoootscooob.
+- TUI/hooks: route `/new` back through `sessions.reset(reason="new")` before switching to the per-client `tui-<uuid>` session key, so isolated TUI resets emit hook-visible `command:new` events again. (#49918)
 
 ### Breaking
 

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -94,6 +94,7 @@ export const SessionsResetParamsSchema = Type.Object(
   {
     key: NonEmptyString,
     reason: Type.Optional(Type.Union([Type.Literal("new"), Type.Literal("reset")])),
+    hookSourceKey: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -242,6 +242,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       key,
       reason,
       commandSource: "gateway:sessions.reset",
+      hookSourceKey: typeof p.hookSourceKey === "string" ? p.hookSourceKey : undefined,
     });
     if (!result.ok) {
       respond(false, undefined, result.error);

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1253,6 +1253,35 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset can use a separate hookSourceKey for command:new context", async () => {
+    const { dir } = await createSessionStoreDir();
+    await writeSingleLineSession(dir, "sess-main", "hello");
+
+    await writeSessionStore({
+      entries: {
+        main: { sessionId: "sess-main", updatedAt: Date.now() },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{ ok: true; key: string }>(ws, "sessions.reset", {
+      key: "agent:main:tui-hook-target",
+      reason: "new",
+      hookSourceKey: "main",
+    });
+    expect(reset.ok).toBe(true);
+    expect(sessionHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    const event = (
+      sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
+    )[0]?.[0] as { sessionKey?: string; context?: { previousSessionEntry?: unknown } } | undefined;
+    if (!event) {
+      throw new Error("expected session hook event");
+    }
+    expect(event.sessionKey).toBe("agent:main:tui-hook-target");
+    expect(event.context?.previousSessionEntry).toMatchObject({ sessionId: "sess-main" });
+    ws.close();
+  });
+
   test("sessions.reset returns unavailable when active run does not stop", async () => {
     const { dir, storePath } = await seedActiveMainSession();
     const waitCallCountAtSnapshotClear: number[] = [];

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -254,6 +254,7 @@ export async function performGatewaySessionReset(params: {
   key: string;
   reason: "new" | "reset";
   commandSource: string;
+  hookSourceKey?: string;
 }): Promise<
   | { ok: true; key: string; entry: SessionEntry }
   | { ok: false; error: ReturnType<typeof errorShape> }
@@ -265,13 +266,19 @@ export async function performGatewaySessionReset(params: {
   })();
   const { entry, legacyKey, canonicalKey } = loadSessionEntry(params.key);
   const hadExistingEntry = Boolean(entry);
+  const hookSourceEntry =
+    typeof params.hookSourceKey === "string" &&
+    params.hookSourceKey.trim() &&
+    params.hookSourceKey !== params.key
+      ? loadSessionEntry(params.hookSourceKey).entry
+      : entry;
   const hookEvent = createInternalHookEvent(
     "command",
     params.reason,
     target.canonicalKey ?? params.key,
     {
-      sessionEntry: entry,
-      previousSessionEntry: entry,
+      sessionEntry: hookSourceEntry,
+      previousSessionEntry: hookSourceEntry,
       commandSource: params.commandSource,
       cfg,
     },

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -250,10 +250,11 @@ export class GatewayChatClient {
     return await this.client.request<SessionsPatchResult>("sessions.patch", opts);
   }
 
-  async resetSession(key: string, reason?: "new" | "reset") {
+  async resetSession(key: string, reason?: "new" | "reset", hookSourceKey?: string) {
     return await this.client.request("sessions.reset", {
       key,
       ...(reason ? { reason } : {}),
+      ...(hookSourceKey ? { hookSourceKey } : {}),
     });
   }
 

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -4,10 +4,12 @@ import { createCommandHandlers } from "./tui-command-handlers.js";
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
+type ResetSessionMock = ReturnType<typeof vi.fn> &
+  ((key: string, reason?: "new" | "reset") => Promise<{ ok: true }>);
 
 function createHarness(params?: {
   sendChat?: ReturnType<typeof vi.fn>;
-  resetSession?: ReturnType<typeof vi.fn>;
+  resetSession?: ResetSessionMock;
   setSession?: SetSessionMock;
   loadHistory?: LoadHistoryMock;
   setActivityStatus?: SetActivityStatusMock;
@@ -15,7 +17,8 @@ function createHarness(params?: {
   activeChatRunId?: string | null;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
-  const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
+  const resetSession =
+    params?.resetSession ?? (vi.fn().mockResolvedValue({ ok: true }) as ResetSessionMock);
   const setSession = params?.setSession ?? (vi.fn().mockResolvedValue(undefined) as SetSessionMock);
   const addUser = vi.fn();
   const addSystem = vi.fn();
@@ -140,7 +143,7 @@ describe("tui command handlers", () => {
     );
   });
 
-  it("creates unique session for /new and resets shared session for /reset", async () => {
+  it("routes /new through gateway reset while keeping a unique TUI session", async () => {
     const loadHistory = vi.fn().mockResolvedValue(undefined);
     const setSessionMock = vi.fn().mockResolvedValue(undefined) as SetSessionMock;
     const { handleCommand, resetSession } = createHarness({
@@ -151,14 +154,21 @@ describe("tui command handlers", () => {
     await handleCommand("/new");
     await handleCommand("/reset");
 
-    // /new creates a unique session key (isolates TUI client) (#39217)
+    // /new keeps the isolated TUI session but reuses gateway reset so hooks can observe it.
     expect(setSessionMock).toHaveBeenCalledTimes(1);
     expect(setSessionMock).toHaveBeenCalledWith(
       expect.stringMatching(/^tui-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/),
     );
-    // /reset still resets the shared session
-    expect(resetSession).toHaveBeenCalledTimes(1);
-    expect(resetSession).toHaveBeenCalledWith("agent:main:main", "reset");
+    expect(resetSession).toHaveBeenCalledTimes(2);
+    expect(resetSession).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(
+        /^agent:main:tui-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+      ),
+      "new",
+    );
+    // /reset still resets the shared session in place.
+    expect(resetSession).toHaveBeenNthCalledWith(2, "agent:main:main", "reset");
     expect(loadHistory).toHaveBeenCalledTimes(1); // /reset calls loadHistory directly; /new does so indirectly via setSession
   });
 

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -5,7 +5,7 @@ type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
 type ResetSessionMock = ReturnType<typeof vi.fn> &
-  ((key: string, reason?: "new" | "reset") => Promise<{ ok: true }>);
+  ((key: string, reason?: "new" | "reset", hookSourceKey?: string) => Promise<{ ok: true }>);
 
 function createHarness(params?: {
   sendChat?: ReturnType<typeof vi.fn>;
@@ -166,6 +166,7 @@ describe("tui command handlers", () => {
         /^agent:main:tui-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
       ),
       "new",
+      "agent:main:main",
     );
     // /reset still resets the shared session in place.
     expect(resetSession).toHaveBeenNthCalledWith(2, "agent:main:main", "reset");

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -465,7 +465,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           // to other connected TUI clients sharing the original session key.
           const uniqueKey = `tui-${randomUUID()}`;
           const nextSessionKey = `agent:${normalizeAgentId(state.currentAgentId)}:${uniqueKey}`;
-          await client.resetSession(nextSessionKey, "new");
+          await client.resetSession(nextSessionKey, "new", state.currentSessionKey);
           await setSession(uniqueKey);
           chatLog.addSystem(`new session: ${formatSessionKey(nextSessionKey)}`);
         } catch (err) {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -464,8 +464,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           // This ensures /new creates a fresh session that doesn't broadcast
           // to other connected TUI clients sharing the original session key.
           const uniqueKey = `tui-${randomUUID()}`;
+          const nextSessionKey = `agent:${normalizeAgentId(state.currentAgentId)}:${uniqueKey}`;
+          await client.resetSession(nextSessionKey, "new");
           await setSession(uniqueKey);
-          chatLog.addSystem(`new session: ${uniqueKey}`);
+          chatLog.addSystem(`new session: ${formatSessionKey(nextSessionKey)}`);
         } catch (err) {
           chatLog.addSystem(`new session failed: ${sanitizeRenderableText(String(err))}`);
         }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `#49918` reported that TUI `/new` stopped emitting hook-visible `command:new` behavior after the per-client session isolation change.
- Why it matters: hook-driven flows like `command-logger` and `session-memory` silently stop running for TUI `/new`, even though users still expect a normal fresh-session reset.
- What changed: `/new` now resets the newly allocated per-client `tui-<uuid>` session through `sessions.reset(reason="new")` before switching the TUI to that unique key, and the command-handler test now locks that route in.
- What did NOT change (scope boundary): `/reset` behavior stays in-place on the current session, and TUI session isolation still uses unique per-client keys.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49918
- Related #

## User-visible / Behavior Changes

TUI `/new` once again emits the same hook-visible reset path as other reset flows, while still creating an isolated `tui-<uuid>` session for the current TUI client.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): TUI command handling + gateway session reset hooks
- Relevant config (redacted): test harness defaults

### Steps

1. Register a hook that listens for `command:new`.
2. Open `openclaw tui` and run `/new`.
3. Observe whether the fresh-session path goes through `sessions.reset(reason="new")` or only switches local session state.

### Expected

- `/new` keeps the isolated `tui-<uuid>` behavior and still emits the standard hook-visible `command:new` reset path.

### Actual

- Before this patch, `/new` only called local `setSession(uniqueKey)` and skipped the gateway reset path entirely.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:

- `pnpm test -- src/tui/tui-command-handlers.test.ts`
- `pnpm test -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts -t 'sessions.reset emits internal command hook with reason'`
- `pnpm exec oxfmt --check src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts`
- `pnpm exec oxlint src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `/new` now routes through gateway reset with reason `new`, `/reset` still resets the shared current session, and existing gateway coverage still confirms that `sessions.reset(reason="new")` emits the internal command hook.
- Edge cases checked: canonical `agent:main:tui-<uuid>` session key generation for `/new` and preserved `/reset` behavior.
- What you did **not** verify: a live interactive TUI session with a real installed hook script.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `37d84d03f8`
- Files/config to restore: `src/tui/tui-command-handlers.ts`, `src/tui/tui-command-handlers.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: `/new` no longer emitting hook-visible resets, or TUI `/new` falling back to the shared main session instead of a unique `tui-<uuid>` key

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `/new` could accidentally stop isolating the TUI client if the canonical unique key routing regresses.
  - Mitigation: the command-handler test asserts both the unique `tui-<uuid>` session handoff and the gateway reset call shape.
