### PR TITLE
fix(export): restore JS placeholders in export HTML template

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 docs/.generated/
+# Export template uses {{PLACEHOLDER}} syntax that Prettier reformats into
+# multi-line blocks, breaking the string replacement at build time (#49957).
+src/auto-reply/reply/export-html/template.html

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,15 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{JS}}</script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #49957 — Session export HTML renders empty in browser because Prettier reformats {{PLACEHOLDER}} syntax into multi-line blocks with semicolons, breaking the .replace() calls in the export pipeline.

Changes:
- template.html: Restore {{MARKED_JS}}, {{HIGHLIGHT_JS}}, {{JS}} to single-line compact format with prettier-ignore comments
- .prettierignore: Added template.html to prevent future corruption

Root cause: template.replace('{{MARKED_JS}}', markedJs) expects the exact string. Prettier reformats it into nested blocks with a label (valid JS), silently corrupting the template.

All 5 existing export security tests pass.