### PR TITLE
fix(exec): isolate PTY process group to prevent cascade kill

### DIFF
--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -1,4 +1,3 @@
-import { killProcessTree } from "../../kill-tree.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
@@ -155,11 +154,14 @@ export async function createPtyAdapter(params: {
 
   const kill = (signal: NodeJS.Signals = "SIGKILL") => {
     try {
-      if (signal === "SIGKILL" && typeof pty.pid === "number" && pty.pid > 0) {
-        killProcessTree(pty.pid);
-      } else if (process.platform === "win32") {
+      if (process.platform === "win32") {
         pty.kill();
       } else {
+        // Use pty.kill() instead of killProcessTree to avoid cascade kills.
+        // killProcessTree sends to -pid (process group), which can kill
+        // unrelated pty=false sessions that share the same process group.
+        // The PTY's child processes are cleaned up by the OS when the PTY
+        // itself is killed, so we don't need explicit tree killing.
         pty.kill(signal);
       }
     } catch {


### PR DESCRIPTION
Fixes #49943 — Bug 2. Isolates PTY process groups to prevent SIGKILL on a zombie PTY from propagating to unrelated pty=false subprocesses. Uses pty.kill() instead of killProcessTree since node-pty does not support child_process.spawn-style detached option.