### PR TITLE
[AI-assisted] Agents: add UTC time to session status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -97,6 +97,28 @@ function getSessionStatusTool(agentSessionKey = "main") {
 }
 
 describe("session_status tool", () => {
+  it("includes a machine-readable UTC time in the status card", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T10:15:00Z"));
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+
+    try {
+      const tool = getSessionStatusTool();
+
+      const result = await tool.execute("call-utc", {});
+      const details = result.details as { ok?: boolean; statusText?: string };
+      expect(details.ok).toBe(true);
+      expect(details.statusText).toContain("2026-03-09 10:15 UTC");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns a status card for the current session", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -341,11 +341,13 @@ export function createSessionStatusTool(opts?: {
         resolved.entry.queueDebounceMs ?? resolved.entry.queueCap ?? resolved.entry.queueDrop,
       );
 
+      const nowMs = Date.now();
       const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
       const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
-      const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+      const userTime = formatUserTime(new Date(nowMs), userTimezone, userTimeFormat);
+      const utcTime = `${new Date(nowMs).toISOString().slice(0, 16).replace("T", " ")} UTC`;
       const timeLine = userTime
-        ? `🕒 Time: ${userTime} (${userTimezone})`
+        ? `🕒 Time: ${userTime} (${userTimezone}) / ${utcTime}`
         : `🕒 Time zone: ${userTimezone}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};


### PR DESCRIPTION
## Summary\n\nAdd a machine-readable UTC timestamp to  so the current time is available in a stable format alongside the localized display. This helps time-sensitive flows like reminders avoid guessing the current time.\n\n## Changes\n\n- append a  marker to the time line in \n- add a regression test that freezes time and asserts the UTC marker is present\n\n## Testing\n\n- 
 RUN  v4.0.18 /private/tmp/openclaw-time-pr

 ✓ src/agents/openclaw-tools.session-status.test.ts (8 tests) 19ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  14:05:17
   Duration  3.97s (transform 2.41s, setup 96ms, import 3.77s, tests 19ms, environment 0ms)\n\n## AI assistance\n\nThis PR was AI-assisted. I reviewed the change and understand what it does.