### PR TITLE
fix(security): show exact workspaceOnly config command

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1320,8 +1320,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
         `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
         "Prompt injection in open groups can trigger command/file actions in these contexts.",
-      remediation:
-        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), run `openclaw config set tools.fs.workspaceOnly true`, and use agents.defaults.sandbox.mode="all" for exposed agents.',
+      remediation: `For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), run "${formatCliCommand("openclaw config set tools.fs.workspaceOnly true")}", and use agents.defaults.sandbox.mode="all" for exposed agents.`,
     });
   }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1320,7 +1320,8 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
         `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
         "Prompt injection in open groups can trigger command/file actions in these contexts.",
-      remediation: `For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), run "${formatCliCommand("openclaw config set tools.fs.workspaceOnly true")}", and use agents.defaults.sandbox.mode="all" for exposed agents.`,
+      remediation:
+        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true globally and on any agent-level overrides (agents.list[].tools.fs.workspaceOnly), and use agents.defaults.sandbox.mode="all" for exposed agents.',
     });
   }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1312,6 +1312,26 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
   const { riskyContexts, hasRuntimeRisk } = collectRiskyToolExposureContexts(cfg);
 
   if (riskyContexts.length > 0) {
+    const riskyAgentIdsWithFsExposure = riskyContexts
+      .map((context) => {
+        const match = context.match(/^agents\.list\.([^\s(]+)/);
+        return context.includes("fs.workspaceOnly=false") ? (match?.[1] ?? null) : null;
+      })
+      .filter((agentId): agentId is string => Boolean(agentId));
+
+    const remediationParts = [
+      'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs).',
+      "Set tools.fs.workspaceOnly=true globally.",
+    ];
+    if (riskyAgentIdsWithFsExposure.length > 0) {
+      remediationParts.push(
+        `For flagged agent ids (${riskyAgentIdsWithFsExposure
+          .map((agentId) => `id "${agentId}"`)
+          .join(", ")}), set that agent entry's tools.fs.workspaceOnly to true.`,
+      );
+    }
+    remediationParts.push('Use agents.defaults.sandbox.mode="all" for exposed agents.');
+
     findings.push({
       checkId: "security.exposure.open_groups_with_runtime_or_fs",
       severity: hasRuntimeRisk ? "critical" : "warn",
@@ -1320,8 +1340,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
         `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
         "Prompt injection in open groups can trigger command/file actions in these contexts.",
-      remediation:
-        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true globally and on any agent-level overrides (agents.list[].tools.fs.workspaceOnly), and use agents.defaults.sandbox.mode="all" for exposed agents.',
+      remediation: remediationParts.join(" "),
     });
   }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1321,7 +1321,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
         `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
         "Prompt injection in open groups can trigger command/file actions in these contexts.",
       remediation:
-        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true, and use agents.defaults.sandbox.mode="all" for exposed agents.',
+        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), run `openclaw config set tools.fs.workspaceOnly true`, and use agents.defaults.sandbox.mode="all" for exposed agents.',
     });
   }
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3678,6 +3678,25 @@ description: test skill
     );
   });
 
+  it("preserves the active profile in the workspaceOnly remediation command", async () => {
+    await withEnvAsync({ OPENCLAW_PROFILE: "danger" }, async () => {
+      const res = await audit({
+        channels: { whatsapp: { groupPolicy: "open" } },
+        tools: {
+          elevated: { enabled: false },
+          profile: "coding",
+        },
+      });
+      const finding = res.findings.find(
+        (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
+      );
+      expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
+      expect(finding?.remediation).toContain(
+        "openclaw --profile danger config set tools.fs.workspaceOnly true",
+      );
+    });
+  });
+
   describe("maybeProbeGateway auth selection", () => {
     const makeProbeCapture = () => {
       let capturedAuth: { token?: string; password?: string } | undefined;

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3621,6 +3621,7 @@ description: test skill
           const finding = res.findings.find(
             (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
           );
+          expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
           expect(finding?.remediation).toContain("openclaw config set tools.fs.workspaceOnly true");
         },
       },

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3609,12 +3609,30 @@ description: test skill
         },
       },
       {
-        name: "includes workspaceOnly guidance for both global and agent-level overrides",
+        name: "includes flagged agent ids instead of an invalid [] path",
         cfg: {
           channels: { whatsapp: { groupPolicy: "open" } },
           tools: {
             elevated: { enabled: false },
-            profile: "coding",
+            profile: "messaging",
+            fs: { workspaceOnly: true },
+          },
+          agents: {
+            defaults: {
+              sandbox: { mode: "all" },
+            },
+            list: [
+              {
+                id: "unsafe-agent",
+                sandbox: {
+                  mode: "off",
+                },
+                tools: {
+                  profile: "coding",
+                  fs: { workspaceOnly: false },
+                },
+              },
+            ],
           },
         } satisfies OpenClawConfig,
         assert: (res: SecurityAuditReport) => {
@@ -3623,7 +3641,8 @@ description: test skill
           );
           expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
           expect(finding?.remediation).toContain("tools.fs.workspaceOnly=true");
-          expect(finding?.remediation).toContain("agent-level overrides");
+          expect(finding?.remediation).toContain('id "unsafe-agent"');
+          expect(finding?.remediation).not.toContain("agents.list[].tools.fs.workspaceOnly");
         },
       },
       {
@@ -3701,8 +3720,8 @@ description: test skill
       (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
     );
     expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
-    expect(finding?.remediation).toContain("agents.list[].tools.fs.workspaceOnly");
-    expect(finding?.remediation).not.toContain("openclaw config set tools.fs.workspaceOnly true");
+    expect(finding?.remediation).toContain('id "worker"');
+    expect(finding?.remediation).not.toContain("agents.list[].tools.fs.workspaceOnly");
   });
 
   describe("maybeProbeGateway auth selection", () => {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3609,7 +3609,7 @@ description: test skill
         },
       },
       {
-        name: "includes the exact workspaceOnly config command in open-group remediation",
+        name: "includes workspaceOnly guidance for both global and agent-level overrides",
         cfg: {
           channels: { whatsapp: { groupPolicy: "open" } },
           tools: {
@@ -3622,7 +3622,8 @@ description: test skill
             (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
           );
           expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
-          expect(finding?.remediation).toContain("openclaw config set tools.fs.workspaceOnly true");
+          expect(finding?.remediation).toContain("tools.fs.workspaceOnly=true");
+          expect(finding?.remediation).toContain("agent-level overrides");
         },
       },
       {
@@ -3678,23 +3679,30 @@ description: test skill
     );
   });
 
-  it("preserves the active profile in the workspaceOnly remediation command", async () => {
-    await withEnvAsync({ OPENCLAW_PROFILE: "danger" }, async () => {
-      const res = await audit({
-        channels: { whatsapp: { groupPolicy: "open" } },
-        tools: {
-          elevated: { enabled: false },
-          profile: "coding",
-        },
-      });
-      const finding = res.findings.find(
-        (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
-      );
-      expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
-      expect(finding?.remediation).toContain(
-        "openclaw --profile danger config set tools.fs.workspaceOnly true",
-      );
+  it("does not imply the global workspaceOnly setting alone fixes agent overrides", async () => {
+    const res = await audit({
+      channels: { whatsapp: { groupPolicy: "open" } },
+      tools: {
+        elevated: { enabled: false },
+        profile: "coding",
+      },
+      agents: {
+        list: [
+          {
+            id: "worker",
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
     });
+    const finding = res.findings.find(
+      (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
+    );
+    expect(finding, "expected open_groups_with_runtime_or_fs finding to exist").toBeDefined();
+    expect(finding?.remediation).toContain("agents.list[].tools.fs.workspaceOnly");
+    expect(finding?.remediation).not.toContain("openclaw config set tools.fs.workspaceOnly true");
   });
 
   describe("maybeProbeGateway auth selection", () => {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3609,6 +3609,22 @@ description: test skill
         },
       },
       {
+        name: "includes the exact workspaceOnly config command in open-group remediation",
+        cfg: {
+          channels: { whatsapp: { groupPolicy: "open" } },
+          tools: {
+            elevated: { enabled: false },
+            profile: "coding",
+          },
+        } satisfies OpenClawConfig,
+        assert: (res: SecurityAuditReport) => {
+          const finding = res.findings.find(
+            (f) => f.checkId === "security.exposure.open_groups_with_runtime_or_fs",
+          );
+          expect(finding?.remediation).toContain("openclaw config set tools.fs.workspaceOnly true");
+        },
+      },
+      {
         name: "warns when config heuristics suggest a likely multi-user setup",
         cfg: {
           channels: {


### PR DESCRIPTION
## Summary
- update the open-group audit remediation to print the exact `openclaw config set` command
- add regression coverage for the remediation text

## Problem
The audit told users to set `tools.fs.workspaceOnly=true`, but not the exact command/path to run. That slows remediation and makes the fix easy to mistype.

## Testing
- `pnpm vitest run src/security/audit.test.ts`
- `pnpm exec oxlint src/security/audit-extra.sync.ts src/security/audit.test.ts`

Closes #50012
