### PR TITLE
fix(ui): use totalTokens context snapshot for usage display

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -323,9 +323,38 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(result.content).toBe(
-      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **30%** of 4k\nModel: `gpt-4.1-mini`",
+      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **38%** of 4k\nModel: `gpt-4.1-mini`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("uses totalTokens (context snapshot) for /usage context percentage, not accumulated inputTokens", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:main", {
+              model: "gpt-5",
+              inputTokens: 510_400, // accumulated billing across all turns
+              outputTokens: 12_000,
+              totalTokens: 109_000, // latest context snapshot
+              contextTokens: 128_000,
+            }),
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "usage",
+      "",
+    );
+
+    // Context % must use totalTokens (109k/128k = 85%), not inputTokens (510.4k/128k = 399%)
+    expect(result.content).toContain("Context: **85%** of 128k");
   });
 
   it("reports the current thinking level for bare /think", async () => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -304,9 +304,11 @@ async function executeUsage(
     const output = session.outputTokens ?? 0;
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;
-    // Use totalTokens (context snapshot) for context-window percentage,
-    // not accumulated billing inputTokens.
-    const pct = ctx > 0 ? Math.round((total / ctx) * 100) : null;
+    // Use totalTokens (context snapshot) for context-window percentage.
+    // Fallback to inputTokens only (not input+output) — output tokens
+    // are completions, not context-window occupants.
+    const contextUsed = session.totalTokens ?? input;
+    const pct = ctx > 0 ? Math.round((contextUsed / ctx) * 100) : null;
 
     const lines = [
       "**Session Usage**",

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -304,7 +304,9 @@ async function executeUsage(
     const output = session.outputTokens ?? 0;
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;
-    const pct = ctx > 0 ? Math.round((input / ctx) * 100) : null;
+    // Use totalTokens (context snapshot) for context-window percentage,
+    // not accumulated billing inputTokens.
+    const pct = ctx > 0 ? Math.round((total / ctx) * 100) : null;
 
     const lines = [
       "**Session Usage**",

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -80,4 +80,40 @@ describe("chat context notice", () => {
     expect(iconStyle.height).toBe("16px");
     expect(icon.getBoundingClientRect().width).toBeLessThan(24);
   });
+
+  it("prefers totalTokens (context snapshot) over accumulated inputTokens", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    // inputTokens is accumulated billing (510.4k); totalTokens is context snapshot (109k)
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                inputTokens: 510_400,
+                totalTokens: 109_000,
+                contextTokens: 128_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const detail = container.querySelector<HTMLElement>(".context-notice__detail");
+    expect(detail).not.toBeNull();
+    // Should show 109k (totalTokens), not 510.4k (accumulated inputTokens)
+    expect(detail!.textContent).toContain("109k");
+    expect(detail!.textContent).not.toContain("510");
+  });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,9 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  // Prefer totalTokens (latest prompt/context snapshot) over inputTokens
+  // (accumulated billing total across all turns) for context-window display.
+  const used = session?.totalTokens ?? session?.inputTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary

Fixes #50196

`renderContextNotice()` in the web UI and the `/usage` slash command incorrectly used `session.inputTokens` (the accumulated billing total across all API turns) to calculate the context-window usage percentage. After long conversations, this caused inflated numbers like **510.4k/128k** instead of the actual context snapshot **109k/128k**.

The fix switches both code paths to use `session.totalTokens` — the prompt/context snapshot set by `deriveSessionTotalTokens()` — with a fallback to `inputTokens` for backward compatibility when `totalTokens` is not yet populated.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] Web UI only (no CLI or gateway changes)

## Security Impact

- [ ] This change has security implications

No security impact. This is a display-only fix that reads an existing field from the session data.

## Evidence

### Symptom evidence (from issue #50196)

User reports context usage showing **510.4k/128k** in the web UI header. After page refresh, it correctly showed **109k/128k**. The accumulated `inputTokens` (billing) was being used instead of the context snapshot `totalTokens`.

### Verified root cause

- `ui/src/ui/views/chat.ts:258` — `renderContextNotice()` used `session?.inputTokens` (accumulated billing total)
- `ui/src/ui/chat/slash-command-executor.ts:307` — `/usage` command used `input` (inputTokens) for context percentage
- The correct field is `totalTokens`, as documented in `src/agents/usage.ts:153`: *"SessionEntry.totalTokens is used as a prompt/context snapshot"*
- `ui/src/ui/presenter.ts:formatSessionTokens()` already correctly uses `totalTokens` for the sessions list view

### Fix touches the implicated code path

- `chat.ts:258`: Changed from `session?.inputTokens ?? 0` to `session?.totalTokens ?? session?.inputTokens ?? 0`
- `slash-command-executor.ts:307-309`: Changed context percentage from `input` to `total` (totalTokens)

## Verification

### Regression tests

1. **slash-command-executor.node.test.ts**: Added test with realistic accumulated scenario (inputTokens=510.4k, totalTokens=109k, contextTokens=128k) — verifies `/usage` shows 85% (109k/128k), not 399% (510.4k/128k)
2. **chat.browser.test.ts**: Added test verifying `renderContextNotice` prefers `totalTokens` (109k) over `inputTokens` (510.4k)
3. Updated existing `/usage` test expectation to reflect the fix (context % now uses totalTokens)

All 15 slash-command node tests pass. All 26 chat unit tests pass.
