### PR TITLE
fix(ui): expand tool cards when verboseDefault is full

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -905,6 +905,7 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,
     contextTokens: contextTokens ?? null,
+    verboseDefault: cfg.agents?.defaults?.verboseDefault ?? null,
   };
 }
 

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -11,6 +11,7 @@ export type GatewaySessionsDefaults = {
   modelProvider: string | null;
   model: string | null;
   contextTokens: number | null;
+  verboseDefault?: string | null;
 };
 
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -116,6 +116,8 @@ export function renderMessageGroup(
     onOpenSidebar?: (content: string) => void;
     showReasoning: boolean;
     showToolCalls?: boolean;
+    /** When true, tool `<details>` elements render with the `open` attribute (verbose=full). */
+    toolsExpanded?: boolean;
     assistantName?: string;
     assistantAvatar?: string | null;
     basePath?: string;
@@ -168,6 +170,7 @@ export function renderMessageGroup(
               isStreaming: group.isStreaming && index === group.messages.length - 1,
               showReasoning: opts.showReasoning,
               showToolCalls: opts.showToolCalls ?? true,
+              toolsExpanded: opts.toolsExpanded,
             },
             opts.onOpenSidebar,
           ),
@@ -547,10 +550,11 @@ function renderMessageImages(images: ImageBlock[]) {
   `;
 }
 
-/** Render tool cards inside a collapsed `<details>` element. */
+/** Render tool cards inside a `<details>` element, optionally expanded. */
 function renderCollapsedToolCards(
   toolCards: ToolCard[],
   onOpenSidebar?: (content: string) => void,
+  expanded?: boolean,
 ) {
   const calls = toolCards.filter((c) => c.kind === "call");
   const results = toolCards.filter((c) => c.kind === "result");
@@ -562,7 +566,7 @@ function renderCollapsedToolCards(
       : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
 
   return html`
-    <details class="chat-tools-collapse">
+    <details class="chat-tools-collapse" ?open=${expanded}>
       <summary class="chat-tools-summary">
         <span class="chat-tools-summary__icon">${icons.zap}</span>
         <span class="chat-tools-summary__count">${totalTools} tool${totalTools === 1 ? "" : "s"}</span>
@@ -636,7 +640,12 @@ function renderExpandButton(markdown: string, onOpenSidebar: (content: string) =
 
 function renderGroupedMessage(
   message: unknown,
-  opts: { isStreaming: boolean; showReasoning: boolean; showToolCalls?: boolean },
+  opts: {
+    isStreaming: boolean;
+    showReasoning: boolean;
+    showToolCalls?: boolean;
+    toolsExpanded?: boolean;
+  },
   onOpenSidebar?: (content: string) => void,
 ) {
   const m = message as Record<string, unknown>;
@@ -671,7 +680,7 @@ function renderGroupedMessage(
     .join(" ");
 
   if (!markdown && hasToolCards && isToolResult) {
-    return renderCollapsedToolCards(toolCards, onOpenSidebar);
+    return renderCollapsedToolCards(toolCards, onOpenSidebar, opts.toolsExpanded);
   }
 
   // Suppress empty bubbles when tool cards are the only content and toggle is off
@@ -704,7 +713,7 @@ function renderGroupedMessage(
       ${
         isToolMessage
           ? html`
-            <details class="chat-tool-msg-collapse">
+            <details class="chat-tool-msg-collapse" ?open=${opts.toolsExpanded}>
               <summary class="chat-tool-msg-summary">
                 <span class="chat-tool-msg-summary__icon">${icons.zap}</span>
                 <span class="chat-tool-msg-summary__label">Tool output</span>
@@ -738,7 +747,7 @@ function renderGroupedMessage(
                       ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
                       : nothing
                 }
-                ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
+                ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar, opts.toolsExpanded) : nothing}
               </div>
             </details>
           `
@@ -764,7 +773,7 @@ function renderGroupedMessage(
                   ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
                   : nothing
             }
-            ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
+            ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar, opts.toolsExpanded) : nothing}
           `
       }
     </div>

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -319,6 +319,7 @@ export type GatewaySessionsDefaults = {
   modelProvider: string | null;
   model: string | null;
   contextTokens: number | null;
+  verboseDefault?: string | null;
 };
 
 export type ChatModelOverride = import("./chat-model-ref.ts").ChatModelOverride;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -6,9 +6,11 @@ import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import { renderChatSessionSelect } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
+import { renderMessageGroup } from "../chat/grouped-render.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
+import type { MessageGroup } from "../types/chat-types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
 import { renderOverview, type OverviewProps } from "./overview.ts";
 
@@ -1128,5 +1130,103 @@ describe("chat view", () => {
     expect(labels.filter((label) => label === "Deep Chat (alpha) / main")).toHaveLength(1);
     expect(labels).toContain("Deep Chat (alpha) / main · named-main");
     expect(labels).toContain("Coding (beta) / main");
+  });
+
+  describe("tool card expansion with verboseDefault=full (#49944)", () => {
+    function createToolCallGroup(): MessageGroup {
+      return {
+        kind: "group",
+        key: "grp-tool-1",
+        role: "assistant",
+        timestamp: Date.now(),
+        isStreaming: false,
+        messages: [
+          {
+            key: "msg-tc-1",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "tool_call", name: "bash", args: { command: "echo TOOL_CARD_TEST_OK" } },
+              ],
+            },
+          },
+          {
+            key: "msg-tr-1",
+            message: {
+              role: "tool",
+              tool_call_id: "call-1",
+              content: "TOOL_CARD_TEST_OK\n",
+            },
+          },
+        ],
+      };
+    }
+
+    it("renders tool cards collapsed by default", () => {
+      const container = document.createElement("div");
+      render(
+        renderMessageGroup(createToolCallGroup(), {
+          showReasoning: false,
+          showToolCalls: true,
+        }),
+        container,
+      );
+
+      const details = container.querySelector<HTMLDetailsElement>("details.chat-tools-collapse");
+      expect(details).not.toBeNull();
+      expect(details!.hasAttribute("open")).toBe(false);
+    });
+
+    it("expands tool cards when toolsExpanded is true", () => {
+      const container = document.createElement("div");
+      render(
+        renderMessageGroup(createToolCallGroup(), {
+          showReasoning: false,
+          showToolCalls: true,
+          toolsExpanded: true,
+        }),
+        container,
+      );
+
+      const details = container.querySelector<HTMLDetailsElement>("details.chat-tools-collapse");
+      expect(details).not.toBeNull();
+      expect(details!.hasAttribute("open")).toBe(true);
+    });
+
+    it("expands tool result collapse when toolsExpanded is true", () => {
+      const container = document.createElement("div");
+      const group: MessageGroup = {
+        kind: "group",
+        key: "grp-tool-2",
+        role: "tool",
+        timestamp: Date.now(),
+        isStreaming: false,
+        messages: [
+          {
+            key: "msg-tr-2",
+            message: {
+              role: "tool",
+              tool_call_id: "call-2",
+              content: "some result text",
+            },
+          },
+        ],
+      };
+
+      render(
+        renderMessageGroup(group, {
+          showReasoning: false,
+          showToolCalls: true,
+          toolsExpanded: true,
+        }),
+        container,
+      );
+
+      const toolMsgCollapse = container.querySelector<HTMLDetailsElement>(
+        "details.chat-tool-msg-collapse",
+      );
+      expect(toolMsgCollapse).not.toBeNull();
+      expect(toolMsgCollapse!.hasAttribute("open")).toBe(true);
+    });
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1193,6 +1193,47 @@ describe("chat view", () => {
       expect(details!.hasAttribute("open")).toBe(true);
     });
 
+    it("inherits verboseDefault=full from session defaults when per-session is unset", () => {
+      const container = document.createElement("div");
+      const props = createProps({
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "tool_call", name: "bash", args: { command: "echo test" } }],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call-1",
+            content: "test output",
+          },
+        ],
+        sessions: {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+            verboseDefault: "full",
+          },
+          sessions: [
+            {
+              key: "main",
+              kind: "direct" as const,
+              updatedAt: Date.now(),
+              // verboseLevel intentionally omitted — session inherits from defaults
+            },
+          ],
+        },
+      });
+      render(renderChat(props), container);
+
+      const details = container.querySelector<HTMLDetailsElement>("details.chat-tools-collapse");
+      expect(details).not.toBeNull();
+      expect(details!.hasAttribute("open")).toBe(true);
+    });
+
     it("expands tool result collapse when toolsExpanded is true", () => {
       const container = document.createElement("div");
       const group: MessageGroup = {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -844,7 +844,8 @@ export function renderChat(props: ChatProps) {
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
-  const toolsExpanded = (activeSession?.verboseLevel ?? "off") === "full";
+  const toolsExpanded =
+    (activeSession?.verboseLevel || props.sessions?.defaults?.verboseDefault || "off") === "full";
   const assistantIdentity = {
     name: props.assistantName,
     avatar:

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -844,6 +844,7 @@ export function renderChat(props: ChatProps) {
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
+  const toolsExpanded = (activeSession?.verboseLevel ?? "off") === "full";
   const assistantIdentity = {
     name: props.assistantName,
     avatar:
@@ -972,6 +973,7 @@ export function renderChat(props: ChatProps) {
               onOpenSidebar: props.onOpenSidebar,
               showReasoning,
               showToolCalls: props.showToolCalls,
+              toolsExpanded,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
               basePath: props.basePath,


### PR DESCRIPTION
## Summary

Fixes #49944.

- Tool `<details>` elements in Control UI always rendered collapsed regardless of the session's `verboseLevel`
- Reads `verboseLevel` from the active session row and threads a `toolsExpanded` flag through `renderMessageGroup` → `renderGroupedMessage` → `renderCollapsedToolCards`
- Conditionally sets the `open` attribute on all three tool-card `<details>` elements when `verboseLevel === "full"`

## Test plan

- [x] 3 new unit tests in `ui/src/ui/views/chat.test.ts` covering collapsed-by-default, expanded tool cards, and expanded tool result collapse
- [x] All 29 existing chat tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm check` (lint + format) passes
- [ ] Manual: set `agents.defaults.verboseDefault = "full"`, run a tool call in Control UI, verify cards render expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)