### PR TITLE
fix(synology-chat): strip channel prefix from peer ID before numeric parse

### DIFF
--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -88,6 +88,20 @@ describe("sendMessage", () => {
     const callArgs = httpsRequest.mock.calls[0];
     expect(callArgs[0]).toBe("https://nas.example.com/incoming");
   });
+
+  it("strips channel prefix from peer ID and sets user_ids (fixes #49989)", async () => {
+    mockSuccessResponse();
+    await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello", "synology-chat:4"));
+    const httpsRequest = vi.mocked(https.request);
+    expect(httpsRequest).toHaveBeenCalled();
+    // Verify the body contains user_ids:[4]
+    const writeCall = httpsRequest.mock.results[0]?.value;
+    const writtenBody = writeCall?.write?.mock?.calls?.[0]?.[0] as string | undefined;
+    expect(writtenBody).toBeDefined();
+    const decoded = decodeURIComponent(writtenBody!.replace("payload=", ""));
+    const payload = JSON.parse(decoded);
+    expect(payload.user_ids).toEqual([4]);
+  });
 });
 
 describe("sendFileUrl", () => {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -213,11 +213,24 @@ function parseNumericUserId(userId?: string | number): number | undefined {
   if (userId === undefined) {
     return undefined;
   }
-  // Strip channel prefix (e.g. "synology-chat:4" → "4") so peer IDs
+
+  if (typeof userId === "number") {
+    return Number.isSafeInteger(userId) && userId > 0 ? userId : undefined;
+  }
+
+  // Strip known channel prefix (e.g. "synology-chat:4" → "4") so peer IDs
   // stored as "<channel>:<id>" resolve to the numeric Chat API user_id.
-  const raw = typeof userId === "number" ? userId : userId.replace(/^[^:]+:/, "");
-  const numericId = typeof raw === "number" ? raw : parseInt(raw, 10);
-  return Number.isNaN(numericId) ? undefined : numericId;
+  // Only strip the known synology-chat prefix to avoid misparsing other formats.
+  const stripped = userId.replace(/^synology[-_]?chat:/i, "").trim();
+
+  // Require the remaining value to be strictly a positive decimal integer
+  // within JS safe integer range to prevent parseInt truncation attacks.
+  if (!/^\d+$/.test(stripped)) {
+    return undefined;
+  }
+
+  const n = Number(stripped);
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined;
 }
 
 function doPost(url: string, body: string, allowInsecureSsl = true): Promise<boolean> {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -213,7 +213,10 @@ function parseNumericUserId(userId?: string | number): number | undefined {
   if (userId === undefined) {
     return undefined;
   }
-  const numericId = typeof userId === "number" ? userId : parseInt(userId, 10);
+  // Strip channel prefix (e.g. "synology-chat:4" → "4") so peer IDs
+  // stored as "<channel>:<id>" resolve to the numeric Chat API user_id.
+  const raw = typeof userId === "number" ? userId : userId.replace(/^[^:]+:/, "");
+  const numericId = typeof raw === "number" ? raw : parseInt(raw, 10);
   return Number.isNaN(numericId) ? undefined : numericId;
 }
 

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {


### PR DESCRIPTION
## Summary
- Fixes #49989 — Synology Chat replies silently dropped because `parseNumericUserId("synology-chat:4")` returns `NaN` (channel prefix not stripped before `parseInt`)
- Strips the `<channel>:` prefix in `parseNumericUserId` so peer IDs stored as `"synology-chat:4"` correctly resolve to numeric user IDs
- Adds regression test confirming `user_ids: [4]` is set when `userId` is `"synology-chat:4"`

## Test plan
- [x] All 12 existing `client.test.ts` tests pass
- [x] New regression test verifies channel-prefixed peer ID → `user_ids:[4]`
- [x] `pnpm format` clean
- [ ] Manual: configure Synology Chat, send a message, verify reply targets the correct user

🤖 Generated with [Claude Code](https://claude.com/claude-code)