### PR TITLE
fix(config): validate denyCommands after gateway.nodes writes

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -348,6 +348,28 @@ describe("config cli", () => {
         denyCommands: ["custom.mycommand"],
       });
     });
+
+    it("rejects allowCommands-only updates that invalidate existing denyCommands", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          port: 18789,
+          nodes: {
+            allowCommands: ["custom.mycommand"],
+            denyCommands: ["custom.mycommand"],
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "set", "gateway.nodes.allowCommands", "[]"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown command "custom.mycommand"'),
+      );
+    });
   });
 
   describe("config get", () => {
@@ -1198,6 +1220,38 @@ describe("config cli", () => {
       expect(payload.errors?.some((entry) => entry.kind === "resolvability")).toBe(true);
       expect(
         payload.errors?.some((entry) => entry.ref?.includes("default:DISCORD_BOT_TOKEN")),
+      ).toBe(true);
+    });
+
+    it("emits structured JSON for denyCommands validation failure in --dry-run --json mode", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "gateway.nodes.denyCommands",
+          '["sendd"]',
+          "--dry-run",
+          "--json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      const raw = mockLog.mock.calls.at(-1)?.[0];
+      expect(typeof raw).toBe("string");
+      const payload = JSON.parse(String(raw)) as {
+        ok: boolean;
+        checks: { schema: boolean };
+        errors?: Array<{ kind: string; message: string }>;
+      };
+      expect(payload.ok).toBe(false);
+      expect(payload.checks.schema).toBe(true);
+      expect(payload.errors?.some((entry) => entry.kind === "schema")).toBe(true);
+      expect(
+        payload.errors?.some((entry) => entry.message.includes('Unknown command "sendd"')),
       ).toBe(true);
     });
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1255,6 +1255,56 @@ describe("config cli", () => {
       ).toBe(true);
     });
 
+    it("keeps the value-mode dry-run note for gateway.nodes writes without json-mode validation", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "gateway.nodes",
+        '{"denyCommands":["system.run"]}',
+        "--dry-run",
+      ]);
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("value mode does not run schema/resolvability checks"),
+      );
+    });
+
+    it("returns structured schema errors instead of crashing on malformed allowCommands", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "gateway.nodes",
+          '{"allowCommands":42,"denyCommands":["system.run"]}',
+          "--strict-json",
+          "--dry-run",
+          "--json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      const raw = mockLog.mock.calls.at(-1)?.[0];
+      expect(typeof raw).toBe("string");
+      const payload = JSON.parse(String(raw)) as {
+        ok: boolean;
+        checks: { schema: boolean };
+        errors?: Array<{ kind: string; message: string }>;
+      };
+      expect(payload.ok).toBe(false);
+      expect(payload.checks.schema).toBe(true);
+      expect(payload.errors?.some((entry) => entry.message.includes("allowCommands"))).toBe(true);
+      expect(payload.errors?.some((entry) => entry.message.includes("TypeError"))).toBe(false);
+    });
+
     it("fails dry-run when provider updates make existing refs unresolvable", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -371,6 +371,49 @@ describe("config cli", () => {
       );
     });
 
+    it("accepts exact denyCommands entries with punctuation when allowCommands declares them", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "gateway.nodes",
+        '{"allowCommands":["camera.capture(v2)","foo|bar"],"denyCommands":["camera.capture(v2)","foo|bar"]}',
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.nodes).toEqual({
+        allowCommands: ["camera.capture(v2)", "foo|bar"],
+        denyCommands: ["camera.capture(v2)", "foo|bar"],
+      });
+    });
+
+    it("rejects unsetting allowCommands when it leaves denyCommands invalid", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          port: 18789,
+          nodes: {
+            allowCommands: ["camera.capture(v2)"],
+            denyCommands: ["camera.capture(v2)"],
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "unset", "gateway.nodes.allowCommands"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown command "camera.capture(v2)"'),
+      );
+    });
+
     it("does not revalidate denyCommands for unrelated gateway.nodes edits", async () => {
       const resolved: OpenClawConfig = {
         gateway: {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -299,6 +299,57 @@ describe("config cli", () => {
     });
   });
 
+  describe("config set - denyCommands validation", () => {
+    it("rejects unknown denyCommands leaf writes", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "set", "gateway.nodes.denyCommands", '["sendd"]']),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining('Unknown command "sendd"'));
+    });
+
+    it("rejects parent object writes that smuggle invalid denyCommands", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "set", "gateway.nodes", '{"denyCommands":["sendd"]}']),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining('Unknown command "sendd"'));
+    });
+
+    it("accepts parent object writes when allowCommands makes the command known", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "gateway.nodes",
+        '{"allowCommands":["custom.mycommand"],"denyCommands":["custom.mycommand"]}',
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.nodes).toEqual({
+        allowCommands: ["custom.mycommand"],
+        denyCommands: ["custom.mycommand"],
+      });
+    });
+  });
+
   describe("config get", () => {
     it("redacts sensitive values", async () => {
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -370,6 +370,28 @@ describe("config cli", () => {
         expect.stringContaining('Unknown command "custom.mycommand"'),
       );
     });
+
+    it("does not revalidate denyCommands for unrelated gateway.nodes edits", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          port: 18789,
+          nodes: {
+            denyCommands: ["sendd"],
+            browser: { mode: "auto" },
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.nodes.browser.mode", '"manual"']);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(mockError).not.toHaveBeenCalledWith(
+        expect.stringContaining('Unknown command "sendd"'),
+      );
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.nodes?.browser).toEqual({ mode: "manual" });
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -71,6 +71,7 @@ type ConfigSetOperation = {
 const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "apiKey"];
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
+const GATEWAY_NODES_ALLOW_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "allowCommands"];
 const GATEWAY_NODES_DENY_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "denyCommands"];
 const GATEWAY_NODES_PATH: PathSegment[] = ["gateway", "nodes"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
@@ -1034,8 +1035,10 @@ export async function runConfigSet(opts: {
       operations,
     });
     const nextConfig = next as OpenClawConfig;
-    const shouldValidateGatewayNodeCommands = operations.some((operation) =>
-      pathOverlaps(operation.setPath, GATEWAY_NODES_PATH),
+    const shouldValidateGatewayNodeCommands = operations.some(
+      (operation) =>
+        pathOverlaps(operation.setPath, GATEWAY_NODES_ALLOW_COMMANDS_PATH) ||
+        pathOverlaps(operation.setPath, GATEWAY_NODES_DENY_COMMANDS_PATH),
     );
 
     if (opts.cliOptions.dryRun) {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1216,6 +1216,18 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
       runtime.exit(1);
       return;
     }
+    const shouldValidateGatewayNodeCommands =
+      pathOverlaps(parsedPath, GATEWAY_NODES_ALLOW_COMMANDS_PATH) ||
+      pathOverlaps(parsedPath, GATEWAY_NODES_DENY_COMMANDS_PATH);
+    if (shouldValidateGatewayNodeCommands) {
+      const denyCommandErrors = collectDenyCommandValidationMessages(next as OpenClawConfig);
+      if (denyCommandErrors.length > 0) {
+        throw new Error(
+          "Invalid denyCommands entries:\n" +
+            denyCommandErrors.map((error) => `- ${error}`).join("\n"),
+        );
+      }
+    }
     await writeConfigFile(next, { unsetPaths: [parsedPath] });
     runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));
   } catch (err) {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -73,7 +73,6 @@ const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const GATEWAY_NODES_ALLOW_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "allowCommands"];
 const GATEWAY_NODES_DENY_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "denyCommands"];
-const GATEWAY_NODES_PATH: PathSegment[] = ["gateway", "nodes"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -15,6 +15,7 @@ import {
   type SecretRef,
   type SecretRefSource,
 } from "../config/types.secrets.js";
+import { validateDenyCommandEntries } from "../config/validate-deny-commands.js";
 import { validateConfigObjectRaw } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
 import { danger, info, success } from "../globals.js";
@@ -70,6 +71,7 @@ type ConfigSetOperation = {
 const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "apiKey"];
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
+const GATEWAY_NODES_DENY_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "denyCommands"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
@@ -333,6 +335,14 @@ function pathEquals(path: PathSegment[], expected: PathSegment[]): boolean {
   return (
     path.length === expected.length && path.every((segment, index) => segment === expected[index])
   );
+}
+
+function pathStartsWith(path: PathSegment[], prefix: PathSegment[]): boolean {
+  return prefix.every((segment, index) => path[index] === segment);
+}
+
+function pathOverlaps(path: PathSegment[], target: PathSegment[]): boolean {
+  return pathStartsWith(path, target) || pathStartsWith(target, path);
 }
 
 function ensureValidOllamaProviderForApiKeySet(
@@ -1012,6 +1022,22 @@ export async function runConfigSet(opts: {
       operations,
     });
     const nextConfig = next as OpenClawConfig;
+    if (
+      operations.some((operation) =>
+        pathOverlaps(operation.setPath, GATEWAY_NODES_DENY_COMMANDS_PATH),
+      )
+    ) {
+      const denyCommandsResult = validateDenyCommandEntries(
+        nextConfig.gateway?.nodes?.denyCommands,
+        nextConfig,
+      );
+      if (!denyCommandsResult.valid) {
+        throw new Error(
+          "Invalid denyCommands entries:\n" +
+            denyCommandsResult.errors.map((error) => `- ${error}`).join("\n"),
+        );
+      }
+    }
 
     if (opts.cliOptions.dryRun) {
       const hasJsonMode = operations.some((operation) => operation.inputMode === "json");

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1041,7 +1041,6 @@ export async function runConfigSet(opts: {
     if (opts.cliOptions.dryRun) {
       const hasJsonMode = operations.some((operation) => operation.inputMode === "json");
       const hasBuilderMode = operations.some((operation) => operation.inputMode === "builder");
-      const schemaChecksEnabled = hasJsonMode || shouldValidateGatewayNodeCommands;
       const refs =
         hasJsonMode || hasBuilderMode
           ? collectDryRunRefs({
@@ -1080,7 +1079,7 @@ export async function runConfigSet(opts: {
         configPath: shortenHomePath(snapshot.path),
         inputModes: [...new Set(operations.map((operation) => operation.inputMode))],
         checks: {
-          schema: schemaChecksEnabled,
+          schema: hasJsonMode,
           resolvability: hasJsonMode || hasBuilderMode,
           resolvabilityComplete:
             (hasJsonMode || hasBuilderMode) && selectedDryRunRefs.skippedExecRefs.length === 0,

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -72,6 +72,7 @@ const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "ap
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const GATEWAY_NODES_DENY_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "denyCommands"];
+const GATEWAY_NODES_PATH: PathSegment[] = ["gateway", "nodes"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
@@ -940,6 +941,17 @@ function collectDryRunSchemaErrors(config: OpenClawConfig): ConfigSetDryRunError
   }));
 }
 
+function collectDenyCommandValidationMessages(config: OpenClawConfig): string[] {
+  return validateDenyCommandEntries(config.gateway?.nodes?.denyCommands, config).errors;
+}
+
+function collectDryRunDenyCommandErrors(config: OpenClawConfig): ConfigSetDryRunError[] {
+  return collectDenyCommandValidationMessages(config).map((message) => ({
+    kind: "schema",
+    message: `gateway.nodes.denyCommands: ${message}`,
+  }));
+}
+
 function formatDryRunFailureMessage(params: {
   errors: ConfigSetDryRunError[];
   skippedExecRefs: number;
@@ -1022,26 +1034,14 @@ export async function runConfigSet(opts: {
       operations,
     });
     const nextConfig = next as OpenClawConfig;
-    if (
-      operations.some((operation) =>
-        pathOverlaps(operation.setPath, GATEWAY_NODES_DENY_COMMANDS_PATH),
-      )
-    ) {
-      const denyCommandsResult = validateDenyCommandEntries(
-        nextConfig.gateway?.nodes?.denyCommands,
-        nextConfig,
-      );
-      if (!denyCommandsResult.valid) {
-        throw new Error(
-          "Invalid denyCommands entries:\n" +
-            denyCommandsResult.errors.map((error) => `- ${error}`).join("\n"),
-        );
-      }
-    }
+    const shouldValidateGatewayNodeCommands = operations.some((operation) =>
+      pathOverlaps(operation.setPath, GATEWAY_NODES_PATH),
+    );
 
     if (opts.cliOptions.dryRun) {
       const hasJsonMode = operations.some((operation) => operation.inputMode === "json");
       const hasBuilderMode = operations.some((operation) => operation.inputMode === "builder");
+      const schemaChecksEnabled = hasJsonMode || shouldValidateGatewayNodeCommands;
       const refs =
         hasJsonMode || hasBuilderMode
           ? collectDryRunRefs({
@@ -1056,6 +1056,9 @@ export async function runConfigSet(opts: {
       const errors: ConfigSetDryRunError[] = [];
       if (hasJsonMode) {
         errors.push(...collectDryRunSchemaErrors(nextConfig));
+      }
+      if (shouldValidateGatewayNodeCommands) {
+        errors.push(...collectDryRunDenyCommandErrors(nextConfig));
       }
       if (hasJsonMode || hasBuilderMode) {
         errors.push(
@@ -1077,7 +1080,7 @@ export async function runConfigSet(opts: {
         configPath: shortenHomePath(snapshot.path),
         inputModes: [...new Set(operations.map((operation) => operation.inputMode))],
         checks: {
-          schema: hasJsonMode,
+          schema: schemaChecksEnabled,
           resolvability: hasJsonMode || hasBuilderMode,
           resolvabilityComplete:
             (hasJsonMode || hasBuilderMode) && selectedDryRunRefs.skippedExecRefs.length === 0,
@@ -1121,6 +1124,16 @@ export async function runConfigSet(opts: {
         );
       }
       return;
+    }
+
+    if (shouldValidateGatewayNodeCommands) {
+      const denyCommandErrors = collectDenyCommandValidationMessages(nextConfig);
+      if (denyCommandErrors.length > 0) {
+        throw new Error(
+          "Invalid denyCommands entries:\n" +
+            denyCommandErrors.map((error) => `- ${error}`).join("\n"),
+        );
+      }
     }
 
     await writeConfigFile(next);

--- a/src/config/validate-deny-commands.test.ts
+++ b/src/config/validate-deny-commands.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import {
+  collectAllKnownNodeCommands,
+  looksLikeCommandPattern,
+  validateDenyCommandEntries,
+} from "./validate-deny-commands.js";
+
+describe("validate-deny-commands", () => {
+  it("collects built-in node commands", () => {
+    const known = collectAllKnownNodeCommands({});
+    expect(known.has("system.run")).toBe(true);
+    expect(known.has("canvas.present")).toBe(true);
+  });
+
+  it("treats custom allowCommands entries as known", () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          allowCommands: ["custom.mycommand"],
+        },
+      },
+    };
+
+    const result = validateDenyCommandEntries(["custom.mycommand"], cfg);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it("rejects typos with a suggestion", () => {
+    const result = validateDenyCommandEntries(["system.rn"], {});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('Did you mean "system.run"');
+  });
+
+  it("detects pattern-like denyCommands entries", () => {
+    expect(looksLikeCommandPattern("system.*")).toBe(true);
+    const result = validateDenyCommandEntries(["system.*"], {});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("exact matching");
+  });
+});

--- a/src/config/validate-deny-commands.test.ts
+++ b/src/config/validate-deny-commands.test.ts
@@ -101,4 +101,26 @@ describe("validate-deny-commands", () => {
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toContain("exact matching");
   });
+
+  it("does not infer patterns from punctuation alone", () => {
+    expect(looksLikeCommandPattern("camera.capture(v2)")).toBe(false);
+    expect(looksLikeCommandPattern("foo|bar")).toBe(false);
+    expect(looksLikeCommandPattern("^caret-prefix")).toBe(false);
+    expect(looksLikeCommandPattern("suffix$")).toBe(false);
+  });
+
+  it("accepts exact allowCommands entries that contain punctuation", () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          allowCommands: ["camera.capture(v2)", "foo|bar"],
+        },
+      },
+    };
+
+    expect(validateDenyCommandEntries(["camera.capture(v2)", "foo|bar"], cfg)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
 });

--- a/src/config/validate-deny-commands.test.ts
+++ b/src/config/validate-deny-commands.test.ts
@@ -27,6 +27,19 @@ describe("validate-deny-commands", () => {
     expect(result).toEqual({ valid: true, errors: [] });
   });
 
+  it("allows exact custom command ids that contain spaces", () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          allowCommands: ["my command"],
+        },
+      },
+    };
+
+    expect(looksLikeCommandPattern("my command")).toBe(false);
+    expect(validateDenyCommandEntries(["my command"], cfg)).toEqual({ valid: true, errors: [] });
+  });
+
   it("does not crash when allowCommands is malformed", () => {
     const cfg: OpenClawConfig = {
       gateway: {

--- a/src/config/validate-deny-commands.test.ts
+++ b/src/config/validate-deny-commands.test.ts
@@ -27,6 +27,42 @@ describe("validate-deny-commands", () => {
     expect(result).toEqual({ valid: true, errors: [] });
   });
 
+  it("does not crash when allowCommands is malformed", () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          allowCommands: 42 as unknown as string[],
+        },
+      },
+    };
+
+    expect(() => validateDenyCommandEntries(["system.run"], cfg)).not.toThrow();
+    expect(validateDenyCommandEntries(["system.run"], cfg)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("ignores non-string allowCommands entries during validation", () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          allowCommands: [42, null, "custom.mycommand"] as unknown as string[],
+        },
+      },
+    };
+
+    const result = validateDenyCommandEntries(["custom.mycommand"], cfg);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it("does not crash when gateway.nodes has a malformed shape", () => {
+    const cfg = {
+      gateway: {
+        nodes: "broken" as unknown,
+      },
+    } as OpenClawConfig;
+
+    expect(() => validateDenyCommandEntries(["system.run"], cfg)).not.toThrow();
+  });
+
   it("rejects typos with a suggestion", () => {
     const result = validateDenyCommandEntries(["system.rn"], {});
     expect(result.valid).toBe(false);

--- a/src/config/validate-deny-commands.test.ts
+++ b/src/config/validate-deny-commands.test.ts
@@ -11,6 +11,7 @@ describe("validate-deny-commands", () => {
     const known = collectAllKnownNodeCommands({});
     expect(known.has("system.run")).toBe(true);
     expect(known.has("canvas.present")).toBe(true);
+    expect(known.has("camera.snap")).toBe(true);
   });
 
   it("treats custom allowCommands entries as known", () => {
@@ -30,6 +31,19 @@ describe("validate-deny-commands", () => {
     const result = validateDenyCommandEntries(["system.rn"], {});
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toContain('Did you mean "system.run"');
+  });
+
+  it("does not suggest commands beyond the max distance", () => {
+    const result = validateDenyCommandEntries(["system.zzzzzz"], {});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).not.toContain('Did you mean "');
+  });
+
+  it("shows namespace-matched examples for unknown commands", () => {
+    const result = validateDenyCommandEntries(["camera.zzzzzz"], {});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("camera.list");
+    expect(result.errors[0]).not.toContain("canvas.present");
   });
 
   it("detects pattern-like denyCommands entries", () => {

--- a/src/config/validate-deny-commands.ts
+++ b/src/config/validate-deny-commands.ts
@@ -99,18 +99,16 @@ export function looksLikeCommandPattern(value: string): boolean {
   if (!value) {
     return false;
   }
-  if (/[?*[\]{}(),|]/.test(value)) {
+  if (value.startsWith("group:")) {
     return true;
   }
-  if (
-    value.startsWith("/") ||
-    value.endsWith("/") ||
-    value.startsWith("^") ||
-    value.endsWith("$")
-  ) {
+  if (value.includes("*") || value.includes("?")) {
     return true;
   }
-  return value.includes("group:");
+  if (value.includes("[") && value.includes("]")) {
+    return true;
+  }
+  return /^\/.+\/[a-z]*$/i.test(value);
 }
 
 export function validateDenyCommandEntries(

--- a/src/config/validate-deny-commands.ts
+++ b/src/config/validate-deny-commands.ts
@@ -10,12 +10,19 @@ export interface DenyCommandValidationResult {
 }
 
 export function collectAllKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
+  // This validator runs before full schema validation, so malformed allowCommands
+  // must not crash known-command collection.
+  const rawAllowCommands = cfg.gateway?.nodes?.allowCommands;
+  const safeAllowCommands = Array.isArray(rawAllowCommands)
+    ? rawAllowCommands.filter((value): value is string => typeof value === "string")
+    : [];
   const baseCfg: OpenClawConfig = {
     ...cfg,
     gateway: {
       ...cfg.gateway,
       nodes: {
         ...cfg.gateway?.nodes,
+        allowCommands: safeAllowCommands,
         denyCommands: [],
       },
     },

--- a/src/config/validate-deny-commands.ts
+++ b/src/config/validate-deny-commands.ts
@@ -1,4 +1,7 @@
-import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
+import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
+  resolveNodeCommandAllowlist,
+} from "../gateway/node-command-policy.js";
 import type { OpenClawConfig } from "./config.js";
 
 export interface DenyCommandValidationResult {
@@ -27,6 +30,9 @@ export function collectAllKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
         out.add(trimmed);
       }
     }
+  }
+  for (const command of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    out.add(command);
   }
   return out;
 }
@@ -59,7 +65,7 @@ function suggestClosest(entry: string, known: Set<string>, maxDistance = 3): str
   const needle = entry.toLowerCase();
   const namespace = needle.split(".")[0] ?? "";
   let best: string | null = null;
-  let bestDistance = maxDistance + 1;
+  let bestDistance = maxDistance;
   let bestSharesNamespace = false;
 
   for (const command of known) {
@@ -130,7 +136,13 @@ export function validateDenyCommandEntries(
     if (!known.has(trimmed)) {
       const suggestion = suggestClosest(trimmed, known);
       const hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
-      const examples = Array.from(known).slice(0, 5).join(", ");
+      const namespace = trimmed.split(".")[0] ?? "";
+      const namespaceMatches = namespace
+        ? Array.from(known).filter((command) => command.startsWith(`${namespace}.`))
+        : [];
+      const examples = (namespaceMatches.length > 0 ? namespaceMatches : Array.from(known))
+        .slice(0, 5)
+        .join(", ");
       errors.push(
         `Unknown command "${trimmed}" in denyCommands.${hint} Known commands include: ${examples}`,
       );

--- a/src/config/validate-deny-commands.ts
+++ b/src/config/validate-deny-commands.ts
@@ -110,7 +110,7 @@ export function looksLikeCommandPattern(value: string): boolean {
   ) {
     return true;
   }
-  return /\s/.test(value) || value.includes("group:");
+  return value.includes("group:");
 }
 
 export function validateDenyCommandEntries(

--- a/src/config/validate-deny-commands.ts
+++ b/src/config/validate-deny-commands.ts
@@ -1,0 +1,144 @@
+import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
+import type { OpenClawConfig } from "./config.js";
+
+export interface DenyCommandValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function collectAllKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
+  const baseCfg: OpenClawConfig = {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      nodes: {
+        ...cfg.gateway?.nodes,
+        denyCommands: [],
+      },
+    },
+  };
+
+  const out = new Set<string>();
+  for (const platform of ["ios", "android", "macos", "linux", "windows", "unknown"] as const) {
+    const allowlist = resolveNodeCommandAllowlist(baseCfg, { platform });
+    for (const command of allowlist) {
+      const trimmed = command.trim();
+      if (trimmed) {
+        out.add(trimmed);
+      }
+    }
+  }
+  return out;
+}
+
+function editDistance(a: string, b: string): number {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    Array<number>(b.length + 1).fill(0),
+  );
+
+  for (let i = 0; i <= a.length; i += 1) {
+    dp[i][0] = i;
+  }
+  for (let j = 0; j <= b.length; j += 1) {
+    dp[0][j] = j;
+  }
+
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+
+  return dp[a.length][b.length];
+}
+
+function suggestClosest(entry: string, known: Set<string>, maxDistance = 3): string | null {
+  const needle = entry.toLowerCase();
+  const namespace = needle.split(".")[0] ?? "";
+  let best: string | null = null;
+  let bestDistance = maxDistance + 1;
+  let bestSharesNamespace = false;
+
+  for (const command of known) {
+    const candidate = command.toLowerCase();
+    const distance = editDistance(needle, candidate);
+    if (distance > bestDistance) {
+      continue;
+    }
+    const sharesNamespace = namespace !== "" && candidate.startsWith(`${namespace}.`);
+    if (
+      distance < bestDistance ||
+      (distance === bestDistance && sharesNamespace && !bestSharesNamespace)
+    ) {
+      best = command;
+      bestDistance = distance;
+      bestSharesNamespace = sharesNamespace;
+    }
+  }
+
+  return best;
+}
+
+export function looksLikeCommandPattern(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (/[?*[\]{}(),|]/.test(value)) {
+    return true;
+  }
+  if (
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.startsWith("^") ||
+    value.endsWith("$")
+  ) {
+    return true;
+  }
+  return /\s/.test(value) || value.includes("group:");
+}
+
+export function validateDenyCommandEntries(
+  entries: unknown,
+  cfg: OpenClawConfig,
+): DenyCommandValidationResult {
+  if (!Array.isArray(entries)) {
+    return { valid: true, errors: [] };
+  }
+
+  const known = collectAllKnownNodeCommands(cfg);
+  const errors: string[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (looksLikeCommandPattern(trimmed)) {
+      errors.push(
+        `"${trimmed}" looks like a pattern, but denyCommands uses exact matching only. Use exact command names instead.`,
+      );
+      continue;
+    }
+
+    if (!known.has(trimmed)) {
+      const suggestion = suggestClosest(trimmed, known);
+      const hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+      const examples = Array.from(known).slice(0, 5).join(", ");
+      errors.push(
+        `Unknown command "${trimmed}" in denyCommands.${hint} Known commands include: ${examples}`,
+      );
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}


### PR DESCRIPTION
## Summary
- validate `gateway.nodes.denyCommands` during `openclaw config set` before write
- catch direct leaf writes plus ancestor-object writes such as `gateway.nodes={...}`
- keep custom commands valid when they are introduced via `allowCommands` in the same update

## Problem
`denyCommands` accepted unknown entries silently on `config set`. A typo like `denyCommands=["sendd"]` looked blocked but was ignored at runtime. Parent-object writes could also bypass an exact-leaf check.

## Testing
- `pnpm vitest run src/config/validate-deny-commands.test.ts src/cli/config-cli.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm exec oxlint src/cli/config-cli.ts src/cli/config-cli.test.ts src/config/validate-deny-commands.ts src/config/validate-deny-commands.test.ts`

Closes #50011
