### PR TITLE
Adding Exa as a web search plugin

### DIFF
--- a/extensions/exa/index.ts
+++ b/extensions/exa/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createExaWebSearchProvider } from "./src/exa-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "exa",
+  name: "Exa Plugin",
+  description: "Bundled Exa plugin",
+  register(api) {
+    api.registerWebSearchProvider(createExaWebSearchProvider());
+  },
+});

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -1,0 +1,26 @@
+{
+  "id": "exa",
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Exa API Key",
+      "help": "Exa API key (fallback: EXA_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "exa-..."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/exa-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Exa plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -1,0 +1,246 @@
+import { Type } from "@sinclair/typebox";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  MAX_SEARCH_COUNT,
+  formatCliCommand,
+  normalizeToIsoDate,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  setTopLevelCredentialValue,
+  setProviderWebSearchPluginConfigValue,
+  type SearchConfigRecord,
+  type WebSearchProviderPlugin,
+  type WebSearchProviderToolDefinition,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const EXA_SEARCH_ENDPOINT = "https://api.exa.ai/search";
+
+type ExaSearchResult = {
+  title?: string;
+  url?: string;
+  publishedDate?: string;
+  highlights?: string[];
+};
+
+type ExaSearchResponse = {
+  results?: ExaSearchResult[];
+};
+
+function resolveExaApiKey(searchConfig?: SearchConfigRecord): string | undefined {
+  return (
+    readConfiguredSecretString(searchConfig?.apiKey, "tools.web.search.apiKey") ??
+    readProviderEnvValue(["EXA_API_KEY"])
+  );
+}
+
+async function runExaSearch(params: {
+  query: string;
+  apiKey: string;
+  count: number;
+  timeoutSeconds: number;
+  dateAfter?: string;
+  dateBefore?: string;
+}): Promise<Array<Record<string, unknown>>> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    numResults: params.count,
+    contents: { highlights: true },
+  };
+  if (params.dateAfter) body.startPublishedDate = params.dateAfter;
+  if (params.dateBefore) body.endPublishedDate = params.dateBefore;
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: EXA_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": params.apiKey,
+          "x-exa-integration": "openclaw",
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`Exa Search API error (${res.status}): ${detail || res.statusText}`);
+      }
+      const data = (await res.json()) as ExaSearchResponse;
+      return (data.results ?? []).map((entry) => {
+        const title = entry.title ?? "";
+        const url = entry.url ?? "";
+        const highlights = (entry.highlights ?? []).filter(
+          (h): h is string => typeof h === "string" && h.length > 0,
+        );
+        return {
+          title: title ? wrapWebContent(title, "web_search") : "",
+          url,
+          description:
+            highlights.length > 0 ? wrapWebContent(highlights.join(" … "), "web_search") : "",
+          published: entry.publishedDate ?? undefined,
+          siteName: resolveSiteName(url) || undefined,
+        };
+      });
+    },
+  );
+}
+
+function createExaSchema() {
+  return Type.Object({
+    query: Type.String({ description: "Search query string." }),
+    count: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-10).",
+        minimum: 1,
+        maximum: MAX_SEARCH_COUNT,
+      }),
+    ),
+    date_after: Type.Optional(
+      Type.String({ description: "Only results published after this date (YYYY-MM-DD)." }),
+    ),
+    date_before: Type.Optional(
+      Type.String({ description: "Only results published before this date (YYYY-MM-DD)." }),
+    ),
+  });
+}
+
+function createExaToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  return {
+    description:
+      "Search the web using Exa, a neural search engine. Returns titles, URLs, and highlighted snippets. Supports date range filtering.",
+    parameters: createExaSchema(),
+    execute: async (args) => {
+      const apiKey = resolveExaApiKey(searchConfig);
+      if (!apiKey) {
+        return {
+          error: "missing_exa_api_key",
+          message: `web_search (exa) needs an Exa API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set EXA_API_KEY in the Gateway environment.`,
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      const count =
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
+
+      const rawDateAfter = readStringParam(params, "date_after");
+      const rawDateBefore = readStringParam(params, "date_before");
+      const dateAfter = rawDateAfter ? normalizeToIsoDate(rawDateAfter) : undefined;
+      if (rawDateAfter && !dateAfter) {
+        return {
+          error: "invalid_date",
+          message: "date_after must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      const dateBefore = rawDateBefore ? normalizeToIsoDate(rawDateBefore) : undefined;
+      if (rawDateBefore && !dateBefore) {
+        return {
+          error: "invalid_date",
+          message: "date_before must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      if (dateAfter && dateBefore && dateAfter > dateBefore) {
+        return {
+          error: "invalid_date_range",
+          message: "date_after must be before date_before.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const cacheKey = buildSearchCacheKey([
+        "exa",
+        query,
+        resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        dateAfter,
+        dateBefore,
+      ]);
+      const cached = readCachedSearchPayload(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const start = Date.now();
+      const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
+      const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+
+      const results = await runExaSearch({
+        query,
+        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        apiKey,
+        timeoutSeconds,
+        dateAfter,
+        dateBefore,
+      });
+      const payload = {
+        query,
+        provider: "exa",
+        count: results.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "exa",
+          wrapped: true,
+        },
+        results,
+      };
+      writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
+      return payload;
+    },
+  };
+}
+
+export function createExaWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "exa",
+    label: "Exa Search",
+    hint: "Neural search · highlighted snippets · date filtering",
+    envVars: ["EXA_API_KEY"],
+    placeholder: "exa-...",
+    signupUrl: "https://exa.ai/",
+    docsUrl: "https://docs.exa.ai/",
+    autoDetectOrder: 5,
+    credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
+    getCredentialValue: (searchConfig) => searchConfig?.apiKey,
+    setCredentialValue: setTopLevelCredentialValue,
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "exa")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "exa", "apiKey", value);
+    },
+    createTool: (ctx) => {
+      const searchConfig = ctx.searchConfig as SearchConfigRecord | undefined;
+      const pluginConfig = resolveProviderWebSearchPluginConfig(ctx.config, "exa");
+      if (!pluginConfig) {
+        return createExaToolDefinition(searchConfig);
+      }
+      return createExaToolDefinition({
+        ...(searchConfig ?? {}),
+        ...(pluginConfig.apiKey === undefined ? {} : { apiKey: pluginConfig.apiKey }),
+      } as SearchConfigRecord);
+    },
+  };
+}

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_SEARCH_COUNT,
   MAX_SEARCH_COUNT,
   formatCliCommand,
-  normalizeToIsoDate,
   readCachedSearchPayload,
   readConfiguredSecretString,
   readNumberParam,
@@ -50,16 +49,12 @@ async function runExaSearch(params: {
   apiKey: string;
   count: number;
   timeoutSeconds: number;
-  dateAfter?: string;
-  dateBefore?: string;
 }): Promise<Array<Record<string, unknown>>> {
-  const body: Record<string, unknown> = {
+  const body = {
     query: params.query,
     numResults: params.count,
     contents: { highlights: true },
   };
-  if (params.dateAfter) body.startPublishedDate = params.dateAfter;
-  if (params.dateBefore) body.endPublishedDate = params.dateBefore;
 
   return withTrustedWebSearchEndpoint(
     {
@@ -100,32 +95,22 @@ async function runExaSearch(params: {
   );
 }
 
-function createExaSchema() {
-  return Type.Object({
-    query: Type.String({ description: "Search query string." }),
-    count: Type.Optional(
-      Type.Number({
-        description: "Number of results to return (1-10).",
-        minimum: 1,
-        maximum: MAX_SEARCH_COUNT,
-      }),
-    ),
-    date_after: Type.Optional(
-      Type.String({ description: "Only results published after this date (YYYY-MM-DD)." }),
-    ),
-    date_before: Type.Optional(
-      Type.String({ description: "Only results published before this date (YYYY-MM-DD)." }),
-    ),
-  });
-}
-
 function createExaToolDefinition(
   searchConfig?: SearchConfigRecord,
 ): WebSearchProviderToolDefinition {
   return {
     description:
-      "Search the web using Exa, a neural search engine. Returns titles, URLs, and highlighted snippets. Supports date range filtering.",
-    parameters: createExaSchema(),
+      "Search the web using Exa, a neural search engine. Returns titles, URLs, and highlighted snippets.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query string." }),
+      count: Type.Optional(
+        Type.Number({
+          description: "Number of results to return (1-10).",
+          minimum: 1,
+          maximum: MAX_SEARCH_COUNT,
+        }),
+      ),
+    }),
     execute: async (args) => {
       const apiKey = resolveExaApiKey(searchConfig);
       if (!apiKey) {
@@ -143,38 +128,10 @@ function createExaToolDefinition(
         searchConfig?.maxResults ??
         undefined;
 
-      const rawDateAfter = readStringParam(params, "date_after");
-      const rawDateBefore = readStringParam(params, "date_before");
-      const dateAfter = rawDateAfter ? normalizeToIsoDate(rawDateAfter) : undefined;
-      if (rawDateAfter && !dateAfter) {
-        return {
-          error: "invalid_date",
-          message: "date_after must be YYYY-MM-DD format.",
-          docs: "https://docs.openclaw.ai/tools/web",
-        };
-      }
-      const dateBefore = rawDateBefore ? normalizeToIsoDate(rawDateBefore) : undefined;
-      if (rawDateBefore && !dateBefore) {
-        return {
-          error: "invalid_date",
-          message: "date_before must be YYYY-MM-DD format.",
-          docs: "https://docs.openclaw.ai/tools/web",
-        };
-      }
-      if (dateAfter && dateBefore && dateAfter > dateBefore) {
-        return {
-          error: "invalid_date_range",
-          message: "date_after must be before date_before.",
-          docs: "https://docs.openclaw.ai/tools/web",
-        };
-      }
-
       const cacheKey = buildSearchCacheKey([
         "exa",
         query,
         resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        dateAfter,
-        dateBefore,
       ]);
       const cached = readCachedSearchPayload(cacheKey);
       if (cached) {
@@ -190,8 +147,6 @@ function createExaToolDefinition(
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
         apiKey,
         timeoutSeconds,
-        dateAfter,
-        dateBefore,
       });
       const payload = {
         query,
@@ -216,7 +171,7 @@ export function createExaWebSearchProvider(): WebSearchProviderPlugin {
   return {
     id: "exa",
     label: "Exa Search",
-    hint: "Neural search · highlighted snippets · date filtering",
+    hint: "Neural search · highlighted snippets",
     envVars: ["EXA_API_KEY"],
     placeholder: "exa-...",
     signupUrl: "https://exa.ai/",

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -87,7 +87,7 @@ async function runExaSearch(params: {
           url,
           description:
             highlights.length > 0 ? wrapWebContent(highlights.join(" … "), "web_search") : "",
-          published: entry.publishedDate ?? undefined,
+          published: entry.publishedDate,
           siteName: resolveSiteName(url) || undefined,
         };
       });

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -176,7 +176,7 @@ export function createExaWebSearchProvider(): WebSearchProviderPlugin {
     placeholder: "exa-...",
     signupUrl: "https://exa.ai/",
     docsUrl: "https://docs.exa.ai/",
-    autoDetectOrder: 5,
+    autoDetectOrder: 65,
     credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
     inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
     getCredentialValue: (searchConfig) => searchConfig?.apiKey,

--- a/src/plugins/bundled-web-search.test.ts
+++ b/src/plugins/bundled-web-search.test.ts
@@ -4,6 +4,7 @@ import { resolveBundledWebSearchPluginIds } from "./bundled-web-search.js";
 it("keeps bundled web search compat ids aligned with bundled manifests", () => {
   expect(resolveBundledWebSearchPluginIds({})).toEqual([
     "brave",
+    "exa",
     "firecrawl",
     "google",
     "moonshot",

--- a/src/plugins/bundled-web-search.ts
+++ b/src/plugins/bundled-web-search.ts
@@ -3,6 +3,7 @@ import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
 export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [
   "brave",
+  "exa",
   "firecrawl",
   "google",
   "moonshot",

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -142,6 +142,7 @@ describe("plugin contract registry", () => {
 
   it("keeps bundled web search ownership explicit", () => {
     expect(findWebSearchIdsForPlugin("brave")).toEqual(["brave"]);
+    expect(findWebSearchIdsForPlugin("exa")).toEqual(["exa"]);
     expect(findWebSearchIdsForPlugin("firecrawl")).toEqual(["firecrawl"]);
     expect(findWebSearchIdsForPlugin("google")).toEqual(["gemini"]);
     expect(findWebSearchIdsForPlugin("moonshot")).toEqual(["kimi"]);

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -6,6 +6,7 @@ import chutesPlugin from "../../../extensions/chutes/index.js";
 import cloudflareAiGatewayPlugin from "../../../extensions/cloudflare-ai-gateway/index.js";
 import copilotProxyPlugin from "../../../extensions/copilot-proxy/index.js";
 import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
+import exaPlugin from "../../../extensions/exa/index.js";
 import falPlugin from "../../../extensions/fal/index.js";
 import firecrawlPlugin from "../../../extensions/firecrawl/index.js";
 import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
@@ -80,6 +81,7 @@ type PluginRegistrationContractEntry = {
 
 const bundledWebSearchPlugins: Array<RegistrablePlugin & { credentialValue: unknown }> = [
   { ...bravePlugin, credentialValue: "BSA-test" },
+  { ...exaPlugin, credentialValue: "exa-test" },
   { ...firecrawlPlugin, credentialValue: "fc-test" },
   { ...googlePlugin, credentialValue: "AIza-test" },
   { ...moonshotPlugin, credentialValue: "sk-test" },

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./web-search-providers.js";
 
 const BUNDLED_WEB_SEARCH_PROVIDERS = [
+  { pluginId: "exa", id: "exa", order: 5 },
   { pluginId: "brave", id: "brave", order: 10 },
   { pluginId: "google", id: "gemini", order: 20 },
   { pluginId: "xai", id: "grok", order: 30 },
@@ -89,6 +90,7 @@ describe("resolvePluginWebSearchProviders", () => {
     const providers = resolvePluginWebSearchProviders({});
 
     expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
+      "exa:exa",
       "brave:brave",
       "google:gemini",
       "xai:grok",
@@ -97,6 +99,7 @@ describe("resolvePluginWebSearchProviders", () => {
       "firecrawl:firecrawl",
     ]);
     expect(providers.map((provider) => provider.credentialPath)).toEqual([
+      "plugins.entries.exa.config.webSearch.apiKey",
       "plugins.entries.brave.config.webSearch.apiKey",
       "plugins.entries.google.config.webSearch.apiKey",
       "plugins.entries.xai.config.webSearch.apiKey",
@@ -123,6 +126,7 @@ describe("resolvePluginWebSearchProviders", () => {
     });
 
     expect(providers.map((provider) => provider.pluginId)).toEqual([
+      "exa",
       "brave",
       "google",
       "xai",

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -8,13 +8,13 @@ import {
 } from "./web-search-providers.js";
 
 const BUNDLED_WEB_SEARCH_PROVIDERS = [
-  { pluginId: "exa", id: "exa", order: 5 },
   { pluginId: "brave", id: "brave", order: 10 },
   { pluginId: "google", id: "gemini", order: 20 },
   { pluginId: "xai", id: "grok", order: 30 },
   { pluginId: "moonshot", id: "kimi", order: 40 },
   { pluginId: "perplexity", id: "perplexity", order: 50 },
   { pluginId: "firecrawl", id: "firecrawl", order: 60 },
+  { pluginId: "exa", id: "exa", order: 65 },
 ] as const;
 
 const { loadOpenClawPluginsMock } = vi.hoisted(() => ({
@@ -90,22 +90,22 @@ describe("resolvePluginWebSearchProviders", () => {
     const providers = resolvePluginWebSearchProviders({});
 
     expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
-      "exa:exa",
       "brave:brave",
       "google:gemini",
       "xai:grok",
       "moonshot:kimi",
       "perplexity:perplexity",
       "firecrawl:firecrawl",
+      "exa:exa",
     ]);
     expect(providers.map((provider) => provider.credentialPath)).toEqual([
-      "plugins.entries.exa.config.webSearch.apiKey",
       "plugins.entries.brave.config.webSearch.apiKey",
       "plugins.entries.google.config.webSearch.apiKey",
       "plugins.entries.xai.config.webSearch.apiKey",
       "plugins.entries.moonshot.config.webSearch.apiKey",
       "plugins.entries.perplexity.config.webSearch.apiKey",
       "plugins.entries.firecrawl.config.webSearch.apiKey",
+      "plugins.entries.exa.config.webSearch.apiKey",
     ]);
     expect(providers.find((provider) => provider.id === "firecrawl")?.applySelectionConfig).toEqual(
       expect.any(Function),
@@ -126,13 +126,13 @@ describe("resolvePluginWebSearchProviders", () => {
     });
 
     expect(providers.map((provider) => provider.pluginId)).toEqual([
-      "exa",
       "brave",
       "google",
       "xai",
       "moonshot",
       "perplexity",
       "firecrawl",
+      "exa",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw has no native Exa web search provider — users must rely on a community plugin for Exa integration.
- **Why it matters:** Exa is a neural search engine optimized for AI applications; bundling it makes it a zero-config option for OpenClaw users with an Exa API key.
- **What changed:** Added `extensions/exa/` as a new bundled web search provider plugin (4 new files), registered it in `BUNDLED_WEB_SEARCH_PLUGIN_IDS`, and updated the contract registry + test expectations.
- **What did NOT change (scope boundary):** No modifications to core config types, Zod schemas, existing providers, or the plugin SDK. Only additive changes to shared registration files (+9 lines across 5 existing files).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20134
- Related #31310, #35062

## User-visible / Behavior Changes

- New `exa` web search provider available when `EXA_API_KEY` is set or configured via `openclaw configure --section web`.
- Exa appears last in auto-detect order (65, after Firecrawl at 60) — it will only auto-select if no other provider keys are configured.
- New config path: `plugins.entries.exa.config.webSearch.apiKey`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — follows existing `readConfiguredSecretString` / `readProviderEnvValue` pattern
- New/changed network calls? `Yes` — POST to `https://api.exa.ai/search` with `x-api-key` header
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Network call is gated behind API key presence. Request goes through `withTrustedWebSearchEndpoint` (same as all other providers). No secrets are logged or exposed. The `x-exa-integration: "openclaw"` header is sent for usage tracking only.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Node.js >=22.16.0
- Model/provider: N/A (web search provider, not model provider)
- Integration/channel (if any): Exa Search API
- Relevant config (redacted): `EXA_API_KEY=exa-***`

### Steps

1. Set `EXA_API_KEY` environment variable
2. Run `openclaw configure --section web` and select Exa, or let auto-detect pick it up
3. Use `web_search` tool — should route through Exa

### Expected

- Search returns titles, URLs, and highlighted snippets from Exa's neural search

### Actual

- (Verified via unit test suite — all 599 plugin tests pass)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 599 plugin tests pass (`pnpm vitest run src/plugins/`). Lint clean (`oxlint --type-aware`: 0 warnings, 0 errors).

## Human Verification (required)

- **Verified scenarios:** Full plugin test suite (599 tests), lint, registration in bundled IDs, contract registry assertions, auto-detect ordering.
- **Edge cases checked:** Missing API key returns descriptive error with docs link. Empty/malformed results handled via fallback defaults.
- **What you did not verify:** Live API call to Exa (no API key available in test environment). UI rendering of Exa in provider selection dropdown.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional `EXA_API_KEY` env var recognized
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `"exa"` from `BUNDLED_WEB_SEARCH_PLUGIN_IDS` in `src/plugins/bundled-web-search.ts`, or set `plugins.entries.exa.enabled: false` in config.
- Files/config to restore: `src/plugins/bundled-web-search.ts` (remove "exa" from array)
- Known bad symptoms reviewers should watch for: Provider selection failing when `EXA_API_KEY` is set but Exa API is unreachable.

## Risks and Mitigations

- Risk: Exa API endpoint becomes unavailable or changes response format.
  - Mitigation: Provider is last in auto-detect order (65); users with other keys configured are unaffected. Response parsing handles missing fields with safe defaults.