### PR TITLE
fix(ui): improve cost precision for small values in usage dashboard

### DIFF
--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -258,8 +258,20 @@ function renderUsageMosaic(
   `;
 }
 
-function formatCost(n: number, decimals = 2): string {
-  return `$${n.toFixed(decimals)}`;
+function formatCost(n: number, decimals?: number): string {
+  if (decimals != null) {
+    return `$${n.toFixed(decimals)}`;
+  }
+  if (n === 0) {
+    return "$0.00";
+  }
+  if (n > 0 && n < 0.01) {
+    return `$${n.toFixed(4)}`;
+  }
+  if (n < 1) {
+    return `$${n.toFixed(3)}`;
+  }
+  return `$${n.toFixed(2)}`;
 }
 
 function formatIsoDate(date: Date): string {


### PR DESCRIPTION
## Problem

The usage dashboard's `formatCost()` in `usage-metrics.ts` used `toFixed(2)` for all values, rounding costs below $0.01 to $0.00. This is misleading for cached tokens on Amazon Bedrock where the actual cost is non-zero but very small (e.g. $0.004).

Note: The main `formatCost` in `ui/format.ts` already handles this correctly with dynamic precision. This was a separate copy that didn't.

## Fix

Use dynamic precision matching the existing `ui/format.ts` logic:
- $0.00 for zero
- 4 decimal places for values < $0.01
- 3 decimal places for values < $1  
- 2 decimal places otherwise
- Explicit `decimals` parameter still works as before

Fixes #50083
Fixes #50082 (duplicate)