### PR TITLE
test(contracts): cover matrix session binding adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: add an expand-to-canvas button on assistant chat bubbles and in-app session navigation from Sessions and Cron views. Thanks @BunsDev.
 - Plugins/context engines: expose `delegateCompactionToRuntime(...)` on the public plugin SDK, refactor the legacy engine to use the shared helper, and clarify `ownsCompaction` delegation semantics for non-owning engines. (#49061) Thanks @jalehman.
 - Plugins/MiniMax: add MiniMax-M2.7 and MiniMax-M2.7-highspeed models and update the default model from M2.5 to M2.7. (#49691) Thanks @liyuan97.
+- Contracts/Matrix: validate Matrix session binding coverage through the real manager, expose the manager on the Matrix runtime API, and let tests pass an explicit state directory for isolated contract setup. (#50369) thanks @ChroniCat.
 
 ### Fixes
 

--- a/extensions/matrix/api.ts
+++ b/extensions/matrix/api.ts
@@ -1,3 +1,8 @@
 export * from "./src/setup-core.js";
 export * from "./src/setup-surface.js";
+export {
+  createMatrixThreadBindingManager,
+  getMatrixThreadBindingManager,
+  resetMatrixThreadBindingsForTests,
+} from "./src/matrix/thread-bindings.js";
 export { matrixOnboardingAdapter as matrixSetupWizard } from "./src/onboarding.js";

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -1,11 +1,6 @@
 export * from "openclaw/plugin-sdk/matrix";
 export * from "./src/auth-precedence.js";
 export {
-  createMatrixThreadBindingManager,
-  getMatrixThreadBindingManager,
-  resetMatrixThreadBindingsForTests,
-} from "./src/matrix/thread-bindings.js";
-export {
   findMatrixAccountEntry,
   hashMatrixAccessToken,
   listMatrixEnvAccountIds,

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -1,6 +1,11 @@
 export * from "openclaw/plugin-sdk/matrix";
 export * from "./src/auth-precedence.js";
 export {
+  createMatrixThreadBindingManager,
+  getMatrixThreadBindingManager,
+  resetMatrixThreadBindingsForTests,
+} from "./src/matrix/thread-bindings.js";
+export {
   findMatrixAccountEntry,
   hashMatrixAccessToken,
   listMatrixEnvAccountIds,

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -173,6 +173,7 @@ function resolveBindingsPath(params: {
   auth: MatrixAuth;
   accountId: string;
   env?: NodeJS.ProcessEnv;
+  stateDir?: string;
 }): string {
   const storagePaths = resolveMatrixStoragePaths({
     homeserver: params.auth.homeserver,
@@ -181,6 +182,7 @@ function resolveBindingsPath(params: {
     accountId: params.accountId,
     deviceId: params.auth.deviceId,
     env: params.env,
+    stateDir: params.stateDir,
   });
   return path.join(storagePaths.rootDir, "thread-bindings.json");
 }
@@ -341,6 +343,7 @@ export async function createMatrixThreadBindingManager(params: {
   auth: MatrixAuth;
   client: MatrixClient;
   env?: NodeJS.ProcessEnv;
+  stateDir?: string;
   idleTimeoutMs: number;
   maxAgeMs: number;
   enableSweeper?: boolean;
@@ -360,6 +363,7 @@ export async function createMatrixThreadBindingManager(params: {
     auth: params.auth,
     accountId: params.accountId,
     env: params.env,
+    stateDir: params.stateDir,
   });
   const loaded = await loadBindingsFromDisk(filePath, params.accountId);
   for (const record of loaded) {

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -1,16 +1,17 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expect, vi } from "vitest";
 import {
   __testing as discordThreadBindingTesting,
   createThreadBindingManager as createDiscordThreadBindingManager,
 } from "../../../../extensions/discord/runtime-api.js";
 import { createFeishuThreadBindingManager } from "../../../../extensions/feishu/api.js";
+import { createMatrixThreadBindingManager } from "../../../../extensions/matrix/runtime-api.js";
 import { createTelegramThreadBindingManager } from "../../../../extensions/telegram/runtime-api.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   getSessionBindingService,
-  registerSessionBindingAdapter,
-  unregisterSessionBindingAdapter,
-  type SessionBindingBindInput,
   type SessionBindingCapabilities,
   type SessionBindingRecord,
 } from "../../../infra/outbound/session-binding-service.js";
@@ -129,7 +130,7 @@ type DirectoryContractEntry = {
 type SessionBindingContractEntry = {
   id: string;
   expectedCapabilities: SessionBindingCapabilities;
-  getCapabilities: () => SessionBindingCapabilities;
+  getCapabilities: () => SessionBindingCapabilities | Promise<SessionBindingCapabilities>;
   bindAndResolve: () => Promise<SessionBindingRecord>;
   unbindAndVerify: (binding: SessionBindingRecord) => Promise<void>;
   cleanup: () => Promise<void> | void;
@@ -594,72 +595,21 @@ const baseSessionBindingCfg = {
   session: { mainKey: "main", scope: "per-sender" },
 } satisfies OpenClawConfig;
 
-function createMatrixSessionBindingRecord(input: SessionBindingBindInput): SessionBindingRecord {
-  const parentConversationId = input.conversation.parentConversationId?.trim() || undefined;
-  const isChildPlacement = input.placement === "child";
-  const conversationId = isChildPlacement ? "$root" : input.conversation.conversationId.trim();
-  return {
-    bindingId: `matrix:ops:${conversationId}:${input.targetSessionKey}`,
-    targetSessionKey: input.targetSessionKey,
-    targetKind: input.targetKind,
-    conversation: {
-      channel: "matrix",
+async function createContractMatrixThreadBindingManager() {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "matrix-contract-thread-bindings-"));
+  return await createMatrixThreadBindingManager({
+    accountId: "ops",
+    auth: {
       accountId: "ops",
-      conversationId,
-      parentConversationId: isChildPlacement
-        ? parentConversationId || input.conversation.conversationId.trim()
-        : parentConversationId,
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "token",
     },
-    status: "active",
-    boundAt: 1,
-  };
-}
-
-function registerMatrixSessionBindingAdapter() {
-  const bindings = new Map<string, SessionBindingRecord>();
-  unregisterSessionBindingAdapter({
-    channel: "matrix",
-    accountId: "ops",
-  });
-  registerSessionBindingAdapter({
-    channel: "matrix",
-    accountId: "ops",
-    capabilities: {
-      placements: ["current", "child"],
-      bindSupported: true,
-      unbindSupported: true,
-    },
-    bind: async (input) => {
-      const binding = createMatrixSessionBindingRecord(input);
-      bindings.set(binding.bindingId, binding);
-      return binding;
-    },
-    listBySession: (targetSessionKey) =>
-      [...bindings.values()].filter((binding) => binding.targetSessionKey === targetSessionKey),
-    resolveByConversation: (ref) =>
-      [...bindings.values()].find(
-        (binding) =>
-          binding.conversation.channel === ref.channel &&
-          binding.conversation.accountId === ref.accountId &&
-          binding.conversation.conversationId === ref.conversationId &&
-          binding.conversation.parentConversationId ===
-            (ref.parentConversationId?.trim() || undefined),
-      ) ?? null,
-    unbind: async (input) => {
-      const removed = [...bindings.values()].filter((binding) => {
-        if (input.bindingId?.trim()) {
-          return binding.bindingId === input.bindingId.trim();
-        }
-        if (input.targetSessionKey?.trim()) {
-          return binding.targetSessionKey === input.targetSessionKey.trim();
-        }
-        return false;
-      });
-      for (const binding of removed) {
-        bindings.delete(binding.bindingId);
-      }
-      return removed;
-    },
+    client: {} as never,
+    stateDir,
+    idleTimeoutMs: 24 * 60 * 60 * 1000,
+    maxAgeMs: 0,
+    enableSweeper: false,
   });
 }
 
@@ -790,15 +740,15 @@ export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
       unbindSupported: true,
       placements: ["current", "child"],
     },
-    getCapabilities: () => {
-      registerMatrixSessionBindingAdapter();
+    getCapabilities: async () => {
+      await createContractMatrixThreadBindingManager();
       return getSessionBindingService().getCapabilities({
         channel: "matrix",
         accountId: "ops",
       });
     },
     bindAndResolve: async () => {
-      registerMatrixSessionBindingAdapter();
+      await createContractMatrixThreadBindingManager();
       const service = getSessionBindingService();
       const binding = await service.bind({
         targetSessionKey: "agent:matrix:subagent:child-1",
@@ -825,10 +775,8 @@ export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
     },
     unbindAndVerify: unbindAndExpectClearedSessionBinding,
     cleanup: async () => {
-      unregisterSessionBindingAdapter({
-        channel: "matrix",
-        accountId: "ops",
-      });
+      const manager = await createContractMatrixThreadBindingManager();
+      manager.stop();
       expect(
         getSessionBindingService().resolveByConversation({
           channel: "matrix",

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -8,6 +8,9 @@ import { createTelegramThreadBindingManager } from "../../../../extensions/teleg
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   getSessionBindingService,
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingBindInput,
   type SessionBindingCapabilities,
   type SessionBindingRecord,
 } from "../../../infra/outbound/session-binding-service.js";
@@ -136,6 +139,7 @@ function expectResolvedSessionBinding(params: {
   channel: string;
   accountId: string;
   conversationId: string;
+  parentConversationId?: string;
   targetSessionKey: string;
 }) {
   expect(
@@ -143,6 +147,7 @@ function expectResolvedSessionBinding(params: {
       channel: params.channel,
       accountId: params.accountId,
       conversationId: params.conversationId,
+      parentConversationId: params.parentConversationId,
     }),
   )?.toMatchObject({
     targetSessionKey: params.targetSessionKey,
@@ -589,6 +594,75 @@ const baseSessionBindingCfg = {
   session: { mainKey: "main", scope: "per-sender" },
 } satisfies OpenClawConfig;
 
+function createMatrixSessionBindingRecord(input: SessionBindingBindInput): SessionBindingRecord {
+  const parentConversationId = input.conversation.parentConversationId?.trim() || undefined;
+  const isChildPlacement = input.placement === "child";
+  const conversationId = isChildPlacement ? "$root" : input.conversation.conversationId.trim();
+  return {
+    bindingId: `matrix:ops:${conversationId}:${input.targetSessionKey}`,
+    targetSessionKey: input.targetSessionKey,
+    targetKind: input.targetKind,
+    conversation: {
+      channel: "matrix",
+      accountId: "ops",
+      conversationId,
+      parentConversationId: isChildPlacement
+        ? parentConversationId || input.conversation.conversationId.trim()
+        : parentConversationId,
+    },
+    status: "active",
+    boundAt: 1,
+  };
+}
+
+function registerMatrixSessionBindingAdapter() {
+  const bindings = new Map<string, SessionBindingRecord>();
+  unregisterSessionBindingAdapter({
+    channel: "matrix",
+    accountId: "ops",
+  });
+  registerSessionBindingAdapter({
+    channel: "matrix",
+    accountId: "ops",
+    capabilities: {
+      placements: ["current", "child"],
+      bindSupported: true,
+      unbindSupported: true,
+    },
+    bind: async (input) => {
+      const binding = createMatrixSessionBindingRecord(input);
+      bindings.set(binding.bindingId, binding);
+      return binding;
+    },
+    listBySession: (targetSessionKey) =>
+      [...bindings.values()].filter((binding) => binding.targetSessionKey === targetSessionKey),
+    resolveByConversation: (ref) =>
+      [...bindings.values()].find(
+        (binding) =>
+          binding.conversation.channel === ref.channel &&
+          binding.conversation.accountId === ref.accountId &&
+          binding.conversation.conversationId === ref.conversationId &&
+          binding.conversation.parentConversationId ===
+            (ref.parentConversationId?.trim() || undefined),
+      ) ?? null,
+    unbind: async (input) => {
+      const removed = [...bindings.values()].filter((binding) => {
+        if (input.bindingId?.trim()) {
+          return binding.bindingId === input.bindingId.trim();
+        }
+        if (input.targetSessionKey?.trim()) {
+          return binding.targetSessionKey === input.targetSessionKey.trim();
+        }
+        return false;
+      });
+      for (const binding of removed) {
+        bindings.delete(binding.bindingId);
+      }
+      return removed;
+    },
+  });
+}
+
 export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
   {
     id: "discord",
@@ -706,6 +780,63 @@ export const sessionBindingContractRegistry: SessionBindingContractEntry[] = [
         accountId: "default",
         conversationId: "oc_group_chat:topic:om_topic_root",
       });
+    },
+  },
+  {
+    id: "matrix",
+    expectedCapabilities: {
+      adapterAvailable: true,
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current", "child"],
+    },
+    getCapabilities: () => {
+      registerMatrixSessionBindingAdapter();
+      return getSessionBindingService().getCapabilities({
+        channel: "matrix",
+        accountId: "ops",
+      });
+    },
+    bindAndResolve: async () => {
+      registerMatrixSessionBindingAdapter();
+      const service = getSessionBindingService();
+      const binding = await service.bind({
+        targetSessionKey: "agent:matrix:subagent:child-1",
+        targetKind: "subagent",
+        conversation: {
+          channel: "matrix",
+          accountId: "ops",
+          conversationId: "!room:example",
+        },
+        placement: "child",
+        metadata: {
+          label: "codex-matrix",
+          introText: "intro root",
+        },
+      });
+      expectResolvedSessionBinding({
+        channel: "matrix",
+        accountId: "ops",
+        conversationId: "$root",
+        parentConversationId: "!room:example",
+        targetSessionKey: "agent:matrix:subagent:child-1",
+      });
+      return binding;
+    },
+    unbindAndVerify: unbindAndExpectClearedSessionBinding,
+    cleanup: async () => {
+      unregisterSessionBindingAdapter({
+        channel: "matrix",
+        accountId: "ops",
+      });
+      expect(
+        getSessionBindingService().resolveByConversation({
+          channel: "matrix",
+          accountId: "ops",
+          conversationId: "$root",
+          parentConversationId: "!room:example",
+        }),
+      ).toBeNull();
     },
   },
   {

--- a/src/channels/plugins/contracts/registry.ts
+++ b/src/channels/plugins/contracts/registry.ts
@@ -7,7 +7,7 @@ import {
   createThreadBindingManager as createDiscordThreadBindingManager,
 } from "../../../../extensions/discord/runtime-api.js";
 import { createFeishuThreadBindingManager } from "../../../../extensions/feishu/api.js";
-import { createMatrixThreadBindingManager } from "../../../../extensions/matrix/runtime-api.js";
+import { createMatrixThreadBindingManager } from "../../../../extensions/matrix/api.js";
 import { createTelegramThreadBindingManager } from "../../../../extensions/telegram/runtime-api.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {

--- a/src/channels/plugins/contracts/session-binding.contract.test.ts
+++ b/src/channels/plugins/contracts/session-binding.contract.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, vi } from "vitest";
 import { __testing as discordThreadBindingTesting } from "../../../../extensions/discord/src/monitor/thread-bindings.manager.js";
 import { __testing as feishuThreadBindingTesting } from "../../../../extensions/feishu/src/thread-bindings.js";
-import { resetMatrixThreadBindingsForTests } from "../../../../extensions/matrix/runtime-api.js";
+import { resetMatrixThreadBindingsForTests } from "../../../../extensions/matrix/api.js";
 import { __testing as telegramThreadBindingTesting } from "../../../../extensions/telegram/src/thread-bindings.js";
 import { __testing as sessionBindingTesting } from "../../../infra/outbound/session-binding-service.js";
 import { sessionBindingContractRegistry } from "./registry.js";

--- a/src/channels/plugins/contracts/session-binding.contract.test.ts
+++ b/src/channels/plugins/contracts/session-binding.contract.test.ts
@@ -1,15 +1,32 @@
-import { beforeEach, describe } from "vitest";
+import { beforeEach, describe, vi } from "vitest";
 import { __testing as discordThreadBindingTesting } from "../../../../extensions/discord/src/monitor/thread-bindings.manager.js";
 import { __testing as feishuThreadBindingTesting } from "../../../../extensions/feishu/src/thread-bindings.js";
+import { resetMatrixThreadBindingsForTests } from "../../../../extensions/matrix/runtime-api.js";
 import { __testing as telegramThreadBindingTesting } from "../../../../extensions/telegram/src/thread-bindings.js";
 import { __testing as sessionBindingTesting } from "../../../infra/outbound/session-binding-service.js";
 import { sessionBindingContractRegistry } from "./registry.js";
 import { installSessionBindingContractSuite } from "./suites.js";
 
+vi.mock("../../../../extensions/matrix/src/matrix/send.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../../extensions/matrix/src/matrix/send.js")
+  >("../../../../extensions/matrix/src/matrix/send.js");
+  return {
+    ...actual,
+    sendMessageMatrix: vi.fn(
+      async (_to: string, _message: string, opts?: { threadId?: string }) => ({
+        messageId: opts?.threadId ? "$reply" : "$root",
+        roomId: "!room:example",
+      }),
+    ),
+  };
+});
+
 beforeEach(() => {
   sessionBindingTesting.resetSessionBindingAdaptersForTests();
   discordThreadBindingTesting.resetThreadBindingsForTests();
   feishuThreadBindingTesting.resetFeishuThreadBindingsForTests();
+  resetMatrixThreadBindingsForTests();
   telegramThreadBindingTesting.resetTelegramThreadBindingsForTests();
 });
 

--- a/src/channels/plugins/contracts/suites.ts
+++ b/src/channels/plugins/contracts/suites.ts
@@ -478,14 +478,14 @@ export function installChannelDirectoryContractSuite(params: {
 }
 
 export function installSessionBindingContractSuite(params: {
-  getCapabilities: () => SessionBindingCapabilities;
+  getCapabilities: () => SessionBindingCapabilities | Promise<SessionBindingCapabilities>;
   bindAndResolve: () => Promise<SessionBindingRecord>;
   unbindAndVerify: (binding: SessionBindingRecord) => Promise<void>;
   cleanup: () => Promise<void> | void;
   expectedCapabilities: SessionBindingCapabilities;
 }) {
-  it("registers the expected session binding capabilities", () => {
-    expect(params.getCapabilities()).toEqual(params.expectedCapabilities);
+  it("registers the expected session binding capabilities", async () => {
+    expect(await params.getCapabilities()).toEqual(params.expectedCapabilities);
   });
 
   it("binds and resolves a session binding through the shared service", async () => {


### PR DESCRIPTION
## Summary

- Problem: the channel contract registry now discovers a Matrix session binding adapter, but `sessionBindingContractRegistry` did not include a matching Matrix entry.
- Why it matters: `src/channels/plugins/contracts/registry.contract.test.ts` fails because the explicit session-binding contract coverage drifts from the adapters registered by channel implementations.
- What changed: added Matrix session-binding coverage to the contract registry and updated the shared session-binding contract suite so capability checks can be async when setup needs lightweight adapter initialization.
- What did NOT change (scope boundary): this does not change Matrix runtime behavior, gateway behavior, or the production session-binding service implementation.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Tests
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #49795

## User-visible / Behavior Changes

No user-visible product behavior changes. This only restores contract coverage so CI correctly validates Matrix session binding support.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - None.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/Vitest dev environment
- Relevant area: `src/channels/plugins/contracts`

### Steps

1. Run `pnpm test -- src/channels/plugins/contracts`.
2. Observe that the registry contract expects explicit session-binding coverage for every registered channel adapter.
3. With this change, Matrix is included in the explicit registry and the session-binding capability check supports async setup.

### Expected

- Contract discovery and explicit registry stay aligned.
- Matrix session binding coverage is exercised in the shared contract suite.

### Actual

- Before this change, the registry contract drifted because Matrix registered a session binding adapter but had no explicit contract entry.

## Evidence

- Local verification:
  - `$env:OPENCLAW_TEST_PROFILE='low'; pnpm test -- src/channels/plugins/contracts`

## Human Verification (required)

- Verified scenarios:
  - `src/channels/plugins/contracts` passes with Matrix session-binding coverage included.
  - The shared session-binding contract suite still passes for existing channel entries after allowing async capability setup.
- What I did not verify:
  - Full repository CI matrix
  - Non-contract Matrix runtime behavior outside the contract harness

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `81e81fc1`.
- Files/config to restore:
  - `src/channels/plugins/contracts/registry.ts`
  - `src/channels/plugins/contracts/suites.ts`

## Risks and Mitigations

- Risk:
  - Contract harness could diverge from production adapter behavior if the lightweight Matrix stub stops matching the intended capabilities.
- Mitigation:
  - The added contract is intentionally narrow and only covers the session-binding surface required by the registry consistency check.
