### PR TITLE
fix(acpx): align ACPX_PINNED_VERSION with package.json (0.1.16 → 0.3.0)

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -67,7 +67,7 @@
     },
     "expectedVersion": {
       "label": "Expected acpx Version",
-      "help": "Exact version to enforce (for example 0.1.16) or \"any\" to skip strict version matching."
+      "help": "Exact version to enforce (for example 0.3.0) or \"any\" to skip strict version matching."
     },
     "cwd": {
       "label": "Default Working Directory",

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -9,7 +9,7 @@ export type AcpxPermissionMode = (typeof ACPX_PERMISSION_MODES)[number];
 export const ACPX_NON_INTERACTIVE_POLICIES = ["deny", "fail"] as const;
 export type AcpxNonInteractivePermissionPolicy = (typeof ACPX_NON_INTERACTIVE_POLICIES)[number];
 
-export const ACPX_PINNED_VERSION = "0.1.16";
+export const ACPX_PINNED_VERSION = "0.3.0";
 export const ACPX_VERSION_ANY = "any";
 const ACPX_BIN_NAME = process.platform === "win32" ? "acpx.cmd" : "acpx";
 


### PR DESCRIPTION
## Summary

- **Bug:** `extensions/acpx/package.json` declares `"acpx": "0.3.0"` but `extensions/acpx/src/config.ts` still has `ACPX_PINNED_VERSION = "0.1.16"`. At startup the version-check logic compares the installed `0.3.0` binary against the expected `0.1.16` constant and marks the ACP runtime unhealthy/unavailable.
- **Fix:** Update `ACPX_PINNED_VERSION` from `"0.1.16"` to `"0.3.0"` to match the actual bundled dependency.
- **Note:** Existing PRs #43998 and #49089 target `0.2.0`, which is also wrong — `package.json` pins `0.3.0`.

Closes #43997

## Test plan

- [ ] `pnpm build` passes (no type errors from the constant change)
- [ ] `pnpm test -- extensions/acpx` passes
- [ ] Verify ACP runtime health check no longer flags a version mismatch at gateway startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)