### PR TITLE
fix(msteams): fix inline pasted image downloads

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -212,6 +212,9 @@ const createMediaEntriesWithType = (contentType: string, ...paths: string[]) =>
   paths.map((path) => ({ path, contentType }));
 const createHostedContentsWithType = (contentType: string, ...ids: string[]) =>
   ids.map((id) => ({ id, contentType, contentBytes: PNG_BASE64 }));
+/** Like createHostedContentsWithType but with contentBytes: null to exercise the $value fetch path. */
+const createHostedContentsNullBytes = (contentType: string, ...ids: string[]) =>
+  ids.map((id) => ({ id, contentType, contentBytes: null }));
 const createImageMediaEntries = (...paths: string[]) =>
   createMediaEntriesWithType(CONTENT_TYPE_IMAGE_PNG, ...paths);
 const createHostedImageContents = (...ids: string[]) =>
@@ -848,6 +851,20 @@ describe("msteams attachments", () => {
       expectAttachmentMediaLength(media, 0);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    it("appends /views/original to Bot Framework attachment URLs", async () => {
+      const bfUrl = "https://smba.trafficmanager.net/amer/72f988bf/v3/attachments/0-wus-d11-abc";
+      const media = await downloadAttachmentsWithFetch(
+        createContentUrlAttachments("image/*", bfUrl),
+        fetchRemoteMediaMock,
+        { allowHosts: ["smba.trafficmanager.net"], resolveFn: publicResolveFn },
+      );
+
+      expect(fetchRemoteMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({ url: `${bfUrl}/views/original` }),
+      );
+      expectAttachmentMediaLength(media, 1);
+    });
   });
 
   describe("buildMSTeamsGraphMessageUrls", () => {
@@ -926,6 +943,41 @@ describe("msteams attachments", () => {
       const calledUrls = fetchMock.mock.calls.map((call) => String(call[0]));
       expect(calledUrls.some((url) => url.startsWith(GRAPH_SHARES_URL_PREFIX))).toBe(true);
       expect(calledUrls).not.toContain(escapedUrl);
+    });
+
+    it("skips hosted content when $value fetch fails", async () => {
+      const tokenProvider = createTokenProvider();
+      const graphFetchMock = vi.fn(async (url: string) => {
+        if (url.endsWith("/hostedContents")) {
+          // contentBytes: null forces the $value fetch path
+          return createGraphCollectionResponse(
+            createHostedContentsNullBytes(CONTENT_TYPE_IMAGE_PNG, "1"),
+          );
+        }
+        if (url.includes("/hostedContents/1/$value")) {
+          return createNotFoundResponse();
+        }
+        if (url.endsWith("/attachments")) {
+          return createGraphCollectionResponse([]);
+        }
+        return createNotFoundResponse();
+      }) as unknown as FetchFn;
+
+      const { media } = await downloadGraphMediaWithMockOptions(
+        {},
+        {
+          fetchFn: graphFetchMock,
+          tokenProvider,
+        },
+      );
+
+      expectAttachmentMediaLength(media.media, 0);
+      expect(saveMediaBufferMock).not.toHaveBeenCalled();
+      // Verify the $value fetch was actually attempted with the correct URL.
+      expect(graphFetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/hostedContents/1/$value"),
+        expect.anything(),
+      );
     });
   });
 

--- a/extensions/msteams/src/attachments.ts
+++ b/extensions/msteams/src/attachments.ts
@@ -3,7 +3,11 @@ export {
   /** @deprecated Use `downloadMSTeamsAttachments` instead. */
   downloadMSTeamsImageAttachments,
 } from "./attachments/download.js";
-export { buildMSTeamsGraphMessageUrls, downloadMSTeamsGraphMedia } from "./attachments/graph.js";
+export {
+  buildMSTeamsGraphMessageUrls,
+  downloadGraphHostedContent,
+  downloadMSTeamsGraphMedia,
+} from "./attachments/graph.js";
 export {
   buildMSTeamsAttachmentPlaceholder,
   summarizeMSTeamsHtmlAttachments,

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -26,6 +26,24 @@ type DownloadCandidate = {
   placeholder: string;
 };
 
+/** Detect Bot Framework /v3/attachments/{id} URLs that need /views/original. */
+const BF_ATTACHMENT_RE = /\/v3\/attachments\/[^/]+\/?$/i;
+function isBotFrameworkAttachmentUrl(url: string): boolean {
+  try {
+    return BF_ATTACHMENT_RE.test(new URL(url).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Rewrite Bot Framework attachment URLs to append /views/original, preserving query strings. */
+function rewriteBotFrameworkUrl(url: string): string {
+  if (!isBotFrameworkAttachmentUrl(url)) return url;
+  const parsed = new URL(url);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "") + "/views/original";
+  return parsed.toString();
+}
+
 function resolveDownloadCandidate(att: MSTeamsAttachmentLike): DownloadCandidate | null {
   const contentType = normalizeContentType(att.contentType);
   const name = typeof att.name === "string" ? att.name.trim() : "";
@@ -62,8 +80,13 @@ function resolveDownloadCandidate(att: MSTeamsAttachmentLike): DownloadCandidate
     return null;
   }
 
+  // Bot Framework attachment URLs (…/v3/attachments/{id}) return JSON metadata;
+  // append /views/original to retrieve the actual binary content.
+  // Preserve any query string (e.g. signed URLs with ?sig=...).
+  let url = rewriteBotFrameworkUrl(contentUrl);
+
   return {
-    url: contentUrl,
+    url,
     fileHint: name || undefined,
     contentTypeHint: contentType,
     placeholder: inferPlaceholder({ contentType, fileName: name }),
@@ -194,8 +217,10 @@ export async function downloadMSTeamsAttachments(params: {
         continue;
       }
       seenUrls.add(inline.url);
+      // Apply Bot Framework URL rewrite to inline <img src> URLs too.
+      const rewrittenUrl = rewriteBotFrameworkUrl(inline.url);
       candidates.push({
-        url: inline.url,
+        url: rewrittenUrl,
         fileHint: inline.fileHint,
         contentTypeHint: inline.contentType,
         placeholder: inline.placeholder,

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -173,7 +173,7 @@ function normalizeGraphAttachment(att: GraphAttachment): MSTeamsAttachmentLike {
  * Download all hosted content from a Teams message (images, documents, etc.).
  * Renamed from downloadGraphHostedImages to support all file types.
  */
-async function downloadGraphHostedContent(params: {
+export async function downloadGraphHostedContent(params: {
   accessToken: string;
   messageUrl: string;
   maxBytes: number;
@@ -191,16 +191,75 @@ async function downloadGraphHostedContent(params: {
     return { media: [], status: hosted.status, count: 0 };
   }
 
+  const fetchFn = params.fetchFn ?? fetch;
   const out: MSTeamsInboundMedia[] = [];
   for (const item of hosted.items) {
+    let buffer: Buffer | undefined;
+    let headerMime: string | undefined;
+
+    // Fast path: use contentBytes when the collection response includes them.
     const contentBytes = typeof item.contentBytes === "string" ? item.contentBytes : "";
-    if (!contentBytes) {
-      continue;
+    if (contentBytes) {
+      try {
+        buffer = Buffer.from(contentBytes, "base64");
+      } catch {
+        // Fall through to $value fetch.
+      }
     }
-    let buffer: Buffer;
-    try {
-      buffer = Buffer.from(contentBytes, "base64");
-    } catch {
+
+    // Graph collection responses typically return contentBytes as null.
+    // Fetch the raw binary from the individual $value endpoint instead.
+    if (!buffer && item.id) {
+      try {
+        const valueUrl = `${params.messageUrl}/hostedContents/${encodeURIComponent(item.id)}/$value`;
+        const { response: valRes, release } = await fetchWithSsrFGuard({
+          url: valueUrl,
+          fetchImpl: fetchFn,
+          init: { headers: { Authorization: `Bearer ${params.accessToken}` } },
+          policy: params.ssrfPolicy,
+        });
+        try {
+          if (valRes.ok) {
+            const contentLength = Number(valRes.headers.get("content-length") ?? "0");
+            if (contentLength > params.maxBytes) {
+              // Skip oversized content without buffering.
+            } else if (valRes.body) {
+              // Stream with bounded read to avoid buffering oversized payloads
+              // when content-length is missing or misreported.
+              const chunks: Uint8Array[] = [];
+              let totalBytes = 0;
+              let oversized = false;
+              const reader = valRes.body.getReader();
+              try {
+                for (;;) {
+                  const { done, value } = await reader.read();
+                  if (done) break;
+                  totalBytes += value.byteLength;
+                  if (totalBytes > params.maxBytes) {
+                    oversized = true;
+                    await reader.cancel();
+                    break;
+                  }
+                  chunks.push(value);
+                }
+              } finally {
+                reader.releaseLock();
+              }
+              if (!oversized && chunks.length > 0) {
+                buffer = Buffer.concat(chunks);
+                headerMime = valRes.headers.get("content-type") ?? undefined;
+              }
+            }
+          }
+        } finally {
+          await release();
+        }
+      } catch {
+        // Network/fetch failure — skip this item.
+      }
+    }
+
+    if (!buffer) {
       continue;
     }
     if (buffer.byteLength > params.maxBytes) {
@@ -208,7 +267,7 @@ async function downloadGraphHostedContent(params: {
     }
     const mime = await getMSTeamsRuntime().media.detectMime({
       buffer,
-      headerMime: item.contentType ?? undefined,
+      headerMime: headerMime ?? item.contentType ?? undefined,
     });
     // Download any file type, not just images
     try {

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -49,7 +49,7 @@ export const DEFAULT_MEDIA_HOST_ALLOWLIST = [
   "asm.skype.com",
   "ams.skype.com",
   "media.ams.skype.com",
-  // Bot Framework attachment URLs
+  // Bot Framework attachment URLs — regional variants (smba, smba.eu, smba.ap, etc.)
   "trafficmanager.net",
   "blob.core.windows.net",
   "azureedge.net",
@@ -59,6 +59,10 @@ export const DEFAULT_MEDIA_HOST_ALLOWLIST = [
 export const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
   "api.botframework.com",
   "botframework.com",
+  // Bot Framework attachment service URLs — regional variants
+  "smba.trafficmanager.net",
+  "smba.eu.trafficmanager.net",
+  "smba.ap.trafficmanager.net",
   "graph.microsoft.com",
   "graph.microsoft.us",
   "graph.microsoft.de",

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -1,6 +1,7 @@
 import {
   buildMSTeamsGraphMessageUrls,
   downloadMSTeamsAttachments,
+  downloadGraphHostedContent,
   downloadMSTeamsGraphMedia,
   type MSTeamsAccessTokenProvider,
   type MSTeamsAttachmentLike,
@@ -51,64 +52,89 @@ export async function resolveMSTeamsInboundMedia(params: {
     preserveFilenames,
   });
 
-  if (mediaList.length === 0) {
-    const onlyHtmlAttachments =
-      attachments.length > 0 &&
-      attachments.every((att) => String(att.contentType ?? "").startsWith("text/html"));
+  // Teams represents inline pasted images as text/html attachments with hostedContents.
+  // Always attempt the Graph hostedContents path when HTML attachments are present,
+  // even if some regular file attachments already downloaded successfully,
+  // because mixed messages can have both regular files and inline pasted images.
+  const hasHtmlAttachments = attachments.some((att) =>
+    String(att.contentType ?? "").startsWith("text/html"),
+  );
 
-    if (onlyHtmlAttachments) {
-      const messageUrls = buildMSTeamsGraphMessageUrls({
+  // Teams represents inline pasted images as text/html attachments with hostedContents.
+  if (hasHtmlAttachments) {
+    const messageUrls = buildMSTeamsGraphMessageUrls({
+      conversationType,
+      conversationId,
+      messageId: activity.id ?? undefined,
+      replyToId: activity.replyToId ?? undefined,
+      conversationMessageId,
+      channelData: activity.channelData,
+    });
+    if (messageUrls.length === 0) {
+      log.debug?.("graph message url unavailable", {
         conversationType,
-        conversationId,
+        hasChannelData: Boolean(activity.channelData),
         messageId: activity.id ?? undefined,
         replyToId: activity.replyToId ?? undefined,
-        conversationMessageId,
-        channelData: activity.channelData,
       });
-      if (messageUrls.length === 0) {
-        log.debug?.("graph message url unavailable", {
-          conversationType,
-          hasChannelData: Boolean(activity.channelData),
-          messageId: activity.id ?? undefined,
-          replyToId: activity.replyToId ?? undefined,
-        });
-      } else {
-        const attempts: Array<{
-          url: string;
-          hostedStatus?: number;
-          attachmentStatus?: number;
-          hostedCount?: number;
-          attachmentCount?: number;
-          tokenError?: boolean;
-        }> = [];
-        for (const messageUrl of messageUrls) {
-          const graphMedia = await downloadMSTeamsGraphMedia({
+    } else if (mediaList.length > 0) {
+      // Mixed message: we already have some media from direct downloads.
+      // Only fetch hostedContents (inline images) to avoid duplicating attachments.
+      for (const messageUrl of messageUrls) {
+        try {
+          const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
+          if (!token) break;
+          const hosted = await downloadGraphHostedContent({
             messageUrl,
-            tokenProvider,
+            accessToken: token,
             maxBytes,
-            allowHosts,
-            authAllowHosts: params.authAllowHosts,
             preserveFilenames,
           });
-          attempts.push({
-            url: messageUrl,
-            hostedStatus: graphMedia.hostedStatus,
-            attachmentStatus: graphMedia.attachmentStatus,
-            hostedCount: graphMedia.hostedCount,
-            attachmentCount: graphMedia.attachmentCount,
-            tokenError: graphMedia.tokenError,
-          });
-          if (graphMedia.media.length > 0) {
-            mediaList = graphMedia.media;
+          if (hosted.media.length > 0) {
+            mediaList = [...mediaList, ...hosted.media];
             break;
           }
-          if (graphMedia.tokenError) {
-            break;
-          }
+        } catch {
+          // Token acquisition or Graph fetch failed — continue to next URL candidate.
         }
-        if (mediaList.length === 0) {
-          log.debug?.("graph media fetch empty", { attempts });
+      }
+    } else {
+      // No media yet: try the full Graph path (hostedContents + attachments).
+      const attempts: Array<{
+        url: string;
+        hostedStatus?: number;
+        attachmentStatus?: number;
+        hostedCount?: number;
+        attachmentCount?: number;
+        tokenError?: boolean;
+      }> = [];
+      for (const messageUrl of messageUrls) {
+        const graphMedia = await downloadMSTeamsGraphMedia({
+          messageUrl,
+          tokenProvider,
+          maxBytes,
+          allowHosts,
+          authAllowHosts: params.authAllowHosts,
+          preserveFilenames,
+        });
+        attempts.push({
+          url: messageUrl,
+          hostedStatus: graphMedia.hostedStatus,
+          attachmentStatus: graphMedia.attachmentStatus,
+          hostedCount: graphMedia.hostedCount,
+          attachmentCount: graphMedia.attachmentCount,
+          tokenError: graphMedia.tokenError,
+        });
+        if (graphMedia.media.length > 0) {
+          mediaList = graphMedia.media;
+          break;
         }
+        if (graphMedia.tokenError) {
+          break;
+        }
+      }
+      if (mediaList.length === 0) {
+        log.debug?.("graph media fetch empty", { attempts });
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes inline pasted image downloads in MSTeams conversations. The Teams API returns `hostedContents` attachments without `contentBytes`, so images are never saved.

### Changes

- Download images via `contentUrl` using the bot's bearer token when `contentBytes` is missing
- Handle both hosted content URLs and direct download URLs
- Properly extract content type from response headers

### Testing

- Verified on v2026.3.13-1 in DM conversations
- Without fix: images detected but not saved to disk (0 bytes / missing files)
- With fix: images correctly downloaded and available for processing

Fixes #50043
Supersedes #10902 (closed by stale bot)
Related to #5448 (locked)