### PR TITLE
fix(exec): only kill PTY on forced exit to avoid PID-recycle hazard

### DIFF
--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -146,6 +146,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
             });
 
       registry.updateState(runId, "running", { pid: adapter.pid });
+      const isPty = input.mode === "pty";
 
       const clearTimers = () => {
         if (timeoutTimer) {
@@ -207,11 +208,12 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
-        // For forced exits (cancel/timeout): kill the full PTY process tree synchronously
-        // while the PID is confirmed live. cancelAdapter is called before wait() can resolve
-        // on forced exits, so the PID is definitely alive here — no PID-recycle hazard.
-        // Natural exits skip this block since the process is already dead.
-        if (forcedReason != null && adapter.pid != null) {
+        // For forced PTY exits (cancel/timeout): kill the full PTY process tree
+        // synchronously while the PID is confirmed live. cancelAdapter is called before
+        // wait() resolves on forced exits, so no PID-recycle hazard at this point.
+        // Natural exits are skipped since the process is already dead.
+        // child adapters skip this: cancelAdapter already called killProcessTree before wait().
+        if (forcedReason != null && isPty && adapter.pid != null) {
           killProcessTree(adapter.pid);
         }
         adapter.dispose();

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -206,6 +206,9 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
+        // Kill PTY synchronously before disposal to prevent zombie PTY sessions
+        // that could accept routed commands after the run is marked done
+        adapter.kill("SIGKILL");
         adapter.dispose();
         active.delete(runId);
 

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -4,6 +4,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createChildAdapter } from "./adapters/child.js";
 import { createPtyAdapter } from "./adapters/pty.js";
 import { createRunRegistry } from "./registry.js";
+import { killProcessTree } from "../kill-tree.js";
 import type {
   ManagedRun,
   ProcessSupervisor,
@@ -206,6 +207,13 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
+        // For forced exits (cancel/timeout): kill the full PTY process tree synchronously
+        // while the PID is confirmed live. cancelAdapter is called before wait() can resolve
+        // on forced exits, so the PID is definitely alive here — no PID-recycle hazard.
+        // Natural exits skip this block since the process is already dead.
+        if (forcedReason != null && adapter.pid != null) {
+          killProcessTree(adapter.pid);
+        }
         adapter.dispose();
         active.delete(runId);
 

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -206,12 +206,6 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
-        // Kill PTY synchronously before disposal only when the exit was forced
-        // (e.g. timeout, manual cancel) — not on natural exits where the process
-        // already terminated and PID may have been recycled by a different session.
-        if (forcedReason != null) {
-          adapter.kill("SIGKILL");
-        }
         adapter.dispose();
         active.delete(runId);
 

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -206,9 +206,12 @@ export function createProcessSupervisor(): ProcessSupervisor {
         }
         settled = true;
         clearTimers();
-        // Kill PTY synchronously before disposal to prevent zombie PTY sessions
-        // that could accept routed commands after the run is marked done
-        adapter.kill("SIGKILL");
+        // Kill PTY synchronously before disposal only when the exit was forced
+        // (e.g. timeout, manual cancel) — not on natural exits where the process
+        // already terminated and PID may have been recycled by a different session.
+        if (forcedReason != null) {
+          adapter.kill("SIGKILL");
+        }
         adapter.dispose();
         active.delete(runId);
 


### PR DESCRIPTION
Guards the unconditional adapter.kill() call added in #50113. Only kills the PTY synchronously when forcedReason is set (timeout, manual cancel), not on natural exits where the process already terminated and the PID may have been recycled by a different session.

Fixes Codex review comment on PR #50113.