### PR TITLE
fix(exec): kill PTY subprocess synchronously on session exit

### DIFF
--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -206,6 +206,9 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
+        // Kill PTY synchronously before disposal to prevent zombie PTY sessions
+        // that could accept routed commands after the run is marked done
+        adapter.kill("SIGKILL");
         adapter.dispose();
         active.delete(runId);
 


### PR DESCRIPTION
Fixes #49943 — Bug 1. When a PTY exec session exits, the PTY subprocess is now killed synchronously inside the supervisor before the run is marked fully exited, preventing zombie PTY sessions from accepting routed commands.