### PR TITLE
fix(feishu): avoid resolving SecretRefs during plugin preflight

### DIFF
--- a/extensions/feishu/index.secretref.test.ts
+++ b/extensions/feishu/index.secretref.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/extensions/plugin-api.js";
+import { createPluginRuntimeMock } from "../../test/helpers/extensions/plugin-runtime-mock.js";
+import plugin from "./index.js";
+
+describe("feishu plugin register SecretRef regression", () => {
+  it("does not resolve SecretRefs while registering tools", () => {
+    const api = createTestPluginApi({
+      id: plugin.id,
+      name: plugin.name,
+      source: "extensions/feishu/index.ts",
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            accounts: {
+              main: {
+                appId: { source: "file", provider: "default", id: "path/to/app-id" },
+                appSecret: { source: "file", provider: "default", id: "path/to/app-secret" },
+                tools: {
+                  chat: true,
+                  doc: true,
+                  drive: true,
+                  perm: true,
+                  wiki: true,
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      runtime: createPluginRuntimeMock(),
+    });
+
+    expect(() => plugin.register(api)).not.toThrow();
+  });
+});

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -6,10 +6,15 @@ import {
   resolveMergedAccountConfig,
 } from "openclaw/plugin-sdk/account-resolution";
 import type { ClawdbotConfig } from "../runtime-api.js";
-import { normalizeResolvedSecretInputString, normalizeSecretInputString } from "./secret-input.js";
+import {
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "./secret-input.js";
 import type {
   FeishuConfig,
   FeishuAccountConfig,
+  FeishuAccountSelectionSource,
   FeishuDefaultAccountSelectionSource,
   FeishuDomain,
   ResolvedFeishuAccount,
@@ -73,6 +78,51 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
     accountId,
     omitKeys: ["defaultAccount"],
   });
+}
+
+function resolveFeishuAccountConfigState(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+}): {
+  accountId: string;
+  selectionSource: FeishuAccountSelectionSource;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  domain: FeishuDomain;
+  config: FeishuConfig;
+} {
+  const hasExplicitAccountId =
+    typeof params.accountId === "string" && params.accountId.trim() !== "";
+  const defaultSelection = hasExplicitAccountId
+    ? null
+    : resolveDefaultFeishuAccountSelection(params.cfg);
+  const accountId = hasExplicitAccountId
+    ? normalizeAccountId(params.accountId)
+    : (defaultSelection?.accountId ?? DEFAULT_ACCOUNT_ID);
+  const selectionSource: FeishuAccountSelectionSource = hasExplicitAccountId
+    ? "explicit"
+    : (defaultSelection?.source ?? "fallback");
+  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
+
+  const baseEnabled = feishuCfg?.enabled !== false;
+  const merged = mergeFeishuAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const configured = Boolean(
+    hasConfiguredSecretInput(merged.appId) && hasConfiguredSecretInput(merged.appSecret),
+  );
+  const accountName = (merged as FeishuAccountConfig).name;
+
+  return {
+    accountId,
+    selectionSource,
+    enabled,
+    configured,
+    name: typeof accountName === "string" ? accountName.trim() || undefined : undefined,
+    domain: merged.domain ?? "feishu",
+    config: merged,
+  };
 }
 
 /**
@@ -168,46 +218,40 @@ export function resolveFeishuAccount(params: {
   cfg: ClawdbotConfig;
   accountId?: string | null;
 }): ResolvedFeishuAccount {
-  const hasExplicitAccountId =
-    typeof params.accountId === "string" && params.accountId.trim() !== "";
-  const defaultSelection = hasExplicitAccountId
-    ? null
-    : resolveDefaultFeishuAccountSelection(params.cfg);
-  const accountId = hasExplicitAccountId
-    ? normalizeAccountId(params.accountId)
-    : (defaultSelection?.accountId ?? DEFAULT_ACCOUNT_ID);
-  const selectionSource = hasExplicitAccountId
-    ? "explicit"
-    : (defaultSelection?.source ?? "fallback");
-  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
-
-  // Base enabled state (top-level)
-  const baseEnabled = feishuCfg?.enabled !== false;
-
-  // Merge configs
-  const merged = mergeFeishuAccountConfig(params.cfg, accountId);
-
-  // Account-level enabled state
-  const accountEnabled = merged.enabled !== false;
-  const enabled = baseEnabled && accountEnabled;
-
-  // Resolve credentials from merged config
-  const creds = resolveFeishuCredentials(merged);
-  const accountName = (merged as FeishuAccountConfig).name;
+  const state = resolveFeishuAccountConfigState(params);
+  const creds = resolveFeishuCredentials(state.config);
 
   return {
-    accountId,
-    selectionSource,
-    enabled,
+    accountId: state.accountId,
+    selectionSource: state.selectionSource,
+    enabled: state.enabled,
     configured: Boolean(creds),
-    name: typeof accountName === "string" ? accountName.trim() || undefined : undefined,
+    name: state.name,
     appId: creds?.appId,
     appSecret: creds?.appSecret,
     encryptKey: creds?.encryptKey,
     verificationToken: creds?.verificationToken,
-    domain: creds?.domain ?? "feishu",
-    config: merged,
+    domain: creds?.domain ?? state.domain,
+    config: state.config,
   };
+}
+
+/**
+ * List all enabled accounts that appear configured from raw config input alone.
+ * This preflight path intentionally does not resolve SecretRefs.
+ */
+export function listEnabledFeishuAccountConfigs(cfg: ClawdbotConfig): Array<{
+  accountId: string;
+  selectionSource: FeishuAccountSelectionSource;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  domain: FeishuDomain;
+  config: FeishuConfig;
+}> {
+  return listFeishuAccountIds(cfg)
+    .map((accountId) => resolveFeishuAccountConfigState({ cfg, accountId }))
+    .filter((account) => account.enabled && account.configured);
 }
 
 /**

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,7 +1,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { createFeishuToolClient } from "./tool-account.js";
 
 // ============ Helpers ============
@@ -538,7 +538,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
     return;

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -133,6 +133,23 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
+  it("does not resolve SecretRefs while describing message tools", () => {
+    const secretRefCfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: { source: "file", provider: "default", id: "path/to/app-id" },
+          appSecret: { source: "file", provider: "default", id: "path/to/app-secret" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(feishuPlugin.actions?.describeMessageTool?.({ cfg: secretRefCfg })).toMatchObject({
+      actions: expect.arrayContaining(["send", "read", "edit"]),
+      capabilities: ["cards"],
+    });
+  });
+
   it("does not advertise reactions when disabled via actions config", () => {
     const disabledCfg = {
       channels: {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -33,8 +33,8 @@ import {
 } from "../runtime-api.js";
 import type { ChannelMessageActionName } from "../runtime-api.js";
 import {
+  listEnabledFeishuAccountConfigs,
   resolveFeishuAccount,
-  resolveFeishuCredentials,
   listFeishuAccountIds,
   listEnabledFeishuAccounts,
   resolveDefaultFeishuAccountId,
@@ -98,10 +98,9 @@ function describeFeishuMessageTool({
 }: Parameters<
   NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
 >[0]): ChannelMessageToolDiscovery {
-  const enabled =
-    cfg.channels?.feishu?.enabled !== false &&
-    Boolean(resolveFeishuCredentials(cfg.channels?.feishu as FeishuConfig | undefined));
-  if (listEnabledFeishuAccounts(cfg).length === 0) {
+  const configuredAccounts = listEnabledFeishuAccountConfigs(cfg);
+  const enabled = cfg.channels?.feishu?.enabled !== false && configuredAccounts.length > 0;
+  if (configuredAccounts.length === 0) {
     return {
       actions: [],
       capabilities: enabled ? ["cards"] : [],
@@ -126,7 +125,9 @@ function describeFeishuMessageTool({
     "channel-info",
     "channel-list",
   ]);
-  if (areAnyFeishuReactionActionsEnabled(cfg)) {
+  if (
+    configuredAccounts.some((account) => isFeishuReactionsActionConfigured(cfg, account.config))
+  ) {
     actions.add("react");
     actions.add("reactions");
   }
@@ -198,13 +199,15 @@ function isFeishuReactionsActionEnabled(params: {
   return gate("reactions");
 }
 
-function areAnyFeishuReactionActionsEnabled(cfg: ClawdbotConfig): boolean {
-  for (const account of listEnabledFeishuAccounts(cfg)) {
-    if (isFeishuReactionsActionEnabled({ cfg, account })) {
-      return true;
-    }
-  }
-  return false;
+function isFeishuReactionsActionConfigured(cfg: ClawdbotConfig, accountConfig: FeishuConfig) {
+  const gate = createActionGate(
+    (accountConfig.actions ??
+      (cfg.channels?.feishu as { actions?: unknown } | undefined)?.actions) as Record<
+      string,
+      boolean | undefined
+    >,
+  );
+  return gate("reactions");
 }
 
 function isSupportedFeishuDirectConversationId(conversationId: string): boolean {

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs, resolveFeishuAccount } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
@@ -126,20 +126,20 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_chat: No Feishu accounts configured, skipping chat tools");
     return;
   }
 
-  const firstAccount = accounts[0];
+  const firstAccount = accounts[0]!;
   const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
   if (!toolsCfg.chat) {
     api.logger.debug?.("feishu_chat: chat tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  const defaultAccountId = firstAccount.accountId;
 
   api.registerTool(
     {
@@ -150,7 +150,9 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuChatParams;
         try {
-          const client = getClient();
+          const client = createFeishuClient(
+            resolveFeishuAccount({ cfg: api.config, accountId: defaultAccountId }),
+          );
           switch (p.action) {
             case "members":
               if (!p.chat_id) {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -5,7 +5,7 @@ import { basename } from "node:path";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
 import { updateColorText } from "./docx-color-text.js";
@@ -1317,7 +1317,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   }
 
   // Check if any account is configured
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_doc: No Feishu accounts configured, skipping doc tools");
     return;

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -169,7 +169,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_drive: No Feishu accounts configured, skipping drive tools");
     return;

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -118,7 +118,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_perm: No Feishu accounts configured, skipping perm tools");
     return;

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -3,7 +3,7 @@ import type { OpenClawPluginApi } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
-import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
+import type { FeishuConfig, FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
 
 type AccountAwareParams = { accountId?: string };
 
@@ -47,7 +47,7 @@ export function createFeishuToolClient(params: {
 }
 
 export function resolveAnyEnabledFeishuToolsConfig(
-  accounts: ResolvedFeishuAccount[],
+  accounts: Array<{ config: FeishuConfig }>,
 ): Required<FeishuToolsConfig> {
   const merged: Required<FeishuToolsConfig> = {
     doc: false,

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import { listEnabledFeishuAccountConfigs } from "./accounts.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
   jsonToolResult,
@@ -157,7 +157,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
+  const accounts = listEnabledFeishuAccountConfigs(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_wiki: No Feishu accounts configured, skipping wiki tools");
     return;


### PR DESCRIPTION
## Summary

Feishu still resolves SecretRef-backed credentials too early in plugin preflight paths.

The gateway runtime can be healthy and Feishu can still receive/send messages, but CLI commands that preload the plugin registry or run message-tool discovery still fail or emit plugin diagnostics like:

- `openclaw plugins list`
- `openclaw doctor`
- `openclaw status` / `openclaw health`
- other command paths that call `describeMessageTool(...)`

with errors such as:

`channels.feishu.appSecret: unresolved SecretRef ...`

## Root Cause

There are two separate preflight paths here:

1. `registerFull(api)` tool registration
2. `describeMessageTool(...)` message capability discovery

Both paths should only answer "is this account configured?" from raw config input.
They should not resolve SecretRefs before runtime execution.

A previous fix addressed part of this problem, but the current main branch still resolves Feishu credentials too early through:

- `listEnabledFeishuAccounts(api.config)` in Feishu tool registration
- `resolveFeishuCredentials(...)` / `listEnabledFeishuAccounts(...)` in message discovery

## What this changes

- restores a config-only Feishu account preflight helper in `accounts.ts`
- uses that helper during full plugin registration for Feishu tool registration
- uses that helper for `describeMessageTool(...)` capability discovery
- keeps runtime execution paths resolving the real account only when the tool/action is actually used

## Scope

This is intended to cover the command paths that currently surface this false-positive SecretRef failure, including plugin preload and message-tool discovery.

## Tests

- adds a regression test for `plugin.register(api)` with SecretRef-backed Feishu config
- adds a regression test for `feishuPlugin.actions.describeMessageTool(...)` with SecretRef-backed Feishu config

## Notes

- rebased onto latest `main` and force-pushed clean history onto this PR branch
- this updates the previous narrow register-only fix into a complete preflight fix
