### PR TITLE
fix(agents): set isError: false in host edit post-write recovery

### DIFF
--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -63,6 +63,7 @@ export function wrapHostEditToolWithPostWriteRecovery(
             oldText !== undefined && oldText.length > 0 && content.includes(oldText);
           if (hasNew && !stillHasOld) {
             return {
+              isError: false,
               content: [
                 {
                   type: "text",

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -61,6 +61,8 @@ describe("createHostWorkspaceEditTool post-write recovery", () => {
       : [];
     const textBlock = content.find((b) => b?.type === "text" && typeof b.text === "string");
     expect(textBlock?.text).toContain("Successfully replaced text");
+    // isError must be explicitly false so the framework does not surface a false failure notification
+    expect((result as { isError?: unknown }).isError).toBe(false);
   });
 
   it("rethrows when file on disk does not contain newText", async () => {


### PR DESCRIPTION
## Summary

When the upstream edit tool throws after the file has already been written (e.g. `generateDiffString` fails inside pi-coding-agent), the post-write recovery wrapper correctly catches the error and returns a success result. However, the returned `AgentToolResult` lacked an explicit `isError: false` field.

Adding `isError: false` explicitly ensures the framework never surfaces a false 'edit failed' notification, even when internal error-handling paths preserve unexpected `isError` flags from caught exceptions.

## Changes

- **`src/agents/pi-tools.host-edit.ts`**: Add `isError: false` to the recovery return object
- **`src/agents/pi-tools.read.host-edit-recovery.test.ts`**: Add an explicit assertion that the recovered result has `isError: false`

## Testing

`npm test -- src/agents/pi-tools.read.host-edit-recovery.test.ts`

## Related

- Closes #32333 (follow-up — the original fix was merged in #32383 but the `isError` field was not explicitly cleared in the recovery return)

