### PR TITLE
fix: prevent interrupt mode from replaying previous assistant reply

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1605,7 +1605,8 @@ export async function runEmbeddedPiAgent(
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
+            lastAssistant:
+              aborted && attempt.assistantTexts.length === 0 ? undefined : attempt.lastAssistant,
             lastToolError: attempt.lastToolError,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -406,9 +406,14 @@ export async function runReplyAgent(params: {
     }
 
     const payloadArray = runResult.payloads ?? [];
+    const wasAborted = runResult.meta?.aborted === true;
 
     if (blockReplyPipeline) {
-      await blockReplyPipeline.flush({ force: true });
+      // Skip flushing buffered block replies when the run was aborted —
+      // the buffer may contain stale content from the interrupted turn.
+      if (!wasAborted) {
+        await blockReplyPipeline.flush({ force: true });
+      }
       blockReplyPipeline.stop();
     }
     if (pendingToolTasks.size > 0) {
@@ -477,6 +482,13 @@ export async function runReplyAgent(params: {
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
     });
+
+    // When the run was aborted (e.g. by interrupt queue mode), skip payload
+    // delivery entirely. The aborted run's payloads may contain stale
+    // `lastAssistant` fallback text from a previous turn. (#50145)
+    if (wasAborted) {
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and


### PR DESCRIPTION
Fixes #50145

## Problem

When `messages.queue.mode` is set to `"interrupt"`, incoming messages that abort an active run cause the **previous turn's assistant reply** to be re-sent to the user before the new (correct) reply is delivered.

## Root Cause

`buildEmbeddedRunPayloads` falls back to `extractAssistantText(lastAssistant)` when `assistantTexts` is empty. After an abort, `assistantTexts` is empty (model never generated new text), but `lastAssistant` still references the previous turn's message from `messagesSnapshot` (full session history). This stale text gets packaged as the current run's output and delivered to the user.

## Fix

Two changes (defense in depth):

### 1. Guard `lastAssistant` fallback (`run.ts`)

When the run was aborted and produced no new assistant text, pass `undefined` instead of the stale `lastAssistant`:

```typescript
lastAssistant:
  aborted && attempt.assistantTexts.length === 0 ? undefined : attempt.lastAssistant,
```

### 2. Early exit for aborted runs (`agent-runner.ts`)

- Skip `blockReplyPipeline.flush()` when aborted (buffer may contain stale content)
- Return early before payload delivery when `wasAborted` is true

```typescript
const wasAborted = runResult.meta?.aborted === true;

if (blockReplyPipeline) {
  if (!wasAborted) {
    await blockReplyPipeline.flush({ force: true });
  }
  blockReplyPipeline.stop();
}

// ...

if (wasAborted) {
  return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
}
```

## Testing

1. Set `messages.queue.mode: "interrupt"`
2. Send message A, then quickly send message B before A completes
3. Verify: only one reply is delivered (combining context from both A and B), no stale replay of previous conversation
