### PR TITLE
Feishu: map bot-menu event keys to slash commands

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -435,7 +435,20 @@ openclaw pairing list feishu
 | `/reset`  | Reset the session |
 | `/model`  | Show/switch model |
 
-> Note: Feishu does not support native command menus yet, so commands must be sent as text.
+> Note: Feishu still does not auto-register native slash-command menus like Telegram. Text commands continue to work everywhere, and bot-menu events can now be mapped to slash commands or the built-in quick-actions launcher.
+
+### Bot menu shortcuts
+
+If your Feishu app has the `application:bot.menu:write` scope and bot-menu events enabled, you can configure Feishu bot menu entries in the Open Platform console and point their `event_key` values at OpenClaw commands:
+
+- `quick-actions` → opens the built-in quick-actions card
+- `status` → runs `/status`
+- `commands` → runs `/commands`
+- `model` → runs `/model`
+- `command:status` → explicit command mapping form
+- `cmd:model gmn/gpt-5.4` → command mapping with arguments
+
+Unrecognized menu keys still fall back to `/menu <event_key>` so existing custom automations keep working.
 
 ## Gateway management commands
 
@@ -539,7 +552,7 @@ Feishu supports ACP for:
 - DMs
 - group topic conversations
 
-Feishu ACP is text-command driven. There are no native slash-command menus, so use `/acp ...` messages directly in the conversation.
+Feishu ACP is still primarily text-command driven. There is no auto-registered native slash-command menu, so use `/acp ...` messages directly in the conversation, or map bot-menu `event_key` values to ACP slash commands manually if you want shortcuts.
 
 #### Persistent ACP bindings
 

--- a/extensions/feishu/src/bot-menu.test.ts
+++ b/extensions/feishu/src/bot-menu.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveFeishuBotMenuCommand } from "./bot-menu.js";
+
+describe("resolveFeishuBotMenuCommand", () => {
+  it("maps built-in native command names to text commands", () => {
+    expect(resolveFeishuBotMenuCommand("status")).toBe("/status");
+    expect(resolveFeishuBotMenuCommand("export-session logs/out.html")).toBe(
+      "/export-session logs/out.html",
+    );
+  });
+
+  it("accepts explicit slash-command event keys", () => {
+    expect(resolveFeishuBotMenuCommand("/model")).toBe("/model");
+    expect(resolveFeishuBotMenuCommand("/export logs/out.html")).toBe(
+      "/export-session logs/out.html",
+    );
+  });
+
+  it("accepts prefixed command payloads", () => {
+    expect(resolveFeishuBotMenuCommand("command:status")).toBe("/status");
+    expect(resolveFeishuBotMenuCommand("cmd:model gmn/gpt-5.4")).toBe("/model gmn/gpt-5.4");
+    expect(resolveFeishuBotMenuCommand("slash:/commands")).toBe("/commands");
+  });
+
+  it("returns null for unrelated event keys", () => {
+    expect(resolveFeishuBotMenuCommand("quick-actions")).toBeNull();
+    expect(resolveFeishuBotMenuCommand("custom-key")).toBeNull();
+    expect(resolveFeishuBotMenuCommand("   ")).toBeNull();
+  });
+});

--- a/extensions/feishu/src/bot-menu.ts
+++ b/extensions/feishu/src/bot-menu.ts
@@ -1,0 +1,49 @@
+import { findCommandByNativeName, normalizeCommandBody } from "openclaw/plugin-sdk/reply-runtime";
+
+const FEISHU_MENU_COMMAND_PREFIXES = ["command:", "cmd:", "slash:", "oc:"] as const;
+
+function normalizeRawBotMenuCommand(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const normalized = normalizeCommandBody(withSlash).trim();
+  return normalized.startsWith("/") ? normalized : null;
+}
+
+export function resolveFeishuBotMenuCommand(eventKey: string): string | null {
+  const trimmed = eventKey.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lowered = trimmed.toLowerCase();
+  for (const prefix of FEISHU_MENU_COMMAND_PREFIXES) {
+    if (!lowered.startsWith(prefix)) {
+      continue;
+    }
+    return normalizeRawBotMenuCommand(trimmed.slice(prefix.length));
+  }
+
+  if (trimmed.startsWith("/")) {
+    return normalizeRawBotMenuCommand(trimmed);
+  }
+
+  const tokenMatch = trimmed.match(/^([^\s]+)(?:\s+([\s\S]+))?$/);
+  if (!tokenMatch) {
+    return null;
+  }
+  const [, token, rest] = tokenMatch;
+  const command = findCommandByNativeName(token, "feishu");
+  if (!command) {
+    return null;
+  }
+
+  const primaryAlias = command.textAliases[0]?.trim();
+  if (!primaryAlias?.startsWith("/")) {
+    return null;
+  }
+  const normalizedRest = rest?.trimStart();
+  return normalizedRest ? `${primaryAlias} ${normalizedRest}` : primaryAlias;
+}

--- a/extensions/feishu/src/card-ux-launcher.test.ts
+++ b/extensions/feishu/src/card-ux-launcher.test.ts
@@ -36,11 +36,13 @@ describe("feishu quick-action launcher", () => {
       };
     };
 
-    const actionBlock = card.body.elements.find((entry) => entry.tag === "action");
-    expect(actionBlock?.actions).toHaveLength(3);
-    expect(actionBlock?.actions?.[0]?.value?.oc).toBe("ocf1");
-    expect(actionBlock?.actions?.[0]?.value?.c?.s).toBe("agent:codex:feishu:chat:chat1");
-    expect(actionBlock?.actions?.[0]?.value?.c?.t).toBeUndefined();
+    const actionBlocks = card.body.elements.filter((entry) => entry.tag === "action");
+    expect(actionBlocks).toHaveLength(2);
+    expect(actionBlocks[0]?.actions).toHaveLength(3);
+    expect(actionBlocks[1]?.actions).toHaveLength(3);
+    expect(actionBlocks[0]?.actions?.[0]?.value?.oc).toBe("ocf1");
+    expect(actionBlocks[0]?.actions?.[0]?.value?.c?.s).toBe("agent:codex:feishu:chat:chat1");
+    expect(actionBlocks[0]?.actions?.[0]?.value?.c?.t).toBeUndefined();
   });
 
   it("opens the launcher from a supported bot menu event", async () => {

--- a/extensions/feishu/src/card-ux-launcher.ts
+++ b/extensions/feishu/src/card-ux-launcher.ts
@@ -42,6 +42,39 @@ export function createQuickActionLauncherCard(params: {
           tag: "action",
           actions: [
             buildFeishuCardButton({
+              label: "Status",
+              type: "primary",
+              value: createFeishuCardInteractionEnvelope({
+                k: "quick",
+                a: "feishu.quick_actions.status",
+                q: "/status",
+                c: context,
+              }),
+            }),
+            buildFeishuCardButton({
+              label: "Commands",
+              value: createFeishuCardInteractionEnvelope({
+                k: "quick",
+                a: "feishu.quick_actions.commands",
+                q: "/commands",
+                c: context,
+              }),
+            }),
+            buildFeishuCardButton({
+              label: "Model",
+              value: createFeishuCardInteractionEnvelope({
+                k: "quick",
+                a: "feishu.quick_actions.model",
+                q: "/model",
+                c: context,
+              }),
+            }),
+          ],
+        },
+        {
+          tag: "action",
+          actions: [
+            buildFeishuCardButton({
               label: "Help",
               value: createFeishuCardInteractionEnvelope({
                 k: "quick",

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -3,6 +3,7 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
+import { resolveFeishuBotMenuCommand } from "./bot-menu.js";
 import {
   handleFeishuMessage,
   parseFeishuMessageEvent,
@@ -525,6 +526,7 @@ function registerEventHandlers(
         if (!operatorOpenId || !eventKey) {
           return;
         }
+        const resolvedCommand = resolveFeishuBotMenuCommand(eventKey);
         const syntheticEvent: FeishuMessageEvent = {
           sender: {
             sender_id: {
@@ -540,7 +542,7 @@ function registerEventHandlers(
             chat_type: "p2p",
             message_type: "text",
             content: JSON.stringify({
-              text: `/menu ${eventKey}`,
+              text: resolvedCommand ?? `/menu ${eventKey}`,
             }),
           },
         };

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -171,6 +171,33 @@ describe("Feishu bot menu handler", () => {
     await pending;
   });
 
+  it("maps native-style bot menu keys to slash commands", async () => {
+    const onBotMenu = await registerHandlers();
+
+    await onBotMenu({
+      event_key: "status",
+      timestamp: "1700000000000",
+      operator: {
+        operator_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+    });
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"/status"}',
+          }),
+        }),
+      }),
+    );
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to the legacy /menu synthetic message path for unrelated bot menu keys", async () => {
     const onBotMenu = await registerHandlers();
 


### PR DESCRIPTION
## Summary

This improves Feishu bot-menu ergonomics so menu entries can behave more like native command shortcuts.

### What changed

- Added `resolveFeishuBotMenuCommand` (`extensions/feishu/src/bot-menu.ts`) to map bot-menu `event_key` values to OpenClaw slash commands.
  - Supports direct native-style keys like `status` / `commands` / `model`
  - Supports explicit prefixes like `command:status` and `cmd:model gmn/gpt-5.4`
  - Preserves existing fallback behavior for unknown keys: `/menu <event_key>`
- Wired mapping into the Feishu event handler (`extensions/feishu/src/monitor.account.ts`) for `application.bot.menu_v6`.
- Expanded quick-actions launcher card (`extensions/feishu/src/card-ux-launcher.ts`) with common command buttons:
  - Status
  - Commands
  - Model
  - (existing) Help / New session / Reset
- Added/updated tests:
  - `extensions/feishu/src/bot-menu.test.ts`
  - `extensions/feishu/src/monitor.bot-menu.test.ts`
  - `extensions/feishu/src/card-ux-launcher.test.ts`
- Updated Feishu docs (`docs/channels/feishu.md`) to explain bot-menu shortcut mapping and current native-menu limitations.

## Why

Feishu now has app capabilities/scopes for bot menu usage, but OpenClaw previously only routed most menu keys through `/menu <key>`. This change makes bot-menu entries useful as direct command shortcuts while keeping backward compatibility.

## Validation

Ran targeted extension tests:

```bash
pnpm test -- extensions/feishu/src/bot-menu.test.ts extensions/feishu/src/monitor.bot-menu.test.ts extensions/feishu/src/card-ux-launcher.test.ts
```

All passed.

## Attribution

Prepared collaboratively by **Kenny Zhou + Clio (OpenClaw assistant)**.
