### PR TITLE
[AI-assisted] Android: LocationDataSource for LocationHandler + unit tests

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -8,27 +8,85 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
-class LocationHandler(
+internal interface LocationDataSource {
+  fun hasFinePermission(context: Context): Boolean
+
+  fun hasCoarsePermission(context: Context): Boolean
+
+  suspend fun fetchLocation(
+    desiredProviders: List<String>,
+    maxAgeMs: Long?,
+    timeoutMs: Long,
+    isPrecise: Boolean,
+  ): LocationCaptureManager.Payload
+}
+
+private class DefaultLocationDataSource(
+  private val capture: LocationCaptureManager,
+) : LocationDataSource {
+  override fun hasFinePermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+
+  override fun hasCoarsePermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+
+  override suspend fun fetchLocation(
+    desiredProviders: List<String>,
+    maxAgeMs: Long?,
+    timeoutMs: Long,
+    isPrecise: Boolean,
+  ): LocationCaptureManager.Payload =
+    capture.getLocation(
+      desiredProviders = desiredProviders,
+      maxAgeMs = maxAgeMs,
+      timeoutMs = timeoutMs,
+      isPrecise = isPrecise,
+    )
+}
+
+class LocationHandler private constructor(
   private val appContext: Context,
-  private val location: LocationCaptureManager,
+  private val dataSource: LocationDataSource,
   private val json: Json,
   private val isForeground: () -> Boolean,
   private val locationPreciseEnabled: () -> Boolean,
 ) {
-  fun hasFineLocationPermission(): Boolean {
-    return (
-      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
-      )
-  }
+  constructor(
+    appContext: Context,
+    location: LocationCaptureManager,
+    json: Json,
+    isForeground: () -> Boolean,
+    locationPreciseEnabled: () -> Boolean,
+  ) : this(
+    appContext = appContext,
+    dataSource = DefaultLocationDataSource(location),
+    json = json,
+    isForeground = isForeground,
+    locationPreciseEnabled = locationPreciseEnabled,
+  )
 
-  fun hasCoarseLocationPermission(): Boolean {
-    return (
-      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_COARSE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
+  fun hasFineLocationPermission(): Boolean = dataSource.hasFinePermission(appContext)
+
+  fun hasCoarseLocationPermission(): Boolean = dataSource.hasCoarsePermission(appContext)
+
+  companion object {
+    internal fun forTesting(
+      appContext: Context,
+      dataSource: LocationDataSource,
+      json: Json = Json { ignoreUnknownKeys = true },
+      isForeground: () -> Boolean = { true },
+      locationPreciseEnabled: () -> Boolean = { true },
+    ): LocationHandler =
+      LocationHandler(
+        appContext = appContext,
+        dataSource = dataSource,
+        json = json,
+        isForeground = isForeground,
+        locationPreciseEnabled = locationPreciseEnabled,
       )
   }
 
@@ -39,7 +97,7 @@ class LocationHandler(
         message = "LOCATION_BACKGROUND_UNAVAILABLE: location requires OpenClaw to stay open",
       )
     }
-    if (!hasFineLocationPermission() && !hasCoarseLocationPermission()) {
+    if (!dataSource.hasFinePermission(appContext) && !dataSource.hasCoarsePermission(appContext)) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_PERMISSION_REQUIRED",
         message = "LOCATION_PERMISSION_REQUIRED: grant Location permission",
@@ -49,9 +107,9 @@ class LocationHandler(
     val preciseEnabled = locationPreciseEnabled()
     val accuracy =
       when (desiredAccuracy) {
-        "precise" -> if (preciseEnabled && hasFineLocationPermission()) "precise" else "balanced"
+        "precise" -> if (preciseEnabled && dataSource.hasFinePermission(appContext)) "precise" else "balanced"
         "coarse" -> "coarse"
-        else -> if (preciseEnabled && hasFineLocationPermission()) "precise" else "balanced"
+        else -> if (preciseEnabled && dataSource.hasFinePermission(appContext)) "precise" else "balanced"
       }
     val providers =
       when (accuracy) {
@@ -61,7 +119,7 @@ class LocationHandler(
       }
     try {
       val payload =
-        location.getLocation(
+        dataSource.fetchLocation(
           desiredProviders = providers,
           maxAgeMs = maxAgeMs,
           timeoutMs = timeoutMs,

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
@@ -1,0 +1,88 @@
+package ai.openclaw.app.node
+
+import android.content.Context
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocationHandlerTest : NodeHandlerRobolectricTest() {
+  @Test
+  fun handleLocationGet_requiresLocationPermissionWhenNeitherFineNorCoarse() =
+    runTest {
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource =
+            FakeLocationDataSource(
+              fineGranted = false,
+              coarseGranted = false,
+            ),
+        )
+
+      val result = handler.handleLocationGet(null)
+
+      assertFalse(result.ok)
+      assertEquals("LOCATION_PERMISSION_REQUIRED", result.error?.code)
+    }
+
+  @Test
+  fun handleLocationGet_requiresForegroundBeforeLocationPermission() =
+    runTest {
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource =
+            FakeLocationDataSource(
+              fineGranted = true,
+              coarseGranted = true,
+            ),
+          isForeground = { false },
+        )
+
+      val result = handler.handleLocationGet(null)
+
+      assertFalse(result.ok)
+      assertEquals("LOCATION_BACKGROUND_UNAVAILABLE", result.error?.code)
+    }
+
+  @Test
+  fun hasFineLocationPermission_reflectsDataSource() {
+    val denied =
+      LocationHandler.forTesting(
+        appContext = appContext(),
+        dataSource = FakeLocationDataSource(fineGranted = false, coarseGranted = true),
+      )
+    assertFalse(denied.hasFineLocationPermission())
+    assertTrue(denied.hasCoarseLocationPermission())
+
+    val granted =
+      LocationHandler.forTesting(
+        appContext = appContext(),
+        dataSource = FakeLocationDataSource(fineGranted = true, coarseGranted = false),
+      )
+    assertTrue(granted.hasFineLocationPermission())
+    assertFalse(granted.hasCoarseLocationPermission())
+  }
+}
+
+private class FakeLocationDataSource(
+  private val fineGranted: Boolean,
+  private val coarseGranted: Boolean,
+) : LocationDataSource {
+  override fun hasFinePermission(context: Context): Boolean = fineGranted
+
+  override fun hasCoarsePermission(context: Context): Boolean = coarseGranted
+
+  override suspend fun fetchLocation(
+    desiredProviders: List<String>,
+    maxAgeMs: Long?,
+    timeoutMs: Long,
+    isPrecise: Boolean,
+  ): LocationCaptureManager.Payload {
+    throw IllegalStateException(
+      "LocationHandlerTest: fetchLocation must not run in this scenario",
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** `LocationHandler` had no unit tests; permission/foreground branches could hang in Robolectric if tests accidentally invoked real `getLocation`.
- **Why it matters:** Aligns with `CalendarHandler` pattern—injectable `LocationDataSource` enables stable tests without depending on system location behavior.
- **What changed:** Added `internal LocationDataSource`, `DefaultLocationDataSource`, `LocationHandler` private ctor + existing 5-arg public secondary ctor, `LocationHandlerTest` + `FakeLocationDataSource`.
- **What did NOT change (scope boundary):** Production still uses `ContextCompat` + `LocationCaptureManager.getLocation`; `NodeRuntime` call site unchanged; no user-visible behavior change.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: (local)
- Runtime/container: Android unit tests (JVM / Robolectric)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `cd apps/android && ./gradlew :app:testDebugUnitTest --tests "ai.openclaw.app.node.LocationHandlerTest"`
2. (optional) `./gradlew :app:compileDebugKotlin`

### Expected

- `LocationHandlerTest` passes.

### Actual

-  PM80256643:android 80256643$ ./gradlew :app:testDebugUnitTest --tests "ai.openclaw.app.node.LocationHandlerTest"

BUILD SUCCESSFUL in 6s
30 actionable tasks: 2 executed, 28 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** No fine/coarse permission → `LOCATION_PERMISSION_REQUIRED`; background → `LOCATION_BACKGROUND_UNAVAILABLE`; `hasFine*Permission` matches fake data source.
- **Edge cases checked:** Tests do not call real `fetchLocation` (fake throws if invoked).
- **What you did not verify:** End-to-end location on physical device (unchanged implementation path).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert this change quickly:** Revert PR or restore `LocationHandler.kt` / remove `LocationHandlerTest.kt`.
- **Files/config to restore:** `apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt`, `apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt`.
- **Known bad symptoms reviewers should watch for:** Build/test failures only; runtime app behavior should be unchanged.

## Risks and Mitigations

- **Risk:** New `LocationHandler` construction paths must respect `LocationDataSource` / secondary ctor pattern.
  - **Mitigation:** Matches existing `CalendarHandler` style; documented in this PR.

None beyond above.