### PR TITLE
test: remove stale compat subpath assertion

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3327,7 +3327,6 @@ module.exports = {
 
   it("derives plugin-sdk subpaths from package exports", () => {
     const subpaths = __testing.listPluginSdkExportedSubpaths();
-    expect(subpaths).toContain("compat");
     expect(subpaths).toContain("telegram");
     expect(subpaths).not.toContain("root-alias");
   });


### PR DESCRIPTION
## Summary
- Fixes part of #49848 — the `compat` plugin-sdk subpath was removed from `package.json` exports but the test assertion in `loader.test.ts` was not updated
- Removes the stale `expect(subpaths).toContain("compat")` line

## Test plan
- [x] `pnpm test -- src/plugins/loader.test.ts -t "derives plugin-sdk subpaths"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)