### PR TITLE
fix(discord): skip updateLastRoute for guild channels to allow daily reset

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -439,7 +439,7 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
-  it("stores group lastRoute with channel target", async () => {
+  it("skips updateLastRoute for guild channel messages to preserve daily reset", async () => {
     const ctx = await createBaseContext({
       baseSessionKey: "agent:main:discord:channel:c1",
       route: BASE_CHANNEL_ROUTE,
@@ -448,12 +448,7 @@ describe("processDiscordMessage session routing", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
 
-    expect(getLastRouteUpdate()).toEqual({
-      sessionKey: "agent:main:discord:channel:c1",
-      channel: "discord",
-      to: "channel:c1",
-      accountId: "default",
-    });
+    expect(getLastRouteUpdate()).toBeUndefined();
   });
 
   it("prefers bound session keys and sets MessageThreadId for bound thread messages", async () => {
@@ -488,12 +483,8 @@ describe("processDiscordMessage session routing", () => {
       SessionKey: "agent:main:subagent:child",
       MessageThreadId: "thread-1",
     });
-    expect(getLastRouteUpdate()).toEqual({
-      sessionKey: "agent:main:subagent:child",
-      channel: "discord",
-      to: "channel:thread-1",
-      accountId: "default",
-    });
+    // Guild thread messages skip updateLastRoute to preserve daily reset
+    expect(getLastRouteUpdate()).toBeUndefined();
   });
 });
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -397,12 +397,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     storePath,
     sessionKey: persistedSessionKey,
     ctx: ctxPayload,
-    updateLastRoute: {
-      sessionKey: persistedSessionKey,
-      channel: "discord",
-      to: lastRouteTo,
-      accountId: route.accountId,
-    },
+    updateLastRoute: isDirectMessage
+      ? {
+          sessionKey: persistedSessionKey,
+          channel: "discord",
+          to: lastRouteTo,
+          accountId: route.accountId,
+        }
+      : undefined,
     onRecordError: (err) => {
       logVerbose(`discord: failed updating session meta: ${String(err)}`);
     },


### PR DESCRIPTION
## What

Discord guild channel and group sessions never trigger the daily session reset. Sessions run indefinitely (7+ days observed) without the expected reset at the configured daily boundary (default 4:00 AM local).

## Root Cause

`message-handler.process.ts` calls `recordInboundSession` with `updateLastRoute` unconditionally for all message types. `updateLastRoute` internally bumps `updatedAt` to `Date.now()`. When `initSessionState` → `evaluateSessionFreshness` subsequently reads the entry, `updatedAt` is always fresh, so `staleDaily` is always `false`.

Telegram and iMessage already guard this: `updateLastRoute: !isGroup ? { ... } : undefined`. The Discord interaction handler (`agent-components.ts`) also guards with `interactionCtx.isDirectMessage`. Only the Discord message handler was missing the guard.

## Fix

Guard `updateLastRoute` with `isDirectMessage` (already destructured at line 89), matching the Telegram pattern. Guild channel messages pass `undefined` instead, preserving the original `updatedAt` for the daily reset check.

## Changes

- `extensions/discord/src/monitor/message-handler.process.ts`: wrap `updateLastRoute` in `isDirectMessage ? { ... } : undefined`
- `extensions/discord/src/monitor/message-handler.process.test.ts`: update 2 tests to assert `undefined` for guild channel route updates

Fixes #50318