### PR TITLE
Improve native command overflow warnings to mention nativeSkills config

### DIFF
--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -574,14 +574,14 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     commandSpecs = appendPluginCommandSpecs({ commandSpecs, runtime });
     runtime.log?.(
       warn(
-        `discord: ${initialCommandCount} commands exceeds limit; removing per-skill commands and keeping /skill.`,
+        `discord: ${initialCommandCount} native commands exceed Discord's ${maxDiscordCommands}-command limit; removing per-skill slash commands (keeping /skill fallback). To control this, set commands.nativeSkills: false or channels.discord.commands.nativeSkills: false.`,
       ),
     );
   }
   if (nativeEnabled && commandSpecs.length > maxDiscordCommands) {
     runtime.log?.(
       warn(
-        `discord: ${commandSpecs.length} commands exceeds limit; some commands may fail to deploy.`,
+        `discord: ${commandSpecs.length} base commands still exceed Discord's ${maxDiscordCommands}-command limit after removing skills; some commands may fail to deploy. Reduce plugin/custom commands or set channels.discord.commands.native: false.`,
       ),
     );
   }

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -275,7 +275,7 @@ describe("bot-native-command-menu", () => {
       "Telegram rejected 100 commands (BOT_COMMANDS_TOO_MUCH); retrying with 80.",
     );
     expect(runtimeLog).toHaveBeenCalledWith(
-      "Telegram accepted 80 commands after BOT_COMMANDS_TOO_MUCH (started with 100; omitted 20). Reduce plugin/skill/custom commands to expose more menu entries.",
+      "Telegram accepted 80 of 100 commands after BOT_COMMANDS_TOO_MUCH (omitted 20). To reduce: set commands.nativeSkills: false or reduce plugin/custom commands.",
     );
     expect(runtimeError).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -56,9 +56,9 @@ function formatTelegramCommandRetrySuccessLog(params: {
 }): string {
   const omittedCount = Math.max(0, params.initialCount - params.acceptedCount);
   return (
-    `Telegram accepted ${params.acceptedCount} commands after BOT_COMMANDS_TOO_MUCH ` +
-    `(started with ${params.initialCount}; omitted ${omittedCount}). ` +
-    "Reduce plugin/skill/custom commands to expose more menu entries."
+    `Telegram accepted ${params.acceptedCount} of ${params.initialCount} commands after BOT_COMMANDS_TOO_MUCH ` +
+    `(omitted ${omittedCount}). ` +
+    "To reduce: set commands.nativeSkills: false or reduce plugin/custom commands."
   );
 }
 
@@ -236,7 +236,7 @@ export function syncTelegramMenuCommands(params: {
           nextCount < retryCommands.length ? nextCount : retryCommands.length - 1;
         if (reducedCount <= 0) {
           runtime.error?.(
-            "Telegram rejected native command registration (BOT_COMMANDS_TOO_MUCH); leaving menu empty. Reduce commands or disable channels.telegram.commands.native.",
+            "Telegram rejected all command registration attempts (BOT_COMMANDS_TOO_MUCH); menu left empty. Set commands.nativeSkills: false to disable per-skill commands, or channels.telegram.commands.native: false to disable all native commands.",
           );
           return;
         }

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -446,9 +446,8 @@ export const registerTelegramNativeCommands = ({
     });
   if (overflowCount > 0) {
     runtime.log?.(
-      `Telegram limits bots to ${maxCommands} commands. ` +
-        `${totalCommands} configured; registering first ${maxCommands}. ` +
-        `Use channels.telegram.commands.native: false to disable, or reduce plugin/skill/custom commands.`,
+      `Telegram limits bots to ${maxCommands} commands; ${totalCommands} configured, registering first ${maxCommands}. ` +
+        `To reduce: set commands.nativeSkills: false (or channels.telegram.commands.nativeSkills: false) to disable per-skill commands.`,
     );
   }
   // Telegram only limits the setMyCommands payload (menu entries).


### PR DESCRIPTION
## Summary
- When Discord/Telegram hit their 100-command platform limit, warning messages now point users to `commands.nativeSkills: false` (or per-provider `channels.<provider>.commands.nativeSkills: false`) instead of the nuclear `commands.native: false` which disables all native commands
- Updated all four overflow/retry warning paths across Discord and Telegram to include actionable config guidance
- Updated test assertion to match new log message

## Context

Addresses #49273 — rather than changing the default from `"auto"` to `false` (which would silently break existing users), this takes the reviewer-recommended approach of improving the overflow handling messages so users can self-diagnose and apply the targeted fix.

Both Discord and Telegram already handle command overflow gracefully (Discord drops skill commands and keeps `/skill` fallback; Telegram pre-truncates and has a retry loop). The actual problem was that the log messages either pointed to the wrong config key or gave vague advice.

## Test plan
- [x] `pnpm test -- extensions/telegram/src/bot-native-command-menu.test.ts` — 11/11 pass
- [x] `pnpm test -- src/config/commands.test` — 8/8 pass
- [ ] Verify Discord overflow warning appears correctly with 100+ skills installed
- [ ] Verify Telegram pre-truncation warning appears correctly with 100+ skills installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)