### PR TITLE
fix: apply default timeout to subagent runs (#25992)

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -74,7 +74,6 @@ import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { FailoverError } from "./failover-error.js";
 import { formatAgentInternalEventsForPrompt } from "./internal-events.js";
-import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { loadModelCatalog } from "./model-catalog.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import {
@@ -614,14 +613,10 @@ async function prepareAgentCommandExecution(
     throw new Error('Invalid verbose level. Use "on", "full", or "off".');
   }
 
-  const laneRaw = typeof opts.lane === "string" ? opts.lane.trim() : "";
-  const isSubagentLane = laneRaw === String(AGENT_LANE_SUBAGENT);
   const timeoutSecondsRaw =
     opts.timeout !== undefined
       ? Number.parseInt(String(opts.timeout), 10)
-      : isSubagentLane
-        ? 0
-        : undefined;
+      : undefined;
   if (
     timeoutSecondsRaw !== undefined &&
     (Number.isNaN(timeoutSecondsRaw) || timeoutSecondsRaw < 0)

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -819,9 +819,8 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
-  // When runTimeoutSeconds is undefined, pass undefined so
-  // resolveAgentTimeoutMs falls back to the global default (600s)
-  // instead of treating 0 as "no timeout" (#25992).
+  // Pass undefined through so resolveAgentTimeoutMs falls back to the
+  // global default (600s) instead of treating 0 as "no timeout" (#25992).
   return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds });
 }
 
@@ -1289,7 +1288,7 @@ export function replaceSubagentRunAfterSteer(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const preserveFrozenResultFallback = params.preserveFrozenResultFallback === true;
   const sessionStartedAt = resolveSubagentSessionStartedAt(source) ?? now;
@@ -1366,7 +1365,7 @@ export function registerSubagentRun(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   subagentRuns.set(params.runId, {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -819,7 +819,10 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
-  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds ?? 0 });
+  // When runTimeoutSeconds is undefined, pass undefined so
+  // resolveAgentTimeoutMs falls back to the global default (600s)
+  // instead of treating 0 as "no timeout" (#25992).
+  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds });
 }
 
 function startSweeper() {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -340,13 +340,15 @@ export async function spawnSubagentDirect(
   const cfg = loadConfig();
 
   // When agent omits runTimeoutSeconds, use the config default.
-  // Falls back to 0 (no timeout) if config key is also unset,
-  // preserving current behavior for existing deployments.
+  // Falls back to undefined if config key is also unset, so the
+  // downstream resolveAgentTimeoutMs() applies the global default
+  // (typically 600s). This prevents subagents from running with no
+  // timeout and holding lanes indefinitely (#25992).
   const cfgSubagentTimeout =
     typeof cfg?.agents?.defaults?.subagents?.runTimeoutSeconds === "number" &&
     Number.isFinite(cfg.agents.defaults.subagents.runTimeoutSeconds)
       ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.runTimeoutSeconds))
-      : 0;
+      : undefined;
   const runTimeoutSeconds =
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
       ? Math.max(0, Math.floor(params.runTimeoutSeconds))


### PR DESCRIPTION
## Summary

Subagent runs default to `timeout=0` (no timeout) in three places, which means stuck subagents can hold lanes **indefinitely** and block the main session — requiring a manual gateway restart to recover.

This PR changes the default to fall through to the global agent timeout (`DEFAULT_AGENT_TIMEOUT_SECONDS = 600s`) when no explicit `runTimeoutSeconds` is configured, so subagents always have a finite timeout.

### Root cause

Three code paths independently default to `0` (no timeout) for subagent runs:

1. **`agent-command.ts`**: `isSubagentLane ? 0 : undefined` — subagent lane explicitly sets timeout to 0
2. **`subagent-spawn.ts`**: `cfgSubagentTimeout` defaults to `0` when `agents.defaults.subagents.runTimeoutSeconds` is not configured
3. **`subagent-registry.ts`**: `resolveSubagentWaitTimeoutMs` uses `runTimeoutSeconds ?? 0`, treating undefined as no-timeout

In `resolveAgentTimeoutMs()`, `overrideSeconds === 0` maps to `MAX_SAFE_TIMEOUT_MS` (~24.8 days), effectively disabling any timeout. A stuck subagent (API hang, exec freeze, etc.) will hold its lane forever.

### Fix

Change all three defaults from `0` to `undefined`, so `resolveAgentTimeoutMs()` falls through to the global default (600s). Users who explicitly set `runTimeoutSeconds: 0` in config or spawn params still get no-timeout behavior.

### Changes

| File | Change |
|------|--------|
| `agent-command.ts` | Remove subagent-lane special case; all lanes use the same timeout resolution |
| `subagent-spawn.ts` | Config fallback: `0` → `undefined` |
| `subagent-registry.ts` | Wait timeout: `?? 0` → pass-through `undefined` |

### Impact

- **Before**: Subagents without explicit timeout run for ~24.8 days (effectively forever)
- **After**: Subagents without explicit timeout use the global default (600s)
- **No breaking change**: Deployments that explicitly set `agents.defaults.subagents.runTimeoutSeconds` or pass `runTimeoutSeconds` in spawn params are unaffected
- **Opt-out**: Set `runTimeoutSeconds: 0` explicitly to restore no-timeout behavior

### Reproduction (from #25992)

1. Spawn multiple subagents without explicit timeout
2. Subagents hit API timeouts or exec hangs
3. Zombie subagents hold lanes indefinitely
4. Main session blocked — `lane wait exceeded: waitedMs=684248` (11+ minutes)
5. Only recoverable via manual session nuke + gateway restart

We experienced this in production: our gateway's single-threaded event loop was completely blocked by a stuck subagent exec call with no timeout protection. The only recovery was `launchctl bootout` + `bootstrap`.

Fixes #25992

🤖 Generated with [Claude Code](https://claude.com/claude-code)