### PR TITLE
Fix priority regressions in export attachments auth and denyCommands

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,4 +1,5 @@
 import { streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
+import * as piAi from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
@@ -99,6 +100,21 @@ describe("resolveModelAuthMode", () => {
     expect(resolveModelAuthMode("aws-bedrock", undefined, { version: 1, profiles: {} })).toBe(
       "aws-sdk",
     );
+  });
+
+  it("treats google-vertex ADC sentinel auth as oauth mode", () => {
+    const getEnvApiKeySpy = vi
+      .spyOn(piAi, "getEnvApiKey")
+      .mockImplementation((provider) =>
+        provider === "google-vertex" ? "<authenticated>" : undefined,
+      );
+    try {
+      expect(resolveModelAuthMode("google-vertex", undefined, { version: 1, profiles: {} })).toBe(
+        "oauth",
+      );
+    } finally {
+      getEnvApiKeySpy.mockRestore();
+    }
   });
 });
 
@@ -486,6 +502,22 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
 
     expect(auth.mode).toBe("aws-sdk");
     expect(auth.apiKey).toBeUndefined();
+  });
+
+  it("does not return apiKey when google-vertex resolves ADC sentinel", async () => {
+    const getEnvApiKeySpy = vi
+      .spyOn(piAi, "getEnvApiKey")
+      .mockImplementation((provider) =>
+        provider === "google-vertex" ? "<authenticated>" : undefined,
+      );
+    try {
+      const auth = await resolveApiKeyForProvider({ provider: "google-vertex" });
+      expect(auth.mode).toBe("oauth");
+      expect(auth.source).toBe("gcloud adc");
+      expect(auth.apiKey).toBeUndefined();
+    } finally {
+      getEnvApiKeySpy.mockRestore();
+    }
   });
 });
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -344,6 +344,12 @@ export async function resolveApiKeyForProvider(params: {
 
   const envResolved = resolveEnvApiKey(provider);
   if (envResolved) {
+    if (isGoogleVertexAdcSentinel({ provider, envResolved })) {
+      return {
+        source: envResolved.source,
+        mode: "oauth",
+      };
+    }
     return {
       apiKey: envResolved.apiKey,
       source: envResolved.source,
@@ -395,6 +401,17 @@ export async function resolveApiKeyForProvider(params: {
 
 export type EnvApiKeyResult = { apiKey: string; source: string };
 export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" | "unknown";
+const GOOGLE_VERTEX_ADC_SENTINEL = "<authenticated>";
+
+function isGoogleVertexAdcSentinel(params: {
+  provider: string;
+  envResolved: EnvApiKeyResult;
+}): boolean {
+  return (
+    normalizeProviderIdForAuth(params.provider) === "google-vertex" &&
+    params.envResolved.apiKey === GOOGLE_VERTEX_ADC_SENTINEL
+  );
+}
 
 export function resolveEnvApiKey(
   provider: string,
@@ -477,6 +494,9 @@ export function resolveModelAuthMode(
 
   const envKey = resolveEnvApiKey(resolved);
   if (envKey?.apiKey) {
+    if (isGoogleVertexAdcSentinel({ provider: resolved, envResolved: envKey })) {
+      return "oauth";
+    }
     return envKey.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key";
   }
 

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -29,6 +29,15 @@ function loadTemplate(fileName: string): string {
   return fs.readFileSync(path.join(EXPORT_HTML_DIR, fileName), "utf-8");
 }
 
+function replaceTemplateScriptToken(template: string, token: string, value: string): string {
+  const literalToken = `{{${token}}}`;
+  if (template.includes(literalToken)) {
+    return template.replace(literalToken, value);
+  }
+  const formattedTokenRegex = new RegExp(`\\{\\s*\\{\\s*${token}\\s*;?\\s*\\}\\s*\\}`, "g");
+  return template.replace(formattedTokenRegex, value);
+}
+
 function generateHtml(sessionData: SessionData): string {
   const template = loadTemplate("template.html");
   const templateCss = loadTemplate("template.css");
@@ -90,12 +99,19 @@ function generateHtml(sessionData: SessionData): string {
     .replace("/* {{CONTAINER_BG_DECL}} */", `--container-bg: ${containerBg};`)
     .replace("/* {{INFO_BG_DECL}} */", `--info-bg: ${infoBg};`);
 
-  return template
-    .replace("{{CSS}}", css)
-    .replace("{{JS}}", templateJs)
-    .replace("{{SESSION_DATA}}", sessionDataBase64)
-    .replace("{{MARKED_JS}}", markedJs)
-    .replace("{{HIGHLIGHT_JS}}", hljsJs);
+  return replaceTemplateScriptToken(
+    replaceTemplateScriptToken(
+      replaceTemplateScriptToken(
+        template.replace("{{CSS}}", css).replace("{{SESSION_DATA}}", sessionDataBase64),
+        "MARKED_JS",
+        markedJs,
+      ),
+      "HIGHLIGHT_JS",
+      hljsJs,
+    ),
+    "JS",
+    templateJs,
+  );
 }
 
 function parseExportArgs(commandBodyNormalized: string): { outputPath?: string } {

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -40,7 +40,10 @@ function renderTemplate(sessionData: SessionData) {
     .replace("{{SESSION_DATA}}", Buffer.from(JSON.stringify(sessionData), "utf8").toString("base64"))
     .replace("{{MARKED_JS}}", "")
     .replace("{{HIGHLIGHT_JS}}", "")
-    .replace("{{JS}}", "");
+    .replace("{{HIGHLIGHT_JS}}", "")
+    .replace(/\{\s*\{\s*JS\s*;?\s*\}\s*\}/g, "")
+    .replace(/\{\s*\{\s*MARKED_JS\s*;?\s*\}\s*\}/g, "")
+    .replace(/\{\s*\{\s*HIGHLIGHT_JS\s*;?\s*\}\s*\}/g, "");
 
   const { document, window } = parseHTML(html);
   if (window.HTMLElement?.prototype) {
@@ -80,6 +83,12 @@ function now() {
 }
 
 describe("export html security hardening", () => {
+  it("keeps script injection placeholders intact", () => {
+    expect(templateHtml).toContain("MARKED_JS");
+    expect(templateHtml).toContain("HIGHLIGHT_JS");
+    expect(templateHtml).toContain("JS");
+  });
+
   it("escapes raw HTML from markdown blocks", () => {
     const attack = "<img src=x onerror=alert(1)>";
     const session: SessionData = {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -209,6 +209,55 @@ describe("config cli", () => {
         apiKey: "ollama-local", // pragma: allowlist secret
       });
     });
+
+    it("warns when gateway.nodes.denyCommands includes unknown names", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "gateway.nodes.denyCommands",
+        '["camera.snap","system.runx"]',
+        "--strict-json",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(
+        mockLog.mock.calls.some(
+          (call) =>
+            String(call[0]).includes(
+              "Warning: gateway.nodes.denyCommands includes unknown command names",
+            ) &&
+            String(call[0]).includes("camera.snap") &&
+            String(call[0]).includes("system.runx"),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not warn when gateway.nodes.denyCommands uses known command names", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "gateway.nodes.denyCommands",
+        '["system.run"]',
+        "--strict-json",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(
+        mockLog.mock.calls.some((call) =>
+          String(call[0]).includes("Warning: gateway.nodes.denyCommands"),
+        ),
+      ).toBe(false);
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -17,6 +17,7 @@ import {
 } from "../config/types.secrets.js";
 import { validateConfigObjectRaw } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
+import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
 import { danger, info, success } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -70,6 +71,7 @@ type ConfigSetOperation = {
 const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "apiKey"];
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
+const GATEWAY_NODE_DENY_COMMANDS_PATH: PathSegment[] = ["gateway", "nodes", "denyCommands"];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
 );
@@ -332,6 +334,149 @@ function pathEquals(path: PathSegment[], expected: PathSegment[]): boolean {
   return (
     path.length === expected.length && path.every((segment, index) => segment === expected[index])
   );
+}
+
+function pathStartsWith(path: PathSegment[], prefix: PathSegment[]): boolean {
+  return path.length >= prefix.length && prefix.every((segment, index) => path[index] === segment);
+}
+
+function normalizeNodeCommand(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function listKnownNodeCommandsForConfig(cfg: OpenClawConfig): Set<string> {
+  const baseCfg: OpenClawConfig = {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      nodes: {
+        ...cfg.gateway?.nodes,
+        denyCommands: [],
+      },
+    },
+  };
+  const known = new Set<string>();
+  for (const platform of ["ios", "android", "macos", "linux", "windows", "unknown"] as const) {
+    for (const cmd of resolveNodeCommandAllowlist(baseCfg, { platform })) {
+      const normalized = normalizeNodeCommand(cmd);
+      if (normalized) {
+        known.add(normalized);
+      }
+    }
+  }
+  return known;
+}
+
+function looksLikeNodeCommandPattern(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (/[?*[\]{}(),|]/.test(value)) {
+    return true;
+  }
+  if (
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.startsWith("^") ||
+    value.endsWith("$")
+  ) {
+    return true;
+  }
+  return /\s/.test(value) || value.includes("group:");
+}
+
+function editDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (!a) {
+    return b.length;
+  }
+  if (!b) {
+    return a.length;
+  }
+  const dp: number[] = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i += 1) {
+    let prev = dp[0] ?? 0;
+    dp[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const temp = dp[j] ?? 0;
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[j] = Math.min((dp[j] ?? 0) + 1, (dp[j - 1] ?? 0) + 1, prev + cost);
+      prev = temp;
+    }
+  }
+  return dp[b.length] ?? 0;
+}
+
+function suggestKnownNodeCommands(unknown: string, known: Set<string>): string[] {
+  const needle = unknown.trim();
+  if (!needle) {
+    return [];
+  }
+  const prefix = needle.includes(".") ? needle.split(".").slice(0, 2).join(".") : needle;
+  const prefixHits = Array.from(known)
+    .filter((cmd) => cmd.startsWith(prefix))
+    .slice(0, 3);
+  if (prefixHits.length > 0) {
+    return prefixHits;
+  }
+  const ranked = Array.from(known)
+    .map((cmd) => ({ cmd, d: editDistance(needle, cmd) }))
+    .toSorted((a, b) => a.d - b.d || a.cmd.localeCompare(b.cmd));
+  const best = ranked[0]?.d ?? Infinity;
+  const threshold = Math.max(2, Math.min(4, best));
+  return ranked
+    .filter((entry) => entry.d <= threshold)
+    .slice(0, 3)
+    .map((entry) => entry.cmd);
+}
+
+function collectNodeDenyCommandWarnings(params: {
+  config: OpenClawConfig;
+  operations: ConfigSetOperation[];
+}): string[] {
+  const touchedDenyCommands = params.operations.some((operation) =>
+    pathStartsWith(operation.setPath, GATEWAY_NODE_DENY_COMMANDS_PATH),
+  );
+  if (!touchedDenyCommands) {
+    return [];
+  }
+  const denyRaw = params.config.gateway?.nodes?.denyCommands;
+  if (!Array.isArray(denyRaw) || denyRaw.length === 0) {
+    return [];
+  }
+  const denyList = denyRaw.map(normalizeNodeCommand).filter(Boolean);
+  if (denyList.length === 0) {
+    return [];
+  }
+  const known = listKnownNodeCommandsForConfig(params.config);
+  const patternLike = denyList.filter((entry) => looksLikeNodeCommandPattern(entry));
+  const unknownExact = denyList.filter(
+    (entry) => !looksLikeNodeCommandPattern(entry) && !known.has(entry),
+  );
+  if (patternLike.length === 0 && unknownExact.length === 0) {
+    return [];
+  }
+  const warnings: string[] = [];
+  if (patternLike.length > 0) {
+    warnings.push(
+      `gateway.nodes.denyCommands pattern-like entries are not exact command names and may be ineffective: ${patternLike.join(", ")}`,
+    );
+  }
+  if (unknownExact.length > 0) {
+    const details = unknownExact.map((entry) => {
+      const suggestions = suggestKnownNodeCommands(entry, known);
+      if (suggestions.length === 0) {
+        return entry;
+      }
+      return `${entry} (did you mean: ${suggestions.join(", ")})`;
+    });
+    warnings.push(
+      `gateway.nodes.denyCommands includes unknown command names: ${details.join(", ")}`,
+    );
+  }
+  return warnings;
 }
 
 function ensureValidOllamaProviderForApiKeySet(
@@ -1050,6 +1195,13 @@ export async function runConfigSet(opts: {
       return;
     }
 
+    const denyCommandWarnings = collectNodeDenyCommandWarnings({
+      config: nextConfig,
+      operations,
+    });
+    for (const warning of denyCommandWarnings) {
+      runtime.log(info(`Warning: ${warning}`));
+    }
     await writeConfigFile(next);
     if (operations.length === 1) {
       runtime.log(

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import * as imageOps from "../media/image-ops.js";
 import {
   buildMessageWithAttachments,
   type ChatAttachment,
@@ -136,6 +137,51 @@ describe("parseMessageWithAttachments", () => {
     expect(parsed.images[0]?.mimeType).toBe("image/png");
     expect(parsed.images[0]?.data).toBe(PNG_1x1);
     expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
+  });
+
+  it("converts HEIC attachments to JPEG before returning prompt images", async () => {
+    const heic = Buffer.from("fake-heic-image").toString("base64");
+    const jpeg = Buffer.from("normalized-jpeg-image");
+    const convertSpy = vi.spyOn(imageOps, "convertHeicToJpeg").mockResolvedValueOnce(jpeg);
+    try {
+      const { parsed, logs } = await parseWithWarnings("x", [
+        {
+          type: "image",
+          mimeType: "image/heic",
+          fileName: "photo.heic",
+          content: heic,
+        },
+      ]);
+      expect(parsed.images).toHaveLength(1);
+      expect(parsed.images[0]?.mimeType).toBe("image/jpeg");
+      expect(parsed.images[0]?.data).toBe(jpeg.toString("base64"));
+      expect(logs).toHaveLength(0);
+      expect(convertSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      convertSpy.mockRestore();
+    }
+  });
+
+  it("drops HEIC attachment when conversion fails", async () => {
+    const heic = Buffer.from("fake-heic-image").toString("base64");
+    const convertSpy = vi
+      .spyOn(imageOps, "convertHeicToJpeg")
+      .mockRejectedValueOnce(new Error("convert failed"));
+    try {
+      const { parsed, logs } = await parseWithWarnings("x", [
+        {
+          type: "image",
+          mimeType: "image/heif",
+          fileName: "photo.heif",
+          content: heic,
+        },
+      ]);
+      expect(parsed.images).toHaveLength(0);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatch(/failed to convert/i);
+    } finally {
+      convertSpy.mockRestore();
+    }
   });
 });
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,4 +1,5 @@
 import { estimateBase64DecodedBytes } from "../media/base64.js";
+import { convertHeicToJpeg } from "../media/image-ops.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 
 export type ChatAttachment = {
@@ -28,6 +29,8 @@ type NormalizedAttachment = {
   mime: string;
   base64: string;
 };
+
+const HEIC_IMAGE_MIMES = new Set(["image/heic", "image/heif"]);
 
 function normalizeMime(mime?: string): string | undefined {
   if (!mime) {
@@ -89,6 +92,26 @@ function validateAttachmentBase64OrThrow(
   return sizeBytes;
 }
 
+async function normalizeImagePayloadForModel(params: {
+  base64: string;
+  mime: string;
+  label: string;
+  log?: AttachmentLog;
+}): Promise<{ data: string; mimeType: string } | null> {
+  if (!HEIC_IMAGE_MIMES.has(params.mime)) {
+    return { data: params.base64, mimeType: params.mime };
+  }
+  try {
+    const jpegBuffer = await convertHeicToJpeg(Buffer.from(params.base64, "base64"));
+    return { data: jpegBuffer.toString("base64"), mimeType: "image/jpeg" };
+  } catch {
+    params.log?.warn(
+      `attachment ${params.label}: failed to convert ${params.mime} to image/jpeg, dropping`,
+    );
+    return null;
+  }
+}
+
 /**
  * Parse attachments and extract images as structured content blocks.
  * Returns the message text and an array of image content blocks
@@ -134,10 +157,20 @@ export async function parseMessageWithAttachments(
       );
     }
 
+    const finalMime = sniffedMime ?? providedMime ?? mime;
+    const normalizedImage = await normalizeImagePayloadForModel({
+      base64: b64,
+      mime: finalMime,
+      label,
+      log,
+    });
+    if (!normalizedImage) {
+      continue;
+    }
     images.push({
       type: "image",
-      data: b64,
-      mimeType: sniffedMime ?? providedMime ?? mime,
+      data: normalizedImage.data,
+      mimeType: normalizedImage.mimeType,
     });
   }
 


### PR DESCRIPTION
## Summary
- fix export session HTML token injection by supporting both plain and formatted script placeholders
- normalize HEIC and HEIF chat attachments to JPEG before prompt image upload
- treat google-vertex ADC sentinel as oauth mode and do not pass it as apiKey
- add config set warnings for gateway.nodes.denyCommands unknown or pattern-like entries
- add regression tests for all four fixes

## Linked issues
- closes #49957
- closes #50081
- closes #50053
- closes #50011

## Validation
- pnpm test src/auto-reply/reply/export-html/template.security.test.ts src/gateway/chat-attachments.test.ts src/agents/model-auth.test.ts src/cli/config-cli.test.ts
- pnpm check and pnpm tsgo still report existing unrelated repo-wide TypeScript errors
