### PR TITLE
fix(slack): support [[reply_to_current]] thread replies

### DIFF
--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -164,4 +164,49 @@ describe("message action threading helpers", () => {
     expect(resolved).toBe("thread-777");
     expect(actionParams.threadId).toBe("thread-777");
   });
+
+  it("maps Slack [[reply_to_current]] to the active thread target", async () => {
+    mockHandledSendAction();
+
+    const call = await runThreadingAction({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "[[reply_to_current]] hi",
+      },
+      toolContext: {
+        currentChannelId: "C123",
+        currentThreadTs: "111.222",
+        replyToMode: "off",
+      },
+    });
+
+    expect(call?.replyToId).toBeUndefined();
+    expect(call?.threadId).toBe("111.222");
+    expect(call?.ctx?.params?.threadId).toBe("111.222");
+    expect(call?.ctx?.params?.message).toBe("hi");
+  });
+
+  it("does not force Slack [[reply_to_current]] outside the active channel", async () => {
+    mockHandledSendAction();
+
+    const call = await runThreadingAction({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "channel:C999",
+        message: "[[reply_to_current]] hi",
+      },
+      toolContext: {
+        currentChannelId: "C123",
+        currentThreadTs: "111.222",
+        replyToMode: "all",
+      },
+    });
+
+    expect(call?.threadId).toBeUndefined();
+    expect(call?.ctx?.params?.threadId).toBeUndefined();
+    expect(call?.ctx?.params?.message).toBe("hi");
+  });
 });

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -207,6 +207,6 @@ describe("message action threading helpers", () => {
 
     expect(call?.threadId).toBeUndefined();
     expect(call?.ctx?.params?.threadId).toBeUndefined();
-    expect(call?.ctx?.params?.message).toBe("hi");
+    expect(call?.ctx?.params?.message).toBe("[from C123] hi");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -68,6 +68,59 @@ export type MessageActionRunnerGateway = {
   mode: GatewayClientMode;
 };
 
+function resolveAndApplyOutboundThreadId(
+  params: Record<string, unknown>,
+  ctx: {
+    cfg: OpenClawConfig;
+    channel: ChannelId;
+    to: string;
+    accountId?: string | null;
+    toolContext?: ChannelThreadingToolContext;
+  },
+): string | undefined {
+  const threadId = readStringParam(params, "threadId");
+  const resolved =
+    threadId ??
+    getChannelPlugin(ctx.channel)?.threading?.resolveAutoThreadId?.({
+      cfg: ctx.cfg,
+      accountId: ctx.accountId,
+      to: ctx.to,
+      toolContext: ctx.toolContext,
+      replyToId: readStringParam(params, "replyTo"),
+    });
+  if (resolved && !params.threadId) {
+    params.threadId = resolved;
+  }
+  return resolved ?? undefined;
+}
+
+function resolveExplicitReplyToCurrentThreadId(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  to: string;
+  accountId?: string | null;
+  toolContext?: ChannelThreadingToolContext;
+  parsedReplyToCurrent: boolean;
+}): string | undefined {
+  if (!params.parsedReplyToCurrent || params.channel !== "slack") {
+    return undefined;
+  }
+  const resolveAutoThreadId = getChannelPlugin(params.channel)?.threading?.resolveAutoThreadId;
+  if (!resolveAutoThreadId) {
+    return undefined;
+  }
+  return resolveAutoThreadId({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    to: params.to,
+    toolContext: params.toolContext
+      ? {
+          ...params.toolContext,
+          replyToMode: "all",
+        }
+      : undefined,
+  });
+}
 export type RunMessageActionParams = {
   cfg: OpenClawConfig;
   action: ChannelMessageActionName;
@@ -452,6 +505,19 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   params.message = message;
   if (!params.replyTo && parsed.replyToId) {
     params.replyTo = parsed.replyToId;
+  }
+  if (!params.threadId && !params.replyTo && parsed.replyToCurrent) {
+    const explicitCurrentThreadId = resolveExplicitReplyToCurrentThreadId({
+      cfg,
+      channel,
+      to,
+      accountId,
+      toolContext: input.toolContext,
+      parsedReplyToCurrent: parsed.replyToCurrent,
+    });
+    if (explicitCurrentThreadId) {
+      params.threadId = explicitCurrentThreadId;
+    }
   }
   if (!params.media) {
     // Use path/filePath if media not set, then fall back to parsed directives


### PR DESCRIPTION
## Summary
- map Slack `[[reply_to_current]]` to the active thread target (`thread_ts`) in outbound message-action sends
- keep behavior scoped to Slack and only when no explicit `threadId`/`replyTo` is set
- align threading test expectation for cross-channel sends to preserve existing cross-context marker behavior

## Changes
- `src/infra/outbound/message-action-runner.ts`
  - add `resolveExplicitReplyToCurrentThreadId(...)`
  - when parsed directive has `replyToCurrent`, resolve Slack thread target via plugin threading helper with effective `replyToMode: "all"`
- `src/infra/outbound/message-action-runner.threading.test.ts`
  - add test for same-channel Slack `[[reply_to_current]]` mapping to `threadId`
  - add test for cross-channel Slack send not forcing thread id
  - update cross-channel message assertion to include existing `[from C123]` decoration

## Validation
- `pnpm test -- src/infra/outbound/message-action-runner.threading.test.ts` (9/9 pass)
- `pnpm test -- src/infra/outbound/message-action-params.test.ts extensions/slack/src/threading.test.ts extensions/slack/src/threading-tool-context.test.ts extensions/slack/src/action-runtime.test.ts` (54 tests pass)

Fixes #50031
