### PR TITLE
fix(plugin-sdk): remove leaked matrix setup entrypoints

### DIFF
--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -1,8 +1,6 @@
 // Narrow plugin-sdk surface for the bundled matrix plugin.
 // Keep this list additive and scoped to symbols used under extensions/matrix.
 
-import { createOptionalChannelSetupSurface } from "./channel-setup.js";
-
 export {
   createActionGate,
   jsonResult,
@@ -108,13 +106,3 @@ export {
   buildProbeChannelStatusSummary,
   collectStatusIssuesFromLastError,
 } from "./status-helpers.js";
-
-const matrixSetup = createOptionalChannelSetupSurface({
-  channel: "matrix",
-  label: "Matrix",
-  npmSpec: "@openclaw/matrix",
-  docsPath: "/channels/matrix",
-});
-
-export const matrixSetupWizard = matrixSetup.setupWizard;
-export const matrixSetupAdapter = matrixSetup.setupAdapter;


### PR DESCRIPTION
## Summary
- Fixes part of #49848 — `matrixSetupWizard` and `matrixSetupAdapter` were exported from `src/plugin-sdk/matrix.ts`, violating the Extension SDK self-import guardrail
- These setup entrypoints create extension cycles when re-exported through the plugin-sdk surface
- Removes the two leaked exports and the now-unused `createOptionalChannelSetupSurface` import/call; the extension's internal barrel remains the correct import path

## Test plan
- [x] `pnpm test -- extensions/matrix/src/runtime-api.test.ts` passes (3/3 tests)
- [x] Grep confirms no other code imports these symbols from the plugin-sdk path

🤖 Generated with [Claude Code](https://claude.com/claude-code)