### PR TITLE
fix: surface skill parse diagnostics instead of silently dropping them

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -370,9 +370,10 @@ function loadSkillEntries(
       const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
       const { skills, diagnostics } = unwrapLoadedSkills(loaded);
       for (const diag of diagnostics) {
-        skillsLogger.warn("Skill parse error: skill was dropped from discovery.", {
+        skillsLogger.warn(`Skill parse ${diag.type}: ${diag.message} (${diag.path})`, {
           path: diag.path,
           message: diag.message,
+          type: diag.type,
           source: params.source,
         });
       }
@@ -452,9 +453,10 @@ function loadSkillEntries(
       const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
       const { skills, diagnostics } = unwrapLoadedSkills(loaded);
       for (const diag of diagnostics) {
-        skillsLogger.warn("Skill parse error: skill was dropped from discovery.", {
+        skillsLogger.warn(`Skill parse ${diag.type}: ${diag.message} (${diag.path})`, {
           path: diag.path,
           message: diag.message,
+          type: diag.type,
           source: params.source,
         });
       }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -277,17 +277,40 @@ function resolveNestedSkillsRoot(
   return { baseDir: dir };
 }
 
-function unwrapLoadedSkills(loaded: unknown): Skill[] {
+type SkillLoadDiagnostic = {
+  type: string;
+  message: string;
+  path: string;
+};
+
+type UnwrapResult = {
+  skills: Skill[];
+  diagnostics: SkillLoadDiagnostic[];
+};
+
+function unwrapLoadedSkills(loaded: unknown): UnwrapResult {
   if (Array.isArray(loaded)) {
-    return loaded as Skill[];
+    return { skills: loaded as Skill[], diagnostics: [] };
   }
-  if (loaded && typeof loaded === "object" && "skills" in loaded) {
-    const skills = (loaded as { skills?: unknown }).skills;
-    if (Array.isArray(skills)) {
-      return skills as Skill[];
+  if (loaded && typeof loaded === "object") {
+    const obj = loaded as Record<string, unknown>;
+    const skills = Array.isArray(obj.skills) ? (obj.skills as Skill[]) : [];
+    const diagnostics: SkillLoadDiagnostic[] = [];
+    if (Array.isArray(obj.diagnostics)) {
+      for (const diag of obj.diagnostics) {
+        if (diag && typeof diag === "object") {
+          const d = diag as Record<string, unknown>;
+          diagnostics.push({
+            type: typeof d.type === "string" ? d.type : "warning",
+            message: typeof d.message === "string" ? d.message : String(d.message ?? "unknown error"),
+            path: typeof d.path === "string" ? d.path : "unknown",
+          });
+        }
+      }
     }
+    return { skills, diagnostics };
   }
-  return [];
+  return { skills: [], diagnostics: [] };
 }
 
 function loadSkillEntries(
@@ -345,8 +368,16 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
+      const { skills, diagnostics } = unwrapLoadedSkills(loaded);
+      for (const diag of diagnostics) {
+        skillsLogger.warn("Skill parse error: skill was dropped from discovery.", {
+          path: diag.path,
+          message: diag.message,
+          source: params.source,
+        });
+      }
       return filterLoadedSkillsInsideRoot({
-        skills: unwrapLoadedSkills(loaded),
+        skills,
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
@@ -419,9 +450,17 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
+      const { skills, diagnostics } = unwrapLoadedSkills(loaded);
+      for (const diag of diagnostics) {
+        skillsLogger.warn("Skill parse error: skill was dropped from discovery.", {
+          path: diag.path,
+          message: diag.message,
+          source: params.source,
+        });
+      }
       loadedSkills.push(
         ...filterLoadedSkillsInsideRoot({
-          skills: unwrapLoadedSkills(loaded),
+          skills,
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,


### PR DESCRIPTION
## Summary

`loadSkillsFromDir()` from `pi-coding-agent` returns `{ skills, diagnostics }`, but `unwrapLoadedSkills()` in `workspace.ts` only extracted the `skills` array and silently discarded `diagnostics`. This caused skills with YAML frontmatter parse errors (e.g. unquoted colons in `description`) to vanish from `openclaw skills list` with zero feedback.

- Extract both `skills` and `diagnostics` from the load result
- Log each diagnostic via `skillsLogger.warn()` with file path, error message, and source
- Matches the actual diagnostic structure from pi-coding-agent: `{ type, message, path }`
- No changes to `loadSkillEntries()` return type — fully backwards compatible

### Example log output after fix

```
[skills] WARN Skill parse error: skill was dropped from discovery.
  path=/home/user/.openclaw/skills/my-skill/SKILL.md
  message=Nested mappings are not allowed in compact mappings at line 3
  source=openclaw-managed
```

## Test plan

- [ ] Create a SKILL.md with unquoted colon in description (e.g. `description: Use when: this`)
- [ ] Run `openclaw skills list` — skill should not appear (unchanged behavior)
- [ ] Check gateway logs — should now show warning with file path and parse error
- [ ] Verify valid skills still load normally (no regression)

Closes #22134

🤖 Generated with [Claude Code](https://claude.com/claude-code)