### PR TITLE
Fix embedded read-image media fallback

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -252,4 +252,33 @@ describe("handleToolExecutionEnd media emission", () => {
       mediaUrls: ["/tmp/canvas-output.png"],
     });
   });
+
+  it("emits media from read start args when image content exists but details.path is missing", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tc-read-1",
+      args: { file_path: "/tmp/read-image.png" },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "read",
+      toolCallId: "tc-read-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "Read image file [image/png]" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/read-image.png"],
+    });
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -15,7 +15,7 @@ import type {
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
-  extractToolResultMediaPaths,
+  extractToolResultMediaPathsWithStartArgs,
   extractToolResultText,
   filterToolResultMediaUrls,
   isToolResultError,
@@ -224,8 +224,9 @@ async function emitToolResultOutput(params: {
   isToolError: boolean;
   result: unknown;
   sanitizedResult: unknown;
+  startArgs?: unknown;
 }) {
-  const { ctx, toolName, meta, isToolError, result, sanitizedResult } = params;
+  const { ctx, toolName, meta, isToolError, result, sanitizedResult, startArgs } = params;
   if (!ctx.params.onToolResult) {
     return;
   }
@@ -284,7 +285,10 @@ async function emitToolResultOutput(params: {
 
   // emitToolOutput() already handles MEDIA: directives when enabled; this path
   // only sends raw media URLs for non-verbose delivery mode.
-  const mediaPaths = filterToolResultMediaUrls(toolName, extractToolResultMediaPaths(result));
+  const mediaPaths = filterToolResultMediaUrls(
+    toolName,
+    extractToolResultMediaPathsWithStartArgs(result, startArgs),
+  );
   if (mediaPaths.length === 0) {
     return;
   }
@@ -545,7 +549,15 @@ export async function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  await emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
+  await emitToolResultOutput({
+    ctx,
+    toolName,
+    meta,
+    isToolError,
+    result,
+    sanitizedResult,
+    startArgs: startData?.args,
+  });
 
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractToolResultMediaPaths,
+  extractToolResultMediaPathsWithStartArgs,
   isToolResultMediaTrusted,
 } from "./pi-embedded-subscribe.tools.js";
 
@@ -73,6 +74,27 @@ describe("extractToolResultMediaPaths", () => {
       ],
     };
     expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
+  it("falls back to startArgs.path when image content exists and details.path is missing", () => {
+    const result = {
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: "base64data", mimeType: "image/png" },
+      ],
+    };
+    expect(extractToolResultMediaPathsWithStartArgs(result, { path: "/tmp/from-args.png" })).toEqual(
+      ["/tmp/from-args.png"],
+    );
+  });
+
+  it("falls back to startArgs.file_path when image content exists and details.path is missing", () => {
+    const result = {
+      content: [{ type: "image", data: "base64data", mimeType: "image/png" }],
+    };
+    expect(
+      extractToolResultMediaPathsWithStartArgs(result, { file_path: "  /tmp/from-file-path.png  " }),
+    ).toEqual(["/tmp/from-file-path.png"]);
   });
 
   it("does not fall back to details.path when MEDIA: paths are found", () => {

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -97,6 +97,15 @@ describe("extractToolResultMediaPaths", () => {
     ).toEqual(["/tmp/from-file-path.png"]);
   });
 
+  it("falls back to startArgs.filePath when image content exists and details.path is missing", () => {
+    const result = {
+      content: [{ type: "image", data: "base64data", mimeType: "image/png" }],
+    };
+    expect(
+      extractToolResultMediaPathsWithStartArgs(result, { filePath: "/tmp/from-filePath.png" }),
+    ).toEqual(["/tmp/from-filePath.png"]);
+  });
+
   it("does not fall back to details.path when MEDIA: paths are found", () => {
     const result = {
       content: [

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -195,6 +195,27 @@ export function filterToolResultMediaUrls(
  * path like saving to a temp file).
  */
 export function extractToolResultMediaPaths(result: unknown): string[] {
+  return extractToolResultMediaPathsWithStartArgs(result);
+}
+
+function readToolMediaPathFromArgs(args: unknown): string | undefined {
+  if (!args || typeof args !== "object") {
+    return undefined;
+  }
+  const record = args as Record<string, unknown>;
+  const directCandidates = [record.path, record.file_path, record.filePath];
+  for (const candidate of directCandidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+export function extractToolResultMediaPathsWithStartArgs(
+  result: unknown,
+  startArgs?: unknown,
+): string[] {
   if (!result || typeof result !== "object") {
     return [];
   }
@@ -235,6 +256,10 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {
       return [p];
+    }
+    const argsPath = readToolMediaPathFromArgs(startArgs);
+    if (argsPath) {
+      return [argsPath];
     }
   }
 


### PR DESCRIPTION
## Summary
- fall back to the originating tool args when embedded tool results contain image blocks but no `details.path`
- thread the original `tool_execution_start` args into the non-verbose media emission path
- add regression tests for direct extraction and `handleToolExecutionEnd` media delivery

## Why
Issue [#41744](https://github.com/openclaw/openclaw/issues/41744) has converged on the same failure mode across multiple reports:
- `toolResult` contains `type: "image"`
- `toolResult.details.path` is sometimes missing
- the runtime therefore drops the image before it reaches outbound `mediaUrls`

This is especially visible for embedded `read` calls that successfully load an image file but only preserve the original file path in the start args (`path` / `file_path`).

## Approach
When `extractToolResultMediaPaths(...)` sees image content with no `MEDIA:` token and no `details.path`, it now optionally falls back to the original tool args:
- `path`
- `file_path`
- `filePath`

`handleToolExecutionEnd(...)` already has access to `startData?.args`, so the non-verbose media emission path now passes those args through.

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-subscribe.tools.media.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`
