### PR TITLE
fix(health): show gateway probe duration in text output

### DIFF
--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -118,6 +118,9 @@ describe("healthCommand", () => {
 
     expect(runtime.exit).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalled();
+    expect(stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"))).toContain(
+      "Gateway probe duration: 5ms",
+    );
   });
 
   it("formats per-account probe timings", () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -794,6 +794,7 @@ export async function healthCommand(
       }
     }
 
+    runtime.log(info(`Gateway probe duration: ${summary.durationMs}ms`));
     if (resolvedAgents.length > 0) {
       const agentLabels = resolvedAgents.map((agent) =>
         agent.isDefault ? `${agent.agentId} (default)` : agent.agentId,


### PR DESCRIPTION
## Summary
- show gateway probe duration in the standard text output for `openclaw health`
- keep `openclaw health --json` unchanged
- add regression coverage for the text output

## Why
`openclaw health --json` already includes `durationMs`, but the default human-facing text output did not surface that timing. This makes the text path less informative when debugging slow gateway / channel health responses.

## Changes
- print `Gateway probe duration: <n>ms` in text output
- add/update tests to lock the behavior

## Linked issue
- Closes #50245

## Test plan
- `pnpm test src/commands/health.test.ts src/commands/health.command.coverage.test.ts`
