### PR TITLE
fix: handle Windows-style session paths when running on POSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/Windows: resolve persisted Windows-style absolute transcript paths by filename on POSIX so imported session stores no longer create literal drive-letter paths under the local sessions directory. (#50116) Thanks @RIPRODUCTIONS.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Harden macOS shell wrapper allowlist parsing [AI]. (#78518) Thanks @pgondhi987.

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -662,6 +662,22 @@ describe("sessions", () => {
     );
   });
 
+  it.runIf(process.platform !== "win32")(
+    "maps Windows absolute sessionFile paths to the local sessions dir",
+    () => {
+      const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+      const sessionFile = resolveSessionFilePath(
+        "sess-1",
+        {
+          sessionFile: String.raw`C:\Users\alice\.openclaw\agents\main\sessions\sess-2.jsonl`,
+        },
+        { sessionsDir },
+      );
+
+      expect(sessionFile).toBe(path.resolve(sessionsDir, "sess-2.jsonl"));
+    },
+  );
+
   it("resolves cross-agent paths when OPENCLAW_STATE_DIR differs from stored paths", () => {
     withStateDir(path.resolve("/different/state"), () => {
       const originalBase = path.resolve("/original/state");

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -7,6 +7,18 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveStateDir } from "../paths.js";
 import { isCompactionCheckpointTranscriptFileName } from "./artifacts.js";
 
+function isWindowsAbsoluteOnPosix(candidate: string): boolean {
+  if (path.sep === "\\") {
+    return false;
+  }
+  return /^[A-Za-z]:[/\\]/.test(candidate);
+}
+
+function extractBasename(candidate: string): string {
+  const parts = candidate.split(/[/\\]/);
+  return parts[parts.length - 1] ?? candidate;
+}
+
 function resolveAgentSessionsDir(
   agentId?: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -182,6 +194,14 @@ function resolvePathWithinSessionsDir(
   if (!trimmed) {
     throw new Error("Session file path must not be empty");
   }
+
+  if (isWindowsAbsoluteOnPosix(trimmed)) {
+    const basename = extractBasename(trimmed);
+    if (basename && basename !== "." && basename !== "..") {
+      return path.resolve(path.resolve(sessionsDir), basename);
+    }
+  }
+
   const resolvedBase = path.resolve(sessionsDir);
   const realBase = safeRealpathSync(resolvedBase) ?? resolvedBase;
   // Normalize absolute paths that are within the sessions directory.


### PR DESCRIPTION
## Summary

- When `sessions.json` is written by a Windows host but read inside a Linux Docker container, paths like `C:\Users\...\abc.jsonl` are treated as relative by `path.isAbsolute` (which only recognises POSIX absolutes)
- This causes `resolvePathWithinSessionsDir` to concatenate the Windows path onto the container base, producing broken paths like `/home/node/.openclaw/.../C:\Users\...\abc.jsonl`
- Adds `isWindowsAbsoluteOnPosix()` guard that detects drive-letter paths on POSIX and extracts the leaf filename, resolving it within the sessions directory

## Test plan

- [ ] Verify `resolvePathWithinSessionsDir` correctly extracts basename from `C:\Users\foo\sessions\abc.jsonl` on Linux
- [ ] Verify `C:/forward/slash/abc.jsonl` variant also handled
- [ ] Verify no behaviour change on native Windows (guard returns false when `path.sep === "\\"`)
- [ ] Verify normal POSIX relative paths still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)