### PR TITLE
fix(windows): stabilize gateway restart and avoid false stale cleanup [AI-assisted]

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 type RestartHealthSnapshot = {
   healthy: boolean;
   staleGatewayPids: number[];
-  runtime: { status?: string };
+  runtime: { status?: string; pid?: number };
   portUsage: { port: number; status: string; listeners: []; hints: []; errors?: string[] };
+  listenerKinds?: { gateway: number[]; unknown: number[]; other: number[] };
 };
 
 type RestartPostCheckContext = {
@@ -21,6 +22,7 @@ type RestartParams = {
 
 const service = {
   readCommand: vi.fn(),
+  readRuntime: vi.fn(),
   restart: vi.fn(),
 };
 
@@ -128,6 +130,7 @@ describe("runDaemonRestart health checks", () => {
 
   beforeEach(() => {
     service.readCommand.mockReset();
+    service.readRuntime.mockReset();
     service.restart.mockReset();
     runServiceRestart.mockReset();
     runServiceStop.mockReset();
@@ -148,6 +151,7 @@ describe("runDaemonRestart health checks", () => {
       programArguments: ["openclaw", "gateway", "--port", "18789"],
       environment: {},
     });
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 1500 });
     service.restart.mockResolvedValue({ outcome: "completed" });
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
@@ -194,6 +198,7 @@ describe("runDaemonRestart health checks", () => {
       staleGatewayPids: [],
       runtime: { status: "running" },
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+      listenerKinds: { gateway: [], unknown: [], other: [] },
     };
     waitForGatewayHealthyRestart.mockResolvedValueOnce(unhealthy).mockResolvedValueOnce(healthy);
     terminateStaleGatewayPids.mockResolvedValue([1993]);
@@ -204,6 +209,9 @@ describe("runDaemonRestart health checks", () => {
     expect(terminateStaleGatewayPids).toHaveBeenCalledWith([1993]);
     expect(service.restart).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(2);
+    for (const [params] of waitForGatewayHealthyRestart.mock.calls) {
+      expect(params).not.toHaveProperty("includeUnknownListenersAsStale");
+    }
   });
 
   it("skips stale-pid retry health checks when the retry restart is only scheduled", async () => {
@@ -240,6 +248,47 @@ describe("runDaemonRestart health checks", () => {
     });
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(renderRestartDiagnostics).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns on Windows when restart health recovers without a clear pid change", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const healthy: RestartHealthSnapshot & {
+      listenerKinds: { gateway: number[]; unknown: number[]; other: number[] };
+    } = {
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running", pid: 1500 },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+      listenerKinds: { gateway: [1500], unknown: [], other: [] },
+    };
+    waitForGatewayHealthyRestart.mockResolvedValue(healthy);
+    const capturedWarnings: string[][] = [];
+    runServiceRestart.mockImplementationOnce(async (params: RestartParams) => {
+      const warnings: string[] = [];
+      capturedWarnings.push(warnings);
+      await params.postRestartCheck?.({
+        json: true,
+        stdout: process.stdout,
+        warnings,
+        fail: (message: string, hints?: string[]) => {
+          const err = new Error(message) as Error & { hints?: string[] };
+          err.hints = hints;
+          throw err;
+        },
+      });
+      return true;
+    });
+
+    try {
+      await expect(runDaemonRestart({ json: true })).resolves.toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+
+    expect(capturedWarnings[0]).toContain(
+      "Gateway restart became healthy, but process identity did not clearly change from pid 1500; runtime may be lagging or the old process may still own the listener.",
+    );
   });
 
   it("signals an unmanaged gateway process on stop", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -151,11 +151,18 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const json = Boolean(opts.json);
   const service = resolveGatewayService();
   let restartedWithoutServiceManager = false;
+  let preRestartRuntimePid: number | undefined;
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
+  if (process.platform === "win32") {
+    preRestartRuntimePid = await service
+      .readRuntime(process.env)
+      .then((runtime) => runtime.pid)
+      .catch(() => undefined);
+  }
 
   return await runServiceRestart({
     serviceNoun: "Gateway",
@@ -204,14 +211,18 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         port: restartPort,
         attempts: POST_RESTART_HEALTH_ATTEMPTS,
         delayMs: POST_RESTART_HEALTH_DELAY_MS,
-        includeUnknownListenersAsStale: process.platform === "win32",
       });
 
       if (!health.healthy && health.staleGatewayPids.length > 0) {
-        const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
+        const staleMsg = `Found positively identified stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
+        const diagnostics = renderRestartDiagnostics(health);
         warnings.push(staleMsg);
+        warnings.push(...diagnostics);
         if (!json) {
           defaultRuntime.log(theme.warn(staleMsg));
+          for (const line of diagnostics) {
+            defaultRuntime.log(theme.muted(line));
+          }
           defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
         }
 
@@ -225,11 +236,23 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           port: restartPort,
           attempts: POST_RESTART_HEALTH_ATTEMPTS,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
-          includeUnknownListenersAsStale: process.platform === "win32",
         });
       }
 
       if (health.healthy) {
+        if (
+          process.platform === "win32" &&
+          preRestartRuntimePid != null &&
+          (health.runtime.pid === preRestartRuntimePid ||
+            health.listenerKinds.gateway.includes(preRestartRuntimePid))
+        ) {
+          const identityWarning = `Gateway restart became healthy, but process identity did not clearly change from pid ${preRestartRuntimePid}; runtime may be lagging or the old process may still own the listener.`;
+          if (!json) {
+            defaultRuntime.log(theme.warn(identityWarning));
+          } else {
+            warnings.push(identityWarning);
+          }
+        }
         return;
       }
 

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -210,6 +210,30 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([]);
   });
 
+  it("treats a busy unknown Windows listener as healthy when the probe succeeds", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    classifyPortListener.mockReturnValue("unknown");
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+    });
+
+    const snapshot = await inspectGatewayRestartWithSnapshot({
+      runtime: { status: "stopped" },
+      portUsage: {
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: 9100, commandLine: "" }],
+        hints: [],
+      },
+      includeUnknownListenersAsStale: true,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.probeResult).toBe("ok");
+  });
+
   it("treats auth-closed probe as healthy gateway reachability", async () => {
     const snapshot = await inspectAmbiguousOwnershipWithProbe({
       ok: false,
@@ -239,5 +263,36 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("reports probe result, listener classification, and failure reason in diagnostics", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    classifyPortListener.mockImplementation((listener) =>
+      "command" in (listener as Record<string, unknown>) ? "unknown" : "gateway",
+    );
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: null,
+    });
+
+    const { inspectGatewayRestart, renderRestartDiagnostics } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service: makeGatewayService({ status: "stopped" }),
+      port: 18789,
+      includeUnknownListenersAsStale: false,
+    });
+
+    const lines = renderRestartDiagnostics({
+      ...snapshot,
+      listenerKinds: { gateway: [9000], unknown: [9100], other: [] },
+      staleGatewayPids: [9000],
+      failureReason: "stale-gateway-listener",
+      probeResult: "failed",
+    });
+
+    expect(lines).toContain("Restart probe: failed.");
+    expect(lines).toContain("Listener classification: gateway=9000; unknown=9100; other=none.");
+    expect(lines).toContain("Stale gateway termination candidates: 9000.");
+    expect(lines).toContain("Restart health failure reason: stale-gateway-listener.");
   });
 });

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -21,6 +21,13 @@ export type GatewayRestartSnapshot = {
   portUsage: PortUsage;
   healthy: boolean;
   staleGatewayPids: number[];
+  probeResult: "ok" | "failed" | "not-run";
+  listenerKinds: {
+    gateway: number[];
+    unknown: number[];
+    other: number[];
+  };
+  failureReason?: "runtime-lag" | "probe-failed" | "stale-gateway-listener";
 };
 
 export type GatewayPortHealthSnapshot = {
@@ -124,35 +131,49 @@ export async function inspectGatewayRestart(params: {
     };
   }
 
+  let probeResult: GatewayRestartSnapshot["probeResult"] = "not-run";
   if (portUsage.status === "busy" && runtime.status !== "running") {
     try {
       const reachable = await confirmGatewayReachable(params.port);
+      probeResult = reachable ? "ok" : "failed";
       if (reachable) {
         return {
           runtime,
           portUsage,
           healthy: true,
           staleGatewayPids: [],
+          probeResult,
+          listenerKinds: { gateway: [], unknown: [], other: [] },
         };
       }
     } catch {
+      probeResult = "failed";
       // Probe is best-effort; keep the ownership-based diagnostics.
     }
   }
 
-  const gatewayListeners =
+  const classifiedListeners =
     portUsage.status === "busy"
-      ? portUsage.listeners.filter(
-          (listener) => classifyPortListener(listener, params.port) === "gateway",
-        )
+      ? portUsage.listeners.map((listener) => ({
+          listener,
+          kind: classifyPortListener(listener, params.port),
+        }))
       : [];
+  const gatewayListeners = classifiedListeners
+    .filter(({ kind }) => kind === "gateway")
+    .map(({ listener }) => listener);
+  const unknownListeners = classifiedListeners
+    .filter(({ kind }) => kind === "unknown")
+    .map(({ listener }) => listener);
+  const otherListeners = classifiedListeners
+    .filter(({ kind }) => kind !== "gateway" && kind !== "unknown")
+    .map(({ listener }) => listener);
   const fallbackListenerPids =
     params.includeUnknownListenersAsStale &&
     process.platform === "win32" &&
     runtime.status !== "running" &&
     portUsage.status === "busy"
-      ? portUsage.listeners
-          .filter((listener) => classifyPortListener(listener, params.port) === "unknown")
+      ? unknownListeners
           .map((listener) => listener.pid)
           .filter((pid): pid is number => Number.isFinite(pid))
       : [];
@@ -169,7 +190,9 @@ export async function inspectGatewayRestart(params: {
   if (!healthy && running && portUsage.status === "busy") {
     try {
       healthy = await confirmGatewayReachable(params.port);
+      probeResult = healthy ? "ok" : "failed";
     } catch {
+      probeResult = "failed";
       // best-effort probe
     }
   }
@@ -192,12 +215,34 @@ export async function inspectGatewayRestart(params: {
       ),
     ]),
   );
+  const failureReason = healthy
+    ? undefined
+    : staleGatewayPids.length > 0
+      ? "stale-gateway-listener"
+      : portUsage.status === "busy" && probeResult === "failed" && runtime.status !== "running"
+        ? "probe-failed"
+        : portUsage.status === "busy" && runtime.status !== "running"
+          ? "runtime-lag"
+          : undefined;
 
   return {
     runtime,
     portUsage,
     healthy,
     staleGatewayPids,
+    probeResult,
+    listenerKinds: {
+      gateway: gatewayListeners
+        .map((listener) => listener.pid)
+        .filter((pid): pid is number => Number.isFinite(pid)),
+      unknown: unknownListeners
+        .map((listener) => listener.pid)
+        .filter((pid): pid is number => Number.isFinite(pid)),
+      other: otherListeners
+        .map((listener) => listener.pid)
+        .filter((pid): pid is number => Number.isFinite(pid)),
+    },
+    failureReason,
   };
 }
 
@@ -288,6 +333,26 @@ export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): stri
 
   if (runtimeSummary) {
     lines.push(`Service runtime: ${runtimeSummary}`);
+  }
+
+  lines.push(`Restart probe: ${snapshot.probeResult}.`);
+
+  const formatPidSummary = (label: string, pids: number[]) =>
+    `${label}=${pids.length > 0 ? pids.join(", ") : "none"}`;
+  lines.push(
+    `Listener classification: ${[
+      formatPidSummary("gateway", snapshot.listenerKinds.gateway),
+      formatPidSummary("unknown", snapshot.listenerKinds.unknown),
+      formatPidSummary("other", snapshot.listenerKinds.other),
+    ].join("; ")}.`,
+  );
+
+  if (snapshot.staleGatewayPids.length > 0) {
+    lines.push(`Stale gateway termination candidates: ${snapshot.staleGatewayPids.join(", ")}.`);
+  }
+
+  if (snapshot.failureReason) {
+    lines.push(`Restart health failure reason: ${snapshot.failureReason}.`);
   }
 
   lines.push(...renderPortUsageDiagnostics(snapshot));

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -31,6 +31,8 @@ const inspectGatewayRestart = vi.fn<(opts?: unknown) => Promise<GatewayRestartSn
     portUsage: { port: 19001, status: "busy", listeners: [], hints: [] },
     healthy: true,
     staleGatewayPids: [],
+    probeResult: "ok",
+    listenerKinds: { gateway: [1234], unknown: [], other: [] },
   }),
 );
 const serviceReadCommand = vi.fn<
@@ -459,6 +461,8 @@ describe("gatherDaemonStatus", () => {
       },
       healthy: false,
       staleGatewayPids: [9000],
+      probeResult: "failed",
+      listenerKinds: { gateway: [9000], unknown: [], other: [] },
     });
 
     const status = await gatherDaemonStatus({

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -1,87 +1,49 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildPortHints,
-  classifyPortListener,
-  formatPortDiagnostics,
-  formatPortListener,
-} from "./ports-format.js";
+import { classifyPortListener } from "./ports-format.js";
 
-describe("ports-format", () => {
-  it("classifies listeners across gateway, ssh, and unknown command lines", () => {
-    const cases = [
-      {
-        listener: { commandLine: "ssh -N -L 18789:127.0.0.1:18789 user@host" },
-        expected: "ssh",
-      },
-      {
-        listener: { command: "ssh" },
-        expected: "ssh",
-      },
-      {
-        listener: { commandLine: "node /Users/me/Projects/openclaw/dist/entry.js gateway" },
-        expected: "gateway",
-      },
-      {
-        listener: { commandLine: "python -m http.server 18789" },
-        expected: "unknown",
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      expect(
-        classifyPortListener(testCase.listener, 18789),
-        JSON.stringify(testCase.listener),
-      ).toBe(testCase.expected);
-    }
-  });
-
-  it("builds ordered hints for mixed listener kinds and multiplicity", () => {
+describe("classifyPortListener", () => {
+  it("only classifies parsed OpenClaw gateway invocations as gateway", () => {
     expect(
-      buildPortHints(
-        [
-          { commandLine: "node dist/index.js openclaw gateway" },
-          { commandLine: "ssh -N -L 18789:127.0.0.1:18789" },
-          { commandLine: "python -m http.server 18789" },
-        ],
+      classifyPortListener(
+        {
+          commandLine:
+            '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
+          command: "node.exe",
+        },
         18789,
       ),
-    ).toEqual([
-      expect.stringContaining("Gateway already running locally."),
-      "SSH tunnel already bound to this port. Close the tunnel or use a different local port in -L.",
-      "Another process is listening on this port.",
-      expect.stringContaining("Multiple listeners detected"),
-    ]);
-    expect(buildPortHints([], 18789)).toEqual([]);
+    ).toBe("gateway");
   });
 
-  it("formats listeners with pid, user, command, and address fallbacks", () => {
+  it("does not classify uncertain OpenClaw-related listeners as gateway", () => {
     expect(
-      formatPortListener({ pid: 123, user: "alice", commandLine: "ssh -N", address: "::1" }),
-    ).toBe("pid 123 alice: ssh -N (::1)");
-    expect(formatPortListener({ command: "ssh", address: "127.0.0.1:18789" })).toBe(
-      "pid ?: ssh (127.0.0.1:18789)",
-    );
-    expect(formatPortListener({})).toBe("pid ?: unknown");
+      classifyPortListener(
+        {
+          commandLine: '"C:\\tools\\helper.exe" --label openclaw --port 18789',
+          command: "helper.exe",
+        },
+        18789,
+      ),
+    ).toBe("unknown");
+
+    expect(
+      classifyPortListener(
+        {
+          command: "node.exe",
+        },
+        18789,
+      ),
+    ).toBe("unknown");
   });
 
-  it("formats free and busy port diagnostics", () => {
+  it("accepts a direct OpenClaw gateway executable path", () => {
     expect(
-      formatPortDiagnostics({
-        port: 18789,
-        status: "free",
-        listeners: [],
-        hints: [],
-      }),
-    ).toEqual(["Port 18789 is free."]);
-
-    const lines = formatPortDiagnostics({
-      port: 18789,
-      status: "busy",
-      listeners: [{ pid: 123, user: "alice", commandLine: "ssh -N -L 18789:127.0.0.1:18789" }],
-      hints: buildPortHints([{ pid: 123, commandLine: "ssh -N -L 18789:127.0.0.1:18789" }], 18789),
-    });
-    expect(lines[0]).toContain("Port 18789 is already in use");
-    expect(lines).toContain("- pid 123 alice: ssh -N -L 18789:127.0.0.1:18789");
-    expect(lines.some((line) => line.includes("SSH tunnel"))).toBe(true);
+      classifyPortListener(
+        {
+          command: "C:\\Program Files\\OpenClaw\\openclaw-gateway.exe",
+        },
+        18789,
+      ),
+    ).toBe("gateway");
   });
 });

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -1,10 +1,39 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
+import { isGatewayArgv } from "./gateway-process-argv.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
+function isGatewayExecutablePath(raw: string): boolean {
+  const normalized = raw.replaceAll("\\", "/").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const withoutQuotes = normalized.replace(/^["']|["']$/g, "");
+  const basename = withoutQuotes.split("/").at(-1) ?? withoutQuotes;
+  return (
+    basename === "openclaw" ||
+    basename === "openclaw.exe" ||
+    basename === "openclaw-gateway" ||
+    basename === "openclaw-gateway.exe"
+  );
+}
+
 export function classifyPortListener(listener: PortListener, port: number): PortListenerKind {
-  const raw = `${listener.commandLine ?? ""} ${listener.command ?? ""}`.trim().toLowerCase();
-  if (raw.includes("openclaw")) {
+  const commandLine = listener.commandLine?.trim() ?? "";
+  const command = listener.command?.trim() ?? "";
+  if (commandLine) {
+    const argv = parseCmdScriptCommandLine(commandLine);
+    if (argv.length > 0 && isGatewayArgv(argv, { allowGatewayBinary: true })) {
+      return "gateway";
+    }
+  }
+  if (isGatewayExecutablePath(command)) {
     return "gateway";
+  }
+
+  const raw = `${commandLine} ${command}`.trim().toLowerCase();
+  if (raw.includes("openclaw")) {
+    return "unknown";
   }
   if (raw.includes("ssh")) {
     const portToken = String(port);


### PR DESCRIPTION
## Problem

On native Windows environments, `openclaw gateway restart` could be unreliable and sometimes incorrect:

- restart could be reported as failed even when the gateway was actually running
- unrelated processes could be misclassified as gateway processes and terminated
- restart recovery could aggressively clean up listeners based on weak attribution
- restart success could be accepted without verifying whether the process was actually replaced

---

## Root cause

This was caused by several Windows-specific issues:

1. **Unknown listeners treated as stale**
   - Due to weak process attribution on Windows, restart recovery could treat unknown listeners as stale and terminate them.

2. **Loose gateway process classification**
   - Any process containing "openclaw" in its command line could be misclassified as a gateway process.

3. **Lagging or unreliable runtime metadata**
   - `schtasks` runtime state may be delayed or incomplete, and is not a reliable signal immediately after restart.

4. **Insufficient restart identity validation**
   - Restart success relied on probe results without checking whether the process identity actually changed.

---

## What changed

### 1. Safer restart recovery (Windows)

- Removed `includeUnknownListenersAsStale` from the Windows service-managed restart path
- Only positively identified gateway processes are eligible for stale cleanup
- Unknown listeners are no longer terminated

---

### 2. Stronger restart health criteria

- On Windows:
  - `port busy + probe success` is treated as sufficient restart health
  - even when scheduled-task runtime is still `unknown` or lagging

---

### 3. Strict gateway process classification

- Gateway identification now requires:
  - valid gateway argv (`isGatewayArgv(...)`), OR
  - executable path clearly matching `openclaw(.exe)` or `openclaw-gateway(.exe)`

- Ambiguous processes remain `unknown` and are never selected for termination

---

### 4. Lightweight restart identity check

- Capture pre-restart PID
- After restart:
  - emit a warning if PID appears unchanged
  - helps surface cases where restart did not clearly replace the process

---

### 5. Improved diagnostics

Restart logs now include:

- runtime state
- probe result
- listener classification (gateway / unknown / other)
- stale termination candidates
- failure reason

---

### 6. Tests updated and added

- `src/cli/daemon-cli/restart-health.test.ts`
- `src/cli/daemon-cli/lifecycle.test.ts`
- `src/infra/ports-format.test.ts`
- `src/cli/daemon-cli/status.gather.test.ts`

Updates include:
- adding required `GatewayRestartSnapshot` fields:
  - `probeResult`
  - `listenerKinds`
- aligning stale mocks/fixtures with the current snapshot shape

---

## Why this fixes Windows restart

Before:

- Weak runtime signal + weak process attribution + aggressive cleanup
- → could kill valid processes or misreport restart failure

After:

- Unknown listeners are never treated as stale
- Gateway process classification is strict
- Probe success is trusted over lagging runtime
- Restart identity is partially verified via PID comparison

This removes false-positive cleanup paths and stabilizes restart behavior on Windows while preserving existing Linux/macOS behavior.

---

## Validation

### Automated

- `pnpm check` passed
- Focused tests related to this change all passed:

```bash
pnpm test -- src/cli/daemon-cli/restart-health.test.ts \
           src/cli/daemon-cli/lifecycle.test.ts \
           src/infra/ports-format.test.ts \
           src/cli/daemon-cli/status.gather.test.ts