### PR TITLE
fix(whatsapp): pass Timestamp to finalizeInboundContext

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -325,6 +325,7 @@ export async function processMessage(params: {
     SenderName: params.msg.senderName,
     SenderId: params.msg.senderJid?.trim() || params.msg.senderE164,
     SenderE164: params.msg.senderE164,
+    Timestamp: params.msg.timestamp,
     CommandAuthorized: commandAuthorized,
     WasMentioned: params.msg.wasMentioned,
     ...(params.msg.location ? toLocationContext(params.msg.location) : {}),


### PR DESCRIPTION
## Problem

WhatsApp was the only channel plugin that did not pass `Timestamp` into the inbound context payload. This means `envelopeTimestamp: "on"` had no effect for WhatsApp messages — the model never saw when messages were sent.

Every other channel correctly sets `Timestamp`:
- Discord, Telegram, Signal, Slack, LINE, iMessage, TUI — all pass it ✅
- **WhatsApp: missing** ❌

## Fix

Add `Timestamp: params.msg.timestamp` to the `finalizeInboundContext` call in `process-message.ts`. The timestamp value (`inbound.messageTimestampMs`) is already available on the message object.

Fixes #50098