### PR TITLE
fix: add provider attribution headers to image tool for OpenRouter free tier

### DIFF
--- a/src/media-understanding/providers/image.ts
+++ b/src/media-understanding/providers/image.ts
@@ -8,6 +8,7 @@ import {
 } from "../../agents/model-auth.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
+import { resolveProviderAttributionHeaders } from "../../agents/provider-attribution.js";
 import { coerceImageAssistantText } from "../../agents/tools/image-tool.helpers.js";
 import type {
   ImageDescriptionRequest,
@@ -188,6 +189,7 @@ export async function describeImagesWithModel(
   }
 
   const context = buildImageContext(prompt, params.images);
+  const attributionHeaders = resolveProviderAttributionHeaders(model.provider);
   const controller = new AbortController();
   const timeout =
     typeof params.timeoutMs === "number" &&
@@ -199,6 +201,7 @@ export async function describeImagesWithModel(
     apiKey,
     maxTokens: resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512),
     signal: controller.signal,
+    ...(attributionHeaders ? { headers: attributionHeaders } : {}),
   }).finally(() => {
     clearTimeout(timeout);
   });


### PR DESCRIPTION
## Problem

The `image` tool bypasses OpenClaw's provider attribution when calling OpenRouter, causing unexpected charges for models that should be free under the OpenClaw free tier.

## Root Cause

`describeImagesWithModel` in `src/media-understanding/providers/image.ts` calls `complete()` without passing the OpenClaw attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`). Regular agent chat goes through `createOpenRouterWrapper` which includes these headers, but the image tool path does not.

## Fix

Import `resolveProviderAttributionHeaders` and pass the resolved headers to the `complete()` call. This uses the existing, well-tested provider attribution infrastructure rather than hardcoding headers.

## Verification

- Normal agent chat with OpenRouter → **free** (has attribution headers ✅)
- Image tool with OpenRouter → was **charged** ❌, now **free** ✅

## Changes

- `src/media-understanding/providers/image.ts`: Added import and header passthrough in `describeImagesWithModel`'s `complete()` call.
