### PR TITLE
fix(acpx): replace --cwd with --cd for Codex CLI working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACPX/Codex: switch Codex-specific ACPX workspace flags from `--cwd` to `--cd`, including the runtime `config show` probe and direct acpx guidance, so Codex launches and config resolution use the intended workspace on current CLI versions without affecting the other coding-agent adapters. (#50019) Thanks @artwist-polyakov and @vincentkoc.
 - Gateway/auth: make local-direct `trusted-proxy` fallback require the configured shared token instead of silently authenticating same-host callers, while keeping same-host reverse proxy identity-header flows on the normal trusted-proxy path. Thanks @zhangning-agent and @vincentkoc.
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
 - LINE/ACP: add current-conversation binding and inbound binding-routing parity so `/acp spawn ... --thread here`, configured ACP bindings, and active conversation-bound ACP sessions work on LINE like the other conversation channels.
@@ -683,7 +684,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory flush: keep transcript-hash dedup active across memory-flush fallback retries so a write-then-throw flush attempt cannot append duplicate `MEMORY.md` entries before the fallback cycle completes. (#34222) Thanks @lml2468.
 - Discord/ACP: forward worker abort signals into ACP turns so timed-out Discord jobs cancel the running turn instead of silently leaving the bound ACP session working in the background.
 - ACP/Codex session replay: preserve hidden assistant thinking when loading or rebinding existing ACP sessions so stored thought chunks do not replay into visible assistant text. Thanks @vincentkoc.
-<<<<<<< HEAD
+  <<<<<<< HEAD
 - Gateway/commands: keep internal `chat.send` slash-command UX while requiring `operator.admin` before internal callers can persist `/exec` defaults or mutate `phone-control` node policy through `/phone arm|disarm`.
 - Plugins/Matrix: move bundled plugin `KeyedAsyncQueue` imports onto the stable `plugin-sdk/core` surface so Matrix Docker/runtime builds do not depend on the brittle keyed-async-queue subpath. Thanks @ecohash-co and @vincentkoc.
 - Plugins/context engines: enforce owner-aware context-engine registration on both loader and public SDK paths so plugins cannot spoof privileged ownership, claim the core `legacy` engine id, or overwrite an existing engine id through direct SDK imports. (#47595) Thanks @vincentkoc.

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -147,7 +147,7 @@ Use this path to drive harness sessions without `/acp` or subagent runtime.
 2. Reuse a stable session name per conversation so follow-up prompts stay in the same harness context.
 3. Prefer `--format quiet` for clean assistant text to relay back to user.
 4. Use `exec` (one-shot) only when the user wants one-shot behavior.
-5. Keep working directory explicit (`--cwd`) when task scope depends on repo context.
+5. Keep working directory explicit (`--cd`) when task scope depends on repo context.
 
 ### Session naming
 
@@ -165,13 +165,13 @@ Persistent session (create if missing, then prompt):
 ${ACPX_CMD} codex sessions show oc-codex-<conversationId> \
   || ${ACPX_CMD} codex sessions new --name oc-codex-<conversationId>
 
-${ACPX_CMD} codex -s oc-codex-<conversationId> --cwd <workspacePath> --format quiet "<prompt>"
+${ACPX_CMD} codex -s oc-codex-<conversationId> --cd <workspacePath> --format quiet "<prompt>"
 ```
 
 One-shot:
 
 ```bash
-${ACPX_CMD} codex exec --cwd <workspacePath> --format quiet "<prompt>"
+${ACPX_CMD} codex exec --cd <workspacePath> --format quiet "<prompt>"
 ```
 
 Cancel in-flight turn:

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.test.ts
@@ -78,7 +78,7 @@ describe("resolveAcpxAgentCommand", () => {
     expect(spawnAndCollectMock).toHaveBeenCalledWith(
       {
         command: "/plugin/node_modules/.bin/acpx",
-        args: ["--cwd", "/plugin", "config", "show"],
+        args: ["--cd", "/plugin", "config", "show"],
         cwd: "/plugin",
         stripProviderAuthEnvVars: true,
       },

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -82,7 +82,7 @@ async function loadAgentOverrides(params: {
   const result = await spawnAndCollect(
     {
       command: params.acpxCommand,
-      args: ["--cwd", params.cwd, "config", "show"],
+      args: ["--cd", params.cwd, "config", "show"],
       cwd: params.cwd,
       stripProviderAuthEnvVars: params.stripProviderAuthEnvVars,
     },

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -234,7 +234,7 @@ describe("resolveSpawnCommand", () => {
       resolveSpawnCommand(
         {
           command: wrapperPath,
-          args: ["--cwd", payload, "agent", "status"],
+          args: ["--cd", payload, "agent", "status"],
         },
         {
           strictWindowsCmdWrapper: true,

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -173,6 +173,13 @@ describe("AcpxRuntime", () => {
     expect(promptArgs).toContain("--ttl");
     expect(promptArgs).toContain("180");
     expect(promptArgs).toContain("--approve-all");
+    expect(promptArgs).toContain("--cd");
+    expect(promptArgs).not.toContain("--cwd");
+
+    // Verify the default-prefix path used by control commands (sessions new, status, etc.)
+    const ensureArgs = (ensure?.args as string[]) ?? [];
+    expect(ensureArgs).toContain("--cd");
+    expect(ensureArgs).not.toContain("--cwd");
   });
 
   it("surfaces signal-only prompt exits as runtime errors", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -909,7 +909,7 @@ export class AcpxRuntime implements AcpRuntime {
       "--format",
       "json",
       "--json-strict",
-      "--cwd",
+      "--cd",
       params.cwd,
       ...buildPermissionArgs(this.config.permissionMode),
       "--non-interactive-permissions",
@@ -933,7 +933,7 @@ export class AcpxRuntime implements AcpRuntime {
     command: string[];
     prefix?: string[];
   }): Promise<string[]> {
-    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
+    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cd", params.cwd];
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,


### PR DESCRIPTION
## Summary

Codex CLI (v0.114.0+) expects `--cd` (or `-C`) for the working directory flag, not `--cwd`. The `acpx` runtime plugin passes `--cwd`, which is **silently ignored** — Codex starts in the gateway default directory instead of the intended workspace.

Fixes #49213

## Changes

**`extensions/acpx/src/runtime.ts`** — two occurrences:

1. `buildPromptArgs()` explicit prefix array (line 635)
2. `buildVerbArgs()` default prefix fallback (line 659)

```diff
- "--cwd",
+ "--cd",
```

**`extensions/acpx/skills/acp-router/SKILL.md`** — three occurrences:

- Rule guidance: `--cwd` -> `--cd`
- Persistent session command template
- One-shot command template

**`extensions/acpx/src/runtime.test.ts`** — regression assertions:

- `buildPromptArgs` path: `expect(promptArgs).toContain("--cd")` / `.not.toContain("--cwd")`
- `buildVerbArgs` default-prefix path: `expect(ensureArgs).toContain("--cd")` / `.not.toContain("--cwd")`

## Why existing PRs were not merged

- #49222 bundles a substantial undescribed refactor (health-check, session-recovery, image-attachments) alongside the 2-line fix — flagged as scope mismatch by Greptile (3/5)
- #49227 fixes runtime.ts and adds one test, but misses the SKILL.md documentation update and only covers one of two code paths

This PR is a clean, minimal fix: 3 files, +12/-5, both code paths tested, documentation updated.

## Test plan

- [x] All 18 `runtime.test.ts` tests pass
- [x] Both `buildPromptArgs` and `buildVerbArgs` paths assert `--cd` and reject `--cwd`
- [x] SKILL.md command templates updated

Generated with [Claude Code](https://claude.com/claude-code)