### PR TITLE
fix: groupPolicy 'open' should not be overridden by explicit group entries

### DIFF
--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -110,6 +110,63 @@ describe("resolveChannelGroupPolicy", () => {
     expect(policy.allowed).toBe(true);
   });
 
+  it("allows unlisted groups when groupPolicy=open with explicit group entries", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-1001234567890": { requireMention: false },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // The listed group should be allowed and carry its config
+    const listed = resolveChannelGroupPolicy({
+      cfg,
+      channel: "telegram",
+      groupId: "-1001234567890",
+    });
+    expect(listed.allowed).toBe(true);
+    expect(listed.groupConfig).toBeDefined();
+
+    // An unlisted group should ALSO be allowed (groupPolicy is "open")
+    const unlisted = resolveChannelGroupPolicy({
+      cfg,
+      channel: "telegram",
+      groupId: "-1009999999999",
+    });
+    expect(unlisted.allowed).toBe(true);
+    expect(unlisted.allowlistEnabled).toBe(false);
+  });
+
+  it("allows unlisted groups when account-level groupPolicy=open with group entries", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              groupPolicy: "open",
+              groups: {
+                "-1001234567890": { requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const unlisted = resolveChannelGroupPolicy({
+      cfg,
+      channel: "telegram",
+      accountId: "default",
+      groupId: "-1009999999999",
+    });
+    expect(unlisted.allowed).toBe(true);
+    expect(unlisted.allowlistEnabled).toBe(false);
+  });
+
   it("still fails closed when groupPolicy=allowlist without groups or groupAllowFrom", () => {
     const cfg = {
       channels: {

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -335,7 +335,11 @@ export function resolveChannelGroupPolicy(params: {
   const groups = resolveChannelGroups(cfg, channel, params.accountId);
   const groupPolicy = resolveChannelGroupPolicyMode(cfg, channel, params.accountId);
   const hasGroups = Boolean(groups && Object.keys(groups).length > 0);
-  const allowlistEnabled = groupPolicy === "allowlist" || hasGroups;
+  // When groupPolicy is explicitly "open", group entries are config overrides
+  // (e.g. requireMention), not an allowlist. Only enable allowlist behavior
+  // when groupPolicy is "allowlist" or when groups exist without an explicit
+  // "open" policy (backwards-compatible implicit allowlist).
+  const allowlistEnabled = groupPolicy === "allowlist" || (groupPolicy !== "open" && hasGroups);
   const normalizedId = params.groupId?.trim();
   const groupConfig = normalizedId
     ? resolveChannelGroupConfig(groups, normalizedId, params.groupIdCaseInsensitive)


### PR DESCRIPTION
## Problem

When `groupPolicy` is set to `"open"` but the `groups` config contains explicit entries (e.g. for per-group `requireMention` overrides), unlisted groups are rejected with **"This group is not allowed."**

### Reproduction

```json
{
  "channels": {
    "telegram": {
      "groupPolicy": "open",
      "accounts": {
        "default": {
          "groupPolicy": "open",
          "groups": {
            "-1001234567890": { "requireMention": false }
          }
        }
      }
    }
  }
}
```

Adding the bot to any group **not** listed in `groups` results in the message: *"This group is not allowed."*

### Root Cause

In `resolveChannelGroupPolicy()` (`src/config/group-policy.ts`):

```typescript
const allowlistEnabled = groupPolicy === "allowlist" || hasGroups;
```

`allowlistEnabled` is set to `true` whenever **any** group entries exist, regardless of the `groupPolicy` value. This means explicit group entries (intended as config overrides) silently convert an `"open"` policy into an allowlist.

### Fix

Only enable implicit allowlist behavior when `groupPolicy` is not explicitly `"open"`:

```typescript
const allowlistEnabled = groupPolicy === "allowlist" || (groupPolicy !== "open" && hasGroups);
```

When `groupPolicy` is `"open"`, group entries serve as **config overrides only** (e.g. `requireMention`, `toolsBySender`), not as access control.

Backwards-compatible: when `groupPolicy` is unset (`undefined`) and groups exist, the implicit allowlist behavior is preserved.

### Tests

Added 2 test cases:
- Channel-level `groupPolicy: "open"` with explicit group entries allows unlisted groups
- Account-level `groupPolicy: "open"` with explicit group entries allows unlisted groups

All 15 tests pass.