### PR TITLE
[codex] export imessage-core plugin-sdk subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,6 +241,10 @@
       "types": "./dist/plugin-sdk/imessage.d.ts",
       "default": "./dist/plugin-sdk/imessage.js"
     },
+    "./plugin-sdk/imessage-core": {
+      "types": "./dist/plugin-sdk/imessage-core.d.ts",
+      "default": "./dist/plugin-sdk/imessage-core.js"
+    },
     "./plugin-sdk/open-prose": {
       "types": "./dist/plugin-sdk/open-prose.d.ts",
       "default": "./dist/plugin-sdk/open-prose.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -50,6 +50,7 @@
   "slack",
   "slack-core",
   "imessage",
+  "imessage-core",
   "open-prose",
   "phone-control",
   "qwen-portal-auth",


### PR DESCRIPTION
## Summary
This fixes a packaging regression in the exported plugin SDK surface. The `imessage-core` source entrypoint exists in the repository and is consumed by the BlueBubbles extension, but it was missing from the package export map and from the generated plugin-sdk entrypoint inventory.

In practice that means source builds can succeed while the running gateway fails to load BlueBubbles at runtime after the dist output is generated. The failure shows up as a missing `openclaw/plugin-sdk/imessage-core` subpath during plugin load, which prevents the extension from starting.

## Root cause
Two packaging lists had drifted from the actual source tree:
- `package.json` did not export `./plugin-sdk/imessage-core`
- `scripts/lib/plugin-sdk-entrypoints.json` did not include `imessage-core`

The plugin loader and build output only expose the subpaths listed there, so the runtime alias package in `dist/plugin-sdk` never emitted the `imessage-core` entrypoint even though the TypeScript source file exists.

## Fix
The change adds `imessage-core` to both places that define the public plugin-sdk contract:
- the package `exports` map
- the generated plugin-sdk entrypoint inventory

That keeps the source tree, package contract, and dist/runtime alias output aligned.

## Validation
I validated this locally by:
- rebuilding from source with `pnpm build`
- rebuilding the Control UI with `pnpm ui:build`
- restarting the local OpenClaw launch agents
- confirming the gateway health check returned `200 OK`
- confirming BlueBubbles loaded successfully after restart instead of failing on the missing subpath

## Contribution Notes
- AI-assisted: yes (`Codex`)
- Testing degree: lightly tested
- Review thread handling: addressed and resolved where applicable before re-requesting review
