### PR TITLE
fix: stop forwarding local cwd to node hosts

### DIFF
--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -100,7 +100,6 @@ export async function executeNodeHostCommand(
       params: {
         command: argv,
         rawCommand: params.command,
-        cwd: params.workdir,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
       },
@@ -113,7 +112,7 @@ export async function executeNodeHostCommand(
   }
   const runArgv = prepared.plan.argv;
   const runRawCommand = prepared.plan.commandText;
-  const runCwd = prepared.plan.cwd ?? params.workdir;
+  const runCwd = typeof prepared.plan.cwd === "string" ? prepared.plan.cwd : undefined;
   const runAgentId = prepared.plan.agentId ?? params.agentId;
   const runSessionKey = prepared.plan.sessionKey ?? params.sessionKey;
 
@@ -194,7 +193,7 @@ export async function executeNodeHostCommand(
       params: {
         command: runArgv,
         rawCommand: runRawCommand,
-        cwd: runCwd,
+        ...(runCwd ? { cwd: runCwd } : {}),
         env: nodeEnv,
         timeoutMs: typeof params.timeoutSec === "number" ? params.timeoutSec * 1000 : undefined,
         agentId: runAgentId,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -30,6 +30,7 @@ import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 export type ExecuteNodeHostCommandParams = {
   command: string;
   workdir: string;
+  forwardedWorkdir?: string;
   env: Record<string, string>;
   requestedEnv?: Record<string, string>;
   requestedNode?: string;
@@ -100,6 +101,7 @@ export async function executeNodeHostCommand(
       params: {
         command: argv,
         rawCommand: params.command,
+        ...(params.forwardedWorkdir ? { cwd: params.forwardedWorkdir } : {}),
         agentId: params.agentId,
         sessionKey: params.sessionKey,
       },
@@ -219,7 +221,7 @@ export async function executeNodeHostCommand(
         approvalId,
         systemRunPlan: prepared.plan,
         env: nodeEnv,
-        workdir: runCwd,
+        workdir: runCwd ?? params.workdir,
         host: "node",
         nodeId,
         security: hostSecurity,

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -290,6 +290,7 @@ describe("exec approvals", () => {
   });
 
   it("does not forward the local cwd to node prepare or run payloads", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-default-cwd-"));
     let prepareParams: Record<string, unknown> | undefined;
     let runParams: Record<string, unknown> | undefined;
 
@@ -316,6 +317,7 @@ describe("exec approvals", () => {
       ask: "off",
       security: "full",
       approvalRunningNoticeMs: 0,
+      cwd: tempDir,
     });
 
     const result = await tool.execute("call-node-cwd", { command: "echo hello" });

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -283,6 +283,79 @@ describe("exec approvals", () => {
     await expect.poll(() => agentParams, { timeout: 2_000, interval: 20 }).toBeTruthy();
   });
 
+  it("does not forward the local cwd to node prepare or run payloads", async () => {
+    let prepareParams: Record<string, unknown> | undefined;
+    let runParams: Record<string, unknown> | undefined;
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "node.invoke") {
+        const invoke = params as {
+          command?: string;
+          params?: Record<string, unknown>;
+        };
+        if (invoke.command === "system.run.prepare") {
+          prepareParams = invoke.params;
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          runParams = invoke.params;
+          return { payload: { success: true, stdout: "ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "off",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-node-cwd", { command: "echo hello" });
+    expect(result.details.status).toBe("completed");
+    expect(prepareParams).toBeTruthy();
+    expect(runParams).toBeTruthy();
+    expect(prepareParams).not.toHaveProperty("cwd");
+    expect(runParams).not.toHaveProperty("cwd");
+  });
+
+  it("reuses a node-provided cwd from the prepare plan for execution", async () => {
+    let runParams: Record<string, unknown> | undefined;
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "node.invoke") {
+        const invoke = params as {
+          command?: string;
+          params?: Record<string, unknown>;
+        };
+        if (invoke.command === "system.run.prepare") {
+          expect(invoke.params).not.toHaveProperty("cwd");
+          return buildSystemRunPreparePayload({
+            ...invoke.params,
+            cwd: "C:\\\\node-workspace",
+          });
+        }
+        if (invoke.command === "system.run") {
+          runParams = invoke.params;
+          return { payload: { success: true, stdout: "ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "off",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-node-remote-cwd", { command: "echo hello" });
+    expect(result.details.status).toBe("completed");
+    expect(runParams).toMatchObject({ cwd: "C:\\\\node-workspace" });
+  });
+
   it("skips approval when node allowlist is satisfied", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-bin-"));
     const binDir = path.join(tempDir, "bin");

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -234,6 +234,7 @@ describe("exec approvals", () => {
   });
 
   it("reuses approval id as the node runId", async () => {
+    let prepareParams: unknown;
     let invokeParams: unknown;
     let agentParams: unknown;
 
@@ -244,6 +245,7 @@ describe("exec approvals", () => {
       onNodeInvoke: (params) => {
         const invoke = params as { command?: string };
         if (invoke.command === "system.run.prepare") {
+          prepareParams = (params as { params?: unknown }).params;
           return buildPreparedSystemRunPayload(params);
         }
         if (invoke.command === "system.run") {
@@ -268,6 +270,7 @@ describe("exec approvals", () => {
       interactive: true,
     });
     const approvalId = details.approvalId;
+    expect(prepareParams).not.toHaveProperty("cwd");
 
     await expect
       .poll(() => (invokeParams as { params?: { runId?: string } } | undefined)?.params?.runId, {
@@ -280,6 +283,9 @@ describe("exec approvals", () => {
     ).toMatchObject({
       suppressNotifyOnExit: true,
     });
+    expect(
+      (invokeParams as { params?: Record<string, unknown> } | undefined)?.params,
+    ).not.toHaveProperty("cwd");
     await expect.poll(() => agentParams, { timeout: 2_000, interval: 20 }).toBeTruthy();
   });
 
@@ -320,7 +326,9 @@ describe("exec approvals", () => {
     expect(runParams).not.toHaveProperty("cwd");
   });
 
-  it("reuses a node-provided cwd from the prepare plan for execution", async () => {
+  it("forwards an explicit workdir to node prepare and execution", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-cwd-"));
+    let prepareParams: Record<string, unknown> | undefined;
     let runParams: Record<string, unknown> | undefined;
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
@@ -330,11 +338,8 @@ describe("exec approvals", () => {
           params?: Record<string, unknown>;
         };
         if (invoke.command === "system.run.prepare") {
-          expect(invoke.params).not.toHaveProperty("cwd");
-          return buildSystemRunPreparePayload({
-            ...invoke.params,
-            cwd: "C:\\\\node-workspace",
-          });
+          prepareParams = invoke.params;
+          return buildPreparedSystemRunPayload(params);
         }
         if (invoke.command === "system.run") {
           runParams = invoke.params;
@@ -351,9 +356,13 @@ describe("exec approvals", () => {
       approvalRunningNoticeMs: 0,
     });
 
-    const result = await tool.execute("call-node-remote-cwd", { command: "echo hello" });
+    const result = await tool.execute("call-node-remote-cwd", {
+      command: "echo hello",
+      workdir: tempDir,
+    });
     expect(result.details.status).toBe("completed");
-    expect(runParams).toMatchObject({ cwd: "C:\\\\node-workspace" });
+    expect(prepareParams).toMatchObject({ cwd: tempDir });
+    expect(runParams).toMatchObject({ cwd: tempDir });
   });
 
   it("skips approval when node allowlist is satisfied", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -346,7 +346,9 @@ export function createExecTool(
           ].join("\n"),
         );
       }
-      const rawWorkdir = params.workdir?.trim() || defaults?.cwd || process.cwd();
+      const requestedWorkdir = params.workdir?.trim();
+      const configuredWorkdir = defaults?.cwd?.trim();
+      const rawWorkdir = requestedWorkdir || configuredWorkdir || process.cwd();
       let workdir = rawWorkdir;
       let containerWorkdir = sandbox?.containerWorkdir;
       if (sandbox) {
@@ -403,6 +405,7 @@ export function createExecTool(
         return executeNodeHostCommand({
           command: params.command,
           workdir,
+          forwardedWorkdir: requestedWorkdir || configuredWorkdir || undefined,
           env,
           requestedEnv: params.env,
           requestedNode: params.node?.trim(),

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -405,7 +405,7 @@ export function createExecTool(
         return executeNodeHostCommand({
           command: params.command,
           workdir,
-          forwardedWorkdir: requestedWorkdir || configuredWorkdir || undefined,
+          forwardedWorkdir: requestedWorkdir || undefined,
           env,
           requestedEnv: params.env,
           requestedNode: params.node?.trim(),


### PR DESCRIPTION
## Summary

- Problem: gateway-driven `host=node` exec always forwarded the agent's local `workdir` into remote `system.run.prepare` / `system.run`, which breaks cross-platform node hosts when that local path is meaningless on the remote machine.
- Why it matters: a Linux gateway sending `/home/...` as `cwd` to a Windows node can fail both during `system.run.prepare` approval hardening and later at process spawn, even when the caller did not configure a remote cwd.
- What changed: `executeNodeHostCommand()` now omits the local cwd from node-host prepare/run payloads, but still reuses a cwd if the node host itself returns one in the prepared plan.
- What did NOT change (scope boundary): gateway-host exec still uses local cwd as before, and this does not add any new remote cwd mapping or translation logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49693
- Related #

## User-visible / Behavior Changes

Agent exec with `tools.exec.host: node` no longer forwards the gateway's local workspace path as the remote node cwd by default. If the node host returns a resolved cwd from `system.run.prepare`, that remote cwd is still used for the actual `system.run` call.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 (local validation), issue reports Linux gateway -> Windows node host
- Runtime/container: Node 20.19.0, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): agent exec `host=node`
- Relevant config (redacted): `tools.exec.host=node`, `tools.exec.security=full`, `tools.exec.ask=off`

### Steps

1. Route agent exec through `executeNodeHostCommand()` with a local gateway workdir.
2. Capture the payloads sent to `node.invoke(system.run.prepare)` and `node.invoke(system.run)`.
3. Verify that no local `cwd` is forwarded unless the node host itself returns one in the prepared plan.

### Expected

- The gateway should not force its local cwd into remote node-host prepare/run payloads.
- If the node host resolves a remote cwd during prepare, that remote cwd should be reused for execution.

### Actual

- Before this change, the local gateway cwd was always sent to both prepare and run.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted regression tests added in `src/agents/bash-tools.exec.approval-id.test.ts` verify both omitted local cwd forwarding and remote prepared-plan cwd reuse.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `git diff --check`; `pnpm exec oxfmt --check` on changed files; targeted `vitest` run for the two new node-host cwd regression tests.
- Edge cases checked: node-host prepare payload omits local cwd; node-host run payload stays cwd-less when prepare returns none; node-host run payload reuses a remote cwd when prepare returns one.
- What you did **not** verify: full `pnpm check` exceeded the local 10-second stop rule and was interrupted; `codex review --base origin/main` is not usable in this environment because local config parsing fails (`approvals_reviewer=never`). A full-file run of `bash-tools.exec.approval-id.test.ts` also reported two unrelated approval-unavailable assertion failures outside the changed node-host cwd path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous node-host cwd forwarding behavior.
- Files/config to restore: `src/agents/bash-tools.exec-host-node.ts`, `src/agents/bash-tools.exec.approval-id.test.ts`
- Known bad symptoms reviewers should watch for: node-host exec unexpectedly running from the node service default cwd when a deployment depended on implicit local cwd forwarding.

## Risks and Mitigations

- Risk: some same-platform node-host setups may have been implicitly relying on the gateway's local cwd being forwarded.
  - Mitigation: the change is scoped to agent-driven node-host payload construction, and still preserves a cwd when the node host itself resolves one in the prepare plan.