### PR TITLE
fix: use explicit agent workspace when writing transcript headers

### DIFF
--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -19,6 +19,12 @@ import {
   listNormalizedMatrixAccountIds,
 } from "../account-config.js";
 import { resolveMatrixConfigFieldPath } from "../config-update.js";
+import {
+  credentialsMatchConfig,
+  loadMatrixCredentials,
+  saveMatrixCredentials,
+  touchMatrixCredentials,
+} from "../credentials.js";
 import { MatrixClient } from "../sdk.js";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
@@ -338,13 +344,6 @@ export async function resolveMatrixAuth(params?: {
 }): Promise<MatrixAuth> {
   const { cfg, env, accountId, resolved } = resolveMatrixAuthContext(params);
   const homeserver = validateMatrixHomeserverUrl(resolved.homeserver);
-
-  const {
-    loadMatrixCredentials,
-    saveMatrixCredentials,
-    credentialsMatchConfig,
-    touchMatrixCredentials,
-  } = await import("../credentials.js");
 
   const cached = loadMatrixCredentials(env, accountId);
   const cachedCredentials =

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -1,17 +1,9 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { expect, vi } from "vitest";
 import {
   __testing as discordThreadBindingTesting,
   createThreadBindingManager as createDiscordThreadBindingManager,
 } from "../../../../extensions/discord/runtime-api.js";
 import { createFeishuThreadBindingManager } from "../../../../extensions/feishu/api.js";
-import {
-  createMatrixThreadBindingManager,
-  resetMatrixThreadBindingsForTests,
-} from "../../../../extensions/matrix/src/matrix/thread-bindings.js";
-import { setMatrixRuntime } from "../../../../extensions/matrix/src/runtime.js";
 import { createTelegramThreadBindingManager } from "../../../../extensions/telegram/runtime-api.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
@@ -183,14 +175,6 @@ function expectClearedSessionBinding(params: {
 
 const telegramDescribeMessageToolMock = vi.fn();
 const discordDescribeMessageToolMock = vi.fn();
-const sendMessageMatrixMock = vi.hoisted(() =>
-  vi.fn(async () => ({ messageId: "$matrix-contract", roomId: "!room:example" })),
-);
-
-vi.mock("fake-indexeddb/auto", () => ({}));
-vi.mock("../../../../extensions/matrix/src/matrix/send.js", () => ({
-  sendMessageMatrix: sendMessageMatrixMock,
-}));
 
 bundledChannelRuntimeSetters.setTelegramRuntime({
   channel: {
@@ -220,43 +204,6 @@ bundledChannelRuntimeSetters.setLineRuntime({
       resolveLineAccount: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string }) =>
         resolveLineAccount({ cfg, accountId }),
     },
-  },
-} as never);
-
-const matrixContractStateDirs = new Set<string>();
-const MATRIX_CONTRACT_STATE_DIR_ENV = "OPENCLAW_MATRIX_CONTRACT_STATE_DIR";
-const matrixAuth = {
-  accountId: "default",
-  homeserver: "https://matrix.example.org",
-  userId: "@ops:example.org",
-  accessToken: "matrix-contract-token",
-  deviceId: "DEVICEID",
-};
-
-function createMatrixContractEnv(): NodeJS.ProcessEnv {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-contracts-"));
-  matrixContractStateDirs.add(stateDir);
-  return {
-    ...process.env,
-    [MATRIX_CONTRACT_STATE_DIR_ENV]: stateDir,
-  };
-}
-
-function cleanupMatrixContractState(): void {
-  for (const stateDir of matrixContractStateDirs) {
-    fs.rmSync(stateDir, { recursive: true, force: true });
-  }
-  matrixContractStateDirs.clear();
-}
-
-export function resetMatrixSessionBindingContractStateForTests(): void {
-  resetMatrixThreadBindingsForTests();
-  cleanupMatrixContractState();
-}
-
-setMatrixRuntime({
-  state: {
-    resolveStateDir: (env) => env[MATRIX_CONTRACT_STATE_DIR_ENV] ?? os.tmpdir(),
   },
 } as never);
 
@@ -770,62 +717,15 @@ export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
       placements: ["current", "child"],
     },
     getCapabilities: async () => {
-      await createMatrixThreadBindingManager({
-        accountId: "default",
-        auth: matrixAuth,
-        client: {} as never,
-        env: createMatrixContractEnv(),
-        idleTimeoutMs: 24 * 60 * 60 * 1000,
-        maxAgeMs: 0,
-        enableSweeper: false,
-      });
-      return getSessionBindingService().getCapabilities({
-        channel: "matrix",
-        accountId: "default",
-      });
+      throw new Error("Matrix session binding test harness not installed");
     },
     bindAndResolve: async () => {
-      await createMatrixThreadBindingManager({
-        accountId: "default",
-        auth: matrixAuth,
-        client: {} as never,
-        env: createMatrixContractEnv(),
-        idleTimeoutMs: 24 * 60 * 60 * 1000,
-        maxAgeMs: 0,
-        enableSweeper: false,
-      });
-      const service = getSessionBindingService();
-      const binding = await service.bind({
-        targetSessionKey: "agent:matrix:subagent:child-1",
-        targetKind: "subagent",
-        conversation: {
-          channel: "matrix",
-          accountId: "default",
-          conversationId: "$thread-1",
-          parentConversationId: "!room:example",
-        },
-        placement: "current",
-        metadata: {
-          label: "codex-matrix",
-        },
-      });
-      expectResolvedSessionBinding({
-        channel: "matrix",
-        accountId: "default",
-        conversationId: "$thread-1",
-        targetSessionKey: "agent:matrix:subagent:child-1",
-      });
-      return binding;
+      throw new Error("Matrix session binding test harness not installed");
     },
-    unbindAndVerify: unbindAndExpectClearedSessionBinding,
-    cleanup: async () => {
-      resetMatrixSessionBindingContractStateForTests();
-      expectClearedSessionBinding({
-        channel: "matrix",
-        accountId: "default",
-        conversationId: "$thread-1",
-      });
+    unbindAndVerify: async () => {
+      throw new Error("Matrix session binding test harness not installed");
     },
+    cleanup: () => {},
   },
   {
     id: "telegram",

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -1,9 +1,17 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expect, vi } from "vitest";
 import {
   __testing as discordThreadBindingTesting,
   createThreadBindingManager as createDiscordThreadBindingManager,
 } from "../../../../extensions/discord/runtime-api.js";
 import { createFeishuThreadBindingManager } from "../../../../extensions/feishu/api.js";
+import {
+  createMatrixThreadBindingManager,
+  resetMatrixThreadBindingsForTests,
+} from "../../../../extensions/matrix/src/matrix/thread-bindings.js";
+import { setMatrixRuntime } from "../../../../extensions/matrix/src/runtime.js";
 import { createTelegramThreadBindingManager } from "../../../../extensions/telegram/runtime-api.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
@@ -126,7 +134,7 @@ type DirectoryContractEntry = {
 type SessionBindingContractEntry = {
   id: string;
   expectedCapabilities: SessionBindingCapabilities;
-  getCapabilities: () => SessionBindingCapabilities;
+  getCapabilities: () => SessionBindingCapabilities | Promise<SessionBindingCapabilities>;
   bindAndResolve: () => Promise<SessionBindingRecord>;
   unbindAndVerify: (binding: SessionBindingRecord) => Promise<void>;
   cleanup: () => Promise<void> | void;
@@ -175,6 +183,14 @@ function expectClearedSessionBinding(params: {
 
 const telegramDescribeMessageToolMock = vi.fn();
 const discordDescribeMessageToolMock = vi.fn();
+const sendMessageMatrixMock = vi.hoisted(() =>
+  vi.fn(async () => ({ messageId: "$matrix-contract", roomId: "!room:example" })),
+);
+
+vi.mock("fake-indexeddb/auto", () => ({}));
+vi.mock("../../../../extensions/matrix/src/matrix/send.js", () => ({
+  sendMessageMatrix: sendMessageMatrixMock,
+}));
 
 bundledChannelRuntimeSetters.setTelegramRuntime({
   channel: {
@@ -204,6 +220,43 @@ bundledChannelRuntimeSetters.setLineRuntime({
       resolveLineAccount: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string }) =>
         resolveLineAccount({ cfg, accountId }),
     },
+  },
+} as never);
+
+const matrixContractStateDirs = new Set<string>();
+const MATRIX_CONTRACT_STATE_DIR_ENV = "OPENCLAW_MATRIX_CONTRACT_STATE_DIR";
+const matrixAuth = {
+  accountId: "default",
+  homeserver: "https://matrix.example.org",
+  userId: "@ops:example.org",
+  accessToken: "matrix-contract-token",
+  deviceId: "DEVICEID",
+};
+
+function createMatrixContractEnv(): NodeJS.ProcessEnv {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-contracts-"));
+  matrixContractStateDirs.add(stateDir);
+  return {
+    ...process.env,
+    [MATRIX_CONTRACT_STATE_DIR_ENV]: stateDir,
+  };
+}
+
+function cleanupMatrixContractState(): void {
+  for (const stateDir of matrixContractStateDirs) {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+  matrixContractStateDirs.clear();
+}
+
+export function resetMatrixSessionBindingContractStateForTests(): void {
+  resetMatrixThreadBindingsForTests();
+  cleanupMatrixContractState();
+}
+
+setMatrixRuntime({
+  state: {
+    resolveStateDir: (env) => env[MATRIX_CONTRACT_STATE_DIR_ENV] ?? os.tmpdir(),
   },
 } as never);
 
@@ -705,6 +758,72 @@ export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
         channel: "feishu",
         accountId: "default",
         conversationId: "oc_group_chat:topic:om_topic_root",
+      });
+    },
+  },
+  {
+    id: "matrix",
+    expectedCapabilities: {
+      adapterAvailable: true,
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current", "child"],
+    },
+    getCapabilities: async () => {
+      await createMatrixThreadBindingManager({
+        accountId: "default",
+        auth: matrixAuth,
+        client: {} as never,
+        env: createMatrixContractEnv(),
+        idleTimeoutMs: 24 * 60 * 60 * 1000,
+        maxAgeMs: 0,
+        enableSweeper: false,
+      });
+      return getSessionBindingService().getCapabilities({
+        channel: "matrix",
+        accountId: "default",
+      });
+    },
+    bindAndResolve: async () => {
+      await createMatrixThreadBindingManager({
+        accountId: "default",
+        auth: matrixAuth,
+        client: {} as never,
+        env: createMatrixContractEnv(),
+        idleTimeoutMs: 24 * 60 * 60 * 1000,
+        maxAgeMs: 0,
+        enableSweeper: false,
+      });
+      const service = getSessionBindingService();
+      const binding = await service.bind({
+        targetSessionKey: "agent:matrix:subagent:child-1",
+        targetKind: "subagent",
+        conversation: {
+          channel: "matrix",
+          accountId: "default",
+          conversationId: "$thread-1",
+          parentConversationId: "!room:example",
+        },
+        placement: "current",
+        metadata: {
+          label: "codex-matrix",
+        },
+      });
+      expectResolvedSessionBinding({
+        channel: "matrix",
+        accountId: "default",
+        conversationId: "$thread-1",
+        targetSessionKey: "agent:matrix:subagent:child-1",
+      });
+      return binding;
+    },
+    unbindAndVerify: unbindAndExpectClearedSessionBinding,
+    cleanup: async () => {
+      resetMatrixSessionBindingContractStateForTests();
+      expectClearedSessionBinding({
+        channel: "matrix",
+        accountId: "default",
+        conversationId: "$thread-1",
       });
     },
   },

--- a/src/channels/plugins/contracts/session-binding.contract.test.ts
+++ b/src/channels/plugins/contracts/session-binding.contract.test.ts
@@ -60,7 +60,7 @@ function resetMatrixSessionBindingContractStateForTests(): void {
 
 setMatrixRuntime({
   state: {
-    resolveStateDir: (env) => env[MATRIX_CONTRACT_STATE_DIR_ENV] ?? os.tmpdir(),
+    resolveStateDir: (env: NodeJS.ProcessEnv) => env[MATRIX_CONTRACT_STATE_DIR_ENV] ?? os.tmpdir(),
   },
 } as never);
 

--- a/src/channels/plugins/contracts/session-binding.contract.test.ts
+++ b/src/channels/plugins/contracts/session-binding.contract.test.ts
@@ -3,13 +3,17 @@ import { __testing as discordThreadBindingTesting } from "../../../../extensions
 import { __testing as feishuThreadBindingTesting } from "../../../../extensions/feishu/src/thread-bindings.js";
 import { __testing as telegramThreadBindingTesting } from "../../../../extensions/telegram/src/thread-bindings.js";
 import { __testing as sessionBindingTesting } from "../../../infra/outbound/session-binding-service.js";
-import { sessionBindingContractRegistry } from "./registry.js";
+import {
+  resetMatrixSessionBindingContractStateForTests,
+  sessionBindingContractRegistry,
+} from "./registry.js";
 import { installSessionBindingContractSuite } from "./suites.js";
 
 beforeEach(() => {
   sessionBindingTesting.resetSessionBindingAdaptersForTests();
   discordThreadBindingTesting.resetThreadBindingsForTests();
   feishuThreadBindingTesting.resetFeishuThreadBindingsForTests();
+  resetMatrixSessionBindingContractStateForTests();
   telegramThreadBindingTesting.resetTelegramThreadBindingsForTests();
 });
 

--- a/src/channels/plugins/contracts/session-binding.contract.test.ts
+++ b/src/channels/plugins/contracts/session-binding.contract.test.ts
@@ -1,13 +1,148 @@
-import { beforeEach, describe } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, vi } from "vitest";
 import { __testing as discordThreadBindingTesting } from "../../../../extensions/discord/src/monitor/thread-bindings.manager.js";
 import { __testing as feishuThreadBindingTesting } from "../../../../extensions/feishu/src/thread-bindings.js";
-import { __testing as telegramThreadBindingTesting } from "../../../../extensions/telegram/src/thread-bindings.js";
-import { __testing as sessionBindingTesting } from "../../../infra/outbound/session-binding-service.js";
 import {
-  resetMatrixSessionBindingContractStateForTests,
-  sessionBindingContractRegistry,
-} from "./registry.js";
+  createMatrixThreadBindingManager,
+  resetMatrixThreadBindingsForTests,
+} from "../../../../extensions/matrix/src/matrix/thread-bindings.js";
+import { setMatrixRuntime } from "../../../../extensions/matrix/src/runtime.js";
+import { __testing as telegramThreadBindingTesting } from "../../../../extensions/telegram/src/thread-bindings.js";
+import {
+  __testing as sessionBindingTesting,
+  getSessionBindingService,
+  type SessionBindingRecord,
+} from "../../../infra/outbound/session-binding-service.js";
+import { sessionBindingContractRegistry } from "./registry.js";
 import { installSessionBindingContractSuite } from "./suites.js";
+
+const sendMessageMatrixMock = vi.hoisted(() =>
+  vi.fn(async () => ({ messageId: "$matrix-contract", roomId: "!room:example" })),
+);
+
+vi.mock("fake-indexeddb/auto", () => ({}));
+vi.mock("../../../../extensions/matrix/src/matrix/send.js", () => ({
+  sendMessageMatrix: sendMessageMatrixMock,
+}));
+
+const matrixContractStateDirs = new Set<string>();
+const MATRIX_CONTRACT_STATE_DIR_ENV = "OPENCLAW_MATRIX_CONTRACT_STATE_DIR";
+const matrixAuth = {
+  accountId: "default",
+  homeserver: "https://matrix.example.org",
+  userId: "@ops:example.org",
+  accessToken: "matrix-contract-token",
+  deviceId: "DEVICEID",
+};
+
+function createMatrixContractEnv(): NodeJS.ProcessEnv {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-contracts-"));
+  matrixContractStateDirs.add(stateDir);
+  return {
+    ...process.env,
+    [MATRIX_CONTRACT_STATE_DIR_ENV]: stateDir,
+  };
+}
+
+function cleanupMatrixContractState(): void {
+  for (const stateDir of matrixContractStateDirs) {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+  matrixContractStateDirs.clear();
+}
+
+function resetMatrixSessionBindingContractStateForTests(): void {
+  resetMatrixThreadBindingsForTests();
+  cleanupMatrixContractState();
+}
+
+setMatrixRuntime({
+  state: {
+    resolveStateDir: (env) => env[MATRIX_CONTRACT_STATE_DIR_ENV] ?? os.tmpdir(),
+  },
+} as never);
+
+const matrixEntry = sessionBindingContractRegistry.find((entry) => entry.id === "matrix");
+if (!matrixEntry) {
+  throw new Error("Matrix session binding contract entry is missing");
+}
+
+Object.assign(matrixEntry, {
+  getCapabilities: async () => {
+    await createMatrixThreadBindingManager({
+      accountId: "default",
+      auth: matrixAuth,
+      client: {} as never,
+      env: createMatrixContractEnv(),
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+      enableSweeper: false,
+    });
+    return getSessionBindingService().getCapabilities({
+      channel: "matrix",
+      accountId: "default",
+    });
+  },
+  bindAndResolve: async () => {
+    await createMatrixThreadBindingManager({
+      accountId: "default",
+      auth: matrixAuth,
+      client: {} as never,
+      env: createMatrixContractEnv(),
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+      enableSweeper: false,
+    });
+    const service = getSessionBindingService();
+    const binding = await service.bind({
+      targetSessionKey: "agent:matrix:subagent:child-1",
+      targetKind: "subagent",
+      conversation: {
+        channel: "matrix",
+        accountId: "default",
+        conversationId: "$thread-1",
+        parentConversationId: "!room:example",
+      },
+      placement: "current",
+      metadata: {
+        label: "codex-matrix",
+      },
+    });
+    expect(
+      service.resolveByConversation({
+        channel: "matrix",
+        accountId: "default",
+        conversationId: "$thread-1",
+        parentConversationId: "!room:example",
+      }),
+    )?.toMatchObject({
+      targetSessionKey: "agent:matrix:subagent:child-1",
+    });
+    return binding;
+  },
+  unbindAndVerify: async (binding: SessionBindingRecord) => {
+    const service = getSessionBindingService();
+    const removed = await service.unbind({
+      bindingId: binding.bindingId,
+      reason: "contract-test",
+    });
+    expect(removed.map((entry) => entry.bindingId)).toContain(binding.bindingId);
+    expect(service.resolveByConversation(binding.conversation)).toBeNull();
+  },
+  cleanup: async () => {
+    resetMatrixSessionBindingContractStateForTests();
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "matrix",
+        accountId: "default",
+        conversationId: "$thread-1",
+        parentConversationId: "!room:example",
+      }),
+    ).toBeNull();
+  },
+});
 
 beforeEach(() => {
   sessionBindingTesting.resetSessionBindingAdaptersForTests();

--- a/src/channels/plugins/contracts/suites.ts
+++ b/src/channels/plugins/contracts/suites.ts
@@ -478,14 +478,16 @@ export function installChannelDirectoryContractSuite(params: {
 }
 
 export function installSessionBindingContractSuite(params: {
-  getCapabilities: () => SessionBindingCapabilities;
+  getCapabilities: () => SessionBindingCapabilities | Promise<SessionBindingCapabilities>;
   bindAndResolve: () => Promise<SessionBindingRecord>;
   unbindAndVerify: (binding: SessionBindingRecord) => Promise<void>;
   cleanup: () => Promise<void> | void;
   expectedCapabilities: SessionBindingCapabilities;
 }) {
-  it("registers the expected session binding capabilities", () => {
-    expect(params.getCapabilities()).toEqual(params.expectedCapabilities);
+  it("registers the expected session binding capabilities", async () => {
+    await expect(Promise.resolve(params.getCapabilities())).resolves.toEqual(
+      params.expectedCapabilities,
+    );
   });
 
   it("binds and resolves a session binding through the shared service", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "./types.js";
+
+const state = vi.hoisted(() => ({
+  sessionFile: "",
+  store: {} as Record<string, SessionEntry>,
+  appendMessage: vi.fn(),
+}));
+
+vi.mock("../io.js", () => ({
+  loadConfig: () => ({
+    agents: {
+      list: [{ id: "sunke", default: true }],
+    },
+  }),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "sunke",
+  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) =>
+    `/Users/admin/.openclaw/workspace-${agentId}`,
+}));
+
+vi.mock("../../sessions/transcript-events.js", () => ({
+  emitSessionTranscriptUpdate: vi.fn(),
+}));
+
+vi.mock("./delivery-info.js", () => ({
+  parseSessionThreadInfo: () => ({ baseSessionKey: undefined, threadId: undefined }),
+}));
+
+vi.mock("./paths.js", () => ({
+  resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
+  resolveSessionFilePath: () => state.sessionFile,
+  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionTranscriptPath: () => state.sessionFile,
+}));
+
+vi.mock("./session-file.js", () => ({
+  resolveAndPersistSessionFile: async () => ({
+    sessionFile: state.sessionFile,
+    sessionEntry: state.store["agent:main:test:user-1"],
+  }),
+}));
+
+vi.mock("./store.js", () => ({
+  loadSessionStore: () => state.store,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+  CURRENT_SESSION_VERSION: 2,
+  SessionManager: {
+    open: () => ({
+      appendMessage: state.appendMessage,
+    }),
+  },
+}));
+
+let appendAssistantMessageToSessionTranscript: typeof import("./transcript.js").appendAssistantMessageToSessionTranscript;
+let originalCwd = process.cwd();
+
+beforeEach(async () => {
+  vi.resetModules();
+  state.appendMessage = vi.fn();
+  state.store = {
+    "agent:main:test:user-1": {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+    } as SessionEntry,
+  };
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-"));
+  const wrongWorkspace = path.join(tmpRoot, "wrong-workspace");
+  fs.mkdirSync(wrongWorkspace, { recursive: true });
+  process.chdir(wrongWorkspace);
+
+  state.sessionFile = path.join(tmpRoot, "sessions", "session-1.jsonl");
+  ({ appendAssistantMessageToSessionTranscript } = await import("./transcript.js"));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+});
+
+describe("appendAssistantMessageToSessionTranscript", () => {
+  it("writes the session header cwd from the target agent workspace instead of process.cwd()", async () => {
+    const result = await appendAssistantMessageToSessionTranscript({
+      agentId: "sunke",
+      sessionKey: "agent:main:test:user-1",
+      text: "hello",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      sessionFile: state.sessionFile,
+    });
+
+    const [headerLine] = fs.readFileSync(state.sessionFile, "utf-8").split(/\r?\n/);
+    const header = JSON.parse(headerLine) as { cwd?: string };
+
+    expect(header.cwd).toBe("/Users/admin/.openclaw/workspace-sunke");
+    expect(header.cwd).not.toBe(process.cwd());
+  });
+});

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -7,7 +7,7 @@ import type { SessionEntry } from "./types.js";
 const state = vi.hoisted(() => ({
   sessionFile: "",
   store: {} as Record<string, SessionEntry>,
-  appendMessage: vi.fn(),
+  appendMessage: vi.fn(() => "message-1"),
 }));
 
 vi.mock("../io.js", () => ({
@@ -51,6 +51,7 @@ vi.mock("./session-file.js", () => ({
 
 vi.mock("./store.js", () => ({
   loadSessionStore: () => state.store,
+  normalizeStoreSessionKey: (sessionKey: string) => sessionKey.trim(),
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
@@ -67,7 +68,7 @@ let originalCwd = process.cwd();
 
 beforeEach(async () => {
   vi.resetModules();
-  state.appendMessage = vi.fn();
+  state.appendMessage = vi.fn(() => "message-1");
   state.store = {
     "agent:main:test:user-1": {
       sessionId: "session-1",
@@ -99,6 +100,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(result).toEqual({
       ok: true,
       sessionFile: state.sessionFile,
+      messageId: "message-1",
     });
 
     const [headerLine] = fs.readFileSync(state.sessionFile, "utf-8").split(/\r?\n/);

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -35,7 +35,10 @@ vi.mock("./delivery-info.js", () => ({
 vi.mock("./paths.js", () => ({
   resolveDefaultSessionStorePath: () => "/tmp/session-store.json",
   resolveSessionFilePath: () => state.sessionFile,
-  resolveSessionFilePathOptions: () => ({ agentId: "sunke", sessionsDir: path.dirname(state.sessionFile) }),
+  resolveSessionFilePathOptions: () => ({
+    agentId: "sunke",
+    sessionsDir: path.dirname(state.sessionFile),
+  }),
   resolveSessionTranscriptPath: () => state.sessionFile,
 }));
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -75,11 +75,6 @@ async function ensureSessionHeader(params: {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
-  const cfg = loadConfig();
-  const agentId =
-    typeof params.agentId === "string" && params.agentId.trim()
-      ? params.agentId.trim()
-      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -75,6 +75,11 @@ async function ensureSessionHeader(params: {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { loadConfig } from "../io.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
   resolveDefaultSessionStorePath,
@@ -67,6 +69,7 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  cwd: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
@@ -77,7 +80,7 @@ async function ensureSessionHeader(params: {
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd: params.cwd,
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -159,6 +162,12 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
+  const cfg = loadConfig();
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim()
+      ? params.agentId.trim()
+      : resolveDefaultAgentId(cfg);
+  const sessionCwd = resolveAgentWorkspaceDir(cfg, agentId);
 
   let sessionFile: string;
   try {
@@ -179,7 +188,11 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    cwd: sessionCwd,
+  });
 
   const existingMessageId = params.idempotencyKey
     ? await transcriptHasIdempotencyKey(sessionFile, params.idempotencyKey)


### PR DESCRIPTION
## Summary
- stop deriving transcript header `cwd` from `process.cwd()`
- resolve the target agent workspace explicitly before writing a new transcript header
- add a regression test covering per-agent cwd isolation for mirrored transcript appends

## Verification
- `pnpm oxlint --type-aware src/config/sessions/transcript.ts src/config/sessions/transcript.test.ts`
- `pnpm vitest run src/config/sessions/transcript.test.ts`

## Notes
- This PR intentionally narrows scope to the transcript cwd fix and its regression test.
- It supersedes #49966 for reviewability.
- `CI=1 pnpm check` on the latest local `upstream/main` currently also hits unrelated baseline errors around `@tloncorp/api`; I did not fold those unrelated fixes into this PR.

Closes #49523