### PR TITLE
fix: use explicit agent workspace when writing transcript headers

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
-import Ajv from "ajv";
+import AjvPkg from "ajv";
 import {
   formatXHighModelHint,
   normalizeThinkLevel,
@@ -214,7 +214,13 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
         // oxlint-disable-next-line typescript/no-explicit-any
         const schema = (params as any).schema as unknown;
         if (schema && typeof schema === "object" && !Array.isArray(schema)) {
-          const ajv = new Ajv.default({ allErrors: true, strict: false });
+          const Ajv = AjvPkg as unknown as new (opts?: object) => {
+            compile: (schema: unknown) => {
+              errors?: Array<{ instancePath?: string; message?: string }>;
+              (value: unknown): boolean;
+            };
+          };
+          const ajv = new Ajv({ allErrors: true, strict: false });
           // oxlint-disable-next-line typescript/no-explicit-any
           const validate = ajv.compile(schema as any);
           const ok = validate(parsed);

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -9,6 +9,13 @@ vi.mock("./create-client.js", () => ({
   createMatrixClient: (...args: unknown[]) => createMatrixClientMock(...args),
 }));
 
+vi.mock("../sdk-runtime.js", () => ({
+  getMatrixLogService: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
 function makeAuth(suffix: string): MatrixAuth {
   return {
     homeserver: "https://matrix.example.org",

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -8,6 +8,18 @@ import {
 } from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
+vi.mock("../../../runtime-api.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../runtime-api.js")>("../../../runtime-api.js");
+  return {
+    ...actual,
+    dispatchReplyFromConfigWithSettledDispatcher: vi.fn().mockResolvedValue({
+      queuedFinal: false,
+      counts: { final: 0, partial: 0, tool: 0 },
+    }),
+  };
+});
+
 describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
   it("stores sender-labeled BodyForAgent for group thread messages", async () => {
     const recordInboundSession = vi.fn().mockResolvedValue(undefined);

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
-import { buildModelsProviderData } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import {
   buildMattermostAllowedModelRefs,
@@ -126,7 +125,7 @@ describe("Mattermost model picker", () => {
     expect(parseMattermostModelPickerContext({ action: "select" })).toBeNull();
   });
 
-  it("falls back to the routed agent default model when no override is stored", async () => {
+  it("falls back to the routed agent default model when no override is stored", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-model-picker-"));
     try {
       const cfg: OpenClawConfig = {
@@ -145,7 +144,14 @@ describe("Mattermost model picker", () => {
           ],
         },
       };
-      const providerData = await buildModelsProviderData(cfg, "support");
+      const providerData = {
+        byProvider: new Map<string, Set<string>>(),
+        providers: [],
+        resolvedDefault: {
+          provider: "openai",
+          model: "gpt-5",
+        },
+      };
 
       expect(
         resolveMattermostModelPickerCurrentModel({

--- a/extensions/nostr/src/config-schema.ts
+++ b/extensions/nostr/src/config-schema.ts
@@ -1,6 +1,10 @@
-import { AllowFromListSchema, DmPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
+import {
+  AllowFromListSchema,
+  buildChannelConfigSchema,
+  DmPolicySchema,
+  MarkdownConfigSchema,
+} from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
-import { MarkdownConfigSchema, buildChannelConfigSchema } from "../api.js";
 
 /**
  * Validates https:// URLs only (no javascript:, data:, file:, etc.)

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { configureClient } from "@tloncorp/api";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-runtime";
 import type {
   ChannelAccountSnapshot,
@@ -16,6 +15,7 @@ import {
   parseTlonTarget,
   resolveTlonOutboundTarget,
 } from "./targets.js";
+import { loadTlonApi } from "./tlon-api.js";
 import { resolveTlonAccount } from "./types.js";
 import { authenticate } from "./urbit/auth.js";
 import { ssrfPolicyFromAllowPrivateNetwork } from "./urbit/context.js";
@@ -164,8 +164,9 @@ export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
     const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
+    const { configureClient } = await loadTlonApi();
 
-    configureClient({
+    await configureClient({
       shipUrl: account.url,
       shipName: account.ship.replace(/^~/, ""),
       verbose: false,

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -1,0 +1,25 @@
+type ConfigureClientParams = {
+  shipUrl: string;
+  shipName: string;
+  verbose?: boolean;
+  getCode?: () => Promise<string> | string;
+};
+
+type UploadFileParams = {
+  blob: Blob;
+  fileName?: string;
+  contentType?: string;
+};
+
+type UploadFileResult = {
+  url: string;
+};
+
+type TlonApiModule = {
+  configureClient: (params: ConfigureClientParams) => Promise<void>;
+  uploadFile: (params: UploadFileParams) => Promise<UploadFileResult>;
+};
+
+export async function loadTlonApi(): Promise<TlonApiModule> {
+  return (await import("@tloncorp/api")) as unknown as TlonApiModule;
+}

--- a/extensions/tlon/src/tloncorp-api.d.ts
+++ b/extensions/tlon/src/tloncorp-api.d.ts
@@ -1,0 +1,14 @@
+declare module "@tloncorp/api" {
+  export function configureClient(params: {
+    shipUrl: string;
+    shipName: string;
+    verbose?: boolean;
+    getCode?: () => Promise<string> | string;
+  }): Promise<void>;
+
+  export function uploadFile(params: {
+    blob: Blob;
+    fileName?: string;
+    contentType?: string;
+  }): Promise<{ url: string }>;
+}

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -1,8 +1,8 @@
 /**
  * Upload an image from a URL to Tlon storage.
  */
-import { uploadFile } from "@tloncorp/api";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/infra-runtime";
+import { loadTlonApi } from "../tlon-api.js";
 import { getDefaultSsrFPolicy } from "./context.js";
 
 /**
@@ -43,6 +43,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
       const fileName = urlPath.split("/").pop() || `upload-${Date.now()}.png`;
 
       // Upload to Tlon storage
+      const { uploadFile } = await loadTlonApi();
       const result = await uploadFile({
         blob,
         fileName,

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -16,17 +16,10 @@ const pnpm = "pnpm";
 const behaviorManifest = loadTestRunnerBehavior();
 const existingFiles = (entries) =>
   entries.map((entry) => entry.file).filter((file) => fs.existsSync(file));
-const unitBehaviorIsolatedFiles = existingFiles(behaviorManifest.unit.isolated);
-const unitSingletonIsolatedFiles = existingFiles(behaviorManifest.unit.singletonIsolated);
-const unitThreadSingletonFiles = existingFiles(behaviorManifest.unit.threadSingleton);
-const unitVmForkSingletonFiles = existingFiles(behaviorManifest.unit.vmForkSingleton);
-const unitBehaviorOverrideSet = new Set([
-  ...unitBehaviorIsolatedFiles,
-  ...unitSingletonIsolatedFiles,
-  ...unitThreadSingletonFiles,
-  ...unitVmForkSingletonFiles,
-]);
-const channelSingletonFiles = [];
+const rawUnitBehaviorIsolatedFiles = existingFiles(behaviorManifest.unit.isolated);
+const rawUnitSingletonIsolatedFiles = existingFiles(behaviorManifest.unit.singletonIsolated);
+const rawUnitThreadSingletonFiles = existingFiles(behaviorManifest.unit.threadSingleton);
+const rawUnitVmForkSingletonFiles = existingFiles(behaviorManifest.unit.vmForkSingleton);
 
 const children = new Set();
 const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
@@ -173,6 +166,30 @@ const passthroughRequiresSingleRun = passthroughOptionArgs.some((arg) => {
 });
 const baseConfigPrefixes = ["src/agents/", "src/auto-reply/", "src/commands/", "test/", "ui/"];
 const normalizeRepoPath = (value) => value.split(path.sep).join("/");
+const inferOwner = (fileFilter) => {
+  if (fileFilter.endsWith(".live.test.ts")) {
+    return "live";
+  }
+  if (fileFilter.endsWith(".e2e.test.ts")) {
+    return "e2e";
+  }
+  if (channelTestPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "channels";
+  }
+  if (fileFilter.startsWith("extensions/")) {
+    return "extensions";
+  }
+  if (fileFilter.startsWith("src/gateway/")) {
+    return "gateway";
+  }
+  if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
+    return "base";
+  }
+  if (fileFilter.startsWith("src/")) {
+    return "unit";
+  }
+  return "base";
+};
 const walkTestFiles = (rootDir) => {
   if (!fs.existsSync(rootDir)) {
     return [];
@@ -206,37 +223,38 @@ const allKnownTestFiles = [
     ...walkTestFiles(path.join("ui", "src", "ui")),
   ]),
 ];
+// Keep the unit-specific behavior lanes aligned with vitest.unit.config.ts. If the
+// manifest accidentally points at a file owned by another config (for example an
+// extension test), we should not count it toward unit sharding.
+const unitBehaviorIsolatedFiles = rawUnitBehaviorIsolatedFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitSingletonIsolatedFiles = rawUnitSingletonIsolatedFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitThreadSingletonFiles = rawUnitThreadSingletonFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitVmForkSingletonFiles = rawUnitVmForkSingletonFiles.filter(
+  (file) => inferOwner(file) === "unit",
+);
+const unitBehaviorOverrideSet = new Set([
+  ...unitBehaviorIsolatedFiles,
+  ...unitSingletonIsolatedFiles,
+  ...unitThreadSingletonFiles,
+  ...unitVmForkSingletonFiles,
+]);
+const channelSingletonFiles = [];
 const inferTarget = (fileFilter) => {
   const isolated = unitBehaviorIsolatedFiles.includes(fileFilter);
-  if (fileFilter.endsWith(".live.test.ts")) {
-    return { owner: "live", isolated };
-  }
-  if (fileFilter.endsWith(".e2e.test.ts")) {
-    return { owner: "e2e", isolated };
-  }
-  if (channelTestPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return { owner: "channels", isolated };
-  }
-  if (fileFilter.startsWith("extensions/")) {
-    return { owner: "extensions", isolated };
-  }
-  if (fileFilter.startsWith("src/gateway/")) {
-    return { owner: "gateway", isolated };
-  }
-  if (baseConfigPrefixes.some((prefix) => fileFilter.startsWith(prefix))) {
-    return { owner: "base", isolated };
-  }
-  if (fileFilter.startsWith("src/")) {
-    return { owner: "unit", isolated };
-  }
-  return { owner: "base", isolated };
+  return { owner: inferOwner(fileFilter), isolated };
 };
 const unitTimingManifest = loadUnitTimingManifest();
 const parseEnvNumber = (name, fallback) => {
   const parsed = Number.parseInt(process.env[name] ?? "", 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 };
-const allKnownUnitFiles = allKnownTestFiles.filter((file) => inferTarget(file).owner === "unit");
+const allKnownUnitFiles = allKnownTestFiles.filter((file) => inferOwner(file) === "unit");
 const defaultHeavyUnitFileLimit =
   testProfile === "serial" ? 0 : testProfile === "low" ? 8 : highMemLocalHost ? 24 : 16;
 const defaultHeavyUnitLaneCount =

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "./types.js";
+
+const state = vi.hoisted(() => ({
+  sessionFile: "",
+  store: {} as Record<string, SessionEntry>,
+  appendMessage: vi.fn(),
+}));
+
+vi.mock("../io.js", () => ({
+  loadConfig: () => ({
+    agents: {
+      list: [{ id: "sunke", default: true }],
+    },
+  }),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "sunke",
+  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) =>
+    `/Users/admin/.openclaw/workspace-${agentId}`,
+}));
+
+vi.mock("../../sessions/transcript-events.js", () => ({
+  emitSessionTranscriptUpdate: vi.fn(),
+}));
+
+vi.mock("./delivery-info.js", () => ({
+  parseSessionThreadInfo: () => ({ baseSessionKey: undefined, threadId: undefined }),
+}));
+
+vi.mock("./paths.js", () => ({
+  resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
+  resolveSessionFilePath: () => state.sessionFile,
+  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionTranscriptPath: () => state.sessionFile,
+}));
+
+vi.mock("./session-file.js", () => ({
+  resolveAndPersistSessionFile: async () => ({
+    sessionFile: state.sessionFile,
+    sessionEntry: state.store["agent:main:test:user-1"],
+  }),
+}));
+
+vi.mock("./store.js", () => ({
+  loadSessionStore: () => state.store,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+  CURRENT_SESSION_VERSION: 2,
+  SessionManager: {
+    open: () => ({
+      appendMessage: state.appendMessage,
+    }),
+  },
+}));
+
+let appendAssistantMessageToSessionTranscript: typeof import("./transcript.js").appendAssistantMessageToSessionTranscript;
+let originalCwd = process.cwd();
+
+beforeEach(async () => {
+  vi.resetModules();
+  state.appendMessage = vi.fn();
+  state.store = {
+    "agent:main:test:user-1": {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+    } as SessionEntry,
+  };
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-"));
+  const wrongWorkspace = path.join(tmpRoot, "wrong-workspace");
+  fs.mkdirSync(wrongWorkspace, { recursive: true });
+  process.chdir(wrongWorkspace);
+
+  state.sessionFile = path.join(tmpRoot, "sessions", "session-1.jsonl");
+  ({ appendAssistantMessageToSessionTranscript } = await import("./transcript.js"));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+});
+
+describe("appendAssistantMessageToSessionTranscript", () => {
+  it("writes the session header cwd from the target agent workspace instead of process.cwd()", async () => {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: "sunke",
+      sessionKey: "agent:main:test:user-1",
+      text: "hello",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      sessionFile: state.sessionFile,
+    });
+
+    const [headerLine] = fs.readFileSync(state.sessionFile, "utf-8").split(/\r?\n/);
+    const header = JSON.parse(headerLine) as { cwd?: string };
+
+    expect(header.cwd).toBe("/Users/admin/.openclaw/workspace-sunke");
+    expect(header.cwd).not.toBe(process.cwd());
+  });
+});

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -35,7 +35,10 @@ vi.mock("./delivery-info.js", () => ({
 vi.mock("./paths.js", () => ({
   resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
   resolveSessionFilePath: () => state.sessionFile,
-  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionFilePathOptions: () => ({
+    agentId: "sunke",
+    sessionsDir: path.dirname(state.sessionFile),
+  }),
   resolveSessionTranscriptPath: () => state.sessionFile,
 }));
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { loadConfig } from "../io.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
@@ -67,17 +69,23 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  agentId?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: resolveAgentWorkspaceDir(cfg, agentId),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -178,7 +186,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, agentId: params.agentId });
 
   if (
     params.idempotencyKey &&

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -69,23 +69,18 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
-  agentId?: string;
+  cwd: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
-  const cfg = loadConfig();
-  const agentId =
-    typeof params.agentId === "string" && params.agentId.trim()
-      ? params.agentId.trim()
-      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: resolveAgentWorkspaceDir(cfg, agentId),
+    cwd: params.cwd,
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -166,6 +161,12 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
+  const sessionCwd = resolveAgentWorkspaceDir(cfg, agentId);
 
   let sessionFile: string;
   try {
@@ -186,7 +187,11 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, agentId: params.agentId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    cwd: sessionCwd,
+  });
 
   if (
     params.idempotencyKey &&

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { loadConfig } from "../io.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { loadConfig } from "../io.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
   resolveDefaultSessionStorePath,

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -1,14 +1,44 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { setDefaultChannelPluginRegistryForTests } from "../../commands/channel-test-helpers.js";
+import { matrixPlugin } from "../../../extensions/matrix/index.js";
+import { msteamsPlugin } from "../../../extensions/msteams/index.js";
+import { nostrPlugin } from "../../../extensions/nostr/index.js";
+import { tlonPlugin } from "../../../extensions/tlon/index.js";
+import { zalouserPlugin } from "../../../extensions/zalouser/index.js";
+import { bundledChannelPlugins } from "../../channels/plugins/bundled.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { resolveOutboundSessionRoute } from "./outbound-session.js";
+
+function setSessionRoutePluginRegistryForTests(): void {
+  const channels = [
+    ...bundledChannelPlugins,
+    matrixPlugin,
+    msteamsPlugin,
+    nostrPlugin,
+    tlonPlugin,
+    zalouserPlugin,
+  ].map((plugin) => ({
+    pluginId: plugin.id,
+    plugin,
+    source: "test" as const,
+  })) as unknown as Parameters<typeof createTestRegistry>[0];
+  setActivePluginRegistry(createTestRegistry(channels));
+}
 
 describe("resolveOutboundSessionRoute", () => {
   beforeEach(() => {
-    setDefaultChannelPluginRegistryForTests();
+    setSessionRoutePluginRegistryForTests();
   });
 
   const baseConfig = {} as OpenClawConfig;
+
+  async function resolveRouteForTest(
+    params: Parameters<typeof resolveOutboundSessionRoute>[0],
+  ): ReturnType<typeof resolveOutboundSessionRoute> {
+    setSessionRoutePluginRegistryForTests();
+    return resolveOutboundSessionRoute(params);
+  }
 
   it("resolves provider-specific session routes", async () => {
     const perChannelPeerCfg = { session: { dmScope: "per-channel-peer" } } as OpenClawConfig;
@@ -268,7 +298,7 @@ describe("resolveOutboundSessionRoute", () => {
     ];
 
     for (const testCase of cases) {
-      const route = await resolveOutboundSessionRoute({
+      const route = await resolveRouteForTest({
         cfg: testCase.cfg,
         channel: testCase.channel,
         agentId: "main",
@@ -293,7 +323,7 @@ describe("resolveOutboundSessionRoute", () => {
   });
 
   it("uses resolved Discord user targets to route bare numeric ids as DMs", async () => {
-    const route = await resolveOutboundSessionRoute({
+    const route = await resolveRouteForTest({
       cfg: { session: { dmScope: "per-channel-peer" } } as OpenClawConfig,
       channel: "discord",
       agentId: "main",
@@ -315,7 +345,7 @@ describe("resolveOutboundSessionRoute", () => {
 
   it("uses resolved Mattermost user targets to route bare ids as DMs", async () => {
     const userId = "dthcxgoxhifn3pwh65cut3ud3w";
-    const route = await resolveOutboundSessionRoute({
+    const route = await resolveRouteForTest({
       cfg: { session: { dmScope: "per-channel-peer" } } as OpenClawConfig,
       channel: "mattermost",
       agentId: "main",
@@ -337,7 +367,7 @@ describe("resolveOutboundSessionRoute", () => {
 
   it("rejects bare numeric Discord targets when the caller has no kind hint", async () => {
     await expect(
-      resolveOutboundSessionRoute({
+      resolveRouteForTest({
         cfg: { session: { dmScope: "per-channel-peer" } } as OpenClawConfig,
         channel: "discord",
         agentId: "main",

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -56,7 +56,8 @@ describe("loadEnabledBundleMcpConfig", () => {
         throw new Error("expected bundled MCP args to include the server path");
       }
       expect(await fs.realpath(loadedServerPath)).toBe(resolvedServerPath);
-      expect(loadedServer.cwd).toBe(resolvedPluginRoot);
+      expect(typeof loadedServer.cwd).toBe("string");
+      expect(await fs.realpath(String(loadedServer.cwd))).toBe(resolvedPluginRoot);
     } finally {
       env.restore();
     }
@@ -145,7 +146,15 @@ describe("loadEnabledBundleMcpConfig", () => {
       delete process.env.OPENCLAW_STATE_DIR;
 
       const pluginRoot = path.join(homeDir, ".openclaw", "extensions", "inline-claude");
+      const serverCommandPath = path.join(pluginRoot, "bin", "server.sh");
+      const serverProbePath = path.join(pluginRoot, "servers", "probe.mjs");
+      const localProbePath = path.join(pluginRoot, "local-probe.mjs");
       await fs.mkdir(path.join(pluginRoot, ".claude-plugin"), { recursive: true });
+      await fs.mkdir(path.dirname(serverCommandPath), { recursive: true });
+      await fs.mkdir(path.dirname(serverProbePath), { recursive: true });
+      await fs.writeFile(serverCommandPath, "#!/bin/sh\n", "utf-8");
+      await fs.writeFile(serverProbePath, "export {};\n", "utf-8");
+      await fs.writeFile(localProbePath, "export {};\n", "utf-8");
       await fs.writeFile(
         path.join(pluginRoot, ".claude-plugin", "plugin.json"),
         `${JSON.stringify(
@@ -179,19 +188,31 @@ describe("loadEnabledBundleMcpConfig", () => {
         },
       });
       const resolvedPluginRoot = await fs.realpath(pluginRoot);
+      const inlineProbe = loaded.config.mcpServers.inlineProbe;
+      const inlineArgs = getServerArgs(inlineProbe);
+      const inlineCommand =
+        isRecord(inlineProbe) && typeof inlineProbe.command === "string"
+          ? inlineProbe.command
+          : undefined;
+      const inlineCwd =
+        isRecord(inlineProbe) && typeof inlineProbe.cwd === "string" ? inlineProbe.cwd : undefined;
+      const inlineEnvPluginRoot =
+        isRecord(inlineProbe) &&
+        isRecord(inlineProbe.env) &&
+        typeof inlineProbe.env.PLUGIN_ROOT === "string"
+          ? inlineProbe.env.PLUGIN_ROOT
+          : undefined;
 
       expect(loaded.diagnostics).toEqual([]);
-      expect(loaded.config.mcpServers.inlineProbe).toEqual({
-        command: path.join(resolvedPluginRoot, "bin", "server.sh"),
-        args: [
-          path.join(resolvedPluginRoot, "servers", "probe.mjs"),
-          path.join(resolvedPluginRoot, "local-probe.mjs"),
-        ],
-        cwd: resolvedPluginRoot,
-        env: {
-          PLUGIN_ROOT: resolvedPluginRoot,
-        },
-      });
+      expect(inlineCommand).toBeDefined();
+      expect(inlineArgs).toHaveLength(2);
+      expect(inlineCwd).toBeDefined();
+      expect(inlineEnvPluginRoot).toBeDefined();
+      expect(await fs.realpath(String(inlineCommand))).toBe(await fs.realpath(serverCommandPath));
+      expect(await fs.realpath(String(inlineArgs?.[0]))).toBe(await fs.realpath(serverProbePath));
+      expect(await fs.realpath(String(inlineArgs?.[1]))).toBe(await fs.realpath(localProbePath));
+      expect(await fs.realpath(String(inlineCwd))).toBe(resolvedPluginRoot);
+      expect(await fs.realpath(String(inlineEnvPluginRoot))).toBe(resolvedPluginRoot);
     } finally {
       env.restore();
     }

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -3,10 +3,17 @@ import type { WindowsAclEntry, WindowsAclSummary } from "./windows-acl.js";
 
 const MOCK_USERNAME = "MockUser";
 
-vi.mock("node:os", () => ({
-  default: { userInfo: () => ({ username: MOCK_USERNAME }) },
-  userInfo: () => ({ username: MOCK_USERNAME }),
-}));
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      userInfo: () => ({ username: MOCK_USERNAME }),
+    },
+    userInfo: () => ({ username: MOCK_USERNAME }),
+  };
+});
 
 let createIcaclsResetCommand: typeof import("./windows-acl.js").createIcaclsResetCommand;
 let formatIcaclsResetCommand: typeof import("./windows-acl.js").formatIcaclsResetCommand;


### PR DESCRIPTION
## Summary

- stop session transcript headers from recording `cwd` via `process.cwd()` in the outbound transcript mirroring path
- resolve transcript header `cwd` explicitly from config + target agent workspace and cover it with a focused regression test
- keep the branch green on current `main` by carrying the small CI-unblock fixes that were required during validation (`scripts/test-parallel.mjs` sharding ownership alignment plus the related extension typing/test fixture fixes)

## Why

Related issue: #49523  
Related regression pattern: #45413

The previous code path in `src/config/sessions/transcript.ts` wrote:

```ts
cwd: process.cwd()
```

That is process-global state. In a multi-agent runtime, other embedded paths can temporarily switch cwd, so a brand-new transcript header can end up recording another agent's workspace.

## Changes

- import `resolveAgentWorkspaceDir` and `resolveDefaultAgentId`
- import `loadConfig`
- make `ensureSessionHeader()` accept explicit transcript workspace context
- resolve header `cwd` from the target agent workspace instead of `process.cwd()`
- add a focused regression test for transcript header cwd isolation
- align unit sharding with actual config ownership in `scripts/test-parallel.mjs`
- carry the minimal follow-up fixes needed for `pnpm check` / `pnpm test:extensions` to stay green on this branch

## Validation

- `CI=1 pnpm check`
- `CI=1 corepack pnpm test:extensions`
- `pnpm vitest run src/config/sessions/transcript.test.ts`
- `CI=true RUNNER_OS=Windows OPENCLAW_TEST_SHARDS=6 OPENCLAW_TEST_SHARD_INDEX=4 OPENCLAW_TEST_LIST_LANES=1 node scripts/test-parallel.mjs | rg '^unit-isolated'`

## Notes

This supersedes #49525 and #49951. Those earlier PRs were created from older branch baselines and GitHub kept generating stale merge refs for them, which pulled unrelated CI noise into the review.
