### PR TITLE
feat(plugins): add before_message_process hook with first-claim-wins semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/error replies: add a default-off `channels.telegram.silentErrorReplies` setting so bot error replies can be delivered silently across regular replies, native commands, and fallback sends. (#19776) Thanks @ImLukeF.
 - Doctor/refactor: start splitting doctor provider checks into `src/commands/doctor/providers/*` by extracting Telegram first-run and group allowlist warnings into a provider-specific module, keeping the current setup guidance and warning behavior intact. Thanks @vincentkoc.
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) Thanks @scoootscooob.
+- Plugins/hooks: add `before_message_process` hook that fires after message routing but before the AI agent runs; plugins can return `{ handled: true }` to intercept the message and skip AI processing (first-claim-wins across registered plugins).
 - Docs/Zalo: clarify the Marketplace-bot support matrix and config guidance so the Zalo channel docs match current Bot Creator behavior more closely. (#47552) Thanks @No898.
 - secrets: harden read-only SecretRef command paths and diagnostics. (#47794) Thanks @joshavant.
 - Browser/existing-session: support `browser.profiles.<name>.userDataDir` so Chrome DevTools MCP can attach to Brave, Edge, and other Chromium-based browsers through their own user data directories. (#48170) Thanks @velvet-shark.

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -88,7 +88,9 @@ These run inside the agent loop or gateway pipeline:
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
-- **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
+- **`message_received`**: fires when a message arrives before it is dispatched to the agent. Observe or enrich inbound data.
+- **`before_message_process`**: fires after routing but before the AI agent runs. Return `{ handled: true }` to intercept the message and skip AI processing entirely (first-claim-wins across registered plugins).
+- **`message_sending` / `message_sent`**: outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -89,7 +89,7 @@ These run inside the agent loop or gateway pipeline:
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
 - **`message_received`**: fires when a message arrives before it is dispatched to the agent. Observe or enrich inbound data.
-- **`before_message_process`**: fires after routing but before the AI agent runs. Return `{ handled: true }` to intercept the message and skip AI processing entirely (first-claim-wins across registered plugins). When intercepted, the message is silently dropped with no automatic reply — the plugin is responsible for any response to the sender. Note: this hook does not fire for ACP-dispatched messages, which follow their own session lifecycle.
+- **`before_message_process`**: fires after routing and abort checks but **before** send-policy gating and ACP dispatch, so plugins can intercept or forward messages even when the AI agent is disabled (e.g. `/send off`). Return `{ handled: true }` to stop all further processing (first-claim-wins across registered plugins). When intercepted, no automatic reply is sent — the plugin is responsible for any response to the sender.
 - **`message_sending` / `message_sent`**: outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -89,7 +89,7 @@ These run inside the agent loop or gateway pipeline:
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
 - **`message_received`**: fires when a message arrives before it is dispatched to the agent. Observe or enrich inbound data.
-- **`before_message_process`**: fires after routing but before the AI agent runs. Return `{ handled: true }` to intercept the message and skip AI processing entirely (first-claim-wins across registered plugins).
+- **`before_message_process`**: fires after routing but before the AI agent runs. Return `{ handled: true }` to intercept the message and skip AI processing entirely (first-claim-wins across registered plugins). When intercepted, the message is silently dropped with no automatic reply — the plugin is responsible for any response to the sender. Note: this hook does not fire for ACP-dispatched messages, which follow their own session lifecycle.
 - **`message_sending` / `message_sent`**: outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2685,7 +2685,7 @@ describe("dispatchReplyFromConfig", () => {
       expect.objectContaining({
         channelId: "telegram",
         accountId: "acc-2",
-        conversationId: "99",
+        conversationId: "telegram:99",
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -42,6 +42,7 @@ const hookMocks = vi.hoisted(() => ({
       async () => ({ status: "no_handler" as const }),
     ),
     runMessageReceived: vi.fn(async () => {}),
+    runBeforeMessageProcess: vi.fn(async () => undefined),
   },
 }));
 const internalHookMocks = vi.hoisted(() => ({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -310,6 +310,8 @@ describe("dispatchReplyFromConfig", () => {
       status: "no_handler",
     });
     hookMocks.runner.runMessageReceived.mockClear();
+    hookMocks.runner.runBeforeMessageProcess.mockClear();
+    hookMocks.runner.runBeforeMessageProcess.mockResolvedValue(undefined);
     hookMocks.registry.plugins = [];
     internalHookMocks.createInternalHookEvent.mockClear();
     internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
@@ -2562,5 +2564,142 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(blockReplySentTexts).not.toContain("Reasoning:\n_thinking..._");
     expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
+  it("skips AI agent when before_message_process hook returns handled:true", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_message_process") as () => boolean,
+    );
+    hookMocks.runner.runBeforeMessageProcess.mockResolvedValue({
+      handled: true,
+      reason: "forwarded to external system",
+    });
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      From: "telegram:user:42",
+      Body: "Hello",
+      BodyForCommands: "Hello",
+      AccountId: "main",
+      SessionKey: "agent:main:telegram:direct:42",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "ai reply" }) as ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+  });
+
+  it("calls AI agent when before_message_process hook returns undefined", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_message_process") as () => boolean,
+    );
+    hookMocks.runner.runBeforeMessageProcess.mockResolvedValue(undefined);
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      Body: "Hello",
+      BodyForCommands: "Hello",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "ai reply" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "ai reply" }),
+    );
+  });
+
+  it("calls AI agent when before_message_process hook returns handled:false", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_message_process") as () => boolean,
+    );
+    hookMocks.runner.runBeforeMessageProcess.mockResolvedValue({ handled: false });
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Body: "Hello",
+      BodyForCommands: "Hello",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "ai reply" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "ai reply" }),
+    );
+  });
+
+  it("passes correct event fields to before_message_process hook", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_message_process") as () => boolean,
+    );
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      From: "telegram:user:99",
+      Body: "body text",
+      BodyForAgent: "[Audio] Transcript: hi",
+      BodyForCommands: "normalized text",
+      Transcript: "hi",
+      Timestamp: 1710000001000,
+      SenderId: "uid-99",
+      SenderName: "Bob",
+      MessageSid: "msg-bmp-1",
+      AccountId: "acc-2",
+      OriginatingTo: "telegram:99",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "ok" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(hookMocks.runner.runBeforeMessageProcess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: ctx.From,
+        content: "normalized text",
+        body: "body text",
+        bodyForAgent: "[Audio] Transcript: hi",
+        transcript: "hi",
+        timestamp: 1710000001000,
+        senderId: "uid-99",
+        senderName: "Bob",
+        isGroup: false,
+        messageId: "msg-bmp-1",
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "acc-2",
+        conversationId: "99",
+      }),
+    );
+  });
+
+  it("does not call before_message_process hook when no handlers registered", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Body: "hello" });
+    const replyResolver = vi.fn(async () => ({ text: "ok" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(hookMocks.runner.runBeforeMessageProcess).not.toHaveBeenCalled();
+    expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
-import type { PluginTargetedInboundClaimOutcome } from "../../plugins/hooks.js";
+import type {
+  PluginHookBeforeMessageProcessResult,
+  PluginTargetedInboundClaimOutcome,
+} from "../../plugins/hooks.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -42,7 +45,9 @@ const hookMocks = vi.hoisted(() => ({
       async () => ({ status: "no_handler" as const }),
     ),
     runMessageReceived: vi.fn(async () => {}),
-    runBeforeMessageProcess: vi.fn(async () => undefined),
+    runBeforeMessageProcess: vi.fn<() => Promise<PluginHookBeforeMessageProcessResult | undefined>>(
+      async () => undefined,
+    ),
   },
 }));
 const internalHookMocks = vi.hoisted(() => ({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2703,4 +2703,32 @@ describe("dispatchReplyFromConfig", () => {
     expect(hookMocks.runner.runBeforeMessageProcess).not.toHaveBeenCalled();
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
+
+  it("runs before_message_process hook even when sendPolicy is deny", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_message_process") as () => boolean,
+    );
+    hookMocks.runner.runBeforeMessageProcess.mockResolvedValue({
+      handled: true,
+      reason: "forwarded to CRM",
+    });
+    const cfg = {
+      session: { sendPolicy: { default: "deny" } },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Body: "Hello",
+      BodyForCommands: "Hello",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "ai reply" }) as ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(hookMocks.runner.runBeforeMessageProcess).toHaveBeenCalledTimes(1);
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -502,6 +502,34 @@ export async function dispatchReplyFromConfig(params: {
       return acpDispatch;
     }
 
+    // Run before_message_process hook — lets plugins intercept messages before the AI agent.
+    // The first handler returning { handled: true } short-circuits all subsequent processing.
+    if (hookRunner?.hasHooks("before_message_process")) {
+      const interceptResult = await hookRunner.runBeforeMessageProcess(
+        {
+          from: hookContext.from,
+          content: hookContext.content,
+          body: hookContext.body,
+          bodyForAgent: hookContext.bodyForAgent,
+          transcript: hookContext.transcript,
+          timestamp: hookContext.timestamp,
+          senderId: hookContext.senderId,
+          senderName: hookContext.senderName,
+          isGroup: hookContext.isGroup,
+          messageId: hookContext.messageId,
+        },
+        toPluginMessageContext(hookContext),
+      );
+      if (interceptResult?.handled) {
+        logVerbose(
+          `dispatch-from-config: message intercepted by before_message_process hook${interceptResult.reason ? `: ${interceptResult.reason}` : ""}`,
+        );
+        recordProcessed("completed", { reason: "before_message_process_handled" });
+        markIdle("message_completed");
+        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+      }
+    }
+
     // Track accumulated block text for TTS generation after streaming completes.
     // When block streaming succeeds, there's no final reply, so we need to generate
     // TTS audio separately from the accumulated block content.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -456,6 +456,36 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal, counts };
     }
 
+    // Run before_message_process hook — fires before send-policy gating and ACP dispatch,
+    // so plugins can intercept or forward messages even when the AI agent is disabled
+    // (e.g. /send off or config-level send policy deny).
+    // The first handler returning { handled: true } short-circuits all subsequent processing.
+    if (hookRunner?.hasHooks("before_message_process")) {
+      const interceptResult = await hookRunner.runBeforeMessageProcess(
+        {
+          from: hookContext.from,
+          content: hookContext.content,
+          body: hookContext.body,
+          bodyForAgent: hookContext.bodyForAgent,
+          transcript: hookContext.transcript,
+          timestamp: hookContext.timestamp,
+          senderId: hookContext.senderId,
+          senderName: hookContext.senderName,
+          isGroup: hookContext.isGroup,
+          messageId: hookContext.messageId,
+        },
+        toPluginMessageContext(hookContext),
+      );
+      if (interceptResult?.handled) {
+        logVerbose(
+          `dispatch-from-config: message intercepted by before_message_process hook${interceptResult.reason ? `: ${interceptResult.reason}` : ""}`,
+        );
+        recordProcessed("completed", { reason: "before_message_process_handled" });
+        markIdle("message_completed");
+        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+      }
+    }
+
     const bypassAcpForCommand = shouldBypassAcpDispatchForCommand(ctx, cfg);
 
     const sendPolicy = resolveSendPolicy({
@@ -500,34 +530,6 @@ export async function dispatchReplyFromConfig(params: {
     });
     if (acpDispatch) {
       return acpDispatch;
-    }
-
-    // Run before_message_process hook — lets plugins intercept messages before the AI agent.
-    // The first handler returning { handled: true } short-circuits all subsequent processing.
-    if (hookRunner?.hasHooks("before_message_process")) {
-      const interceptResult = await hookRunner.runBeforeMessageProcess(
-        {
-          from: hookContext.from,
-          content: hookContext.content,
-          body: hookContext.body,
-          bodyForAgent: hookContext.bodyForAgent,
-          transcript: hookContext.transcript,
-          timestamp: hookContext.timestamp,
-          senderId: hookContext.senderId,
-          senderName: hookContext.senderName,
-          isGroup: hookContext.isGroup,
-          messageId: hookContext.messageId,
-        },
-        toPluginMessageContext(hookContext),
-      );
-      if (interceptResult?.handled) {
-        logVerbose(
-          `dispatch-from-config: message intercepted by before_message_process hook${interceptResult.reason ? `: ${interceptResult.reason}` : ""}`,
-        );
-        recordProcessed("completed", { reason: "before_message_process_handled" });
-        markIdle("message_completed");
-        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-      }
     }
 
     // Track accumulated block text for TTS generation after streaming completes.

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -32,6 +32,8 @@ import type {
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookBeforeMessageProcessEvent,
+  PluginHookBeforeMessageProcessResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -75,6 +77,8 @@ export type {
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookBeforeMessageProcessEvent,
+  PluginHookBeforeMessageProcessResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -592,6 +596,24 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   /**
+   * Run before_message_process hook.
+   * Fires after message routing but before the AI agent processes the message.
+   * The first handler that returns { handled: true } intercepts the message;
+   * subsequent handlers are skipped and the AI agent is bypassed.
+   * Runs sequentially in priority order (first-claim wins).
+   */
+  async function runBeforeMessageProcess(
+    event: PluginHookBeforeMessageProcessEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<PluginHookBeforeMessageProcessResult | undefined> {
+    return runClaimingHook<"before_message_process", PluginHookBeforeMessageProcessResult>(
+      "before_message_process",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -934,6 +956,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,
     runMessageReceived,
+    runBeforeMessageProcess,
     runMessageSending,
     runMessageSent,
     // Tool hooks

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1687,8 +1687,6 @@ export type PluginHookBeforeMessageProcessEvent = {
   isGroup: boolean;
   /** Provider message ID */
   messageId?: string;
-  /** Additional provider-specific metadata */
-  metadata?: Record<string, unknown>;
 };
 
 export type PluginHookBeforeMessageProcessResult = {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1389,6 +1389,7 @@ export type PluginHookName =
   | "before_reset"
   | "inbound_claim"
   | "message_received"
+  | "before_message_process"
   | "message_sending"
   | "message_sent"
   | "before_tool_call"
@@ -1416,6 +1417,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_reset",
   "inbound_claim",
   "message_received",
+  "before_message_process",
   "message_sending",
   "message_sent",
   "before_tool_call",
@@ -1660,6 +1662,40 @@ export type PluginHookMessageReceivedEvent = {
   content: string;
   timestamp?: number;
   metadata?: Record<string, unknown>;
+};
+
+// before_message_process hook — fires after message routing, before AI agent processes the message.
+// Return { handled: true } to intercept the message and prevent AI agent processing.
+export type PluginHookBeforeMessageProcessEvent = {
+  /** Sender identifier (e.g. phone number, user ID) */
+  from: string;
+  /** Normalised message content (text the agent would see) */
+  content: string;
+  /** Raw message body from the channel, if available */
+  body?: string;
+  /** Body prepared for the agent (e.g. with audio transcript injected) */
+  bodyForAgent?: string;
+  /** Transcribed audio text, if the message contained audio */
+  transcript?: string;
+  /** Unix timestamp (ms) when the message was received */
+  timestamp?: number;
+  /** Provider-level sender ID */
+  senderId?: string;
+  /** Human-readable sender name */
+  senderName?: string;
+  /** Whether this message arrived in a group/channel context */
+  isGroup: boolean;
+  /** Provider message ID */
+  messageId?: string;
+  /** Additional provider-specific metadata */
+  metadata?: Record<string, unknown>;
+};
+
+export type PluginHookBeforeMessageProcessResult = {
+  /** Set to true to intercept the message — AI agent will not process it */
+  handled: boolean;
+  /** Optional description logged when the message is intercepted */
+  reason?: string;
 };
 
 // message_sending hook
@@ -1918,6 +1954,13 @@ export type PluginHookHandlerMap = {
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
+  before_message_process: (
+    event: PluginHookBeforeMessageProcessEvent,
+    ctx: PluginHookMessageContext,
+  ) =>
+    | Promise<PluginHookBeforeMessageProcessResult | void>
+    | PluginHookBeforeMessageProcessResult
+    | void;
   message_sending: (
     event: PluginHookMessageSendingEvent,
     ctx: PluginHookMessageContext,

--- a/src/plugins/wired-hooks-before-message-process.test.ts
+++ b/src/plugins/wired-hooks-before-message-process.test.ts
@@ -23,9 +23,7 @@ describe("before_message_process hook runner", () => {
 
   it("returns handled:true from first handler that intercepts", async () => {
     const handler = vi.fn().mockResolvedValue({ handled: true, reason: "kefu intercept" });
-    const registry = createMockPluginRegistry([
-      { hookName: "before_message_process", handler },
-    ]);
+    const registry = createMockPluginRegistry([{ hookName: "before_message_process", handler }]);
     const runner = createHookRunner(registry);
 
     const result = await runner.runBeforeMessageProcess(
@@ -42,9 +40,7 @@ describe("before_message_process hook runner", () => {
 
   it("returns undefined when handler returns handled:false", async () => {
     const handler = vi.fn().mockResolvedValue({ handled: false });
-    const registry = createMockPluginRegistry([
-      { hookName: "before_message_process", handler },
-    ]);
+    const registry = createMockPluginRegistry([{ hookName: "before_message_process", handler }]);
     const runner = createHookRunner(registry);
 
     const result = await runner.runBeforeMessageProcess(
@@ -57,9 +53,7 @@ describe("before_message_process hook runner", () => {
 
   it("returns undefined when handler returns void", async () => {
     const handler = vi.fn().mockResolvedValue(undefined);
-    const registry = createMockPluginRegistry([
-      { hookName: "before_message_process", handler },
-    ]);
+    const registry = createMockPluginRegistry([{ hookName: "before_message_process", handler }]);
     const runner = createHookRunner(registry);
 
     const result = await runner.runBeforeMessageProcess(
@@ -110,9 +104,7 @@ describe("before_message_process hook runner", () => {
 
   it("passes all event fields to handler", async () => {
     const handler = vi.fn().mockResolvedValue(undefined);
-    const registry = createMockPluginRegistry([
-      { hookName: "before_message_process", handler },
-    ]);
+    const registry = createMockPluginRegistry([{ hookName: "before_message_process", handler }]);
     const runner = createHookRunner(registry);
 
     await runner.runBeforeMessageProcess(

--- a/src/plugins/wired-hooks-before-message-process.test.ts
+++ b/src/plugins/wired-hooks-before-message-process.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Test: before_message_process hook wiring
+ *
+ * Verifies runner dispatch, first-claim-wins semantics, and pass-through
+ * when no handler intercepts.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+
+describe("before_message_process hook runner", () => {
+  it("returns undefined when no hooks are registered", async () => {
+    const registry = createMockPluginRegistry([]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "hello", isGroup: false },
+      { channelId: "telegram" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns handled:true from first handler that intercepts", async () => {
+    const handler = vi.fn().mockResolvedValue({ handled: true, reason: "kefu intercept" });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "help me", isGroup: false },
+      { channelId: "telegram", accountId: "main" },
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      { from: "user-1", content: "help me", isGroup: false },
+      { channelId: "telegram", accountId: "main" },
+    );
+    expect(result).toEqual({ handled: true, reason: "kefu intercept" });
+  });
+
+  it("returns undefined when handler returns handled:false", async () => {
+    const handler = vi.fn().mockResolvedValue({ handled: false });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "hello", isGroup: false },
+      { channelId: "telegram" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when handler returns void", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "hello", isGroup: false },
+      { channelId: "telegram" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("stops at first handler that claims (first-claim-wins)", async () => {
+    const handlerA = vi.fn().mockResolvedValue({ handled: true });
+    const handlerB = vi.fn().mockResolvedValue({ handled: true });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler: handlerA },
+      { hookName: "before_message_process", handler: handlerB },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "hello", isGroup: false },
+      { channelId: "telegram" },
+    );
+
+    expect(handlerA).toHaveBeenCalledTimes(1);
+    expect(handlerB).not.toHaveBeenCalled();
+    expect(result?.handled).toBe(true);
+  });
+
+  it("falls through to second handler when first declines", async () => {
+    const handlerA = vi.fn().mockResolvedValue(undefined);
+    const handlerB = vi.fn().mockResolvedValue({ handled: true, reason: "second plugin" });
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler: handlerA },
+      { hookName: "before_message_process", handler: handlerB },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeMessageProcess(
+      { from: "user-1", content: "hello", isGroup: false },
+      { channelId: "telegram" },
+    );
+
+    expect(handlerA).toHaveBeenCalledTimes(1);
+    expect(handlerB).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ handled: true, reason: "second plugin" });
+  });
+
+  it("passes all event fields to handler", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const registry = createMockPluginRegistry([
+      { hookName: "before_message_process", handler },
+    ]);
+    const runner = createHookRunner(registry);
+
+    await runner.runBeforeMessageProcess(
+      {
+        from: "telegram:user:42",
+        content: "normalized",
+        body: "raw body",
+        bodyForAgent: "[Audio] Transcript: hi",
+        transcript: "hi",
+        timestamp: 1710000000000,
+        senderId: "uid-42",
+        senderName: "Alice",
+        isGroup: true,
+        messageId: "msg-1",
+      },
+      { channelId: "telegram", accountId: "main", conversationId: "group:chat1" },
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "telegram:user:42",
+        content: "normalized",
+        body: "raw body",
+        bodyForAgent: "[Audio] Transcript: hi",
+        transcript: "hi",
+        timestamp: 1710000000000,
+        senderId: "uid-42",
+        senderName: "Alice",
+        isGroup: true,
+        messageId: "msg-1",
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "main",
+        conversationId: "group:chat1",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: the plugin SDK has no message interception hook before the AI agent runs. 
  The existing `message_received` hook is observational (fire-and-forget) and cannot 
  stop downstream agent processing.
- Why it matters: routing plugins (e.g. customer-service plugins) 
  often need to forward inbound messages to external systems before the AI agent replies. 
  In addition, some plugins may need to perform lightweight pre-processing such as 
  authentication checks, request validation, or filtering, and decide whether to skip 
  AI processing entirely.
- What changed: this adds a new `before_message_process` hook that runs after message 
  routing but before the AI agent starts. Plugins can use this hook to intercept 
  messages for forwarding, filtering, or pre-checks (e.g. authentication). If a plugin 
  returns `{ handled: true }`, the message is intercepted and AI processing is skipped. 
  Multiple handlers run sequentially with first-claim-wins semantics.
- What did NOT change: existing hook behavior is unchanged. This does not introduce a 
  full authentication/authorization system and does not modify ACP dispatch, tool 
  execution, session lifecycle, or message routing semantics.

## Relationship with #43422 (before_dispatch)
#43422 proposes a `before_dispatch` hook for authentication gate scenarios. This PR 
takes a different approach:
| Aspect | #43422 (before_dispatch) | This PR (before_message_process) |
|--------|-------------------------|----------------------------------|
| Primary use case | Authentication/authorization | Customer-service routing & pre-processing |
| Event fields | sessionKey, channelId, conversationId, content, isGroup, messageId | from, content, body, bodyForAgent, transcript, timestamp, senderId, senderName, isGroup, messageId |
| Return value | { block?: boolean, replyText?: string } | { handled?: boolean, reason?: string } |
| Reply capability | Can send custom reply when blocked | Intercept only (no reply) |
| Session requirement | Requires sessionKey | Works with or without session |
**Why both?** `before_message_process` provides richer inbound message context 
(body, transcript, senderName, etc.) for customer-service plugins that need to 
forward complete context to external systems. 

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #43418 (Feature Request: before_dispatch hook for pre-LLM interception)
- Related #43422 (PR: feat(plugins): add before_dispatch hook)

## User-visible / Behavior Changes

Plugins can now register `api.on("before_message_process", handler)`:

```ts
api.on("before_message_process", async (event, ctx) => {
  const forwarded = await sendToExternalSystem(event, ctx);
  if (forwarded) {
    return { handled: true, reason: "forwarded to kefu" };
  }
  // return undefined / void / { handled: false } to continue normal AI processing
});
```

- Returning `{ handled: true }` intercepts the inbound message and prevents AI agent processing.
- Returning `undefined`, `void`, or `{ handled: false }` lets the message continue through the normal AI path.
- When multiple plugins register this hook, the first plugin that returns `handled: true` wins and later handlers are not called.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - This adds a new interception capability for plugins, but it does not expand data access or token scope.
  - The hook only allows a plugin to short-circuit AI processing for the current inbound message.
  - First-claim-wins semantics ensure that at most one plugin intercepts a message.
  - Interceptions are logged with an optional reason to make debugging easier.

## Repro + Verification

### Environment

- OS: macOS / Linux / Windows
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): any configured channel such as Telegram or Discord
- Relevant config (redacted): none

### Steps

1. Install a plugin that registers `before_message_process` and returns `{ handled: true }`.
2. Restart the gateway.
3. Send an inbound message through a configured channel.

### Expected

- The AI agent does not process the message.
- The dispatcher returns without queuing a final AI reply.
- Logs show that the message was intercepted by `before_message_process`.

### Actual

- Added focused test coverage for the new hook path:
  - `src/plugins/wired-hooks-before-message-process.test.ts` covers no-hook pass-through, `handled: true` interception, `handled: false` pass-through, `void` pass-through, first-claim-wins behavior, second-handler fallback, and full event field propagation.
  - `src/auto-reply/reply/dispatch-from-config.test.ts` adds dispatch-path coverage for `handled: true` short-circuiting, `undefined` continuing into the AI path, and `handled: false` continuing into the AI path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Relevant coverage:

- `src/plugins/wired-hooks-before-message-process.test.ts`
  - no handlers registered
  - handled true intercepts
  - handled false and void pass through
  - first-claim-wins across multiple handlers
  - full event field propagation
- `src/auto-reply/reply/dispatch-from-config.test.ts`
  - skips AI agent when the hook intercepts
  - continues normal AI processing when the hook does not intercept

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the dispatch path and added tests for both intercept and pass-through behavior.
- Edge cases checked: `handled: false`, `undefined`, no registered hook, and multiple handlers with first-claim-wins behavior.
- What you did **not** verify: production performance under high concurrency with many plugins installed.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove the plugin registration for `before_message_process`, or revert the hook dispatch block in `dispatch-from-config.ts`.
- Files/config to restore: `src/auto-reply/reply/dispatch-from-config.ts`, `src/plugins/hooks.ts`, `src/plugins/types.ts`
- Known bad symptoms reviewers should watch for: inbound messages arrive but the AI agent does not reply because a plugin unexpectedly returned `{ handled: true }`.

## Risks and Mitigations

- Risk: a plugin could accidentally intercept messages and suppress AI responses.
  - Mitigation: interception requires an explicit `{ handled: true }` return value, uses first-claim-wins semantics, and logs an optional reason for debugging.
