### PR TITLE
fix(exec): kill PTY subprocess when session marked done

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -541,6 +541,8 @@ export async function runExecProcess(opts: {
         isNormalExit && !isShellFailure ? "completed" : "failed";
 
       markExited(session, exit.exitCode, exit.exitSignal, status);
+      // Kill the PTY synchronously after marking session as done to prevent zombie PTY sessions
+      supervisor.cancel(sessionId, "session-done");
       maybeNotifyOnExit(session, status);
       if (!session.child && session.stdin) {
         session.stdin.destroyed = true;
@@ -590,6 +592,8 @@ export async function runExecProcess(opts: {
     })
     .catch((err): ExecProcessOutcome => {
       markExited(session, null, null, "failed");
+      // Kill the PTY synchronously after marking session as done to prevent zombie PTY sessions
+      supervisor.cancel(sessionId, "session-done");
       maybeNotifyOnExit(session, "failed");
       const aggregated = session.aggregated.trim();
       const message = aggregated ? `${aggregated}\n\n${String(err)}` : String(err);

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -54,6 +54,7 @@ export async function createPtyAdapter(params: {
     name: params.name ?? process.env.TERM ?? "xterm-256color",
     cols: params.cols ?? 120,
     rows: params.rows ?? 30,
+    detached: true,
   });
 
   let dataListener: PtyDisposable | null = null;


### PR DESCRIPTION
Fixes #49943 — Bug 1. When a session is marked done, the PTY subprocess is now killed synchronously to prevent zombie PTY sessions from accepting routed commands.