### PR TITLE
[codex] LINE: avoid runtime lookup during onboarding

### DIFF
--- a/extensions/line/src/config-adapter.ts
+++ b/extensions/line/src/config-adapter.ts
@@ -1,13 +1,11 @@
 import { createScopedChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
-import type { OpenClawConfig, ResolvedLineAccount } from "../api.js";
-import { getLineRuntime } from "./runtime.js";
-
-function resolveLineRuntimeAccount(cfg: OpenClawConfig, accountId?: string | null) {
-  return getLineRuntime().channel.line.resolveLineAccount({
-    cfg,
-    accountId: accountId ?? undefined,
-  });
-}
+import {
+  listLineAccountIds,
+  resolveDefaultLineAccountId,
+  resolveLineAccount,
+  type OpenClawConfig,
+  type ResolvedLineAccount,
+} from "../runtime-api.js";
 
 export function normalizeLineAllowFrom(entry: string): string {
   return entry.replace(/^line:(?:user:)?/i, "");
@@ -19,9 +17,10 @@ export const lineConfigAdapter = createScopedChannelConfigAdapter<
   OpenClawConfig
 >({
   sectionKey: "line",
-  listAccountIds: (cfg) => getLineRuntime().channel.line.listLineAccountIds(cfg),
-  resolveAccount: (cfg, accountId) => resolveLineRuntimeAccount(cfg, accountId),
-  defaultAccountId: (cfg) => getLineRuntime().channel.line.resolveDefaultLineAccountId(cfg),
+  listAccountIds: listLineAccountIds,
+  resolveAccount: (cfg, accountId) =>
+    resolveLineAccount({ cfg, accountId: accountId ?? undefined }),
+  defaultAccountId: resolveDefaultLineAccountId,
   clearBaseFields: ["channelSecret", "tokenFile", "secretFile"],
   resolveAllowFrom: (account) => account.config.allowFrom,
   formatAllowFrom: (allowFrom) =>

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -277,6 +277,32 @@ describe("setupChannels", () => {
     expect(multiselect).not.toHaveBeenCalled();
   });
 
+  it("renders the QuickStart channel picker without requiring the LINE runtime", async () => {
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "__skip__";
+      }
+      return "__done__";
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    await expect(
+      runSetupChannels({} as OpenClawConfig, prompter, {
+        quickstartDefaults: true,
+      }),
+    ).resolves.toEqual({} as OpenClawConfig);
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select channel (QuickStart)" }),
+    );
+    expect(multiselect).not.toHaveBeenCalled();
+  });
+
   it("continues Telegram setup when the plugin registry is empty", async () => {
     // Simulate missing registry entries (the scenario reported in #25545).
     setActivePluginRegistry(createEmptyPluginRegistry());


### PR DESCRIPTION
## Summary

- Problem: QuickStart onboarding could crash after the channel primer with `LINE runtime not initialized - plugin not registered` when rendering the channel picker.
- Why it matters: `pnpm openclaw onboard --install-daemon` could fail before the operator selected any channel, blocking a common first-run path.
- What changed: the LINE config adapter now resolves account state through runtime-neutral LINE account helpers instead of the plugin runtime store, and a regression test covers rendering the QuickStart picker without a LINE runtime.
- What did NOT change (scope boundary): this does not change LINE runtime behavior after startup, credential resolution semantics, network calls, daemon install behavior, or channel setup flows beyond removing the premature runtime dependency.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

QuickStart onboarding no longer requires the LINE plugin runtime to be initialized just to render `Select channel (QuickStart)`. Users hitting `pnpm openclaw onboard --install-daemon` should now reach the channel picker instead of failing immediately after the channel primer.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev CLI run
- Model/provider: N/A
- Integration/channel (if any): LINE onboarding surface
- Relevant config (redacted): empty/default local config

### Steps

1. Run `pnpm openclaw onboard --install-daemon`.
2. Accept the security prompt and stay on QuickStart.
3. Wait for onboarding to render the channel picker after the `How channels work` note.

### Expected

- QuickStart reaches `Select channel (QuickStart)` without crashing.

### Actual

- Before this change, onboarding could throw `LINE runtime not initialized - plugin not registered` while building the QuickStart picker.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/commands/onboard-channels.e2e.test.ts` and confirmed the full file passes, including the new regression that renders QuickStart and skips from the picker.
- Edge cases checked: empty config, QuickStart skip path, existing onboarding channel tests in the same file.
- What you did **not** verify: I did not complete a full end-to-end manual onboarding after the fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `013ecde2b1401b6da19cf77047ac43e5dda7e483`.
- Files/config to restore: `extensions/line/src/config-adapter.ts`, `src/commands/onboard-channels.e2e.test.ts`.
- Known bad symptoms reviewers should watch for: LINE setup/account resolution regressing in onboarding or the QuickStart picker failing to render.

## Risks and Mitigations

- Risk: LINE config adapter now depends on the runtime-neutral account helpers rather than the runtime store, so any mismatch between those code paths could surface in setup/config views.
- Mitigation: the adapter now matches the same pure-account pattern used by the other channel plugins, and onboarding coverage now exercises the QuickStart path directly.
