### PR TITLE
feat: auto-log agent-to-agent communications to bus.jsonl

### DIFF
--- a/src/agents/tools/sessions-send-comms-log.test.ts
+++ b/src/agents/tools/sessions-send-comms-log.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendCommsLog, type CommsLogEntry } from "./sessions-send-comms-log.js";
+
+describe("appendCommsLog", () => {
+  let tmpDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "comms-log-test-"));
+    originalEnv = process.env.SIGNAL_DIR;
+    process.env.SIGNAL_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SIGNAL_DIR;
+    } else {
+      process.env.SIGNAL_DIR = originalEnv;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a JSONL entry to bus.jsonl", () => {
+    const entry: CommsLogEntry = {
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+      messagePreview: "Hello from tech",
+      replyPreview: "Hello back",
+    };
+
+    appendCommsLog(entry);
+
+    const logPath = path.join(tmpDir, "bus.jsonl");
+    expect(fs.existsSync(logPath)).toBe(true);
+
+    const lines = fs.readFileSync(logPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.type).toBe("MESSAGE");
+    expect(parsed.from).toBe("agent:tech:main");
+    expect(parsed.to).toBe("agent:content:main");
+    expect(parsed.status).toBe("ok");
+    expect(parsed.messagePreview).toBe("Hello from tech");
+    expect(parsed.replyPreview).toBe("Hello back");
+  });
+
+  it("appends multiple entries", () => {
+    const entry1: CommsLogEntry = {
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+    };
+    const entry2: CommsLogEntry = {
+      type: "MESSAGE",
+      from: "agent:content:main",
+      to: "agent:tech:main",
+      ts: "2026-03-18T19:01:00Z",
+      status: "accepted",
+    };
+
+    appendCommsLog(entry1);
+    appendCommsLog(entry2);
+
+    const logPath = path.join(tmpDir, "bus.jsonl");
+    const lines = fs.readFileSync(logPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("truncates long previews", () => {
+    const longMessage = "a".repeat(300);
+    const entry: CommsLogEntry = {
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+      messagePreview: longMessage.slice(0, 200),
+    };
+
+    appendCommsLog(entry);
+
+    const logPath = path.join(tmpDir, "bus.jsonl");
+    const parsed = JSON.parse(fs.readFileSync(logPath, "utf-8").trim());
+    expect(parsed.messagePreview.length).toBe(200);
+  });
+
+  it("does not throw on write failure", () => {
+    process.env.SIGNAL_DIR = "/nonexistent/readonly/path";
+    // Should not throw
+    expect(() => {
+      appendCommsLog({
+        type: "MESSAGE",
+        from: "a",
+        to: "b",
+        ts: "2026-01-01T00:00:00Z",
+        status: "ok",
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/agents/tools/sessions-send-comms-log.ts
+++ b/src/agents/tools/sessions-send-comms-log.ts
@@ -1,0 +1,54 @@
+/**
+ * Agent-to-agent communication logger.
+ *
+ * Appends a structured JSONL entry to `~/.openclaw/shared/signals/bus.jsonl`
+ * every time sessions_send completes. This provides automatic observability
+ * for all inter-agent communication without requiring agent cooperation.
+ *
+ * The log file can be consumed by external dashboards or skills.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface CommsLogEntry {
+  /** Signal type — always "MESSAGE" for sessions_send */
+  type: "MESSAGE";
+  /** Source agent session key */
+  from: string;
+  /** Target agent session key */
+  to: string;
+  /** ISO 8601 timestamp */
+  ts: string;
+  /** Outcome: ok, accepted, timeout, error, forbidden */
+  status: string;
+  /** Truncated message (first 200 chars) */
+  messagePreview?: string;
+  /** Truncated reply (first 200 chars) */
+  replyPreview?: string;
+}
+
+function resolveLogPath(): string {
+  const envDir = process.env.SIGNAL_DIR;
+  const dir = envDir || path.join(os.homedir(), ".openclaw", "shared", "signals");
+  return path.join(dir, "bus.jsonl");
+}
+
+/**
+ * Append a communication log entry. Fire-and-forget — errors are silently
+ * swallowed so logging never disrupts the sessions_send flow.
+ */
+export function appendCommsLog(entry: CommsLogEntry): void {
+  try {
+    const logPath = resolveLogPath();
+    const dir = path.dirname(logPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const line = JSON.stringify(entry) + "\n";
+    fs.appendFileSync(logPath, line, "utf-8");
+  } catch {
+    // Silently ignore — logging must never break sessions_send
+  }
+}

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -21,6 +21,7 @@ import {
   resolveVisibleSessionReference,
   stripToolMessages,
 } from "./sessions-helpers.js";
+import { appendCommsLog } from "./sessions-send-comms-log.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
@@ -287,6 +288,14 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         startA2AFlow(undefined, runId);
+        appendCommsLog({
+          type: "MESSAGE",
+          from: effectiveRequesterKey,
+          to: displayKey,
+          ts: new Date().toISOString(),
+          status: "accepted",
+          messagePreview: message?.slice(0, 200),
+        });
         return jsonResult({
           runId,
           status: "accepted",
@@ -354,6 +363,16 @@ export function createSessionsSendTool(opts?: {
       const last = filtered.length > 0 ? filtered[filtered.length - 1] : undefined;
       const reply = last ? extractAssistantText(last) : undefined;
       startA2AFlow(reply ?? undefined);
+
+      appendCommsLog({
+        type: "MESSAGE",
+        from: effectiveRequesterKey,
+        to: displayKey,
+        ts: new Date().toISOString(),
+        status: "ok",
+        messagePreview: message?.slice(0, 200),
+        replyPreview: reply?.slice(0, 200),
+      });
 
       return jsonResult({
         runId,


### PR DESCRIPTION
## Summary

Adds automatic JSONL logging for all `sessions_send` calls, providing observability for agent-to-agent communication without requiring any agent behavior change.

## Problem

Currently, agent-to-agent communication via `sessions_send` is invisible to the operator. There's no centralized record of which agent talked to which, what was said, or what the outcome was. The `ANNOUNCE_SKIP` pattern means many conversations leave no trace.

Users running multi-agent setups (2+ agents) have no way to debug communication failures, audit task handoffs, or understand collaboration patterns.

## Solution

A new `sessions-send-comms-log.ts` module that appends a structured JSONL entry to `~/.openclaw/shared/signals/bus.jsonl` every time `sessions_send` completes.

### What gets logged

```json
{
  "type": "MESSAGE",
  "from": "agent:tech:main",
  "to": "agent:content:main",
  "ts": "2026-03-18T19:00:00Z",
  "status": "ok",
  "messagePreview": "Please review the website...",
  "replyPreview": "Looks good, merging now"
}
```

### Design decisions

- **Fire-and-forget**: Errors are silently swallowed — logging never disrupts `sessions_send`
- **No config required**: Works out of the box, writes to a sensible default path
- **Configurable**: `SIGNAL_DIR` env var overrides the log directory
- **Privacy-aware**: Message/reply previews are truncated to 200 chars
- **Zero dependencies**: Uses only Node.js builtins (fs, path, os)

### What this enables

External tools and skills can read `bus.jsonl` to provide:
- Communication dashboards (who talked to whom, when)
- Task handoff tracking
- Trust scoring between agents
- Debugging failed cross-agent workflows

## Changes

| File | Change |
|------|--------|
| `sessions-send-comms-log.ts` | New module: JSONL logger |
| `sessions-send-comms-log.test.ts` | 4 tests (write, append, truncate, error handling) |
| `sessions-send-tool.ts` | 2 call sites: sync + fire-and-forget paths |

## Testing

- 4 unit tests passing (vitest)
- Tested manually with a 6-agent OpenClaw setup
- Verified log output is valid JSONL readable by `jq`