### PR TITLE
fix(plugin-sdk): export bluebubbles facade helpers

### DIFF
--- a/src/plugin-sdk/bluebubbles.test.ts
+++ b/src/plugin-sdk/bluebubbles.test.ts
@@ -1,0 +1,18 @@
+import * as bluebubblesSdk from "openclaw/plugin-sdk/bluebubbles";
+import { describe, expect, it } from "vitest";
+
+describe("bluebubbles plugin-sdk facade", () => {
+  it("exports the webhook guard used by the bundled plugin", () => {
+    expect(typeof bluebubblesSdk.beginWebhookRequestPipelineOrReject).toBe("function");
+  });
+
+  it("exports pairing helpers used by the bundled plugin", () => {
+    expect(typeof bluebubblesSdk.createChannelPairingController).toBe("function");
+    expect(typeof bluebubblesSdk.createScopedPairingAccess).toBe("function");
+  });
+
+  it("exports reply prefix helpers used by the bundled plugin", () => {
+    expect(typeof bluebubblesSdk.createChannelReplyPipeline).toBe("function");
+    expect(typeof bluebubblesSdk.createReplyPrefixOptions).toBe("function");
+  });
+});

--- a/src/plugin-sdk/bluebubbles.ts
+++ b/src/plugin-sdk/bluebubbles.ts
@@ -51,7 +51,7 @@ export type {
   ChannelMessageActionName,
 } from "../channels/plugins/types.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
-export { createChannelReplyPipeline } from "./channel-reply-pipeline.js";
+export { createChannelReplyPipeline, createReplyPrefixOptions } from "./channel-reply-pipeline.js";
 export type { OpenClawConfig } from "../config/config.js";
 export type { DmPolicy, GroupPolicy } from "../config/types.js";
 export { ToolPolicySchema } from "../config/zod-schema.agent-runtime.js";
@@ -79,7 +79,7 @@ export type { WizardPrompter } from "../wizard/prompts.js";
 export { isAllowedParsedChatSender } from "./allow-from.js";
 export { readBooleanParam } from "./boolean-param.js";
 export { mapAllowFromEntries } from "./channel-config-helpers.js";
-export { createChannelPairingController } from "./channel-pairing.js";
+export { createChannelPairingController, createScopedPairingAccess } from "./channel-pairing.js";
 export { resolveRequestUrl } from "./request-url.js";
 export {
   buildComputedAccountStatusSnapshot,
@@ -87,6 +87,7 @@ export {
 } from "./status-helpers.js";
 export { extractToolSend } from "./tool-send.js";
 export {
+  beginWebhookRequestPipelineOrReject,
   createWebhookInFlightLimiter,
   normalizeWebhookPath,
   readWebhookBodyOrReject,


### PR DESCRIPTION
## Summary
- export the BlueBubbles webhook guard, pairing helper, and reply prefix helper from the bundled plugin-sdk facade
- add a focused facade test so the bundled BlueBubbles plugin surface stays covered

## Testing
- pnpm exec vitest run --config vitest.config.ts src/plugin-sdk/bluebubbles.test.ts
- pnpm build