### PR TITLE
docs: sync zh-CN onboarding pages

### DIFF
--- a/docs/zh-CN/automation/gmail-pubsub.md
+++ b/docs/zh-CN/automation/gmail-pubsub.md
@@ -5,10 +5,10 @@ read_when:
 summary: 通过 gogcli 将 Gmail Pub/Sub 推送接入 OpenClaw webhooks
 title: Gmail PubSub
 x-i18n:
-  generated_at: "2026-02-03T07:43:25Z"
-  model: claude-opus-4-5
-  provider: pi
-  source_hash: dfb92133b69177e4e984b7d072f5dc28aa53a9e0cf984a018145ed811aa96195
+  generated_at: "2026-03-19T09:20:40Z"
+  model: gpt-5.4
+  provider: openai
+  source_hash: 0c8a87516e12091f96209f570012cdba895265af3d48ba848e0260535535bd18
   source_path: automation/gmail-pubsub.md
   workflow: 15
 ---
@@ -21,7 +21,7 @@ x-i18n:
 
 - 已安装并登录 `gcloud`（[安装指南](https://docs.cloud.google.com/sdk/docs/install-sdk)）。
 - 已安装 `gog` (gogcli) 并为 Gmail 账户授权（[gogcli.sh](https://gogcli.sh/)）。
-- 已启用 OpenClaw hooks（参见 [Webhooks](/automation/webhook)）。
+- 已启用 OpenClaw hooks（参见 [Webhooks](/zh-CN/automation/webhook)）。
 - 已登录 `tailscale`（[tailscale.com](https://tailscale.com/)）。支持的设置使用 Tailscale Funnel 作为公共 HTTPS 端点。
   其他隧道服务也可以使用，但需要自行配置/不受支持，需要手动接入。
   目前，我们支持的是 Tailscale。
@@ -90,7 +90,7 @@ x-i18n:
 - Gmail hook 内容默认使用外部内容安全边界包装。
   要禁用（危险），请设置 `hooks.gmail.allowUnsafeExternalContent: true`。
 
-要进一步自定义负载处理，请添加 `hooks.mappings` 或在 `hooks.transformsDir` 下添加 JS/TS 转换模块（参见 [Webhooks](/automation/webhook)）。
+要进一步自定义负载处理，请添加 `hooks.mappings` 或在 `hooks.transformsDir` 下添加 JS/TS 转换模块（参见 [Webhooks](/zh-CN/automation/webhook)）。
 
 ## 向导（推荐）
 

--- a/docs/zh-CN/start/onboarding-overview.md
+++ b/docs/zh-CN/start/onboarding-overview.md
@@ -2,14 +2,14 @@
 read_when:
   - 选择一种新手引导路径
   - 设置新环境
-sidebarTitle: Onboarding Overview
+sidebarTitle: 新手引导概览
 summary: OpenClaw 新手引导选项与流程概览
 title: 新手引导概览
 x-i18n:
-  generated_at: "2026-03-16T06:27:56Z"
+  generated_at: "2026-03-19T09:20:40Z"
   model: gpt-5.4
   provider: openai
-  source_hash: 8a22945f0780515be7ec1b94b5ff486828cf9b8f060ab598a31eb17ee0a5c60b
+  source_hash: 6e3af4ba946f6a71119701398ee9670baaa3b6dccca51e0c6278ef5d84815c6a
   source_path: start/onboarding-overview.md
   workflow: 15
 ---
@@ -35,24 +35,24 @@ openclaw onboard
 当你希望完全控制 Gateway 网关、工作区、
 渠道和 Skills 时，请使用 CLI 新手引导。文档：
 
-- [CLI 新手引导](/start/wizard)
-- [`openclaw onboard` 命令](/cli/onboard)
+- [新手引导（CLI）](/zh-CN/start/wizard)
+- [`openclaw onboard` 命令](/zh-CN/cli/onboard)
 
 ## macOS 应用新手引导
 
 如果你希望在 macOS 上使用完全引导式设置，请使用 OpenClaw 应用。文档：
 
-- [新手引导（macOS 应用）](/start/onboarding)
+- [新手引导（macOS 应用）](/zh-CN/start/onboarding)
 
 ## 自定义提供商
 
 如果你需要一个未列出的端点，包括那些
 公开标准 OpenAI 或 Anthropic API 的托管提供商，请在
-在 CLI 新手引导中选择 **Custom Provider**。系统会要求你：
+CLI 新手引导中选择 **Custom Provider**。系统会要求你：
 
 - 选择兼容 OpenAI、兼容 Anthropic，或 **Unknown**（自动检测）。
 - 输入基础 URL 和 API 密钥（如果提供商需要）。
 - 提供模型 ID 和可选别名。
 - 选择一个 Endpoint ID，以便多个自定义端点可以共存。
 
-如需详细步骤，请按照上面的 CLI 新手引导文档操作。
+如需详细步骤，请参阅上面的 CLI 新手引导文档。

--- a/docs/zh-CN/start/onboarding.md
+++ b/docs/zh-CN/start/onboarding.md
@@ -2,104 +2,89 @@
 read_when:
   - 设计 macOS 新手引导助手
   - 实现认证或身份设置
-summary: OpenClaw 的首次运行新手引导流程（macOS 应用）
-title: 新手引导
+summary: OpenClaw 的首次运行设置流程（macOS 应用）
+title: 新手引导（macOS 应用）
+sidebarTitle: 新手引导：macOS 应用
 x-i18n:
-  generated_at: "2026-02-03T07:54:07Z"
-  model: claude-opus-4-5
-  provider: pi
-  source_hash: ae883b2deb1f9032be7c47a04d67e1741dffbdcc4445de1e0bbaa976e606bc10
+  generated_at: "2026-03-19T09:20:40Z"
+  model: gpt-5.4
+  provider: openai
+  source_hash: 6556aef83f3fcb5bcc28b5e1d1be189c6e861cdca1594bfe72c4394f85c3e6b6
   source_path: start/onboarding.md
   workflow: 15
 ---
 
 # 新手引导（macOS 应用）
 
-本文档描述**当前**的首次运行新手引导流程。目标是流畅的"第 0 天"体验：选择 Gateway 网关运行位置、连接认证、运行向导，然后让智能体自行引导。
+本文档描述**当前**的首次运行设置流程。目标是提供顺畅的“第 0 天”体验：选择 Gateway 网关运行位置、连接认证、运行向导，然后让智能体自行完成初始引导。
+如需了解各类新手引导路径的整体概览，请参阅 [新手引导概览](/zh-CN/start/onboarding-overview)。
 
-## 页面顺序（当前）
+<Steps>
+<Step title="确认 macOS 警告">
+<Frame>
+<img src="/assets/macos-onboarding/01-macos-warning.jpeg" alt="" />
+</Frame>
+</Step>
+<Step title="允许发现本地网络">
+<Frame>
+<img src="/assets/macos-onboarding/02-local-networks.jpeg" alt="" />
+</Frame>
+</Step>
+<Step title="欢迎页与安全提示">
+<Frame caption="阅读显示的安全提示，并据此做出选择。">
+<img src="/assets/macos-onboarding/03-security-notice.png" alt="" />
+</Frame>
 
-1. 欢迎 + 安全提示
-2. **Gateway 网关选择**（本地 / 远程 / 稍后配置）
-3. **认证（Anthropic OAuth）** — 仅限本地
-4. **设置向导**（Gateway 网关驱动）
-5. **权限**（TCC 提示）
-6. **CLI**（可选）
-7. **新手引导聊天**（专用会话）
-8. 就绪
+安全信任模型：
 
-## 1) 欢迎 + 安全提示
+- 默认情况下，OpenClaw 是一个个人智能体，围绕单一受信任操作员边界设计。
+- 共享或多用户部署需要额外收紧：拆分信任边界、尽量减少工具访问，并遵循 [安全性](/zh-CN/gateway/security)。
+- 本地新手引导现在默认将新配置写为 `tools.profile: "coding"`，这样新的本地安装会保留文件系统和运行时工具，而不必直接启用不受限制的 `full` 配置。
+- 如果启用了 hooks、webhooks 或其他不受信任的内容源，请使用更强的现代模型档位，并保持严格的工具策略和沙箱隔离。
 
-阅读显示的安全提示并相应决定。
+</Step>
+<Step title="本地还是远程">
+<Frame>
+<img src="/assets/macos-onboarding/04-choose-gateway.png" alt="" />
+</Frame>
 
-## 2) 本地 vs 远程
+**Gateway 网关**运行在哪里？
 
-**Gateway 网关**在哪里运行？
+- **此 Mac（仅本地）：** 新手引导可以在本地配置认证并写入凭据。
+- **远程（通过 SSH/Tailnet）：** 新手引导**不会**配置本地认证；凭据必须已经存在于 Gateway 网关主机上。
+- **稍后配置：** 跳过设置，并让应用保持未配置状态。
 
-- **本地（此 Mac）：** 新手引导可以在本地运行 OAuth 流程并写入凭证。
-- **远程（通过 SSH/Tailnet）：** 新手引导**不会**在本地运行 OAuth；凭证必须存在于 Gateway 网关主机上。
-- **稍后配置：** 跳过设置并保持应用未配置状态。
+<Tip>
+**Gateway 认证提示：**
 
-Gateway 网关认证提示：
+- 向导现在即使在 loopback 上也会生成 **token**，因此本地 WS 客户端也必须通过认证。
+- 如果你禁用认证，任何本地进程都可以连接；这只适用于完全受信任的机器。
+- 对多机器访问或非 loopback 绑定，请使用 **token**。
 
-- 向导现在即使对于 loopback 也会生成**令牌**，因此本地 WS 客户端必须认证。
-- 如果你禁用认证，任何本地进程都可以连接；仅在完全受信任的机器上使用。
-- 对于多机器访问或非 loopback 绑定，使用**令牌**。
+</Tip>
+</Step>
+<Step title="权限">
+<Frame caption="选择你希望授予 OpenClaw 的权限。">
+<img src="/assets/macos-onboarding/05-permissions.png" alt="" />
+</Frame>
 
-## 3) 仅限本地的认证（Anthropic OAuth）
+新手引导会请求以下场景所需的 TCC 权限：
 
-macOS 应用支持 Anthropic OAuth（Claude Pro/Max）。流程：
-
-- 打开浏览器进行 OAuth（PKCE）
-- 要求用户粘贴 `code#state` 值
-- 将凭证写入 `~/.openclaw/credentials/oauth.json`
-
-其他提供商（OpenAI、自定义 API）目前通过环境变量或配置文件配置。
-
-## 4) 设置向导（Gateway 网关驱动）
-
-应用可以运行与 CLI 相同的设置向导。这使新手引导与 Gateway 网关端行为保持同步，避免在 SwiftUI 中重复逻辑。
-
-## 5) 权限
-
-新手引导请求以下所需的 TCC 权限：
-
+- 自动化（AppleScript）
 - 通知
 - 辅助功能
 - 屏幕录制
-- 麦克风 / 语音识别
-- 自动化（AppleScript）
+- 麦克风
+- 语音识别
+- 相机
+- 位置
 
-## 6) CLI（可选）
-
-应用可以通过 npm/pnpm 安装全局 `openclaw` CLI，以便终端工作流和 launchd 任务开箱即用。
-
-## 7) 新手引导聊天（专用会话）
-
-设置完成后，应用会打开一个专用的新手引导聊天会话，让智能体可以自我介绍并指导后续步骤。这使首次运行指导与你的正常对话分开。
-
-## 智能体引导仪式
-
-在首次智能体运行时，OpenClaw 会引导一个工作区（默认 `~/.openclaw/workspace`）：
-
-- 初始化 `AGENTS.md`、`BOOTSTRAP.md`、`IDENTITY.md`、`USER.md`
-- 运行简短的问答仪式（一次一个问题）
-- 将身份 + 偏好写入 `IDENTITY.md`、`USER.md`、`SOUL.md`
-- 完成后删除 `BOOTSTRAP.md`，使其只运行一次
-
-## 可选：Gmail 钩子（手动）
-
-Gmail Pub/Sub 设置目前是手动步骤。使用：
-
-```bash
-openclaw webhooks gmail setup --account you@gmail.com
-```
-
-参阅 [/automation/gmail-pubsub](/automation/gmail-pubsub) 了解详情。
-
-## 远程模式说明
-
-当 Gateway 网关在另一台机器上运行时，凭证和工作区文件存储在**该主机上**。如果你需要在远程模式下使用 OAuth，请在 Gateway 网关主机上创建：
-
-- `~/.openclaw/credentials/oauth.json`
-- `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
+</Step>
+<Step title="CLI">
+  <Info>此步骤为可选项。</Info>
+  应用可以通过 npm/pnpm 安装全局 `openclaw` CLI，让终端工作流和 launchd 任务开箱即用。
+</Step>
+<Step title="新手引导聊天（专用会话）">
+  设置完成后，应用会打开一个专用的新手引导聊天会话，让智能体先自我介绍并引导后续步骤。这会将首次运行指导与你的日常对话分开。关于首次智能体运行时 Gateway 网关主机上会发生什么，请参阅 [智能体引导](/zh-CN/start/bootstrapping)。
+</Step>
+</Steps>


### PR DESCRIPTION
## Summary

- Problem: `docs/zh-CN/start/onboarding.md` was still based on an older onboarding flow and no longer matched the current English source.
- Why it matters: the zh-CN onboarding pages could send readers through outdated steps and mixed-language internal links.
- What changed: synced the zh-CN onboarding pages to the current English structure/content and updated the affected zh-CN Gmail Pub/Sub links to point at zh-CN docs.
- What did NOT change (scope boundary): no product behavior, code paths, build output, or non-targeted zh-CN docs outside these pages.

## Change Type (select all)

- [x] Docs
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- zh-CN onboarding now matches the current English onboarding flow and sections.
- zh-CN onboarding overview uses the current labels/links for the CLI and macOS onboarding docs.
- zh-CN Gmail Pub/Sub references now point to zh-CN Webhooks docs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node 22 / pnpm via corepack
- Model/provider: N/A (docs only)
- Integration/channel (if any): Mintlify docs
- Relevant config (redacted): N/A

### Steps

1. Compare `docs/start/onboarding.md`, `docs/start/onboarding-overview.md`, and `docs/automation/gmail-pubsub.md` against their zh-CN counterparts.
2. Sync the outdated zh-CN onboarding content to the current English source and fix affected zh-CN internal links.
3. Run docs validation on the touched files.

### Expected

- zh-CN pages match the current English source for the touched docs.
- Internal docs links resolve cleanly.

### Actual

- The touched zh-CN pages now match the current English source and docs link checks pass.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: compared the touched zh-CN pages against the current English source sections and verified the rewritten structure/content matches.
- Edge cases checked: zh-CN internal links for onboarding and Gmail Pub/Sub/Webhooks, markdown lint on touched docs, link audit, and `oxfmt --check` on the touched docs.
- What you did **not** verify: full-site zh-CN parity beyond the touched pages, and a rendered Mintlify preview.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `3ce5912b2`.
- Files/config to restore: `docs/zh-CN/start/onboarding.md`, `docs/zh-CN/start/onboarding-overview.md`, `docs/zh-CN/automation/gmail-pubsub.md`.
- Known bad symptoms reviewers should watch for: stale zh-CN onboarding steps or links unexpectedly routing to English docs.

## Risks and Mitigations

- Risk: zh-CN phrasing could still differ subtly from the English source in wording.
  - Mitigation: the touched pages were checked section-by-section against the current English docs, and link/lint/format validation passed.