### PR TITLE
fix(time): unify human-day semantics for daily boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/agents: avoid rebuilding core tools for plugin-only allowlists and keep the full plugin registry cache warm across scoped plugin loads, reducing per-turn latency spikes. Fixes #75882, #75907, #75906, #75887, and #75851. (#75922) Thanks @obviyus.
 - Agents/failover: classify bare `status: internal server error` provider messages as retryable server errors so model fallback can rotate instead of stopping. (#73844) Thanks @thesomewhatyou.
 - Gateway/startup: return the shared retryable startup-sidecars error for startup-gated control-plane RPCs such as sessions.create, sessions.send, sessions.abort, agent.wait, and tools.effective, so clients can retry early sidecar races. (#76012) Thanks @scoootscooob.
+- Sessions: align daily reset, session-memory, memory-flush, and usage day boundaries with the configured user timezone instead of host or UTC dates. Thanks @CNZSMJ.
 
 ## 2026.4.30
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -91,7 +91,12 @@ function getSessionSnapshotForTest(
     }),
   });
   const freshness = entry
-    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now: Date.now(), policy: resetPolicy, cfg })
+    ? evaluateSessionFreshness({
+        updatedAt: entry.updatedAt,
+        now: Date.now(),
+        policy: resetPolicy,
+        cfg,
+      })
     : { fresh: false };
 
   return {
@@ -370,9 +375,9 @@ describe("getSessionSnapshot", () => {
             store: storePath,
             reset: { mode: "daily", atHour: 4 },
           },
-        } as Parameters<typeof getSessionSnapshot>[0];
+        } as OpenClawConfig;
 
-        const snapshot = getSessionSnapshot(cfg, "whatsapp:+15550001111", true, {
+        const snapshot = getSessionSnapshotForTest(cfg, "whatsapp:+15550001111", {
           sessionKey,
         });
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -338,6 +338,52 @@ describe("getSessionSnapshot", () => {
       process.env.TZ = originalTz;
     }
   });
+
+  it("treats malformed session store entries without updatedAt as stale", async () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = "UTC";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 17, 21, 0, 0)));
+    try {
+      await withTempDir("openclaw-snapshot-", async (root) => {
+        const storePath = path.join(root, "sessions.json");
+        const sessionKey = "agent:main:whatsapp:dm:s1";
+
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [sessionKey]: {
+              sessionId: "snapshot-session",
+              lastChannel: "whatsapp",
+            },
+          }),
+          "utf8",
+        );
+
+        const cfg = {
+          agents: {
+            defaults: {
+              userTimezone: "Asia/Shanghai",
+            },
+          },
+          session: {
+            store: storePath,
+            reset: { mode: "daily", atHour: 4 },
+          },
+        } as Parameters<typeof getSessionSnapshot>[0];
+
+        const snapshot = getSessionSnapshot(cfg, "whatsapp:+15550001111", true, {
+          sessionKey,
+        });
+
+        expect(snapshot.fresh).toBe(false);
+        expect(snapshot.dailyResetAt).toBe(Date.UTC(2026, 0, 17, 20, 0, 0));
+      });
+    } finally {
+      vi.useRealTimers();
+      process.env.TZ = originalTz;
+    }
+  });
 });
 
 describe("web auto-reply util", () => {

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -91,7 +91,7 @@ function getSessionSnapshotForTest(
     }),
   });
   const freshness = entry
-    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now: Date.now(), policy: resetPolicy })
+    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now: Date.now(), policy: resetPolicy, cfg })
     : { fresh: false };
 
   return {
@@ -293,6 +293,49 @@ describe("getSessionSnapshot", () => {
       });
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("uses configured userTimezone for daily freshness instead of host timezone", async () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = "UTC";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 17, 21, 0, 0)));
+    try {
+      await withTempDir("openclaw-snapshot-", async (root) => {
+        const storePath = path.join(root, "sessions.json");
+        const sessionKey = "agent:main:whatsapp:dm:s1";
+
+        await saveSessionStore(storePath, {
+          [sessionKey]: {
+            sessionId: "snapshot-session",
+            updatedAt: Date.UTC(2026, 0, 17, 19, 30, 0),
+            lastChannel: "whatsapp",
+          },
+        });
+
+        const cfg = {
+          agents: {
+            defaults: {
+              userTimezone: "Asia/Shanghai",
+            },
+          },
+          session: {
+            store: storePath,
+            reset: { mode: "daily", atHour: 4 },
+          },
+        } as OpenClawConfig;
+
+        const snapshot = getSessionSnapshotForTest(cfg, "whatsapp:+15550001111", {
+          sessionKey,
+        });
+
+        expect(snapshot.fresh).toBe(false);
+        expect(snapshot.dailyResetAt).toBe(Date.UTC(2026, 0, 17, 20, 0, 0));
+      });
+    } finally {
+      vi.useRealTimers();
+      process.env.TZ = originalTz;
     }
   });
 });

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -323,6 +323,7 @@ export function resolveSession(opts: {
         }),
         now,
         policy: resetPolicy,
+        cfg: opts.cfg,
       }).fresh
     : false;
   const sessionId =

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3,17 +3,20 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   clearMemoryPluginState,
   registerMemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
+  resolveMemoryFlushResetAtHour,
   runMemoryFlushIfNeeded,
   runPreflightCompactionIfNeeded,
   setAgentRunnerMemoryTestDeps,
 } from "./agent-runner-memory.js";
 import { createTestFollowupRun, writeTestSessionStore } from "./agent-runner.test-fixtures.js";
+import { resolveMemoryFlushRelativePathForRun } from "./memory-flush.js";
 
 const compactEmbeddedPiSessionMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
@@ -767,5 +770,79 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.silentExpected).toBe(true);
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
+  });
+});
+
+const DIRECT_SESSION_CONTEXT = {
+  Provider: "whatsapp",
+  OriginatingChannel: "telegram",
+  ChatType: "direct",
+} as unknown as TemplateContext;
+
+describe("resolveMemoryFlushResetAtHour", () => {
+  it("uses the direct session daily reset boundary", () => {
+    const cfg = {
+      session: {
+        reset: {
+          atHour: 4,
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveMemoryFlushResetAtHour({
+        cfg,
+        sessionCtx: DIRECT_SESSION_CONTEXT,
+        sessionKey: "main",
+      }),
+    ).toBe(4);
+  });
+
+  it("skips reset-cycle day keys for non-daily reset policies", () => {
+    const cfg = {
+      session: {
+        reset: {
+          mode: "idle",
+          idleMinutes: 30,
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveMemoryFlushResetAtHour({
+        cfg,
+        sessionCtx: DIRECT_SESSION_CONTEXT,
+        sessionKey: "main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses the reset-cycle day key before the daily reset hour", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+      session: {
+        reset: {
+          atHour: 4,
+        },
+      },
+    } as OpenClawConfig;
+
+    const resetAtHour = resolveMemoryFlushResetAtHour({
+      cfg,
+      sessionCtx: DIRECT_SESSION_CONTEXT,
+      sessionKey: "main",
+    });
+
+    expect(
+      resolveMemoryFlushRelativePathForRun({
+        cfg,
+        nowMs: Date.UTC(2026, 2, 20, 17, 10, 0), // 2026-03-21 01:10 +08:00
+        resetAtHour,
+      }),
+    ).toBe("memory/2026-03-20.md");
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -12,6 +12,7 @@ import {
   normalizeUsage,
   type UsageLike,
 } from "../../agents/usage.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveFreshSessionTotalTokens,
@@ -20,6 +21,13 @@ import {
   type SessionEntry,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
+import { resolveGroupSessionKey } from "../../config/sessions/group.js";
+import {
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+  resolveThreadFlag,
+} from "../../config/sessions/reset.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readSessionMessagesAsync } from "../../gateway/session-utils.fs.js";
 import { logVerbose } from "../../globals.js";
@@ -39,6 +47,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
+  resolveMemoryFlushRelativePathForRun,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
@@ -168,6 +177,48 @@ export type SessionTranscriptUsageSnapshot = {
 const TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS = 8192;
 const TRANSCRIPT_TAIL_CHUNK_BYTES = 64 * 1024;
 const FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN = 4;
+
+export function resolveMemoryFlushResetAtHour(params: {
+  cfg: OpenClawConfig;
+  sessionCtx: TemplateContext;
+  sessionKey?: string;
+}): number | undefined {
+  const sessionCfg = params.cfg.session;
+  const groupResolution = resolveGroupSessionKey(params.sessionCtx) ?? undefined;
+  const normalizedChatType = normalizeChatType(params.sessionCtx.ChatType);
+  const isGroup =
+    normalizedChatType != null && normalizedChatType !== "direct" ? true : Boolean(groupResolution);
+  const isThread = resolveThreadFlag({
+    sessionKey: params.sessionKey,
+    messageThreadId: params.sessionCtx.MessageThreadId,
+    threadLabel: params.sessionCtx.ThreadLabel,
+    threadStarterBody: params.sessionCtx.ThreadStarterBody,
+    parentSessionKey: params.sessionCtx.ParentSessionKey,
+  });
+  const resetType = resolveSessionResetType({
+    sessionKey: params.sessionKey,
+    isGroup,
+    isThread,
+  });
+  const channelReset = resolveChannelResetConfig({
+    sessionCfg,
+    channel:
+      groupResolution?.channel ??
+      (params.sessionCtx.OriginatingChannel as string | undefined) ??
+      params.sessionCtx.Surface ??
+      params.sessionCtx.Provider,
+  });
+  const resetPolicy = resolveSessionResetPolicy({
+    sessionCfg,
+    resetType,
+    resetOverride: channelReset,
+  });
+  return resetPolicy.mode === "daily" ? resetPolicy.atHour : undefined;
+}
+
+function replaceMemoryFlushPlanPath(text: string, fromPath: string, toPath: string): string {
+  return fromPath === toPath ? text : text.replaceAll(fromPath, toPath);
+}
 
 function parseUsageFromTranscriptLine(line: string): ReturnType<typeof normalizeUsage> | undefined {
   const trimmed = line.trim();
@@ -871,15 +922,34 @@ export async function runMemoryFlushIfNeeded(params: {
   }
   let memoryCompactionCompleted = false;
   const memoryFlushNowMs = memoryDeps.now();
+  const memoryFlushResetAtHour = resolveMemoryFlushResetAtHour({
+    cfg: params.cfg,
+    sessionCtx: params.sessionCtx,
+    sessionKey: params.sessionKey,
+  });
   const activeMemoryFlushPlan =
     resolveMemoryFlushPlan({
       cfg: params.cfg,
       nowMs: memoryFlushNowMs,
     }) ?? memoryFlushPlan;
-  const memoryFlushWritePath = activeMemoryFlushPlan.relativePath;
+  const memoryFlushWritePath = resolveMemoryFlushRelativePathForRun({
+    cfg: params.cfg,
+    nowMs: memoryFlushNowMs,
+    resetAtHour: memoryFlushResetAtHour,
+  });
+  const effectiveMemoryFlushPrompt = replaceMemoryFlushPlanPath(
+    activeMemoryFlushPlan.prompt,
+    activeMemoryFlushPlan.relativePath,
+    memoryFlushWritePath,
+  );
+  const effectiveMemoryFlushSystemPrompt = replaceMemoryFlushPlanPath(
+    activeMemoryFlushPlan.systemPrompt,
+    activeMemoryFlushPlan.relativePath,
+    memoryFlushWritePath,
+  );
   const flushSystemPrompt = [
     params.followupRun.run.extraSystemPrompt,
-    activeMemoryFlushPlan.systemPrompt,
+    effectiveMemoryFlushSystemPrompt,
   ]
     .filter(Boolean)
     .join("\n\n");
@@ -914,7 +984,7 @@ export async function runMemoryFlushIfNeeded(params: {
           silentExpected: true,
           trigger: "memory",
           memoryFlushWritePath,
-          prompt: activeMemoryFlushPlan.prompt,
+          prompt: effectiveMemoryFlushPrompt,
           transcriptPrompt: "",
           extraSystemPrompt: flushSystemPrompt,
           bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -932,11 +932,19 @@ export async function runMemoryFlushIfNeeded(params: {
       cfg: params.cfg,
       nowMs: memoryFlushNowMs,
     }) ?? memoryFlushPlan;
-  const memoryFlushWritePath = resolveMemoryFlushRelativePathForRun({
+  const defaultMemoryFlushWritePath = resolveMemoryFlushRelativePathForRun({
+    cfg: params.cfg,
+    nowMs: memoryFlushNowMs,
+  });
+  const resetCycleMemoryFlushWritePath = resolveMemoryFlushRelativePathForRun({
     cfg: params.cfg,
     nowMs: memoryFlushNowMs,
     resetAtHour: memoryFlushResetAtHour,
   });
+  const memoryFlushWritePath =
+    activeMemoryFlushPlan.relativePath === defaultMemoryFlushWritePath
+      ? resetCycleMemoryFlushWritePath
+      : activeMemoryFlushPlan.relativePath;
   const effectiveMemoryFlushPrompt = replaceMemoryFlushPlanPath(
     activeMemoryFlushPlan.prompt,
     activeMemoryFlushPlan.relativePath,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -2,22 +2,28 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildMemoryFlushPlan } from "../../../extensions/memory-core/index.js";
+import { resolveCronStyleNow } from "../../agents/current-time.js";
+import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../agents/pi-settings.js";
+import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import * as sessions from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  type MemoryFlushPlan,
   registerMemoryFlushPlanResolver,
   restoreMemoryPluginState,
 } from "../../plugins/memory-state.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { resolveMemoryFlushRelativePathForRun } from "./memory-flush.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
@@ -62,6 +68,36 @@ const initialMemoryPluginState = {
   flushPlanResolver: getMemoryFlushPlanResolver(),
   runtime: getMemoryRuntime(),
 };
+
+const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4_000;
+const DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
+const MEMORY_FLUSH_TARGET_HINT =
+  "Store durable memories only in memory/YYYY-MM-DD.md (create memory/ if needed).";
+const MEMORY_FLUSH_APPEND_ONLY_HINT =
+  "If memory/YYYY-MM-DD.md already exists, APPEND new content only and do not overwrite existing entries.";
+const MEMORY_FLUSH_READ_ONLY_HINT =
+  "Treat workspace bootstrap/reference files such as MEMORY.md, DREAMS.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.";
+const MEMORY_FLUSH_REQUIRED_HINTS = [
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+];
+const DEFAULT_MEMORY_FLUSH_PROMPT = [
+  "Pre-compaction memory flush.",
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  "Do NOT create timestamped variant files (e.g., YYYY-MM-DD-HHMM.md); always use the canonical YYYY-MM-DD.md filename.",
+  `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
+].join(" ");
+const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
+  "Pre-compaction memory flush turn.",
+  "The session is near auto-compaction; capture durable memories to disk.",
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
+].join(" ");
 
 let modelFallbackModule: typeof import("../../agents/model-fallback.js");
 let onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
@@ -338,9 +374,88 @@ async function runReplyAgentWithBase(params: {
   });
 }
 
+function normalizeNonNegativeInt(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  const int = Math.floor(value);
+  return int >= 0 ? int : null;
+}
+
+function ensureNoReplyHint(text: string): string {
+  if (text.includes(SILENT_REPLY_TOKEN)) {
+    return text;
+  }
+  return `${text}\n\nIf no user-visible reply is needed, start with ${SILENT_REPLY_TOKEN}.`;
+}
+
+function ensureMemoryFlushSafetyHints(text: string): string {
+  let next = text.trim();
+  for (const hint of MEMORY_FLUSH_REQUIRED_HINTS) {
+    if (!next.includes(hint)) {
+      next = next ? `${next}\n\n${hint}` : hint;
+    }
+  }
+  return next;
+}
+
+function appendCurrentTimeLine(text: string, timeLine: string): string {
+  const trimmed = text.trimEnd();
+  if (!trimmed) {
+    return timeLine;
+  }
+  if (trimmed.includes("Current time:")) {
+    return trimmed;
+  }
+  return `${trimmed}\n${timeLine}`;
+}
+
+function resolveMemoryFlushDateStamp(relativePath: string): string {
+  const match = /^memory\/(\d{4}-\d{2}-\d{2})\.md$/.exec(relativePath);
+  return match?.[1] ?? "YYYY-MM-DD";
+}
+
+function buildTestMemoryFlushPlan(params: {
+  cfg?: OpenClawConfig;
+  nowMs?: number;
+}): MemoryFlushPlan | null {
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const cfg = params.cfg;
+  const defaults = cfg?.agents?.defaults?.compaction?.memoryFlush;
+  if (defaults?.enabled === false) {
+    return null;
+  }
+
+  const relativePath = resolveMemoryFlushRelativePathForRun({ cfg, nowMs });
+  const dateStamp = resolveMemoryFlushDateStamp(relativePath);
+  const { timeLine } = resolveCronStyleNow(cfg ?? {}, nowMs);
+  const promptBase = ensureNoReplyHint(
+    ensureMemoryFlushSafetyHints(defaults?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT),
+  );
+  const systemPrompt = ensureNoReplyHint(
+    ensureMemoryFlushSafetyHints(
+      defaults?.systemPrompt?.trim() || DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT,
+    ),
+  );
+
+  return {
+    softThresholdTokens:
+      normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+    forceFlushTranscriptBytes:
+      parseNonNegativeByteSize(defaults?.forceFlushTranscriptBytes) ??
+      DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
+    reserveTokensFloor:
+      normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
+      DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+    prompt: appendCurrentTimeLine(promptBase.replaceAll("YYYY-MM-DD", dateStamp), timeLine),
+    systemPrompt: systemPrompt.replaceAll("YYYY-MM-DD", dateStamp),
+    relativePath,
+  };
+}
+
 function registerBuiltInMemoryFlushPlanResolver() {
   registerMemoryFlushPlanResolver(({ cfg, nowMs }) => {
-    return buildMemoryFlushPlan({
+    return buildTestMemoryFlushPlan({
       cfg,
       nowMs,
     });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1,8 +1,25 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
+import * as sessions from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import {
+  getMemoryFlushPlanResolver,
+  getMemoryPromptSectionBuilder,
+  getMemoryRuntime,
+  registerMemoryFlushPlanResolver,
+  restoreMemoryPluginState,
+} from "../../plugins/memory-state.js";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import type { TemplateContext } from "../templating.js";
-import type { GetReplyOptions } from "../types.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import {
+  resolveMemoryFlushPromptForRun,
+  resolveMemoryFlushRelativePathForRun,
+  resolveMemoryFlushSettings,
+} from "./memory-flush.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
@@ -22,10 +39,28 @@ type AgentRunParams = {
   silentExpected?: boolean;
 };
 
+type EmbeddedRunParams = {
+  prompt?: string;
+  extraSystemPrompt?: string;
+  memoryFlushWritePath?: string;
+  sessionId?: string;
+  sessionFile?: string;
+  silentExpected?: boolean;
+  bootstrapPromptWarningSignaturesSeen?: string[];
+  bootstrapPromptWarningSignature?: string;
+  onAgentEvent?: (evt: { stream?: string; data?: { phase?: string; willRetry?: boolean } }) => void;
+};
+
 const state = vi.hoisted(() => ({
   compactEmbeddedPiSessionMock: vi.fn(),
   runEmbeddedPiAgentMock: vi.fn(),
 }));
+
+const initialMemoryPluginState = {
+  promptBuilder: getMemoryPromptSectionBuilder(),
+  flushPlanResolver: getMemoryFlushPlanResolver(),
+  runtime: getMemoryRuntime(),
+};
 
 let modelFallbackModule: typeof import("../../agents/model-fallback.js");
 let onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
@@ -93,6 +128,7 @@ beforeEach(() => {
     payloads: [{ text: "final" }],
     meta: { agentMeta: { usage: { input: 1, output: 1 } } },
   });
+  restoreMemoryPluginState(initialMemoryPluginState);
   vi.mocked(enqueueFollowupRun).mockClear();
   vi.mocked(refreshQueuedFollowupSession).mockClear();
   vi.mocked(scheduleFollowupDrain).mockClear();
@@ -187,6 +223,143 @@ function createMinimalRun(params?: {
   };
 }
 
+async function seedSessionStore(params: {
+  storePath: string;
+  sessionKey: string;
+  entry: Record<string, unknown>;
+}) {
+  await fs.mkdir(path.dirname(params.storePath), { recursive: true });
+  await fs.writeFile(
+    params.storePath,
+    JSON.stringify({ [params.sessionKey]: params.entry }, null, 2),
+    "utf-8",
+  );
+}
+
+function createBaseRun(params: {
+  storePath: string;
+  sessionEntry: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  runOverrides?: Partial<FollowupRun["run"]>;
+}) {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "whatsapp",
+    OriginatingTo: "+15550001111",
+    AccountId: "primary",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: params.config ?? {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+  const run = {
+    ...followupRun.run,
+    ...params.runOverrides,
+    config: params.config ?? followupRun.run.config,
+  };
+
+  return {
+    typing,
+    sessionCtx,
+    resolvedQueue,
+    followupRun: { ...followupRun, run },
+  };
+}
+
+async function runReplyAgentWithBase(params: {
+  baseRun: ReturnType<typeof createBaseRun>;
+  storePath: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry;
+  commandBody: string;
+  typingMode?: "instant";
+}): Promise<void> {
+  const runReplyAgent = await getRunReplyAgent();
+  const { typing, sessionCtx, resolvedQueue, followupRun } = params.baseRun;
+  await runReplyAgent({
+    commandBody: params.commandBody,
+    followupRun,
+    queueKey: params.sessionKey,
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing,
+    sessionCtx,
+    sessionEntry: params.sessionEntry,
+    sessionStore: { [params.sessionKey]: params.sessionEntry } as Record<string, SessionEntry>,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    defaultModel: "anthropic/claude-opus-4-6",
+    agentCfgContextTokens: 100_000,
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: params.typingMode ?? "instant",
+  });
+}
+
+function resolveMemoryFlushDateStamp(relativePath: string): string {
+  return relativePath.replace(/^memory\//, "").replace(/\.md$/, "");
+}
+
+function registerBuiltInMemoryFlushPlanResolver() {
+  registerMemoryFlushPlanResolver(({ cfg, nowMs }) => {
+    const settings = resolveMemoryFlushSettings(cfg);
+    if (!settings) {
+      return null;
+    }
+    const resolvedNowMs = Number.isFinite(nowMs) ? (nowMs as number) : Date.now();
+    const relativePath = resolveMemoryFlushRelativePathForRun({
+      cfg,
+      nowMs: resolvedNowMs,
+    });
+    return {
+      softThresholdTokens: settings.softThresholdTokens,
+      forceFlushTranscriptBytes: settings.forceFlushTranscriptBytes,
+      reserveTokensFloor: settings.reserveTokensFloor,
+      prompt: resolveMemoryFlushPromptForRun({
+        prompt: settings.prompt,
+        cfg,
+        nowMs: resolvedNowMs,
+      }),
+      systemPrompt: settings.systemPrompt.replaceAll(
+        "YYYY-MM-DD",
+        resolveMemoryFlushDateStamp(relativePath),
+      ),
+      relativePath,
+    };
+  });
+}
 describe("runReplyAgent heartbeat followup guard", () => {
   it("drops heartbeat runs when another run is active", async () => {
     const { run, typing } = createMinimalRun({
@@ -278,6 +451,13 @@ describe("runReplyAgent heartbeat followup guard", () => {
 });
 
 describe("runReplyAgent typing (heartbeat)", () => {
+  async function withTempStateDir<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+    return await withStateDirEnv(
+      "openclaw-typing-heartbeat-",
+      async ({ stateDir }) => await fn(stateDir),
+    );
+  }
+
   it("signals typing for normal runs", async () => {
     const onPartialReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
@@ -640,6 +820,121 @@ describe("runReplyAgent typing (heartbeat)", () => {
     vi.useRealTimers();
   });
 
+  it("delivers tool results in order even when dispatched concurrently", async () => {
+    const deliveryOrder: string[] = [];
+    const onToolResult = vi.fn(async (payload: { text?: string }) => {
+      // Simulate variable network latency: first result is slower than second
+      const delay = payload.text === "first" ? 5 : 1;
+      await new Promise((r) => setTimeout(r, delay));
+      deliveryOrder.push(payload.text ?? "");
+    });
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      // Fire two tool results without awaiting each one; await both at the end.
+      const first = params.onToolResult?.({ text: "first", mediaUrls: [] });
+      const second = params.onToolResult?.({ text: "second", mediaUrls: [] });
+      await Promise.all([first, second]);
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const { run } = createMinimalRun({
+      typingMode: "message",
+      opts: { onToolResult },
+    });
+    await run();
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    // Despite "first" having higher latency, it must be delivered before "second"
+    expect(deliveryOrder).toEqual(["first", "second"]);
+  });
+
+  it("continues delivering later tool results after an earlier tool result fails", async () => {
+    const delivered: string[] = [];
+    const onToolResult = vi.fn(async (payload: { text?: string }) => {
+      if (payload.text === "first") {
+        throw new Error("simulated delivery failure");
+      }
+      delivered.push(payload.text ?? "");
+    });
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      const first = params.onToolResult?.({ text: "first", mediaUrls: [] });
+      const second = params.onToolResult?.({ text: "second", mediaUrls: [] });
+      await Promise.allSettled([first, second]);
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const { run } = createMinimalRun({
+      typingMode: "message",
+      opts: { onToolResult },
+    });
+    await run();
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    expect(delivered).toEqual(["second"]);
+  });
+
+  it("announces auto-compaction in verbose mode and tracks count", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: Date.now() };
+      const sessionStore = { main: sessionEntry };
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async (_params: AgentRunParams) => {
+        return {
+          payloads: [{ text: "final" }],
+          meta: { agentMeta: { compactionCount: 1 } },
+        };
+      });
+
+      const { run } = createMinimalRun({
+        resolvedVerboseLevel: "on",
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+      expect(Array.isArray(res)).toBe(true);
+      const payloads = res as { text?: string }[];
+      expect(payloads[0]?.text).toContain("Auto-compaction complete");
+      expect(payloads[0]?.text).toContain("count 1");
+      expect(sessionStore.main.compactionCount).toBe(1);
+    });
+  });
+
+  it("refreshes queued followups when auto-compaction rotates the session", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: Date.now() };
+      const sessionStore = { main: sessionEntry };
+
+      state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "final" }],
+        meta: {
+          agentMeta: {
+            sessionId: "session-rotated",
+            compactionCount: 1,
+          },
+        },
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      await run();
+
+      expect(vi.mocked(refreshQueuedFollowupSession)).toHaveBeenCalledWith({
+        key: "main",
+        previousSessionId: "session",
+        nextSessionId: "session-rotated",
+        nextSessionFile: expect.stringContaining("session-rotated.jsonl"),
+      });
+    });
+  });
   it("announces model fallback only when verbose mode is enabled", async () => {
     const cases = [
       { name: "verbose on", verbose: "on" as const, expectNotice: true },
@@ -1139,4 +1434,724 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 });
 
-import type { ReplyPayload } from "../types.js";
+describe("runReplyAgent memory flush", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  async function withTempStore<T>(fn: (storePath: string) => Promise<T>): Promise<T> {
+    const dir = path.join(fixtureRoot, `case-${++caseId}`);
+    await fs.mkdir(dir, { recursive: true });
+    return await fn(path.join(dir, "sessions.json"));
+  }
+
+  async function normalizeComparablePath(filePath: string): Promise<string> {
+    const parent = await fs.realpath(path.dirname(filePath)).catch(() => path.dirname(filePath));
+    return path.join(parent, path.basename(filePath));
+  }
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-memory-flush-"));
+  });
+
+  beforeEach(() => {
+    registerBuiltInMemoryFlushPlanResolver();
+  });
+
+  afterAll(async () => {
+    restoreMemoryPluginState(initialMemoryPluginState);
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("skips memory flush for CLI providers", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      state.runEmbeddedPiAgentMock.mockImplementation(async () => ({
+        payloads: [{ text: "ok" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      }));
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: {
+          agents: {
+            defaults: {
+              cliBackends: {
+                "codex-cli": {
+                  command: "codex",
+                  args: ["exec", "--json"],
+                },
+              },
+            },
+          },
+        },
+        runOverrides: { provider: "codex-cli" },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const call = state.runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+        | { prompt?: string }
+        | undefined;
+      expect(call?.prompt).toBe("hello");
+    });
+  });
+
+  it("runs preflight compaction when transcript-estimated tokens cross the threshold", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionFile = "session-relative.jsonl";
+      const workspaceDir = path.dirname(storePath);
+      const transcriptPath = path.join(path.dirname(storePath), sessionFile);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          message: {
+            role: "user",
+            content: "x".repeat(320_000),
+            timestamp: Date.now(),
+          },
+        })}\n`,
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(workspaceDir, "AGENTS.md"),
+        [
+          "## Session Startup",
+          "Read AGENTS.md before replying.",
+          "",
+          "## Red Lines",
+          "Never skip safety checks.",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        sessionFile,
+        totalTokens: 10,
+        totalTokensFresh: false,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      state.compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: {
+          summary: "compacted",
+          firstKeptEntryId: "first-kept",
+          tokensBefore: 90_000,
+          tokensAfter: 8_000,
+        },
+      });
+      const calls: Array<{ prompt?: string; extraSystemPrompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({
+          prompt: params.prompt,
+          extraSystemPrompt: params.extraSystemPrompt,
+        });
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        runOverrides: { sessionFile, workspaceDir },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(state.compactEmbeddedPiSessionMock).toHaveBeenCalledOnce();
+      const compactionCall = state.compactEmbeddedPiSessionMock.mock.calls[0]?.[0] as
+        | {
+            sessionId?: string;
+            sessionKey?: string;
+            trigger?: string;
+            currentTokenCount?: number;
+            sessionFile?: string;
+          }
+        | undefined;
+      expect(compactionCall?.sessionId).toBe("session");
+      expect(compactionCall?.sessionKey).toBe(sessionKey);
+      expect(compactionCall?.trigger).toBe("budget");
+      expect(compactionCall?.currentTokenCount).toEqual(expect.any(Number));
+      expect(await normalizeComparablePath(compactionCall?.sessionFile ?? "")).toBe(
+        await normalizeComparablePath(transcriptPath),
+      );
+      expect(calls.map((call) => call.prompt)).toEqual(["hello"]);
+      expect(calls[0]?.extraSystemPrompt).toContain("Post-compaction context refresh");
+      expect(calls[0]?.extraSystemPrompt).toContain("Read AGENTS.md before replying.");
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].compactionCount).toBe(2);
+    });
+  });
+
+  it("uses configured prompts for memory flush runs", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<EmbeddedRunParams> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push(params);
+        if (params.prompt?.includes("Write notes.")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                memoryFlush: {
+                  prompt: "Write notes.",
+                  systemPrompt: "Flush memory now.",
+                },
+              },
+            },
+          },
+        },
+        runOverrides: { extraSystemPrompt: "extra system" },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      const flushCall = calls[0];
+      expect(flushCall?.prompt).toContain("Write notes.");
+      expect(flushCall?.prompt).toContain("NO_REPLY");
+      expect(flushCall?.prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(flushCall?.prompt).toContain("MEMORY.md");
+      expect(flushCall?.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
+      expect(flushCall?.extraSystemPrompt).toContain("extra system");
+      expect(flushCall?.extraSystemPrompt).toContain("Flush memory now.");
+      expect(flushCall?.extraSystemPrompt).toContain("NO_REPLY");
+      expect(flushCall?.extraSystemPrompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(flushCall?.extraSystemPrompt).toContain("MEMORY.md");
+      expect(flushCall?.silentExpected).toBe(true);
+      expect(calls[1]?.prompt).toBe("hello");
+    });
+  });
+
+  it("preserves plugin-provided memory flush paths", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionFile = "oversized-session.jsonl";
+      const transcriptPath = path.join(path.dirname(storePath), sessionFile);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "x".repeat(3_000), "utf-8");
+
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        sessionFile,
+        totalTokens: 10,
+        totalTokensFresh: false,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      registerMemoryFlushPlanResolver(() => ({
+        softThresholdTokens: 4_000,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1_000,
+        prompt: "Plugin flush into memory/custom-snapshot.md.",
+        systemPrompt: "Plugin system prompt for memory/custom-snapshot.md.",
+        relativePath: "memory/custom-snapshot.md",
+      }));
+
+      const calls: Array<EmbeddedRunParams> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push(params);
+        if (params.prompt?.includes("Plugin flush into")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        runOverrides: { sessionFile },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.memoryFlushWritePath).toBe("memory/custom-snapshot.md");
+      expect(calls[0]?.prompt).toContain("Plugin flush into memory/custom-snapshot.md.");
+      expect(calls[0]?.prompt).not.toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(calls[0]?.extraSystemPrompt).toContain(
+        "Plugin system prompt for memory/custom-snapshot.md.",
+      );
+      expect(calls[0]?.extraSystemPrompt).not.toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(calls[1]?.prompt).toBe("hello");
+    });
+  });
+
+  it("passes stored bootstrap warning signatures to memory flush runs", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+        systemPromptReport: {
+          source: "run",
+          generatedAt: Date.now(),
+          systemPrompt: {
+            chars: 1,
+            projectContextChars: 0,
+            nonProjectContextChars: 1,
+          },
+          injectedWorkspaceFiles: [],
+          skills: {
+            promptChars: 0,
+            entries: [],
+          },
+          tools: {
+            listChars: 0,
+            schemaChars: 0,
+            entries: [],
+          },
+          bootstrapTruncation: {
+            warningMode: "once",
+            warningShown: true,
+            promptWarningSignature: "sig-b",
+            warningSignaturesSeen: ["sig-a", "sig-b"],
+            truncatedFiles: 1,
+            nearLimitFiles: 0,
+            totalNearLimit: false,
+          },
+        },
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<EmbeddedRunParams> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push(params);
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
+      expect(calls[0]?.bootstrapPromptWarningSignature).toBe("sig-b");
+    });
+  });
+
+  it("runs a memory flush turn and updates session metadata", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{
+        prompt?: string;
+        extraSystemPrompt?: string;
+        memoryFlushWritePath?: string;
+        sessionId?: string;
+        sessionFile?: string;
+      }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({
+          prompt: params.prompt,
+          extraSystemPrompt: params.extraSystemPrompt,
+          memoryFlushWritePath: params.memoryFlushWritePath,
+          sessionId: params.sessionId,
+          sessionFile: params.sessionFile,
+        });
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          params.onAgentEvent?.({
+            stream: "compaction",
+            data: { phase: "end", willRetry: false },
+          });
+          return {
+            payloads: [],
+            meta: { agentMeta: { sessionId: "session-rotated" } },
+          };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.prompt).toContain("Pre-compaction memory flush.");
+      expect(calls[0]?.prompt).toContain("Current time:");
+      expect(calls[0]?.prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(calls[0]?.prompt).toContain("MEMORY.md");
+      expect(calls[0]?.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
+      expect(calls[0]?.extraSystemPrompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(calls[0]?.extraSystemPrompt).toContain("MEMORY.md");
+      expect(calls[1]?.prompt).toBe("hello");
+      expect(calls[1]?.sessionId).toBe("session-rotated");
+      expect(await normalizeComparablePath(calls[1]?.sessionFile ?? "")).toBe(
+        await normalizeComparablePath(path.join(path.dirname(storePath), "session-rotated.jsonl")),
+      );
+      expect(vi.mocked(refreshQueuedFollowupSession)).toHaveBeenCalledWith({
+        key: sessionKey,
+        previousSessionId: "session",
+        nextSessionId: "session-rotated",
+        nextSessionFile: expect.stringContaining("session-rotated.jsonl"),
+      });
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].memoryFlushAt).toBeTypeOf("number");
+      expect(stored[sessionKey].memoryFlushCompactionCount).toBe(2);
+      expect(stored[sessionKey].compactionCount).toBe(2);
+      expect(stored[sessionKey].sessionId).toBe("session-rotated");
+      expect(await normalizeComparablePath(stored[sessionKey].sessionFile)).toBe(
+        await normalizeComparablePath(path.join(path.dirname(storePath), "session-rotated.jsonl")),
+      );
+    });
+  });
+
+  it("runs memory flush when transcript fallback uses a relative sessionFile path", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionFile = "session-relative.jsonl";
+      const transcriptPath = path.join(path.dirname(storePath), sessionFile);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(
+        transcriptPath,
+        JSON.stringify({ usage: { input: 90_000, output: 8_000 } }),
+        "utf-8",
+      );
+
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        sessionFile,
+        totalTokens: 10,
+        totalTokensFresh: false,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{ prompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({ prompt: params.prompt });
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        runOverrides: { sessionFile },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.prompt).toContain("Pre-compaction memory flush.");
+      expect(calls[0]?.prompt).toContain("Current time:");
+      expect(calls[0]?.prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(calls[1]?.prompt).toBe("hello");
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].memoryFlushAt).toBeTypeOf("number");
+    });
+  });
+
+  it("forces memory flush when transcript file exceeds configured byte threshold", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionFile = "oversized-session.jsonl";
+      const transcriptPath = path.join(path.dirname(storePath), sessionFile);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "x".repeat(3_000), "utf-8");
+
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        sessionFile,
+        totalTokens: 10,
+        totalTokensFresh: false,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{ prompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({ prompt: params.prompt });
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                memoryFlush: {
+                  forceFlushTranscriptBytes: 256,
+                },
+              },
+            },
+          },
+        },
+        runOverrides: { sessionFile },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.prompt).toContain("Pre-compaction memory flush.");
+      expect(calls[1]?.prompt).toBe("hello");
+    });
+  });
+
+  it("skips memory flush when disabled in config", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      state.runEmbeddedPiAgentMock.mockImplementation(async () => ({
+        payloads: [{ text: "ok" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      }));
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: { agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } } },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const call = state.runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+        | { prompt?: string }
+        | undefined;
+      expect(call?.prompt).toBe("hello");
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].memoryFlushAt).toBeUndefined();
+    });
+  });
+
+  it("skips memory flush after a prior flush in the same compaction cycle", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 2,
+        memoryFlushCompactionCount: 2,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{ prompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({ prompt: params.prompt });
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls.map((call) => call.prompt)).toEqual(["hello"]);
+    });
+  });
+
+  it("increments compaction count when flush compaction completes", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          params.onAgentEvent?.({
+            stream: "compaction",
+            data: { phase: "end", willRetry: false },
+          });
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].compactionCount).toBe(2);
+      expect(stored[sessionKey].memoryFlushCompactionCount).toBe(2);
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -458,6 +458,27 @@ describe("runReplyAgent typing (heartbeat)", () => {
     );
   }
 
+  async function writeCorruptGeminiSessionFixture(params: {
+    stateDir: string;
+    sessionId: string;
+    persistStore: boolean;
+  }) {
+    const storePath = path.join(params.stateDir, "sessions", "sessions.json");
+    const sessionEntry: SessionEntry = { sessionId: params.sessionId, updatedAt: Date.now() };
+    const sessionStore = { main: sessionEntry };
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    if (params.persistStore) {
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+    }
+
+    const transcriptPath = sessions.resolveSessionTranscriptPath(params.sessionId);
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    await fs.writeFile(transcriptPath, "bad", "utf-8");
+
+    return { storePath, sessionEntry, sessionStore, transcriptPath };
+  }
+
   it("signals typing for normal runs", async () => {
     const onPartialReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
@@ -1397,6 +1418,162 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(payload.text).toContain("/new");
   });
 
+  it("resets the session after role ordering payloads", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "Message ordering conflict - please try again.", isError: true }],
+        meta: {
+          durationMs: 1,
+          error: {
+            kind: "role_ordering",
+            message: 'messages: roles must alternate between "user" and "assistant"',
+          },
+        },
+      }));
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({
+        text: expect.stringContaining("Message ordering conflict"),
+      });
+      if (!payload) {
+        throw new Error("expected payload");
+      }
+      expect(payload.text?.toLowerCase()).toContain("reset");
+      expect(sessionStore.main.sessionId).not.toBe(sessionId);
+      await expect(fs.access(transcriptPath)).rejects.toBeDefined();
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
+    });
+  });
+
+  it("resets corrupted Gemini sessions and deletes transcripts", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { storePath, sessionEntry, sessionStore, transcriptPath } =
+        await writeCorruptGeminiSessionFixture({
+          stateDir,
+          sessionId: "session-corrupt",
+          persistStore: true,
+        });
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          "function call turn comes immediately after a user turn or after a function response turn",
+        );
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      expect(res).toMatchObject({
+        text: expect.stringContaining("Session history was corrupted"),
+      });
+      expect(sessionStore.main).toBeUndefined();
+      await expect(fs.access(transcriptPath)).rejects.toThrow();
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main).toBeUndefined();
+    });
+  });
+
+  it("keeps sessions intact on other errors", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-ok";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const sessionEntry = { sessionId, updatedAt: Date.now() };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error("INVALID_ARGUMENT: some other failure");
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      expect(res).toMatchObject({
+        text: expect.stringContaining("Something went wrong while processing your request"),
+      });
+      expect(sessionStore.main).toBeDefined();
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(persisted.main).toBeDefined();
+    });
+  });
+
+  it("still replies even if session reset fails to persist", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const saveSpy = vi
+        .spyOn(sessions, "saveSessionStore")
+        .mockRejectedValueOnce(new Error("boom"));
+      try {
+        const { storePath, sessionEntry, sessionStore, transcriptPath } =
+          await writeCorruptGeminiSessionFixture({
+            stateDir,
+            sessionId: "session-corrupt",
+            persistStore: false,
+          });
+
+        state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+          throw new Error(
+            "function call turn comes immediately after a user turn or after a function response turn",
+          );
+        });
+
+        const { run } = createMinimalRun({
+          sessionEntry,
+          sessionStore,
+          sessionKey: "main",
+          storePath,
+        });
+        const res = await run();
+
+        expect(res).toMatchObject({
+          text: expect.stringContaining("Session history was corrupted"),
+        });
+        expect(sessionStore.main).toBeUndefined();
+        await expect(fs.access(transcriptPath)).rejects.toThrow();
+      } finally {
+        saveSpy.mockRestore();
+      }
+    });
+  });
   it("returns friendly message for role ordering errors thrown as exceptions", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
       throw new Error("400 Incorrect role information");

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMemoryFlushPlan } from "../../../extensions/memory-core/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import * as sessions from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
@@ -17,11 +18,6 @@ import {
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import {
-  resolveMemoryFlushPromptForRun,
-  resolveMemoryFlushRelativePathForRun,
-  resolveMemoryFlushSettings,
-} from "./memory-flush.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
@@ -342,36 +338,12 @@ async function runReplyAgentWithBase(params: {
   });
 }
 
-function resolveMemoryFlushDateStamp(relativePath: string): string {
-  return relativePath.replace(/^memory\//, "").replace(/\.md$/, "");
-}
-
 function registerBuiltInMemoryFlushPlanResolver() {
   registerMemoryFlushPlanResolver(({ cfg, nowMs }) => {
-    const settings = resolveMemoryFlushSettings(cfg);
-    if (!settings) {
-      return null;
-    }
-    const resolvedNowMs = Number.isFinite(nowMs) ? (nowMs as number) : Date.now();
-    const relativePath = resolveMemoryFlushRelativePathForRun({
+    return buildMemoryFlushPlan({
       cfg,
-      nowMs: resolvedNowMs,
+      nowMs,
     });
-    return {
-      softThresholdTokens: settings.softThresholdTokens,
-      forceFlushTranscriptBytes: settings.forceFlushTranscriptBytes,
-      reserveTokensFloor: settings.reserveTokensFloor,
-      prompt: resolveMemoryFlushPromptForRun({
-        prompt: settings.prompt,
-        cfg,
-        nowMs: resolvedNowMs,
-      }),
-      systemPrompt: settings.systemPrompt.replaceAll(
-        "YYYY-MM-DD",
-        resolveMemoryFlushDateStamp(relativePath),
-      ),
-      relativePath,
-    };
   });
 }
 describe("runReplyAgent heartbeat followup guard", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -56,6 +56,7 @@ type EmbeddedRunParams = {
 const state = vi.hoisted(() => ({
   compactEmbeddedPiSessionMock: vi.fn(),
   runEmbeddedPiAgentMock: vi.fn(),
+  runCliAgentMock: vi.fn(),
 }));
 
 const initialMemoryPluginState = {
@@ -107,6 +108,10 @@ vi.mock("../../agents/pi-embedded.js", () => ({
   runEmbeddedPiAgent: (params: unknown) => state.runEmbeddedPiAgentMock(params),
 }));
 
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (params: unknown) => state.runCliAgentMock(params),
+}));
+
 vi.mock("./queue.js", () => ({
   enqueueFollowupRun: vi.fn(),
   refreshQueuedFollowupSession: vi.fn(),
@@ -129,6 +134,11 @@ beforeEach(() => {
   });
   state.runEmbeddedPiAgentMock.mockReset();
   state.runEmbeddedPiAgentMock.mockResolvedValue({
+    payloads: [{ text: "final" }],
+    meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+  });
+  state.runCliAgentMock.mockReset();
+  state.runCliAgentMock.mockResolvedValue({
     payloads: [{ text: "final" }],
     meta: { agentMeta: { usage: { input: 1, output: 1 } } },
   });
@@ -1657,10 +1667,6 @@ describe("runReplyAgent memory flush", () => {
 
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
 
-      state.runEmbeddedPiAgentMock.mockImplementation(async () => ({
-        payloads: [{ text: "ok" }],
-        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
-      }));
       const baseRun = createBaseRun({
         storePath,
         sessionEntry,
@@ -1687,10 +1693,9 @@ describe("runReplyAgent memory flush", () => {
         commandBody: "hello",
       });
 
-      expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
-      const call = state.runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
-        | { prompt?: string }
-        | undefined;
+      expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+      expect(state.runCliAgentMock).toHaveBeenCalledTimes(1);
+      const call = state.runCliAgentMock.mock.calls[0]?.[0] as { prompt?: string } | undefined;
       expect(call?.prompt).toBe("hello");
     });
   });
@@ -1809,6 +1814,14 @@ describe("runReplyAgent memory flush", () => {
       };
 
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+      registerMemoryFlushPlanResolver(() => ({
+        softThresholdTokens: 4_000,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 20_000,
+        prompt: "Write notes.\nNO_REPLY to memory/2023-11-14.md and MEMORY.md",
+        systemPrompt: "Flush memory now. NO_REPLY memory/2023-11-14.md MEMORY.md",
+        relativePath: "memory/2023-11-14.md",
+      }));
 
       const calls: Array<EmbeddedRunParams> = [];
       state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
@@ -1825,18 +1838,6 @@ describe("runReplyAgent memory flush", () => {
       const baseRun = createBaseRun({
         storePath,
         sessionEntry,
-        config: {
-          agents: {
-            defaults: {
-              compaction: {
-                memoryFlush: {
-                  prompt: "Write notes.",
-                  systemPrompt: "Flush memory now.",
-                },
-              },
-            },
-          },
-        },
         runOverrides: { extraSystemPrompt: "extra system" },
       });
 
@@ -1857,7 +1858,7 @@ describe("runReplyAgent memory flush", () => {
       expect(flushCall?.extraSystemPrompt).toContain("extra system");
       expect(flushCall?.extraSystemPrompt).toContain("Flush memory now.");
       expect(flushCall?.extraSystemPrompt).toContain("NO_REPLY");
-      expect(flushCall?.extraSystemPrompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+      expect(flushCall?.extraSystemPrompt).toContain("memory/2023-11-14.md");
       expect(flushCall?.extraSystemPrompt).toContain("MEMORY.md");
       expect(flushCall?.silentExpected).toBe(true);
       expect(calls[1]?.prompt).toBe("hello");
@@ -2110,6 +2111,14 @@ describe("runReplyAgent memory flush", () => {
       };
 
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+      registerMemoryFlushPlanResolver(() => ({
+        softThresholdTokens: 4_000,
+        forceFlushTranscriptBytes: 256,
+        reserveTokensFloor: 20_000,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
 
       const calls: Array<{ prompt?: string }> = [];
       state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
@@ -2139,8 +2148,6 @@ describe("runReplyAgent memory flush", () => {
 
       expect(calls).toHaveLength(2);
       expect(calls[0]?.prompt).toContain("Pre-compaction memory flush.");
-      expect(calls[0]?.prompt).toContain("Current time:");
-      expect(calls[0]?.prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
       expect(calls[1]?.prompt).toBe("hello");
 
       const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
@@ -2166,6 +2173,14 @@ describe("runReplyAgent memory flush", () => {
       };
 
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+      registerMemoryFlushPlanResolver(() => ({
+        softThresholdTokens: 4_000,
+        forceFlushTranscriptBytes: 256,
+        reserveTokensFloor: 20_000,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
 
       const calls: Array<{ prompt?: string }> = [];
       state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
@@ -2221,6 +2236,7 @@ describe("runReplyAgent memory flush", () => {
       };
 
       await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+      registerMemoryFlushPlanResolver(() => null);
 
       state.runEmbeddedPiAgentMock.mockImplementation(async () => ({
         payloads: [{ text: "ok" }],

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -9,6 +9,8 @@ import {
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
+  listMemoryCorpusSupplements,
+  listMemoryPromptSupplements,
   registerMemoryFlushPlanResolver,
   restoreMemoryPluginState,
 } from "../../plugins/memory-state.js";
@@ -57,7 +59,9 @@ const state = vi.hoisted(() => ({
 }));
 
 const initialMemoryPluginState = {
+  corpusSupplements: listMemoryCorpusSupplements(),
   promptBuilder: getMemoryPromptSectionBuilder(),
+  promptSupplements: listMemoryPromptSupplements(),
   flushPlanResolver: getMemoryFlushPlanResolver(),
   runtime: getMemoryRuntime(),
 };

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -10,6 +10,7 @@ import { parseDurationMs } from "../../cli/parse-duration.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { formatHumanDayKey } from "../../infra/format-time/human-day.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import {
@@ -321,7 +322,7 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
         ? `Session ${sessionCost ?? "n/a"}${sessionSuffix}${sessionTokens ? ` · ${sessionTokens} tokens` : ""}`
         : "Session n/a";
 
-    const todayKey = new Date().toLocaleDateString("en-CA");
+    const todayKey = formatHumanDayKey(Date.now(), params.cfg);
     const todayEntry = summary.daily.find((entry) => entry.date === todayKey);
     const todayCost = formatUsd(todayEntry?.totalCost);
     const todayMissing = todayEntry?.missingCostEntries ?? 0;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -3,6 +3,23 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  formatHumanDayKey,
+  resolveHumanResetCycleKey,
+} from "../../infra/format-time/human-day.js";
+
+export function resolveMemoryFlushRelativePathForRun(params: {
+  cfg?: OpenClawConfig;
+  nowMs?: number;
+  resetAtHour?: number;
+}): string {
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const dateStamp =
+    typeof params.resetAtHour === "number" && Number.isFinite(params.resetAtHour)
+      ? resolveHumanResetCycleKey(nowMs, Math.floor(params.resetAtHour), params.cfg)
+      : formatHumanDayKey(nowMs, params.cfg);
+  return `memory/${dateStamp}.md`;
+}
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -277,6 +277,48 @@ describe("session hook context wiring", () => {
     }
   });
 
+  it("keeps the daily end reason across a DST-skipped reset hour", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(Date.UTC(2026, 2, 8, 8, 0, 0)));
+      const sessionKey = "agent:main:telegram:direct:dst-gap";
+      const storePath = await createStorePath("openclaw-session-hook-dst-gap");
+      const transcriptPath = await writeTranscript(storePath, "dst-gap-session", "dst gap");
+      await writeStore(storePath, {
+        [sessionKey]: {
+          sessionId: "dst-gap-session",
+          sessionFile: transcriptPath,
+          updatedAt: Date.UTC(2026, 2, 8, 6, 30, 0), // 01:30 local before the skipped 02:00 reset hour
+        },
+      });
+      const cfg = {
+        agents: {
+          defaults: {
+            userTimezone: "America/New_York",
+          },
+        },
+        session: {
+          store: storePath,
+          reset: {
+            mode: "daily",
+            atHour: 2,
+          },
+        },
+      } as OpenClawConfig;
+
+      await initSessionState({
+        ctx: { Body: "hello", SessionKey: sessionKey },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      const [event] = hookRunnerMocks.runSessionEnd.mock.calls[0] ?? [];
+      expect(event).toMatchObject({ reason: "daily" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("marks idle stale rollovers with reason idle", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -445,6 +445,7 @@ export async function initSessionState(params: {
           lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
           now,
           policy: resetPolicy,
+          cfg,
         })
     : undefined;
   const softResetAllowed =

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -1,3 +1,8 @@
+import {
+  resolveHumanResetBoundaryMs,
+  resolveHumanResetCycleKey,
+} from "../../infra/format-time/human-day.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import type { SessionConfig, SessionResetConfig } from "../types.base.js";
 import { DEFAULT_IDLE_MINUTES } from "./types.js";
 
@@ -20,14 +25,12 @@ export type SessionFreshness = {
 export const DEFAULT_RESET_MODE: SessionResetMode = "daily";
 export const DEFAULT_RESET_AT_HOUR = 4;
 
-export function resolveDailyResetAtMs(now: number, atHour: number): number {
-  const normalizedAtHour = normalizeResetAtHour(atHour);
-  const resetAt = new Date(now);
-  resetAt.setHours(normalizedAtHour, 0, 0, 0);
-  if (now < resetAt.getTime()) {
-    resetAt.setDate(resetAt.getDate() - 1);
-  }
-  return resetAt.getTime();
+export function resolveDailyResetAtMs(
+  now: number,
+  atHour: number,
+  cfg?: OpenClawConfig,
+): number | undefined {
+  return resolveHumanResetBoundaryMs(now, normalizeResetAtHour(atHour), cfg);
 }
 
 export function resolveSessionResetPolicy(params: {
@@ -75,6 +78,7 @@ export function evaluateSessionFreshness(params: {
   lastInteractionAt?: number;
   now: number;
   policy: SessionResetPolicy;
+  cfg?: OpenClawConfig;
 }): SessionFreshness {
   const updatedAt = resolveTimestamp(params.updatedAt, params.now) ?? 0;
   const sessionStartedAt = resolveTimestamp(params.sessionStartedAt, params.now) ?? updatedAt;
@@ -82,13 +86,17 @@ export function evaluateSessionFreshness(params: {
     resolveTimestamp(params.lastInteractionAt, params.now) ?? sessionStartedAt;
   const dailyResetAt =
     params.policy.mode === "daily"
-      ? resolveDailyResetAtMs(params.now, params.policy.atHour)
+      ? resolveDailyResetAtMs(params.now, params.policy.atHour, params.cfg)
       : undefined;
   const idleExpiresAt =
     params.policy.idleMinutes != null && params.policy.idleMinutes > 0
       ? lastInteractionAt + params.policy.idleMinutes * 60_000
       : undefined;
-  const staleDaily = dailyResetAt != null && sessionStartedAt < dailyResetAt;
+  const staleDaily =
+    params.policy.mode === "daily"
+      ? resolveHumanResetCycleKey(sessionStartedAt, params.policy.atHour, params.cfg) <
+        resolveHumanResetCycleKey(params.now, params.policy.atHour, params.cfg)
+      : false;
   const staleIdle = idleExpiresAt != null && params.now > idleExpiresAt;
   return {
     fresh: !(staleDaily || staleIdle),

--- a/src/config/sessions/reset.test.ts
+++ b/src/config/sessions/reset.test.ts
@@ -62,4 +62,20 @@ describe("session reset timezone semantics", () => {
     const boundaryMs = resolveDailyResetAtMs(now, 4, shanghaiCfg);
     expect(boundaryMs).toBe(Date.UTC(2026, 2, 18, 20, 0, 0));
   });
+
+  it("treats invalid activity timestamps as stale instead of throwing", () => {
+    const now = Date.UTC(2026, 2, 18, 21, 0, 0); // 2026-03-19 05:00 +08:00
+
+    const freshness = evaluateSessionFreshness({
+      updatedAt: Number.NaN,
+      now,
+      policy: dailyPolicy,
+      cfg: shanghaiCfg,
+    });
+
+    expect(freshness).toEqual({
+      fresh: false,
+      dailyResetAt: Date.UTC(2026, 2, 18, 20, 0, 0),
+    });
+  });
 });

--- a/src/config/sessions/reset.test.ts
+++ b/src/config/sessions/reset.test.ts
@@ -1,7 +1,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
-import { isThreadSessionKey, resolveSessionResetType } from "./reset.js";
+import type { OpenClawConfig } from "../config.js";
+import {
+  evaluateSessionFreshness,
+  isThreadSessionKey,
+  resolveDailyResetAtMs,
+  resolveSessionResetType,
+  type SessionResetPolicy,
+} from "./reset.js";
 
 describe("session reset thread detection", () => {
   beforeEach(() => {
@@ -19,5 +26,40 @@ describe("session reset thread detection", () => {
     const sessionKey = "agent:main:telegram:group:-100123:topic:77";
     expect(isThreadSessionKey(sessionKey)).toBe(true);
     expect(resolveSessionResetType({ sessionKey })).toBe("thread");
+  });
+});
+
+describe("session reset timezone semantics", () => {
+  const shanghaiCfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        userTimezone: "Asia/Shanghai",
+      },
+    },
+  };
+
+  const dailyPolicy: SessionResetPolicy = {
+    mode: "daily",
+    atHour: 4,
+  };
+
+  it("treats sessions before the local reset hour as part of the previous human day", () => {
+    const updatedAt = Date.UTC(2026, 2, 18, 19, 30, 0); // 2026-03-19 03:30 +08:00
+    const now = Date.UTC(2026, 2, 18, 21, 0, 0); // 2026-03-19 05:00 +08:00
+
+    const freshness = evaluateSessionFreshness({
+      updatedAt,
+      now,
+      policy: dailyPolicy,
+      cfg: shanghaiCfg,
+    });
+
+    expect(freshness.fresh).toBe(false);
+  });
+
+  it("returns a daily reset boundary anchored to the configured human timezone", () => {
+    const now = Date.UTC(2026, 2, 18, 21, 0, 0); // 2026-03-19 05:00 +08:00
+    const boundaryMs = resolveDailyResetAtMs(now, 4, shanghaiCfg);
+    expect(boundaryMs).toBe(Date.UTC(2026, 2, 18, 20, 0, 0));
   });
 });

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -135,6 +135,7 @@ export function resolveCronSession(params: {
       }),
       now: params.nowMs,
       policy: resetPolicy,
+      cfg: params.cfg,
     });
 
     if (freshness.fresh) {

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -86,14 +86,14 @@ describe("costUsageCache bounded growth", () => {
     // oldest-first, never the newest.
     const lastStartMs = Date.UTC(2026, 0, 1) + (ITERATIONS - 1) * DAY_MS;
     const lastEndMs = lastStartMs + ((ITERATIONS - 1) % 3 === 0 ? DAY_MS : 7 * DAY_MS) - 1;
-    const lastCacheKey = `${lastStartMs}-${lastEndMs}`;
+    const lastCacheKey = `${lastStartMs}-${lastEndMs}-utc`;
     expect(__test.costUsageCache.has(lastCacheKey)).toBe(true);
 
     // Tertiary: the oldest entry must have been evicted once the cap was
     // exceeded. Pre-fix all 600 entries remain and this fails too.
     const firstStartMs = Date.UTC(2026, 0, 1);
     const firstEndMs = firstStartMs + DAY_MS - 1;
-    const firstCacheKey = `${firstStartMs}-${firstEndMs}`;
+    const firstCacheKey = `${firstStartMs}-${firstEndMs}-utc`;
     expect(__test.costUsageCache.has(firstCacheKey)).toBe(false);
   });
 
@@ -125,7 +125,7 @@ describe("costUsageCache bounded growth", () => {
     });
     await Promise.resolve();
 
-    expect(__test.costUsageCache.has("1-2")).toBe(true);
+    expect(__test.costUsageCache.has("1-2-utc")).toBe(true);
     expect(mocks.loadCostUsageSummary).toHaveBeenCalledTimes(257);
     void inFlight.catch(() => {});
     void repeated.catch(() => {});

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -341,10 +341,12 @@ async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: OpenClawConfig;
-  dayBucketMode: DayBucketMode;
-  interpretationCacheKey: string;
+  dayBucketMode?: DayBucketMode;
+  interpretationCacheKey?: string;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}-${params.interpretationCacheKey}`;
+  const dayBucketMode = params.dayBucketMode ?? { type: "utc" };
+  const interpretationCacheKey = params.interpretationCacheKey ?? "utc";
+  const cacheKey = `${params.startMs}-${params.endMs}-${interpretationCacheKey}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
@@ -363,7 +365,7 @@ async function loadCostUsageSummaryCached(params: {
     startMs: params.startMs,
     endMs: params.endMs,
     config: params.config,
-    dayBucketMode: params.dayBucketMode,
+    dayBucketMode,
   })
     .then((summary) => {
       setCostUsageCache(cacheKey, { summary, updatedAt: Date.now() });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadProviderUsageSummary } from "../../infra/provider-usage.js";
 import type {
   CostUsageSummary,
+  DayBucketMode,
   SessionDailyModelUsage,
   SessionMessageCounts,
   SessionModelUsage,
@@ -320,12 +321,30 @@ async function discoverAllSessionsForUsage(params: {
   return results.flat().toSorted((a, b) => b.mtime - a.mtime);
 }
 
+function resolveDayBucketMode(interpretation: DateInterpretation): DayBucketMode {
+  if (interpretation.mode === "specific") {
+    return { type: "specific", utcOffsetMinutes: interpretation.utcOffsetMinutes };
+  }
+  if (interpretation.mode === "gateway") {
+    return { type: "gateway" };
+  }
+  return { type: "utc" };
+}
+
+function formatInterpretationCacheKey(interpretation: DateInterpretation): string {
+  return interpretation.mode === "specific"
+    ? `specific:${interpretation.utcOffsetMinutes}`
+    : interpretation.mode;
+}
+
 async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: OpenClawConfig;
+  dayBucketMode: DayBucketMode;
+  interpretationCacheKey: string;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const cacheKey = `${params.startMs}-${params.endMs}-${params.interpretationCacheKey}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
@@ -344,6 +363,7 @@ async function loadCostUsageSummaryCached(params: {
     startMs: params.startMs,
     endMs: params.endMs,
     config: params.config,
+    dayBucketMode: params.dayBucketMode,
   })
     .then((summary) => {
       setCostUsageCache(cacheKey, { summary, updatedAt: Date.now() });
@@ -395,6 +415,10 @@ export const usageHandlers: GatewayRequestHandlers = {
   },
   "usage.cost": async ({ respond, params, context }) => {
     const config = context.getRuntimeConfig();
+    const interpretation = resolveDateInterpretation({
+      mode: params?.mode,
+      utcOffset: params?.utcOffset,
+    });
     const { startMs, endMs } = parseDateRange({
       startDate: params?.startDate,
       endDate: params?.endDate,
@@ -402,7 +426,13 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+    const summary = await loadCostUsageSummaryCached({
+      startMs,
+      endMs,
+      config,
+      dayBucketMode: resolveDayBucketMode(interpretation),
+      interpretationCacheKey: formatInterpretationCacheKey(interpretation),
+    });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params, context }) => {
@@ -420,6 +450,10 @@ export const usageHandlers: GatewayRequestHandlers = {
 
     const p = params;
     const config = context.getRuntimeConfig();
+    const interpretation = resolveDateInterpretation({
+      mode: p.mode,
+      utcOffset: p.utcOffset,
+    });
     const { startMs, endMs } = parseDateRange({
       startDate: p.startDate,
       endDate: p.endDate,
@@ -639,6 +673,7 @@ export const usageHandlers: GatewayRequestHandlers = {
         agentId,
         startMs,
         endMs,
+        dayBucketMode: resolveDayBucketMode(interpretation),
       });
 
       if (usage) {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -67,12 +67,12 @@ function createMockSessionContent(
 
 async function runNewWithPreviousSessionEntry(params: {
   tempDir: string;
-  previousSessionEntry: { sessionId: string; sessionFile?: string };
+  previousSessionEntry: { sessionId: string; sessionFile?: string; updatedAt?: number };
   cfg?: OpenClawConfig;
   action?: "new" | "reset";
   sessionKey?: string;
   workspaceDirOverride?: string;
-  timestamp?: Date;
+  eventTimestamp?: Date;
 }): Promise<{ files: string[]; memoryContent: string }> {
   const event = createHookEvent(
     "command",
@@ -88,8 +88,8 @@ async function runNewWithPreviousSessionEntry(params: {
       ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
     },
   );
-  if (params.timestamp) {
-    event.timestamp = params.timestamp;
+  if (params.eventTimestamp) {
+    event.timestamp = params.eventTimestamp;
   }
 
   await handler(event);
@@ -258,7 +258,7 @@ describe("session-memory hook", () => {
 
       const { files, memoryContent } = await runNewWithPreviousSessionEntry({
         tempDir,
-        timestamp: new Date("2026-01-01T04:30:15.000Z"),
+        eventTimestamp: new Date("2026-01-01T04:30:15.000Z"),
         previousSessionEntry: {
           sessionId: "local-time-session",
         },
@@ -608,5 +608,56 @@ describe("session-memory hook", () => {
 
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
+  });
+
+  it("uses the userTimezone and prior session activity for human-day filenames", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "test-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Late-night wrap-up" },
+        { role: "assistant", content: "Captured before midnight UTC confusion" },
+      ]),
+    });
+
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: tempDir,
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+      hooks: {
+        internal: {
+          entries: {
+            "session-memory": {
+              enabled: true,
+              llmSlug: false,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const sessionUpdatedAt = Date.UTC(2026, 2, 18, 16, 20, 0); // 2026-03-19 00:20 +08:00
+    const eventTimestamp = new Date(Date.UTC(2026, 2, 18, 16, 30, 0)); // 00:30 +08:00
+
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      eventTimestamp,
+      previousSessionEntry: {
+        sessionId: "test-123",
+        sessionFile,
+        updatedAt: sessionUpdatedAt,
+      },
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toBe("2026-03-19-0030.md");
+    expect(memoryContent).toContain("# Session: 2026-03-19 00:20:00 (Asia/Shanghai)");
   });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -46,13 +46,22 @@ afterAll(async () => {
  * Create a mock session JSONL file with various entry types
  */
 function createMockSessionContent(
-  entries: Array<{ role: string; content: string } | ({ type: string } & Record<string, unknown>)>,
+  entries: Array<
+    | { role: string; content: string; timestamp?: string | number | Date }
+    | ({ type: string } & Record<string, unknown>)
+  >,
 ): string {
   return entries
     .map((entry) => {
       if ("role" in entry) {
         return JSON.stringify({
           type: "message",
+          ...(entry.timestamp != null
+            ? {
+                timestamp:
+                  entry.timestamp instanceof Date ? entry.timestamp.toISOString() : entry.timestamp,
+              }
+            : {}),
           message: {
             role: entry.role,
             content: entry.content,
@@ -659,5 +668,61 @@ describe("session-memory hook", () => {
     expect(files).toHaveLength(1);
     expect(files[0]).toBe("2026-03-19-0030.md");
     expect(memoryContent).toContain("# Session: 2026-03-19 00:20:00 (Asia/Shanghai)");
+  });
+
+  it("uses the last transcript message timestamp instead of updatedAt for day labels", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "test-session.jsonl",
+      content: createMockSessionContent([
+        {
+          role: "user",
+          content: "That near-miss on the ride home was brutal",
+          timestamp: "2026-03-20T15:50:00.000Z", // 2026-03-20 23:50 +08:00
+        },
+        {
+          role: "assistant",
+          content: "Good thing the seat belt caught it",
+          timestamp: "2026-03-20T15:51:00.000Z",
+        },
+      ]),
+    });
+
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: tempDir,
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+      hooks: {
+        internal: {
+          entries: {
+            "session-memory": {
+              enabled: true,
+              llmSlug: false,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      eventTimestamp: new Date(Date.UTC(2026, 2, 20, 16, 10, 0)), // 2026-03-21 00:10 +08:00
+      previousSessionEntry: {
+        sessionId: "test-123",
+        sessionFile,
+        updatedAt: Date.UTC(2026, 2, 20, 16, 15, 0), // control-path write after midnight
+      },
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toBe("2026-03-20-0010.md");
+    expect(memoryContent).toContain("# Session: 2026-03-20 23:51:00 (Asia/Shanghai)");
   });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
-import { withEnvAsync } from "../../../test-utils/env.js";
 import { createHookEvent } from "../../hooks.js";
 import {
   findPreviousSessionFile,
@@ -261,22 +260,29 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
-  it("uses local timezone date and fallback time in memory filenames and headers", async () => {
-    await withEnvAsync({ TZ: "America/New_York" }, async () => {
-      const tempDir = await createCaseWorkspace("workspace");
-
-      const { files, memoryContent } = await runNewWithPreviousSessionEntry({
-        tempDir,
-        eventTimestamp: new Date("2026-01-01T04:30:15.000Z"),
-        previousSessionEntry: {
-          sessionId: "local-time-session",
+  it("uses configured userTimezone date and fallback time in memory filenames and headers", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: tempDir,
+          userTimezone: "America/New_York",
         },
-      });
+      },
+    } as OpenClawConfig;
 
-      expect(files).toEqual(["2025-12-31-2330.md"]);
-      expect(memoryContent).toMatch(/^# Session: 2025-12-31 23:30:15(?: EST| GMT-5)?/);
-      expect(memoryContent).not.toContain("# Session: 2026-01-01 04:30:15 UTC");
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      eventTimestamp: new Date("2026-01-01T04:30:15.000Z"),
+      previousSessionEntry: {
+        sessionId: "local-time-session",
+      },
     });
+
+    expect(files).toEqual(["2025-12-31-2330.md"]);
+    expect(memoryContent).toContain("# Session: 2025-12-31 23:30:15 (America/New_York)");
+    expect(memoryContent).not.toContain("# Session: 2026-01-01 04:30:15 UTC");
   });
 
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -524,7 +524,7 @@ describe("session-memory hook", () => {
     }
 
     expectMemoryConversation({
-      memoryContent: memoryContent!,
+      memoryContent,
       user: "Newest rotated transcript",
       assistant: "Newest summary",
       absent: "Older rotated transcript",
@@ -558,7 +558,7 @@ describe("session-memory hook", () => {
     }
 
     expectMemoryConversation({
-      memoryContent: memoryContent!,
+      memoryContent,
       user: "Active transcript message",
       assistant: "Active transcript summary",
       absent: "Reset fallback message",

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -519,6 +519,9 @@ describe("session-memory hook", () => {
 
     const memoryContent = await getRecentSessionContentWithResetFallback(activeSessionFile!);
     expect(memoryContent).toBeTruthy();
+    if (!memoryContent) {
+      throw new Error("Expected reset fallback transcript content");
+    }
 
     expectMemoryConversation({
       memoryContent: memoryContent!,
@@ -550,6 +553,9 @@ describe("session-memory hook", () => {
 
     const memoryContent = await getRecentSessionContentWithResetFallback(activeSessionFile!);
     expect(memoryContent).toBeTruthy();
+    if (!memoryContent) {
+      throw new Error("Expected active transcript content");
+    }
 
     expectMemoryConversation({
       memoryContent: memoryContent!,

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -14,6 +14,11 @@ import {
 } from "../../../agents/agent-scope.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  formatHumanDayKey,
+  formatHumanTime,
+  resolveHumanTimezone,
+} from "../../../infra/format-time/human-day.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
@@ -27,63 +32,6 @@ import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
-
-function pickDateTimePart(
-  parts: Intl.DateTimeFormatPart[],
-  type: Intl.DateTimeFormatPartTypes,
-): string | undefined {
-  return parts.find((part) => part.type === type)?.value;
-}
-
-function resolveLocalTimeZone(): string | undefined {
-  const timeZone = process.env.TZ?.trim();
-  if (!timeZone) {
-    return undefined;
-  }
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
-    return timeZone;
-  } catch {
-    return undefined;
-  }
-}
-
-function formatLocalSessionTimestamp(date: Date): {
-  date: string;
-  time: string;
-  timeSlug: string;
-  timeZoneName?: string;
-} {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: resolveLocalTimeZone(),
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hourCycle: "h23",
-    timeZoneName: "short",
-  }).formatToParts(date);
-
-  const year = pickDateTimePart(parts, "year") ?? String(date.getFullYear()).padStart(4, "0");
-  const month = pickDateTimePart(parts, "month") ?? String(date.getMonth() + 1).padStart(2, "0");
-  const day = pickDateTimePart(parts, "day") ?? String(date.getDate()).padStart(2, "0");
-  const hour = pickDateTimePart(parts, "hour") ?? String(date.getHours()).padStart(2, "0");
-  const minute = pickDateTimePart(parts, "minute") ?? String(date.getMinutes()).padStart(2, "0");
-  const second = pickDateTimePart(parts, "second") ?? String(date.getSeconds()).padStart(2, "0");
-  const timeZoneName = [...parts]
-    .toReversed()
-    .find((part) => part.type === "timeZoneName")
-    ?.value?.trim();
-
-  return {
-    date: `${year}-${month}-${day}`,
-    time: `${hour}:${minute}:${second}`,
-    timeSlug: `${hour}${minute}`,
-    timeZoneName,
-  };
-}
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -137,11 +85,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Use the user's local timezone for memory artifact names and headings.
-    const now = new Date(event.timestamp);
-    const localTimestamp = formatLocalSessionTimestamp(now);
-    const dateStr = localTimestamp.date;
-
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
     const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
@@ -181,6 +124,14 @@ const saveSessionToMemory: HookHandler = async (event) => {
     });
 
     const sessionFile = currentSessionFile || undefined;
+    const eventTimestampMs = event.timestamp.getTime();
+    const sessionTimestampMs =
+      typeof sessionEntry.updatedAt === "number" && Number.isFinite(sessionEntry.updatedAt)
+        ? Math.floor(sessionEntry.updatedAt)
+        : eventTimestampMs;
+    const dateStr = formatHumanDayKey(sessionTimestampMs, cfg);
+    const timeStr = formatHumanTime(sessionTimestampMs, cfg, { includeSeconds: true });
+    const timeZone = resolveHumanTimezone(cfg);
 
     // Read message count from hook config (default: 15)
     const hookConfig = resolveHookConfig(cfg, "session-memory");
@@ -218,7 +169,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // If no slug, use timestamp
     if (!slug) {
-      slug = localTimestamp.timeSlug;
+      slug = formatHumanTime(eventTimestampMs, cfg, { compact: true });
       log.debug("Using fallback timestamp slug", { slug });
     }
 
@@ -230,16 +181,13 @@ const saveSessionToMemory: HookHandler = async (event) => {
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
 
-    const timeStr = localTimestamp.time;
-    const timeZoneSuffix = localTimestamp.timeZoneName ? ` ${localTimestamp.timeZoneName}` : "";
-
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
     const source = (context.commandSource as string) || "unknown";
 
     // Build Markdown entry
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr}${timeZoneSuffix}`,
+      `# Session: ${dateStr} ${timeStr} (${timeZone})`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -29,7 +29,10 @@ import {
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
-import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
+import {
+  findPreviousSessionFile,
+  getRecentSessionExcerptWithResetFallback,
+} from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
 
@@ -125,13 +128,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     const sessionFile = currentSessionFile || undefined;
     const eventTimestampMs = event.timestamp.getTime();
-    const sessionTimestampMs =
-      typeof sessionEntry.updatedAt === "number" && Number.isFinite(sessionEntry.updatedAt)
-        ? Math.floor(sessionEntry.updatedAt)
-        : eventTimestampMs;
-    const dateStr = formatHumanDayKey(sessionTimestampMs, cfg);
-    const timeStr = formatHumanTime(sessionTimestampMs, cfg, { includeSeconds: true });
-    const timeZone = resolveHumanTimezone(cfg);
 
     // Read message count from hook config (default: 15)
     const hookConfig = resolveHookConfig(cfg, "session-memory");
@@ -142,10 +138,16 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     let slug: string | null = null;
     let sessionContent: string | null = null;
+    let lastMessageTimestampMs: number | undefined;
 
     if (sessionFile) {
       // Get recent conversation content, with fallback to rotated reset transcript.
-      sessionContent = await getRecentSessionContentWithResetFallback(sessionFile, messageCount);
+      const transcriptExcerpt = await getRecentSessionExcerptWithResetFallback(
+        sessionFile,
+        messageCount,
+      );
+      sessionContent = transcriptExcerpt.content;
+      lastMessageTimestampMs = transcriptExcerpt.lastMessageTimestampMs;
       log.debug("Session content loaded", {
         length: sessionContent?.length ?? 0,
         messageCount,
@@ -166,6 +168,15 @@ const saveSessionToMemory: HookHandler = async (event) => {
         log.debug("Generated slug", { slug });
       }
     }
+
+    const sessionTimestampMs =
+      lastMessageTimestampMs ??
+      (typeof sessionEntry.updatedAt === "number" && Number.isFinite(sessionEntry.updatedAt)
+        ? Math.floor(sessionEntry.updatedAt)
+        : eventTimestampMs);
+    const dateStr = formatHumanDayKey(sessionTimestampMs, cfg);
+    const timeStr = formatHumanTime(sessionTimestampMs, cfg, { includeSeconds: true });
+    const timeZone = resolveHumanTimezone(cfg);
 
     // If no slug, use timestamp
     if (!slug) {

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeTimestamp } from "../../../agents/date-time.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 
 function extractTextMessageContent(content: unknown): string | undefined {
@@ -21,15 +22,21 @@ function extractTextMessageContent(content: unknown): string | undefined {
   return undefined;
 }
 
-export async function getRecentSessionContent(
+export type SessionTranscriptExcerpt = {
+  content: string | null;
+  lastMessageTimestampMs?: number;
+};
+
+export async function getRecentSessionExcerpt(
   sessionFilePath: string,
   messageCount: number = 15,
-): Promise<string | null> {
+): Promise<SessionTranscriptExcerpt> {
   try {
     const content = await fs.readFile(sessionFilePath, "utf-8");
     const lines = content.trim().split("\n");
 
     const allMessages: string[] = [];
+    let lastMessageTimestampMs: number | undefined;
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
@@ -47,6 +54,10 @@ export async function getRecentSessionContent(
             const text = extractTextMessageContent(msg.content);
             if (text && !text.startsWith("/")) {
               allMessages.push(`${role}: ${text}`);
+              const normalizedTimestamp = normalizeTimestamp(entry.timestamp ?? msg.timestamp);
+              if (normalizedTimestamp) {
+                lastMessageTimestampMs = normalizedTimestamp.timestampMs;
+              }
             }
           }
         }
@@ -55,18 +66,29 @@ export async function getRecentSessionContent(
       }
     }
 
-    return allMessages.slice(-messageCount).join("\n");
+    const recentMessages = allMessages.slice(-messageCount);
+    return {
+      content: recentMessages.length > 0 ? recentMessages.join("\n") : null,
+      lastMessageTimestampMs,
+    };
   } catch {
-    return null;
+    return { content: null };
   }
 }
 
-export async function getRecentSessionContentWithResetFallback(
+export async function getRecentSessionContent(
   sessionFilePath: string,
   messageCount: number = 15,
 ): Promise<string | null> {
-  const primary = await getRecentSessionContent(sessionFilePath, messageCount);
-  if (primary) {
+  return (await getRecentSessionExcerpt(sessionFilePath, messageCount)).content;
+}
+
+export async function getRecentSessionExcerptWithResetFallback(
+  sessionFilePath: string,
+  messageCount: number = 15,
+): Promise<SessionTranscriptExcerpt> {
+  const primary = await getRecentSessionExcerpt(sessionFilePath, messageCount);
+  if (primary.content) {
     return primary;
   }
 
@@ -82,13 +104,21 @@ export async function getRecentSessionContentWithResetFallback(
     }
 
     const latestResetPath = path.join(dir, resetCandidates[resetCandidates.length - 1]);
-    return (await getRecentSessionContent(latestResetPath, messageCount)) || primary;
+    const fallback = await getRecentSessionExcerpt(latestResetPath, messageCount);
+    return fallback.content ? fallback : primary;
   } catch {
     return primary;
   }
 }
 
-function stripResetSuffix(fileName: string): string {
+export async function getRecentSessionContentWithResetFallback(
+  sessionFilePath: string,
+  messageCount: number = 15,
+): Promise<string | null> {
+  return (await getRecentSessionExcerptWithResetFallback(sessionFilePath, messageCount)).content;
+}
+
+export function stripResetSuffix(fileName: string): string {
   const resetIndex = fileName.indexOf(".reset.");
   return resetIndex === -1 ? fileName : fileName.slice(0, resetIndex);
 }

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -45,6 +45,7 @@ export async function getRecentSessionExcerpt(
             role?: unknown;
             content?: unknown;
             provenance?: unknown;
+            timestamp?: unknown;
           };
           const role = msg.role;
           if ((role === "user" || role === "assistant") && "content" in msg && msg.content) {

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -7,7 +7,12 @@ import {
   formatDurationSeconds,
 } from "./format-duration.js";
 import { formatTimeAgo, formatRelativeTimestamp } from "./format-relative.js";
-import { formatHumanDayKey, formatHumanTime, resolveHumanResetCycleKey } from "./human-day.js";
+import {
+  formatHumanDayKey,
+  formatHumanTime,
+  resolveHumanResetBoundaryMs,
+  resolveHumanResetCycleKey,
+} from "./human-day.js";
 
 const invalidDurationInputs = [null, undefined, -100] as const;
 
@@ -223,6 +228,18 @@ describe("human-day", () => {
     const afterReset = Date.UTC(2026, 2, 18, 21, 0, 0); // 05:00 on Mar 19 in Asia/Shanghai
     expect(resolveHumanResetCycleKey(beforeReset, 4, shanghaiCfg)).toBe("2026-03-18");
     expect(resolveHumanResetCycleKey(afterReset, 4, shanghaiCfg)).toBe("2026-03-19");
+  });
+
+  it("returns the first real boundary after a DST-skipped reset hour", () => {
+    const newYorkCfg = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+      },
+    };
+    const now = Date.UTC(2026, 2, 8, 8, 0, 0); // 04:00 local after the DST spring-forward gap
+    expect(resolveHumanResetBoundaryMs(now, 2, newYorkCfg)).toBe(Date.UTC(2026, 2, 8, 7, 0, 0));
   });
 });
 

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -7,6 +7,7 @@ import {
   formatDurationSeconds,
 } from "./format-duration.js";
 import { formatTimeAgo, formatRelativeTimestamp } from "./format-relative.js";
+import { formatHumanDayKey, formatHumanTime, resolveHumanResetCycleKey } from "./human-day.js";
 
 const invalidDurationInputs = [null, undefined, -100] as const;
 
@@ -195,6 +196,33 @@ describe("format-datetime", () => {
         undefined,
       );
     });
+  });
+});
+
+describe("human-day", () => {
+  const shanghaiCfg = {
+    agents: {
+      defaults: {
+        userTimezone: "Asia/Shanghai",
+      },
+    },
+  };
+
+  it("formats human day keys using userTimezone", () => {
+    expect(formatHumanDayKey(Date.UTC(2026, 2, 18, 16, 30, 0), shanghaiCfg)).toBe("2026-03-19");
+  });
+
+  it("formats compact and full human times using userTimezone", () => {
+    const ts = Date.UTC(2026, 2, 18, 16, 30, 45);
+    expect(formatHumanTime(ts, shanghaiCfg, { compact: true })).toBe("0030");
+    expect(formatHumanTime(ts, shanghaiCfg, { includeSeconds: true })).toBe("00:30:45");
+  });
+
+  it("computes reset cycles using the human local day", () => {
+    const beforeReset = Date.UTC(2026, 2, 18, 19, 30, 0); // 03:30 on Mar 19 in Asia/Shanghai
+    const afterReset = Date.UTC(2026, 2, 18, 21, 0, 0); // 05:00 on Mar 19 in Asia/Shanghai
+    expect(resolveHumanResetCycleKey(beforeReset, 4, shanghaiCfg)).toBe("2026-03-18");
+    expect(resolveHumanResetCycleKey(afterReset, 4, shanghaiCfg)).toBe("2026-03-19");
   });
 });
 

--- a/src/infra/format-time/human-day.ts
+++ b/src/infra/format-time/human-day.ts
@@ -159,6 +159,7 @@ export function resolveHumanResetBoundaryMs(
   const [year, month, day] = cycleKey.split("-").map(Number);
   const wallClockMs = Date.UTC(year, month - 1, day, atHour, 0, 0, 0);
   let guessMs = wallClockMs;
+  let latestCandidateMs = guessMs;
 
   // Re-run once or twice in case the target local time lands on a DST boundary.
   for (let index = 0; index < 3; index += 1) {
@@ -167,11 +168,15 @@ export function resolveHumanResetBoundaryMs(
       return undefined;
     }
     const candidateMs = wallClockMs - offsetMinutes * 60_000;
+    latestCandidateMs = Math.max(latestCandidateMs, candidateMs);
     if (candidateMs === guessMs) {
       return candidateMs;
     }
     guessMs = candidateMs;
   }
 
-  return undefined;
+  // Spring-forward gaps have no fixed-point wall clock. When the correction
+  // oscillates, choose the later candidate so the reset fires at the first
+  // real instant after the skipped local time.
+  return latestCandidateMs;
 }

--- a/src/infra/format-time/human-day.ts
+++ b/src/infra/format-time/human-day.ts
@@ -173,5 +173,5 @@ export function resolveHumanResetBoundaryMs(
     guessMs = candidateMs;
   }
 
-  return guessMs;
+  return undefined;
 }

--- a/src/infra/format-time/human-day.ts
+++ b/src/infra/format-time/human-day.ts
@@ -1,0 +1,177 @@
+import { resolveUserTimezone } from "../../agents/date-time.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+type HumanDateTimeParts = {
+  timeZone: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  dayKey: string;
+};
+
+function resolvePart(parts: Intl.DateTimeFormatPart[], type: string): string | undefined {
+  return parts.find((part) => part.type === type)?.value;
+}
+
+function formatDayKeyFromParts(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function shiftDayKey(dayKey: string, days: number): string {
+  const [year, month, day] = dayKey.split("-").map(Number);
+  const shifted = new Date(Date.UTC(year, month - 1, day + days));
+  return formatDayKeyFromParts(
+    shifted.getUTCFullYear(),
+    shifted.getUTCMonth() + 1,
+    shifted.getUTCDate(),
+  );
+}
+
+function resolveShortOffsetMinutes(nowMs: number, timeZone: string): number | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(nowMs));
+    const raw = resolvePart(parts, "timeZoneName")?.trim();
+    if (!raw || raw === "GMT" || raw === "UTC") {
+      return 0;
+    }
+    const match = raw.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/);
+    if (!match) {
+      return undefined;
+    }
+    const sign = match[1] === "-" ? -1 : 1;
+    const hours = Number(match[2]);
+    const minutes = Number(match[3] ?? "0");
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+      return undefined;
+    }
+    return sign * (hours * 60 + minutes);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveHumanDateTimeParts(nowMs: number, cfg?: OpenClawConfig): HumanDateTimeParts {
+  const timeZone = resolveHumanTimezone(cfg);
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(nowMs));
+    const year = Number(resolvePart(parts, "year"));
+    const month = Number(resolvePart(parts, "month"));
+    const day = Number(resolvePart(parts, "day"));
+    const hour = Number(resolvePart(parts, "hour"));
+    const minute = Number(resolvePart(parts, "minute"));
+    const second = Number(resolvePart(parts, "second"));
+    if (
+      [year, month, day, hour, minute, second].every((value) => Number.isFinite(value)) &&
+      year > 0 &&
+      month > 0 &&
+      day > 0
+    ) {
+      return {
+        timeZone,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        dayKey: formatDayKeyFromParts(year, month, day),
+      };
+    }
+  } catch {
+    // Fall through to UTC-derived values below.
+  }
+
+  const fallback = new Date(nowMs);
+  return {
+    timeZone,
+    year: fallback.getUTCFullYear(),
+    month: fallback.getUTCMonth() + 1,
+    day: fallback.getUTCDate(),
+    hour: fallback.getUTCHours(),
+    minute: fallback.getUTCMinutes(),
+    second: fallback.getUTCSeconds(),
+    dayKey: fallback.toISOString().slice(0, 10),
+  };
+}
+
+export function resolveHumanTimezone(cfg?: OpenClawConfig): string {
+  return resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+}
+
+export function formatHumanDayKey(value: number | Date, cfg?: OpenClawConfig): string {
+  const nowMs = value instanceof Date ? value.getTime() : value;
+  return resolveHumanDateTimeParts(nowMs, cfg).dayKey;
+}
+
+export function formatHumanTime(
+  value: number | Date,
+  cfg?: OpenClawConfig,
+  opts?: { compact?: boolean; includeSeconds?: boolean },
+): string {
+  const nowMs = value instanceof Date ? value.getTime() : value;
+  const parts = resolveHumanDateTimeParts(nowMs, cfg);
+  const hh = String(parts.hour).padStart(2, "0");
+  const mm = String(parts.minute).padStart(2, "0");
+  if (opts?.compact) {
+    return `${hh}${mm}`;
+  }
+  if (opts?.includeSeconds) {
+    return `${hh}:${mm}:${String(parts.second).padStart(2, "0")}`;
+  }
+  return `${hh}:${mm}`;
+}
+
+export function resolveHumanResetCycleKey(
+  nowMs: number,
+  atHour: number,
+  cfg?: OpenClawConfig,
+): string {
+  const parts = resolveHumanDateTimeParts(nowMs, cfg);
+  const currentMinutes = parts.hour * 60 + parts.minute;
+  return currentMinutes < atHour * 60 ? shiftDayKey(parts.dayKey, -1) : parts.dayKey;
+}
+
+export function resolveHumanResetBoundaryMs(
+  nowMs: number,
+  atHour: number,
+  cfg?: OpenClawConfig,
+): number | undefined {
+  const timeZone = resolveHumanTimezone(cfg);
+  const cycleKey = resolveHumanResetCycleKey(nowMs, atHour, cfg);
+  const [year, month, day] = cycleKey.split("-").map(Number);
+  const wallClockMs = Date.UTC(year, month - 1, day, atHour, 0, 0, 0);
+  let guessMs = wallClockMs;
+
+  // Re-run once or twice in case the target local time lands on a DST boundary.
+  for (let index = 0; index < 3; index += 1) {
+    const offsetMinutes = resolveShortOffsetMinutes(guessMs, timeZone);
+    if (offsetMinutes === undefined || !Number.isFinite(offsetMinutes)) {
+      return undefined;
+    }
+    const candidateMs = wallClockMs - offsetMinutes * 60_000;
+    if (candidateMs === guessMs) {
+      return candidateMs;
+    }
+    guessMs = candidateMs;
+  }
+
+  return guessMs;
+}

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -237,6 +237,70 @@ describe("session cost usage", () => {
     });
   });
 
+  it("keeps explicit UTC usage buckets aligned with the requested date interpretation", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-utc-buckets-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-utc.jsonl");
+
+    const entries = [
+      {
+        type: "message",
+        timestamp: "2026-03-18T15:30:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 5,
+            output: 5,
+            totalTokens: 10,
+            cost: { total: 0.01 },
+          },
+        },
+      },
+      {
+        type: "message",
+        timestamp: "2026-03-18T16:30:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 7,
+            output: 8,
+            totalTokens: 15,
+            cost: { total: 0.02 },
+          },
+        },
+      },
+    ];
+
+    await fs.writeFile(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    const config = {
+      agents: {
+        defaults: {
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({
+        days: 30,
+        config,
+        dayBucketMode: { type: "utc" },
+      });
+      expect(summary.daily.map((entry) => entry.date)).toEqual(["2026-03-18"]);
+      expect(summary.daily[0]?.totalTokens).toBe(25);
+    });
+  });
+
   it("summarizes a single session file", async () => {
     const root = await makeSessionCostRoot("cost-session");
     const sessionFile = path.join(root, "session.jsonl");
@@ -268,6 +332,67 @@ describe("session cost usage", () => {
     expect(summary?.totalCost).toBeCloseTo(0.03, 5);
     expect(summary?.totalTokens).toBe(30);
     expect(summary?.lastActivity).toBeGreaterThan(0);
+  });
+
+  it("labels session daily breakdown with the requested day bucket mode", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-buckets-"));
+    const sessionFile = path.join(root, "session.jsonl");
+
+    const entries = [
+      {
+        type: "message",
+        timestamp: "2026-03-18T15:30:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 5,
+            output: 5,
+            totalTokens: 10,
+            cost: { total: 0.01 },
+          },
+        },
+      },
+      {
+        type: "message",
+        timestamp: "2026-03-18T16:30:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 7,
+            output: 8,
+            totalTokens: 15,
+            cost: { total: 0.02 },
+          },
+        },
+      },
+    ];
+
+    await fs.writeFile(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    const config = {
+      agents: {
+        defaults: {
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const summary = await loadSessionCostSummary({
+      sessionFile,
+      config,
+      dayBucketMode: { type: "utc" },
+    });
+
+    expect(summary?.activityDates).toEqual(["2026-03-18"]);
+    expect(summary?.dailyBreakdown).toEqual([{ date: "2026-03-18", tokens: 25, cost: 0.03 }]);
   });
 
   it("captures message counts, tool usage, and model usage", async () => {

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -230,7 +230,11 @@ describe("session cost usage", () => {
     } as unknown as OpenClawConfig;
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config });
+      const summary = await loadCostUsageSummary({
+        startMs: Date.parse("2026-03-18T00:00:00.000Z"),
+        endMs: Date.parse("2026-03-19T23:59:59.999Z"),
+        config,
+      });
       expect(summary.daily.map((entry) => entry.date)).toEqual(["2026-03-18", "2026-03-19"]);
       expect(summary.daily[0]?.totalTokens).toBe(10);
       expect(summary.daily[1]?.totalTokens).toBe(15);
@@ -292,7 +296,8 @@ describe("session cost usage", () => {
 
     await withStateDir(root, async () => {
       const summary = await loadCostUsageSummary({
-        days: 30,
+        startMs: Date.parse("2026-03-18T00:00:00.000Z"),
+        endMs: Date.parse("2026-03-18T23:59:59.999Z"),
         config,
         dayBucketMode: { type: "utc" },
       });

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -176,6 +176,67 @@ describe("session cost usage", () => {
     });
   });
 
+  it("groups daily totals by userTimezone instead of host or UTC day", async () => {
+    const root = await makeSessionCostRoot("cost-timezone");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-tz.jsonl");
+
+    const entries = [
+      {
+        type: "message",
+        timestamp: "2026-03-18T15:30:00.000Z", // 2026-03-18 23:30 in Asia/Shanghai
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 5,
+            output: 5,
+            totalTokens: 10,
+            cost: { total: 0.01 },
+          },
+        },
+      },
+      {
+        type: "message",
+        timestamp: "2026-03-18T16:30:00.000Z", // 2026-03-19 00:30 in Asia/Shanghai
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.2",
+          usage: {
+            input: 7,
+            output: 8,
+            totalTokens: 15,
+            cost: { total: 0.02 },
+          },
+        },
+      },
+    ];
+
+    await fs.writeFile(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    const config = {
+      agents: {
+        defaults: {
+          userTimezone: "Asia/Shanghai",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.daily.map((entry) => entry.date)).toEqual(["2026-03-18", "2026-03-19"]);
+      expect(summary.daily[0]?.totalTokens).toBe(10);
+      expect(summary.daily[1]?.totalTokens).toBe(15);
+    });
+  });
+
   it("summarizes a single session file", async () => {
     const root = await makeSessionCostRoot("cost-session");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -22,6 +22,7 @@ import { asFiniteNumber } from "../shared/number-coercion.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+import { formatHumanDayKey } from "./format-time/human-day.js";
 import type {
   CostBreakdown,
   CostUsageTotals,
@@ -158,8 +159,8 @@ const parseTranscriptEntry = (entry: Record<string, unknown>): ParsedTranscriptE
   };
 };
 
-const formatDayKey = (date: Date): string =>
-  date.toLocaleDateString("en-CA", { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+const formatDayKey = (date: Date, config?: OpenClawConfig): string =>
+  formatHumanDayKey(date, config);
 
 const formatUtcDayKey = (date: Date): string =>
   `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
@@ -467,7 +468,7 @@ export async function loadCostUsageSummary(params?: {
         if (!ts || ts < sinceTime || ts > untilTime) {
           return;
         }
-        const dayKey = formatDayKey(entry.timestamp ?? now);
+        const dayKey = formatDayKey(entry.timestamp ?? now, params?.config);
         const bucket = dailyMap.get(dayKey) ?? emptyTotals();
         applyUsageTotals(bucket, entry.usage);
         if (entry.costBreakdown?.total !== undefined) {
@@ -686,7 +687,7 @@ export async function loadSessionCostSummary(params: {
             latencyMs <= MAX_LATENCY_MS
           ) {
             latencyValues.push(latencyMs);
-            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts));
+            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts), params?.config);
             const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
             dailyLatencies.push(latencyMs);
             dailyLatencyMap.set(dayKey, dailyLatencies);
@@ -711,7 +712,7 @@ export async function loadSessionCostSummary(params: {
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
+        const dayKey = formatDayKey(entry.timestamp, params?.config);
         activityDatesSet.add(dayKey);
         const daily = dailyMessageMap.get(dayKey) ?? {
           date: dayKey,
@@ -753,7 +754,7 @@ export async function loadSessionCostSummary(params: {
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
+        const dayKey = formatDayKey(entry.timestamp, params?.config);
         const entryTokenTotals = computeUsageTokenTotals(entry.usage);
         // Preserve the legacy dailyBreakdown token basis until daily metrics are
         // refactored separately. The precise quarter-hour bucket below uses

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -59,6 +59,12 @@ export type {
   SessionToolUsage,
 } from "./session-cost-usage.types.js";
 
+export type DayBucketMode =
+  | { type: "human" }
+  | { type: "utc" }
+  | { type: "gateway" }
+  | { type: "specific"; utcOffsetMinutes: number };
+
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
   output: 0,
@@ -159,8 +165,30 @@ const parseTranscriptEntry = (entry: Record<string, unknown>): ParsedTranscriptE
   };
 };
 
-const formatDayKey = (date: Date, config?: OpenClawConfig): string =>
-  formatHumanDayKey(date, config);
+const formatDayKeyWithOffset = (date: Date, utcOffsetMinutes: number): string =>
+  new Date(date.getTime() + utcOffsetMinutes * 60_000).toISOString().slice(0, 10);
+
+const formatGatewayDayKey = (date: Date): string =>
+  date.toLocaleDateString("en-CA", {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
+
+const formatDayKey = (
+  date: Date,
+  config?: OpenClawConfig,
+  mode: DayBucketMode = { type: "human" },
+): string => {
+  if (mode.type === "utc") {
+    return date.toISOString().slice(0, 10);
+  }
+  if (mode.type === "gateway") {
+    return formatGatewayDayKey(date);
+  }
+  if (mode.type === "specific") {
+    return formatDayKeyWithOffset(date, mode.utcOffsetMinutes);
+  }
+  return formatHumanDayKey(date, config);
+};
 
 const formatUtcDayKey = (date: Date): string =>
   `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
@@ -418,6 +446,7 @@ export async function loadCostUsageSummary(params?: {
   days?: number;
   config?: OpenClawConfig;
   agentId?: string;
+  dayBucketMode?: DayBucketMode;
 }): Promise<CostUsageSummary> {
   const now = new Date();
   let sinceTime: number;
@@ -468,7 +497,7 @@ export async function loadCostUsageSummary(params?: {
         if (!ts || ts < sinceTime || ts > untilTime) {
           return;
         }
-        const dayKey = formatDayKey(entry.timestamp ?? now, params?.config);
+        const dayKey = formatDayKey(entry.timestamp ?? now, params?.config, params?.dayBucketMode);
         const bucket = dailyMap.get(dayKey) ?? emptyTotals();
         applyUsageTotals(bucket, entry.usage);
         if (entry.costBreakdown?.total !== undefined) {
@@ -612,6 +641,7 @@ export async function loadSessionCostSummary(params: {
   agentId?: string;
   startMs?: number;
   endMs?: number;
+  dayBucketMode?: DayBucketMode;
 }): Promise<SessionCostSummary | null> {
   const sessionFile = resolveExistingUsageSessionFile(params);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
@@ -687,7 +717,11 @@ export async function loadSessionCostSummary(params: {
             latencyMs <= MAX_LATENCY_MS
           ) {
             latencyValues.push(latencyMs);
-            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts), params?.config);
+            const dayKey = formatDayKey(
+              entry.timestamp ?? new Date(ts),
+              params?.config,
+              params?.dayBucketMode,
+            );
             const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
             dailyLatencies.push(latencyMs);
             dailyLatencyMap.set(dayKey, dailyLatencies);
@@ -712,7 +746,7 @@ export async function loadSessionCostSummary(params: {
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp, params?.config);
+        const dayKey = formatDayKey(entry.timestamp, params?.config, params?.dayBucketMode);
         activityDatesSet.add(dayKey);
         const daily = dailyMessageMap.get(dayKey) ?? {
           date: dayKey,
@@ -754,7 +788,7 @@ export async function loadSessionCostSummary(params: {
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp, params?.config);
+        const dayKey = formatDayKey(entry.timestamp, params?.config, params?.dayBucketMode);
         const entryTokenTotals = computeUsageTokenTotals(entry.usage);
         // Preserve the legacy dailyBreakdown token basis until daily metrics are
         // refactored separately. The precise quarter-hour bucket below uses


### PR DESCRIPTION
## Summary

- Problem: OpenClaw currently uses a mix of UTC, host local time, and `userTimezone` when deciding what counts as "today". That makes daily memory files, daily session reset, and usage summaries disagree with each other.
- Why it matters: users experience this as "the system got the date wrong" even when the raw timestamps are technically correct. Session-memory files can land on the wrong day, daily reset can roll over at the host timezone instead of the user's timezone, and `/usage cost` can report a different "Today" than the usage bucket summary.
- What changed: introduced a shared "human day" helper and applied it to all user-facing daily boundary logic covered by this PR.
- What did NOT change (scope boundary): no config schema changes, no protocol/storage timestamp changes, no cron scheduling changes, no log-display changes, and no model-prompt copy changes.

## Core idea: Human Day

This PR adds a small shared abstraction for the **human day**: the calendar day as experienced by the user, using the existing `agents.defaults.userTimezone` with host-timezone fallback.

The goal is not to replace UTC everywhere. The goal is to make all **user-facing daily boundary decisions** answer the same question the same way:

> "For this user, what day is it?"

That daily-boundary logic now lives in one place instead of being reimplemented ad hoc with `toISOString()`, host-local `setHours()`, or `toLocaleDateString()`.

## What changed

### Shared helper

Added `src/infra/format-time/human-day.ts` with shared helpers for:

- resolving the human timezone from existing config
- formatting a `YYYY-MM-DD` day key for that timezone
- formatting local wall-clock time for human-facing daily artifacts
- resolving the daily reset cycle key/boundary in that timezone

### Session memory

Updated `src/hooks/bundled/session-memory/handler.ts`:

- session-memory filenames now use the human day instead of UTC date slicing
- fallback HHMM slug now uses human local time instead of UTC time
- markdown header now shows the human local time and timezone label
- the memory file date is based on the previous session's `updatedAt` when available, which better matches "the day this session actually belonged to" than UTC event time

This fixes the class of bug where a late-night session in `Asia/Shanghai` gets stored as the previous UTC date.

### Session reset

Updated `src/config/sessions/reset.ts` and its callers so daily freshness is evaluated using the human-day reset cycle instead of host-local `Date#setHours()`.

This means `session.reset.atHour` now behaves consistently with the configured user timezone for daily rollover decisions.

### Usage daily buckets

Updated `src/infra/session-cost-usage.ts` so daily aggregation uses the same human-day key.

Also updated `/usage cost` in `src/auto-reply/reply/commands-session.ts` so the `Today` line uses the exact same day-key logic as the bucket summary.

### Memory flush

Updated `src/auto-reply/reply/memory-flush.ts` so the canonical `memory/YYYY-MM-DD.md` path uses the same shared human-day helper.

## Why this approach

This PR intentionally fixes one specific class of time bugs:

- **user-facing daily boundary logic**

It does **not** try to solve every timezone-related behavior in one shot.

That separation is deliberate:

- raw transcript / protocol timestamps should remain UTC
- cron scheduling has its own semantics and should stay separate
- log display defaults are a separate UX topic

Keeping this PR centered on **human-day semantics** makes the behavior easier to reason about and the scope easier to review.

## User-visible behavior changes

- Session-memory files now land on the user's calendar day instead of the UTC day.
- Session-memory markdown headers now show local time with timezone label.
- Daily session reset now follows the user's calendar day instead of the gateway host's local day.
- Usage daily buckets and `/usage cost` now agree on what counts as `Today`.
- Memory flush canonical daily path now matches the same day-boundary logic.

## Security impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.userTimezone`

### Representative repros fixed by this PR

1. Configure `agents.defaults.userTimezone: "Asia/Shanghai"`.
2. End a session at `2026-03-19 00:20 +08:00` (still `2026-03-18` in UTC).
3. Trigger `session-memory`.
4. Before this PR, the file can be named with the UTC day. After this PR, it uses the user-local day.

And:

1. Configure `session.reset.atHour: 4` with `agents.defaults.userTimezone: "Asia/Shanghai"`.
2. Compare a session updated at `03:30 +08:00` with `now = 05:00 +08:00`.
3. Before this PR, daily rollover logic depended on host-local time. After this PR, it follows the configured human-day boundary.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added/updated targeted tests for:

- shared human-day helper behavior
- daily reset boundary behavior in `Asia/Shanghai`
- usage daily aggregation across a UTC midnight split
- session-memory filename/header behavior for late-night local sessions

## Human Verification

- Verified scenarios:
  - `pnpm test -- src/config/sessions/reset.test.ts src/infra/format-time/format-time.test.ts src/infra/session-cost-usage.test.ts src/hooks/bundled/session-memory/handler.test.ts`
  - `pnpm build`
  - `pnpm format`
- Edge cases checked:
  - local day crossing UTC midnight
  - daily reset cutoff before/after configured reset hour
  - usage buckets and `/usage cost` sharing the same day key
- What I did **not** verify:
  - full live channel end-to-end behavior across every integration
  - DST-specific end-to-end behavior outside unit coverage

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: existing session-memory filenames created before this fix may use a different date convention than newly created ones.
  - Mitigation: this is expected for bugfix rollout and does not affect transcript integrity.
- Risk: daily reset behavior may change for users who were unintentionally relying on gateway host timezone.
  - Mitigation: the new behavior aligns daily reset with the existing `userTimezone` concept used elsewhere in the product.
