### PR TITLE
fix(acpx): stabilize bound completion feedback routing

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1022,6 +1022,68 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBeUndefined();
   });
 
+  it("keeps bound telegram plain destinations threadless even when requester is in a topic", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-telegram-plain-bound",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-telegram-topic-bound",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+    registerSessionBindingAdapter({
+      channel: "telegram",
+      accountId: "default",
+      listBySession: (targetSessionKey: string) =>
+        targetSessionKey === "agent:main:subagent:test"
+          ? [
+              {
+                bindingId: "telegram:default:24680",
+                targetSessionKey,
+                targetKind: "subagent",
+                conversation: {
+                  channel: "telegram",
+                  accountId: "default",
+                  conversationId: "24680",
+                },
+                status: "active",
+                boundAt: Date.now(),
+              },
+            ]
+          : [],
+      resolveByConversation: () => null,
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-telegram-plain-bound",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "channel:-1003852453363",
+        accountId: "default",
+        threadId: "761",
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("channel:24680");
+    expect(call?.params?.threadId).toBeUndefined();
+  });
+
   it("routes manual completion announce agent delivery for telegram forum topics", async () => {
     sendSpy.mockClear();
     agentSpy.mockClear();

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -585,9 +585,11 @@ async function resolveSubagentCompletionOrigin(params: {
   if (route.mode === "bound" && route.binding) {
     const bindingConversationId = String(route.binding.conversation.conversationId).trim();
     if (route.binding.conversation.channel === "telegram") {
+      const bindingConversationLooksLikeTopic = /:topic:\d+$/.test(bindingConversationId);
       const canDecodeBindingTopic =
         Boolean(bindingConversationId) &&
-        (!parentConversationId || bindingConversationId !== parentConversationId);
+        (bindingConversationLooksLikeTopic ||
+          (Boolean(threadId) && bindingConversationId === threadId));
       const parsedTopic = canDecodeBindingTopic
         ? parseTelegramTopicConversation({
             conversationId: bindingConversationId,
@@ -613,7 +615,14 @@ async function resolveSubagentCompletionOrigin(params: {
         to: `channel:${bindingConversationId}`,
         threadId: route.binding.conversation.channel === "telegram" ? undefined : threadId,
       },
-      requesterOrigin,
+      route.binding.conversation.channel === "telegram"
+        ? requesterOrigin
+          ? (() => {
+              const { threadId: _threadId, ...rest } = requesterOrigin;
+              return rest;
+            })()
+          : requesterOrigin
+        : requesterOrigin,
     );
   }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,3 +1,4 @@
+import { parseTelegramTopicConversation } from "../acp/conversation-id.js";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
@@ -536,10 +537,41 @@ async function resolveSubagentCompletionOrigin(params: {
     requesterOrigin?.threadId != null && requesterOrigin.threadId !== ""
       ? String(requesterOrigin.threadId).trim()
       : undefined;
-  const conversationId =
-    threadId || (to?.startsWith("channel:") ? to.slice("channel:".length) : "");
-  const requesterConversation: ConversationRef | undefined =
-    channel && conversationId ? { channel, accountId, conversationId } : undefined;
+  const parentConversationId = to?.startsWith("channel:") ? to.slice("channel:".length) : undefined;
+  const requesterConversation: ConversationRef | undefined = (() => {
+    if (!channel) {
+      return undefined;
+    }
+    if (channel === "telegram") {
+      const parsedTopic = threadId
+        ? parseTelegramTopicConversation({
+            conversationId: threadId,
+            parentConversationId,
+          })
+        : null;
+      const conversationId =
+        parsedTopic?.canonicalConversationId || threadId || parentConversationId || "";
+      if (!conversationId) {
+        return undefined;
+      }
+      return {
+        channel,
+        accountId,
+        conversationId,
+        ...(parentConversationId ? { parentConversationId } : {}),
+      };
+    }
+    const conversationId = threadId || parentConversationId || "";
+    if (!conversationId) {
+      return undefined;
+    }
+    return {
+      channel,
+      accountId,
+      conversationId,
+      ...(parentConversationId ? { parentConversationId } : {}),
+    };
+  })();
 
   const route = createBoundDeliveryRouter().resolveDestination({
     eventKind: "task_completion",
@@ -548,15 +580,30 @@ async function resolveSubagentCompletionOrigin(params: {
     failClosed: false,
   });
   if (route.mode === "bound" && route.binding) {
+    const bindingConversationId = String(route.binding.conversation.conversationId).trim();
+    if (route.binding.conversation.channel === "telegram") {
+      const parsedTopic = parseTelegramTopicConversation({
+        conversationId: bindingConversationId,
+        parentConversationId,
+      });
+      if (parsedTopic) {
+        return mergeDeliveryContext(
+          {
+            channel: route.binding.conversation.channel,
+            accountId: route.binding.conversation.accountId,
+            to: `channel:${parsedTopic.chatId}`,
+            threadId: parsedTopic.topicId,
+          },
+          requesterOrigin,
+        );
+      }
+    }
     return mergeDeliveryContext(
       {
         channel: route.binding.conversation.channel,
         accountId: route.binding.conversation.accountId,
-        to: `channel:${route.binding.conversation.conversationId}`,
-        threadId:
-          requesterOrigin?.threadId != null && requesterOrigin.threadId !== ""
-            ? String(requesterOrigin.threadId)
-            : undefined,
+        to: `channel:${bindingConversationId}`,
+        threadId,
       },
       requesterOrigin,
     );

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -543,7 +543,10 @@ async function resolveSubagentCompletionOrigin(params: {
       return undefined;
     }
     if (channel === "telegram") {
-      const parsedTopic = threadId
+      const canDecodeRequesterTopic =
+        Boolean(threadId) &&
+        (!parentConversationId || String(threadId).trim() !== parentConversationId);
+      const parsedTopic = canDecodeRequesterTopic
         ? parseTelegramTopicConversation({
             conversationId: threadId,
             parentConversationId,
@@ -582,10 +585,15 @@ async function resolveSubagentCompletionOrigin(params: {
   if (route.mode === "bound" && route.binding) {
     const bindingConversationId = String(route.binding.conversation.conversationId).trim();
     if (route.binding.conversation.channel === "telegram") {
-      const parsedTopic = parseTelegramTopicConversation({
-        conversationId: bindingConversationId,
-        parentConversationId,
-      });
+      const canDecodeBindingTopic =
+        Boolean(bindingConversationId) &&
+        (!parentConversationId || bindingConversationId !== parentConversationId);
+      const parsedTopic = canDecodeBindingTopic
+        ? parseTelegramTopicConversation({
+            conversationId: bindingConversationId,
+            parentConversationId,
+          })
+        : null;
       if (parsedTopic) {
         return mergeDeliveryContext(
           {
@@ -603,7 +611,7 @@ async function resolveSubagentCompletionOrigin(params: {
         channel: route.binding.conversation.channel,
         accountId: route.binding.conversation.accountId,
         to: `channel:${bindingConversationId}`,
-        threadId,
+        threadId: route.binding.conversation.channel === "telegram" ? undefined : threadId,
       },
       requesterOrigin,
     );

--- a/test/issue-55-completion-origin-regression.test.mjs
+++ b/test/issue-55-completion-origin-regression.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const distRoot = new URL("../dist/", import.meta.url);
+const candidate = fs
+  .readdirSync(distRoot)
+  .find(
+    (name) =>
+      /^.*\.js$/.test(name) &&
+      fs
+        .readFileSync(new URL(`../dist/${name}`, import.meta.url), "utf8")
+        .includes("async function resolveSubagentCompletionOrigin(params) {"),
+  );
+assert.ok(candidate, "built dist file containing resolveSubagentCompletionOrigin should exist");
+
+const file = new URL(`../dist/${candidate}`, import.meta.url);
+const source = fs.readFileSync(file, "utf8");
+const start = source.indexOf("async function resolveSubagentCompletionOrigin(params) {");
+const end = source.indexOf("\nasync function sendAnnounce(item) {", start);
+assert.ok(start >= 0 && end > start, "resolveSubagentCompletionOrigin should exist");
+const fnSource = source.slice(start, end);
+
+function loadResolver(routeResult, hookRunner = null) {
+  const sandbox = {
+    parseTelegramTopicConversation({ conversationId, parentConversationId }) {
+      const direct = /^(-?\d+):topic:(\d+)$/.exec(String(conversationId).trim());
+      if (direct) {
+        return {
+          chatId: direct[1],
+          topicId: direct[2],
+          canonicalConversationId: `${direct[1]}:topic:${direct[2]}`,
+        };
+      }
+      const child = String(conversationId).trim();
+      const parent = parentConversationId == null ? "" : String(parentConversationId).trim();
+      if (/^\d+$/.test(child) && /^-?\d+$/.test(parent)) {
+        return {
+          chatId: parent,
+          topicId: child,
+          canonicalConversationId: `${parent}:topic:${child}`,
+        };
+      }
+      return null;
+    },
+    normalizeDeliveryContext(value) {
+      return value ? { ...value } : value;
+    },
+    normalizeAccountId(value) {
+      return value == null || value === "" ? "default" : String(value);
+    },
+    normalizeAccountId$1(value) {
+      return value == null || value === "" ? "default" : String(value);
+    },
+    normalizeAccountId$2(value) {
+      return value == null || value === "" ? "default" : String(value);
+    },
+    normalizeAccountId$3(value) {
+      return value == null || value === "" ? "default" : String(value);
+    },
+    createBoundDeliveryRouter() {
+      return {
+        resolveDestination(input) {
+          sandbox.capturedInput = input;
+          return routeResult;
+        },
+      };
+    },
+    mergeDeliveryContext(primary, fallback) {
+      return { ...fallback, ...primary };
+    },
+    getGlobalHookRunner() {
+      return hookRunner;
+    },
+    isDeliverableMessageChannel() {
+      return true;
+    },
+    capturedInput: null,
+  };
+  const script = new vm.Script(
+    `${fnSource}; globalThis.resolver = resolveSubagentCompletionOrigin;`,
+  );
+  vm.createContext(sandbox);
+  script.runInContext(sandbox);
+  return { resolver: sandbox.resolver, sandbox };
+}
+
+{
+  const { resolver, sandbox } = loadResolver({
+    mode: "bound",
+    binding: {
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1003852453363:topic:761",
+      },
+    },
+  });
+  const result = await resolver({
+    childSessionKey: "agent:coding:subagent:child",
+    requesterSessionKey: "agent:main:telegram:group:-1003852453363:topic:761",
+    requesterOrigin: {
+      channel: "telegram",
+      accountId: "default",
+      to: "channel:-1003852453363",
+      threadId: "761",
+    },
+    childRunId: "run-1",
+    spawnMode: "run",
+    expectsCompletionMessage: true,
+  });
+  assert.equal(sandbox.capturedInput.requester.conversationId, "-1003852453363:topic:761");
+  assert.equal(sandbox.capturedInput.requester.parentConversationId, "-1003852453363");
+  assert.deepEqual(result, {
+    channel: "telegram",
+    accountId: "default",
+    to: "channel:-1003852453363",
+    threadId: "761",
+  });
+}
+
+{
+  const { resolver, sandbox } = loadResolver({
+    mode: "bound",
+    binding: {
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "123-thread",
+      },
+    },
+  });
+  const result = await resolver({
+    childSessionKey: "agent:coding:subagent:child",
+    requesterSessionKey: "agent:main:discord:thread:123-thread",
+    requesterOrigin: {
+      channel: "discord",
+      accountId: "default",
+      to: "channel:999-parent",
+      threadId: "123-thread",
+    },
+    childRunId: "run-2",
+    spawnMode: "run",
+    expectsCompletionMessage: true,
+  });
+  assert.equal(sandbox.capturedInput.requester.conversationId, "123-thread");
+  assert.deepEqual(result, {
+    channel: "discord",
+    accountId: "default",
+    to: "channel:123-thread",
+    threadId: "123-thread",
+  });
+}
+
+console.log("issue-55 completion origin regression checks passed");

--- a/test/issue-55-completion-origin-regression.test.mjs
+++ b/test/issue-55-completion-origin-regression.test.mjs
@@ -124,6 +124,38 @@ function loadResolver(routeResult, hookRunner = null) {
     mode: "bound",
     binding: {
       conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "123456789",
+      },
+    },
+  });
+  const result = await resolver({
+    childSessionKey: "agent:coding:subagent:child",
+    requesterSessionKey: "agent:main:telegram:direct:123456789",
+    requesterOrigin: {
+      channel: "telegram",
+      accountId: "default",
+      to: "channel:123456789",
+      threadId: "123456789",
+    },
+    childRunId: "run-dm",
+    spawnMode: "run",
+    expectsCompletionMessage: true,
+  });
+  assert.equal(sandbox.capturedInput.requester.conversationId, "123456789");
+  assert.equal(sandbox.capturedInput.requester.parentConversationId, "123456789");
+  assert.equal(result.channel, "telegram");
+  assert.equal(result.accountId, "default");
+  assert.equal(result.to, "channel:123456789");
+  assert.equal(result.threadId, undefined);
+}
+
+{
+  const { resolver, sandbox } = loadResolver({
+    mode: "bound",
+    binding: {
+      conversation: {
         channel: "discord",
         accountId: "default",
         conversationId: "123-thread",


### PR DESCRIPTION
## Summary
Stabilize ACPX/subagent completion feedback routing for Telegram topic-bound conversations.

## What changed
- normalize Telegram `to + threadId` into canonical conversation id before bound match
- restore Telegram completion targets into deliverable form after match:
  - `to=channel:<chatId>`
  - `threadId=<topicId>`
- preserve fallback behavior for non-Telegram / no-binding / hook paths
- add regression coverage for completion-origin routing

## Validation
- `pnpm build`
- `node test/issue-55-completion-origin-regression.test.mjs`

## Files
- `src/agents/subagent-announce.ts`
- `test/issue-55-completion-origin-regression.test.mjs`

## Issue linkage
Refs #55
Refs #53
