### PR TITLE
fix(ui): keep chat delete confirm inside viewport

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -416,8 +416,7 @@ img.chat-avatar {
 }
 
 .chat-delete-confirm {
-  position: absolute;
-  bottom: calc(100% + 6px);
+  position: fixed;
   background: var(--card, #1a1a1a);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);
@@ -430,11 +429,19 @@ img.chat-avatar {
 }
 
 .chat-delete-confirm--left {
-  right: 0;
+  transform-origin: bottom right;
 }
 
 .chat-delete-confirm--right {
-  left: 0;
+  transform-origin: bottom left;
+}
+
+.chat-delete-confirm--below.chat-delete-confirm--left {
+  transform-origin: top right;
+}
+
+.chat-delete-confirm--below.chat-delete-confirm--right {
+  transform-origin: top left;
 }
 
 .chat-delete-confirm__text {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -322,6 +322,9 @@ const SKIP_DELETE_CONFIRM_KEY = "openclaw:skipDeleteConfirm";
 type DeleteConfirmSide = "left" | "right";
 type DeleteConfirmPlacement = "above" | "below";
 type RectLike = Pick<DOMRect, "left" | "right" | "top" | "bottom" | "width" | "height">;
+type DeleteConfirmPopoverElement = HTMLDivElement & {
+  _removeDeleteConfirm?: () => void;
+};
 
 function clamp(value: number, min: number, max: number): number {
   if (max <= min) {
@@ -375,12 +378,14 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
           }
           const btn = e.currentTarget as HTMLElement;
           const wrap = btn.closest(".chat-delete-wrap") as HTMLElement;
-          const existing = wrap?.querySelector(".chat-delete-confirm");
+          const existing = wrap?.querySelector(
+            ".chat-delete-confirm",
+          ) as DeleteConfirmPopoverElement | null;
           if (existing) {
-            existing.remove();
+            existing._removeDeleteConfirm ? existing._removeDeleteConfirm() : existing.remove();
             return;
           }
-          const popover = document.createElement("div");
+          const popover = document.createElement("div") as DeleteConfirmPopoverElement;
           popover.className = `chat-delete-confirm chat-delete-confirm--${side}`;
           popover.innerHTML = `
             <p class="chat-delete-confirm__text">Delete this message?</p>
@@ -432,6 +437,7 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
               removePopover();
             }
           };
+          popover._removeDeleteConfirm = removePopover;
           requestAnimationFrame(() => {
             document.addEventListener("click", closeOnOutside, true);
             document.addEventListener("scroll", removePopover, true);

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -320,6 +320,38 @@ function extractGroupText(group: MessageGroup): string {
 const SKIP_DELETE_CONFIRM_KEY = "openclaw:skipDeleteConfirm";
 
 type DeleteConfirmSide = "left" | "right";
+type DeleteConfirmPlacement = "above" | "below";
+type RectLike = Pick<DOMRect, "left" | "right" | "top" | "bottom" | "width" | "height">;
+
+function clamp(value: number, min: number, max: number): number {
+  if (max <= min) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+export function resolveDeleteConfirmViewportPosition(
+  buttonRect: RectLike,
+  popoverRect: Pick<DOMRect, "width" | "height">,
+  side: DeleteConfirmSide,
+  viewportWidth = window.innerWidth,
+  viewportHeight = window.innerHeight,
+): { left: number; top: number; placement: DeleteConfirmPlacement } {
+  const gap = 6;
+  const margin = 12;
+  const maxLeft = Math.max(margin, viewportWidth - popoverRect.width - margin);
+  const preferredLeft = side === "left" ? buttonRect.right - popoverRect.width : buttonRect.left;
+  const left = clamp(preferredLeft, margin, maxLeft);
+
+  const aboveTop = buttonRect.top - popoverRect.height - gap;
+  const belowTop = buttonRect.bottom + gap;
+  const maxTop = Math.max(margin, viewportHeight - popoverRect.height - margin);
+  const placement: DeleteConfirmPlacement = aboveTop >= margin ? "above" : "below";
+  const preferredTop = placement === "above" ? aboveTop : belowTop;
+  const top = clamp(preferredTop, margin, maxTop);
+
+  return { left, top, placement };
+}
 
 function shouldSkipDeleteConfirm(): boolean {
   try {
@@ -363,29 +395,48 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
           `;
           wrap.appendChild(popover);
 
+          const { left, top, placement } = resolveDeleteConfirmViewportPosition(
+            btn.getBoundingClientRect(),
+            popover.getBoundingClientRect(),
+            side,
+          );
+          popover.style.left = `${left}px`;
+          popover.style.top = `${top}px`;
+          popover.classList.toggle("chat-delete-confirm--below", placement === "below");
+
           const cancel = popover.querySelector(".chat-delete-confirm__cancel")!;
           const yes = popover.querySelector(".chat-delete-confirm__yes")!;
           const check = popover.querySelector(".chat-delete-confirm__check") as HTMLInputElement;
 
-          cancel.addEventListener("click", () => popover.remove());
+          const removePopover = () => {
+            popover.remove();
+            document.removeEventListener("click", closeOnOutside, true);
+            document.removeEventListener("scroll", removePopover, true);
+            window.removeEventListener("resize", removePopover);
+          };
+
+          cancel.addEventListener("click", removePopover);
           yes.addEventListener("click", () => {
             if (check.checked) {
               try {
                 getSafeLocalStorage()?.setItem(SKIP_DELETE_CONFIRM_KEY, "1");
               } catch {}
             }
-            popover.remove();
+            removePopover();
             onDelete();
           });
 
           // Close on click outside
           const closeOnOutside = (evt: MouseEvent) => {
             if (!popover.contains(evt.target as Node) && evt.target !== btn) {
-              popover.remove();
-              document.removeEventListener("click", closeOnOutside, true);
+              removePopover();
             }
           };
-          requestAnimationFrame(() => document.addEventListener("click", closeOnOutside, true));
+          requestAnimationFrame(() => {
+            document.addEventListener("click", closeOnOutside, true);
+            document.addEventListener("scroll", removePopover, true);
+            window.addEventListener("resize", removePopover);
+          });
         }}
       >${icons.trash ?? icons.x}</button>
     </span>

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -6,6 +6,7 @@ import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import { renderChatSessionSelect } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
+import { resolveDeleteConfirmViewportPosition } from "../chat/grouped-render.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
@@ -673,6 +674,52 @@ describe("chat view", () => {
     );
     expect(confirm).not.toBeNull();
     expect(confirm?.classList.contains("chat-delete-confirm--right")).toBe(true);
+  });
+
+  it("keeps delete confirm anchored above the trigger when there is room", () => {
+    expect(
+      resolveDeleteConfirmViewportPosition(
+        {
+          left: 260,
+          right: 284,
+          top: 220,
+          bottom: 244,
+          width: 24,
+          height: 24,
+        } as DOMRect,
+        { width: 200, height: 96 } as DOMRect,
+        "left",
+        320,
+        480,
+      ),
+    ).toEqual({
+      left: 84,
+      top: 118,
+      placement: "above",
+    });
+  });
+
+  it("flips delete confirm below the trigger when there is no room above", () => {
+    expect(
+      resolveDeleteConfirmViewportPosition(
+        {
+          left: 8,
+          right: 32,
+          top: 18,
+          bottom: 42,
+          width: 24,
+          height: 24,
+        } as DOMRect,
+        { width: 200, height: 96 } as DOMRect,
+        "right",
+        320,
+        480,
+      ),
+    ).toEqual({
+      left: 12,
+      top: 48,
+      placement: "below",
+    });
   });
 
   it("patches the current session model from the chat header picker", async () => {


### PR DESCRIPTION
## Summary
- position the chat delete confirmation popover relative to the viewport instead of the clipped scroll container
- clamp the popover horizontally and flip it below the trigger when there is no room above
- add focused chat view coverage for the viewport positioning helper

Closes #50277

## Verification
- `pnpm --dir ui test -- src/ui/views/chat.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/styles/chat/grouped.css ui/src/ui/views/chat.test.ts`