### PR TITLE
fix(llm-task): fix AJV ESM import and test mock

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.test.ts
+++ b/extensions/llm-task/src/llm-task-tool.test.ts
@@ -13,7 +13,7 @@ vi.mock("@sinclair/typebox", () => ({
 vi.mock("ajv", () => ({
   default: class MockAjv {
     compile(schema: unknown) {
-      return (value: unknown) => {
+      const validate = (value: unknown) => {
         if (
           schema &&
           typeof schema === "object" &&
@@ -22,17 +22,15 @@ vi.mock("ajv", () => ({
             "string"
         ) {
           const ok = typeof (value as { foo?: unknown })?.foo === "string";
-          (this as { errors?: Array<{ instancePath: string; message: string }> }).errors = ok
-            ? undefined
-            : [{ instancePath: "/foo", message: "must be string" }];
+          validate.errors = ok ? undefined : [{ instancePath: "/foo", message: "must be string" }];
           return ok;
         }
-        (this as { errors?: Array<{ instancePath: string; message: string }> }).errors = undefined;
+        validate.errors = undefined;
         return true;
       };
+      validate.errors = undefined as Array<{ instancePath: string; message: string }> | undefined;
+      return validate;
     }
-
-    errors?: Array<{ instancePath: string; message: string }>;
   },
 }));
 

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -214,7 +214,7 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
         // oxlint-disable-next-line typescript/no-explicit-any
         const schema = (params as any).schema as unknown;
         if (schema && typeof schema === "object" && !Array.isArray(schema)) {
-          const ajv = new Ajv.default({ allErrors: true, strict: false });
+          const ajv = new Ajv({ allErrors: true, strict: false });
           // oxlint-disable-next-line typescript/no-explicit-any
           const validate = ajv.compile(schema as any);
           const ok = validate(parsed);


### PR DESCRIPTION
## Summary
- Fixes part of #49848 — `llm-task-tool.test.ts` fails with `"default.default is not a constructor"`
- Source fix: `new Ajv.default({...})` → `new Ajv({...})` — the default import already gives the class in ESM
- Mock fix: attach `errors` to the returned validator function instead of the class instance, matching how the source reads `validate.errors`

## Test plan
- [x] All 13 `llm-task-tool.test.ts` tests pass
- [x] "validates schema" and "throws on schema mismatch" now pass correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)