### PR TITLE
fix(ci): align matrix install smoke dependency checks

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -62,9 +62,9 @@ jobs:
         run: |
           docker run --rm --entrypoint sh openclaw-dockerfile-smoke:local -lc 'which openclaw && openclaw --version'
 
-      # This smoke validates that the build-arg path preinstalls selected
-      # extension deps and that matrix plugin discovery stays healthy in the
-      # final runtime image.
+      # This smoke validates that the build-arg path preinstalls the matrix
+      # runtime deps declared by the plugin and that matrix discovery stays
+      # healthy in the final runtime image.
       - name: Build extension Dockerfile smoke image
         uses: useblacksmith/build-push-action@v2
         with:
@@ -84,9 +84,13 @@ jobs:
             openclaw --version &&
             node -e "
               const Module = require(\"node:module\");
+              const matrixPackage = require(\"/app/extensions/matrix/package.json\");
               const requireFromMatrix = Module.createRequire(\"/app/extensions/matrix/package.json\");
-              requireFromMatrix.resolve(\"@vector-im/matrix-bot-sdk/package.json\");
-              requireFromMatrix.resolve(\"@matrix-org/matrix-sdk-crypto-nodejs/package.json\");
+              const mirroredRuntimeDeps =
+                matrixPackage.openclaw?.releaseChecks?.rootDependencyMirrorAllowlist ?? [];
+              for (const dep of mirroredRuntimeDeps) {
+                requireFromMatrix.resolve(dep);
+              }
               const { spawnSync } = require(\"node:child_process\");
               const run = spawnSync(\"openclaw\", [\"plugins\", \"list\", \"--json\"], { encoding: \"utf8\" });
               if (run.status !== 0) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `install-smoke` hard-codes `@vector-im/matrix-bot-sdk`, but the current `extensions/matrix/package.json` on `main` declares its mirrored runtime deps via `openclaw.releaseChecks.rootDependencyMirrorAllowlist`.
- Why it matters: the matrix Dockerfile smoke fails on `main` and on unrelated PRs even when the currently declared matrix runtime deps are installed.
- What changed: the smoke now reads the matrix plugin's mirrored runtime deps from `extensions/matrix/package.json` and resolves those packages from the built image instead of asserting a stale package name.
- What did NOT change (scope boundary): no CLI, matrix runtime, or plugin implementation code changed; this only updates the workflow assertion.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #40953

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.4.1
- Runtime/container: local temp workspace reproduction of the Dockerfile install inputs; Docker unavailable on this host
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin packaging / install smoke
- Relevant config (redacted): `pnpm 10.23.0`

### Steps

1. Copy the root install manifests plus `extensions/matrix/package.json` into a temp workspace, matching the Dockerfile's `ext-deps` input shape.
2. Run `pnpm install --frozen-lockfile` in that temp workspace.
3. Resolve the packages checked by the install-smoke script from `Module.createRequire(.../extensions/matrix/package.json)`.

### Expected

- The smoke should verify the matrix runtime deps declared by the plugin metadata, not a stale hard-coded package.

### Actual

- Before this change, the smoke required `@vector-im/matrix-bot-sdk`, which is not part of the current matrix plugin dependency set on `main`.
- After this change, the same minimal install path resolves the current mirrored runtime deps successfully.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the Dockerfile install inputs in a temp workspace and confirmed the current matrix mirrored runtime deps resolve from the extension-local require path.
- Edge cases checked: packages that do not export `package.json` (for example `music-metadata`) still resolve because the workflow now resolves package entrypoints rather than `dep/package.json`.
- What you did **not** verify: full Docker build / GitHub Actions run locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous matrix smoke assertions in `.github/workflows/install-smoke.yml`
- Files/config to restore: `.github/workflows/install-smoke.yml`
- Known bad symptoms reviewers should watch for: the install-smoke job starts failing on a matrix package name that is no longer declared by `extensions/matrix/package.json`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the smoke now trusts `openclaw.releaseChecks.rootDependencyMirrorAllowlist` as the source of truth for mirrored matrix runtime deps.
- Mitigation: that metadata already exists to track the mirrored runtime dependency set, and using it removes the current hard-coded drift that is breaking CI.
