### PR TITLE
fix(auth): persist final auth profile after successful fallback

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -8,7 +8,6 @@ import {
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { prepareProviderRuntimeAuth } from "../../plugins/provider-runtime.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -29,14 +28,8 @@ import {
   resolveContextWindowInfo,
 } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import {
-  coerceToFailoverError,
-  describeFailoverError,
-  FailoverError,
-  resolveFailoverStatus,
-} from "../failover-error.js";
-import {
-  applyLocalNoAuthHeaderOverride,
   ensureAuthProfileStore,
   getApiKeyForModel,
   resolveAuthProfileOrder,
@@ -65,10 +58,9 @@ import {
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
-import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
-import { resolveModelAsync } from "./model.js";
+import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
@@ -82,18 +74,16 @@ import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
-type RuntimeAuthState = {
-  sourceApiKey: string;
-  authMode: string;
-  profileId?: string;
-  expiresAt?: number;
+type CopilotTokenState = {
+  githubToken: string;
+  expiresAt: number;
   refreshTimer?: ReturnType<typeof setTimeout>;
   refreshInFlight?: Promise<void>;
 };
 
-const RUNTIME_AUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
-const RUNTIME_AUTH_REFRESH_RETRY_MS = 60 * 1000;
-const RUNTIME_AUTH_REFRESH_MIN_DELAY_MS = 5 * 1000;
+const COPILOT_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+const COPILOT_REFRESH_RETRY_MS = 60 * 1000;
+const COPILOT_REFRESH_MIN_DELAY_MS = 5 * 1000;
 // Keep overload pacing noticeable enough to avoid tight retry bursts, but short
 // enough that fallback still feels responsive within a single turn.
 const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
@@ -303,7 +293,6 @@ export async function runEmbeddedPiAgent(
       ensureRuntimePluginsLoaded({
         config: params.config,
         workspaceDir: resolvedWorkspace,
-        allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
       });
       const prevCwd = process.cwd();
 
@@ -372,7 +361,7 @@ export async function runEmbeddedPiAgent(
         log.info(`[hooks] model overridden to ${modelId}`);
       }
 
-      const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+      const { model, error, authStorage, modelRegistry } = resolveModel(
         provider,
         modelId,
         agentDir,
@@ -385,21 +374,20 @@ export async function runEmbeddedPiAgent(
           model: modelId,
         });
       }
-      let runtimeModel = model;
 
       const ctxInfo = resolveContextWindowInfo({
         cfg: params.config,
         provider,
         modelId,
-        modelContextWindow: runtimeModel.contextWindow,
+        modelContextWindow: model.contextWindow,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
       });
       // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
       // threshold uses the effective limit, not the native context window.
-      let effectiveModel =
-        ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
-          ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
-          : runtimeModel;
+      const effectiveModel =
+        ctxInfo.tokens < (model.contextWindow ?? Infinity)
+          ? { ...model, contextWindow: ctxInfo.tokens }
+          : model;
       const ctxGuard = evaluateContextWindowGuard({
         info: ctxInfo,
         warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -453,142 +441,103 @@ export async function runEmbeddedPiAgent(
       const attemptedThinking = new Set<ThinkLevel>();
       let apiKeyInfo: ApiKeyInfo | null = null;
       let lastProfileId: string | undefined;
-      let runtimeAuthState: RuntimeAuthState | null = null;
-      let runtimeAuthRefreshCancelled = false;
-      const hasRefreshableRuntimeAuth = () => Boolean(runtimeAuthState?.sourceApiKey.trim());
+      const copilotTokenState: CopilotTokenState | null =
+        model.provider === "github-copilot" ? { githubToken: "", expiresAt: 0 } : null;
+      let copilotRefreshCancelled = false;
+      const hasCopilotGithubToken = () => Boolean(copilotTokenState?.githubToken.trim());
 
-      const clearRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState?.refreshTimer) {
+      const clearCopilotRefreshTimer = () => {
+        if (!copilotTokenState?.refreshTimer) {
           return;
         }
-        clearTimeout(runtimeAuthState.refreshTimer);
-        runtimeAuthState.refreshTimer = undefined;
+        clearTimeout(copilotTokenState.refreshTimer);
+        copilotTokenState.refreshTimer = undefined;
       };
 
-      const stopRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState) {
+      const stopCopilotRefreshTimer = () => {
+        if (!copilotTokenState) {
           return;
         }
-        runtimeAuthRefreshCancelled = true;
-        clearRuntimeAuthRefreshTimer();
+        copilotRefreshCancelled = true;
+        clearCopilotRefreshTimer();
       };
 
-      const refreshRuntimeAuth = async (reason: string): Promise<void> => {
-        if (!runtimeAuthState) {
+      const refreshCopilotToken = async (reason: string): Promise<void> => {
+        if (!copilotTokenState) {
           return;
         }
-        if (runtimeAuthState.refreshInFlight) {
-          await runtimeAuthState.refreshInFlight;
+        if (copilotTokenState.refreshInFlight) {
+          await copilotTokenState.refreshInFlight;
           return;
         }
-        runtimeAuthState.refreshInFlight = (async () => {
-          const sourceApiKey = runtimeAuthState?.sourceApiKey.trim() ?? "";
-          if (!sourceApiKey) {
-            throw new Error(`Runtime auth refresh requires a source credential.`);
+        const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+        copilotTokenState.refreshInFlight = (async () => {
+          const githubToken = copilotTokenState.githubToken.trim();
+          if (!githubToken) {
+            throw new Error("Copilot refresh requires a GitHub token.");
           }
-          log.debug(`Refreshing runtime auth for ${runtimeModel.provider} (${reason})...`);
-          const preparedAuth = await prepareProviderRuntimeAuth({
-            provider: runtimeModel.provider,
-            config: params.config,
-            workspaceDir: resolvedWorkspace,
-            env: process.env,
-            context: {
-              config: params.config,
-              agentDir,
-              workspaceDir: resolvedWorkspace,
-              env: process.env,
-              provider: runtimeModel.provider,
-              modelId,
-              model: runtimeModel,
-              apiKey: sourceApiKey,
-              authMode: runtimeAuthState?.authMode ?? "unknown",
-              profileId: runtimeAuthState?.profileId,
-            },
+          log.debug(`Refreshing GitHub Copilot token (${reason})...`);
+          const copilotToken = await resolveCopilotApiToken({
+            githubToken,
           });
-          if (!preparedAuth?.apiKey) {
-            throw new Error(
-              `Provider "${runtimeModel.provider}" does not support runtime auth refresh.`,
-            );
-          }
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          if (preparedAuth.baseUrl) {
-            runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-            effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-          }
-          runtimeAuthState = {
-            ...runtimeAuthState,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            const remaining = preparedAuth.expiresAt - Date.now();
-            log.debug(
-              `Runtime auth refreshed for ${runtimeModel.provider}; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
-            );
-          }
+          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+          copilotTokenState.expiresAt = copilotToken.expiresAt;
+          const remaining = copilotToken.expiresAt - Date.now();
+          log.debug(
+            `Copilot token refreshed; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
+          );
         })()
           .catch((err) => {
-            log.warn(
-              `Runtime auth refresh failed for ${runtimeModel.provider}: ${describeUnknownError(err)}`,
-            );
+            log.warn(`Copilot token refresh failed: ${describeUnknownError(err)}`);
             throw err;
           })
           .finally(() => {
-            if (runtimeAuthState) {
-              runtimeAuthState.refreshInFlight = undefined;
-            }
+            copilotTokenState.refreshInFlight = undefined;
           });
-        await runtimeAuthState.refreshInFlight;
+        await copilotTokenState.refreshInFlight;
       };
 
-      const scheduleRuntimeAuthRefresh = (): void => {
-        if (!runtimeAuthState || runtimeAuthRefreshCancelled) {
+      const scheduleCopilotRefresh = (): void => {
+        if (!copilotTokenState || copilotRefreshCancelled) {
           return;
         }
-        if (!hasRefreshableRuntimeAuth()) {
-          log.warn(
-            `Skipping runtime auth refresh scheduling for ${runtimeModel.provider}; source credential missing.`,
-          );
+        if (!hasCopilotGithubToken()) {
+          log.warn("Skipping Copilot refresh scheduling; GitHub token missing.");
           return;
         }
-        if (!runtimeAuthState.expiresAt) {
-          return;
-        }
-        clearRuntimeAuthRefreshTimer();
+        clearCopilotRefreshTimer();
         const now = Date.now();
-        const refreshAt = runtimeAuthState.expiresAt - RUNTIME_AUTH_REFRESH_MARGIN_MS;
-        const delayMs = Math.max(RUNTIME_AUTH_REFRESH_MIN_DELAY_MS, refreshAt - now);
+        const refreshAt = copilotTokenState.expiresAt - COPILOT_REFRESH_MARGIN_MS;
+        const delayMs = Math.max(COPILOT_REFRESH_MIN_DELAY_MS, refreshAt - now);
         const timer = setTimeout(() => {
-          if (runtimeAuthRefreshCancelled) {
+          if (copilotRefreshCancelled) {
             return;
           }
-          refreshRuntimeAuth("scheduled")
-            .then(() => scheduleRuntimeAuthRefresh())
+          refreshCopilotToken("scheduled")
+            .then(() => scheduleCopilotRefresh())
             .catch(() => {
-              if (runtimeAuthRefreshCancelled) {
+              if (copilotRefreshCancelled) {
                 return;
               }
               const retryTimer = setTimeout(() => {
-                if (runtimeAuthRefreshCancelled) {
+                if (copilotRefreshCancelled) {
                   return;
                 }
-                refreshRuntimeAuth("scheduled-retry")
-                  .then(() => scheduleRuntimeAuthRefresh())
+                refreshCopilotToken("scheduled-retry")
+                  .then(() => scheduleCopilotRefresh())
                   .catch(() => undefined);
-              }, RUNTIME_AUTH_REFRESH_RETRY_MS);
-              const activeRuntimeAuthState = runtimeAuthState;
-              if (activeRuntimeAuthState) {
-                activeRuntimeAuthState.refreshTimer = retryTimer;
-              }
-              if (runtimeAuthRefreshCancelled && activeRuntimeAuthState) {
+              }, COPILOT_REFRESH_RETRY_MS);
+              copilotTokenState.refreshTimer = retryTimer;
+              if (copilotRefreshCancelled) {
                 clearTimeout(retryTimer);
-                activeRuntimeAuthState.refreshTimer = undefined;
+                copilotTokenState.refreshTimer = undefined;
               }
             });
         }, delayMs);
-        runtimeAuthState.refreshTimer = timer;
-        if (runtimeAuthRefreshCancelled) {
+        copilotTokenState.refreshTimer = timer;
+        if (copilotRefreshCancelled) {
           clearTimeout(timer);
-          runtimeAuthState.refreshTimer = undefined;
+          copilotTokenState.refreshTimer = undefined;
         }
       };
 
@@ -644,7 +593,7 @@ export async function runEmbeddedPiAgent(
 
       const resolveApiKeyForCandidate = async (candidate?: string) => {
         return getApiKeyForModel({
-          model: runtimeModel,
+          model,
           cfg: params.config,
           profileId: candidate,
           store: authStore,
@@ -658,55 +607,28 @@ export async function runEmbeddedPiAgent(
         if (!apiKeyInfo.apiKey) {
           if (apiKeyInfo.mode !== "aws-sdk") {
             throw new Error(
-              `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
+              `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
             );
           }
           lastProfileId = resolvedProfileId;
           return;
         }
-        let runtimeAuthHandled = false;
-        const preparedAuth = await prepareProviderRuntimeAuth({
-          provider: runtimeModel.provider,
-          config: params.config,
-          workspaceDir: resolvedWorkspace,
-          env: process.env,
-          context: {
-            config: params.config,
-            agentDir,
-            workspaceDir: resolvedWorkspace,
-            env: process.env,
-            provider: runtimeModel.provider,
-            modelId,
-            model: runtimeModel,
-            apiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-          },
-        });
-        if (preparedAuth?.baseUrl) {
-          runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-          effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-        }
-        if (preparedAuth?.apiKey) {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          runtimeAuthState = {
-            sourceApiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            scheduleRuntimeAuthRefresh();
+        if (model.provider === "github-copilot") {
+          const { resolveCopilotApiToken } =
+            await import("../../providers/github-copilot-token.js");
+          const copilotToken = await resolveCopilotApiToken({
+            githubToken: apiKeyInfo.apiKey,
+          });
+          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+          if (copilotTokenState) {
+            copilotTokenState.githubToken = apiKeyInfo.apiKey;
+            copilotTokenState.expiresAt = copilotToken.expiresAt;
+            scheduleCopilotRefresh();
           }
-          runtimeAuthHandled = true;
-        }
-        if (runtimeAuthHandled) {
-          // Plugin-owned runtime auth already stored the exchanged credential.
         } else {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, apiKeyInfo.apiKey);
-          runtimeAuthState = null;
+          authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
         }
-        lastProfileId = apiKeyInfo.profileId;
+        lastProfileId = resolvedProfileId;
       };
 
       const advanceAuthProfile = async (): Promise<boolean> => {
@@ -793,11 +715,11 @@ export async function runEmbeddedPiAgent(
         }
       }
 
-      const maybeRefreshRuntimeAuthForAuthError = async (
+      const maybeRefreshCopilotForAuthError = async (
         errorText: string,
         retried: boolean,
       ): Promise<boolean> => {
-        if (!runtimeAuthState || retried) {
+        if (!copilotTokenState || retried) {
           return false;
         }
         if (!isFailoverErrorMessage(errorText)) {
@@ -807,8 +729,8 @@ export async function runEmbeddedPiAgent(
           return false;
         }
         try {
-          await refreshRuntimeAuth("auth-error");
-          scheduleRuntimeAuthRefresh();
+          await refreshCopilotToken("auth-error");
+          scheduleCopilotRefresh();
           return true;
         } catch {
           return false;
@@ -918,7 +840,7 @@ export async function runEmbeddedPiAgent(
             };
           }
           runLoopIterations += 1;
-          const runtimeAuthRetry = authRetryPending;
+          const copilotAuthRetry = authRetryPending;
           authRetryPending = false;
           attemptedThinking.add(thinkLevel);
           await fs.mkdir(resolvedWorkspace, { recursive: true });
@@ -954,7 +876,6 @@ export async function runEmbeddedPiAgent(
             workspaceDir: resolvedWorkspace,
             agentDir,
             config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
             contextEngine,
             contextTokenBudget: ctxInfo.tokens,
             skillsSnapshot: params.skillsSnapshot,
@@ -963,7 +884,7 @@ export async function runEmbeddedPiAgent(
             disableTools: params.disableTools,
             provider,
             modelId,
-            model: applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+            model: effectiveModel,
             authProfileId: lastProfileId,
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             authStorage,
@@ -1142,30 +1063,24 @@ export async function runEmbeddedPiAgent(
                   force: true,
                   compactionTarget: "budget",
                   runtimeContext: {
-                    ...buildEmbeddedCompactionRuntimeContext({
-                      sessionKey: params.sessionKey,
-                      messageChannel: params.messageChannel,
-                      messageProvider: params.messageProvider,
-                      agentAccountId: params.agentAccountId,
-                      currentChannelId: params.currentChannelId,
-                      currentThreadTs: params.currentThreadTs,
-                      currentMessageId: params.currentMessageId,
-                      authProfileId: lastProfileId,
-                      workspaceDir: resolvedWorkspace,
-                      agentDir,
-                      config: params.config,
-                      skillsSnapshot: params.skillsSnapshot,
-                      senderIsOwner: params.senderIsOwner,
-                      senderId: params.senderId,
-                      provider,
-                      modelId,
-                      thinkLevel,
-                      reasoningLevel: params.reasoningLevel,
-                      bashElevated: params.bashElevated,
-                      extraSystemPrompt: params.extraSystemPrompt,
-                      ownerNumbers: params.ownerNumbers,
-                    }),
+                    sessionKey: params.sessionKey,
+                    messageChannel: params.messageChannel,
+                    messageProvider: params.messageProvider,
+                    agentAccountId: params.agentAccountId,
+                    authProfileId: lastProfileId,
+                    workspaceDir: resolvedWorkspace,
+                    agentDir,
+                    config: params.config,
+                    skillsSnapshot: params.skillsSnapshot,
+                    senderIsOwner: params.senderIsOwner,
+                    provider,
+                    model: modelId,
                     runId: params.runId,
+                    thinkLevel,
+                    reasoningLevel: params.reasoningLevel,
+                    bashElevated: params.bashElevated,
+                    extraSystemPrompt: params.extraSystemPrompt,
+                    ownerNumbers: params.ownerNumbers,
                     trigger: "overflow",
                     ...(observedOverflowTokens !== undefined
                       ? { currentTokenCount: observedOverflowTokens }
@@ -1301,18 +1216,8 @@ export async function runEmbeddedPiAgent(
           }
 
           if (promptError && !aborted) {
-            // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
-            // FailoverError so rate-limit classification works even for nested shapes.
-            const normalizedPromptFailover = coerceToFailoverError(promptError, {
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              profileId: lastProfileId,
-            });
-            const promptErrorDetails = normalizedPromptFailover
-              ? describeFailoverError(normalizedPromptFailover)
-              : describeFailoverError(promptError);
-            const errorText = promptErrorDetails.message || describeUnknownError(promptError);
-            if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
+            const errorText = describeUnknownError(promptError);
+            if (await maybeRefreshCopilotForAuthError(errorText, copilotAuthRetry)) {
               authRetryPending = true;
               continue;
             }
@@ -1375,16 +1280,14 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
-            const promptFailoverReason =
-              promptErrorDetails.reason ?? classifyFailoverReason(errorText);
+            const promptFailoverReason = classifyFailoverReason(errorText);
             const promptProfileFailureReason =
               resolveAuthProfileFailureReason(promptFailoverReason);
             await maybeMarkAuthProfileFailure({
               profileId: lastProfileId,
               reason: promptProfileFailureReason,
             });
-            const promptFailoverFailure =
-              promptFailoverReason !== null || isFailoverErrorMessage(errorText);
+            const promptFailoverFailure = isFailoverErrorMessage(errorText);
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({
@@ -1426,16 +1329,13 @@ export async function runEmbeddedPiAgent(
               const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
               logPromptFailoverDecision("fallback_model", { status });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              throw (
-                normalizedPromptFailover ??
-                new FailoverError(errorText, {
-                  reason: promptFailoverReason ?? "unknown",
-                  provider,
-                  model: modelId,
-                  profileId: lastProfileId,
-                  status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-                })
-              );
+              throw new FailoverError(errorText, {
+                reason: promptFailoverReason ?? "unknown",
+                provider,
+                model: modelId,
+                profileId: lastProfileId,
+                status,
+              });
             }
             if (promptFailoverFailure || promptFailoverReason) {
               logPromptFailoverDecision("surface_error");
@@ -1482,9 +1382,9 @@ export async function runEmbeddedPiAgent(
 
           if (
             authFailure &&
-            (await maybeRefreshRuntimeAuthForAuthError(
+            (await maybeRefreshCopilotForAuthError(
               lastAssistant?.errorMessage ?? "",
-              runtimeAuthRetry,
+              copilotAuthRetry,
             ))
           ) {
             authRetryPending = true;
@@ -1666,6 +1566,7 @@ export async function runEmbeddedPiAgent(
           }
           return {
             payloads: payloads.length ? payloads : undefined,
+            finalAuthProfileId: lastProfileId,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,
@@ -1699,7 +1600,7 @@ export async function runEmbeddedPiAgent(
         }
       } finally {
         await contextEngine.dispose?.();
-        stopRuntimeAuthRefreshTimer();
+        stopCopilotRefreshTimer();
         process.chdir(prevCwd);
       }
     }),

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -59,6 +59,8 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentMediaUrls: string[];
   messagingToolSentTargets: MessagingToolSend[];
   successfulCronAdds?: number;
+  /** Final auth profile that actually succeeded for this run, after any rotation. */
+  finalAuthProfileId?: string;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -74,6 +74,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   // Count of successful cron.add tool calls in this run.
   successfulCronAdds?: number;
+  /** Final auth profile that actually succeeded for this run, after any rotation. */
+  finalAuthProfileId?: string;
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -3,40 +3,22 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import "../cron/isolated-agent.mocks.js";
-import * as authProfilesModule from "../agents/auth-profiles.js";
 import * as cliRunnerModule from "../agents/cli-runner.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
+import type { EmbeddedPiRunResult } from "../agents/pi-embedded-runner/types.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import * as commandSecretGatewayModule from "../cli/command-secret-gateway.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
-import * as sessionPathsModule from "../config/sessions/paths.js";
+import * as sessionsModule from "../config/sessions.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { agentCommand, agentCommandFromIngress } from "./agent.js";
 import * as agentDeliveryModule from "./agent/delivery.js";
-
-vi.mock("../logging/subsystem.js", () => {
-  const createMockLogger = () => ({
-    subsystem: "test",
-    isEnabled: vi.fn(() => true),
-    trace: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    fatal: vi.fn(),
-    raw: vi.fn(),
-    child: vi.fn(() => createMockLogger()),
-  });
-  return {
-    createSubsystemLogger: vi.fn(() => createMockLogger()),
-  };
-});
 
 vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/auth-profiles.js")>();
@@ -46,13 +28,10 @@ vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../agents/workspace.js", () => {
-  const resolveDefaultAgentWorkspaceDir = () => "/tmp/openclaw-workspace";
+vi.mock("../agents/workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/workspace.js")>();
   return {
-    DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/openclaw-workspace",
-    DEFAULT_AGENTS_FILENAME: "AGENTS.md",
-    DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
-    resolveDefaultAgentWorkspaceDir,
+    ...actual,
     ensureAgentWorkspace: vi.fn(async ({ dir }: { dir: string }) => ({ dir })),
   };
 });
@@ -240,7 +219,16 @@ async function expectDefaultThinkLevel(params: {
 function createTelegramOutboundPlugin() {
   const sendWithTelegram = async (
     ctx: {
-      deps?: { [channelId: string]: unknown };
+      deps?: {
+        sendTelegram?: (
+          to: string,
+          text: string,
+          opts: Record<string, unknown>,
+        ) => Promise<{
+          messageId: string;
+          chatId: string;
+        }>;
+      };
       to: string;
       text: string;
       accountId?: string | null;
@@ -248,13 +236,7 @@ function createTelegramOutboundPlugin() {
     },
     mediaUrl?: string,
   ) => {
-    const sendTelegram = ctx.deps?.["telegram"] as
-      | ((
-          to: string,
-          text: string,
-          opts: Record<string, unknown>,
-        ) => Promise<{ messageId: string; chatId: string }>)
-      | undefined;
+    const sendTelegram = ctx.deps?.sendTelegram;
     if (!sendTelegram) {
       throw new Error("sendTelegram dependency missing");
     }
@@ -427,35 +409,13 @@ describe("agentCommand", () => {
     });
   });
 
-  it("requires explicit allowModelOverride for ingress runs", async () => {
-    await withTempHome(async (home) => {
-      const store = path.join(home, "sessions.json");
-      mockConfig(home, store);
-      await expect(
-        // Runtime guard for non-TS callers; TS callsites are statically typed.
-        agentCommandFromIngress(
-          {
-            message: "hi",
-            to: "+1555",
-            senderIsOwner: false,
-          } as never,
-          runtime,
-        ),
-      ).rejects.toThrow("allowModelOverride must be explicitly set for ingress agent runs.");
-    });
-  });
-
   it("honors explicit senderIsOwner for ingress runs", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       mockConfig(home, store);
-      await agentCommandFromIngress(
-        { message: "hi", to: "+1555", senderIsOwner: false, allowModelOverride: false },
-        runtime,
-      );
+      await agentCommandFromIngress({ message: "hi", to: "+1555", senderIsOwner: false }, runtime);
       const ingressCall = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
       expect(ingressCall?.senderIsOwner).toBe(false);
-      expect(ingressCall).not.toHaveProperty("allowModelOverride");
     });
   });
 
@@ -506,7 +466,7 @@ describe("agentCommand", () => {
       const store = path.join(customStoreDir, "sessions.json");
       writeSessionStoreSeed(store, {});
       mockConfig(home, store);
-      const resolveSessionFilePathSpy = vi.spyOn(sessionPathsModule, "resolveSessionFilePath");
+      const resolveSessionFilePathSpy = vi.spyOn(sessionsModule, "resolveSessionFilePath");
 
       await agentCommand({ message: "resume me", sessionId: "session-custom-123" }, runtime);
 
@@ -730,146 +690,113 @@ describe("agentCommand", () => {
     });
   });
 
-  it("applies per-run provider and model overrides without persisting them", async () => {
-    await withTempHome(async (home) => {
-      const store = path.join(home, "sessions.json");
-      mockConfig(home, store, {
-        models: {
-          "anthropic/claude-opus-4-5": {},
-          "openai/gpt-4.1-mini": {},
-        },
-      });
-
-      await agentCommand(
-        {
-          message: "use the override",
-          sessionKey: "agent:main:subagent:run-override",
-          provider: "openai",
-          model: "gpt-4.1-mini",
-        },
-        runtime,
-      );
-
-      expectLastRunProviderModel("openai", "gpt-4.1-mini");
-
-      const saved = readSessionStore<{
-        providerOverride?: string;
-        modelOverride?: string;
-      }>(store);
-      expect(saved["agent:main:subagent:run-override"]?.providerOverride).toBeUndefined();
-      expect(saved["agent:main:subagent:run-override"]?.modelOverride).toBeUndefined();
-    });
-  });
-
-  it("rejects explicit override values that contain control characters", async () => {
-    await withTempHome(async (home) => {
-      const store = path.join(home, "sessions.json");
-      mockConfig(home, store, {
-        models: {
-          "anthropic/claude-opus-4-5": {},
-          "openai/gpt-4.1-mini": {},
-        },
-      });
-
-      await expect(
-        agentCommand(
-          {
-            message: "use an invalid override",
-            sessionKey: "agent:main:subagent:invalid-override",
-            provider: "openai\u001b[31m",
-            model: "gpt-4.1-mini",
-          },
-          runtime,
-        ),
-      ).rejects.toThrow("Provider override contains invalid control characters.");
-    });
-  });
-
-  it("sanitizes provider/model text in model-allowlist errors", async () => {
-    const parseModelRefSpy = vi.spyOn(modelSelectionModule, "parseModelRef");
-    parseModelRefSpy.mockImplementationOnce(() => ({
-      provider: "anthropic\u001b[31m",
-      model: "claude-haiku-4-5\u001b[32m",
-    }));
-    try {
-      await withTempHome(async (home) => {
-        const store = path.join(home, "sessions.json");
-        mockConfig(home, store, {
-          models: {
-            "openai/gpt-4.1-mini": {},
-          },
-        });
-
-        await expect(
-          agentCommand(
-            {
-              message: "use disallowed override",
-              sessionKey: "agent:main:subagent:sanitized-override-error",
-              model: "claude-haiku-4-5",
-            },
-            runtime,
-          ),
-        ).rejects.toThrow(
-          'Model override "anthropic/claude-haiku-4-5" is not allowed for agent "main".',
-        );
-      });
-    } finally {
-      parseModelRefSpy.mockRestore();
-    }
-  });
-
-  it("keeps stored auth profile overrides during one-off cross-provider runs", async () => {
+  it("persists final rotated auth profile after a successful run", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       writeSessionStoreSeed(store, {
-        "agent:main:subagent:temp-openai-run": {
-          sessionId: "session-temp-openai-run",
+        "agent:main:main": {
+          sessionId: "sess-rotated-profile",
           updatedAt: Date.now(),
-          authProfileOverride: "anthropic:work",
-          authProfileOverrideSource: "user",
-          authProfileOverrideCompactionCount: 2,
+          authProfileOverride: "openai-codex:default",
+          authProfileOverrideSource: "auto",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
         },
       });
       mockConfig(home, store, {
-        models: {
-          "anthropic/claude-opus-4-5": {},
-          "openai/gpt-4.1-mini": {},
-        },
-      });
-      vi.mocked(authProfilesModule.ensureAuthProfileStore).mockReturnValue({
-        version: 1,
-        profiles: {
-          "anthropic:work": {
-            provider: "anthropic",
+        model: { primary: "openai-codex/gpt-5.4" },
+        auth: {
+          profiles: {
+            "openai-codex:default": { provider: "openai-codex", type: "oauth", access: "a" },
+            "openai-codex:account2": { provider: "openai-codex", type: "oauth", access: "b" },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
           },
         },
-      } as never);
+      });
 
-      await agentCommand(
-        {
-          message: "use a different provider once",
-          sessionKey: "agent:main:subagent:temp-openai-run",
-          provider: "openai",
-          model: "gpt-4.1-mini",
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        finalAuthProfileId: "openai-codex:account2",
+        meta: {
+          durationMs: 10,
+          aborted: false,
+          agentMeta: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            sessionId: "sess-rotated-profile",
+          },
         },
-        runtime,
-      );
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        successfulCronAdds: 0,
+      } as unknown as EmbeddedPiRunResult);
 
-      expectLastRunProviderModel("openai", "gpt-4.1-mini");
-      expect(getLastEmbeddedCall()?.authProfileId).toBeUndefined();
+      await runAgentWithSessionKey("agent:main:main");
 
-      const saved = readSessionStore<{
-        authProfileOverride?: string;
-        authProfileOverrideSource?: string;
-        authProfileOverrideCompactionCount?: number;
-      }>(store);
-      expect(saved["agent:main:subagent:temp-openai-run"]?.authProfileOverride).toBe(
-        "anthropic:work",
-      );
-      expect(saved["agent:main:subagent:temp-openai-run"]?.authProfileOverrideSource).toBe("user");
-      expect(saved["agent:main:subagent:temp-openai-run"]?.authProfileOverrideCompactionCount).toBe(
-        2,
-      );
+      const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<string, unknown>;
+      const entry = saved["agent:main:main"];
+      expect(entry?.authProfileOverride).toBe("openai-codex:account2");
+      expect(entry?.authProfileOverrideSource).toBe("auto");
+      expect(entry?.authProfileOverrideCompactionCount).toBeUndefined();
+    });
+  });
+
+  it("preserves user-pinned auth profile source when persisting the final rotated auth profile", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:main": {
+          sessionId: "sess-user-pinned-profile",
+          updatedAt: Date.now(),
+          authProfileOverride: "openai-codex:default",
+          authProfileOverrideSource: "user",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      });
+      mockConfig(home, store, {
+        model: { primary: "openai-codex/gpt-5.4" },
+        auth: {
+          profiles: {
+            "openai-codex:default": { provider: "openai-codex", type: "oauth", access: "a" },
+            "openai-codex:account2": { provider: "openai-codex", type: "oauth", access: "b" },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
+          },
+        },
+      });
+
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        finalAuthProfileId: "openai-codex:account2",
+        meta: {
+          durationMs: 10,
+          aborted: false,
+          agentMeta: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            sessionId: "sess-user-pinned-profile",
+          },
+        },
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        successfulCronAdds: 0,
+      } as unknown as EmbeddedPiRunResult);
+
+      await runAgentWithSessionKey("agent:main:main");
+
+      const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<string, unknown>;
+      const entry = saved["agent:main:main"];
+      expect(entry?.authProfileOverride).toBe("openai-codex:account2");
+      expect(entry?.authProfileOverrideSource).toBe("user");
+      expect(entry?.authProfileOverrideCompactionCount).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,1 +1,1324 @@
-export * from "../agents/agent-command.js";
+import fs from "node:fs/promises";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { getAcpSessionManager } from "../acp/control-plane/manager.js";
+import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
+import { toAcpRuntimeError } from "../acp/runtime/errors.js";
+import { resolveAcpSessionCwd } from "../acp/runtime/session-identifiers.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("commands/agent");
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveEffectiveModelFallbacks,
+  resolveSessionAgentId,
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
+import { ensureAuthProfileStore, saveAuthProfileStore } from "../agents/auth-profiles.js";
+import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
+import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budget.js";
+import { runCliAgent } from "../agents/cli-runner.js";
+import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { FailoverError } from "../agents/failover-error.js";
+import { formatAgentInternalEventsForPrompt } from "../agents/internal-events.js";
+import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runWithModelFallback } from "../agents/model-fallback.js";
+import {
+  buildAllowedModelSet,
+  isCliProvider,
+  modelKey,
+  normalizeModelRef,
+  normalizeProviderId,
+  resolveConfiguredModelRef,
+  resolveDefaultModelForAgent,
+  resolveThinkingDefault,
+} from "../agents/model-selection.js";
+import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
+import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
+import { resolveAgentTimeoutMs } from "../agents/timeout.js";
+import { ensureAgentWorkspace } from "../agents/workspace.js";
+import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
+import {
+  formatThinkingLevels,
+  formatXHighModelHint,
+  normalizeThinkLevel,
+  normalizeVerboseLevel,
+  supportsXHighThinking,
+  type ThinkLevel,
+  type VerboseLevel,
+} from "../auto-reply/thinking.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+} from "../auto-reply/tokens.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
+import { getAgentRuntimeCommandSecretTargetIds } from "../cli/command-secret-targets.js";
+import { type CliDeps, createDefaultDeps } from "../cli/deps.js";
+import {
+  loadConfig,
+  readConfigFileSnapshotForWrite,
+  setRuntimeConfigSnapshot,
+} from "../config/config.js";
+import {
+  mergeSessionEntry,
+  resolveAgentIdFromSessionKey,
+  type SessionEntry,
+  updateSessionStore,
+} from "../config/sessions.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import {
+  clearAgentRunContext,
+  emitAgentEvent,
+  registerAgentRunContext,
+} from "../infra/agent-events.js";
+import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
+import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { applyVerboseOverride } from "../sessions/level-overrides.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import { resolveSendPolicy } from "../sessions/send-policy.js";
+import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { resolveMessageChannel } from "../utils/message-channel.js";
+import { deliverAgentCommandResult } from "./agent/delivery.js";
+import { resolveAgentRunContext } from "./agent/run-context.js";
+import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
+import { resolveSession } from "./agent/session.js";
+import type { AgentCommandIngressOpts, AgentCommandOpts } from "./agent/types.js";
+
+type PersistSessionEntryParams = {
+  sessionStore: Record<string, SessionEntry>;
+  sessionKey: string;
+  storePath: string;
+  entry: SessionEntry;
+};
+
+type OverrideFieldClearedByDelete =
+  | "providerOverride"
+  | "modelOverride"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+  | "fallbackNoticeSelectedModel"
+  | "fallbackNoticeActiveModel"
+  | "fallbackNoticeReason"
+  | "claudeCliSessionId";
+
+const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
+  "providerOverride",
+  "modelOverride",
+  "authProfileOverride",
+  "authProfileOverrideSource",
+  "authProfileOverrideCompactionCount",
+  "fallbackNoticeSelectedModel",
+  "fallbackNoticeActiveModel",
+  "fallbackNoticeReason",
+  "claudeCliSessionId",
+];
+
+async function persistSessionEntry(params: PersistSessionEntryParams): Promise<void> {
+  const persisted = await updateSessionStore(params.storePath, (store) => {
+    const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
+    // Preserve explicit `delete` clears done by session override helpers.
+    for (const field of OVERRIDE_FIELDS_CLEARED_BY_DELETE) {
+      if (!Object.hasOwn(params.entry, field)) {
+        Reflect.deleteProperty(merged, field);
+      }
+    }
+    store[params.sessionKey] = merged;
+    return merged;
+  });
+  params.sessionStore[params.sessionKey] = persisted;
+}
+
+function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boolean }): string {
+  if (!params.isFallbackRetry) {
+    return params.body;
+  }
+  return "Continue where you left off. The previous model attempt failed or timed out.";
+}
+
+function prependInternalEventContext(
+  body: string,
+  events: AgentCommandOpts["internalEvents"],
+): string {
+  if (body.includes("OpenClaw runtime context (internal):")) {
+    return body;
+  }
+  const renderedEvents = formatAgentInternalEventsForPrompt(events);
+  if (!renderedEvents) {
+    return body;
+  }
+  return [renderedEvents, body].filter(Boolean).join("\n\n");
+}
+
+function createAcpVisibleTextAccumulator() {
+  let pendingSilentPrefix = "";
+  let visibleText = "";
+  const startsWithWordChar = (chunk: string): boolean => /^[\p{L}\p{N}]/u.test(chunk);
+
+  const resolveNextCandidate = (base: string, chunk: string): string => {
+    if (!base) {
+      return chunk;
+    }
+    if (
+      isSilentReplyText(base, SILENT_REPLY_TOKEN) &&
+      !chunk.startsWith(base) &&
+      startsWithWordChar(chunk)
+    ) {
+      return chunk;
+    }
+    // Some ACP backends emit cumulative snapshots even on text_delta-style hooks.
+    // Accept those only when they strictly extend the buffered text.
+    if (chunk.startsWith(base) && chunk.length > base.length) {
+      return chunk;
+    }
+    return `${base}${chunk}`;
+  };
+
+  const mergeVisibleChunk = (base: string, chunk: string): { text: string; delta: string } => {
+    if (!base) {
+      return { text: chunk, delta: chunk };
+    }
+    if (chunk.startsWith(base) && chunk.length > base.length) {
+      const delta = chunk.slice(base.length);
+      return { text: chunk, delta };
+    }
+    return {
+      text: `${base}${chunk}`,
+      delta: chunk,
+    };
+  };
+
+  return {
+    consume(chunk: string): { text: string; delta: string } | null {
+      if (!chunk) {
+        return null;
+      }
+
+      if (!visibleText) {
+        const leadCandidate = resolveNextCandidate(pendingSilentPrefix, chunk);
+        const trimmedLeadCandidate = leadCandidate.trim();
+        if (
+          isSilentReplyText(trimmedLeadCandidate, SILENT_REPLY_TOKEN) ||
+          isSilentReplyPrefixText(trimmedLeadCandidate, SILENT_REPLY_TOKEN)
+        ) {
+          pendingSilentPrefix = leadCandidate;
+          return null;
+        }
+        if (pendingSilentPrefix) {
+          pendingSilentPrefix = "";
+          visibleText = leadCandidate;
+          return {
+            text: visibleText,
+            delta: leadCandidate,
+          };
+        }
+      }
+
+      const nextVisible = mergeVisibleChunk(visibleText, chunk);
+      visibleText = nextVisible.text;
+      return nextVisible.delta ? nextVisible : null;
+    },
+    finalize(): string {
+      return visibleText.trim();
+    },
+    finalizeRaw(): string {
+      return visibleText;
+    },
+  };
+}
+
+const ACP_TRANSCRIPT_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+} as const;
+
+async function persistAcpTurnTranscript(params: {
+  body: string;
+  finalText: string;
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  threadId?: string | number;
+  sessionCwd: string;
+}): Promise<SessionEntry | undefined> {
+  const promptText = params.body;
+  const replyText = params.finalText;
+  if (!promptText && !replyText) {
+    return params.sessionEntry;
+  }
+
+  const { sessionFile, sessionEntry } = await resolveSessionTranscriptFile({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    agentId: params.sessionAgentId,
+    threadId: params.threadId,
+  });
+  const hadSessionFile = await fs
+    .access(sessionFile)
+    .then(() => true)
+    .catch(() => false);
+  const sessionManager = SessionManager.open(sessionFile);
+  await prepareSessionManagerForRun({
+    sessionManager,
+    sessionFile,
+    hadSessionFile,
+    sessionId: params.sessionId,
+    cwd: params.sessionCwd,
+  });
+
+  if (promptText) {
+    sessionManager.appendMessage({
+      role: "user",
+      content: promptText,
+      timestamp: Date.now(),
+    });
+  }
+
+  if (replyText) {
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: replyText }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "acp-runtime",
+      usage: ACP_TRANSCRIPT_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+  }
+
+  emitSessionTranscriptUpdate(sessionFile);
+  return sessionEntry;
+}
+
+async function runAgentAttempt(params: {
+  providerOverride: string;
+  modelOverride: string;
+  cfg: ReturnType<typeof loadConfig>;
+  sessionEntry: SessionEntry | undefined;
+  sessionId: string;
+  sessionKey: string | undefined;
+  sessionAgentId: string;
+  sessionFile: string;
+  workspaceDir: string;
+  body: string;
+  isFallbackRetry: boolean;
+  resolvedThinkLevel: ThinkLevel;
+  timeoutMs: number;
+  runId: string;
+  opts: AgentCommandOpts & { senderIsOwner: boolean };
+  runContext: ReturnType<typeof resolveAgentRunContext>;
+  spawnedBy: string | undefined;
+  messageChannel: ReturnType<typeof resolveMessageChannel>;
+  skillsSnapshot: ReturnType<typeof buildWorkspaceSkillSnapshot> | undefined;
+  resolvedVerboseLevel: VerboseLevel | undefined;
+  agentDir: string;
+  onAgentEvent: (evt: { stream: string; data?: Record<string, unknown> }) => void;
+  primaryProvider: string;
+  originalAuthProfileOverrideSource?: SessionEntry["authProfileOverrideSource"];
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  allowTransientCooldownProbe?: boolean;
+}): Promise<Awaited<ReturnType<typeof runEmbeddedPiAgent>>> {
+  const initialAuthProfileOverrideSource =
+    params.originalAuthProfileOverrideSource ??
+    params.sessionEntry?.authProfileOverrideSource ??
+    (params.sessionKey
+      ? params.sessionStore?.[params.sessionKey]?.authProfileOverrideSource
+      : undefined);
+  const effectivePrompt = resolveFallbackRetryPrompt({
+    body: params.body,
+    isFallbackRetry: params.isFallbackRetry,
+  });
+  const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+    params.sessionEntry?.systemPromptReport,
+  );
+  const bootstrapPromptWarningSignature =
+    bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+  if (isCliProvider(params.providerOverride, params.cfg)) {
+    const cliSessionId = getCliSessionId(params.sessionEntry, params.providerOverride);
+    const runCliWithSession = (nextCliSessionId: string | undefined) =>
+      runCliAgent({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        agentId: params.sessionAgentId,
+        sessionFile: params.sessionFile,
+        workspaceDir: params.workspaceDir,
+        config: params.cfg,
+        prompt: effectivePrompt,
+        provider: params.providerOverride,
+        model: params.modelOverride,
+        thinkLevel: params.resolvedThinkLevel,
+        timeoutMs: params.timeoutMs,
+        runId: params.runId,
+        extraSystemPrompt: params.opts.extraSystemPrompt,
+        cliSessionId: nextCliSessionId,
+        bootstrapPromptWarningSignaturesSeen,
+        bootstrapPromptWarningSignature,
+        images: params.isFallbackRetry ? undefined : params.opts.images,
+        streamParams: params.opts.streamParams,
+      });
+    return runCliWithSession(cliSessionId).catch(async (err) => {
+      // Handle CLI session expired error
+      if (
+        err instanceof FailoverError &&
+        err.reason === "session_expired" &&
+        cliSessionId &&
+        params.sessionKey &&
+        params.sessionStore &&
+        params.storePath
+      ) {
+        log.warn(
+          `CLI session expired, clearing from session store: provider=${params.providerOverride} sessionKey=${params.sessionKey}`,
+        );
+
+        // Clear the expired session ID from the session store
+        const entry = params.sessionStore[params.sessionKey];
+        if (entry) {
+          const updatedEntry = { ...entry };
+          if (params.providerOverride === "claude-cli") {
+            delete updatedEntry.claudeCliSessionId;
+          }
+          if (updatedEntry.cliSessionIds) {
+            const normalizedProvider = normalizeProviderId(params.providerOverride);
+            const newCliSessionIds = { ...updatedEntry.cliSessionIds };
+            delete newCliSessionIds[normalizedProvider];
+            updatedEntry.cliSessionIds = newCliSessionIds;
+          }
+          updatedEntry.updatedAt = Date.now();
+
+          await persistSessionEntry({
+            sessionStore: params.sessionStore,
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            entry: updatedEntry,
+          });
+
+          // Update the session entry reference
+          params.sessionEntry = updatedEntry;
+        }
+
+        // Retry with no session ID (will create a new session)
+        return runCliWithSession(undefined).then(async (result) => {
+          // Update session store with new CLI session ID if available
+          if (
+            result.meta.agentMeta?.sessionId &&
+            params.sessionKey &&
+            params.sessionStore &&
+            params.storePath
+          ) {
+            const entry = params.sessionStore[params.sessionKey];
+            if (entry) {
+              const updatedEntry = { ...entry };
+              setCliSessionId(
+                updatedEntry,
+                params.providerOverride,
+                result.meta.agentMeta.sessionId,
+              );
+              if (params.providerOverride === params.primaryProvider) {
+                try {
+                  const authStore = ensureAuthProfileStore();
+                  const providerKey = normalizeProviderId(params.primaryProvider);
+                  const winningProfileId =
+                    result.finalAuthProfileId?.trim() || authStore.lastGood?.[providerKey]?.trim();
+                  if (winningProfileId) {
+                    const preserveUserPin =
+                      initialAuthProfileOverrideSource === "user" ||
+                      updatedEntry.authProfileOverrideSource === "user";
+                    updatedEntry.authProfileOverride = winningProfileId;
+                    updatedEntry.authProfileOverrideSource = preserveUserPin ? "user" : "auto";
+                    delete updatedEntry.authProfileOverrideCompactionCount;
+                    const winningProfile = authStore.profiles[winningProfileId];
+                    if (winningProfile) {
+                      authStore.lastGood = {
+                        ...authStore.lastGood,
+                        [providerKey]: winningProfileId,
+                      };
+                      saveAuthProfileStore(authStore, params.agentDir);
+                    }
+                  }
+                } catch {
+                  // Best-effort sync only; session persistence remains authoritative for this path.
+                }
+              }
+              updatedEntry.updatedAt = Date.now();
+
+              await persistSessionEntry({
+                sessionStore: params.sessionStore,
+                sessionKey: params.sessionKey,
+                storePath: params.storePath,
+                entry: updatedEntry,
+              });
+            }
+          }
+          return result;
+        });
+      }
+      throw err;
+    });
+  }
+
+  const authProfileId =
+    params.providerOverride === params.primaryProvider
+      ? params.sessionEntry?.authProfileOverride
+      : undefined;
+  const result = await runEmbeddedPiAgent({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.sessionAgentId,
+    trigger: "user",
+    messageChannel: params.messageChannel,
+    agentAccountId: params.runContext.accountId,
+    messageTo: params.opts.replyTo ?? params.opts.to,
+    messageThreadId: params.opts.threadId,
+    groupId: params.runContext.groupId,
+    groupChannel: params.runContext.groupChannel,
+    groupSpace: params.runContext.groupSpace,
+    spawnedBy: params.spawnedBy,
+    currentChannelId: params.runContext.currentChannelId,
+    currentThreadTs: params.runContext.currentThreadTs,
+    replyToMode: params.runContext.replyToMode,
+    hasRepliedRef: params.runContext.hasRepliedRef,
+    senderIsOwner: params.opts.senderIsOwner,
+    sessionFile: params.sessionFile,
+    workspaceDir: params.workspaceDir,
+    config: params.cfg,
+    skillsSnapshot: params.skillsSnapshot,
+    prompt: effectivePrompt,
+    images: params.isFallbackRetry ? undefined : params.opts.images,
+    clientTools: params.opts.clientTools,
+    provider: params.providerOverride,
+    model: params.modelOverride,
+    authProfileId,
+    authProfileIdSource: authProfileId ? params.sessionEntry?.authProfileOverrideSource : undefined,
+    thinkLevel: params.resolvedThinkLevel,
+    verboseLevel: params.resolvedVerboseLevel,
+    timeoutMs: params.timeoutMs,
+    runId: params.runId,
+    lane: params.opts.lane,
+    abortSignal: params.opts.abortSignal,
+    extraSystemPrompt: params.opts.extraSystemPrompt,
+    inputProvenance: params.opts.inputProvenance,
+    streamParams: params.opts.streamParams,
+    agentDir: params.agentDir,
+    allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    onAgentEvent: params.onAgentEvent,
+    bootstrapPromptWarningSignaturesSeen,
+    bootstrapPromptWarningSignature,
+  });
+  if (
+    params.providerOverride === params.primaryProvider &&
+    params.sessionStore &&
+    params.sessionKey &&
+    params.storePath
+  ) {
+    const finalAuthProfileId = result.finalAuthProfileId?.trim();
+    if (finalAuthProfileId) {
+      const entry = params.sessionStore[params.sessionKey];
+      if (entry) {
+        const updatedEntry = { ...entry };
+        const preserveUserPin =
+          initialAuthProfileOverrideSource === "user" ||
+          updatedEntry.authProfileOverrideSource === "user";
+        updatedEntry.authProfileOverride = finalAuthProfileId;
+        updatedEntry.authProfileOverrideSource = preserveUserPin ? "user" : "auto";
+        delete updatedEntry.authProfileOverrideCompactionCount;
+        updatedEntry.updatedAt = Date.now();
+        await persistSessionEntry({
+          sessionStore: params.sessionStore,
+          sessionKey: params.sessionKey,
+          storePath: params.storePath,
+          entry: updatedEntry,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+async function prepareAgentCommandExecution(
+  opts: AgentCommandOpts & { senderIsOwner: boolean },
+  runtime: RuntimeEnv,
+) {
+  const message = opts.message ?? "";
+  if (!message.trim()) {
+    throw new Error("Message (--message) is required");
+  }
+  const body = prependInternalEventContext(message, opts.internalEvents);
+  if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agentId) {
+    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  }
+
+  const loadedRaw = loadConfig();
+  const sourceConfig = await (async () => {
+    try {
+      const { snapshot } = await readConfigFileSnapshotForWrite();
+      if (snapshot.valid) {
+        return snapshot.resolved;
+      }
+    } catch {
+      // Fall back to runtime-loaded config when source snapshot is unavailable.
+    }
+    return loadedRaw;
+  })();
+  const { resolvedConfig: cfg, diagnostics } = await resolveCommandSecretRefsViaGateway({
+    config: loadedRaw,
+    commandName: "agent",
+    targetIds: getAgentRuntimeCommandSecretTargetIds(),
+  });
+  setRuntimeConfigSnapshot(cfg, sourceConfig);
+  const normalizedSpawned = normalizeSpawnedRunMetadata({
+    spawnedBy: opts.spawnedBy,
+    groupId: opts.groupId,
+    groupChannel: opts.groupChannel,
+    groupSpace: opts.groupSpace,
+    workspaceDir: opts.workspaceDir,
+  });
+  for (const entry of diagnostics) {
+    runtime.log(`[secrets] ${entry}`);
+  }
+  const agentIdOverrideRaw = opts.agentId?.trim();
+  const agentIdOverride = agentIdOverrideRaw ? normalizeAgentId(agentIdOverrideRaw) : undefined;
+  if (agentIdOverride) {
+    const knownAgents = listAgentIds(cfg);
+    if (!knownAgents.includes(agentIdOverride)) {
+      throw new Error(
+        `Unknown agent id "${agentIdOverrideRaw}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+      );
+    }
+  }
+  if (agentIdOverride && opts.sessionKey) {
+    const sessionAgentId = resolveAgentIdFromSessionKey(opts.sessionKey);
+    if (sessionAgentId !== agentIdOverride) {
+      throw new Error(
+        `Agent id "${agentIdOverrideRaw}" does not match session key agent "${sessionAgentId}".`,
+      );
+    }
+  }
+  const agentCfg = cfg.agents?.defaults;
+  const configuredModel = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const thinkingLevelsHint = formatThinkingLevels(configuredModel.provider, configuredModel.model);
+
+  const thinkOverride = normalizeThinkLevel(opts.thinking);
+  const thinkOnce = normalizeThinkLevel(opts.thinkingOnce);
+  if (opts.thinking && !thinkOverride) {
+    throw new Error(`Invalid thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+  if (opts.thinkingOnce && !thinkOnce) {
+    throw new Error(`Invalid one-shot thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+
+  const verboseOverride = normalizeVerboseLevel(opts.verbose);
+  if (opts.verbose && !verboseOverride) {
+    throw new Error('Invalid verbose level. Use "on", "full", or "off".');
+  }
+
+  const laneRaw = typeof opts.lane === "string" ? opts.lane.trim() : "";
+  const isSubagentLane = laneRaw === String(AGENT_LANE_SUBAGENT);
+  const timeoutSecondsRaw =
+    opts.timeout !== undefined
+      ? Number.parseInt(String(opts.timeout), 10)
+      : isSubagentLane
+        ? 0
+        : undefined;
+  if (
+    timeoutSecondsRaw !== undefined &&
+    (Number.isNaN(timeoutSecondsRaw) || timeoutSecondsRaw < 0)
+  ) {
+    throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
+  }
+  const timeoutMs = resolveAgentTimeoutMs({
+    cfg,
+    overrideSeconds: timeoutSecondsRaw,
+  });
+
+  const sessionResolution = resolveSession({
+    cfg,
+    to: opts.to,
+    sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
+    agentId: agentIdOverride,
+  });
+
+  const {
+    sessionId,
+    sessionKey,
+    sessionEntry: sessionEntryRaw,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+  } = sessionResolution;
+  const sessionAgentId =
+    agentIdOverride ??
+    resolveSessionAgentId({
+      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
+      config: cfg,
+    });
+  const outboundSession = buildOutboundSessionContext({
+    cfg,
+    agentId: sessionAgentId,
+    sessionKey,
+  });
+  // Internal callers (for example subagent spawns) may pin workspace inheritance.
+  const workspaceDirRaw =
+    normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  const agentDir = resolveAgentDir(cfg, sessionAgentId);
+  const workspace = await ensureAgentWorkspace({
+    dir: workspaceDirRaw,
+    ensureBootstrapFiles: !agentCfg?.skipBootstrap,
+  });
+  const workspaceDir = workspace.dir;
+  const runId = opts.runId?.trim() || sessionId;
+  const acpManager = getAcpSessionManager();
+  const acpResolution = sessionKey
+    ? acpManager.resolveSession({
+        cfg,
+        sessionKey,
+      })
+    : null;
+
+  return {
+    body,
+    cfg,
+    normalizedSpawned,
+    agentCfg,
+    thinkOverride,
+    thinkOnce,
+    verboseOverride,
+    timeoutMs,
+    sessionId,
+    sessionKey,
+    sessionEntry: sessionEntryRaw,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+    sessionAgentId,
+    outboundSession,
+    workspaceDir,
+    agentDir,
+    runId,
+    acpManager,
+    acpResolution,
+  };
+}
+
+async function agentCommandInternal(
+  opts: AgentCommandOpts & { senderIsOwner: boolean },
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  const prepared = await prepareAgentCommandExecution(opts, runtime);
+  const {
+    body,
+    cfg,
+    normalizedSpawned,
+    agentCfg,
+    thinkOverride,
+    thinkOnce,
+    verboseOverride,
+    timeoutMs,
+    sessionId,
+    sessionKey,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+    sessionAgentId,
+    outboundSession,
+    workspaceDir,
+    agentDir,
+    runId,
+    acpManager,
+    acpResolution,
+  } = prepared;
+  let sessionEntry = prepared.sessionEntry;
+  const originalAuthProfileOverrideSource = sessionEntry?.authProfileOverrideSource;
+
+  try {
+    if (opts.deliver === true) {
+      const sendPolicy = resolveSendPolicy({
+        cfg,
+        entry: sessionEntry,
+        sessionKey,
+        channel: sessionEntry?.channel,
+        chatType: sessionEntry?.chatType,
+      });
+      if (sendPolicy === "deny") {
+        throw new Error("send blocked by session policy");
+      }
+    }
+
+    if (acpResolution?.kind === "stale") {
+      throw acpResolution.error;
+    }
+
+    if (acpResolution?.kind === "ready" && sessionKey) {
+      const startedAt = Date.now();
+      registerAgentRunContext(runId, {
+        sessionKey,
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "start",
+          startedAt,
+        },
+      });
+
+      const visibleTextAccumulator = createAcpVisibleTextAccumulator();
+      let stopReason: string | undefined;
+      try {
+        const dispatchPolicyError = resolveAcpDispatchPolicyError(cfg);
+        if (dispatchPolicyError) {
+          throw dispatchPolicyError;
+        }
+        const acpAgent = normalizeAgentId(
+          acpResolution.meta.agent || resolveAgentIdFromSessionKey(sessionKey),
+        );
+        const agentPolicyError = resolveAcpAgentPolicyError(cfg, acpAgent);
+        if (agentPolicyError) {
+          throw agentPolicyError;
+        }
+
+        await acpManager.runTurn({
+          cfg,
+          sessionKey,
+          text: body,
+          mode: "prompt",
+          requestId: runId,
+          signal: opts.abortSignal,
+          onEvent: (event) => {
+            if (event.type === "done") {
+              stopReason = event.stopReason;
+              return;
+            }
+            if (event.type !== "text_delta") {
+              return;
+            }
+            if (event.stream && event.stream !== "output") {
+              return;
+            }
+            if (!event.text) {
+              return;
+            }
+            const visibleUpdate = visibleTextAccumulator.consume(event.text);
+            if (!visibleUpdate) {
+              return;
+            }
+            emitAgentEvent({
+              runId,
+              stream: "assistant",
+              data: {
+                text: visibleUpdate.text,
+                delta: visibleUpdate.delta,
+              },
+            });
+          },
+        });
+      } catch (error) {
+        const acpError = toAcpRuntimeError({
+          error,
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "ACP turn failed before completion.",
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            error: acpError.message,
+            endedAt: Date.now(),
+          },
+        });
+        throw acpError;
+      }
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: Date.now(),
+        },
+      });
+
+      const finalTextRaw = visibleTextAccumulator.finalizeRaw();
+      const finalText = visibleTextAccumulator.finalize();
+      try {
+        sessionEntry = await persistAcpTurnTranscript({
+          body,
+          finalText: finalTextRaw,
+          sessionId,
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          storePath,
+          sessionAgentId,
+          threadId: opts.threadId,
+          sessionCwd: resolveAcpSessionCwd(acpResolution.meta) ?? workspaceDir,
+        });
+      } catch (error) {
+        log.warn(
+          `ACP transcript persistence failed for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      const normalizedFinalPayload = normalizeReplyPayload({
+        text: finalText,
+      });
+      const payloads = normalizedFinalPayload ? [normalizedFinalPayload] : [];
+      const result = {
+        payloads,
+        meta: {
+          durationMs: Date.now() - startedAt,
+          aborted: opts.abortSignal?.aborted === true,
+          stopReason,
+        },
+      };
+
+      return await deliverAgentCommandResult({
+        cfg,
+        deps,
+        runtime,
+        opts,
+        outboundSession,
+        sessionEntry,
+        result,
+        payloads,
+      });
+    }
+
+    let resolvedThinkLevel = thinkOnce ?? thinkOverride ?? persistedThinking;
+    const resolvedVerboseLevel =
+      verboseOverride ?? persistedVerbose ?? (agentCfg?.verboseDefault as VerboseLevel | undefined);
+
+    if (sessionKey) {
+      registerAgentRunContext(runId, {
+        sessionKey,
+        verboseLevel: resolvedVerboseLevel,
+      });
+    }
+
+    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
+    const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const skillsSnapshot = needsSkillsSnapshot
+      ? buildWorkspaceSkillSnapshot(workspaceDir, {
+          config: cfg,
+          eligibility: { remote: getRemoteSkillEligibility() },
+          snapshotVersion: skillsSnapshotVersion,
+          skillFilter,
+        })
+      : sessionEntry?.skillsSnapshot;
+
+    if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
+      const current = sessionEntry ?? {
+        sessionId,
+        updatedAt: Date.now(),
+      };
+      const next: SessionEntry = {
+        ...current,
+        sessionId,
+        updatedAt: Date.now(),
+        skillsSnapshot,
+      };
+      await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+      });
+      sessionEntry = next;
+    }
+
+    // Persist explicit /command overrides to the session store when we have a key.
+    if (sessionStore && sessionKey) {
+      const entry = sessionStore[sessionKey] ??
+        sessionEntry ?? { sessionId, updatedAt: Date.now() };
+      const next: SessionEntry = { ...entry, sessionId, updatedAt: Date.now() };
+      if (thinkOverride) {
+        next.thinkingLevel = thinkOverride;
+      }
+      applyVerboseOverride(next, verboseOverride);
+      await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+      });
+      sessionEntry = next;
+    }
+
+    const configuredDefaultRef = resolveDefaultModelForAgent({
+      cfg,
+      agentId: sessionAgentId,
+    });
+    const { provider: defaultProvider, model: defaultModel } = normalizeModelRef(
+      configuredDefaultRef.provider,
+      configuredDefaultRef.model,
+    );
+    let provider = defaultProvider;
+    let model = defaultModel;
+    const hasAllowlist = agentCfg?.models && Object.keys(agentCfg.models).length > 0;
+    const hasStoredOverride = Boolean(
+      sessionEntry?.modelOverride || sessionEntry?.providerOverride,
+    );
+    const needsModelCatalog = hasAllowlist || hasStoredOverride;
+    let allowedModelKeys = new Set<string>();
+    let allowedModelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
+    let modelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | null = null;
+    let allowAnyModel = false;
+
+    if (needsModelCatalog) {
+      modelCatalog = await loadModelCatalog({ config: cfg });
+      const allowed = buildAllowedModelSet({
+        cfg,
+        catalog: modelCatalog,
+        defaultProvider,
+        defaultModel,
+        agentId: sessionAgentId,
+      });
+      allowedModelKeys = allowed.allowedKeys;
+      allowedModelCatalog = allowed.allowedCatalog;
+      allowAnyModel = allowed.allowAny ?? false;
+    }
+
+    if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
+      const entry = sessionEntry;
+      const overrideProvider = sessionEntry.providerOverride?.trim() || defaultProvider;
+      const overrideModel = sessionEntry.modelOverride?.trim();
+      if (overrideModel) {
+        const normalizedOverride = normalizeModelRef(overrideProvider, overrideModel);
+        const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
+        if (
+          !isCliProvider(normalizedOverride.provider, cfg) &&
+          !allowAnyModel &&
+          !allowedModelKeys.has(key)
+        ) {
+          const { updated } = applyModelOverrideToSessionEntry({
+            entry,
+            selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+          });
+          if (updated) {
+            await persistSessionEntry({
+              sessionStore,
+              sessionKey,
+              storePath,
+              entry,
+            });
+          }
+        }
+      }
+    }
+
+    const storedProviderOverride = sessionEntry?.providerOverride?.trim();
+    const storedModelOverride = sessionEntry?.modelOverride?.trim();
+    if (storedModelOverride) {
+      const candidateProvider = storedProviderOverride || defaultProvider;
+      const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);
+      const key = modelKey(normalizedStored.provider, normalizedStored.model);
+      if (
+        isCliProvider(normalizedStored.provider, cfg) ||
+        allowAnyModel ||
+        allowedModelKeys.has(key)
+      ) {
+        provider = normalizedStored.provider;
+        model = normalizedStored.model;
+      }
+    }
+    if (sessionEntry) {
+      const authProfileId = sessionEntry.authProfileOverride;
+      if (authProfileId) {
+        const entry = sessionEntry;
+        const store = ensureAuthProfileStore();
+        const profile = store.profiles[authProfileId];
+        if (!profile || profile.provider !== provider) {
+          if (sessionStore && sessionKey) {
+            await clearSessionAuthProfileOverride({
+              sessionEntry: entry,
+              sessionStore,
+              sessionKey,
+              storePath,
+            });
+          }
+        }
+      }
+    }
+
+    if (!resolvedThinkLevel) {
+      let catalogForThinking = modelCatalog ?? allowedModelCatalog;
+      if (!catalogForThinking || catalogForThinking.length === 0) {
+        modelCatalog = await loadModelCatalog({ config: cfg });
+        catalogForThinking = modelCatalog;
+      }
+      resolvedThinkLevel = resolveThinkingDefault({
+        cfg,
+        provider,
+        model,
+        catalog: catalogForThinking,
+      });
+    }
+    if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+      const explicitThink = Boolean(thinkOnce || thinkOverride);
+      if (explicitThink) {
+        throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
+      }
+      resolvedThinkLevel = "high";
+      if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
+        const entry = sessionEntry;
+        entry.thinkingLevel = "high";
+        entry.updatedAt = Date.now();
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry,
+        });
+      }
+    }
+    let sessionFile: string | undefined;
+    if (sessionStore && sessionKey) {
+      const resolvedSessionFile = await resolveSessionTranscriptFile({
+        sessionId,
+        sessionKey,
+        sessionStore,
+        storePath,
+        sessionEntry,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
+      });
+      sessionFile = resolvedSessionFile.sessionFile;
+      sessionEntry = resolvedSessionFile.sessionEntry;
+    }
+    if (!sessionFile) {
+      const resolvedSessionFile = await resolveSessionTranscriptFile({
+        sessionId,
+        sessionKey: sessionKey ?? sessionId,
+        sessionEntry,
+        agentId: sessionAgentId,
+        threadId: opts.threadId,
+      });
+      sessionFile = resolvedSessionFile.sessionFile;
+      sessionEntry = resolvedSessionFile.sessionEntry;
+    }
+
+    const startedAt = Date.now();
+    let lifecycleEnded = false;
+
+    let result: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+    let fallbackProvider = provider;
+    let fallbackModel = model;
+    try {
+      const runContext = resolveAgentRunContext(opts);
+      const messageChannel = resolveMessageChannel(
+        runContext.messageChannel,
+        opts.replyChannel ?? opts.channel,
+      );
+      const spawnedBy = normalizedSpawned.spawnedBy ?? sessionEntry?.spawnedBy;
+      // Keep fallback candidate resolution centralized so session model overrides,
+      // per-agent overrides, and default fallbacks stay consistent across callers.
+      const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
+        cfg,
+        agentId: sessionAgentId,
+        hasSessionModelOverride: Boolean(storedModelOverride),
+      });
+
+      // Track model fallback attempts so retries on an existing session don't
+      // re-inject the original prompt as a duplicate user message.
+      let fallbackAttemptIndex = 0;
+      const fallbackResult = await runWithModelFallback({
+        cfg,
+        provider,
+        model,
+        runId,
+        agentDir,
+        fallbacksOverride: effectiveFallbacksOverride,
+        run: (providerOverride, modelOverride, runOptions) => {
+          const isFallbackRetry = fallbackAttemptIndex > 0;
+          fallbackAttemptIndex += 1;
+          return runAgentAttempt({
+            providerOverride,
+            modelOverride,
+            cfg,
+            sessionEntry,
+            sessionId,
+            sessionKey,
+            sessionAgentId,
+            sessionFile,
+            workspaceDir,
+            body,
+            isFallbackRetry,
+            resolvedThinkLevel,
+            timeoutMs,
+            runId,
+            opts,
+            runContext,
+            spawnedBy,
+            messageChannel,
+            skillsSnapshot,
+            resolvedVerboseLevel,
+            agentDir,
+            primaryProvider: provider,
+            originalAuthProfileOverrideSource,
+            sessionStore,
+            storePath,
+            allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            onAgentEvent: (evt) => {
+              // Track lifecycle end for fallback emission below.
+              if (
+                evt.stream === "lifecycle" &&
+                typeof evt.data?.phase === "string" &&
+                (evt.data.phase === "end" || evt.data.phase === "error")
+              ) {
+                lifecycleEnded = true;
+              }
+            },
+          });
+        },
+      });
+      result = fallbackResult.result;
+      fallbackProvider = fallbackResult.provider;
+      fallbackModel = fallbackResult.model;
+      if (!lifecycleEnded) {
+        const stopReason = result.meta.stopReason;
+        if (stopReason && stopReason !== "end_turn") {
+          console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+        }
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            startedAt,
+            endedAt: Date.now(),
+            aborted: result.meta.aborted ?? false,
+            stopReason,
+          },
+        });
+      }
+    } catch (err) {
+      if (!lifecycleEnded) {
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            startedAt,
+            endedAt: Date.now(),
+            error: String(err),
+          },
+        });
+      }
+      throw err;
+    }
+
+    // Update token+model fields in the session store.
+    if (sessionStore && sessionKey) {
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        contextTokensOverride: agentCfg?.contextTokens,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: provider,
+        defaultModel: model,
+        fallbackProvider,
+        fallbackModel,
+        result,
+      });
+
+      // Note: authProfileOverride is now persisted in runAgentAttempt using
+      // finalAuthProfileId from the run result. This ensures the session
+      // remembers which profile actually succeeded after any fallback rotation.
+    }
+
+    const payloads = result.payloads ?? [];
+    return await deliverAgentCommandResult({
+      cfg,
+      deps,
+      runtime,
+      opts,
+      outboundSession,
+      sessionEntry,
+      result,
+      payloads,
+    });
+  } finally {
+    clearAgentRunContext(runId);
+  }
+}
+
+export async function agentCommand(
+  opts: AgentCommandOpts,
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  return await agentCommandInternal(
+    {
+      ...opts,
+      // agentCommand is the trusted-operator entrypoint used by CLI/local flows.
+      // Ingress callers must opt into owner semantics explicitly via
+      // agentCommandFromIngress so network-facing paths cannot inherit this default by accident.
+      senderIsOwner: opts.senderIsOwner ?? true,
+    },
+    runtime,
+    deps,
+  );
+}
+
+export async function agentCommandFromIngress(
+  opts: AgentCommandIngressOpts,
+  runtime: RuntimeEnv = defaultRuntime,
+  deps: CliDeps = createDefaultDeps(),
+) {
+  if (typeof opts.senderIsOwner !== "boolean") {
+    // HTTP/WS ingress must declare the trust level explicitly at the boundary.
+    // This keeps network-facing callers from silently picking up the local trusted default.
+    throw new Error("senderIsOwner must be explicitly set for ingress agent runs.");
+  }
+  return await agentCommandInternal(
+    {
+      ...opts,
+      senderIsOwner: opts.senderIsOwner,
+    },
+    runtime,
+    deps,
+  );
+}


### PR DESCRIPTION
## Summary

- return `finalAuthProfileId` from embedded runs after successful fallback rotation
- persist the winning auth profile back to session `authProfileOverride`
- use the resolved winning profile id for persistence instead of a stale/raw profile source
- preserve `authProfileOverrideSource = "user"` when the session started from a user-pinned auth profile
- add focused regression coverage for final-profile persistence and user-pinned source preservation

## Why this replacement PR exists

This PR replaces #46642.

The earlier PR accumulated correct fixes, but its latest heads repeatedly failed to trigger the normal `pull_request` workflows (`CI`, `Install Smoke`, `Workflow Sanity`) and only ran `pull_request_target` labeler workflows, even after both empty and non-empty retrigger commits. To restore normal CI visibility, this replacement PR carries the same intended fix on a fresh branch.

## Problem

When `openai-codex:default` hit cooldown/rate-limit and the run successfully rotated to `openai-codex:account2`:

- `lastGood` could be updated
- but the session `authProfileOverride` could remain pinned to the stale default profile
- so the next request could start from the wrong/stale override again

There was also a source-tracking edge case where a user-pinned override source could be unintentionally rewritten as `auto` after a successful fallback rotation.

## Root cause

- the embedded runner did not reliably propagate the final winning auth profile id for session persistence
- successful fallback runs did not consistently persist the winner back into the session override
- the persistence path needed to preserve the original `user` source when a user-pinned session successfully rotated to another profile

## What changed

1. track the winning profile with the resolved final profile id
2. expose it as `finalAuthProfileId` in embedded run results
3. persist that id back to session `authProfileOverride` after a successful run
4. preserve `authProfileOverrideSource = "user"` when the session started user-pinned
5. add regression tests for:
   - final fallback winner persistence
   - first-run session persistence
   - user-pinned source preservation

## What this PR does NOT change

- it does not change initial auth-profile selection order logic (that stays in #45462)
- it does not change `lastGood` provider-key normalization persistence logic (that stays in #45699)
- it does not alter user intent by converting existing user-pinned sessions into automatic selection mode

## Validation

### Manual validation

1. set `lastGood = null`
2. put `openai-codex:default` in cooldown
3. run a request
4. verify fallback succeeds on `openai-codex:account2`
5. verify both:
   - `lastGood = openai-codex:account2`
   - `authProfileOverride = openai-codex:account2`
6. run a second request and confirm it stays on `account2`

### Regression coverage

- persists final rotated auth profile after a successful run
- allows first-run session persistence
- preserves user-pinned auth profile source when persisting the final rotated auth profile

## Scope

This PR is intentionally limited to successful fallback winner persistence. It is the runtime/session persistence leg of the auth-profile fallback fix set and is intentionally separate from #45462 and #45699.
