### PR TITLE
feishu: log outbound reply delivery results

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -57,8 +57,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
-    sendMediaFeishuMock.mockResolvedValue(undefined);
-    sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_text" });
+    sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "om_card_md" });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media" });
+    sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "om_card" });
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -220,12 +222,18 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps auto mode plain text on non-streaming send path", async () => {
-    const { options } = createDispatcherHarness();
+    const runtime = createRuntimeLogger();
+    const { options } = createDispatcherHarness({ runtime });
     await options.deliver({ text: "plain text" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "feishu[main] outbound text send ok chat=oc_chat kind=final messageId=om_text",
+      ),
+    );
   });
 
   it("suppresses internal block payload delivery", async () => {
@@ -444,7 +452,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes replyInThread to sendMessageFeishu for plain text", async () => {
+    const runtime = createRuntimeLogger();
     const { options } = createDispatcherHarness({
+      runtime,
       replyToMessageId: "om_msg",
       replyInThread: true,
     });
@@ -455,6 +465,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "feishu[main] outbound text reply ok chat=oc_chat replyTo=om_msg thread=true kind=final messageId=om_text",
+      ),
     );
   });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -296,6 +296,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     reasoningText = "";
   };
 
+  const logOutboundResult = (details: {
+    kind: "text" | "card" | "media";
+    mode: "send" | "reply";
+    infoKind?: string;
+    messageId?: string;
+  }) => {
+    params.runtime.log?.(
+      `feishu[${account.accountId}] outbound ${details.kind} ${details.mode} ok` +
+        ` chat=${chatId}` +
+        (sendReplyToMessageId ? ` replyTo=${sendReplyToMessageId}` : "") +
+        (effectiveReplyInThread ? ` thread=${String(effectiveReplyInThread)}` : "") +
+        (details.infoKind ? ` kind=${details.infoKind}` : "") +
+        (details.messageId ? ` messageId=${details.messageId}` : ""),
+    );
+  };
+
   const sendChunkedTextReply = async (params: {
     text: string;
     useCard: boolean;
@@ -320,9 +336,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         accountId,
       };
       if (params.useCard) {
-        await sendMarkdownCardFeishu(message);
+        const result = await sendMarkdownCardFeishu(message);
+        logOutboundResult({
+          kind: "card",
+          mode: sendReplyToMessageId ? "reply" : "send",
+          infoKind: params.infoKind,
+          messageId: result.messageId,
+        });
       } else {
-        await sendMessageFeishu(message);
+        const result = await sendMessageFeishu(message);
+        logOutboundResult({
+          kind: "text",
+          mode: sendReplyToMessageId ? "reply" : "send",
+          infoKind: params.infoKind,
+          messageId: result.messageId,
+        });
       }
       first = false;
     }
@@ -398,13 +426,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // Send media even when streaming handled the text
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
+                const result = await sendMediaFeishu({
                   cfg,
                   to: chatId,
                   mediaUrl,
                   replyToMessageId: sendReplyToMessageId,
                   replyInThread: effectiveReplyInThread,
                   accountId,
+                });
+                logOutboundResult({
+                  kind: "media",
+                  mode: sendReplyToMessageId ? "reply" : "send",
+                  infoKind: info?.kind,
+                  messageId: result?.messageId,
                 });
               }
             }
@@ -419,7 +453,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
-              await sendStructuredCardFeishu({
+              const result = await sendStructuredCardFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -429,6 +463,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 accountId,
                 header: cardHeader,
                 note: cardNote,
+              });
+              logOutboundResult({
+                kind: "card",
+                mode: sendReplyToMessageId ? "reply" : "send",
+                infoKind: info?.kind,
+                messageId: result.messageId,
               });
               first = false;
             }
@@ -442,13 +482,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         if (hasMedia) {
           for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
+            const result = await sendMediaFeishu({
               cfg,
               to: chatId,
               mediaUrl,
               replyToMessageId: sendReplyToMessageId,
               replyInThread: effectiveReplyInThread,
               accountId,
+            });
+            logOutboundResult({
+              kind: "media",
+              mode: sendReplyToMessageId ? "reply" : "send",
+              infoKind: info?.kind,
+              messageId: result?.messageId,
             });
           }
         }


### PR DESCRIPTION
## Summary
- log successful Feishu outbound text/card/media deliveries from the reply dispatcher
- include whether the send was a direct send vs reply, plus chat/reply target context
- cover the new logging behavior with reply-dispatcher tests

## Why
Feishu inbound handling already logs clearly, but outbound delivery still ends at `queuedFinal=true, replies=1`. That makes it hard to tell whether a missing user-visible reply was never sent, failed during send, or was sent successfully but not shown by the client. This adds the missing success-side observability without changing reply routing semantics.

## Testing
- pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts
- pnpm vitest run extensions/feishu/src/send.reply-fallback.test.ts