### PR TITLE
fix(plugins): preserve singletons in source runtime shims

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -4,7 +4,66 @@ const path = require("node:path");
 const fs = require("node:fs");
 
 let monolithicSdk = null;
-const jitiLoaders = new Map();
+let jitiLoader = null;
+let defaultJitiTransform = null;
+
+const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx"];
+const SOURCE_IMPORT_PATTERNS = [
+  /(from\s+["'])(\.[^"'()]+)\.js(["'])/g,
+  /(import\s+["'])(\.[^"'()]+)\.js(["'])/g,
+  /(import\s*\(\s*["'])(\.[^"'()]+)\.js(["'])/g,
+];
+
+function getDefaultJitiTransform() {
+  if (defaultJitiTransform) {
+    return defaultJitiTransform;
+  }
+  const jitiPackageRoot = path.dirname(require.resolve("jiti/package.json"));
+  defaultJitiTransform = require(path.join(jitiPackageRoot, "dist", "babel.cjs"));
+  return defaultJitiTransform;
+}
+
+function resolveLocalSourceShimSpecifier(filename, specifier) {
+  if (
+    !filename ||
+    !SOURCE_MODULE_EXTENSIONS.includes(path.extname(filename)) ||
+    !specifier.startsWith(".")
+  ) {
+    return null;
+  }
+  const jsPath = path.resolve(path.dirname(filename), `${specifier}.js`);
+  if (fs.existsSync(jsPath)) {
+    return null;
+  }
+  for (const extension of SOURCE_MODULE_EXTENSIONS) {
+    const candidate = path.resolve(path.dirname(filename), `${specifier}${extension}`);
+    if (fs.existsSync(candidate)) {
+      return `${specifier}${extension}`;
+    }
+  }
+  return null;
+}
+
+function rewriteLocalSourceJsSpecifiers(source, filename) {
+  if (!filename || !SOURCE_MODULE_EXTENSIONS.includes(path.extname(filename))) {
+    return source;
+  }
+  let rewritten = source;
+  for (const pattern of SOURCE_IMPORT_PATTERNS) {
+    rewritten = rewritten.replace(pattern, (match, prefix, specifier, suffix) => {
+      const replacement = resolveLocalSourceShimSpecifier(filename, specifier);
+      return replacement ? `${prefix}${replacement}${suffix}` : match;
+    });
+  }
+  return rewritten;
+}
+
+function transformJitiSource(opts) {
+  return getDefaultJitiTransform()({
+    ...opts,
+    source: rewriteLocalSourceJsSpecifiers(opts.source, opts.filename),
+  });
+}
 
 function emptyPluginConfigSchema() {
   function error(message) {
@@ -61,20 +120,20 @@ function resolveControlCommandGate(params) {
   return { commandAuthorized, shouldBlock };
 }
 
-function getJiti(tryNative) {
-  if (jitiLoaders.has(tryNative)) {
-    return jitiLoaders.get(tryNative);
+function getJiti() {
+  if (jitiLoader) {
+    return jitiLoader;
   }
 
   const { createJiti } = require("jiti");
-  const jitiLoader = createJiti(__filename, {
+  jitiLoader = createJiti(__filename, {
     interopDefault: true,
     // Prefer Node's native sync ESM loader for built dist/plugin-sdk/*.js files
     // so local plugins do not create a second transpiled OpenClaw core graph.
-    tryNative,
+    tryNative: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+    transform: transformJitiSource,
   });
-  jitiLoaders.set(tryNative, jitiLoader);
   return jitiLoader;
 }
 
@@ -83,17 +142,19 @@ function loadMonolithicSdk() {
     return monolithicSdk;
   }
 
+  const jiti = getJiti();
+
   const distCandidate = path.resolve(__dirname, "..", "..", "dist", "plugin-sdk", "compat.js");
   if (fs.existsSync(distCandidate)) {
     try {
-      monolithicSdk = getJiti(true)(distCandidate);
+      monolithicSdk = jiti(distCandidate);
       return monolithicSdk;
     } catch {
       // Fall through to source alias if dist is unavailable or stale.
     }
   }
 
-  monolithicSdk = getJiti(false)(path.join(__dirname, "compat.ts"));
+  monolithicSdk = jiti(path.join(__dirname, "compat.ts"));
   return monolithicSdk;
 }
 

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -25,7 +25,7 @@ function loadRootAliasWithStubs(options?: {
 }) {
   let createJitiCalls = 0;
   let jitiLoadCalls = 0;
-  const createJitiOptions: Record<string, unknown>[] = [];
+  let lastJitiOptions: Record<string, unknown> | undefined;
   const loadedSpecifiers: string[] = [];
   const monolithicExports = options?.monolithicExports ?? {
     slowHelper: () => "loaded",
@@ -42,30 +42,40 @@ function loadRootAliasWithStubs(options?: {
     __dirname: string,
   ) => void;
   const module = { exports: {} as Record<string, unknown> };
-  const localRequire = ((id: string) => {
-    if (id === "node:path") {
-      return path;
-    }
-    if (id === "node:fs") {
-      return {
-        existsSync: () => options?.distExists ?? false,
-      };
-    }
-    if (id === "jiti") {
-      return {
-        createJiti(_filename: string, jitiOptions?: Record<string, unknown>) {
-          createJitiCalls += 1;
-          createJitiOptions.push(jitiOptions ?? {});
-          return (specifier: string) => {
-            jitiLoadCalls += 1;
-            loadedSpecifiers.push(specifier);
-            return monolithicExports;
-          };
-        },
-      };
-    }
-    throw new Error(`unexpected require: ${id}`);
-  }) as NodeJS.Require;
+  const localRequire = Object.assign(
+    ((id: string) => {
+      if (id === "node:path") {
+        return path;
+      }
+      if (id === "node:fs") {
+        return {
+          existsSync: () => options?.distExists ?? false,
+        };
+      }
+      if (id === "jiti") {
+        return {
+          createJiti(_filename: string, jitiOptions?: Record<string, unknown>) {
+            createJitiCalls += 1;
+            lastJitiOptions = jitiOptions;
+            return (specifier: string) => {
+              jitiLoadCalls += 1;
+              loadedSpecifiers.push(specifier);
+              return monolithicExports;
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected require: ${id}`);
+    }) as NodeJS.Require,
+    {
+      resolve(id: string) {
+        if (id === "jiti/package.json") {
+          return require.resolve(id);
+        }
+        throw new Error(`unexpected require.resolve: ${id}`);
+      },
+    },
+  );
   wrapper(module.exports, localRequire, module, rootAliasPath, path.dirname(rootAliasPath));
   return {
     moduleExports: module.exports,
@@ -75,8 +85,8 @@ function loadRootAliasWithStubs(options?: {
     get jitiLoadCalls() {
       return jitiLoadCalls;
     },
-    get createJitiOptions() {
-      return createJitiOptions;
+    get lastJitiOptions() {
+      return lastJitiOptions;
     },
     loadedSpecifiers,
   };
@@ -121,22 +131,11 @@ describe("plugin-sdk root alias", () => {
     expect("slowHelper" in lazyRootSdk).toBe(true);
     expect(lazyModule.createJitiCalls).toBe(1);
     expect(lazyModule.jitiLoadCalls).toBe(1);
-    expect(lazyModule.createJitiOptions.at(-1)?.tryNative).toBe(false);
+    expect(lazyModule.lastJitiOptions?.tryNative).toBe(true);
+    expect(typeof lazyModule.lastJitiOptions?.transform).toBe("function");
     expect((lazyRootSdk.slowHelper as () => string)()).toBe("loaded");
     expect(Object.keys(lazyRootSdk)).toContain("slowHelper");
     expect(Object.getOwnPropertyDescriptor(lazyRootSdk, "slowHelper")).toBeDefined();
-  });
-
-  it("prefers native loading when compat resolves to dist", () => {
-    const lazyModule = loadRootAliasWithStubs({
-      distExists: true,
-      monolithicExports: {
-        slowHelper: () => "loaded",
-      },
-    });
-
-    expect((lazyModule.moduleExports.slowHelper as () => string)()).toBe("loaded");
-    expect(lazyModule.createJitiOptions.at(-1)?.tryNative).toBe(true);
   });
 
   it("forwards delegateCompactionToRuntime through the compat-backed root alias", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { createJiti } from "jiti";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 async function importFreshPluginTestModules() {
@@ -3339,47 +3338,33 @@ module.exports = {
     expect(options.interopDefault).toBe(true);
     expect(options.extensions).toContain(".js");
     expect(options.extensions).toContain(".ts");
+    expect(typeof options.transform).toBe("function");
     expect("alias" in options).toBe(false);
   });
 
-  it("uses transpiled Jiti loads for source TypeScript plugin entries", () => {
-    expect(__testing.shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(true);
-    expect(
-      __testing.shouldPreferNativeJiti("/repo/extensions/discord/src/channel.runtime.ts"),
-    ).toBe(false);
-  });
+  it("rewrites missing local .js source shim imports without touching real .js files", () => {
+    const dir = makeTempDir();
+    const shimFile = path.join(dir, "runtime-shim.ts");
+    fs.writeFileSync(path.join(dir, "helper.ts"), 'export const helperValue = "ok";\n', "utf-8");
+    fs.writeFileSync(path.join(dir, "present.js"), 'export const presentValue = "js";\n', "utf-8");
 
-  it("loads source runtime shims through the non-native Jiti boundary", async () => {
-    const jiti = createJiti(import.meta.url, {
-      ...__testing.buildPluginLoaderJitiOptions({}),
-      tryNative: false,
-    });
-    const discordChannelRuntime = path.join(
-      process.cwd(),
-      "extensions",
-      "discord",
-      "src",
-      "channel.runtime.ts",
-    );
-    const discordVoiceRuntime = path.join(
-      process.cwd(),
-      "extensions",
-      "discord",
-      "src",
-      "voice",
-      "manager.runtime.ts",
+    const rewritten = __testing.rewriteLocalSourceJsSpecifiers(
+      [
+        'import { helperValue } from "./helper.js";',
+        'import "./present.js";',
+        'import { getPluginCommandSpecs } from "../../src/plugins/commands.js";',
+        "",
+      ].join("\n"),
+      shimFile,
     );
 
-    await expect(jiti.import(discordChannelRuntime)).resolves.toMatchObject({
-      discordSetupWizard: expect.any(Object),
-    });
-    await expect(jiti.import(discordVoiceRuntime)).resolves.toMatchObject({
-      DiscordVoiceManager: expect.any(Function),
-      DiscordVoiceReadyListener: expect.any(Function),
-    });
+    expect(rewritten).toContain('from "./helper.ts"');
+    expect(rewritten).toContain('import "./present.js"');
+    expect(rewritten).toContain('from "../../src/plugins/commands.js"');
   });
 
-  it("loads source TypeScript plugins that route through local runtime shims", () => {
+  it("keeps source runtime shim plugin commands on the canonical registry", async () => {
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "source-runtime-shim",
       filename: "source-runtime-shim.ts",
@@ -3387,7 +3372,14 @@ module.exports = {
 
 export default {
   id: "source-runtime-shim",
-  register() {},
+  register(api) {
+    api.registerCommand({
+      name: "voice",
+      description: "Voice call",
+      nativeNames: { telegram: "voice", discord: "voice" },
+      handler: async () => ({ text: "ok" }),
+    });
+  },
 };`,
     });
     fs.writeFileSync(
@@ -3399,11 +3391,14 @@ export const runtimeValue = helperValue;`,
     );
     fs.writeFileSync(
       path.join(plugin.dir, "helper.ts"),
-      `export const helperValue = "ok";`,
+      'export const helperValue = "ok";\n',
       "utf-8",
     );
+    const { clearPluginCommands, getPluginCommandSpecs } = await import("./commands.js");
 
-    const registry = loadOpenClawPlugins({
+    clearPluginCommands();
+
+    const active = loadOpenClawPlugins({
       cache: false,
       workspaceDir: plugin.dir,
       config: {
@@ -3412,10 +3407,21 @@ export const runtimeValue = helperValue;`,
           allow: ["source-runtime-shim"],
         },
       },
+      onlyPluginIds: ["source-runtime-shim"],
     });
 
-    const record = registry.plugins.find((entry) => entry.id === "source-runtime-shim");
-    expect(record?.status).toBe("loaded");
+    expect(active.plugins.find((entry) => entry.id === "source-runtime-shim")?.status).toBe(
+      "loaded",
+    );
+    expect(getPluginCommandSpecs("telegram")).toEqual([
+      {
+        name: "voice",
+        description: "Voice call",
+        acceptsArgs: false,
+      },
+    ]);
+
+    clearPluginCommands();
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createJiti } from "jiti";
+import { createJiti, type TransformOptions, type TransformResult } from "jiti";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isChannelConfigured } from "../config/plugin-auto-enable.js";
@@ -66,6 +67,7 @@ export type PluginLoadOptions = {
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 const registryCache = new Map<string, PluginRegistry>();
 const openAllowlistWarningCache = new Set<string>();
+const require = createRequire(import.meta.url);
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "config",
@@ -98,6 +100,76 @@ type LoaderModuleResolveParams = {
   cwd?: string;
   moduleUrl?: string;
 };
+
+const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx"] as const;
+
+const SOURCE_IMPORT_PATTERNS = [
+  /(from\s+["'])(\.[^"'()]+)\.js(["'])/g,
+  /(import\s+["'])(\.[^"'()]+)\.js(["'])/g,
+  /(import\s*\(\s*["'])(\.[^"'()]+)\.js(["'])/g,
+] as const;
+
+let defaultJitiTransform: ((opts: TransformOptions) => TransformResult) | null = null;
+
+function getDefaultJitiTransform(): (opts: TransformOptions) => TransformResult {
+  if (defaultJitiTransform) {
+    return defaultJitiTransform;
+  }
+  const jitiPackageRoot = path.dirname(require.resolve("jiti/package.json"));
+  defaultJitiTransform = require(path.join(jitiPackageRoot, "dist", "babel.cjs")) as (
+    opts: TransformOptions,
+  ) => TransformResult;
+  return defaultJitiTransform;
+}
+
+function resolveLocalSourceShimSpecifier(
+  filename: string | undefined,
+  specifier: string,
+): string | null {
+  if (!filename || path.extname(filename) === ".js" || !specifier.startsWith(".")) {
+    return null;
+  }
+  const jsPath = path.resolve(path.dirname(filename), `${specifier}.js`);
+  if (fs.existsSync(jsPath)) {
+    return null;
+  }
+  for (const extension of SOURCE_MODULE_EXTENSIONS) {
+    const candidate = path.resolve(path.dirname(filename), `${specifier}${extension}`);
+    if (fs.existsSync(candidate)) {
+      return `${specifier}${extension}`;
+    }
+  }
+  return null;
+}
+
+function rewriteLocalSourceJsSpecifiers(source: string, filename?: string): string {
+  if (
+    !filename ||
+    !SOURCE_MODULE_EXTENSIONS.includes(
+      path.extname(filename) as (typeof SOURCE_MODULE_EXTENSIONS)[number],
+    )
+  ) {
+    return source;
+  }
+  let rewritten = source;
+  for (const pattern of SOURCE_IMPORT_PATTERNS) {
+    rewritten = rewritten.replace(
+      pattern,
+      (match, prefix: string, specifier: string, suffix: string) => {
+        const replacement = resolveLocalSourceShimSpecifier(filename, specifier);
+        return replacement ? `${prefix}${replacement}${suffix}` : match;
+      },
+    );
+  }
+  return rewritten;
+}
+
+function transformPluginLoaderSource(opts: TransformOptions): TransformResult {
+  return getDefaultJitiTransform()({
+    ...opts,
+    source: rewriteLocalSourceJsSpecifiers(opts.source, opts.filename),
+  });
+}
 
 function resolveLoaderModulePath(params: LoaderModuleResolveParams = {}): string {
   return params.modulePath ?? fileURLToPath(params.moduleUrl ?? import.meta.url);
@@ -206,6 +278,7 @@ function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
     // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
     tryNative: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+    transform: transformPluginLoaderSource,
     ...(Object.keys(aliasMap).length > 0
       ? {
           alias: aliasMap,
@@ -288,26 +361,14 @@ const resolvePluginSdkScopedAliasMap = (): Record<string, string> => {
   return aliasMap;
 };
 
-function shouldPreferNativeJiti(modulePath: string): boolean {
-  switch (path.extname(modulePath).toLowerCase()) {
-    case ".js":
-    case ".mjs":
-    case ".cjs":
-    case ".json":
-      return true;
-    default:
-      return false;
-  }
-}
-
 export const __testing = {
   buildPluginLoaderJitiOptions,
   listPluginSdkAliasCandidates,
   listPluginSdkExportedSubpaths,
+  rewriteLocalSourceJsSpecifiers,
   resolvePluginSdkAliasCandidateOrder,
   resolvePluginSdkAliasFile,
   resolvePluginRuntimeModulePath,
-  shouldPreferNativeJiti,
   maxPluginRegistryCacheEntries: MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
 };
 
@@ -867,28 +928,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   }
 
   // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).
-  const jitiLoaders = new Map<boolean, ReturnType<typeof createJiti>>();
-  const getJiti = (modulePath: string) => {
-    const tryNative = shouldPreferNativeJiti(modulePath);
-    const cached = jitiLoaders.get(tryNative);
-    if (cached) {
-      return cached;
+  let jitiLoader: ReturnType<typeof createJiti> | null = null;
+  const getJiti = () => {
+    if (jitiLoader) {
+      return jitiLoader;
     }
     const pluginSdkAlias = resolvePluginSdkAlias();
     const aliasMap = {
       ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
       ...resolvePluginSdkScopedAliasMap(),
     };
-    const loader = createJiti(import.meta.url, {
-      ...buildPluginLoaderJitiOptions(aliasMap),
-      // Source .ts runtime shims import sibling ".js" specifiers that only exist
-      // after build. Disable native loading for source entries so Jiti rewrites
-      // those imports against the source graph, while keeping native dist/*.js
-      // loading for the canonical built module graph.
-      tryNative,
-    });
-    jitiLoaders.set(tryNative, loader);
-    return loader;
+    jitiLoader = createJiti(import.meta.url, buildPluginLoaderJitiOptions(aliasMap));
+    return jitiLoader;
   };
 
   let createPluginRuntimeFactory: ((options?: CreatePluginRuntimeOptions) => PluginRuntime) | null =
@@ -903,7 +954,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (!runtimeModulePath) {
       throw new Error("Unable to resolve plugin runtime module");
     }
-    const runtimeModule = getJiti(runtimeModulePath)(runtimeModulePath) as {
+    const runtimeModule = getJiti()(runtimeModulePath) as {
       createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
     };
     if (typeof runtimeModule.createPluginRuntime !== "function") {
@@ -1236,7 +1287,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      mod = getJiti()(safeSource) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `3d8afb96bd` fixed source plugin shim loading by routing source `.ts` plugin entries through a separate non-native JITI boundary, which recreated the split-personality module-graph problem for plugin/core singletons.
- Why it matters: plugin command registration lives in a module-local registry, so loading source runtime shims through a second JITI graph caused commands like `/voice`, `/phone`, and `/pair` to register in one graph while Telegram and Discord read from another.
- What changed: kept a single native-preferring JITI boundary in both the plugin loader and `plugin-sdk` root alias, and added a narrow source-shim rewrite that only rewrites missing local relative `.js` imports to sibling source files such as `.ts` when they actually exist.
- What did NOT change (scope boundary): this does not reintroduce the older dual-loader approach, does not disable native loading for whole source plugin graphs, and does not change plugin manifests, config, or runtime staging layout.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #50007

## User-visible / Behavior Changes

- Source-loaded plugins that depend on local runtime shim files continue to load.
- Plugin-registered commands now stay on the canonical registry again, so commands such as `/voice`, `/phone`, and `/pair` show up again in Telegram and Discord instead of disappearing due to split module state.
- No config or workflow changes are required.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram, Discord plugin command registration path
- Relevant config (redacted): local source plugin loaded from workspace path

### Steps

1. Load a source plugin whose `.ts` entry imports a local runtime shim that itself imports sibling `.js` specifiers.
2. Let that plugin register native commands such as `/voice` through the plugin command registry.
3. Read published plugin command specs from the Telegram or Discord native-command path.

### Expected

- Source plugin shims load successfully.
- Telegram/Discord see the same plugin command registry as plugin registration and publish `/voice`, `/phone`, and `/pair`.

### Actual

- Before this change, the source-shim fix in `3d8afb96bd` loaded those plugins through a second JITI graph, so command registration and Telegram/Discord publication observed different singleton state.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/plugins/loader.test.ts -t "source runtime shim|canonical registry|plugin loader jiti boundary|rewrites missing local"`
  - `pnpm test -- src/plugin-sdk/root-alias.test.ts`
  - `pnpm check`
  - Confirmed the branch history contains only the final delta, with no standalone `Revert:` commit left in the stack.
- Edge cases checked:
  - Missing local `./helper.js` source shim imports rewrite to sibling `./helper.ts`.
  - Existing real `.js` files are left alone.
  - Non-local imports such as core `src/plugins/commands.js` are not rewritten.
  - Source runtime shim plugins still register commands into the canonical registry visible to Telegram.
- What you did **not** verify:
  - Full live Telegram or Discord end-to-end command sync against external services in this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `78d33d4f55`
- Files/config to restore: `src/plugins/loader.ts`, `src/plugin-sdk/root-alias.cjs`, and the associated tests
- Known bad symptoms reviewers should watch for: source plugins failing to load local runtime shims again, or Telegram/Discord missing plugin-registered commands such as `/voice`, `/phone`, and `/pair`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the import rewrite could touch source imports outside the intended shim cases.
  - Mitigation: the rewrite is limited to local relative `.js` specifiers, only when the real `.js` file is absent, and only when a sibling source module exists.
- Risk: future loader changes could accidentally reintroduce a second JITI graph.
  - Mitigation: regression tests now cover source runtime shim loading and canonical plugin command registry visibility.
