### PR TITLE
fix(admscp): cleanup adm scope handling for internal channels

### DIFF
--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -35,6 +35,7 @@ export const handlePluginCommand: CommandHandler = async (
     args: match.args,
     senderId: command.senderId,
     channel: command.channel,
+    gatewayClientScopes: params.ctx.GatewayClientScopes,
     channelId: command.channelId,
     isAuthorizedSender: command.isAuthorizedSender,
     commandBody: command.commandBodyNormalized,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -113,6 +113,7 @@ const { setDefaultChannelPluginRegistryForTests } =
   await import("../../commands/channel-test-helpers.js");
 const internalHooks = await import("../../hooks/internal-hooks.js");
 const { clearPluginCommands, registerPluginCommand } = await import("../../plugins/commands.js");
+const { createRuntimeConfig } = await import("../../plugins/runtime/runtime-config.js");
 const { abortEmbeddedPiRun, compactEmbeddedPiSession } =
   await import("../../agents/pi-embedded.js");
 const { resetBashChatCommandForTests } = await import("./bash-command.js");
@@ -1474,6 +1475,84 @@ describe("handleCommands plugin commands", () => {
 
     expect(commandResult.shouldContinue).toBe(false);
     expect(commandResult.reply?.text).toBe("from plugin");
+    clearPluginCommands();
+  });
+
+  it("blocks config-mutating plugin commands on internal channel without operator.admin", async () => {
+    clearPluginCommands();
+    writeConfigFileMock.mockClear();
+    const runtimeConfig = createRuntimeConfig();
+    let wroteConfig = false;
+    const registration = registerPluginCommand("test-plugin", {
+      name: "mutcfg",
+      description: "Writes config",
+      handler: async (ctx) => {
+        await runtimeConfig.writeConfigFile({
+          ...ctx.config,
+          testPluginWrite: { blocked: true },
+        } as OpenClawConfig);
+        wroteConfig = true;
+        return { text: "mutated" };
+      },
+    });
+    expect(registration.ok).toBe(true);
+
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/mutcfg", cfg, {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.write"],
+    });
+    params.command.senderIsOwner = true;
+
+    const commandResult = await handleCommands(params);
+    expect(commandResult.shouldContinue).toBe(false);
+    expect(commandResult.reply?.text).toContain("requires operator.admin");
+    expect(wroteConfig).toBe(false);
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+
+    clearPluginCommands();
+  });
+
+  it("allows config-mutating plugin commands on internal channel with operator.admin", async () => {
+    clearPluginCommands();
+    writeConfigFileMock.mockClear();
+    const runtimeConfig = createRuntimeConfig();
+    let wroteConfig = false;
+    const registration = registerPluginCommand("test-plugin", {
+      name: "mutcfgadmin",
+      description: "Writes config",
+      handler: async (ctx) => {
+        await runtimeConfig.writeConfigFile({
+          ...ctx.config,
+          testPluginWrite: { allowed: true },
+        } as OpenClawConfig);
+        wroteConfig = true;
+        return { text: "mutated-admin" };
+      },
+    });
+    expect(registration.ok).toBe(true);
+
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/mutcfgadmin", cfg, {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.admin"],
+    });
+    params.command.senderIsOwner = true;
+
+    const commandResult = await handleCommands(params);
+    expect(commandResult.shouldContinue).toBe(false);
+    expect(commandResult.reply?.text).toBe("mutated-admin");
+    expect(wroteConfig).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalled();
+
     clearPluginCommands();
   });
 });

--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -62,6 +62,7 @@ export async function applyInlineDirectivesFastLane(
 
   const directiveAck = await handleDirectiveOnly({
     cfg,
+    ctx,
     directives,
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -11,6 +11,8 @@ import type { ExecAsk, ExecHost, ExecSecurity } from "../../infra/exec-approvals
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import type { MsgContext } from "../templating.js";
 import { formatThinkingLevels, formatXHighModelHint, supportsXHighThinking } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -55,6 +57,15 @@ function resolveExecDefaults(params: {
       "on-miss",
     node: params.sessionEntry?.execNode ?? agentExec?.node ?? globalExec?.node,
   };
+}
+
+function canPersistExecDefaults(ctx?: MsgContext): boolean {
+  const channel = (ctx?.Provider ?? ctx?.Surface ?? "").trim().toLowerCase();
+  if (!channel || !isInternalMessageChannel(channel)) {
+    return true;
+  }
+  const scopes = ctx?.GatewayClientScopes ?? [];
+  return scopes.includes("operator.admin");
 }
 
 export async function handleDirectiveOnly(
@@ -268,6 +279,11 @@ export async function handleDirectiveOnly(
         ),
       };
     }
+    if (directives.cleaned.trim().length === 0 && !canPersistExecDefaults(params.ctx)) {
+      return {
+        text: "/exec requires operator.admin for gateway clients.",
+      };
+    }
   }
 
   const queueAck = maybeHandleQueueDirective({
@@ -289,6 +305,9 @@ export async function handleDirectiveOnly(
       text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`,
     };
   }
+
+  const execPersistenceBlocked =
+    directives.hasExecDirective && directives.hasExecOptions && !canPersistExecDefaults(params.ctx);
 
   const nextThinkLevel = directives.hasThinkDirective
     ? directives.thinkLevel
@@ -345,7 +364,7 @@ export async function handleDirectiveOnly(
       elevatedChanged ||
       (directives.elevatedLevel !== prevElevatedLevel && directives.elevatedLevel !== undefined);
   }
-  if (directives.hasExecDirective && directives.hasExecOptions) {
+  if (directives.hasExecDirective && directives.hasExecOptions && !execPersistenceBlocked) {
     if (directives.execHost) {
       sessionEntry.execHost = directives.execHost;
     }
@@ -455,21 +474,25 @@ export async function handleDirectiveOnly(
     }
   }
   if (directives.hasExecDirective && directives.hasExecOptions) {
-    const execParts: string[] = [];
-    if (directives.execHost) {
-      execParts.push(`host=${directives.execHost}`);
-    }
-    if (directives.execSecurity) {
-      execParts.push(`security=${directives.execSecurity}`);
-    }
-    if (directives.execAsk) {
-      execParts.push(`ask=${directives.execAsk}`);
-    }
-    if (directives.execNode) {
-      execParts.push(`node=${directives.execNode}`);
-    }
-    if (execParts.length > 0) {
-      parts.push(formatDirectiveAck(`Exec defaults set (${execParts.join(", ")}).`));
+    if (execPersistenceBlocked) {
+      parts.push("/exec requires operator.admin for gateway clients.");
+    } else {
+      const execParts: string[] = [];
+      if (directives.execHost) {
+        execParts.push(`host=${directives.execHost}`);
+      }
+      if (directives.execSecurity) {
+        execParts.push(`security=${directives.execSecurity}`);
+      }
+      if (directives.execAsk) {
+        execParts.push(`ask=${directives.execAsk}`);
+      }
+      if (directives.execNode) {
+        execParts.push(`node=${directives.execNode}`);
+      }
+      if (execParts.length > 0) {
+        parts.push(formatDirectiveAck(`Exec defaults set (${execParts.join(", ")}).`));
+      }
     }
   }
   if (shouldDowngradeXHigh) {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -5,7 +5,10 @@ import {
 } from "../../agents/auth-profiles.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { updateSessionStore } from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import type { MsgContext } from "../templating.js";
 import { handleDirectiveOnly } from "./directive-handling.impl.js";
 import { parseInlineDirectives } from "./directive-handling.js";
 import {
@@ -644,5 +647,82 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(result?.text ?? "").not.toContain("failed");
     expect(sessionEntry.thinkingLevel).toBe("off");
     expect(sessionStore["agent:main:dm:1"]?.thinkingLevel).toBe("off");
+  });
+
+  it("blocks /exec persistence for internal operator.write clients", async () => {
+    vi.mocked(updateSessionStore).mockClear();
+    const directives = parseInlineDirectives("/exec host=gateway");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const ctx = {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.write"],
+    } as MsgContext;
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        ctx,
+        directives,
+        sessionEntry,
+        sessionStore,
+      }),
+    );
+
+    expect(result?.text).toContain("requires operator.admin");
+    expect(sessionEntry.execHost).toBeUndefined();
+    expect(sessionStore["agent:main:dm:1"]?.execHost).toBeUndefined();
+    expect(vi.mocked(updateSessionStore)).not.toHaveBeenCalled();
+  });
+
+  it("blocks /exec persistence for internal operator.write clients with trailing text", async () => {
+    vi.mocked(updateSessionStore).mockClear();
+    const directives = parseInlineDirectives("/exec host=gateway hello");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const ctx = {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.write"],
+    } as MsgContext;
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        ctx,
+        directives,
+        sessionEntry,
+        sessionStore,
+      }),
+    );
+
+    expect(result?.text).toContain("requires operator.admin");
+    expect(sessionEntry.execHost).toBeUndefined();
+    expect(sessionStore["agent:main:dm:1"]?.execHost).toBeUndefined();
+  });
+
+  it("allows /exec persistence for internal operator.admin clients", async () => {
+    vi.mocked(updateSessionStore).mockClear();
+    const directives = parseInlineDirectives("/exec host=gateway");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const ctx = {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.admin"],
+    } as MsgContext;
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        ctx,
+        directives,
+        sessionEntry,
+        sessionStore,
+      }),
+    );
+
+    expect(result?.text).toContain("Exec defaults set");
+    expect(sessionEntry.execHost).toBe("gateway");
+    expect(sessionStore["agent:main:dm:1"]?.execHost).toBe("gateway");
+    expect(vi.mocked(updateSessionStore)).toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -7,6 +7,7 @@ import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./
 
 export type HandleDirectiveOnlyCoreParams = {
   cfg: OpenClawConfig;
+  ctx?: MsgContext;
   directives: InlineDirectives;
   sessionEntry: SessionEntry;
   sessionStore: Record<string, SessionEntry>;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -15,15 +15,27 @@ import { type SessionEntry, updateSessionStore } from "../../config/sessions.js"
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import type { MsgContext } from "../templating.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { enqueueModeSwitchEvents } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
 
+function canPersistExecDefaults(ctx?: MsgContext): boolean {
+  const channel = (ctx?.Provider ?? ctx?.Surface ?? "").trim().toLowerCase();
+  if (!channel || !isInternalMessageChannel(channel)) {
+    return true;
+  }
+  const scopes = ctx?.GatewayClientScopes ?? [];
+  return scopes.includes("operator.admin");
+}
+
 export async function persistInlineDirectives(params: {
   directives: InlineDirectives;
   effectiveModelDirective?: string;
   cfg: OpenClawConfig;
+  ctx?: MsgContext;
   agentDir?: string;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
@@ -57,6 +69,7 @@ export async function persistInlineDirectives(params: {
     initialModelLabel,
     formatModelSwitchEvent,
     agentCfg,
+    ctx,
   } = params;
   let { provider, model } = params;
   const activeAgentId = sessionKey
@@ -75,6 +88,8 @@ export async function persistInlineDirectives(params: {
       directives.elevatedLevel !== undefined &&
       elevatedEnabled &&
       elevatedAllowed;
+    const execPersistenceBlocked =
+      directives.hasExecDirective && directives.hasExecOptions && !canPersistExecDefaults(ctx);
     let reasoningChanged =
       directives.hasReasoningDirective && directives.reasoningLevel !== undefined;
     let updated = false;
@@ -113,7 +128,7 @@ export async function persistInlineDirectives(params: {
         (directives.elevatedLevel !== prevElevatedLevel && directives.elevatedLevel !== undefined);
       updated = true;
     }
-    if (directives.hasExecDirective && directives.hasExecOptions) {
+    if (directives.hasExecDirective && directives.hasExecOptions && !execPersistenceBlocked) {
       if (directives.execHost) {
         sessionEntry.execHost = directives.execHost;
         updated = true;

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -162,6 +162,7 @@ export async function applyInlineDirectiveOverrides(params: {
     const currentThinkLevel = resolvedDefaultThinkLevel;
     const directiveReply = await handleDirectiveOnly({
       ...createDirectiveHandlingBase(),
+      ctx,
       currentThinkLevel,
       currentFastMode,
       currentVerboseLevel,
@@ -251,6 +252,7 @@ export async function applyInlineDirectiveOverrides(params: {
     directives,
     effectiveModelDirective,
     cfg,
+    ctx,
     agentDir,
     sessionEntry,
     sessionStore,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -284,6 +284,27 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(register).not.toHaveBeenCalled();
   });
 
+  it("sets CommandAuthorized=false for operator.write chat.send callers", async () => {
+    createTranscriptFixture("openclaw-chat-send-write-scope-command-auth-");
+    mockState.finalText = "ok";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-write-scope-command-auth",
+      client: {
+        connect: {
+          scopes: ["operator.write"],
+        },
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx?.CommandAuthorized).toBe(false);
+  });
+
   it("chat.inject keeps message defined when directive tag is the only content", async () => {
     createTranscriptFixture("openclaw-chat-inject-directive-only-");
     const respond = vi.fn();

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1289,6 +1289,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       // See: https://github.com/moltbot/moltbot/issues/3658
       const stampedMessage = injectTimestamp(messageForAgent, timestampOptsFromConfig(cfg));
 
+      const commandAuthorized =
+        Array.isArray(client?.connect?.scopes) && client.connect.scopes.includes(ADMIN_SCOPE);
+
       const ctx: MsgContext = {
         Body: messageForAgent,
         BodyForAgent: stampedMessage,
@@ -1305,7 +1308,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         AccountId: accountId,
         MessageThreadId: messageThreadId,
         ChatType: "direct",
-        CommandAuthorized: true,
+        CommandAuthorized: commandAuthorized,
         MessageSid: clientRunId,
         SenderId: clientInfo?.id,
         SenderName: clientInfo?.displayName,

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -13,6 +13,10 @@ import {
   getCurrentPluginConversationBinding,
   requestPluginConversationBinding,
 } from "./conversation-binding.js";
+import {
+  isPluginCommandScopeError,
+  withPluginRuntimeCommandScope,
+} from "./runtime/plugin-command-scope.js";
 import type {
   OpenClawPluginCommandDefinition,
   PluginCommandContext,
@@ -372,6 +376,7 @@ export async function executePluginCommand(params: {
   args?: string;
   senderId?: string;
   channel: string;
+  gatewayClientScopes?: string[];
   channelId?: PluginCommandContext["channelId"];
   isAuthorizedSender: boolean;
   commandBody: string;
@@ -453,12 +458,22 @@ export async function executePluginCommand(params: {
   // Lock registry during execution to prevent concurrent modifications
   registryLocked = true;
   try {
-    const result = await command.handler(ctx);
+    const result = await withPluginRuntimeCommandScope(
+      {
+        commandName: command.name,
+        channel,
+        gatewayClientScopes: params.gatewayClientScopes,
+      },
+      () => command.handler(ctx),
+    );
     logVerbose(
       `Plugin command /${command.name} executed successfully for ${senderId || "unknown"}`,
     );
     return result;
   } catch (err) {
+    if (isPluginCommandScopeError(err)) {
+      return { text: err.message };
+    }
     const error = err as Error;
     logVerbose(`Plugin command /${command.name} error: ${error.message}`);
     // Don't leak internal error details - return a safe generic message

--- a/src/plugins/runtime/plugin-command-scope.ts
+++ b/src/plugins/runtime/plugin-command-scope.ts
@@ -1,0 +1,46 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type PluginRuntimeCommandScope = {
+  commandName: string;
+  channel: string;
+  gatewayClientScopes?: string[];
+};
+
+const PLUGIN_RUNTIME_COMMAND_SCOPE_KEY: unique symbol = Symbol.for(
+  "openclaw.pluginRuntimeCommandScope",
+);
+
+const pluginRuntimeCommandScope = (() => {
+  const globalState = globalThis as typeof globalThis & {
+    [PLUGIN_RUNTIME_COMMAND_SCOPE_KEY]?: AsyncLocalStorage<PluginRuntimeCommandScope>;
+  };
+  const existing = globalState[PLUGIN_RUNTIME_COMMAND_SCOPE_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new AsyncLocalStorage<PluginRuntimeCommandScope>();
+  globalState[PLUGIN_RUNTIME_COMMAND_SCOPE_KEY] = created;
+  return created;
+})();
+
+export function withPluginRuntimeCommandScope<T>(
+  scope: PluginRuntimeCommandScope,
+  run: () => T,
+): T {
+  return pluginRuntimeCommandScope.run(scope, run);
+}
+
+export function getPluginRuntimeCommandScope(): PluginRuntimeCommandScope | undefined {
+  return pluginRuntimeCommandScope.getStore();
+}
+
+export class PluginCommandScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginCommandScopeError";
+  }
+}
+
+export function isPluginCommandScopeError(err: unknown): err is PluginCommandScopeError {
+  return err instanceof PluginCommandScopeError;
+}

--- a/src/plugins/runtime/runtime-config.ts
+++ b/src/plugins/runtime/runtime-config.ts
@@ -1,9 +1,22 @@
 import { loadConfig, writeConfigFile } from "../../config/config.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { getPluginRuntimeCommandScope, PluginCommandScopeError } from "./plugin-command-scope.js";
 import type { PluginRuntime } from "./types.js";
 
 export function createRuntimeConfig(): PluginRuntime["config"] {
   return {
     loadConfig,
-    writeConfigFile,
+    writeConfigFile: (...args) => {
+      const scope = getPluginRuntimeCommandScope();
+      if (scope && isInternalMessageChannel(scope.channel)) {
+        const scopes = scope.gatewayClientScopes ?? [];
+        if (!scopes.includes("operator.admin")) {
+          throw new PluginCommandScopeError(
+            `/${scope.commandName} requires operator.admin for gateway clients.`,
+          );
+        }
+      }
+      return writeConfigFile(...args);
+    },
   };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Internal gateway clients scoped to `operator.write` needed cleanup for consistency across a few mutation and command-authorization paths. 
- Why it matters: This keeps internal scope behavior predictable and aligned across gateway and plugin execution flows.
- What changed: Added explicit `operator.admin` checks for internal-channel command authorization, `/exec` default persistence, and plugin runtime config writes (which seems useful in the long-term instead of defining checks for every mutatable plugin call). added plugin command scope propagation via runtime context.
- What did NOT change (scope boundary): No secret/token handling changes, no new network calls, no new tool/command surface, and non-internal channel behavior remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

# Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- Internal callers now need `operator.admin` to persist `/exec` defaults.
- Internal callers now need `operator.admin` when plugin commands perform runtime config writes. This also avoids metadata reliance for enforcement on new and existing plugins.
- `chat.send` now sets `CommandAuthorized` from actual gateway client scopes instead of always true.
- Existing `operator.admin` flows continue to work as expected.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) yes
- Secrets/tokens handling changed? (`Yes/No`) no
- New/changed network calls? (`Yes/No`) no
- Command/tool execution surface changed? (`Yes/No`) no
- Data access scope changed? (`Yes/No`) yes
- If any `Yes`, explain risk + mitigation:
- Risk: Internal scope behavior across write paths was not fully aligned.
- Mitigation: Standardized `operator.admin` checks for the relevant internal authorization and write paths, with regression tests for both non-admin and admin callers.

## Repro + Verification

### Environment

Gateway:
- OS: Ubuntu 22.04.5 LTS
- Runtime/container: local gateway on a non-tls WS (not containerized)
- Model/provider: N/A (scope/authorization logic)
- Integration/channel (if any): internal gateway channel
- Relevant config (redacted): gateway client scopes `["operator.write"]` vs `["operator.admin"]`

Client:
- OS: Mac OS
- Runtime/container: remote calls to gateway from local script
- Model/provider: N/A (scope/authorization logic)
- Integration/channel (if any): internal gateway channel
- Relevant config (redacted): gateway client scopes `["operator.write"]` vs `["operator.admin"]`

### Evidence

Attach at least one:

- [x] Failing test/log before + passing after
Several tests proving out the fix without further issues.
- [x] Trace/log snippets
resulting response when commandAuthorization is false when scope is `operator.write`:
`⚠️ This command requires authorization.`
### Human Verification (required)

What you personally verified (not just CI), and how:

- Verified full Vitest suite in this environment per contributing doc. What scripts failed also failed in the main branch and appeared unrelated to these changes.
- Ran real calls against a real remote gateway using an `operator.write` scope and confirmed the primary fix path by observing command-surface denial (`⚠️ This command requires authorization`) instead of broad command access from `chat.send`.
- Confirmed added defense-in-depth (future-proof) for `/exec` by sending `/exec host=gateway` and then checking session state to ensure exec defaults were not persisted (`execHost` remained unset).
- Confirmed added defense-in-depth (future-proof) for plugin config mutation by running `/phone arm writes 30s` and verifying both denial response and no mutation to `gateway.nodes.allowCommands` / `gateway.nodes.denyCommands`.

- Edge cases checked: `chat.final` without inline message payload was handled by history fallback in the script, so checks were based on final observable state, not only direct reply text.

- What you did **not** verify: I did not test other plugins outside of `/phone`, however since the admin enforcement on the sink is applied for any plugins trying to write to configs, it did not seem necessary to test further plugins.


## Compatibility / Migration

- Backward compatible? (`Yes/No`) no
- Config/env changes? (`Yes/No`) no
- Migration needed? (`Yes/No`) yes
- If yes, exact upgrade steps:
- Identify internal clients/automations that perform `/exec` persistence or plugin config mutation using `operator.write`.
- Move those callers to `operator.admin` where write access is expected or required.
- Re-run affected flows and confirm behavior matches intended scopes.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit.
- Files/config to restore: files in this pr
- Known bad symptoms reviewers should watch for: Internal automations using `operator.write` for write operations now return `requires operator.admin` or response gates that are now appropriately enforced in a preceding func/check.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing internal workflows may rely on `operator.write` for operations that now out of necessity require `operator.admin`.
- Mitigation: Clear error messaging, targeted scope checks limited to internal write paths, and regression tests for both scope levels.
