### PR TITLE
config: use channel catalog plugin ids for auto-enable

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -39,6 +39,7 @@ export type ChannelPluginCatalogEntry = {
 
 type CatalogOptions = {
   workspaceDir?: string;
+  loadPaths?: string[];
   catalogPaths?: string[];
   env?: NodeJS.ProcessEnv;
 };
@@ -338,6 +339,7 @@ export function listChannelPluginCatalogEntries(
 ): ChannelPluginCatalogEntry[] {
   const discovery = discoverOpenClawPlugins({
     workspaceDir: options.workspaceDir,
+    extraPaths: options.loadPaths,
     env: options.env,
   });
   const resolved = new Map<string, { entry: ChannelPluginCatalogEntry; priority: number }>();

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -533,7 +533,7 @@ describe("applyPluginAutoEnable", () => {
       expect(result.config.plugins?.entries?.apn).toBeUndefined();
     });
 
-    it("uses catalog plugin ids when manifest registry channel mappings are missing", () => {
+    it("uses catalog plugin ids when manifest registry channel mappings are stale", () => {
       const stateDir = makeTempDir();
       const pluginDir = path.join(stateDir, "extensions", "wecom-openclaw-plugin");
       writePluginManifestFixture({
@@ -560,6 +560,8 @@ describe("applyPluginAutoEnable", () => {
           channels: { wecom: { corpId: "wx-demo" } },
         },
         env,
+        // Simulate a startup registry snapshot that knows the plugin id but
+        // has not populated its channel->plugin mapping yet.
         manifestRegistry: makeRegistry([{ id: "wecom-openclaw-plugin", channels: [] }]),
       });
 
@@ -569,6 +571,115 @@ describe("applyPluginAutoEnable", () => {
 
       const validated = validateConfigObjectWithPlugins(result.config, { env });
       expect(validated.ok).toBe(true);
+    });
+
+    it("uses catalog plugin ids from plugins.load.paths when registry mappings are missing", () => {
+      const pluginRoot = makeTempDir();
+      writePluginManifestFixture({
+        rootDir: pluginRoot,
+        id: "wecom-openclaw-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: pluginRoot,
+        packageName: "@wecom/wecom-openclaw-plugin",
+        channelId: "wecom",
+        channelLabel: "WeCom",
+      });
+
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { wecom: { corpId: "wx-demo" } },
+          plugins: {
+            load: {
+              paths: [pluginRoot],
+            },
+          },
+        },
+        env: {
+          ...process.env,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+        },
+        manifestRegistry: makeRegistry([{ id: "wecom-openclaw-plugin", channels: [] }]),
+      });
+
+      expect(result.config.plugins?.entries?.["wecom-openclaw-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.wecom).toBeUndefined();
+    });
+
+    it("applies preferOver using channel ids even when plugin ids differ", () => {
+      const preferredRoot = makeTempDir();
+      writePluginManifestFixture({
+        rootDir: preferredRoot,
+        id: "preferred-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: preferredRoot,
+        packageName: "@test/preferred-plugin",
+        channelId: "preferred-channel",
+        channelLabel: "Preferred",
+      });
+      const preferredPackageJsonPath = path.join(preferredRoot, "package.json");
+      const preferredPackageJson = JSON.parse(
+        fs.readFileSync(preferredPackageJsonPath, "utf-8"),
+      ) as Record<string, unknown>;
+      fs.writeFileSync(
+        preferredPackageJsonPath,
+        JSON.stringify(
+          {
+            ...preferredPackageJson,
+            openclaw: {
+              ...(preferredPackageJson.openclaw as Record<string, unknown>),
+              channel: {
+                ...((preferredPackageJson.openclaw as Record<string, unknown>).channel as Record<
+                  string,
+                  unknown
+                >),
+                preferOver: ["secondary-channel"],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const secondaryRoot = makeTempDir();
+      writePluginManifestFixture({
+        rootDir: secondaryRoot,
+        id: "secondary-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: secondaryRoot,
+        packageName: "@test/secondary-plugin",
+        channelId: "secondary-channel",
+        channelLabel: "Secondary",
+      });
+
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: {
+            "preferred-channel": { token: "preferred" },
+            "secondary-channel": { token: "secondary" },
+          },
+          plugins: {
+            load: {
+              paths: [preferredRoot, secondaryRoot],
+            },
+          },
+        },
+        env: {
+          ...process.env,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+        },
+        manifestRegistry: makeRegistry([
+          { id: "preferred-plugin", channels: [] },
+          { id: "secondary-plugin", channels: [] },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["preferred-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["secondary-plugin"]?.enabled).toBeUndefined();
     });
   });
 });

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -539,6 +539,9 @@ describe("applyPluginAutoEnable", () => {
       writePluginManifestFixture({
         rootDir: pluginDir,
         id: "wecom-openclaw-plugin",
+        // Keep the on-disk manifest schema-valid for config validation; the injected
+        // manifestRegistry below intentionally simulates the stale startup snapshot
+        // where channel mappings have not been populated yet.
         channels: ["wecom"],
       });
       writePackageChannelFixture({
@@ -604,6 +607,112 @@ describe("applyPluginAutoEnable", () => {
 
       expect(result.config.plugins?.entries?.["wecom-openclaw-plugin"]?.enabled).toBe(true);
       expect(result.config.plugins?.entries?.wecom).toBeUndefined();
+    });
+
+    it("prefers bundled plugin ids over non-explicit global duplicates", () => {
+      const stateDir = makeTempDir();
+      const bundledDir = makeTempDir();
+      const globalPluginDir = path.join(stateDir, "extensions", "shared-global-plugin");
+      writePluginManifestFixture({
+        rootDir: globalPluginDir,
+        id: "shared-global-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: globalPluginDir,
+        packageName: "@test/shared-global-plugin",
+        channelId: "shared-channel",
+        channelLabel: "Shared Channel",
+      });
+
+      const bundledPluginDir = path.join(bundledDir, "shared-bundled-plugin");
+      writePluginManifestFixture({
+        rootDir: bundledPluginDir,
+        id: "shared-bundled-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: bundledPluginDir,
+        packageName: "@test/shared-bundled-plugin",
+        channelId: "shared-channel",
+        channelLabel: "Shared Channel",
+      });
+
+      const env = {
+        ...process.env,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      };
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { "shared-channel": { token: "demo" } },
+        },
+        env,
+        manifestRegistry: makeRegistry([
+          { id: "shared-global-plugin", channels: [] },
+          { id: "shared-bundled-plugin", channels: [] },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["shared-bundled-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["shared-global-plugin"]).toBeUndefined();
+    });
+
+    it("prefers explicit installed global duplicates over bundled plugin ids", () => {
+      const stateDir = makeTempDir();
+      const bundledDir = makeTempDir();
+      const globalPluginDir = path.join(stateDir, "extensions", "shared-global-plugin");
+      writePluginManifestFixture({
+        rootDir: globalPluginDir,
+        id: "shared-global-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: globalPluginDir,
+        packageName: "@test/shared-global-plugin",
+        channelId: "shared-channel",
+        channelLabel: "Shared Channel",
+      });
+
+      const bundledPluginDir = path.join(bundledDir, "shared-bundled-plugin");
+      writePluginManifestFixture({
+        rootDir: bundledPluginDir,
+        id: "shared-bundled-plugin",
+      });
+      writePackageChannelFixture({
+        rootDir: bundledPluginDir,
+        packageName: "@test/shared-bundled-plugin",
+        channelId: "shared-channel",
+        channelLabel: "Shared Channel",
+      });
+
+      const env = {
+        ...process.env,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      };
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { "shared-channel": { token: "demo" } },
+          plugins: {
+            installs: {
+              "shared-global-plugin": {
+                installPath: globalPluginDir,
+                source: "path",
+              },
+            },
+          },
+        },
+        env,
+        manifestRegistry: makeRegistry([
+          { id: "shared-global-plugin", channels: [] },
+          { id: "shared-bundled-plugin", channels: [] },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["shared-global-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["shared-bundled-plugin"]).toBeUndefined();
     });
 
     it("applies preferOver using channel ids even when plugin ids differ", () => {

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -7,7 +7,7 @@ import {
   clearPluginManifestRegistryCache,
   type PluginManifestRegistry,
 } from "../plugins/manifest-registry.js";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObject, validateConfigObjectWithPlugins } from "./config.js";
 import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
 
 const tempDirs: string[] = [];
@@ -36,15 +36,46 @@ function makeTempDir() {
   return dir;
 }
 
-function writePluginManifestFixture(params: { rootDir: string; id: string; channels: string[] }) {
+function writePluginManifestFixture(params: { rootDir: string; id: string; channels?: string[] }) {
   mkdirSafe(params.rootDir);
+  const manifest: Record<string, unknown> = {
+    id: params.id,
+    configSchema: { type: "object" },
+  };
+  if (params.channels) {
+    manifest.channels = params.channels;
+  }
   fs.writeFileSync(
     path.join(params.rootDir, "openclaw.plugin.json"),
+    JSON.stringify(manifest, null, 2),
+    "utf-8",
+  );
+  fs.writeFileSync(path.join(params.rootDir, "index.ts"), "export default {}", "utf-8");
+}
+
+function writePackageChannelFixture(params: {
+  rootDir: string;
+  packageName: string;
+  channelId: string;
+  channelLabel?: string;
+}) {
+  mkdirSafe(params.rootDir);
+  fs.writeFileSync(
+    path.join(params.rootDir, "package.json"),
     JSON.stringify(
       {
-        id: params.id,
-        channels: params.channels,
-        configSchema: { type: "object" },
+        name: params.packageName,
+        version: "1.0.0",
+        openclaw: {
+          channel: {
+            id: params.channelId,
+            label: params.channelLabel ?? params.channelId,
+            blurb: "fixture channel",
+          },
+          install: {
+            npmSpec: params.packageName,
+          },
+        },
       },
       null,
       2,
@@ -500,6 +531,44 @@ describe("applyPluginAutoEnable", () => {
 
       expect(result.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
       expect(result.config.plugins?.entries?.apn).toBeUndefined();
+    });
+
+    it("uses catalog plugin ids when manifest registry channel mappings are missing", () => {
+      const stateDir = makeTempDir();
+      const pluginDir = path.join(stateDir, "extensions", "wecom-openclaw-plugin");
+      writePluginManifestFixture({
+        rootDir: pluginDir,
+        id: "wecom-openclaw-plugin",
+        channels: ["wecom"],
+      });
+      writePackageChannelFixture({
+        rootDir: pluginDir,
+        packageName: "@wecom/wecom-openclaw-plugin",
+        channelId: "wecom",
+        channelLabel: "WeCom",
+      });
+
+      const env = {
+        ...process.env,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+      };
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { wecom: { corpId: "wx-demo" } },
+        },
+        env,
+        manifestRegistry: makeRegistry([{ id: "wecom-openclaw-plugin", channels: [] }]),
+      });
+
+      expect(result.config.plugins?.entries?.["wecom-openclaw-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.wecom).toBeUndefined();
+      expect(result.changes.join("\n")).toContain("wecom configured, enabled automatically.");
+
+      const validated = validateConfigObjectWithPlugins(result.config, { env });
+      expect(validated.ok).toBe(true);
     });
   });
 });

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -11,6 +11,7 @@ import {
   listChatChannels,
   normalizeChatChannelId,
 } from "../channels/registry.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import {
   loadPluginManifestRegistry,
   type PluginManifestRegistry,
@@ -314,6 +315,24 @@ function resolvePluginIdForChannel(
   return channelToPluginId.get(channelId) ?? channelId;
 }
 
+function findCatalogEntryForPluginId(
+  pluginId: string,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
+): ChannelPluginCatalogEntry | undefined {
+  return catalogEntries.find((entry) => entry.id === pluginId || entry.pluginId === pluginId);
+}
+
+function resolveChannelPreferenceKey(
+  pluginId: string,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
+): string {
+  const builtInId = normalizeChatChannelId(pluginId);
+  if (builtInId) {
+    return builtInId;
+  }
+  return findCatalogEntryForPluginId(pluginId, catalogEntries)?.id ?? pluginId;
+}
+
 function listKnownChannelPluginIds(catalogEntries: readonly ChannelPluginCatalogEntry[]): string[] {
   return Array.from(
     new Set([
@@ -348,7 +367,11 @@ function resolveConfiguredPlugins(
   registry: PluginManifestRegistry,
 ): PluginEnableChange[] {
   const changes: PluginEnableChange[] = [];
-  const catalogEntries = listChannelPluginCatalogEntries({ env });
+  const normalizedPlugins = normalizePluginsConfig(cfg.plugins);
+  const catalogEntries = listChannelPluginCatalogEntries({
+    env,
+    loadPaths: normalizedPlugins.loadPaths,
+  });
   // Build reverse map: channel ID → plugin ID from installed plugin manifests.
   const channelToPluginId = buildChannelToPluginIdMap(registry, catalogEntries);
   for (const channelId of collectCandidateChannelIds(cfg, catalogEntries)) {
@@ -402,12 +425,19 @@ function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
   return Array.isArray(deny) && deny.includes(pluginId);
 }
 
-function resolvePreferredOverIds(pluginId: string, env: NodeJS.ProcessEnv): string[] {
-  const normalized = normalizeChatChannelId(pluginId);
-  if (normalized) {
-    return getChatChannelMeta(normalized).preferOver ?? [];
+function resolvePreferredOverIds(
+  pluginId: string,
+  env: NodeJS.ProcessEnv,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
+): string[] {
+  const preferenceKey = resolveChannelPreferenceKey(pluginId, catalogEntries);
+  const builtInId = normalizeChatChannelId(preferenceKey);
+  if (builtInId) {
+    return getChatChannelMeta(builtInId).preferOver ?? [];
   }
-  const catalogEntry = getChannelPluginCatalogEntry(pluginId, { env });
+  const catalogEntry =
+    findCatalogEntryForPluginId(pluginId, catalogEntries) ??
+    getChannelPluginCatalogEntry(preferenceKey, { env });
   return catalogEntry?.meta.preferOver ?? [];
 }
 
@@ -416,7 +446,9 @@ function shouldSkipPreferredPluginAutoEnable(
   entry: PluginEnableChange,
   configured: PluginEnableChange[],
   env: NodeJS.ProcessEnv,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
 ): boolean {
+  const entryPreferenceKey = resolveChannelPreferenceKey(entry.pluginId, catalogEntries);
   for (const other of configured) {
     if (other.pluginId === entry.pluginId) {
       continue;
@@ -427,8 +459,8 @@ function shouldSkipPreferredPluginAutoEnable(
     if (isPluginExplicitlyDisabled(cfg, other.pluginId)) {
       continue;
     }
-    const preferOver = resolvePreferredOverIds(other.pluginId, env);
-    if (preferOver.includes(entry.pluginId)) {
+    const preferOver = resolvePreferredOverIds(other.pluginId, env, catalogEntries);
+    if (preferOver.includes(entryPreferenceKey)) {
       return true;
     }
   }
@@ -496,6 +528,11 @@ export function applyPluginAutoEnable(params: {
   if (configured.length === 0) {
     return { config: params.config, changes: [] };
   }
+  const normalizedPlugins = normalizePluginsConfig(params.config.plugins);
+  const catalogEntries = listChannelPluginCatalogEntries({
+    env,
+    loadPaths: normalizedPlugins.loadPaths,
+  });
 
   let next = params.config;
   const changes: string[] = [];
@@ -512,7 +549,7 @@ export function applyPluginAutoEnable(params: {
     if (isPluginExplicitlyDisabled(next, entry.pluginId)) {
       continue;
     }
-    if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, env)) {
+    if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, env, catalogEntries)) {
       continue;
     }
     const allow = next.plugins?.allow;

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -4,6 +4,7 @@ import { hasMeaningfulChannelConfig } from "../channels/config-presence.js";
 import {
   getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries,
+  type ChannelPluginCatalogEntry,
 } from "../channels/plugins/catalog.js";
 import {
   getChatChannelMeta,
@@ -280,13 +281,21 @@ function isProviderConfigured(cfg: OpenClawConfig, providerId: string): boolean 
   return false;
 }
 
-function buildChannelToPluginIdMap(registry: PluginManifestRegistry): Map<string, string> {
+function buildChannelToPluginIdMap(
+  registry: PluginManifestRegistry,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
+): Map<string, string> {
   const map = new Map<string, string>();
   for (const record of registry.plugins) {
     for (const channelId of record.channels) {
       if (channelId && !map.has(channelId)) {
         map.set(channelId, record.id);
       }
+    }
+  }
+  for (const entry of catalogEntries) {
+    if (entry.id && entry.pluginId && !map.has(entry.id)) {
+      map.set(entry.id, entry.pluginId);
     }
   }
   return map;
@@ -305,17 +314,20 @@ function resolvePluginIdForChannel(
   return channelToPluginId.get(channelId) ?? channelId;
 }
 
-function listKnownChannelPluginIds(env: NodeJS.ProcessEnv): string[] {
+function listKnownChannelPluginIds(catalogEntries: readonly ChannelPluginCatalogEntry[]): string[] {
   return Array.from(
     new Set([
       ...listChatChannels().map((meta) => meta.id),
-      ...listChannelPluginCatalogEntries({ env }).map((entry) => entry.id),
+      ...catalogEntries.map((entry) => entry.id),
     ]),
   );
 }
 
-function collectCandidateChannelIds(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
-  const channelIds = new Set<string>(listKnownChannelPluginIds(env));
+function collectCandidateChannelIds(
+  cfg: OpenClawConfig,
+  catalogEntries: readonly ChannelPluginCatalogEntry[],
+): string[] {
+  const channelIds = new Set<string>(listKnownChannelPluginIds(catalogEntries));
   const configuredChannels = cfg.channels as Record<string, unknown> | undefined;
   if (!configuredChannels || typeof configuredChannels !== "object") {
     return Array.from(channelIds);
@@ -336,9 +348,10 @@ function resolveConfiguredPlugins(
   registry: PluginManifestRegistry,
 ): PluginEnableChange[] {
   const changes: PluginEnableChange[] = [];
+  const catalogEntries = listChannelPluginCatalogEntries({ env });
   // Build reverse map: channel ID → plugin ID from installed plugin manifests.
-  const channelToPluginId = buildChannelToPluginIdMap(registry);
-  for (const channelId of collectCandidateChannelIds(cfg, env)) {
+  const channelToPluginId = buildChannelToPluginIdMap(registry, catalogEntries);
+  for (const channelId of collectCandidateChannelIds(cfg, catalogEntries)) {
     const pluginId = resolvePluginIdForChannel(channelId, channelToPluginId);
     if (isChannelConfigured(cfg, channelId, env)) {
       changes.push({ pluginId, reason: `${channelId} configured` });

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -1,22 +1,21 @@
 import { hasAnyWhatsAppAuth } from "openclaw/plugin-sdk/whatsapp";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import { hasMeaningfulChannelConfig } from "../channels/config-presence.js";
-import {
-  getChannelPluginCatalogEntry,
-  listChannelPluginCatalogEntries,
-  type ChannelPluginCatalogEntry,
-} from "../channels/plugins/catalog.js";
+import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
 import {
   getChatChannelMeta,
   listChatChannels,
   normalizeChatChannelId,
 } from "../channels/registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { discoverOpenClawPlugins, type PluginCandidate } from "../plugins/discovery.js";
 import {
   loadPluginManifestRegistry,
   type PluginManifestRegistry,
 } from "../plugins/manifest-registry.js";
-import { isRecord } from "../utils.js";
+import { loadPluginManifest } from "../plugins/manifest.js";
+import { isPathInside, safeStatSync } from "../plugins/path-safety.js";
+import { isRecord, resolveUserPath } from "../utils.js";
 import type { OpenClawConfig } from "./config.js";
 import { ensurePluginAllowlisted } from "./plugins-allowlist.js";
 
@@ -30,12 +29,236 @@ export type PluginAutoEnableResult = {
   changes: string[];
 };
 
+type AutoEnableChannelCatalogEntry = {
+  id: string;
+  pluginId?: string;
+  preferOver: string[];
+};
+
+type PathMatcher = {
+  exact: Set<string>;
+  dirs: string[];
+};
+
+type InstallTrackingRule = {
+  trackedWithoutPaths: boolean;
+  matcher: PathMatcher;
+};
+
+type PluginProvenanceIndex = {
+  loadPathMatcher: PathMatcher;
+  installRules: Map<string, InstallTrackingRule>;
+};
+
 const PROVIDER_PLUGIN_IDS: Array<{ pluginId: string; providerId: string }> = [
   { pluginId: "google", providerId: "google-gemini-cli" },
   { pluginId: "qwen-portal-auth", providerId: "qwen-portal" },
   { pluginId: "copilot-proxy", providerId: "copilot-proxy" },
   { pluginId: "minimax", providerId: "minimax-portal" },
 ];
+
+function createPathMatcher(): PathMatcher {
+  return { exact: new Set<string>(), dirs: [] };
+}
+
+function addPathToMatcher(matcher: PathMatcher, rawPath: string, env: NodeJS.ProcessEnv): void {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return;
+  }
+  const resolved = resolveUserPath(trimmed, env);
+  if (!resolved) {
+    return;
+  }
+  if (matcher.exact.has(resolved) || matcher.dirs.includes(resolved)) {
+    return;
+  }
+  const stat = safeStatSync(resolved);
+  if (stat?.isDirectory()) {
+    matcher.dirs.push(resolved);
+    return;
+  }
+  matcher.exact.add(resolved);
+}
+
+function matchesPathMatcher(matcher: PathMatcher, sourcePath: string): boolean {
+  if (matcher.exact.has(sourcePath)) {
+    return true;
+  }
+  return matcher.dirs.some((dirPath) => isPathInside(dirPath, sourcePath));
+}
+
+function buildProvenanceIndex(params: {
+  config: OpenClawConfig;
+  normalizedLoadPaths: string[];
+  env: NodeJS.ProcessEnv;
+}): PluginProvenanceIndex {
+  const loadPathMatcher = createPathMatcher();
+  for (const loadPath of params.normalizedLoadPaths) {
+    addPathToMatcher(loadPathMatcher, loadPath, params.env);
+  }
+
+  const installRules = new Map<string, InstallTrackingRule>();
+  const installs = params.config.plugins?.installs ?? {};
+  for (const [pluginId, install] of Object.entries(installs)) {
+    const rule: InstallTrackingRule = {
+      trackedWithoutPaths: false,
+      matcher: createPathMatcher(),
+    };
+    const trackedPaths = [install.installPath, install.sourcePath]
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean);
+    if (trackedPaths.length === 0) {
+      rule.trackedWithoutPaths = true;
+    } else {
+      for (const trackedPath of trackedPaths) {
+        addPathToMatcher(rule.matcher, trackedPath, params.env);
+      }
+    }
+    installRules.set(pluginId, rule);
+  }
+
+  return { loadPathMatcher, installRules };
+}
+
+function matchesExplicitInstallRule(params: {
+  pluginId: string;
+  source: string;
+  index: PluginProvenanceIndex;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const sourcePath = resolveUserPath(params.source, params.env);
+  const installRule = params.index.installRules.get(params.pluginId);
+  if (!installRule || installRule.trackedWithoutPaths) {
+    return false;
+  }
+  return matchesPathMatcher(installRule.matcher, sourcePath);
+}
+
+function resolveCandidateDuplicateRank(params: {
+  candidate: PluginCandidate;
+  pluginId: string;
+  provenance: PluginProvenanceIndex;
+  env: NodeJS.ProcessEnv;
+}): number {
+  const isExplicitInstall =
+    params.candidate.origin === "global" &&
+    matchesExplicitInstallRule({
+      pluginId: params.pluginId,
+      source: params.candidate.source,
+      index: params.provenance,
+      env: params.env,
+    });
+
+  if (params.candidate.origin === "config") {
+    return 0;
+  }
+  if (params.candidate.origin === "global" && isExplicitInstall) {
+    return 1;
+  }
+  if (params.candidate.origin === "bundled") {
+    return 2;
+  }
+  if (params.candidate.origin === "workspace") {
+    return 3;
+  }
+  return 4;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
+}
+
+function createAutoEnableChannelCatalogEntry(params: {
+  id: string;
+  pluginId?: string;
+  preferOver?: unknown;
+}): AutoEnableChannelCatalogEntry | null {
+  const id = params.id.trim();
+  if (!id) {
+    return null;
+  }
+  const pluginId = typeof params.pluginId === "string" ? params.pluginId.trim() : "";
+  return {
+    id,
+    ...(pluginId ? { pluginId } : {}),
+    preferOver: normalizeStringList(params.preferOver),
+  };
+}
+
+function buildAutoEnableChannelCatalogEntries(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): AutoEnableChannelCatalogEntry[] {
+  const normalizedPlugins = normalizePluginsConfig(params.config.plugins);
+  const uiCatalogEntries = listChannelPluginCatalogEntries({
+    env: params.env,
+    loadPaths: normalizedPlugins.loadPaths,
+  });
+  const resolved = new Map<string, { entry: AutoEnableChannelCatalogEntry; rank: number }>();
+  const provenance = buildProvenanceIndex({
+    config: params.config,
+    normalizedLoadPaths: normalizedPlugins.loadPaths,
+    env: params.env,
+  });
+  const discovery = discoverOpenClawPlugins({
+    extraPaths: normalizedPlugins.loadPaths,
+    env: params.env,
+  });
+
+  for (const candidate of discovery.candidates) {
+    const channel = candidate.packageManifest?.channel;
+    const channelId = typeof channel?.id === "string" ? channel.id.trim() : "";
+    if (!channelId) {
+      continue;
+    }
+    const manifestResult = loadPluginManifest(candidate.rootDir, candidate.origin !== "bundled");
+    if (!manifestResult.ok) {
+      continue;
+    }
+    const entry = createAutoEnableChannelCatalogEntry({
+      id: channelId,
+      pluginId: manifestResult.manifest.id,
+      preferOver: channel?.preferOver,
+    });
+    if (!entry) {
+      continue;
+    }
+    const rank = resolveCandidateDuplicateRank({
+      candidate,
+      pluginId: manifestResult.manifest.id,
+      provenance,
+      env: params.env,
+    });
+    const existing = resolved.get(entry.id);
+    if (!existing || rank < existing.rank) {
+      resolved.set(entry.id, { entry, rank });
+    }
+  }
+
+  for (const entry of uiCatalogEntries) {
+    if (resolved.has(entry.id)) {
+      continue;
+    }
+    const normalizedEntry = createAutoEnableChannelCatalogEntry({
+      id: entry.id,
+      pluginId: entry.pluginId,
+      preferOver: entry.meta.preferOver,
+    });
+    if (!normalizedEntry) {
+      continue;
+    }
+    resolved.set(normalizedEntry.id, {
+      entry: normalizedEntry,
+      rank: Number.POSITIVE_INFINITY,
+    });
+  }
+
+  return Array.from(resolved.values()).map(({ entry }) => entry);
+}
 
 function hasNonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
@@ -284,7 +507,7 @@ function isProviderConfigured(cfg: OpenClawConfig, providerId: string): boolean 
 
 function buildChannelToPluginIdMap(
   registry: PluginManifestRegistry,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): Map<string, string> {
   const map = new Map<string, string>();
   for (const record of registry.plugins) {
@@ -317,14 +540,14 @@ function resolvePluginIdForChannel(
 
 function findCatalogEntryForPluginId(
   pluginId: string,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
-): ChannelPluginCatalogEntry | undefined {
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
+): AutoEnableChannelCatalogEntry | undefined {
   return catalogEntries.find((entry) => entry.id === pluginId || entry.pluginId === pluginId);
 }
 
 function resolveChannelPreferenceKey(
   pluginId: string,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): string {
   const builtInId = normalizeChatChannelId(pluginId);
   if (builtInId) {
@@ -333,7 +556,9 @@ function resolveChannelPreferenceKey(
   return findCatalogEntryForPluginId(pluginId, catalogEntries)?.id ?? pluginId;
 }
 
-function listKnownChannelPluginIds(catalogEntries: readonly ChannelPluginCatalogEntry[]): string[] {
+function listKnownChannelPluginIds(
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
+): string[] {
   return Array.from(
     new Set([
       ...listChatChannels().map((meta) => meta.id),
@@ -344,7 +569,7 @@ function listKnownChannelPluginIds(catalogEntries: readonly ChannelPluginCatalog
 
 function collectCandidateChannelIds(
   cfg: OpenClawConfig,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): string[] {
   const channelIds = new Set<string>(listKnownChannelPluginIds(catalogEntries));
   const configuredChannels = cfg.channels as Record<string, unknown> | undefined;
@@ -365,13 +590,9 @@ function resolveConfiguredPlugins(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   registry: PluginManifestRegistry,
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): PluginEnableChange[] {
   const changes: PluginEnableChange[] = [];
-  const normalizedPlugins = normalizePluginsConfig(cfg.plugins);
-  const catalogEntries = listChannelPluginCatalogEntries({
-    env,
-    loadPaths: normalizedPlugins.loadPaths,
-  });
   // Build reverse map: channel ID → plugin ID from installed plugin manifests.
   const channelToPluginId = buildChannelToPluginIdMap(registry, catalogEntries);
   for (const channelId of collectCandidateChannelIds(cfg, catalogEntries)) {
@@ -427,26 +648,21 @@ function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
 
 function resolvePreferredOverIds(
   pluginId: string,
-  env: NodeJS.ProcessEnv,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): string[] {
   const preferenceKey = resolveChannelPreferenceKey(pluginId, catalogEntries);
   const builtInId = normalizeChatChannelId(preferenceKey);
   if (builtInId) {
     return getChatChannelMeta(builtInId).preferOver ?? [];
   }
-  const catalogEntry =
-    findCatalogEntryForPluginId(pluginId, catalogEntries) ??
-    getChannelPluginCatalogEntry(preferenceKey, { env });
-  return catalogEntry?.meta.preferOver ?? [];
+  return findCatalogEntryForPluginId(pluginId, catalogEntries)?.preferOver ?? [];
 }
 
 function shouldSkipPreferredPluginAutoEnable(
   cfg: OpenClawConfig,
   entry: PluginEnableChange,
   configured: PluginEnableChange[],
-  env: NodeJS.ProcessEnv,
-  catalogEntries: readonly ChannelPluginCatalogEntry[],
+  catalogEntries: readonly AutoEnableChannelCatalogEntry[],
 ): boolean {
   const entryPreferenceKey = resolveChannelPreferenceKey(entry.pluginId, catalogEntries);
   for (const other of configured) {
@@ -459,7 +675,7 @@ function shouldSkipPreferredPluginAutoEnable(
     if (isPluginExplicitlyDisabled(cfg, other.pluginId)) {
       continue;
     }
-    const preferOver = resolvePreferredOverIds(other.pluginId, env, catalogEntries);
+    const preferOver = resolvePreferredOverIds(other.pluginId, catalogEntries);
     if (preferOver.includes(entryPreferenceKey)) {
       return true;
     }
@@ -524,15 +740,11 @@ export function applyPluginAutoEnable(params: {
   const env = params.env ?? process.env;
   const registry =
     params.manifestRegistry ?? loadPluginManifestRegistry({ config: params.config, env });
-  const configured = resolveConfiguredPlugins(params.config, env, registry);
+  const catalogEntries = buildAutoEnableChannelCatalogEntries({ config: params.config, env });
+  const configured = resolveConfiguredPlugins(params.config, env, registry, catalogEntries);
   if (configured.length === 0) {
     return { config: params.config, changes: [] };
   }
-  const normalizedPlugins = normalizePluginsConfig(params.config.plugins);
-  const catalogEntries = listChannelPluginCatalogEntries({
-    env,
-    loadPaths: normalizedPlugins.loadPaths,
-  });
 
   let next = params.config;
   const changes: string[] = [];
@@ -549,7 +761,7 @@ export function applyPluginAutoEnable(params: {
     if (isPluginExplicitlyDisabled(next, entry.pluginId)) {
       continue;
     }
-    if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, env, catalogEntries)) {
+    if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, catalogEntries)) {
       continue;
     }
     const allow = next.plugins?.allow;


### PR DESCRIPTION
Fixes #50323.

## Summary
- fall back to channel catalog plugin ids when plugin auto-enable cannot derive a channel -> plugin id mapping from the manifest registry alone
- keep manifest-registry mappings authoritative when they are present
- add a disk-backed regression covering the wecom-style channel/plugin-id mismatch path

## Testing
- `npm exec --yes pnpm@10.23.0 -- vitest run src/config/plugin-auto-enable.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check src/config/plugin-auto-enable.ts src/config/plugin-auto-enable.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint src/config/plugin-auto-enable.ts src/config/plugin-auto-enable.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`
  - `build` passed
  - `check` hit unrelated current upstream baseline TypeScript failures in untouched files under `extensions/matrix`, `extensions/phone-control`, `src/agents`, `src/commands/channels`, and `src/infra/matrix-plugin-helper.test.ts`
- `npm exec --yes pnpm@10.23.0 -- test`
  - started the shared repo test runner but did not reach a clean completion signal before stalling in unrelated outbound baseline failures, so I am not claiming a green repo-wide test run

AI-assisted: yes