### PR TITLE
fix(auth): filter pi-ai "<authenticated>" sentinel for google-vertex

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -423,7 +423,7 @@ export function resolveEnvApiKey(
 
   if (normalized === "google-vertex") {
     const envKey = getEnvApiKey(normalized);
-    if (!envKey) {
+    if (!envKey || envKey.startsWith("<")) {
       return null;
     }
     return { apiKey: envKey, source: "gcloud adc" };


### PR DESCRIPTION
## Problem

`pi-ai`'s `getEnvApiKey("google-vertex")` returns the literal string `"<authenticated>"` as a sentinel when ADC environment variables (`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) are set. OpenClaw's `resolveEnvApiKey` treated this as a real API key and passed it downstream, causing the Google GenAI SDK to attempt API key auth with `"<authenticated>"` instead of using Application Default Credentials (ADC).

Result: **401 CREDENTIALS_MISSING** errors for all google-vertex requests when using service account auth.

## Fix

Filter out sentinel values (strings starting with `<`) returned by `getEnvApiKey` for the google-vertex provider. When filtered, `resolveEnvApiKey` returns `null`, allowing the auth flow to fall through to ADC-based authentication.

Fixes #50053