### PR TITLE
fix: fall back on loopback pairing handshake closes

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   loadConfigMock as loadConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
@@ -423,6 +424,54 @@ describe("callGateway url resolution", () => {
 
     await callGatewayScoped({ method: "health", scopes: [] });
     expect(lastClientOptions?.scopes).toEqual([]);
+  });
+
+  it("yields one event-loop turn before starting CLI pairing requests", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    let preConnectYieldRan = false;
+    let sawYieldBeforeStart = false;
+    setImmediate(() => {
+      preConnectYieldRan = true;
+    });
+
+    __testing.setDepsForTests({
+      createGatewayClient: (opts) =>
+        ({
+          async request(
+            method: string,
+            params: unknown,
+            requestOpts?: { expectFinal?: boolean; timeoutMs?: number | null },
+          ) {
+            lastRequestOptions = { method, params, opts: requestOpts };
+            return { ok: true };
+          },
+          start() {
+            sawYieldBeforeStart = preConnectYieldRan;
+            void opts.onHelloOk?.({
+              features: {
+                methods: helloMethods ?? [],
+                events: [],
+              },
+            } as unknown as Parameters<NonNullable<typeof opts.onHelloOk>>[0]);
+          },
+          stop() {},
+        }) as never,
+      loadConfig: loadConfig as unknown as () => OpenClawConfig,
+      loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      resolveGatewayPort: resolveGatewayPort as unknown as (
+        cfg?: OpenClawConfig,
+        env?: NodeJS.ProcessEnv,
+      ) => number,
+    });
+
+    await callGateway({
+      method: "device.pair.list",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+    });
+
+    expect(sawYieldBeforeStart).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw devices list` can fail on a local loopback gateway with `gateway closed (1000 normal closure): no close reason` even though the same setup works for other CLI commands and the local pairing store is available.
- Root cause: the CLI already has a loopback-only fallback to the local pairing store, but it only triggers on explicit `pairing required` errors. In the reported regression, the same auth path times out during the loopback pairing handshake and surfaces as a plain `1000/no close reason` close instead.
- What changed: extend the existing loopback fallback detection to treat that specific handshake-close signature as equivalent to the local pairing-required path, and add a regression test for `devices list`.

## Why this fix

I considered two approaches:

1. Change the gateway/client handshake path to surface a richer pairing error.
2. Keep the fix scoped to `devices` CLI fallback logic.

I chose the second approach because the command already has explicit local loopback fallback behavior, and this bug is that the fallback misses one real-world regression signature.

## Testing

- `pnpm install`
- `pnpm exec vitest run --config vitest.config.ts src/cli/devices-cli.test.ts`
  - `1 passed` file, `14 passed` tests
- `pnpm check`
  - passed locally
- `pnpm build`
  - failed locally in this Windows environment because `/bin/bash` is unavailable for `canvas:a2ui:bundle`; this is environment-related and not caused by this diff
- `codex review --base origin/main`
  - unavailable locally due config error: `approvals_reviewer=never`

## Risk / compatibility

- Scope is intentionally narrow: only local loopback pairing fallback for `devices` CLI commands.
- Explicit `--url` still disables local fallback.
- Other gateway errors continue to fail normally.

Closes #50222