### PR TITLE
docs(cron): clarify routing metadata should stay out of user-facing output

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -187,6 +187,10 @@ Delivery config:
 Announce delivery suppresses messaging tool sends for the run; use `delivery.channel`/`delivery.to`
 to target the chat instead. When `delivery.mode = "none"`, no summary is posted to the main session.
 
+When writing isolated job prompts, avoid embedding routing text (for example: "send to telegram:...")
+in user-facing output templates. Keep delivery routing in top-level `delivery` config so end-users see
+only the intended report content.
+
 If `delivery` is omitted for isolated jobs, OpenClaw defaults to `announce`.
 
 #### Announce delivery flow


### PR DESCRIPTION
This docs tweak comes from a real usage issue we hit with cron-delivered reports.

In practice, some isolated cron prompts included routing lines (for example destination/channel instructions), and those lines could end up in the user-facing message text. That makes delivered reports noisy and confusing.

This change clarifies the intended pattern:
- keep routing in top-level `delivery` config
- keep prompt/report templates focused on user-visible content only

Files changed:
- `docs/automation/cron-jobs.md` only
