### PR TITLE
Add MAX Messenger to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,10 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **MAX Messenger** — MAX Messenger channel plugin with long polling, outbound delivery, file attachments, typing indicators, and access control.
+  npm: `@biguxuzz/max`
+  repo: `https://github.com/biguxuzz/openclaw-max-plugin`
+  install: `openclaw plugins install @biguxuzz/max`
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **MAX Messenger** — MAX Messenger channel plugin with long polling, outbound delivery, file attachments, typing indicators, and access control.
+  npm: `@biguxuzz/max`
+  repo: `https://github.com/biguxuzz/openclaw-max-plugin`
+  install: `openclaw plugins install @biguxuzz/max`


### PR DESCRIPTION
## Summary

Adds MAX Messenger plugin to the community plugins listing.

## Plugin details

- **npm**: `@biguxuzz/max@1.2.1`
- **repo**: https://github.com/biguxuzz/openclaw-max-plugin
- **Features**: Long polling, streaming responses (edit-based), outbound delivery, file attachments, typing indicators, webhook with secret validation, env var support, access control (open/pairing/closed/allowlist/disabled)
- **Install**: `openclaw plugins install @biguxuzz/max`

## Testing

Actively used in production with OpenClaw 2026.3.8 on Linux.

## Note

Published under `@biguxuzz` scope. Happy to transfer to `@openclaw` if access is granted.