### PR TITLE
feat: auto-log agent-to-agent communications to bus.jsonl

### DIFF
--- a/src/agents/tools/sessions-send-comms-log.test.ts
+++ b/src/agents/tools/sessions-send-comms-log.test.ts
@@ -1,0 +1,172 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendCommsLog, type CommsLogEntry } from "./sessions-send-comms-log.js";
+
+describe("appendCommsLog", () => {
+  let tmpDir: string;
+  let originalEnv: string | undefined;
+  let originalCommsLog: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "comms-log-test-"));
+    originalEnv = process.env.SIGNAL_DIR;
+    originalCommsLog = process.env.OPENCLAW_COMMS_LOG;
+    process.env.SIGNAL_DIR = tmpDir;
+    delete process.env.OPENCLAW_COMMS_LOG;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SIGNAL_DIR;
+    } else {
+      process.env.SIGNAL_DIR = originalEnv;
+    }
+    if (originalCommsLog === undefined) {
+      delete process.env.OPENCLAW_COMMS_LOG;
+    } else {
+      process.env.OPENCLAW_COMMS_LOG = originalCommsLog;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const logPath = () => path.join(tmpDir, "bus.jsonl");
+
+  // Poll until file exists and has content, avoiding flaky setTimeout
+  const flush = () =>
+    vi.waitFor(() => expect(fs.existsSync(logPath())).toBe(true), { timeout: 2000 });
+
+  it("writes a JSONL entry to bus.jsonl", async () => {
+    const entry: CommsLogEntry = {
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+      messagePreview: "Hello from tech",
+      replyPreview: "Hello back",
+    };
+
+    appendCommsLog(entry);
+    await flush();
+
+    const lines = fs.readFileSync(logPath(), "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.type).toBe("MESSAGE");
+    expect(parsed.from).toBe("agent:tech:main");
+    expect(parsed.to).toBe("agent:content:main");
+    expect(parsed.status).toBe("ok");
+    expect(parsed.messagePreview).toBe("Hello from tech");
+    expect(parsed.replyPreview).toBe("Hello back");
+  });
+
+  it("appends multiple entries", async () => {
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+    });
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "agent:content:main",
+      to: "agent:tech:main",
+      ts: "2026-03-18T19:01:00Z",
+      status: "accepted",
+    });
+    await flush();
+
+    // Wait a bit more for the second entry
+    await vi.waitFor(
+      () => {
+        const lines = fs.readFileSync(logPath(), "utf-8").trim().split("\n");
+        expect(lines.length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("truncates previews longer than 200 characters", async () => {
+    const longMessage = "a".repeat(300);
+    const longReply = "b".repeat(250);
+
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "ok",
+      messagePreview: longMessage,
+      replyPreview: longReply,
+    });
+    await flush();
+
+    const parsed = JSON.parse(fs.readFileSync(logPath(), "utf-8").trim());
+    // 200 chars + "…" = 201 total
+    expect(parsed.messagePreview).toHaveLength(201);
+    expect(parsed.messagePreview.endsWith("…")).toBe(true);
+    expect(parsed.replyPreview).toHaveLength(201);
+    expect(parsed.replyPreview.endsWith("…")).toBe(true);
+  });
+
+  it("preserves short previews without truncation", async () => {
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "a",
+      to: "b",
+      ts: "2026-01-01T00:00:00Z",
+      status: "ok",
+      messagePreview: "short message",
+    });
+    await flush();
+
+    const parsed = JSON.parse(fs.readFileSync(logPath(), "utf-8").trim());
+    expect(parsed.messagePreview).toBe("short message");
+  });
+
+  it("logs failure statuses", async () => {
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "agent:tech:main",
+      to: "agent:content:main",
+      ts: "2026-03-18T19:00:00Z",
+      status: "timeout",
+      messagePreview: "timed out request",
+    });
+    await flush();
+
+    const parsed = JSON.parse(fs.readFileSync(logPath(), "utf-8").trim());
+    expect(parsed.status).toBe("timeout");
+  });
+
+  it("does not throw on write failure", () => {
+    process.env.SIGNAL_DIR = "/nonexistent/readonly/path";
+    expect(() => {
+      appendCommsLog({
+        type: "MESSAGE",
+        from: "a",
+        to: "b",
+        ts: "2026-01-01T00:00:00Z",
+        status: "ok",
+      });
+    }).not.toThrow();
+  });
+
+  it("respects OPENCLAW_COMMS_LOG=off", async () => {
+    process.env.OPENCLAW_COMMS_LOG = "off";
+    appendCommsLog({
+      type: "MESSAGE",
+      from: "a",
+      to: "b",
+      ts: "2026-01-01T00:00:00Z",
+      status: "ok",
+    });
+    // Give it time to write (it shouldn't)
+    await new Promise((r) => setTimeout(r, 100));
+    expect(fs.existsSync(logPath())).toBe(false);
+  });
+});

--- a/src/agents/tools/sessions-send-comms-log.ts
+++ b/src/agents/tools/sessions-send-comms-log.ts
@@ -1,0 +1,110 @@
+/**
+ * Agent-to-agent communication logger.
+ *
+ * Appends a structured JSONL entry to `~/.openclaw/shared/signals/bus.jsonl`
+ * every time sessions_send completes. This provides automatic observability
+ * for all inter-agent communication without requiring agent cooperation.
+ *
+ * The log file can be consumed by external dashboards or skills.
+ *
+ * Privacy note: message/reply previews are truncated to 200 chars. Operators
+ * who handle sensitive user data can disable logging entirely by setting
+ * the environment variable OPENCLAW_COMMS_LOG=off, or override the log
+ * directory with SIGNAL_DIR.
+ *
+ * Size management: the log file is capped at MAX_LOG_SIZE_BYTES (50 MB).
+ * When the limit is reached, logging silently stops until the file is
+ * rotated or truncated externally (e.g. by a cron job or dashboard tool).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface CommsLogEntry {
+  /** Signal type — always "MESSAGE" for sessions_send */
+  type: "MESSAGE";
+  /** Source agent session key */
+  from: string;
+  /** Target agent session key */
+  to: string;
+  /** ISO 8601 timestamp */
+  ts: string;
+  /** Outcome: ok, accepted, timeout, error, forbidden */
+  status: string;
+  /** Truncated message (first 200 chars) */
+  messagePreview?: string;
+  /** Truncated reply (first 200 chars) */
+  replyPreview?: string;
+}
+
+const MAX_PREVIEW = 200;
+/** Stop logging when bus.jsonl exceeds 50 MB */
+const MAX_LOG_SIZE_BYTES = 50 * 1024 * 1024;
+
+function truncate(text: string | undefined): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  return text.length > MAX_PREVIEW ? text.slice(0, MAX_PREVIEW) + "…" : text;
+}
+
+function resolveLogPath(): string {
+  const envDir = process.env.SIGNAL_DIR;
+  const dir = envDir || path.join(os.homedir(), ".openclaw", "shared", "signals");
+  return path.join(dir, "bus.jsonl");
+}
+
+function isLoggingEnabled(): boolean {
+  const flag = process.env.OPENCLAW_COMMS_LOG;
+  return flag !== "off" && flag !== "false" && flag !== "0";
+}
+
+/** Cached directory-exists flag to avoid repeated sync stat calls. */
+let dirEnsured = false;
+
+/**
+ * Append a communication log entry. Fire-and-forget — errors are silently
+ * swallowed so logging never disrupts the sessions_send flow.
+ * Uses fully async I/O to avoid blocking the event loop.
+ */
+export function appendCommsLog(entry: CommsLogEntry): void {
+  if (!isLoggingEnabled()) {
+    return;
+  }
+
+  const truncated: CommsLogEntry = {
+    ...entry,
+    messagePreview: truncate(entry.messagePreview),
+    replyPreview: truncate(entry.replyPreview),
+  };
+
+  const logPath = resolveLogPath();
+  const line = JSON.stringify(truncated) + "\n";
+
+  const doAppend = async () => {
+    try {
+      // Ensure directory exists (once per process)
+      if (!dirEnsured) {
+        await fs.promises.mkdir(path.dirname(logPath), { recursive: true });
+        dirEnsured = true;
+      }
+
+      // Size guard: skip if file exceeds limit
+      try {
+        const stat = await fs.promises.stat(logPath);
+        if (stat.size > MAX_LOG_SIZE_BYTES) {
+          return;
+        }
+      } catch {
+        // File doesn't exist yet — that's fine, append will create it
+      }
+
+      await fs.promises.appendFile(logPath, line, "utf-8");
+    } catch {
+      // Silently ignore — logging must never break sessions_send
+    }
+  };
+
+  void doAppend();
+}

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -21,6 +21,7 @@ import {
   resolveVisibleSessionReference,
   stripToolMessages,
 } from "./sessions-helpers.js";
+import { appendCommsLog } from "./sessions-send-comms-log.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
@@ -287,6 +288,14 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         startA2AFlow(undefined, runId);
+        appendCommsLog({
+          type: "MESSAGE",
+          from: effectiveRequesterKey,
+          to: displayKey,
+          ts: new Date().toISOString(),
+          status: "accepted",
+          messagePreview: message,
+        });
         return jsonResult({
           runId,
           status: "accepted",
@@ -321,15 +330,32 @@ export function createSessionsSendTool(opts?: {
       } catch (err) {
         const messageText =
           err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+        const failStatus = messageText.includes("gateway timeout") ? "timeout" : "error";
+        appendCommsLog({
+          type: "MESSAGE",
+          from: effectiveRequesterKey,
+          to: displayKey,
+          ts: new Date().toISOString(),
+          status: failStatus,
+          messagePreview: message,
+        });
         return jsonResult({
           runId,
-          status: messageText.includes("gateway timeout") ? "timeout" : "error",
+          status: failStatus,
           error: messageText,
           sessionKey: displayKey,
         });
       }
 
       if (waitStatus === "timeout") {
+        appendCommsLog({
+          type: "MESSAGE",
+          from: effectiveRequesterKey,
+          to: displayKey,
+          ts: new Date().toISOString(),
+          status: "timeout",
+          messagePreview: message,
+        });
         return jsonResult({
           runId,
           status: "timeout",
@@ -338,6 +364,14 @@ export function createSessionsSendTool(opts?: {
         });
       }
       if (waitStatus === "error") {
+        appendCommsLog({
+          type: "MESSAGE",
+          from: effectiveRequesterKey,
+          to: displayKey,
+          ts: new Date().toISOString(),
+          status: "error",
+          messagePreview: message,
+        });
         return jsonResult({
           runId,
           status: "error",
@@ -354,6 +388,16 @@ export function createSessionsSendTool(opts?: {
       const last = filtered.length > 0 ? filtered[filtered.length - 1] : undefined;
       const reply = last ? extractAssistantText(last) : undefined;
       startA2AFlow(reply ?? undefined);
+
+      appendCommsLog({
+        type: "MESSAGE",
+        from: effectiveRequesterKey,
+        to: displayKey,
+        ts: new Date().toISOString(),
+        status: "ok",
+        messagePreview: message,
+        replyPreview: reply,
+      });
 
       return jsonResult({
         runId,


### PR DESCRIPTION
## Summary

Adds automatic JSONL logging for all `sessions_send` calls, providing observability for agent-to-agent communication without requiring any agent behavior change.

## Problem

Currently, agent-to-agent communication via `sessions_send` is invisible to the operator. There's no centralized record of which agent talked to which, what was said, or what the outcome was. The `ANNOUNCE_SKIP` pattern means many conversations leave no trace.

Users running multi-agent setups (2+ agents) have no way to debug communication failures, audit task handoffs, or understand collaboration patterns.

## Solution

A new `sessions-send-comms-log.ts` module that appends a structured JSONL entry to `~/.openclaw/shared/signals/bus.jsonl` every time `sessions_send` completes.

### What gets logged

```json
{
  "type": "MESSAGE",
  "from": "agent:tech:main",
  "to": "agent:content:main",
  "ts": "2026-03-18T19:00:00Z",
  "status": "ok",
  "messagePreview": "Please review the website...",
  "replyPreview": "Looks good, merging now"
}
```

### All exit paths are logged

| Path | Status logged |
|------|--------------|
| Sync success (reply received) | `ok` |
| Fire-and-forget (accepted) | `accepted` |
| Gateway timeout | `timeout` |
| Gateway error | `error` |
| callGateway exception | `timeout` or `error` |

### Design decisions

- **Fire-and-forget**: Errors are silently swallowed — logging never disrupts `sessions_send`
- **Async I/O**: Uses `fs.promises.appendFile` to avoid blocking the event loop
- **Built-in truncation**: Message/reply previews capped at 200 chars inside the logger, not at call sites
- **No config required**: Works out of the box with sensible default path
- **Configurable**: `SIGNAL_DIR` env var overrides the log directory
- **Zero dependencies**: Only Node.js builtins (fs, path, os)

### What this enables

External tools and skills can read `bus.jsonl` to provide:
- Communication dashboards (who talked to whom, when)
- Task handoff tracking
- Trust scoring between agents
- Debugging failed cross-agent workflows

## Changes

| File | Change |
|------|--------|
| `sessions-send-comms-log.ts` | New module: async JSONL logger with built-in truncation |
| `sessions-send-comms-log.test.ts` | 6 tests (write, append, truncation, short preserve, failure status, error handling) |
| `sessions-send-tool.ts` | 5 call sites: sync success, fire-and-forget, catch, timeout, error |

## Testing

- 6 unit tests passing (vitest)
- Lint clean (oxlint, 0 errors)
- TypeScript clean (no type errors in changed files)
- Tested manually with a 6-agent OpenClaw setup