### PR TITLE
ui: avoid stale provider prefixes in model picker

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -539,14 +539,22 @@ function resolveModelOverrideValue(state: AppViewState): string {
   // Include provider prefix so the value matches option keys (provider/model).
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
-    return resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
+    return resolveServerChatModelValue(
+      activeRow.model,
+      activeRow.modelProvider,
+      state.chatModelCatalog ?? [],
+    );
   }
   return "";
 }
 
 function resolveDefaultModelValue(state: AppViewState): string {
   const defaults = state.sessionsResult?.defaults;
-  return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
+  return resolveServerChatModelValue(
+    defaults?.model,
+    defaults?.modelProvider,
+    state.chatModelCatalog ?? [],
+  );
 }
 
 function buildChatModelOptions(

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -47,4 +47,20 @@ describe("chat-model-ref helpers", () => {
     expect(resolveServerChatModelValue("gpt-5-mini", "openai")).toBe("openai/gpt-5-mini");
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
   });
+
+  it("prefers an existing catalog option when the server model is already qualified", () => {
+    expect(resolveServerChatModelValue("anthropic/claude-sonnet-4-5", "openai", catalog)).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+  });
+
+  it("still prefixes providers for slash-containing model ids when that is the catalog key", () => {
+    const slashCatalog: ModelCatalogEntry[] = [
+      { id: "hf:moonshotai/Kimi-K2.5", name: "Kimi K2.5", provider: "synthetic" },
+    ];
+
+    expect(resolveServerChatModelValue("hf:moonshotai/Kimi-K2.5", "synthetic", slashCatalog)).toBe(
+      "synthetic/hf:moonshotai/Kimi-K2.5",
+    );
+  });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -65,11 +65,30 @@ export function normalizeChatModelOverrideValue(
 export function resolveServerChatModelValue(
   model?: string | null,
   provider?: string | null,
+  catalog: ModelCatalogEntry[] = [],
 ): string {
   if (typeof model !== "string") {
     return "";
   }
-  return buildQualifiedChatModelValue(model, provider);
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+  const qualified = buildQualifiedChatModelValue(trimmedModel, provider);
+  if (catalog.length === 0) {
+    return qualified;
+  }
+
+  const optionKeys = new Set(
+    catalog.map((entry) => buildQualifiedChatModelValue(entry.id, entry.provider).toLowerCase()),
+  );
+  if (optionKeys.has(qualified.toLowerCase())) {
+    return qualified;
+  }
+  if (optionKeys.has(trimmedModel.toLowerCase())) {
+    return trimmedModel;
+  }
+  return qualified;
 }
 
 export function formatChatModelDisplay(value: string): string {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -812,37 +812,40 @@ describe("chat view", () => {
         ok: false,
       } satisfies Partial<Response>),
     );
-    const { state } = createChatHeaderState({
-      model: "gemini-2.0-flash-lite",
-      modelProvider: "google",
-      preservePreviousProviderOnQualifiedPatch: true,
-      models: [
-        { id: "gemini-2.0-flash-lite", name: "Gemini 2.0 Flash Lite", provider: "google" },
-        { id: "qwen3.5-9b", name: "Qwen 3.5 9B", provider: "lmstudio_mbp" },
-      ],
-    });
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    try {
+      const { state } = createChatHeaderState({
+        model: "gemini-2.0-flash-lite",
+        modelProvider: "google",
+        preservePreviousProviderOnQualifiedPatch: true,
+        models: [
+          { id: "gemini-2.0-flash-lite", name: "Gemini 2.0 Flash Lite", provider: "google" },
+          { id: "qwen3.5-9b", name: "Qwen 3.5 9B", provider: "lmstudio_mbp" },
+        ],
+      });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
 
-    const modelSelect = container.querySelector<HTMLSelectElement>(
-      'select[data-chat-model-select="true"]',
-    );
-    expect(modelSelect?.value).toBe("google/gemini-2.0-flash-lite");
+      const modelSelect = container.querySelector<HTMLSelectElement>(
+        'select[data-chat-model-select="true"]',
+      );
+      expect(modelSelect?.value).toBe("google/gemini-2.0-flash-lite");
 
-    modelSelect!.value = "lmstudio_mbp/qwen3.5-9b";
-    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
-    await flushTasks();
-    render(renderChatSessionSelect(state), container);
+      modelSelect!.value = "lmstudio_mbp/qwen3.5-9b";
+      modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+      await flushTasks();
+      render(renderChatSessionSelect(state), container);
 
-    const rerendered = container.querySelector<HTMLSelectElement>(
-      'select[data-chat-model-select="true"]',
-    );
-    expect(rerendered?.value).toBe("lmstudio_mbp/qwen3.5-9b");
-    const optionValues = Array.from(rerendered?.querySelectorAll("option") ?? []).map(
-      (option) => option.value,
-    );
-    expect(optionValues).not.toContain("google/lmstudio_mbp/qwen3.5-9b");
-    vi.unstubAllGlobals();
+      const rerendered = container.querySelector<HTMLSelectElement>(
+        'select[data-chat-model-select="true"]',
+      );
+      expect(rerendered?.value).toBe("lmstudio_mbp/qwen3.5-9b");
+      const optionValues = Array.from(rerendered?.querySelectorAll("option") ?? []).map(
+        (option) => option.value,
+      );
+      expect(optionValues).not.toContain("google/lmstudio_mbp/qwen3.5-9b");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("prefers the session label over displayName in the grouped chat session selector", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -25,13 +25,17 @@ function createSessions(): SessionsListResult {
 function createChatHeaderState(
   overrides: {
     model?: string | null;
+    modelProvider?: string | null;
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
+    preservePreviousProviderOnQualifiedPatch?: boolean;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
-  let currentModelProvider = currentModel ? "openai" : null;
+  let currentModelProvider = overrides.modelProvider ?? (currentModel ? "openai" : null);
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
+  const preservePreviousProviderOnQualifiedPatch =
+    overrides.preservePreviousProviderOnQualifiedPatch ?? false;
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
     { id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" },
@@ -46,8 +50,12 @@ function createChatHeaderState(
         const normalized = nextModel.trim();
         const slashIndex = normalized.indexOf("/");
         if (slashIndex > 0) {
-          currentModelProvider = normalized.slice(0, slashIndex);
-          currentModel = normalized.slice(slashIndex + 1);
+          currentModel = preservePreviousProviderOnQualifiedPatch
+            ? normalized
+            : normalized.slice(slashIndex + 1);
+          if (!preservePreviousProviderOnQualifiedPatch) {
+            currentModelProvider = normalized.slice(0, slashIndex);
+          }
         } else {
           currentModel = normalized;
           const matchingProviders = catalog
@@ -795,6 +803,46 @@ describe("chat view", () => {
     );
     expect(optionValues).toContain("openai/gpt-5-mini");
     expect(optionValues).not.toContain("gpt-5-mini");
+  });
+
+  it("keeps the selected provider-qualified model when sessions.list returns a stale provider", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state } = createChatHeaderState({
+      model: "gemini-2.0-flash-lite",
+      modelProvider: "google",
+      preservePreviousProviderOnQualifiedPatch: true,
+      models: [
+        { id: "gemini-2.0-flash-lite", name: "Gemini 2.0 Flash Lite", provider: "google" },
+        { id: "qwen3.5-9b", name: "Qwen 3.5 9B", provider: "lmstudio_mbp" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect?.value).toBe("google/gemini-2.0-flash-lite");
+
+    modelSelect!.value = "lmstudio_mbp/qwen3.5-9b";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+    render(renderChatSessionSelect(state), container);
+
+    const rerendered = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(rerendered?.value).toBe("lmstudio_mbp/qwen3.5-9b");
+    const optionValues = Array.from(rerendered?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    expect(optionValues).not.toContain("google/lmstudio_mbp/qwen3.5-9b");
+    vi.unstubAllGlobals();
   });
 
   it("prefers the session label over displayName in the grouped chat session selector", () => {


### PR DESCRIPTION
Fixes #50197.

## Summary
- normalize server-returned chat model values against the loaded model catalog before rebuilding the picker value
- prefer an already-qualified catalog key when a stale `modelProvider` would otherwise prepend the wrong provider
- keep the existing provider prefix behavior for slash-containing model ids whose catalog key really is `provider/model`

## Testing
- `npm exec --yes pnpm@10.23.0 -- exec vitest run --config vitest.config.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat-model-ref.test.ts` (passed `ui/src/ui/views/chat.test.ts`, 27 tests)
- `npm exec --yes pnpm@10.23.0 -- exec vitest run --config /tmp/vitest-50197-chat-model-ref.config.ts` (passed `ui/src/ui/chat-model-ref.test.ts`, 7 tests)
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check ui/src/ui/chat-model-ref.ts ui/src/ui/chat-model-ref.test.ts ui/src/ui/app-render.helpers.ts ui/src/ui/views/chat.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint ui/src/ui/chat-model-ref.ts ui/src/ui/chat-model-ref.test.ts ui/src/ui/app-render.helpers.ts ui/src/ui/views/chat.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh` (`build` passed, `check` passed, `test` surfaced an unrelated failure in `src/plugin-sdk/runtime-api-guardrails.test.ts` before I stopped the run)

AI-assisted: yes.
