### PR TITLE
feat: add opt-in X-OpenClaw-Agent header for per-agent LLM tracking

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.agent-header.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.agent-header.test.ts
@@ -1,0 +1,99 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { runExtraParamsCase } from "./extra-params.test-support.js";
+
+function makeCfg(injectAgentHeader?: boolean): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        "my-proxy": {
+          baseUrl: "http://localhost:8080/v1",
+          models: [],
+          ...(injectAgentHeader !== undefined ? { injectAgentHeader } : {}),
+        },
+      },
+    },
+  };
+}
+
+function applyAndCapture(params: {
+  provider: string;
+  agentId?: string;
+  callerHeaders?: Record<string, string>;
+  cfg?: OpenClawConfig;
+}) {
+  return runExtraParamsCase({
+    applyModelId: "gpt-4o",
+    applyProvider: params.provider,
+    callerHeaders: params.callerHeaders,
+    cfg: params.cfg ?? makeCfg(true),
+    agentId: params.agentId,
+    model: {
+      api: "openai-completions",
+      provider: params.provider,
+      id: "gpt-4o",
+    } as Model<"openai-completions">,
+    payload: {},
+  });
+}
+
+describe("extra-params: Agent ID header injection", () => {
+  it("injects X-OpenClaw-Agent when injectAgentHeader is true and agentId is provided", () => {
+    const { headers } = applyAndCapture({
+      provider: "my-proxy",
+      agentId: "main",
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBe("main");
+  });
+
+  it("does NOT inject when injectAgentHeader is not set", () => {
+    const { headers } = applyAndCapture({
+      provider: "my-proxy",
+      agentId: "main",
+      cfg: makeCfg(),
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBeUndefined();
+  });
+
+  it("does NOT inject when agentId is undefined", () => {
+    const { headers } = applyAndCapture({
+      provider: "my-proxy",
+      agentId: undefined,
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBeUndefined();
+  });
+
+  it("does NOT inject when injectAgentHeader is false", () => {
+    const { headers } = applyAndCapture({
+      provider: "my-proxy",
+      agentId: "main",
+      cfg: makeCfg(false),
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBeUndefined();
+  });
+
+  it("overrides caller-supplied X-OpenClaw-Agent header", () => {
+    const { headers } = applyAndCapture({
+      provider: "my-proxy",
+      agentId: "grace",
+      callerHeaders: { "X-OpenClaw-Agent": "spoofed" },
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBe("grace");
+  });
+
+  it("does NOT affect providers without matching config entry", () => {
+    const { headers } = applyAndCapture({
+      provider: "other-provider",
+      agentId: "main",
+      cfg: makeCfg(true),
+    });
+
+    expect(headers?.["X-OpenClaw-Agent"]).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.test-support.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test-support.ts
@@ -20,6 +20,7 @@ type RunExtraParamsCaseParams<
   options?: SimpleStreamOptions;
   payload: TPayload;
   thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  agentId?: string;
 };
 
 export function runExtraParamsCase<
@@ -44,6 +45,7 @@ export function runExtraParamsCase<
     params.applyModelId ?? params.model.id,
     undefined,
     params.thinkingLevel,
+    params.agentId,
   );
 
   const context: Context = { messages: [] };

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -169,6 +169,18 @@ function createParallelToolCallsWrapper(
   };
 }
 
+function createAgentIdHeaderWrapper(baseStreamFn: StreamFn | undefined, agentId: string): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        "X-OpenClaw-Agent": agentId,
+      },
+    });
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also applies verified provider-specific request wrappers, such as OpenRouter attribution.
@@ -311,6 +323,14 @@ export function applyExtraParamsToAgent(
           ? rawParallelToolCalls
           : typeof rawParallelToolCalls;
       log.warn(`ignoring invalid parallel_tool_calls param: ${summary}`);
+    }
+  }
+
+  if (agentId) {
+    const providerConfig = cfg?.models?.providers?.[provider];
+    if (providerConfig?.injectAgentHeader === true) {
+      log.debug(`injecting X-OpenClaw-Agent header for ${provider}/${modelId}: ${agentId}`);
+      agent.streamFn = createAgentIdHeaderWrapper(agent.streamFn, agentId);
     }
   }
 }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -706,6 +706,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Provider API adapter selection controlling request/response compatibility handling for model calls. Use the adapter that matches your upstream provider protocol to avoid feature mismatch.",
   "models.providers.*.injectNumCtxForOpenAICompat":
     "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
+  "models.providers.*.injectAgentHeader":
+    "When true, adds an X-OpenClaw-Agent header containing the current agent ID to outgoing LLM requests. Useful for per-agent usage tracking with local proxies.",
   "models.providers.*.headers":
     "Static HTTP headers merged into provider requests for tenant routing, proxy auth, or custom gateway requirements. Use this sparingly and keep sensitive header values in secrets.",
   "models.providers.*.authHeader":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -421,6 +421,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.providers.*.auth": "Model Provider Auth Mode",
   "models.providers.*.api": "Model Provider API Adapter",
   "models.providers.*.injectNumCtxForOpenAICompat": "Model Provider Inject num_ctx (OpenAI Compat)",
+  "models.providers.*.injectAgentHeader": "Model Provider Inject Agent ID Header",
   "models.providers.*.headers": "Model Provider Headers",
   "models.providers.*.authHeader": "Model Provider Authorization Header",
   "models.providers.*.models": "Model Provider Model List",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -67,6 +67,7 @@ export type ModelProviderConfig = {
   auth?: ModelProviderAuthMode;
   api?: ModelApi;
   injectNumCtxForOpenAICompat?: boolean;
+  injectAgentHeader?: boolean;
   headers?: Record<string, SecretInput>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -254,6 +254,7 @@ export const ModelProviderSchema = z
       .optional(),
     api: ModelApiSchema.optional(),
     injectNumCtxForOpenAICompat: z.boolean().optional(),
+    injectAgentHeader: z.boolean().optional(),
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),


### PR DESCRIPTION
## Summary

Closes #50117

- Adds `injectAgentHeader` boolean to `ModelProviderConfig` so users can opt-in to `X-OpenClaw-Agent: <agentId>` header injection on outgoing LLM requests
- Injects via a new `createAgentIdHeaderWrapper` in the existing `applyExtraParamsToAgent` pipeline, following the same pattern as Kilocode/OpenRouter header wrappers
- Only fires when `injectAgentHeader: true` is set on the matching provider config AND an `agentId` is present

### Config example

```yaml
models:
  providers:
    my-proxy:
      baseUrl: http://localhost:8080/v1
      injectAgentHeader: true
      models:
        - id: gpt-4o
          name: GPT-4o
```

Every request to `my-proxy` will include `X-OpenClaw-Agent: main` (or whichever agent ID is active).

### Files changed

| File | Change |
|------|--------|
| `src/config/types.models.ts` | +1: type field |
| `src/config/zod-schema.core.ts` | +1: Zod schema |
| `src/config/schema.labels.ts` | +1: label |
| `src/config/schema.help.ts` | +2: help text |
| `src/agents/pi-embedded-runner/extra-params.ts` | +20: wrapper + wiring |
| `src/agents/pi-embedded-runner/extra-params.test-support.ts` | +2: agentId passthrough |
| `src/agents/pi-embedded-runner/extra-params.agent-header.test.ts` | NEW: 6 tests |

## Test plan

- [x] `pnpm tsgo` — no new type errors
- [x] New test file passes (6/6): injects header, skips when disabled/missing agentId/false/wrong provider, overrides caller-supplied header
- [x] Existing extra-params tests unaffected (kilocode, cache-retention, xai-tool-payload all pass)
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)