### PR TITLE
feat: add OpenViking session bridge plugin

### DIFF
--- a/extensions/openviking-session-bridge/index.ts
+++ b/extensions/openviking-session-bridge/index.ts
@@ -1,0 +1,229 @@
+/**
+ * OpenViking Session Bridge
+ *
+ * Flushes OpenClaw session transcripts into OpenViking at session boundaries.
+ *
+ * Trigger: `session_end` hook (fire-and-forget, incremental, idempotent).
+ * Command:  `/done`  — synchronous flush; user still needs to send `/new` to
+ *            rotate the session (see INSTALL.md for auto-reset config tip).
+ *
+ * Enabled: false by default — set `enabled: true` in plugin config to activate.
+ *
+ * Deviation from PRD:
+ *   - Located under extensions/ (repo-native) rather than the non-existent plugins/.
+ *   - /done flushes synchronously but does NOT auto-reset the session.
+ *     To get reset-on-done, add "/done" to session.resetTriggers in clawdbot.json.
+ */
+
+import { homedir } from "node:os";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import { parseOVSessionBridgeConfig } from "./src/config.js";
+import { flushSessionToOV, flushWithTimeout } from "./src/flush.js";
+import { loadCheckpoint } from "./src/state.js";
+import type { SessionCheckpoint } from "./src/types.js";
+
+// Module-level tracking map: sessionId → metadata needed for flush.
+// Populated via session_start; used by session_end and /done.
+type TrackedSession = {
+  sessionId: string;
+  sessionKey: string;
+  agentId: string;
+  sessionFile?: string;
+};
+
+const activeSessions = new Map<string, TrackedSession>();
+
+const sessionBridgePlugin = {
+  id: "openviking-session-bridge",
+  name: "OpenViking Session Bridge",
+  description: "Flush session transcripts to OpenViking at session boundaries",
+  configSchema: emptyPluginConfigSchema(),
+
+  register(api: OpenClawPluginApi) {
+    const cfg = parseOVSessionBridgeConfig(api.pluginConfig ?? {});
+
+    if (!cfg.enabled) {
+      api.logger.info("openviking-session-bridge: disabled (set enabled:true to activate)");
+      // Still register hooks as no-ops so the plugin loads cleanly.
+    }
+
+    // -------------------------------------------------------------------------
+    // session_start: track active sessions for later flush resolution
+    // -------------------------------------------------------------------------
+    api.on("session_start", (event, ctx) => {
+      if (!event.sessionId) return;
+      const sessionKey = ctx?.sessionKey ?? event.sessionKey ?? "";
+      const agentId = ctx?.agentId ?? "main";
+      activeSessions.set(event.sessionId, {
+        sessionId: event.sessionId,
+        sessionKey,
+        agentId,
+      });
+      api.logger.debug?.(
+        `openviking-session-bridge: tracking session ${event.sessionId} (key=${sessionKey})`,
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // session_end: fire-and-forget incremental flush
+    // -------------------------------------------------------------------------
+    api.on("session_end", (event, ctx) => {
+      if (!cfg.enabled) return;
+      if (!event.sessionId) return;
+
+      const sessionId = event.sessionId;
+      const sessionKey = ctx?.sessionKey ?? event.sessionKey ?? "";
+      const agentId = ctx?.agentId ?? "main";
+
+      // Resolve sessionFile: try tracked entry first, then fall back to
+      // standard path resolution via OpenClaw state dir.
+      const tracked = activeSessions.get(sessionId);
+      const sessionFile = tracked?.sessionFile ?? resolveSessionFile(sessionId, agentId, api);
+
+      api.logger.debug?.(
+        `openviking-session-bridge: session_end for ${sessionId} (file=${sessionFile ?? "?"})`,
+      );
+
+      // Fire-and-forget: the main event loop must not block here.
+      void (async () => {
+        try {
+          const result = await flushSessionToOV({
+            openclawSessionId: sessionId,
+            sessionKey,
+            agentId,
+            sessionFile,
+            cfg,
+            isFinalFlush: true,
+          });
+
+          if (result.skipped) {
+            api.logger.debug?.(
+              `openviking-session-bridge: session ${sessionId} flush skipped (finalized=${result.finalized})`,
+            );
+          } else if (result.ok) {
+            api.logger.info(
+              `openviking-session-bridge: flushed ${result.turnsFlushed} turns for session ${sessionId}` +
+                (result.finalized ? " (committed)" : ""),
+            );
+          } else {
+            api.logger.warn(
+              `openviking-session-bridge: flush failed for session ${sessionId}: ${result.error}`,
+            );
+          }
+        } catch (err) {
+          api.logger.warn(
+            `openviking-session-bridge: unexpected error during flush: ${String(err)}`,
+          );
+        } finally {
+          activeSessions.delete(sessionId);
+        }
+      })();
+    });
+
+    // -------------------------------------------------------------------------
+    // /done command: synchronous flush with timeout
+    //
+    // Flushes ALL non-finalized tracked sessions (typically just one).
+    // Returns confirmation reply; user should send /new to start a fresh session.
+    //
+    // To auto-reset on /done, add "/done" to session.resetTriggers in
+    // clawdbot.json and the plugin will still flush synchronously.
+    // -------------------------------------------------------------------------
+    api.registerCommand({
+      name: "done",
+      description:
+        "Flush current session to OpenViking synchronously, then confirm. " +
+        "Follow with /new to start a fresh session.",
+      handler: async () => {
+        if (!cfg.enabled) {
+          return {
+            text: "openviking-session-bridge is disabled. Set enabled:true in plugin config to activate.",
+          };
+        }
+
+        // Collect all non-finalized sessions to flush.
+        const toFlush: TrackedSession[] = [];
+        for (const session of activeSessions.values()) {
+          const cp: SessionCheckpoint | null = loadCheckpoint(cfg.stateDir, session.sessionId);
+          if (!cp?.finalized) {
+            const sessionFile =
+              session.sessionFile ?? resolveSessionFile(session.sessionId, session.agentId, api);
+            toFlush.push({ ...session, sessionFile });
+          }
+        }
+
+        if (toFlush.length === 0) {
+          return { text: "✅ No active sessions to flush. Use /new to start fresh." };
+        }
+
+        const results = await Promise.all(
+          toFlush.map((s) =>
+            flushWithTimeout(
+              {
+                openclawSessionId: s.sessionId,
+                sessionKey: s.sessionKey,
+                agentId: s.agentId,
+                sessionFile: s.sessionFile,
+                cfg,
+                isFinalFlush: true,
+              },
+              cfg.flushTimeoutMs,
+            ),
+          ),
+        );
+
+        const succeeded = results.filter((r) => r.ok && !r.skipped);
+        const failed = results.filter((r) => !r.ok);
+        const skipped = results.filter((r) => r.skipped);
+
+        if (failed.length > 0) {
+          const errors = failed.map((r) => r.error ?? "unknown").join("; ");
+          api.logger.warn(`openviking-session-bridge: /done flush failed: ${errors}`);
+          return {
+            text:
+              `⚠️ Session flush partially failed (${failed.length}/${toFlush.length}). ` +
+              `Check logs. Errors: ${errors}`,
+          };
+        }
+
+        const totalTurns = succeeded.reduce((sum, r) => sum + r.turnsFlushed, 0);
+        const note = skipped.length > 0 ? ` (${skipped.length} already finalized)` : "";
+
+        return {
+          text:
+            `✅ Session saved to OpenViking (${totalTurns} turn${totalTurns === 1 ? "" : "s"} flushed${note}). ` +
+            `Use /new to start a fresh session.`,
+        };
+      },
+    });
+
+    api.logger.info(
+      `openviking-session-bridge: registered (enabled=${cfg.enabled}, baseUrl=${cfg.baseUrl})`,
+    );
+  },
+};
+
+/**
+ * Best-effort resolution of the session transcript file path.
+ * Mirrors the standard OpenClaw state directory structure:
+ *   ~/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl
+ *
+ * Respects OPENCLAW_STATE_DIR env var if set (same as OpenClaw core).
+ */
+function resolveSessionFile(
+  sessionId: string,
+  agentId: string,
+  _api: OpenClawPluginApi,
+): string | undefined {
+  try {
+    const stateDir =
+      process.env.OPENCLAW_STATE_DIR ??
+      `${process.env.HOME ?? process.env.USERPROFILE ?? homedir()}/.openclaw`;
+    return `${stateDir}/agents/${agentId}/sessions/${sessionId}.jsonl`;
+  } catch {
+    return undefined;
+  }
+}
+
+export default sessionBridgePlugin;

--- a/extensions/openviking-session-bridge/index.ts
+++ b/extensions/openviking-session-bridge/index.ts
@@ -17,28 +17,78 @@
 
 import { homedir } from "node:os";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
-import { parseOVSessionBridgeConfig } from "./src/config.js";
-import { flushSessionToOV, flushWithTimeout } from "./src/flush.js";
-import { loadCheckpoint } from "./src/state.js";
+import { buildOVPluginConfigSchema, parseOVSessionBridgeConfig } from "./src/config.js";
+import { enqueueFlush, flushWithTimeout } from "./src/flush.js";
+import { listPendingCheckpoints, loadCheckpoint } from "./src/state.js";
 import type { SessionCheckpoint } from "./src/types.js";
 
-// Module-level tracking map: sessionId → metadata needed for flush.
-// Populated via session_start; used by session_end and /done.
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// Maximum number of sessions tracked in activeSessions before we start
+// evicting the oldest entries (guards against unbounded growth in long-lived
+// processes with many short sessions that never fire session_end).
+const MAX_TRACKED_SESSIONS = 500;
+
+// Sessions older than this TTL are eligible for eviction from activeSessions
+// even if session_end was never fired (e.g. process restart, crash).
+const SESSION_TRACKING_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Maximum attempts for the session_end fire-and-forget flush before giving up.
+const SESSION_END_MAX_RETRIES = 3;
+
+// Base delay between session_end retry attempts (multiplied by attempt index).
+const SESSION_END_RETRY_BASE_DELAY_MS = 2_000;
+
+// ── Module-level session tracking ────────────────────────────────────────────
+
 type TrackedSession = {
   sessionId: string;
   sessionKey: string;
   agentId: string;
   sessionFile?: string;
+  /** Epoch ms when this session was first tracked (for TTL eviction). */
+  trackedAt: number;
 };
 
 const activeSessions = new Map<string, TrackedSession>();
+
+/**
+ * Evict stale entries from activeSessions.
+ *
+ * Runs on every session_start.  Removes entries older than SESSION_TRACKING_TTL_MS
+ * first, then trims by age if the map still exceeds MAX_TRACKED_SESSIONS.
+ * O(n) per call but n is bounded by MAX_TRACKED_SESSIONS so cost is small.
+ */
+function pruneActiveSessions(): void {
+  const now = Date.now();
+
+  // Remove TTL-expired entries.
+  for (const [id, s] of activeSessions.entries()) {
+    if (now - s.trackedAt > SESSION_TRACKING_TTL_MS) {
+      activeSessions.delete(id);
+    }
+  }
+
+  // If still over the cap, evict oldest first.
+  if (activeSessions.size > MAX_TRACKED_SESSIONS) {
+    const sorted = [...activeSessions.entries()].sort(([, a], [, b]) => a.trackedAt - b.trackedAt);
+    const excess = activeSessions.size - MAX_TRACKED_SESSIONS;
+    for (let i = 0; i < excess; i++) {
+      if (sorted[i]) activeSessions.delete(sorted[i][0]);
+    }
+  }
+}
+
+// ── Plugin definition ─────────────────────────────────────────────────────────
 
 const sessionBridgePlugin = {
   id: "openviking-session-bridge",
   name: "OpenViking Session Bridge",
   description: "Flush session transcripts to OpenViking at session boundaries",
-  configSchema: emptyPluginConfigSchema(),
+  // Matches the configSchema declared in openclaw.plugin.json; provides
+  // runtime validation and UI hints (replaces the previous emptyPluginConfigSchema()
+  // which rejected any non-empty config object).
+  configSchema: buildOVPluginConfigSchema(),
 
   register(api: OpenClawPluginApi) {
     const cfg = parseOVSessionBridgeConfig(api.pluginConfig ?? {});
@@ -55,10 +105,15 @@ const sessionBridgePlugin = {
       if (!event.sessionId) return;
       const sessionKey = ctx?.sessionKey ?? event.sessionKey ?? "";
       const agentId = ctx?.agentId ?? "main";
+
+      // Evict stale entries before adding new ones.
+      pruneActiveSessions();
+
       activeSessions.set(event.sessionId, {
         sessionId: event.sessionId,
         sessionKey,
         agentId,
+        trackedAt: Date.now(),
       });
       api.logger.debug?.(
         `openviking-session-bridge: tracking session ${event.sessionId} (key=${sessionKey})`,
@@ -66,7 +121,11 @@ const sessionBridgePlugin = {
     });
 
     // -------------------------------------------------------------------------
-    // session_end: fire-and-forget incremental flush
+    // session_end: fire-and-forget incremental flush with retry
+    //
+    // Uses enqueueFlush() to prevent concurrent flushes for the same session
+    // (e.g. if /done fires simultaneously).  Retries on transient failures with
+    // exponential back-off before giving up.
     // -------------------------------------------------------------------------
     api.on("session_end", (event, ctx) => {
       if (!cfg.enabled) return;
@@ -76,8 +135,6 @@ const sessionBridgePlugin = {
       const sessionKey = ctx?.sessionKey ?? event.sessionKey ?? "";
       const agentId = ctx?.agentId ?? "main";
 
-      // Resolve sessionFile: try tracked entry first, then fall back to
-      // standard path resolution via OpenClaw state dir.
       const tracked = activeSessions.get(sessionId);
       const sessionFile = tracked?.sessionFile ?? resolveSessionFile(sessionId, agentId, api);
 
@@ -85,39 +142,58 @@ const sessionBridgePlugin = {
         `openviking-session-bridge: session_end for ${sessionId} (file=${sessionFile ?? "?"})`,
       );
 
-      // Fire-and-forget: the main event loop must not block here.
-      void (async () => {
-        try {
-          const result = await flushSessionToOV({
-            openclawSessionId: sessionId,
-            sessionKey,
-            agentId,
-            sessionFile,
-            cfg,
-            isFinalFlush: true,
-          });
+      const flushParams = {
+        openclawSessionId: sessionId,
+        sessionKey,
+        agentId,
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      };
 
-          if (result.skipped) {
-            api.logger.debug?.(
-              `openviking-session-bridge: session ${sessionId} flush skipped (finalized=${result.finalized})`,
-            );
-          } else if (result.ok) {
-            api.logger.info(
-              `openviking-session-bridge: flushed ${result.turnsFlushed} turns for session ${sessionId}` +
-                (result.finalized ? " (committed)" : ""),
-            );
-          } else {
-            api.logger.warn(
-              `openviking-session-bridge: flush failed for session ${sessionId}: ${result.error}`,
-            );
+      // Fire-and-forget with retry: the main event loop must not block here.
+      void (async () => {
+        let lastResult: {
+          ok: boolean;
+          skipped?: boolean;
+          turnsFlushed?: number;
+          finalized?: boolean;
+          error?: string;
+        } | null = null;
+
+        for (let attempt = 0; attempt < SESSION_END_MAX_RETRIES; attempt++) {
+          try {
+            lastResult = await enqueueFlush(flushParams);
+            if (lastResult.ok || lastResult.skipped) break; // success or idempotent skip
+          } catch (err) {
+            lastResult = { ok: false, error: String(err) };
           }
-        } catch (err) {
-          api.logger.warn(
-            `openviking-session-bridge: unexpected error during flush: ${String(err)}`,
-          );
-        } finally {
-          activeSessions.delete(sessionId);
+          if (attempt < SESSION_END_MAX_RETRIES - 1) {
+            const delay = SESSION_END_RETRY_BASE_DELAY_MS * (attempt + 1);
+            api.logger.debug?.(
+              `openviking-session-bridge: session_end retry ${attempt + 1}/${SESSION_END_MAX_RETRIES - 1} ` +
+                `in ${delay}ms for session ${sessionId}: ${lastResult?.error ?? "unknown error"}`,
+            );
+            await new Promise<void>((r) => setTimeout(r, delay));
+          }
         }
+
+        if (lastResult?.skipped) {
+          api.logger.debug?.(
+            `openviking-session-bridge: session ${sessionId} flush skipped (finalized=${lastResult.finalized})`,
+          );
+        } else if (lastResult?.ok) {
+          api.logger.info(
+            `openviking-session-bridge: flushed ${lastResult.turnsFlushed ?? 0} turns for session ${sessionId}` +
+              (lastResult.finalized ? " (committed)" : ""),
+          );
+        } else {
+          api.logger.warn(
+            `openviking-session-bridge: flush failed for session ${sessionId} after ${SESSION_END_MAX_RETRIES} attempts: ${lastResult?.error ?? "unknown"}`,
+          );
+        }
+
+        activeSessions.delete(sessionId);
       })();
     });
 
@@ -126,6 +202,9 @@ const sessionBridgePlugin = {
     //
     // Flushes ALL non-finalized tracked sessions (typically just one).
     // Returns confirmation reply; user should send /new to start a fresh session.
+    //
+    // Uses flushWithTimeout (which internally uses enqueueFlush) so concurrent
+    // session_end flushes are coalesced rather than doubled.
     //
     // To auto-reset on /done, add "/done" to session.resetTriggers in
     // clawdbot.json and the plugin will still flush synchronously.
@@ -201,6 +280,55 @@ const sessionBridgePlugin = {
     api.logger.info(
       `openviking-session-bridge: registered (enabled=${cfg.enabled}, baseUrl=${cfg.baseUrl})`,
     );
+
+    // -------------------------------------------------------------------------
+    // Startup replay: re-flush sessions from previous process runs that were
+    // interrupted before session_end completed (e.g. process killed mid-flush).
+    //
+    // We scan stateDir for non-finalized checkpoints not currently in
+    // activeSessions (those are still live and will flush via session_end).
+    // Per-turn checkpointing ensures replayed flushes resume from the correct
+    // offset without resending already-delivered turns.
+    // -------------------------------------------------------------------------
+    if (cfg.enabled) {
+      void (async () => {
+        const pending = listPendingCheckpoints(cfg.stateDir);
+        if (pending.length === 0) return;
+
+        api.logger.info(
+          `openviking-session-bridge: startup replay — ${pending.length} non-finalized checkpoint(s) found`,
+        );
+
+        for (const cp of pending) {
+          // Skip sessions still actively tracked (session_end will handle them).
+          if (activeSessions.has(cp.openclawSessionId)) continue;
+
+          const sessionFile = resolveSessionFile(cp.openclawSessionId, cp.agentId, api);
+          api.logger.debug?.(
+            `openviking-session-bridge: startup replay for session ${cp.openclawSessionId}`,
+          );
+
+          void enqueueFlush({
+            openclawSessionId: cp.openclawSessionId,
+            sessionKey: cp.sessionKey,
+            agentId: cp.agentId,
+            sessionFile,
+            cfg,
+            isFinalFlush: true,
+          }).then((result) => {
+            if (result.ok && !result.skipped) {
+              api.logger.info(
+                `openviking-session-bridge: startup-replay flushed ${result.turnsFlushed} turn(s) for ${cp.openclawSessionId}`,
+              );
+            } else if (!result.ok) {
+              api.logger.warn(
+                `openviking-session-bridge: startup-replay flush failed for ${cp.openclawSessionId}: ${result.error}`,
+              );
+            }
+          });
+        }
+      })();
+    }
   },
 };
 

--- a/extensions/openviking-session-bridge/index.ts
+++ b/extensions/openviking-session-bridge/index.ts
@@ -18,7 +18,7 @@
 import { homedir } from "node:os";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { buildOVPluginConfigSchema, parseOVSessionBridgeConfig } from "./src/config.js";
-import { enqueueFlush, flushWithTimeout } from "./src/flush.js";
+import { enqueueFlush, flushWithTimeout, flushWithRetry } from "./src/flush.js";
 import { listPendingCheckpoints, loadCheckpoint } from "./src/state.js";
 import type { SessionCheckpoint } from "./src/types.js";
 
@@ -38,6 +38,13 @@ const SESSION_END_MAX_RETRIES = 3;
 
 // Base delay between session_end retry attempts (multiplied by attempt index).
 const SESSION_END_RETRY_BASE_DELAY_MS = 2_000;
+
+// Maximum retry attempts for startup replay of interrupted sessions.
+const STARTUP_REPLAY_MAX_RETRIES = 4;
+
+// Base delay between startup replay retry attempts (linear back-off).
+// At 5s base: delays are 5s, 10s, 15s across up to 3 retries.
+const STARTUP_REPLAY_RETRY_BASE_DELAY_MS = 5_000;
 
 // ── Module-level session tracking ────────────────────────────────────────────
 
@@ -308,21 +315,33 @@ const sessionBridgePlugin = {
             `openviking-session-bridge: startup replay for session ${cp.openclawSessionId}`,
           );
 
-          void enqueueFlush({
+          const replayParams = {
             openclawSessionId: cp.openclawSessionId,
             sessionKey: cp.sessionKey,
             agentId: cp.agentId,
             sessionFile,
             cfg,
             isFinalFlush: true,
+          };
+
+          // Fire-and-forget with retry/back-off so transient startup failures
+          // (e.g. OV server not yet ready) are retried rather than silently
+          // dropped as they were with the previous single-attempt approach.
+          void flushWithRetry(replayParams, {
+            maxRetries: STARTUP_REPLAY_MAX_RETRIES,
+            retryBaseDelayMs: STARTUP_REPLAY_RETRY_BASE_DELAY_MS,
           }).then((result) => {
             if (result.ok && !result.skipped) {
               api.logger.info(
                 `openviking-session-bridge: startup-replay flushed ${result.turnsFlushed} turn(s) for ${cp.openclawSessionId}`,
               );
-            } else if (!result.ok) {
+            } else if (result.skipped) {
+              api.logger.debug?.(
+                `openviking-session-bridge: startup-replay skipped ${cp.openclawSessionId} (finalized=${result.finalized})`,
+              );
+            } else {
               api.logger.warn(
-                `openviking-session-bridge: startup-replay flush failed for ${cp.openclawSessionId}: ${result.error}`,
+                `openviking-session-bridge: startup-replay flush failed for ${cp.openclawSessionId} after ${STARTUP_REPLAY_MAX_RETRIES} attempt(s): ${result.error}`,
               );
             }
           });

--- a/extensions/openviking-session-bridge/openclaw.plugin.json
+++ b/extensions/openviking-session-bridge/openclaw.plugin.json
@@ -1,0 +1,61 @@
+{
+  "id": "openviking-session-bridge",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "baseUrl": { "type": "string" },
+      "apiKey": { "type": "string" },
+      "agentId": { "type": "string" },
+      "timeoutMs": { "type": "number" },
+      "flushTimeoutMs": { "type": "number" },
+      "stateDir": { "type": "string" },
+      "commitOnFlush": { "type": "boolean" }
+    }
+  },
+  "uiHints": {
+    "enabled": {
+      "label": "Enabled",
+      "help": "Enable or disable the OpenViking session bridge (default: false)"
+    },
+    "baseUrl": {
+      "label": "OpenViking Base URL",
+      "placeholder": "http://127.0.0.1:1933",
+      "help": "HTTP URL of the running OpenViking server"
+    },
+    "apiKey": {
+      "label": "OpenViking API Key",
+      "sensitive": true,
+      "placeholder": "${OPENVIKING_API_KEY}",
+      "help": "Optional API key for OpenViking server"
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "default",
+      "help": "Agent identifier sent to OpenViking (X-OpenViking-Agent header)"
+    },
+    "timeoutMs": {
+      "label": "Request Timeout (ms)",
+      "placeholder": "15000",
+      "advanced": true
+    },
+    "flushTimeoutMs": {
+      "label": "Flush Timeout (ms)",
+      "placeholder": "30000",
+      "help": "Maximum time to wait for a synchronous flush (e.g. /done command)",
+      "advanced": true
+    },
+    "stateDir": {
+      "label": "State Directory",
+      "placeholder": "~/.openclaw/data/openviking-session-bridge",
+      "help": "Directory for checkpoint files",
+      "advanced": true
+    },
+    "commitOnFlush": {
+      "label": "Commit On Flush",
+      "help": "Commit (extract memories from) the OV session at session_end. Default: true",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/openviking-session-bridge/package.json
+++ b/extensions/openviking-session-bridge/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openclaw/openviking-session-bridge",
+  "version": "2026.3.18",
+  "private": true,
+  "description": "Flush OpenClaw session transcripts into OpenViking at session boundaries",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.2"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/openviking-session-bridge/src/client.ts
+++ b/extensions/openviking-session-bridge/src/client.ts
@@ -5,11 +5,26 @@ export class OVSessionBridgeClient {
     private readonly apiKey: string,
     private readonly agentId: string,
     private readonly timeoutMs: number,
+    /**
+     * Optional caller-supplied AbortSignal.  When fired, all in-flight HTTP
+     * requests issued by this client are aborted immediately rather than
+     * waiting for the per-request timeout to expire.  Used by flushWithTimeout
+     * to propagate cancellation so a timed-out /done actually stops work.
+     */
+    private readonly abortSignal?: AbortSignal,
   ) {}
 
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    // Combine the per-request timeout signal with any caller-supplied signal.
+    // AbortSignal.any fires as soon as the earliest signal fires.
+    const signal =
+      this.abortSignal != null
+        ? AbortSignal.any([controller.signal, this.abortSignal])
+        : controller.signal;
+
     try {
       const headers = new Headers(init.headers ?? {});
       if (this.apiKey) headers.set("X-API-Key", this.apiKey);
@@ -21,7 +36,7 @@ export class OVSessionBridgeClient {
       const res = await fetch(`${this.baseUrl}${path}`, {
         ...init,
         headers,
-        signal: controller.signal,
+        signal,
       });
 
       const payload = (await res.json().catch(() => ({}))) as {

--- a/extensions/openviking-session-bridge/src/client.ts
+++ b/extensions/openviking-session-bridge/src/client.ts
@@ -1,0 +1,89 @@
+/** Minimal HTTP client for the OpenViking session API. */
+export class OVSessionBridgeClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+    private readonly agentId: string,
+    private readonly timeoutMs: number,
+  ) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const headers = new Headers(init.headers ?? {});
+      if (this.apiKey) headers.set("X-API-Key", this.apiKey);
+      if (this.agentId) headers.set("X-OpenViking-Agent", this.agentId);
+      if (init.body && !headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+      }
+
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+
+      const payload = (await res.json().catch(() => ({}))) as {
+        status?: string;
+        result?: T;
+        error?: { code?: string; message?: string };
+      };
+
+      if (!res.ok || payload.status === "error") {
+        const code = payload.error?.code ? ` [${payload.error.code}]` : "";
+        const msg = payload.error?.message ?? `HTTP ${res.status}`;
+        throw new Error(`OpenViking request failed${code}: ${msg}`);
+      }
+
+      return (payload.result ?? payload) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async healthCheck(): Promise<void> {
+    await this.request<{ status: string }>("/health");
+  }
+
+  /** Create a new session; returns the server-assigned session ID. */
+  async createSession(): Promise<string> {
+    const result = await this.request<{ session_id: string }>("/api/v1/sessions", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    return result.session_id;
+  }
+
+  /** Append a single message to an existing OV session. */
+  async addSessionMessage(sessionId: string, role: string, content: string): Promise<void> {
+    await this.request<{ session_id: string }>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify({ role, content }),
+      },
+    );
+  }
+
+  /**
+   * Commit a session — archives it and triggers memory extraction.
+   * Uses wait=true by default (blocks until complete).
+   */
+  async commitSession(sessionId: string): Promise<void> {
+    await this.request<unknown>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit?wait=true`,
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      },
+    );
+  }
+
+  /** Delete a session (cleanup fallback). */
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.request<unknown>(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, {
+      method: "DELETE",
+    });
+  }
+}

--- a/extensions/openviking-session-bridge/src/config.ts
+++ b/extensions/openviking-session-bridge/src/config.ts
@@ -1,0 +1,71 @@
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+export type OVSessionBridgeConfig = {
+  enabled: boolean;
+  baseUrl: string;
+  apiKey: string;
+  agentId: string;
+  timeoutMs: number;
+  /** Maximum wall-clock ms for a synchronous /done flush before giving up. */
+  flushTimeoutMs: number;
+  stateDir: string;
+  /** Commit (extract memories) on final flush. Default true. */
+  commitOnFlush: boolean;
+};
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_FLUSH_TIMEOUT_MS = 30_000;
+const DEFAULT_AGENT_ID = "default";
+const DEFAULT_STATE_DIR = join(homedir(), ".openclaw", "data", "openviking-session-bridge");
+
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const v = process.env[envVar as string];
+    if (!v) throw new Error(`Environment variable ${envVar} is not set`);
+    return v;
+  });
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+export function parseOVSessionBridgeConfig(raw: unknown): OVSessionBridgeConfig {
+  const cfg =
+    raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const enabled = cfg.enabled === true; // default: false (must explicitly opt in)
+
+  const rawBaseUrl =
+    typeof cfg.baseUrl === "string" && cfg.baseUrl.trim()
+      ? cfg.baseUrl.trim()
+      : (process.env.OPENVIKING_BASE_URL ?? process.env.OPENVIKING_URL ?? DEFAULT_BASE_URL);
+  const baseUrl = resolveEnvVars(rawBaseUrl).replace(/\/+$/, "");
+
+  const rawApiKey =
+    typeof cfg.apiKey === "string" ? cfg.apiKey : (process.env.OPENVIKING_API_KEY ?? "");
+  const apiKey = rawApiKey ? resolveEnvVars(rawApiKey) : "";
+
+  const agentId =
+    typeof cfg.agentId === "string" && cfg.agentId.trim() ? cfg.agentId.trim() : DEFAULT_AGENT_ID;
+
+  const timeoutMs = Math.max(1_000, toNumber(cfg.timeoutMs, DEFAULT_TIMEOUT_MS));
+  const flushTimeoutMs = Math.max(5_000, toNumber(cfg.flushTimeoutMs, DEFAULT_FLUSH_TIMEOUT_MS));
+
+  const rawStateDir =
+    typeof cfg.stateDir === "string" && cfg.stateDir.trim()
+      ? cfg.stateDir.trim().replace(/^~/, homedir())
+      : DEFAULT_STATE_DIR;
+  const stateDir = resolvePath(rawStateDir);
+
+  const commitOnFlush = cfg.commitOnFlush !== false;
+
+  return { enabled, baseUrl, apiKey, agentId, timeoutMs, flushTimeoutMs, stateDir, commitOnFlush };
+}

--- a/extensions/openviking-session-bridge/src/config.ts
+++ b/extensions/openviking-session-bridge/src/config.ts
@@ -14,16 +14,57 @@ export type OVSessionBridgeConfig = {
   commitOnFlush: boolean;
 };
 
+// ── Schema type (structural subset of OpenClawPluginConfigSchema) ────────────
+// We define it locally so config.ts stays free of SDK imports.  The shape is
+// structurally compatible with OpenClawPluginConfigSchema from the SDK.
+
+type SafeParseResult =
+  | { success: true; data?: unknown }
+  | {
+      success: false;
+      error: { issues?: Array<{ path: Array<string | number>; message: string }> };
+    };
+
+type PluginConfigUiHint = {
+  label?: string;
+  help?: string;
+  tags?: string[];
+  advanced?: boolean;
+  sensitive?: boolean;
+  placeholder?: string;
+};
+
+export type OVPluginConfigSchema = {
+  safeParse?: (value: unknown) => SafeParseResult;
+  uiHints?: Record<string, PluginConfigUiHint>;
+  jsonSchema?: Record<string, unknown>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_FLUSH_TIMEOUT_MS = 30_000;
 const DEFAULT_AGENT_ID = "default";
 const DEFAULT_STATE_DIR = join(homedir(), ".openclaw", "data", "openviking-session-bridge");
 
-function resolveEnvVars(value: string): string {
-  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
-    const v = process.env[envVar as string];
-    if (!v) throw new Error(`Environment variable ${envVar} is not set`);
+/**
+ * Substitute `${VAR}` placeholders from process.env.
+ *
+ * Behaviour on missing variable:
+ *  - strict=false (default): leaves the placeholder intact (e.g. "${MY_VAR}").
+ *    The plugin loads successfully; the raw placeholder surfaces as an obviously
+ *    wrong value at the first API call, which is logged clearly.
+ *  - strict=true: throws immediately — use only when the caller knows the plugin
+ *    is enabled and the value is required.
+ */
+function resolveEnvVars(value: string, strict = false): string {
+  return value.replace(/\$\{([^}]+)\}/g, (original, envVar: string) => {
+    const v = process.env[envVar];
+    if (v == null || v === "") {
+      if (strict) throw new Error(`Environment variable ${envVar} is not set`);
+      return original; // leave placeholder intact — surfaced on first API call
+    }
     return v;
   });
 }
@@ -47,11 +88,15 @@ export function parseOVSessionBridgeConfig(raw: unknown): OVSessionBridgeConfig 
     typeof cfg.baseUrl === "string" && cfg.baseUrl.trim()
       ? cfg.baseUrl.trim()
       : (process.env.OPENVIKING_BASE_URL ?? process.env.OPENVIKING_URL ?? DEFAULT_BASE_URL);
-  const baseUrl = resolveEnvVars(rawBaseUrl).replace(/\/+$/, "");
+  // Lenient resolution: a missing env var leaves the placeholder, which surfaces
+  // as an HTTP error on first use rather than crashing the plugin at load time.
+  const baseUrl = resolveEnvVars(rawBaseUrl, false).replace(/\/+$/, "");
 
   const rawApiKey =
     typeof cfg.apiKey === "string" ? cfg.apiKey : (process.env.OPENVIKING_API_KEY ?? "");
-  const apiKey = rawApiKey ? resolveEnvVars(rawApiKey) : "";
+  // apiKey: lenient — a missing env var yields "" (unauthenticated). The first
+  // authenticated call will fail with a clear 401 rather than crashing at load.
+  const apiKey = rawApiKey ? resolveEnvVars(rawApiKey, false) : "";
 
   const agentId =
     typeof cfg.agentId === "string" && cfg.agentId.trim() ? cfg.agentId.trim() : DEFAULT_AGENT_ID;
@@ -68,4 +113,112 @@ export function parseOVSessionBridgeConfig(raw: unknown): OVSessionBridgeConfig 
   const commitOnFlush = cfg.commitOnFlush !== false;
 
   return { enabled, baseUrl, apiKey, agentId, timeoutMs, flushTimeoutMs, stateDir, commitOnFlush };
+}
+
+/**
+ * Build the runtime plugin config schema for the session bridge.
+ *
+ * The returned object is structurally compatible with OpenClawPluginConfigSchema
+ * from the SDK; it matches the shape declared in openclaw.plugin.json and
+ * provides `safeParse` so OpenClaw can validate user-supplied config at load time.
+ */
+export function buildOVPluginConfigSchema(): OVPluginConfigSchema {
+  return {
+    jsonSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        baseUrl: { type: "string" },
+        apiKey: { type: "string" },
+        agentId: { type: "string" },
+        timeoutMs: { type: "number" },
+        flushTimeoutMs: { type: "number" },
+        stateDir: { type: "string" },
+        commitOnFlush: { type: "boolean" },
+      },
+    },
+    uiHints: {
+      enabled: {
+        label: "Enabled",
+        help: "Enable or disable the OpenViking session bridge (default: false)",
+      },
+      baseUrl: {
+        label: "OpenViking Base URL",
+        placeholder: "http://127.0.0.1:1933",
+        help: "HTTP URL of the running OpenViking server",
+      },
+      apiKey: {
+        label: "OpenViking API Key",
+        sensitive: true,
+        placeholder: "${OPENVIKING_API_KEY}",
+        help: "Optional API key for OpenViking server",
+      },
+      agentId: {
+        label: "Agent ID",
+        placeholder: "default",
+        help: "Agent identifier sent to OpenViking (X-OpenViking-Agent header)",
+      },
+      timeoutMs: {
+        label: "Request Timeout (ms)",
+        placeholder: "15000",
+        advanced: true,
+      },
+      flushTimeoutMs: {
+        label: "Flush Timeout (ms)",
+        placeholder: "30000",
+        help: "Maximum time to wait for a synchronous flush (e.g. /done command)",
+        advanced: true,
+      },
+      stateDir: {
+        label: "State Directory",
+        placeholder: "~/.openclaw/data/openviking-session-bridge",
+        help: "Directory for checkpoint files",
+        advanced: true,
+      },
+      commitOnFlush: {
+        label: "Commit On Flush",
+        help: "Commit (extract memories from) the OV session at session_end. Default: true",
+        advanced: true,
+      },
+    },
+    safeParse(value: unknown): SafeParseResult {
+      if (value === undefined || value === null) {
+        return { success: true, data: value };
+      }
+      if (typeof value !== "object" || Array.isArray(value)) {
+        return {
+          success: false,
+          error: { issues: [{ path: [], message: "config must be an object" }] },
+        };
+      }
+      const cfg = value as Record<string, unknown>;
+      const issues: Array<{ path: Array<string | number>; message: string }> = [];
+
+      const BOOL_FIELDS = ["enabled", "commitOnFlush"] as const;
+      const NUM_FIELDS = ["timeoutMs", "flushTimeoutMs"] as const;
+      const STR_FIELDS = ["baseUrl", "apiKey", "agentId", "stateDir"] as const;
+
+      for (const k of BOOL_FIELDS) {
+        if (k in cfg && typeof cfg[k] !== "boolean") {
+          issues.push({ path: [k], message: `${k} must be a boolean` });
+        }
+      }
+      for (const k of NUM_FIELDS) {
+        if (k in cfg && (typeof cfg[k] !== "number" || !Number.isFinite(cfg[k] as number))) {
+          issues.push({ path: [k], message: `${k} must be a finite number` });
+        }
+      }
+      for (const k of STR_FIELDS) {
+        if (k in cfg && typeof cfg[k] !== "string") {
+          issues.push({ path: [k], message: `${k} must be a string` });
+        }
+      }
+
+      if (issues.length > 0) {
+        return { success: false, error: { issues } };
+      }
+      return { success: true, data: value };
+    },
+  };
 }

--- a/extensions/openviking-session-bridge/src/flush.ts
+++ b/extensions/openviking-session-bridge/src/flush.ts
@@ -16,6 +16,22 @@ export type FlushParams = {
   cfg: OVSessionBridgeConfig;
   /** If true, commit the OV session at the end (triggers memory extraction). */
   isFinalFlush: boolean;
+  /**
+   * Optional AbortSignal to propagate cancellation into in-flight HTTP
+   * requests.  When fired, all OV API calls in this flush are aborted
+   * immediately rather than waiting for the per-request timeout.
+   *
+   * Used by flushWithTimeout: the caller-side timer calls abort() so a
+   * timed-out /done actually cancels in-flight work rather than merely
+   * timing out the caller while the work continues in the background.
+   *
+   * Note: with enqueueFlush coalescing, the signal from the *first* caller's
+   * params is the one threaded into the actual HTTP work.  Subsequent callers
+   * that join the in-flight promise share its result but their individual
+   * signals are not retroactively threaded in — the background work is bounded
+   * by cfg.timeoutMs per request and clears the mutex naturally.
+   */
+  signal?: AbortSignal;
 };
 
 export type FlushResult = {
@@ -82,7 +98,7 @@ export function enqueueFlush(params: FlushParams): Promise<FlushResult> {
  * directly bypasses the per-session mutex and risks concurrent flushes.
  */
 export async function flushSessionToOV(params: FlushParams): Promise<FlushResult> {
-  const { openclawSessionId, sessionKey, agentId, sessionFile, cfg, isFinalFlush } = params;
+  const { openclawSessionId, sessionKey, agentId, sessionFile, cfg, isFinalFlush, signal } = params;
 
   // Skip entirely when plugin is disabled (caller should check, but double-guard here).
   if (!cfg.enabled) {
@@ -121,7 +137,15 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
     };
   }
 
-  const client = new OVSessionBridgeClient(cfg.baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
+  // Pass the caller-supplied abort signal into the HTTP client so that
+  // in-flight requests can be cancelled (e.g. when flushWithTimeout fires).
+  const client = new OVSessionBridgeClient(
+    cfg.baseUrl,
+    cfg.apiKey,
+    cfg.agentId,
+    cfg.timeoutMs,
+    signal,
+  );
 
   let ovSessionId = existingOvSessionId;
   // Track how many turns have been successfully sent in this flush attempt.
@@ -237,24 +261,31 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
  * session is already in-flight (e.g. fired by session_end), the caller joins it
  * rather than starting a duplicate.
  *
- * On timeout the caller receives ok:false immediately, but the underlying flush
- * continues running in the background — partial progress is checkpointed per
- * turn, so a subsequent flush for the same session will resume from the correct
- * offset rather than re-sending already-delivered turns.
+ * On timeout the caller receives ok:false immediately.  Cancellation is
+ * propagated via an AbortController whose signal is threaded through the flush
+ * params into the OV HTTP client — so in-flight HTTP requests are aborted
+ * immediately rather than running to their own per-request timeout.
  *
- * Residual risk: HTTP requests in-flight at the time of the timeout cannot be
- * cancelled without threading an AbortController through the client (future
- * work). The background work is bounded: it completes or hits its own per-
- * request timeout (cfg.timeoutMs) and then clears the mutex naturally.
+ * Coalescing note: if a flush was already in-flight when this function is called
+ * (started by another caller without an abort signal), the coalesced join shares
+ * that flush's result but the abort signal is not retroactively threaded in.
+ * The background work is bounded by cfg.timeoutMs per HTTP request and clears
+ * the mutex naturally.  Partial-progress checkpointing is preserved in both
+ * cases.
  */
 export async function flushWithTimeout(
   params: FlushParams,
   timeoutMs: number,
 ): Promise<FlushResult> {
-  const flushPromise = enqueueFlush(params);
+  const controller = new AbortController();
+  // Thread the abort signal into the flush so in-flight HTTP requests are
+  // actually cancelled when the timeout fires, not just the caller unblocked.
+  const paramsWithSignal: FlushParams = { ...params, signal: controller.signal };
+  const flushPromise = enqueueFlush(paramsWithSignal);
 
   return new Promise<FlushResult>((resolve) => {
     const timer = setTimeout(() => {
+      controller.abort("flush timeout");
       resolve({
         ok: false,
         turnsFlushed: 0,
@@ -280,4 +311,52 @@ export async function flushWithTimeout(
         });
       });
   });
+}
+
+/**
+ * Flush with automatic retry and linear back-off on transient failures.
+ *
+ * Suitable for fire-and-forget contexts where the first attempt may fail
+ * transiently (e.g. the OV server not yet available at process startup).
+ * Each attempt is coalesced through the per-session mutex (enqueueFlush),
+ * so concurrent callers for the same session are never doubled up.
+ *
+ * Returns the result of the last attempt — ok:true on any success, ok:false
+ * if all attempts are exhausted.
+ */
+export async function flushWithRetry(
+  params: FlushParams,
+  opts: { maxRetries: number; retryBaseDelayMs: number },
+): Promise<FlushResult> {
+  let lastResult: FlushResult | null = null;
+
+  for (let attempt = 0; attempt < opts.maxRetries; attempt++) {
+    try {
+      lastResult = await enqueueFlush(params);
+      if (lastResult.ok || lastResult.skipped) return lastResult;
+    } catch (err) {
+      lastResult = {
+        ok: false,
+        turnsFlushed: 0,
+        finalized: false,
+        skipped: false,
+        error: String(err),
+      };
+    }
+
+    if (attempt < opts.maxRetries - 1) {
+      // Linear back-off: delay grows by retryBaseDelayMs per attempt.
+      await new Promise<void>((r) => setTimeout(r, opts.retryBaseDelayMs * (attempt + 1)));
+    }
+  }
+
+  return (
+    lastResult ?? {
+      ok: false,
+      turnsFlushed: 0,
+      finalized: false,
+      skipped: false,
+      error: "no attempts made",
+    }
+  );
 }

--- a/extensions/openviking-session-bridge/src/flush.ts
+++ b/extensions/openviking-session-bridge/src/flush.ts
@@ -27,6 +27,43 @@ export type FlushResult = {
   error?: string;
 };
 
+// ── Per-session flush mutex ───────────────────────────────────────────────────
+//
+// Ensures at most one flush is in-flight for any given session at a time.
+// A new flush request for a session that is already flushing coalesces into
+// the existing promise rather than launching a second concurrent flush.
+// This prevents double messages and the corruption that can follow.
+//
+// The map is module-level (singleton for the plugin's lifetime) which is safe
+// because flushes are keyed by openclawSessionId (globally unique).
+const sessionFlushMutex = new Map<string, Promise<FlushResult>>();
+
+/**
+ * Enqueue a flush for the given session.
+ *
+ * If a flush is already in-flight for the same sessionId, the caller joins it
+ * rather than starting a duplicate.  When the in-flight flush settles it is
+ * removed from the map so the next call starts a fresh flush.
+ *
+ * This is the preferred call site for fire-and-forget callers (e.g. session_end
+ * hooks) as well as /done which needs the result.
+ */
+export function enqueueFlush(params: FlushParams): Promise<FlushResult> {
+  const { openclawSessionId } = params;
+  const inflight = sessionFlushMutex.get(openclawSessionId);
+  if (inflight) return inflight;
+
+  const p = flushSessionToOV(params);
+  sessionFlushMutex.set(openclawSessionId, p);
+  void p.finally(() => {
+    // Clean up only if this is still the registered promise (not already replaced).
+    if (sessionFlushMutex.get(openclawSessionId) === p) {
+      sessionFlushMutex.delete(openclawSessionId);
+    }
+  });
+  return p;
+}
+
 /**
  * Incrementally flush new transcript turns to OpenViking for a given session.
  * Safe to call multiple times (idempotent via checkpoint).
@@ -36,9 +73,13 @@ export type FlushResult = {
  *  2. Read transcript file; extract normalized turns.
  *  3. Skip turns already flushed (index < lastFlushedIndex).
  *  4. If OV session doesn't exist yet, create it.
- *  5. Append delta turns to OV session.
+ *  5. Append delta turns to OV session — checkpoint is advanced after each
+ *     successful push to prevent duplicate resends on retry.
  *  6. Update checkpoint.
  *  7. If isFinalFlush and commitOnFlush: commit OV session, mark finalized.
+ *
+ * NOTE: Prefer `enqueueFlush` over calling this directly. Calling this function
+ * directly bypasses the per-session mutex and risks concurrent flushes.
  */
 export async function flushSessionToOV(params: FlushParams): Promise<FlushResult> {
   const { openclawSessionId, sessionKey, agentId, sessionFile, cfg, isFinalFlush } = params;
@@ -83,20 +124,47 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
   const client = new OVSessionBridgeClient(cfg.baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
 
   let ovSessionId = existingOvSessionId;
+  // Track how many turns have been successfully sent in this flush attempt.
+  // Updated incrementally so the catch block can save accurate partial progress.
+  let currentFlushedIndex = lastFlushedIndex;
+
   try {
     // Create OV session if not yet provisioned.
     if (!ovSessionId) {
       // Verify server is reachable before creating a session.
       await client.healthCheck();
       ovSessionId = await client.createSession();
+      // Persist the new ovSessionId immediately so that if we crash before
+      // sending any turns, we reuse the session on retry rather than leaking
+      // an orphaned OV session.
+      saveCheckpoint(cfg.stateDir, {
+        openclawSessionId,
+        sessionKey,
+        agentId,
+        ovSessionId,
+        lastFlushedIndex: currentFlushedIndex,
+        finalized: false,
+        updatedAt: new Date().toISOString(),
+      });
     }
 
-    // Push delta turns.
+    // Push delta turns one by one, advancing the checkpoint after each
+    // successful send.  This means a retry after a partial failure will
+    // resume from the correct offset instead of re-sending already-delivered
+    // turns (which would create duplicate messages).
     for (const turn of delta) {
       await client.addSessionMessage(ovSessionId, turn.role, turn.text);
+      currentFlushedIndex++;
+      saveCheckpoint(cfg.stateDir, {
+        openclawSessionId,
+        sessionKey,
+        agentId,
+        ovSessionId,
+        lastFlushedIndex: currentFlushedIndex,
+        finalized: false,
+        updatedAt: new Date().toISOString(),
+      });
     }
-
-    const newLastFlushedIndex = lastFlushedIndex + delta.length;
 
     // Determine if we should finalize now.
     const shouldFinalize = isFinalFlush && cfg.commitOnFlush;
@@ -105,13 +173,13 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
       await client.commitSession(ovSessionId);
     }
 
-    // Persist updated checkpoint.
+    // Persist final checkpoint state.
     const updated: SessionCheckpoint = {
       openclawSessionId,
       sessionKey,
       agentId,
       ovSessionId,
-      lastFlushedIndex: newLastFlushedIndex,
+      lastFlushedIndex: currentFlushedIndex,
       finalized: shouldFinalize,
       updatedAt: new Date().toISOString(),
     };
@@ -120,37 +188,40 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
     return {
       ok: true,
       ovSessionId,
-      turnsFlushed: delta.length,
+      turnsFlushed: currentFlushedIndex - lastFlushedIndex,
       finalized: shouldFinalize,
       skipped: false,
     };
   } catch (err) {
-    // Save partial progress so a retry resumes from the right offset.
-    if (ovSessionId && delta.length > 0) {
-      // We might have sent some turns; can't know exactly how many without tracking per-turn.
-      // Conservative: don't advance lastFlushedIndex on error so we retry from the same point.
-    }
-    // Persist provisional ovSessionId even on failure so we reuse the session next time.
+    // Per-turn checkpointing above has already persisted progress for any
+    // turns that were successfully sent before the error.  We only need
+    // to save here if the OV session was freshly created this run and no
+    // per-turn save happened yet (i.e. createSession succeeded but the
+    // first addSessionMessage failed).
     if (ovSessionId && !checkpoint?.ovSessionId) {
-      const partial: SessionCheckpoint = {
-        openclawSessionId,
-        sessionKey,
-        agentId,
-        ovSessionId,
-        lastFlushedIndex: checkpoint?.lastFlushedIndex ?? 0,
-        finalized: false,
-        updatedAt: new Date().toISOString(),
-      };
-      try {
-        saveCheckpoint(cfg.stateDir, partial);
-      } catch {
-        /* best-effort */
+      const reloaded = loadCheckpoint(cfg.stateDir, openclawSessionId);
+      if (!reloaded?.ovSessionId) {
+        // The per-session save after createSession should have handled this,
+        // but guard against any edge case where it was skipped.
+        try {
+          saveCheckpoint(cfg.stateDir, {
+            openclawSessionId,
+            sessionKey,
+            agentId,
+            ovSessionId,
+            lastFlushedIndex: currentFlushedIndex,
+            finalized: false,
+            updatedAt: new Date().toISOString(),
+          });
+        } catch {
+          /* best-effort */
+        }
       }
     }
     return {
       ok: false,
       ovSessionId: ovSessionId ?? undefined,
-      turnsFlushed: 0,
+      turnsFlushed: currentFlushedIndex - lastFlushedIndex,
       finalized: false,
       skipped: false,
       error: String(err),
@@ -159,14 +230,30 @@ export async function flushSessionToOV(params: FlushParams): Promise<FlushResult
 }
 
 /**
- * Wrap flushSessionToOV with a wall-clock timeout.
- * On timeout, resolves with ok:false so callers can decide whether to block.
+ * Wrap a flush with a wall-clock timeout while preventing concurrent flushes
+ * for the same session.
+ *
+ * Uses `enqueueFlush` to coalesce concurrent callers: if a flush for the given
+ * session is already in-flight (e.g. fired by session_end), the caller joins it
+ * rather than starting a duplicate.
+ *
+ * On timeout the caller receives ok:false immediately, but the underlying flush
+ * continues running in the background — partial progress is checkpointed per
+ * turn, so a subsequent flush for the same session will resume from the correct
+ * offset rather than re-sending already-delivered turns.
+ *
+ * Residual risk: HTTP requests in-flight at the time of the timeout cannot be
+ * cancelled without threading an AbortController through the client (future
+ * work). The background work is bounded: it completes or hits its own per-
+ * request timeout (cfg.timeoutMs) and then clears the mutex naturally.
  */
 export async function flushWithTimeout(
   params: FlushParams,
   timeoutMs: number,
 ): Promise<FlushResult> {
-  return new Promise((resolve) => {
+  const flushPromise = enqueueFlush(params);
+
+  return new Promise<FlushResult>((resolve) => {
     const timer = setTimeout(() => {
       resolve({
         ok: false,
@@ -177,7 +264,7 @@ export async function flushWithTimeout(
       });
     }, timeoutMs);
 
-    flushSessionToOV(params)
+    flushPromise
       .then((result) => {
         clearTimeout(timer);
         resolve(result);

--- a/extensions/openviking-session-bridge/src/flush.ts
+++ b/extensions/openviking-session-bridge/src/flush.ts
@@ -1,0 +1,196 @@
+import { OVSessionBridgeClient } from "./client.js";
+import type { OVSessionBridgeConfig } from "./config.js";
+import { loadCheckpoint, saveCheckpoint } from "./state.js";
+import { readTranscriptFile } from "./transcript.js";
+import type { SessionCheckpoint } from "./types.js";
+
+export type FlushParams = {
+  openclawSessionId: string;
+  sessionKey: string;
+  agentId: string;
+  /**
+   * Absolute path to the JSONL session transcript file.
+   * If undefined, the flush is a no-op (no file to read).
+   */
+  sessionFile?: string;
+  cfg: OVSessionBridgeConfig;
+  /** If true, commit the OV session at the end (triggers memory extraction). */
+  isFinalFlush: boolean;
+};
+
+export type FlushResult = {
+  ok: boolean;
+  ovSessionId?: string;
+  turnsFlushed: number;
+  finalized: boolean;
+  skipped: boolean;
+  error?: string;
+};
+
+/**
+ * Incrementally flush new transcript turns to OpenViking for a given session.
+ * Safe to call multiple times (idempotent via checkpoint).
+ *
+ * Flow:
+ *  1. Load checkpoint (contains ovSessionId + lastFlushedIndex).
+ *  2. Read transcript file; extract normalized turns.
+ *  3. Skip turns already flushed (index < lastFlushedIndex).
+ *  4. If OV session doesn't exist yet, create it.
+ *  5. Append delta turns to OV session.
+ *  6. Update checkpoint.
+ *  7. If isFinalFlush and commitOnFlush: commit OV session, mark finalized.
+ */
+export async function flushSessionToOV(params: FlushParams): Promise<FlushResult> {
+  const { openclawSessionId, sessionKey, agentId, sessionFile, cfg, isFinalFlush } = params;
+
+  // Skip entirely when plugin is disabled (caller should check, but double-guard here).
+  if (!cfg.enabled) {
+    return { ok: true, turnsFlushed: 0, finalized: false, skipped: true };
+  }
+
+  // Load existing checkpoint.
+  const checkpoint = loadCheckpoint(cfg.stateDir, openclawSessionId);
+
+  // Already finalized — idempotent no-op.
+  if (checkpoint?.finalized) {
+    return {
+      ok: true,
+      ovSessionId: checkpoint.ovSessionId ?? undefined,
+      turnsFlushed: 0,
+      finalized: true,
+      skipped: true,
+    };
+  }
+
+  const lastFlushedIndex = checkpoint?.lastFlushedIndex ?? 0;
+  const existingOvSessionId = checkpoint?.ovSessionId ?? null;
+
+  // Read transcript and extract new turns since last flush.
+  const allTurns = sessionFile ? await readTranscriptFile(sessionFile) : [];
+  const delta = allTurns.slice(lastFlushedIndex);
+
+  // If no new content and not a final flush, skip.
+  if (delta.length === 0 && !isFinalFlush) {
+    return {
+      ok: true,
+      ovSessionId: existingOvSessionId ?? undefined,
+      turnsFlushed: 0,
+      finalized: false,
+      skipped: true,
+    };
+  }
+
+  const client = new OVSessionBridgeClient(cfg.baseUrl, cfg.apiKey, cfg.agentId, cfg.timeoutMs);
+
+  let ovSessionId = existingOvSessionId;
+  try {
+    // Create OV session if not yet provisioned.
+    if (!ovSessionId) {
+      // Verify server is reachable before creating a session.
+      await client.healthCheck();
+      ovSessionId = await client.createSession();
+    }
+
+    // Push delta turns.
+    for (const turn of delta) {
+      await client.addSessionMessage(ovSessionId, turn.role, turn.text);
+    }
+
+    const newLastFlushedIndex = lastFlushedIndex + delta.length;
+
+    // Determine if we should finalize now.
+    const shouldFinalize = isFinalFlush && cfg.commitOnFlush;
+
+    if (shouldFinalize) {
+      await client.commitSession(ovSessionId);
+    }
+
+    // Persist updated checkpoint.
+    const updated: SessionCheckpoint = {
+      openclawSessionId,
+      sessionKey,
+      agentId,
+      ovSessionId,
+      lastFlushedIndex: newLastFlushedIndex,
+      finalized: shouldFinalize,
+      updatedAt: new Date().toISOString(),
+    };
+    saveCheckpoint(cfg.stateDir, updated);
+
+    return {
+      ok: true,
+      ovSessionId,
+      turnsFlushed: delta.length,
+      finalized: shouldFinalize,
+      skipped: false,
+    };
+  } catch (err) {
+    // Save partial progress so a retry resumes from the right offset.
+    if (ovSessionId && delta.length > 0) {
+      // We might have sent some turns; can't know exactly how many without tracking per-turn.
+      // Conservative: don't advance lastFlushedIndex on error so we retry from the same point.
+    }
+    // Persist provisional ovSessionId even on failure so we reuse the session next time.
+    if (ovSessionId && !checkpoint?.ovSessionId) {
+      const partial: SessionCheckpoint = {
+        openclawSessionId,
+        sessionKey,
+        agentId,
+        ovSessionId,
+        lastFlushedIndex: checkpoint?.lastFlushedIndex ?? 0,
+        finalized: false,
+        updatedAt: new Date().toISOString(),
+      };
+      try {
+        saveCheckpoint(cfg.stateDir, partial);
+      } catch {
+        /* best-effort */
+      }
+    }
+    return {
+      ok: false,
+      ovSessionId: ovSessionId ?? undefined,
+      turnsFlushed: 0,
+      finalized: false,
+      skipped: false,
+      error: String(err),
+    };
+  }
+}
+
+/**
+ * Wrap flushSessionToOV with a wall-clock timeout.
+ * On timeout, resolves with ok:false so callers can decide whether to block.
+ */
+export async function flushWithTimeout(
+  params: FlushParams,
+  timeoutMs: number,
+): Promise<FlushResult> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({
+        ok: false,
+        turnsFlushed: 0,
+        finalized: false,
+        skipped: false,
+        error: `flush timed out after ${timeoutMs}ms`,
+      });
+    }, timeoutMs);
+
+    flushSessionToOV(params)
+      .then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      })
+      .catch((err: unknown) => {
+        clearTimeout(timer);
+        resolve({
+          ok: false,
+          turnsFlushed: 0,
+          finalized: false,
+          skipped: false,
+          error: String(err),
+        });
+      });
+  });
+}

--- a/extensions/openviking-session-bridge/src/state.ts
+++ b/extensions/openviking-session-bridge/src/state.ts
@@ -44,3 +44,41 @@ export function markFinalized(stateDir: string, sessionId: string): void {
   if (!existing) return;
   saveCheckpoint(stateDir, { ...existing, finalized: true, updatedAt: new Date().toISOString() });
 }
+
+/**
+ * Return all non-finalized checkpoints found in stateDir.
+ *
+ * Used at plugin startup to replay sessions that were interrupted before
+ * session_end fired or before the flush completed (e.g. process killed).
+ * Corrupted or unreadable checkpoint files are silently skipped.
+ */
+export function listPendingCheckpoints(stateDir: string): SessionCheckpoint[] {
+  try {
+    if (!fs.existsSync(stateDir)) return [];
+    const entries = fs.readdirSync(stateDir);
+    const pending: SessionCheckpoint[] = [];
+    for (const file of entries) {
+      // Only process our checkpoint files; ignore tmp files from in-progress writes.
+      if (!file.endsWith(".json") || file.includes(".tmp.")) continue;
+      const p = path.join(stateDir, file);
+      try {
+        const raw = fs.readFileSync(p, "utf-8");
+        const cp = JSON.parse(raw) as unknown;
+        if (
+          cp &&
+          typeof cp === "object" &&
+          !Array.isArray(cp) &&
+          typeof (cp as Record<string, unknown>).openclawSessionId === "string" &&
+          (cp as Record<string, unknown>).finalized === false
+        ) {
+          pending.push(cp as SessionCheckpoint);
+        }
+      } catch {
+        // Skip corrupted entries.
+      }
+    }
+    return pending;
+  } catch {
+    return [];
+  }
+}

--- a/extensions/openviking-session-bridge/src/state.ts
+++ b/extensions/openviking-session-bridge/src/state.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { SessionCheckpoint } from "./types.js";
+
+function checkpointPath(stateDir: string, sessionId: string): string {
+  // Sanitize sessionId to prevent path traversal (UUIDs only in practice).
+  const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+  return path.join(stateDir, `${safe}.json`);
+}
+
+function ensureStateDir(stateDir: string): void {
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true });
+  }
+}
+
+export function loadCheckpoint(stateDir: string, sessionId: string): SessionCheckpoint | null {
+  const p = checkpointPath(stateDir, sessionId);
+  try {
+    const raw = fs.readFileSync(p, "utf-8");
+    const parsed = JSON.parse(raw) as SessionCheckpoint;
+    if (parsed.openclawSessionId !== sessionId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCheckpoint(stateDir: string, checkpoint: SessionCheckpoint): void {
+  ensureStateDir(stateDir);
+  const p = checkpointPath(stateDir, checkpoint.openclawSessionId);
+  // Atomic write: write to temp file, then rename.
+  const tmp = `${p}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(checkpoint, null, 2), "utf-8");
+  fs.renameSync(tmp, p);
+}
+
+/**
+ * Mark a checkpoint as finalized (committed to OV; no further flushing needed).
+ * No-op if the checkpoint doesn't exist.
+ */
+export function markFinalized(stateDir: string, sessionId: string): void {
+  const existing = loadCheckpoint(stateDir, sessionId);
+  if (!existing) return;
+  saveCheckpoint(stateDir, { ...existing, finalized: true, updatedAt: new Date().toISOString() });
+}

--- a/extensions/openviking-session-bridge/src/transcript.ts
+++ b/extensions/openviking-session-bridge/src/transcript.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import type { NormalizedTurn } from "./types.js";
+
+// Roles that represent conversational content worth capturing.
+const CONTENT_ROLES = new Set(["user", "assistant"]);
+
+// Prefixes / exact strings that signal a no-op reply (should not be flushed).
+const NO_REPLY_PATTERN = /^\s*NO_REPLY\s*$/i;
+
+/**
+ * Extract readable text from a message `content` field.
+ * Handles:
+ *   - plain string  (legacy and most common)
+ *   - array of content parts ({ type: "text", text: "..." } or { type: "text_delta", text: "..." })
+ *
+ * Non-text parts (tool_use, tool_result, image, etc.) are silently skipped.
+ */
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (!part || typeof part !== "object") continue;
+      const p = part as Record<string, unknown>;
+      const type = typeof p.type === "string" ? p.type : "";
+      if (type === "text" || type === "text_delta") {
+        if (typeof p.text === "string" && p.text) parts.push(p.text);
+      }
+      // Skip: tool_use, tool_result, image, thinking, redacted_thinking, etc.
+    }
+    return parts.join("\n").trim();
+  }
+
+  return "";
+}
+
+/**
+ * Returns true for entries that are noise and should NOT be sent to OpenViking:
+ *   - tool calls / tool results
+ *   - system messages
+ *   - thinking / reflection blocks
+ *   - binary / media-only content with no text
+ *   - NO_REPLY placeholder responses
+ */
+function isNoiseTurn(role: string, text: string): boolean {
+  if (!CONTENT_ROLES.has(role)) return true;
+  if (!text.trim()) return true; // empty after extraction → skip
+  if (NO_REPLY_PATTERN.test(text)) return true;
+  return false;
+}
+
+/**
+ * Parse a raw JSONL session file and return a flat list of normalized turns.
+ * Lines that fail JSON parse or lack the expected shape are silently skipped.
+ */
+export async function readTranscriptFile(sessionFile: string): Promise<NormalizedTurn[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(sessionFile, "utf-8");
+  } catch {
+    // File not yet created or already archived.
+    return [];
+  }
+
+  const turns: NormalizedTurn[] = [];
+  let index = 0;
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    // Transcripts store conversational entries as { type: "message", message: { role, content } }
+    if (entry.type !== "message" || !entry.message) continue;
+
+    const msg = entry.message as Record<string, unknown>;
+    const role = typeof msg.role === "string" ? msg.role : "";
+    const text = extractTextFromContent(msg.content);
+
+    if (isNoiseTurn(role, text)) continue;
+
+    turns.push({
+      index,
+      role: role as "user" | "assistant",
+      text: text.trim(),
+    });
+    index++;
+  }
+
+  return turns;
+}

--- a/extensions/openviking-session-bridge/src/types.ts
+++ b/extensions/openviking-session-bridge/src/types.ts
@@ -1,0 +1,21 @@
+/** One normalized turn from the OpenClaw session transcript. */
+export type NormalizedTurn = {
+  /** Zero-based index in the full filtered turn list. */
+  index: number;
+  role: "user" | "assistant";
+  text: string;
+};
+
+/** Per-session checkpoint stored in stateDir/{sessionId}.json */
+export type SessionCheckpoint = {
+  openclawSessionId: string;
+  sessionKey: string;
+  agentId: string;
+  /** OpenViking session ID (null = not yet created). */
+  ovSessionId: string | null;
+  /** Index of the last successfully flushed turn (exclusive: next flush starts here). */
+  lastFlushedIndex: number;
+  /** True once the session has been committed to OV and is permanently closed. */
+  finalized: boolean;
+  updatedAt: string;
+};

--- a/extensions/openviking-session-bridge/tests/flush.test.ts
+++ b/extensions/openviking-session-bridge/tests/flush.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { OVSessionBridgeConfig } from "../src/config.js";
-import { flushSessionToOV } from "../src/flush.js";
-import { saveCheckpoint } from "../src/state.js";
+import { enqueueFlush, flushSessionToOV, flushWithTimeout } from "../src/flush.js";
+import { loadCheckpoint, saveCheckpoint } from "../src/state.js";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -160,7 +160,6 @@ describe("flushSessionToOV", () => {
     expect(result.ovSessionId).toBe("ov-new-session");
 
     // Verify checkpoint was saved.
-    const { loadCheckpoint } = await import("../src/state.js");
     const cp = loadCheckpoint(tmpDir, "s2");
     expect(cp?.finalized).toBe(true);
     expect(cp?.lastFlushedIndex).toBe(2);
@@ -287,5 +286,375 @@ describe("flushSessionToOV", () => {
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // ── per-turn checkpoint advancement ───────────────────────────────────────
+
+  it("advances checkpoint after each successfully sent turn (partial-progress semantics)", async () => {
+    const sessionFile = path.join(tmpDir, "session-partial.jsonl");
+    writeTranscript(sessionFile, [
+      { role: "user", content: "Turn A" },
+      { role: "assistant", content: "Turn B" },
+      { role: "user", content: "Turn C" },
+    ]);
+
+    let callCount = 0;
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const u = String(url);
+      const method = opts.method ?? "GET";
+      if (u.includes("/health")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok" }) });
+      }
+      if (u.endsWith("/api/v1/sessions") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-partial" } }),
+        });
+      }
+      if (u.includes("/messages") && method === "POST") {
+        callCount++;
+        // Fail on the 3rd message send to simulate a mid-stream error.
+        if (callCount === 3) {
+          return Promise.reject(new Error("network blip on turn 3"));
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              result: { session_id: "ov-partial", message_count: callCount },
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({ status: "error", error: { message: `unexpected: ${method} ${u}` } }),
+      });
+    });
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-partial",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(false);
+    // 2 turns were sent successfully before the failure.
+    expect(result.turnsFlushed).toBe(2);
+
+    // Checkpoint must reflect the 2 successfully sent turns so a retry
+    // does not re-send them (duplicate-message prevention).
+    const cp = loadCheckpoint(tmpDir, "s-partial");
+    expect(cp?.lastFlushedIndex).toBe(2);
+    expect(cp?.ovSessionId).toBe("ov-partial");
+    expect(cp?.finalized).toBe(false);
+  });
+
+  it("retry after partial failure sends only the remaining turn", async () => {
+    const sessionFile = path.join(tmpDir, "session-retry.jsonl");
+    writeTranscript(sessionFile, [
+      { role: "user", content: "Turn 1" },
+      { role: "assistant", content: "Turn 2" },
+      { role: "user", content: "Turn 3" },
+    ]);
+
+    // Seed checkpoint: 2 turns already sent, OV session exists.
+    saveCheckpoint(tmpDir, {
+      openclawSessionId: "s-retry",
+      sessionKey: "k",
+      agentId: "main",
+      ovSessionId: "ov-retry-existing",
+      lastFlushedIndex: 2,
+      finalized: false,
+      updatedAt: new Date().toISOString(),
+    });
+
+    let messageCalls = 0;
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const u = String(url);
+      const method = opts.method ?? "GET";
+      if (u.includes("/messages") && method === "POST") {
+        messageCalls++;
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              result: { session_id: "ov-retry-existing", message_count: messageCalls },
+            }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({ status: "error", error: { message: `unexpected: ${method} ${u}` } }),
+      });
+    });
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-retry",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(true);
+    // Only 1 new turn (Turn 3) should be sent — not all 3.
+    expect(result.turnsFlushed).toBe(1);
+    expect(messageCalls).toBe(1);
+  });
+});
+
+// ── flushWithTimeout / enqueueFlush serialization ────────────────────────────
+
+describe("flushWithTimeout + enqueueFlush serialization", () => {
+  let tmpDir: string;
+  let cfg: OVSessionBridgeConfig;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    cfg = makeConfig({ stateDir: tmpDir });
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("concurrent enqueueFlush calls for the same session are coalesced (not doubled)", async () => {
+    const sessionFile = path.join(tmpDir, "session-concurrent.jsonl");
+    writeTranscript(sessionFile, [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+
+    let sessionCreateCount = 0;
+    let messageCount = 0;
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const u = String(url);
+      const method = opts.method ?? "GET";
+      if (u.includes("/health")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok" }) });
+      }
+      if (u.endsWith("/api/v1/sessions") && method === "POST") {
+        sessionCreateCount++;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-coalesce" } }),
+        });
+      }
+      if (u.includes("/messages") && method === "POST") {
+        messageCount++;
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              result: { session_id: "ov-coalesce", message_count: messageCount },
+            }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({ status: "error", error: { message: `unexpected: ${method} ${u}` } }),
+      });
+    });
+
+    const params = {
+      openclawSessionId: "s-concurrent",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    };
+
+    // Fire two concurrent flush requests for the same session.
+    const [r1, r2] = await Promise.all([enqueueFlush(params), enqueueFlush(params)]);
+
+    // Both callers should get a successful result.
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+
+    // Only ONE OV session should have been created and only 2 messages sent
+    // (not 4 from doubled work).
+    expect(sessionCreateCount).toBe(1);
+    expect(messageCount).toBe(2);
+  });
+
+  it("flushWithTimeout resolves with timeout error if flush is slow", async () => {
+    const sessionFile = path.join(tmpDir, "session-slow.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Slow" }]);
+
+    // Simulate a very slow network response.
+    fetchMock.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+
+    const result = await flushWithTimeout(
+      {
+        openclawSessionId: "s-slow",
+        sessionKey: "k",
+        agentId: "main",
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      },
+      50, // 50ms timeout
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/);
+  });
+});
+
+// ── config schema ─────────────────────────────────────────────────────────────
+
+describe("buildOVPluginConfigSchema", () => {
+  it("accepts valid config", async () => {
+    const { buildOVPluginConfigSchema } = await import("../src/config.js");
+    const schema = buildOVPluginConfigSchema();
+    const result = schema.safeParse?.({
+      enabled: true,
+      baseUrl: "http://127.0.0.1:1933",
+      apiKey: "secret",
+      agentId: "main",
+      timeoutMs: 10000,
+      flushTimeoutMs: 30000,
+      stateDir: "/tmp/test",
+      commitOnFlush: true,
+    });
+    expect(result?.success).toBe(true);
+  });
+
+  it("accepts empty/undefined config (all defaults)", async () => {
+    const { buildOVPluginConfigSchema } = await import("../src/config.js");
+    const schema = buildOVPluginConfigSchema();
+    expect(schema.safeParse?.(undefined)?.success).toBe(true);
+    expect(schema.safeParse?.({})?.success).toBe(true);
+  });
+
+  it("rejects config with wrong field types", async () => {
+    const { buildOVPluginConfigSchema } = await import("../src/config.js");
+    const schema = buildOVPluginConfigSchema();
+    const result = schema.safeParse?.({ enabled: "yes", timeoutMs: "fast" });
+    expect(result?.success).toBe(false);
+    if (result && !result.success && result.error?.issues) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("has jsonSchema with all config properties", async () => {
+    const { buildOVPluginConfigSchema } = await import("../src/config.js");
+    const schema = buildOVPluginConfigSchema();
+    const props = (schema.jsonSchema?.properties ?? {}) as Record<string, unknown>;
+    for (const key of [
+      "enabled",
+      "baseUrl",
+      "apiKey",
+      "agentId",
+      "timeoutMs",
+      "flushTimeoutMs",
+      "stateDir",
+      "commitOnFlush",
+    ]) {
+      expect(props).toHaveProperty(key);
+    }
+  });
+});
+
+// ── resolveEnvVars leniency ───────────────────────────────────────────────────
+
+describe("parseOVSessionBridgeConfig env var resolution", () => {
+  it("does not throw when a referenced env var is not set (lenient by default)", async () => {
+    const { parseOVSessionBridgeConfig } = await import("../src/config.js");
+    // OPENVIKING_MISSING_VAR is deliberately not set in test env.
+    expect(() =>
+      parseOVSessionBridgeConfig({
+        enabled: false,
+        baseUrl: "${OPENVIKING_MISSING_VAR}",
+        apiKey: "${ANOTHER_MISSING_VAR}",
+      }),
+    ).not.toThrow();
+  });
+
+  it("leaves ${VAR} placeholder intact when env var is unset (lenient)", async () => {
+    const { parseOVSessionBridgeConfig } = await import("../src/config.js");
+    const cfg = parseOVSessionBridgeConfig({
+      enabled: false,
+      baseUrl: "${OPENVIKING_DEFINITELY_NOT_SET_XYZ}",
+    });
+    // The placeholder should be left as-is so it's visibly wrong at first use.
+    expect(cfg.baseUrl).toBe("${OPENVIKING_DEFINITELY_NOT_SET_XYZ}");
+  });
+});
+
+// ── listPendingCheckpoints ────────────────────────────────────────────────────
+
+describe("listPendingCheckpoints", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ov-pending-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array for empty dir", async () => {
+    const { listPendingCheckpoints } = await import("../src/state.js");
+    expect(listPendingCheckpoints(tmpDir)).toEqual([]);
+  });
+
+  it("returns non-finalized checkpoints only", async () => {
+    const { listPendingCheckpoints } = await import("../src/state.js");
+    const base = {
+      sessionKey: "k",
+      agentId: "main",
+      ovSessionId: null,
+      lastFlushedIndex: 2,
+      updatedAt: new Date().toISOString(),
+    };
+    saveCheckpoint(tmpDir, { ...base, openclawSessionId: "s-pending", finalized: false });
+    saveCheckpoint(tmpDir, { ...base, openclawSessionId: "s-done", finalized: true });
+
+    const pending = listPendingCheckpoints(tmpDir);
+    expect(pending.map((p) => p.openclawSessionId)).toContain("s-pending");
+    expect(pending.map((p) => p.openclawSessionId)).not.toContain("s-done");
+  });
+
+  it("skips tmp files from in-progress writes", async () => {
+    const { listPendingCheckpoints } = await import("../src/state.js");
+    // Write a .tmp. file that should be ignored.
+    fs.writeFileSync(
+      path.join(tmpDir, "s-tmp.json.tmp.12345"),
+      JSON.stringify({ openclawSessionId: "s-tmp", finalized: false }),
+    );
+    expect(listPendingCheckpoints(tmpDir)).toHaveLength(0);
   });
 });

--- a/extensions/openviking-session-bridge/tests/flush.test.ts
+++ b/extensions/openviking-session-bridge/tests/flush.test.ts
@@ -1,0 +1,291 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OVSessionBridgeConfig } from "../src/config.js";
+import { flushSessionToOV } from "../src/flush.js";
+import { saveCheckpoint } from "../src/state.js";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ov-flush-test-"));
+}
+
+function writeTranscript(filePath: string, turns: { role: string; content: string }[]): void {
+  const lines = [
+    JSON.stringify({ type: "session", version: 3, id: "sess", timestamp: "2026-01-01T00:00:00Z" }),
+    ...turns.map((t) =>
+      JSON.stringify({ type: "message", message: { role: t.role, content: t.content } }),
+    ),
+  ];
+  fs.writeFileSync(filePath, lines.join("\n"), "utf-8");
+}
+
+function makeConfig(overrides: Partial<OVSessionBridgeConfig> = {}): OVSessionBridgeConfig {
+  return {
+    enabled: true,
+    baseUrl: "http://localhost:1933",
+    apiKey: "",
+    agentId: "test-agent",
+    timeoutMs: 5000,
+    flushTimeoutMs: 10000,
+    stateDir: "", // set per-test
+    commitOnFlush: true,
+    ...overrides,
+  };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("flushSessionToOV", () => {
+  let tmpDir: string;
+  let cfg: OVSessionBridgeConfig;
+
+  // We mock fetch globally so no real HTTP calls are made.
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    cfg = makeConfig({ stateDir: tmpDir });
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  function mockOvSuccess(ovSessionId: string): void {
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const method = opts.method ?? "GET";
+      const u = String(url);
+
+      if (u.endsWith("/health") || u.includes("/health")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      }
+      if (u.endsWith("/api/v1/sessions") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: ovSessionId } }),
+        });
+      }
+      if (u.includes("/messages") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              result: { session_id: ovSessionId, message_count: 1 },
+            }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            status: "error",
+            error: { message: `unexpected call: ${method} ${u}` },
+          }),
+      });
+    });
+  }
+
+  it("skips when plugin is disabled", async () => {
+    const result = await flushSessionToOV({
+      openclawSessionId: "s1",
+      sessionKey: "k1",
+      agentId: "main",
+      cfg: makeConfig({ enabled: false, stateDir: tmpDir }),
+      isFinalFlush: true,
+    });
+    expect(result.skipped).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips already-finalized sessions (idempotency)", async () => {
+    saveCheckpoint(tmpDir, {
+      openclawSessionId: "s-fin",
+      sessionKey: "k",
+      agentId: "main",
+      ovSessionId: "ov-fin",
+      lastFlushedIndex: 3,
+      finalized: true,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-fin",
+      sessionKey: "k",
+      agentId: "main",
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.finalized).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("creates OV session, flushes turns, and commits on final flush", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    writeTranscript(sessionFile, [
+      { role: "user", content: "Hello OV" },
+      { role: "assistant", content: "Hello back" },
+    ]);
+    mockOvSuccess("ov-new-session");
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s2",
+      sessionKey: "k2",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.turnsFlushed).toBe(2);
+    expect(result.finalized).toBe(true);
+    expect(result.ovSessionId).toBe("ov-new-session");
+
+    // Verify checkpoint was saved.
+    const { loadCheckpoint } = await import("../src/state.js");
+    const cp = loadCheckpoint(tmpDir, "s2");
+    expect(cp?.finalized).toBe(true);
+    expect(cp?.lastFlushedIndex).toBe(2);
+    expect(cp?.ovSessionId).toBe("ov-new-session");
+  });
+
+  it("incremental flush: only sends new turns since last checkpoint", async () => {
+    const sessionFile = path.join(tmpDir, "session-inc.jsonl");
+    writeTranscript(sessionFile, [
+      { role: "user", content: "Turn 1" },
+      { role: "assistant", content: "Turn 2" },
+      { role: "user", content: "Turn 3" },
+    ]);
+
+    // Pre-existing checkpoint: 2 turns already sent.
+    saveCheckpoint(tmpDir, {
+      openclawSessionId: "s-inc",
+      sessionKey: "k",
+      agentId: "main",
+      ovSessionId: "ov-existing",
+      lastFlushedIndex: 2,
+      finalized: false,
+      updatedAt: new Date().toISOString(),
+    });
+
+    // Only the /messages and /commit calls should happen (no /health or session create).
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const u = String(url);
+      const method = opts.method ?? "GET";
+      if (u.includes("/messages") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              result: { session_id: "ov-existing", message_count: 3 },
+            }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({ status: "error", error: { message: `unexpected: ${method} ${u}` } }),
+      });
+    });
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-inc",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.turnsFlushed).toBe(1); // only Turn 3 was new
+    expect(result.ovSessionId).toBe("ov-existing");
+
+    // Verify only 1 addMessage call was made.
+    const messageCalls = fetchMock.mock.calls.filter((args: unknown[]) =>
+      String(args[0]).includes("/messages"),
+    );
+    expect(messageCalls).toHaveLength(1);
+  });
+
+  it("does not commit when commitOnFlush is false", async () => {
+    const sessionFile = path.join(tmpDir, "session-nc.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Hi" }]);
+    mockOvSuccess("ov-no-commit");
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-nc",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg: { ...cfg, commitOnFlush: false },
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.finalized).toBe(false);
+
+    const commitCalls = fetchMock.mock.calls.filter((args: unknown[]) =>
+      String(args[0]).includes("/commit"),
+    );
+    expect(commitCalls).toHaveLength(0);
+  });
+
+  it("returns ok:false on network error", async () => {
+    const sessionFile = path.join(tmpDir, "session-err.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Hi" }]);
+
+    fetchMock.mockRejectedValue(new Error("connection refused"));
+
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-err",
+      sessionKey: "k",
+      agentId: "main",
+      sessionFile,
+      cfg,
+      isFinalFlush: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/connection refused/);
+  });
+
+  it("returns ok:true with skipped:true when no turns and not final", async () => {
+    const result = await flushSessionToOV({
+      openclawSessionId: "s-empty",
+      sessionKey: "k",
+      agentId: "main",
+      cfg,
+      isFinalFlush: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/openviking-session-bridge/tests/flush.test.ts
+++ b/extensions/openviking-session-bridge/tests/flush.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { OVSessionBridgeConfig } from "../src/config.js";
-import { enqueueFlush, flushSessionToOV, flushWithTimeout } from "../src/flush.js";
+import { enqueueFlush, flushSessionToOV, flushWithTimeout, flushWithRetry } from "../src/flush.js";
 import { loadCheckpoint, saveCheckpoint } from "../src/state.js";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -656,5 +656,256 @@ describe("listPendingCheckpoints", () => {
       JSON.stringify({ openclawSessionId: "s-tmp", finalized: false }),
     );
     expect(listPendingCheckpoints(tmpDir)).toHaveLength(0);
+  });
+});
+
+// ── Fix 1: abort/cancellation propagation ────────────────────────────────────
+//
+// Verifies that flushWithTimeout threads an AbortSignal into the HTTP client
+// so in-flight requests are actually cancelled when the timeout fires.
+
+describe("flushWithTimeout abort propagation", () => {
+  let tmpDir: string;
+  let cfg: OVSessionBridgeConfig;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    cfg = makeConfig({ stateDir: tmpDir });
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("propagates AbortSignal to in-flight fetch and marks it aborted on timeout", async () => {
+    const sessionFile = path.join(tmpDir, "session-abort-sig.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Abort me" }]);
+
+    // Capture the signal passed to fetch; reject when it fires.
+    let capturedSignal: AbortSignal | null = null;
+    fetchMock.mockImplementation((_url: string, opts: RequestInit) => {
+      capturedSignal = (opts.signal as AbortSignal) ?? null;
+      return new Promise<Response>((_resolve, reject) => {
+        (opts.signal as AbortSignal | undefined)?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        });
+        // Never resolves otherwise — simulates a stalled HTTP request.
+      });
+    });
+
+    const result = await flushWithTimeout(
+      {
+        openclawSessionId: "s-abort-sig",
+        sessionKey: "k",
+        agentId: "main",
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      },
+      50, // 50ms timeout — fires before the stalled fetch resolves
+    );
+
+    // Caller receives a timeout error immediately.
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/);
+
+    // The fetch must have received a signal that is now in the aborted state,
+    // confirming that in-flight HTTP work was actually cancelled.
+    // Use a type assertion here: TypeScript narrows capturedSignal to never after
+    // the not.toBeNull() vitest assertion (TS sees the callback as possibly-not-called).
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as AbortSignal | null)?.aborted).toBe(true);
+  });
+
+  it("does NOT abort the fetch when flush completes before timeout fires", async () => {
+    const sessionFile = path.join(tmpDir, "session-no-abort.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Fast" }]);
+
+    let capturedSignal: AbortSignal | null = null;
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      capturedSignal = (opts.signal as AbortSignal) ?? null;
+      const u = String(url);
+      const method = (opts.method ?? "GET") as string;
+      if (u.includes("/health")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok" }) });
+      }
+      if (u.endsWith("/api/v1/sessions") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-fast" } }),
+        });
+      }
+      if (u.includes("/messages") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-fast" } }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ status: "error", error: { message: "unexpected" } }),
+      });
+    });
+
+    const result = await flushWithTimeout(
+      {
+        openclawSessionId: "s-no-abort",
+        sessionKey: "k",
+        agentId: "main",
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      },
+      5_000, // ample timeout — flush completes long before this fires
+    );
+
+    expect(result.ok).toBe(true);
+    // The signal should NOT be aborted since the flush succeeded.
+    // Type assertion: TS narrows capturedSignal in closure-assigned vars.
+    expect((capturedSignal as AbortSignal | null)?.aborted).toBe(false);
+  });
+});
+
+// ── Fix 2: startup replay retry (flushWithRetry) ──────────────────────────────
+//
+// Verifies that flushWithRetry retries on transient failures and eventually
+// returns ok:true when a later attempt succeeds.
+
+describe("flushWithRetry", () => {
+  let tmpDir: string;
+  let cfg: OVSessionBridgeConfig;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    cfg = makeConfig({ stateDir: tmpDir });
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("succeeds on second attempt after first transient failure", async () => {
+    const sessionFile = path.join(tmpDir, "session-retry-r.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Retry me" }]);
+
+    let healthCallCount = 0;
+    fetchMock.mockImplementation((url: string, opts: RequestInit) => {
+      const u = String(url);
+      const method = (opts.method ?? "GET") as string;
+
+      if (u.includes("/health")) {
+        healthCallCount++;
+        // First health-check fails; subsequent calls succeed.
+        if (healthCallCount === 1) {
+          return Promise.reject(new Error("OV server not ready yet"));
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok" }) });
+      }
+      if (u.endsWith("/api/v1/sessions") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-retry-r2" } }),
+        });
+      }
+      if (u.includes("/messages") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: { session_id: "ov-retry-r2" } }),
+        });
+      }
+      if (u.includes("/commit") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "ok", result: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({ status: "error", error: { message: `unexpected: ${method} ${u}` } }),
+      });
+    });
+
+    const result = await flushWithRetry(
+      {
+        openclawSessionId: "s-retry-r2",
+        sessionKey: "k",
+        agentId: "main",
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      },
+      { maxRetries: 3, retryBaseDelayMs: 1 }, // 1ms delays for test speed
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.turnsFlushed).toBe(1);
+    // Health was called twice: once for the failing attempt, once for the retry.
+    expect(healthCallCount).toBe(2);
+  });
+
+  it("returns ok:false after all retries exhausted", async () => {
+    const sessionFile = path.join(tmpDir, "session-exhaust.jsonl");
+    writeTranscript(sessionFile, [{ role: "user", content: "Always fails" }]);
+
+    // All fetch calls fail unconditionally.
+    fetchMock.mockRejectedValue(new Error("permanent failure"));
+
+    const result = await flushWithRetry(
+      {
+        openclawSessionId: "s-exhaust",
+        sessionKey: "k",
+        agentId: "main",
+        sessionFile,
+        cfg,
+        isFinalFlush: true,
+      },
+      { maxRetries: 3, retryBaseDelayMs: 1 },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/permanent failure/);
+  });
+
+  it("stops retrying immediately when the session is already finalized (skipped)", async () => {
+    // Pre-seed a finalized checkpoint so the flush returns skipped on first attempt.
+    saveCheckpoint(tmpDir, {
+      openclawSessionId: "s-finalized-r",
+      sessionKey: "k",
+      agentId: "main",
+      ovSessionId: "ov-done",
+      lastFlushedIndex: 3,
+      finalized: true,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await flushWithRetry(
+      {
+        openclawSessionId: "s-finalized-r",
+        sessionKey: "k",
+        agentId: "main",
+        cfg,
+        isFinalFlush: true,
+      },
+      { maxRetries: 5, retryBaseDelayMs: 1 },
+    );
+
+    // Should short-circuit on the first attempt (skipped=true counts as done).
+    expect(result.skipped).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/openviking-session-bridge/tests/state.test.ts
+++ b/extensions/openviking-session-bridge/tests/state.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { loadCheckpoint, saveCheckpoint, markFinalized } from "../src/state.js";
+import type { SessionCheckpoint } from "../src/types.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ov-state-test-"));
+}
+
+const SAMPLE: SessionCheckpoint = {
+  openclawSessionId: "session-abc-123",
+  sessionKey: "agent:main:telegram:group:1001:topic:2",
+  agentId: "main",
+  ovSessionId: "ov-xyz-456",
+  lastFlushedIndex: 5,
+  finalized: false,
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("checkpoint store", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for missing checkpoint", () => {
+    expect(loadCheckpoint(tmpDir, "no-such-session")).toBeNull();
+  });
+
+  it("round-trips a checkpoint", () => {
+    saveCheckpoint(tmpDir, SAMPLE);
+    const loaded = loadCheckpoint(tmpDir, SAMPLE.openclawSessionId);
+    expect(loaded).toMatchObject(SAMPLE);
+  });
+
+  it("overwrites an existing checkpoint", () => {
+    saveCheckpoint(tmpDir, SAMPLE);
+    const updated: SessionCheckpoint = { ...SAMPLE, lastFlushedIndex: 10 };
+    saveCheckpoint(tmpDir, updated);
+    const loaded = loadCheckpoint(tmpDir, SAMPLE.openclawSessionId);
+    expect(loaded?.lastFlushedIndex).toBe(10);
+  });
+
+  it("creates stateDir if it does not exist", () => {
+    const nested = path.join(tmpDir, "deep", "nested");
+    expect(fs.existsSync(nested)).toBe(false);
+    saveCheckpoint(nested, SAMPLE);
+    expect(fs.existsSync(nested)).toBe(true);
+    expect(loadCheckpoint(nested, SAMPLE.openclawSessionId)).not.toBeNull();
+  });
+
+  it("markFinalized sets finalized:true on an existing checkpoint", () => {
+    saveCheckpoint(tmpDir, SAMPLE);
+    markFinalized(tmpDir, SAMPLE.openclawSessionId);
+    const loaded = loadCheckpoint(tmpDir, SAMPLE.openclawSessionId);
+    expect(loaded?.finalized).toBe(true);
+  });
+
+  it("markFinalized is a no-op for missing session", () => {
+    // Should not throw.
+    markFinalized(tmpDir, "no-such-session");
+  });
+
+  it("rejects checkpoint with mismatched sessionId", () => {
+    const filePath = path.join(tmpDir, "session-abc-123.json");
+    fs.writeFileSync(filePath, JSON.stringify({ ...SAMPLE, openclawSessionId: "different-id" }));
+    expect(loadCheckpoint(tmpDir, "session-abc-123")).toBeNull();
+  });
+});

--- a/extensions/openviking-session-bridge/tests/transcript.test.ts
+++ b/extensions/openviking-session-bridge/tests/transcript.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readTranscriptFile } from "../src/transcript.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ov-bridge-test-"));
+}
+
+function writeLines(filePath: string, lines: unknown[]): void {
+  fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join("\n"), "utf-8");
+}
+
+describe("readTranscriptFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array for non-existent file", async () => {
+    const result = await readTranscriptFile(path.join(tmpDir, "missing.jsonl"));
+    expect(result).toEqual([]);
+  });
+
+  it("parses user and assistant messages", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      { type: "session", version: 3, id: "test-id", timestamp: "2026-01-01T00:00:00Z" },
+      { type: "message", message: { role: "user", content: "Hello" } },
+      { type: "message", message: { role: "assistant", content: "World" } },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ index: 0, role: "user", text: "Hello" });
+    expect(turns[1]).toMatchObject({ index: 1, role: "assistant", text: "World" });
+  });
+
+  it("skips non-message entries", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      { type: "model_change", modelId: "claude-3" },
+      { type: "message", message: { role: "user", content: "Hi" } },
+      { type: "thinking_level_change", thinkingLevel: "high" },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.role).toBe("user");
+  });
+
+  it("skips NO_REPLY responses", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      { type: "message", message: { role: "user", content: "silent command" } },
+      { type: "message", message: { role: "assistant", content: "NO_REPLY" } },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.role).toBe("user");
+  });
+
+  it("skips system messages", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      { type: "message", message: { role: "system", content: "You are..." } },
+      { type: "message", message: { role: "user", content: "Hi" } },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(1);
+  });
+
+  it("extracts text from content parts array", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Part one" },
+            { type: "tool_use", id: "tu1", name: "search", input: {} },
+            { type: "text", text: "Part two" },
+          ],
+        },
+      },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.text).toBe("Part one\nPart two");
+  });
+
+  it("skips entries with only tool parts (no text)", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu1", name: "bash", input: {} }],
+        },
+      },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(0);
+  });
+
+  it("skips malformed JSON lines", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    fs.writeFileSync(
+      filePath,
+      [
+        JSON.stringify({ type: "message", message: { role: "user", content: "Hello" } }),
+        "{bad json here",
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Hi" } }),
+      ].join("\n"),
+    );
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns).toHaveLength(2);
+  });
+
+  it("assigns sequential indexes", async () => {
+    const filePath = path.join(tmpDir, "session.jsonl");
+    writeLines(filePath, [
+      { type: "message", message: { role: "user", content: "A" } },
+      { type: "message", message: { role: "user", content: "NO_REPLY" } }, // skipped
+      { type: "message", message: { role: "assistant", content: "B" } },
+      { type: "message", message: { role: "user", content: "C" } },
+    ]);
+
+    const turns = await readTranscriptFile(filePath);
+    expect(turns.map((t) => t.index)).toEqual([0, 1, 2]);
+  });
+});

--- a/extensions/openviking-session-bridge/tsconfig.json
+++ b/extensions/openviking-session-bridge/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/extensions/openviking-session-bridge/vitest.config.ts
+++ b/extensions/openviking-session-bridge/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    globals: false,
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/types.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a disabled-by-default OpenViking session bridge extension that flushes OpenClaw session transcripts to OV on `session_end` and via `/done`
- add checkpointed incremental flushing, per-session coalescing, retry/backoff, startup replay, and real abort propagation for synchronous timeout handling
- add test coverage for transcript parsing, checkpoint state, partial-failure recovery, concurrency, retry, and abort behavior

## Testing
- npm test
