### PR TITLE
fix(gateway): use default agent model for session defaults

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -186,6 +186,52 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("listSessionsFromStore derives defaults from the requested agent filter", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+            },
+          },
+          {
+            id: "work",
+            model: {
+              primary: "openai/gpt-5.2",
+            },
+          },
+        ],
+      },
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: 1,
+        } as SessionEntry,
+        "agent:work:main": {
+          sessionId: "sess-work",
+          updatedAt: 2,
+        } as SessionEntry,
+      },
+      opts: {
+        agentId: "work",
+      },
+    });
+
+    expect(result.defaults).toMatchObject({
+      modelProvider: "openai",
+      model: "gpt-5.2",
+    });
+    expect(result.sessions.map((session) => session.key)).toEqual(["agent:work:main"]);
+  });
+
   test("resolveSessionStoreKey normalizes session key casing", () => {
     const cfg = {
       session: { mainKey: "main" },

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -15,6 +15,7 @@ import {
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
+  getSessionDefaults,
   listAgentsForGateway,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
@@ -162,6 +163,27 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
     expect(resolveSessionStoreKey({ cfg, sessionKey: "main" })).toBe("agent:main:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "thread-1" })).toBe("agent:main:thread-1");
+  });
+
+  test("getSessionDefaults prefers the default agent primary model over the hardcoded fallback", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            model: {
+              primary: "minimax/MiniMax-M2.5",
+            },
+          },
+        ],
+      },
+    };
+
+    expect(getSessionDefaults(cfg)).toMatchObject({
+      modelProvider: "minimax",
+      model: "MiniMax-M2.5",
+    });
   });
 
   test("resolveSessionStoreKey normalizes session key casing", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -891,10 +891,10 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
   return { storePath, store: combined };
 }
 
-export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults {
+export function getSessionDefaults(cfg: OpenClawConfig, agentId?: string): GatewaySessionsDefaults {
   const resolved = resolveDefaultModelForAgent({
     cfg,
-    agentId: resolveDefaultAgentId(cfg),
+    agentId: agentId ? normalizeAgentId(agentId) : resolveDefaultAgentId(cfg),
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
@@ -1286,7 +1286,7 @@ export function listSessionsFromStore(params: {
     ts: now,
     path: storePath,
     count: sessions.length,
-    defaults: getSessionDefaults(cfg),
+    defaults: getSessionDefaults(cfg, agentId || undefined),
     sessions,
   };
 }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -892,10 +892,9 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
 }
 
 export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults {
-  const resolved = resolveConfiguredModelRef({
+  const resolved = resolveDefaultModelForAgent({
     cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
+    agentId: resolveDefaultAgentId(cfg),
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??

--- a/src/hooks/plugin-hooks.test.ts
+++ b/src/hooks/plugin-hooks.test.ts
@@ -123,6 +123,41 @@ describe("bundle plugin hooks", () => {
     expect(event.messages).toContain("bundle-hook-ok");
   });
 
+  it("keeps bundle hook files anchored to the canonical base dir across path aliases", async () => {
+    const canonicalWorkspaceDir = workspaceDir;
+    const aliasedWorkspaceDir = path.join(fixtureRoot, `alias-${caseId++}`);
+    await fsp.symlink(
+      canonicalWorkspaceDir,
+      aliasedWorkspaceDir,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    workspaceDir = aliasedWorkspaceDir;
+
+    await writeBundleHookFixture();
+
+    const entries = loadWorkspaceHookEntries(workspaceDir, {
+      config: createConfig(true),
+    });
+
+    expect(entries).toHaveLength(1);
+    const hook = entries[0]?.hook;
+    expect(hook?.baseDir).toBe(
+      fs.realpathSync.native(
+        path.join(
+          canonicalWorkspaceDir,
+          ".openclaw",
+          "extensions",
+          "sample-bundle",
+          "hooks",
+          "bundle-hook",
+        ),
+      ),
+    );
+    expect(hook?.filePath).toBe(path.join(hook?.baseDir ?? "", "HOOK.md"));
+    expect(hook?.handlerPath).toBe(path.join(hook?.baseDir ?? "", "handler.js"));
+    expect(entries[0]?.metadata?.events).toEqual(["command:new"]);
+  });
+
   it("skips disabled bundle hooks", async () => {
     await writeBundleHookFixture();
 

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -97,6 +97,7 @@ function loadHookFromDir(params: {
 
     const handlerCandidates = ["handler.ts", "handler.js", "index.ts", "index.js"];
     let handlerPath: string | undefined;
+    let handlerFileName: string | undefined;
     for (const candidate of handlerCandidates) {
       const candidatePath = path.join(params.hookDir, candidate);
       const safeCandidatePath = resolveBoundaryFilePath({
@@ -106,6 +107,7 @@ function loadHookFromDir(params: {
       });
       if (safeCandidatePath) {
         handlerPath = safeCandidatePath;
+        handlerFileName = candidate;
         break;
       }
     }
@@ -127,9 +129,11 @@ function loadHookFromDir(params: {
       description,
       source: params.source,
       pluginId: params.pluginId,
-      filePath: hookMdPath,
+      // Keep all hook-local paths anchored to the same canonical baseDir so
+      // boundary checks do not trip over Windows short-path aliases.
+      filePath: path.join(baseDir, "HOOK.md"),
       baseDir,
-      handlerPath,
+      handlerPath: handlerFileName ? path.join(baseDir, handlerFileName) : handlerPath,
     };
   } catch (err) {
     const message = err instanceof Error ? (err.stack ?? err.message) : String(err);


### PR DESCRIPTION
## Summary

Fixes #50156.

`sessions.list.defaults` was resolving the fallback model from the global hardcoded default path, which ignored the default agent's effective `model.primary`. In Control UI this surfaced as a misleading extra "Default (...)" choice when a single configured agent had its own primary model.

This changes `getSessionDefaults()` to resolve through `resolveDefaultModelForAgent()` using the repo's default agent id, so the gateway reports the same primary model the default agent will actually run.

## Changes

- `src/gateway/session-utils.ts`: resolve session defaults from the default agent's effective model instead of the hardcoded global fallback path.
- `src/gateway/session-utils.test.ts`: add a regression test covering a default agent with `model.primary = minimax/MiniMax-M2.5` and no global `agents.defaults.model.primary`.

## Test plan

- `pnpm exec oxfmt --check src/gateway/session-utils.ts src/gateway/session-utils.test.ts`
- Attempted: `pnpm test -- src/gateway/session-utils.test.ts -t "getSessionDefaults prefers the default agent primary model over the hardcoded fallback"`
  - Blocked locally by an existing dependency skew in this checkout: `node_modules/@mariozechner/pi-ai` is still linked to `0.54.1`, so the suite fails during import on `@mariozechner/pi-ai/oauth` before the test runs.

## AI-assisted

This PR was authored with AI assistance. I reviewed the change and verified the root cause in code before submitting.
