### PR TITLE
fix(ui): preserve sub-cent usage costs in dashboard

### DIFF
--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -4,6 +4,7 @@ import {
   mergeUsageDailyLatency,
   mergeUsageLatency,
 } from "../../../../src/shared/usage-aggregates.js";
+import { formatCost as formatUiCost } from "../format.ts";
 import { UsageSessionEntry, UsageTotals, UsageAggregates } from "./usageTypes.ts";
 
 const CHARS_PER_TOKEN = 4;
@@ -258,8 +259,14 @@ function renderUsageMosaic(
   `;
 }
 
-function formatCost(n: number, decimals = 2): string {
-  return `$${n.toFixed(decimals)}`;
+function formatCost(n: number, decimals?: number): string {
+  if (!Number.isFinite(n)) {
+    return "$0.00";
+  }
+  if (typeof decimals === "number") {
+    return `$${n.toFixed(decimals)}`;
+  }
+  return formatUiCost(n);
 }
 
 function formatIsoDate(date: Date): string {

--- a/ui/src/ui/views/usage-render-details.test.ts
+++ b/ui/src/ui/views/usage-render-details.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { formatCost } from "./usage-metrics.ts";
 import {
   computeFilteredUsage,
   CHART_BAR_WIDTH_RATIO,
   CHART_MAX_BAR_WIDTH,
 } from "./usage-render-details.ts";
-import { formatCost } from "./usage-metrics.ts";
 import type { TimeSeriesPoint, UsageSessionEntry } from "./usageTypes.ts";
 
 function makePoint(overrides: Partial<TimeSeriesPoint> = {}): TimeSeriesPoint {

--- a/ui/src/ui/views/usage-render-details.test.ts
+++ b/ui/src/ui/views/usage-render-details.test.ts
@@ -4,6 +4,7 @@ import {
   CHART_BAR_WIDTH_RATIO,
   CHART_MAX_BAR_WIDTH,
 } from "./usage-render-details.ts";
+import { formatCost } from "./usage-metrics.ts";
 import type { TimeSeriesPoint, UsageSessionEntry } from "./usageTypes.ts";
 
 function makePoint(overrides: Partial<TimeSeriesPoint> = {}): TimeSeriesPoint {
@@ -132,5 +133,23 @@ describe("chart bar sizing", () => {
         expect(barGap).toBeGreaterThanOrEqual(0);
       }
     }
+  });
+});
+
+describe("usage cost formatting", () => {
+  it("preserves sub-cent cache costs instead of rounding them to zero", () => {
+    expect(formatCost(0.0047)).toBe("$0.0047");
+  });
+
+  it("keeps three decimals for costs below one dollar by default", () => {
+    expect(formatCost(0.125)).toBe("$0.125");
+  });
+
+  it("allows explicit precision overrides for derived metrics", () => {
+    expect(formatCost(0.125, 4)).toBe("$0.1250");
+  });
+
+  it("falls back to a zero-dollar string for invalid values", () => {
+    expect(formatCost(Number.NaN)).toBe("$0.00");
   });
 });

--- a/ui/src/ui/views/usage-render-details.test.ts
+++ b/ui/src/ui/views/usage-render-details.test.ts
@@ -141,8 +141,16 @@ describe("usage cost formatting", () => {
     expect(formatCost(0.0047)).toBe("$0.0047");
   });
 
+  it("renders exactly zero as $0.00", () => {
+    expect(formatCost(0)).toBe("$0.00");
+  });
+
   it("keeps three decimals for costs below one dollar by default", () => {
     expect(formatCost(0.125)).toBe("$0.125");
+  });
+
+  it("uses two decimals for costs at or above one dollar", () => {
+    expect(formatCost(1.5)).toBe("$1.50");
   });
 
   it("allows explicit precision overrides for derived metrics", () => {


### PR DESCRIPTION
﻿## Summary

- Problem: the Usage dashboard formatted costs with a local `toFixed(2)` helper, so sub-cent cached token costs such as `$0.0047` were displayed as `$0.00`.
- Why it matters: this makes Bedrock cache-hit usage look free when it is actually discounted, which is misleading for cost tracking.
- What changed: default cost formatting in `usage-metrics.ts` now delegates to the shared UI formatter for dynamic precision, while explicit precision overrides remain intact for derived metrics.
- What did NOT change (scope boundary): no backend aggregation or provider billing logic changed in this PR; this is a UI formatting fix plus regression coverage only.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #50083

## User-visible / Behavior Changes

- Usage dashboard costs below one cent now preserve sub-cent precision instead of rounding to `$0.00`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local workspace
- Model/provider: Usage dashboard / Bedrock cache-hit cost display path
- Integration/channel (if any): Control UI Usage dashboard
- Relevant config (redacted): None

### Steps

1. Open the Usage dashboard with usage totals that include sub-cent cache-hit costs.
2. Render the cost through `usage-metrics.ts` default formatting.
3. Observe the displayed cost label.

### Expected

- Costs like `0.0047` render as `$0.0047` instead of `$0.00`.
- Explicit precision overrides such as `formatCost(value, 4)` continue to work.

### Actual

- Covered by the new regression tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted local verification:
`pnpm --dir ui test -- src/ui/views/usage-render-details.test.ts`

Result:
- `Test Files 1 passed`
- `Tests 12 passed`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: sub-cent costs preserve precision; costs below one dollar keep three decimals by default; explicit precision overrides still render fixed decimals.
- Edge cases checked: `NaN` falls back to `$0.00`.
- What you did **not** verify: manual browser verification against a live Bedrock-backed dashboard; full `pnpm build && pnpm check && pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `ui/src/ui/views/usage-metrics.ts`, `ui/src/ui/views/usage-render-details.test.ts`
- Known bad symptoms reviewers should watch for: only Usage dashboard cost labels regressing back to two-decimal rounding

## Risks and Mitigations

- Risk: callers that intentionally relied on two-decimal default formatting in `usage-metrics.ts` could now render more precision for values below `$1`.
  - Mitigation: explicit precision overrides are preserved, and the default path now matches the shared UI cost formatter already used elsewhere.

AI-assisted: yes. I verified the change locally and understand the formatting and test coverage added here.
