### PR TITLE
fix: delete confirm dialog overflows viewport near top of chat

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -405,7 +405,7 @@ img.chat-avatar {
 
 .chat-delete-confirm {
   position: absolute;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
   background: var(--card, #1a1a1a);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);


### PR DESCRIPTION
The delete confirmation popover uses `position: absolute; bottom: calc(100% + 6px)` to appear above the delete button. When a message is near the top of the chat view, this pushes the dialog out of the visible area, making the buttons unreachable.

Switched to `top: calc(100% + 6px)` so the popover renders below the button instead, keeping it within the viewport.

Fixes #50277