### PR TITLE
fix(browser): add logging for silent CDP/MCP errors

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -1,4 +1,5 @@
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { logWarn } from "../logger.js";
 import {
   appendCdpPath,
   fetchJson,

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -166,7 +166,9 @@ export async function evaluateJavaScript(opts: {
   exceptionDetails?: CdpExceptionDetails;
 }> {
   return await withCdpSocket(opts.wsUrl, async (send) => {
-    await send("Runtime.enable").catch(() => {});
+    await send("Runtime.enable").catch((err) => {
+      logWarn(`cdp: Runtime.enable failed (non-fatal): ${String(err)}`);
+    });
     const evaluated = (await send("Runtime.evaluate", {
       expression: opts.expression,
       awaitPromise: Boolean(opts.awaitPromise),
@@ -285,7 +287,9 @@ export async function snapshotAria(opts: {
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
   return await withCdpSocket(opts.wsUrl, async (send) => {
-    await send("Accessibility.enable").catch(() => {});
+    await send("Accessibility.enable").catch((err) => {
+      logWarn(`cdp: Accessibility.enable failed (non-fatal): ${String(err)}`);
+    });
     const res = (await send("Accessibility.getFullAXTree")) as {
       nodes?: RawAXNode[];
     };

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { logWarn } from "../logger.js";
 import type { ChromeMcpSnapshotNode } from "./chrome-mcp.snapshot.js";
 import type { BrowserTab } from "./client.js";
 import { BrowserProfileUnavailableError, BrowserTabNotFoundError } from "./errors.js";

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -206,7 +206,9 @@ async function closeChromeMcpSessionsForProfile(
     if (key !== keepKey && cacheKeyMatchesProfileName(key, profileName)) {
       sessions.delete(key);
       closed = true;
-      await session.client.close().catch(() => {});
+      await session.client.close().catch((closeErr) => {
+        logWarn(`chrome-mcp: client close failed (non-fatal): ${String(closeErr)}`);
+      });
     }
   }
 
@@ -245,7 +247,9 @@ async function createRealSession(
         throw new Error("Chrome MCP server did not expose the expected navigation tools.");
       }
     } catch (err) {
-      await client.close().catch(() => {});
+      await client.close().catch((closeErr) => {
+        logWarn(`chrome-mcp: client close failed (non-fatal): ${String(closeErr)}`);
+      });
       const targetLabel = userDataDir
         ? `the configured Chromium user data dir (${userDataDir})`
         : "Google Chrome's default profile";
@@ -281,7 +285,9 @@ async function getSession(profileName: string, userDataDir?: string): Promise<Ch
         if (pendingSessions.get(cacheKey) === pending) {
           sessions.set(cacheKey, created);
         } else {
-          await created.client.close().catch(() => {});
+          await created.client.close().catch((closeErr) => {
+            logWarn(`chrome-mcp: client close failed (non-fatal): ${String(closeErr)}`);
+          });
         }
         return created;
       })();
@@ -324,7 +330,9 @@ async function callTool(
   } catch (err) {
     // Transport/connection error — tear down session so it reconnects on next call
     sessions.delete(cacheKey);
-    await session.client.close().catch(() => {});
+    await session.client.close().catch((err) => {
+      logWarn(`chrome-mcp: session close failed for "${profileName}" (non-fatal): ${String(err)}`);
+    });
     throw err;
   }
   // Tool-level errors (element not found, script error, etc.) don't indicate a
@@ -341,7 +349,9 @@ async function withTempFile<T>(fn: (filePath: string) => Promise<T>): Promise<T>
   try {
     return await fn(filePath);
   } finally {
-    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true }).catch((err) => {
+      logWarn(`chrome-mcp: temp dir cleanup failed (non-fatal): ${String(err)}`);
+    });
   }
 }
 
@@ -381,7 +391,9 @@ export async function closeChromeMcpSession(profileName: string): Promise<boolea
 export async function stopAllChromeMcpSessions(): Promise<void> {
   const names = [...new Set([...sessions.keys()].map((key) => JSON.parse(key)[0] as string))];
   for (const name of names) {
-    await closeChromeMcpSession(name).catch(() => {});
+    await closeChromeMcpSession(name).catch((err) => {
+      logWarn(`chrome-mcp: stop session failed for "${name}" (non-fatal): ${String(err)}`);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Adds warning logs for previously silent failures in browser CDP and Chrome MCP modules. Improves debuggability without changing error handling behavior.

Fixes #46146

## Root Cause

Several error paths in browser CDP and Chrome MCP modules were silently swallowing errors with empty catch blocks (`catch(() => {})`), making it impossible to diagnose connection and cleanup failures.

## Changes

### src/browser/cdp.ts
- Log warning when `Runtime.enable` fails (non-fatal)
- Log warning when `Accessibility.enable` fails (non-fatal)

### src/browser/chrome-mcp.ts
- Log warning when client close fails (non-fatal)
- Log warning when session close fails (non-fatal)
- Log warning when temp dir cleanup fails (non-fatal)
- Log warning when stop session fails (non-fatal)

## Testing

- [x] No functional changes - only adds logging
- [x] All error paths now log warnings for debugging
- [x] Error handling behavior unchanged - still non-fatal

## Impact

- **Before:** Silent failures, impossible to debug
- **After:** Warning logs appear, easier to diagnose issues

No breaking changes. Backward compatible.

## Related Issue

Fixes #46146
