### PR TITLE
fix(cli): show gateway probe duration in text output

### DIFF
--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -11,6 +11,7 @@ export async function probeGatewayStatus(opts: {
   json?: boolean;
   configPath?: string;
 }) {
+  const startedAt = Date.now();
   try {
     await withProgress(
       {
@@ -31,11 +32,15 @@ export async function probeGatewayStatus(opts: {
           ...(opts.configPath ? { configPath: opts.configPath } : {}),
         }),
     );
-    return { ok: true } as const;
+    return {
+      ok: true,
+      durationMs: Math.max(0, Date.now() - startedAt),
+    } as const;
   } catch (err) {
     return {
       ok: false,
       error: err instanceof Error ? err.message : String(err),
+      durationMs: Math.max(0, Date.now() - startedAt),
     } as const;
   }
 }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -3,11 +3,17 @@ import { captureEnv } from "../../test-utils/env.js";
 import type { GatewayRestartSnapshot } from "./restart-health.js";
 
 const callGatewayStatusProbe = vi.fn<
-  (opts?: unknown) => Promise<{ ok: boolean; url?: string; error?: string | null }>
+  (opts?: unknown) => Promise<{
+    ok: boolean;
+    url?: string;
+    error?: string | null;
+    durationMs?: number;
+  }>
 >(async (_opts?: unknown) => ({
   ok: true,
   url: "ws://127.0.0.1:19001",
   error: null,
+  durationMs: 42,
 }));
 const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
   enabled: true,
@@ -195,6 +201,7 @@ describe("gatherDaemonStatus", () => {
     expect(status.gateway?.probeUrl).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
+    expect(status.rpc?.durationMs).toBe(42);
   });
 
   it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -113,6 +113,7 @@ export type DaemonStatus = {
     error?: string;
     url?: string;
     authWarning?: string;
+    durationMs?: number;
   };
   health?: {
     healthy: boolean;

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -117,4 +117,80 @@ describe("printDaemonStatus", () => {
     );
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("openclaw gateway restart"));
   });
+
+  it("prints RPC duration in success text rows", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        rpc: {
+          ok: true,
+          durationMs: 77,
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("RPC duration:"));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("77ms"));
+  });
+
+  it("prints RPC duration in failure text rows", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        rpc: {
+          ok: false,
+          durationMs: 98,
+          error: "gateway closed",
+          url: "ws://127.0.0.1:18789",
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("RPC duration:"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("98ms"));
+  });
+
+  it("keeps JSON RPC payload stable when duration exists", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        rpc: {
+          ok: true,
+          durationMs: 77,
+          url: "ws://127.0.0.1:18789",
+        },
+        extraServices: [],
+      },
+      { json: true },
+    );
+
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0])) as {
+      rpc?: { ok?: boolean; url?: string; durationMs?: number };
+    };
+    expect(payload.rpc?.ok).toBe(true);
+    expect(payload.rpc?.url).toBe("ws://127.0.0.1:18789");
+    expect(payload.rpc?.durationMs).toBeUndefined();
+  });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -32,16 +32,24 @@ import {
 
 function sanitizeDaemonStatusForJson(status: DaemonStatus): DaemonStatus {
   const command = status.service.command;
-  if (!command?.environment) {
-    return status;
-  }
-  const safeEnv = filterDaemonEnv(command.environment);
-  const nextCommand = {
-    ...command,
-    environment: Object.keys(safeEnv).length > 0 ? safeEnv : undefined,
-  };
+  const rpc = status.rpc
+    ? {
+        ...status.rpc,
+        durationMs: undefined,
+      }
+    : undefined;
+  const nextCommand = command?.environment
+    ? {
+        ...command,
+        environment: (() => {
+          const safeEnv = filterDaemonEnv(command.environment ?? {});
+          return Object.keys(safeEnv).length > 0 ? safeEnv : undefined;
+        })(),
+      }
+    : command;
   return {
     ...status,
+    ...(rpc ? { rpc } : {}),
     service: {
       ...status.service,
       command: nextCommand,
@@ -177,10 +185,20 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     );
   }
   if (rpc) {
+    const durationLine =
+      typeof rpc.durationMs === "number"
+        ? `${label("RPC duration:")} ${infoText(`${rpc.durationMs}ms`)}`
+        : null;
     if (rpc.ok) {
       defaultRuntime.log(`${label("RPC probe:")} ${okText("ok")}`);
+      if (durationLine) {
+        defaultRuntime.log(durationLine);
+      }
     } else {
       defaultRuntime.error(`${label("RPC probe:")} ${errorText("failed")}`);
+      if (durationLine) {
+        defaultRuntime.error(durationLine);
+      }
       if (rpc.authWarning) {
         defaultRuntime.error(`${label("RPC auth:")} ${warnText(rpc.authWarning)}`);
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway deep text status did not show RPC probe duration.
- Why it matters: operators need probe latency visibility during troubleshooting.
- What changed: capture RPC probe duration, print `RPC duration: <n>ms` in success/failure text output, and add tests.
- What did NOT change (scope boundary): JSON output contract remains stable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw gateway status --deep` text output now shows `RPC duration: <n>ms` when available.
- Success and failure probe rows both include duration.
- JSON output is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local CLI config

### Steps

1. Run `pnpm test -- src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/status.print.test.ts`.
2. Run `openclaw gateway status --deep` and inspect text output paths.
3. Confirm duration appears for both success and failure probe rows.

### Expected

- Text output includes probe status and duration.

### Actual

- Tests pass and text renderer includes duration for both outcomes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: status gather propagation, success/failure text rendering, JSON stability.
- Edge cases checked: failure branch still prints duration and preserves failure status.
- What you did **not** verify: full remote daemon E2E.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 114520a6d.
- Files/config to restore: daemon-cli probe/gather/print files.
- Known bad symptoms reviewers should watch for: missing/duplicate RPC duration lines.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: additional line in human text output may affect ad-hoc scraping.
  - Mitigation: machine consumers should use stable `--json` output.
