### PR TITLE
CLI: add LLM log source with pretty trace output

### DIFF
--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { colorize, theme } from "../terminal/theme.js";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
-import { formatLogTimestamp } from "./logs-cli.js";
+import { formatLogTimestamp, formatPrettyJson } from "./logs-cli.js";
 
 const callGatewayFromCli = vi.fn();
 
@@ -34,6 +35,7 @@ describe("logs cli", () => {
   it("writes output directly to stdout/stderr", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",
+      source: "gateway",
       cursor: 1,
       size: 123,
       lines: ["raw line"],
@@ -56,13 +58,14 @@ describe("logs cli", () => {
 
     expect(stdoutWrites.join("")).toContain("Log file:");
     expect(stdoutWrites.join("")).toContain("raw line");
-    expect(stderrWrites.join("")).toContain("Log tail truncated");
+    expect(stderrWrites.join("")).toContain("older lines were omitted");
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 
   it("wires --local-time through CLI parsing and emits local timestamps", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",
+      source: "gateway",
       lines: [
         JSON.stringify({
           time: "2025-01-01T12:00:00.000Z",
@@ -90,6 +93,7 @@ describe("logs cli", () => {
   it("warns when the output pipe closes", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",
+      source: "gateway",
       lines: ["line one"],
     });
 
@@ -107,6 +111,260 @@ describe("logs cli", () => {
     await runLogsCli(["logs"]);
 
     expect(stderrWrites.join("")).toContain("output stdout closed");
+  });
+
+  it("renders llm trace lines as pretty-printed json blocks", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/cache-trace.jsonl",
+      source: "llm",
+      lines: [
+        JSON.stringify({
+          ts: "2025-01-01T12:00:00.000Z",
+          stage: "prompt:before",
+          provider: "openai",
+          modelId: "gpt-5.4",
+          prompt: "hello world",
+          messages: [{ role: "user", content: "check token usage" }],
+        }),
+      ],
+    });
+
+    const stdoutWrites: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "llm", "--plain"]);
+
+    const output = stdoutWrites.join("");
+    expect(output).toContain("cache-trace.jsonl");
+    expect(output).toContain("(llm)");
+    expect(output).toContain("prompt:before openai/gpt-5.4");
+    expect(output).toContain('  "prompt": "hello world"');
+    expect(output).toContain('  "messages": [');
+    expect(output).toContain("    {");
+  });
+
+  it("colors JSON string values even when they are followed by commas", () => {
+    const output = formatPrettyJson(
+      {
+        type: "thinking",
+        thinking: "waiting for new content",
+        thinkingSignature: "reasoning",
+      },
+      true,
+    );
+
+    expect(output).toContain(colorize(true, theme.success, '"thinking"'));
+    expect(output).toContain(colorize(true, theme.success, '"waiting for new content"'));
+    expect(output).toContain(colorize(true, theme.success, '"reasoning"'));
+  });
+
+  it("prints a hint when llm trace is disabled", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/cache-trace.jsonl",
+      source: "llm",
+      lines: [],
+      hint: "LLM logs are disabled. Enable diagnostics.cacheTrace.enabled=true.",
+    });
+
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "llm", "--plain"]);
+
+    expect(stdoutWrites.join("")).toContain("cache-trace.jsonl");
+    expect(stderrWrites.join("")).toContain("llm: LLM logs are disabled");
+  });
+
+  it("uses a larger default max-bytes window for llm logs", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/cache-trace.jsonl",
+      source: "llm",
+      lines: [],
+    });
+
+    await runLogsCli(["logs", "--source", "llm"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "logs.tail",
+      expect.objectContaining({ source: "llm" }),
+      expect.objectContaining({ maxBytes: 1_000_000, source: "llm" }),
+      expect.anything(),
+    );
+  });
+
+  it("explains when a trace line is larger than the current tail window", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/cache-trace.jsonl",
+      source: "llm",
+      lines: [],
+      truncated: true,
+    });
+
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "llm", "--plain", "--max-bytes", "200000"]);
+
+    expect(stderrWrites.join("")).toContain("before a full trace line was captured");
+  });
+
+  it("suppresses truncation noise when llm tail already includes complete events", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/cache-trace.jsonl",
+      source: "llm",
+      truncated: true,
+      lines: [
+        JSON.stringify({
+          ts: "2025-01-01T12:00:00.000Z",
+          stage: "session:after",
+          provider: "openai",
+          modelId: "gpt-5.4",
+          messages: [{ role: "assistant", content: "latest answer" }],
+          usage: { input: 10, output: 5, totalTokens: 15 },
+        }),
+      ],
+    });
+
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "llm", "--plain"]);
+
+    expect(stderrWrites.join("")).not.toContain("Log tail truncated");
+  });
+
+  it("combines all sources in chronological order", async () => {
+    callGatewayFromCli
+      .mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        source: "gateway",
+        lines: [
+          JSON.stringify({
+            time: "2025-01-01T12:00:02.000Z",
+            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
+            0: "gateway line",
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        file: "/tmp/cache-trace.jsonl",
+        source: "llm",
+        lines: [
+          JSON.stringify({
+            ts: "2025-01-01T12:00:01.000Z",
+            stage: "prompt:before",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            prompt: "first",
+          }),
+        ],
+      });
+
+    const stdoutWrites: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "all", "--plain"]);
+
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      1,
+      "logs.tail",
+      expect.objectContaining({ source: "all" }),
+      expect.objectContaining({ source: "gateway" }),
+      expect.anything(),
+    );
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      2,
+      "logs.tail",
+      expect.objectContaining({ source: "all" }),
+      expect.objectContaining({ source: "llm" }),
+      expect.anything(),
+    );
+    const output = stdoutWrites.join("");
+    const llmIndex = output.indexOf("prompt:before openai/gpt-5.4");
+    const gatewayIndex = output.indexOf("gateway line");
+    expect(llmIndex).toBeGreaterThan(-1);
+    expect(gatewayIndex).toBeGreaterThan(llmIndex);
+  });
+
+  it("prints the llm-disabled hint during --source all even when llm lines exist", async () => {
+    callGatewayFromCli
+      .mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        source: "gateway",
+        lines: [],
+      })
+      .mockResolvedValueOnce({
+        file: "/tmp/cache-trace.jsonl",
+        source: "llm",
+        lines: [
+          JSON.stringify({
+            ts: "2025-01-01T12:00:01.000Z",
+            stage: "session:after",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            messages: [{ role: "assistant", content: "old output" }],
+          }),
+        ],
+        hint: "LLM logs are disabled for the current gateway process. Existing cache-trace.jsonl contents may be historical.",
+      });
+
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "all", "--plain"]);
+
+    expect(stderrWrites.join("")).toContain(
+      "llm: LLM logs are disabled for the current gateway process",
+    );
+    expect(stderrWrites.join("")).toContain("historical");
+  });
+
+  it("tags truncation notices with their source during --source all", async () => {
+    callGatewayFromCli
+      .mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        source: "gateway",
+        lines: ["raw line"],
+        truncated: true,
+      })
+      .mockResolvedValueOnce({
+        file: "/tmp/cache-trace.jsonl",
+        source: "llm",
+        lines: [],
+      });
+
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runLogsCli(["logs", "--source", "all", "--plain"]);
+
+    expect(stderrWrites.join("")).toContain("gateway: Showing only the most recent log tail");
   });
 
   describe("formatLogTimestamp", () => {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -12,12 +12,17 @@ import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
 type LogsTailPayload = {
   file?: string;
+  source?: "gateway" | "llm";
   cursor?: number;
   size?: number;
   lines?: string[];
   truncated?: boolean;
   reset?: boolean;
+  hint?: string;
 };
+
+type LogsSource = "gateway" | "llm";
+type LogsSourceOption = LogsSource | "all";
 
 type LogsCliOptions = {
   limit?: string;
@@ -28,11 +33,14 @@ type LogsCliOptions = {
   plain?: boolean;
   color?: boolean;
   localTime?: boolean;
+  source?: LogsSourceOption;
   url?: string;
   token?: string;
   timeout?: string;
   expectFinal?: boolean;
 };
+
+const DEFAULT_LOGS_MAX_BYTES = 1_000_000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) {
@@ -44,21 +52,40 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 async function fetchLogs(
   opts: LogsCliOptions,
+  source: LogsSource,
   cursor: number | undefined,
   showProgress: boolean,
 ): Promise<LogsTailPayload> {
   const limit = parsePositiveInt(opts.limit, 200);
-  const maxBytes = parsePositiveInt(opts.maxBytes, 250_000);
+  const maxBytes = parsePositiveInt(opts.maxBytes, DEFAULT_LOGS_MAX_BYTES);
   const payload = await callGatewayFromCli(
     "logs.tail",
     opts,
-    { cursor, limit, maxBytes },
+    { cursor, limit, maxBytes, source },
     { progress: showProgress },
   );
   if (!payload || typeof payload !== "object") {
     throw new Error("Unexpected logs.tail response");
   }
   return payload as LogsTailPayload;
+}
+
+function resolveSources(source: LogsSourceOption | undefined): LogsSource[] {
+  if (source === "all") {
+    return ["gateway", "llm"];
+  }
+  return [source ?? "gateway"];
+}
+
+function parseSourceOption(source: string | undefined): LogsSourceOption {
+  if (!source || source === "gateway" || source === "llm" || source === "all") {
+    return (source ?? "gateway") as LogsSourceOption;
+  }
+  throw new Error(`Invalid --source value: ${source}. Expected gateway, llm, or all.`);
+}
+
+function toPublicSource(source: LogsSource | undefined): "gateway" | "llm" {
+  return source === "gateway" ? "gateway" : "llm";
 }
 
 export function formatLogTimestamp(
@@ -86,26 +113,37 @@ export function formatLogTimestamp(
   return timeString;
 }
 
-function formatLogLine(
-  raw: string,
+type DisplayLine = {
+  time?: string;
+  level?: string;
+  label?: string;
+  message: string;
+};
+
+type ParsedTraceLine = {
+  raw: string;
+  time?: string;
+  level?: string;
+  label: string;
+  message: string;
+  parsed: Record<string, unknown>;
+};
+
+function formatDisplayLine(
+  line: DisplayLine,
   opts: {
     pretty: boolean;
     rich: boolean;
     localTime: boolean;
   },
 ): string {
-  const parsed = parseLogLine(raw);
-  if (!parsed) {
-    return raw;
-  }
-  const label = parsed.subsystem ?? parsed.module ?? "";
-  const time = formatLogTimestamp(parsed.time, opts.pretty ? "pretty" : "plain", opts.localTime);
-  const level = parsed.level ?? "";
+  const time = formatLogTimestamp(line.time, opts.pretty ? "pretty" : "plain", opts.localTime);
+  const level = line.level ?? "";
+  const label = line.label ?? "";
   const levelLabel = level.padEnd(5).trim();
-  const message = parsed.message || parsed.raw;
 
   if (!opts.pretty) {
-    return [time, level, label, message].filter(Boolean).join(" ").trim();
+    return [time, level, label, line.message].filter(Boolean).join(" ").trim();
   }
 
   const timeLabel = colorize(opts.rich, theme.muted, time);
@@ -120,15 +158,103 @@ function formatLogLine(
           : colorize(opts.rich, theme.info, levelLabel);
   const messageValue =
     level === "error" || level === "fatal"
-      ? colorize(opts.rich, theme.error, message)
+      ? colorize(opts.rich, theme.error, line.message)
       : level === "warn"
-        ? colorize(opts.rich, theme.warn, message)
+        ? colorize(opts.rich, theme.warn, line.message)
         : level === "debug" || level === "trace"
-          ? colorize(opts.rich, theme.muted, message)
-          : colorize(opts.rich, theme.info, message);
+          ? colorize(opts.rich, theme.muted, line.message)
+          : colorize(opts.rich, theme.info, line.message);
 
   const head = [timeLabel, levelValue, labelValue].filter(Boolean).join(" ");
   return [head, messageValue].filter(Boolean).join(" ").trim();
+}
+
+function colorizeJsonScalar(value: string, rich: boolean): string {
+  const match = value.match(/^(\s*)(.*?)(,?)(\s*)$/u);
+  if (!match) {
+    return value;
+  }
+  const [, leadingWhitespace, scalar, trailingComma, trailingWhitespace] = match;
+  const trimmed = scalar.trim();
+
+  let coloredScalar = scalar;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    coloredScalar = colorize(rich, theme.success, scalar);
+  } else if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/u.test(trimmed)) {
+    coloredScalar = colorize(rich, theme.warn, scalar);
+  } else if (trimmed === "true" || trimmed === "false") {
+    coloredScalar = colorize(rich, theme.accentBright, scalar);
+  } else if (trimmed === "null") {
+    coloredScalar = colorize(rich, theme.muted, scalar);
+  }
+
+  return `${leadingWhitespace}${coloredScalar}${trailingComma}${trailingWhitespace}`;
+}
+
+function colorizePrettyJsonBlock(text: string, rich: boolean): string {
+  if (!rich) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => {
+      const keyMatch = line.match(/^(\s*)"((?:\\.|[^"\\])*)"(:\s*)(.*)$/u);
+      if (keyMatch) {
+        const [, indent, key, separator, rest] = keyMatch;
+        const coloredKey = colorize(rich, theme.accentBright, `"${key}"`);
+        const coloredRest = colorizeJsonScalar(rest, rich);
+        return `${indent}${coloredKey}${separator}${coloredRest}`;
+      }
+      return colorizeJsonScalar(line, rich);
+    })
+    .join("\n");
+}
+
+export function formatPrettyJson(value: unknown, rich: boolean): string {
+  try {
+    return colorizePrettyJsonBlock(JSON.stringify(value, null, 2) ?? String(value), rich);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseTraceLine(raw: string): ParsedTraceLine | null {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.stage !== "string") {
+      return null;
+    }
+
+    const provider =
+      typeof parsed.provider === "string" && parsed.provider.trim().length > 0
+        ? parsed.provider
+        : undefined;
+    const modelId =
+      typeof parsed.modelId === "string" && parsed.modelId.trim().length > 0
+        ? parsed.modelId
+        : undefined;
+    const label = provider ? `llm/${provider}` : "llm";
+
+    const contextLabel = [provider, modelId].filter(Boolean).join("/");
+    const parts = [parsed.stage];
+    if (contextLabel) {
+      parts.push(contextLabel);
+    }
+    if (typeof parsed.error === "string" && parsed.error.trim().length > 0) {
+      parts.push(`error=${parsed.error}`);
+    }
+
+    return {
+      raw,
+      time: typeof parsed.ts === "string" ? parsed.ts : undefined,
+      level: typeof parsed.error === "string" ? "error" : "info",
+      label,
+      message: parts.join(" "),
+      parsed,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function createLogWriters() {
@@ -153,6 +279,125 @@ function createLogWriters() {
     emitJsonLine: (payload: Record<string, unknown>, toStdErr = false) =>
       writer.write(toStdErr ? process.stderr : process.stdout, `${JSON.stringify(payload)}\n`),
   };
+}
+
+type ParsedOutputLine = {
+  source: LogsSource;
+  raw: string;
+  rendered: string;
+  jsonPayload?: Record<string, unknown>;
+  sortTime?: number;
+};
+
+function parseSortTime(raw: string): number | undefined {
+  const parsed = parseLogLine(raw);
+  const timeCandidate = parsed?.time ?? parseTraceLine(raw)?.time;
+  if (!timeCandidate) {
+    return undefined;
+  }
+  const timestamp = new Date(timeCandidate).getTime();
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function buildParsedOutputLine(
+  raw: string,
+  source: LogsSource,
+  opts: {
+    pretty: boolean;
+    rich: boolean;
+    localTime: boolean;
+  },
+): ParsedOutputLine {
+  const parsed = parseLogLine(raw);
+  if (
+    parsed &&
+    (parsed.time || parsed.level || parsed.subsystem || parsed.module || parsed.message.trim())
+  ) {
+    return {
+      source,
+      raw,
+      rendered: formatDisplayLine(
+        {
+          time: parsed.time,
+          level: parsed.level,
+          label: parsed.subsystem ?? parsed.module,
+          message: parsed.message || parsed.raw,
+        },
+        opts,
+      ),
+      jsonPayload: { type: "log", source: toPublicSource(source), ...parsed },
+      sortTime: parseSortTime(raw),
+    };
+  }
+
+  const trace = parseTraceLine(raw);
+  if (trace) {
+    const heading = formatDisplayLine(
+      {
+        time: trace.time,
+        level: trace.level,
+        label: trace.label,
+        message: trace.message,
+      },
+      opts,
+    );
+    return {
+      source,
+      raw,
+      rendered: `${heading}\n${formatPrettyJson(trace.parsed, opts.rich)}\n`,
+      jsonPayload: { type: "trace", source: toPublicSource(source), ...trace },
+      sortTime: parseSortTime(raw),
+    };
+  }
+
+  return {
+    source,
+    raw,
+    rendered: raw,
+    jsonPayload: { type: "raw", source: toPublicSource(source), raw },
+    sortTime: undefined,
+  };
+}
+
+function sortOutputLines(lines: ParsedOutputLine[]): ParsedOutputLine[] {
+  return [...lines].toSorted((a, b) => {
+    const aTime = a.sortTime;
+    const bTime = b.sortTime;
+    if (aTime != null && bTime != null && aTime !== bTime) {
+      return aTime - bTime;
+    }
+    if (aTime != null && bTime == null) {
+      return -1;
+    }
+    if (aTime == null && bTime != null) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+function getTruncatedNotice(payload: LogsTailPayload): string {
+  if (payload.source === "llm" && Array.isArray(payload.lines) && payload.lines.length === 0) {
+    return "Log tail truncated before a full trace line was captured. Retry with a larger --max-bytes value.";
+  }
+  return "Showing only the most recent log tail; older lines were omitted. Increase --max-bytes for more history.";
+}
+
+function shouldReportTruncation(payload: LogsTailPayload): boolean {
+  if (!payload.truncated) {
+    return false;
+  }
+  if (payload.source === "llm" && Array.isArray(payload.lines) && payload.lines.length > 0) {
+    // Trace files are tailed from the end on purpose; avoid noisy notices when
+    // we already captured the newest complete events.
+    return false;
+  }
+  return true;
+}
+
+function formatSourceNotice(source: LogsSource | undefined, message: string): string {
+  const prefix = toPublicSource(source);
+  return `${prefix}: ${message}`;
 }
 
 function emitGatewayError(
@@ -200,13 +445,14 @@ export function registerLogsCli(program: Command) {
     .command("logs")
     .description("Tail gateway file logs via RPC")
     .option("--limit <n>", "Max lines to return", "200")
-    .option("--max-bytes <n>", "Max bytes to read", "250000")
+    .option("--max-bytes <n>", "Max bytes to read", String(DEFAULT_LOGS_MAX_BYTES))
     .option("--follow", "Follow log output", false)
     .option("--interval <ms>", "Polling interval in ms", "1000")
     .option("--json", "Emit JSON log lines", false)
     .option("--plain", "Plain text output (no ANSI styling)", false)
     .option("--no-color", "Disable ANSI colors")
     .option("--local-time", "Display timestamps in local timezone", false)
+    .option("--source <source>", "Log source: gateway, llm, or all", "gateway")
     .addHelpText(
       "after",
       () =>
@@ -218,106 +464,177 @@ export function registerLogsCli(program: Command) {
   logs.action(async (opts: LogsCliOptions) => {
     const { logLine, errorLine, emitJsonLine } = createLogWriters();
     const interval = parsePositiveInt(opts.interval, 1000);
-    let cursor: number | undefined;
     let first = true;
     const jsonMode = Boolean(opts.json);
     const pretty = !jsonMode && Boolean(process.stdout.isTTY) && !opts.plain;
     const rich = isRich() && opts.color !== false;
     const localTime =
       Boolean(opts.localTime) || (!!process.env.TZ && isValidTimeZone(process.env.TZ));
+    const sourceOption = parseSourceOption(opts.source);
+    const sources = resolveSources(sourceOption);
+    const cursors = new Map<LogsSource, number | undefined>();
 
     while (true) {
-      let payload: LogsTailPayload;
-      // Show progress spinner only on first fetch, not during follow polling
-      const showProgress = first && !opts.follow;
       try {
-        payload = await fetchLogs(opts, cursor, showProgress);
+        const payloads = await Promise.all(
+          sources.map(async (source, index) => {
+            const showProgress = first && !opts.follow && index === 0;
+            const payload = await fetchLogs(opts, source, cursors.get(source), showProgress);
+            return { source, payload };
+          }),
+        );
+        if (jsonMode) {
+          if (first) {
+            for (const { payload } of payloads) {
+              if (
+                !emitJsonLine({
+                  type: "meta",
+                  file: payload.file,
+                  source: toPublicSource(payload.source),
+                  cursor: payload.cursor,
+                  size: payload.size,
+                })
+              ) {
+                return;
+              }
+            }
+          }
+
+          const mergedLines = sortOutputLines(
+            payloads.flatMap(({ source, payload }) =>
+              (Array.isArray(payload.lines) ? payload.lines : []).map((line) =>
+                buildParsedOutputLine(line, source, { pretty, rich, localTime }),
+              ),
+            ),
+          );
+          for (const line of mergedLines) {
+            if (
+              !emitJsonLine(
+                line.jsonPayload ?? {
+                  type: "raw",
+                  source: toPublicSource(line.source),
+                  raw: line.raw,
+                },
+              )
+            ) {
+              return;
+            }
+          }
+
+          if (first) {
+            for (const { payload } of payloads) {
+              if (payload.hint) {
+                if (
+                  !emitJsonLine({
+                    type: "hint",
+                    source: toPublicSource(payload.source),
+                    message: payload.hint,
+                  })
+                ) {
+                  return;
+                }
+              }
+            }
+          }
+
+          for (const { payload } of payloads) {
+            if (payload.truncated) {
+              if (!shouldReportTruncation(payload)) {
+                continue;
+              }
+              if (
+                !emitJsonLine({
+                  type: "notice",
+                  source: toPublicSource(payload.source),
+                  message: getTruncatedNotice(payload),
+                })
+              ) {
+                return;
+              }
+            }
+            if (payload.reset) {
+              if (
+                !emitJsonLine({
+                  type: "notice",
+                  source: toPublicSource(payload.source),
+                  message: "Log cursor reset (file rotated).",
+                })
+              ) {
+                return;
+              }
+            }
+          }
+        } else {
+          if (first) {
+            for (const { payload } of payloads) {
+              if (!payload.file) {
+                continue;
+              }
+              const prefix = pretty ? colorize(rich, theme.muted, "Log file:") : "Log file:";
+              const suffix =
+                toPublicSource(payload.source) !== "gateway"
+                  ? ` (${toPublicSource(payload.source)})`
+                  : "";
+              if (!logLine(`${prefix} ${payload.file}${suffix}`)) {
+                return;
+              }
+            }
+          }
+
+          const mergedLines = sortOutputLines(
+            payloads.flatMap(({ source, payload }) =>
+              (Array.isArray(payload.lines) ? payload.lines : []).map((line) =>
+                buildParsedOutputLine(line, source, { pretty, rich, localTime }),
+              ),
+            ),
+          );
+          for (const line of mergedLines) {
+            if (!logLine(line.rendered)) {
+              return;
+            }
+          }
+
+          if (first) {
+            for (const { payload } of payloads) {
+              if (payload.hint) {
+                if (!errorLine(formatSourceNotice(payload.source, payload.hint))) {
+                  return;
+                }
+              }
+            }
+          }
+
+          for (const { payload } of payloads) {
+            if (payload.truncated) {
+              if (!shouldReportTruncation(payload)) {
+                continue;
+              }
+              if (!errorLine(formatSourceNotice(payload.source, getTruncatedNotice(payload)))) {
+                return;
+              }
+            }
+            if (payload.reset) {
+              if (
+                !errorLine(formatSourceNotice(payload.source, "Log cursor reset (file rotated)."))
+              ) {
+                return;
+              }
+            }
+          }
+        }
+
+        for (const { source, payload } of payloads) {
+          const nextCursor =
+            typeof payload.cursor === "number" && Number.isFinite(payload.cursor)
+              ? payload.cursor
+              : cursors.get(source);
+          cursors.set(source, nextCursor);
+        }
       } catch (err) {
         emitGatewayError(err, opts, jsonMode ? "json" : "text", rich, emitJsonLine, errorLine);
         process.exit(1);
         return;
       }
-      const lines = Array.isArray(payload.lines) ? payload.lines : [];
-      if (jsonMode) {
-        if (first) {
-          if (
-            !emitJsonLine({
-              type: "meta",
-              file: payload.file,
-              cursor: payload.cursor,
-              size: payload.size,
-            })
-          ) {
-            return;
-          }
-        }
-        for (const line of lines) {
-          const parsed = parseLogLine(line);
-          if (parsed) {
-            if (!emitJsonLine({ type: "log", ...parsed })) {
-              return;
-            }
-          } else {
-            if (!emitJsonLine({ type: "raw", raw: line })) {
-              return;
-            }
-          }
-        }
-        if (payload.truncated) {
-          if (
-            !emitJsonLine({
-              type: "notice",
-              message: "Log tail truncated (increase --max-bytes).",
-            })
-          ) {
-            return;
-          }
-        }
-        if (payload.reset) {
-          if (
-            !emitJsonLine({
-              type: "notice",
-              message: "Log cursor reset (file rotated).",
-            })
-          ) {
-            return;
-          }
-        }
-      } else {
-        if (first && payload.file) {
-          const prefix = pretty ? colorize(rich, theme.muted, "Log file:") : "Log file:";
-          if (!logLine(`${prefix} ${payload.file}`)) {
-            return;
-          }
-        }
-        for (const line of lines) {
-          if (
-            !logLine(
-              formatLogLine(line, {
-                pretty,
-                rich,
-                localTime,
-              }),
-            )
-          ) {
-            return;
-          }
-        }
-        if (payload.truncated) {
-          if (!errorLine("Log tail truncated (increase --max-bytes).")) {
-            return;
-          }
-        }
-        if (payload.reset) {
-          if (!errorLine("Log cursor reset (file rotated).")) {
-            return;
-          }
-        }
-      }
-      cursor =
-        typeof payload.cursor === "number" && Number.isFinite(payload.cursor)
-          ? payload.cursor
-          : cursor;
       first = false;
 
       if (!opts.follow) {

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -6,6 +6,7 @@ export const LogsTailParamsSchema = Type.Object(
     cursor: Type.Optional(Type.Integer({ minimum: 0 })),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
     maxBytes: Type.Optional(Type.Integer({ minimum: 1, maximum: 1_000_000 })),
+    source: Type.Optional(Type.Union([Type.Literal("gateway"), Type.Literal("llm")])),
   },
   { additionalProperties: false },
 );
@@ -13,11 +14,13 @@ export const LogsTailParamsSchema = Type.Object(
 export const LogsTailResultSchema = Type.Object(
   {
     file: NonEmptyString,
+    source: Type.Optional(Type.Union([Type.Literal("gateway"), Type.Literal("llm")])),
     cursor: Type.Integer({ minimum: 0 }),
     size: Type.Integer({ minimum: 0 }),
     lines: Type.Array(Type.String()),
     truncated: Type.Optional(Type.Boolean()),
     reset: Type.Optional(Type.Boolean()),
+    hint: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/logs.ts
+++ b/src/gateway/server-methods/logs.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { loadConfig } from "../../config/config.js";
+import { resolveStateDir } from "../../config/paths.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { clamp } from "../../utils.js";
+import { resolveUserPath } from "../../utils.js";
+import { parseBooleanValue } from "../../utils/boolean.js";
 import {
   ErrorCodes,
   errorShape,
@@ -11,10 +15,11 @@ import {
 import type { GatewayRequestHandlers } from "./types.js";
 
 const DEFAULT_LIMIT = 500;
-const DEFAULT_MAX_BYTES = 250_000;
+const DEFAULT_MAX_BYTES = 1_000_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
 const ROLLING_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
+type LogsSource = "gateway" | "llm";
 
 function isRollingLogFile(file: string): boolean {
   return ROLLING_LOG_RE.test(path.basename(file));
@@ -48,6 +53,29 @@ async function resolveLogFile(file: string): Promise<string> {
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
     .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
   return sorted[0]?.path ?? file;
+}
+
+function resolveLlmLogFile(): string {
+  const config = loadConfig();
+  const configuredFile = config.diagnostics?.cacheTrace?.filePath?.trim();
+  const envFile = process.env.OPENCLAW_CACHE_TRACE_FILE?.trim();
+  const filePath = configuredFile || envFile;
+  return filePath
+    ? resolveUserPath(filePath)
+    : path.join(resolveStateDir(process.env), "logs", "cache-trace.jsonl");
+}
+
+async function resolveLogFileForSource(source: LogsSource): Promise<string> {
+  if (source === "llm") {
+    return resolveLlmLogFile();
+  }
+  return resolveLogFile(getResolvedLoggerSettings().file);
+}
+
+function isLlmSourceEnabled(): boolean {
+  const config = loadConfig();
+  const envEnabled = parseBooleanValue(process.env.OPENCLAW_CACHE_TRACE);
+  return envEnabled ?? config.diagnostics?.cacheTrace?.enabled ?? false;
 }
 
 async function readLogSlice(params: {
@@ -158,17 +186,26 @@ export const logsHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const p = params as { cursor?: number; limit?: number; maxBytes?: number };
-    const configuredFile = getResolvedLoggerSettings().file;
+    const p = params as {
+      cursor?: number;
+      limit?: number;
+      maxBytes?: number;
+      source?: LogsSource;
+    };
+    const source: LogsSource = p.source ?? "gateway";
     try {
-      const file = await resolveLogFile(configuredFile);
+      const file = await resolveLogFileForSource(source);
       const result = await readLogSlice({
         file,
         cursor: p.cursor,
         limit: p.limit ?? DEFAULT_LIMIT,
         maxBytes: p.maxBytes ?? DEFAULT_MAX_BYTES,
       });
-      respond(true, { file, ...result }, undefined);
+      const hint =
+        source === "llm" && !isLlmSourceEnabled()
+          ? "LLM logs are disabled for the current gateway process. Enable diagnostics.cacheTrace.enabled=true or set OPENCLAW_CACHE_TRACE=1, restart the gateway, then reproduce the run. Existing cache-trace.jsonl contents may be historical."
+          : undefined;
+      respond(true, { file, source, ...result, hint }, undefined);
     } catch (err) {
       respond(
         false,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1043,4 +1043,123 @@ describe("logs.tail", () => {
 
     await fsPromises.rm(tempDir, { recursive: true, force: true });
   });
+
+  it("reads llm logs from the configured llm log path override", async () => {
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-llm-logs-"));
+    const llmLog = path.join(tempDir, "cache-trace.jsonl");
+
+    await fsPromises.writeFile(llmLog, '{"stage":"prompt:before","prompt":"hello"}\n');
+    const previousOverride = process.env.OPENCLAW_CACHE_TRACE_FILE;
+    process.env.OPENCLAW_CACHE_TRACE_FILE = llmLog;
+
+    const respond = vi.fn();
+    await logsHandlers["logs.tail"]({
+      params: { source: "llm" },
+      respond,
+      context: {} as unknown as Parameters<(typeof logsHandlers)["logs.tail"]>[0]["context"],
+      client: null,
+      req: { id: "req-2", type: "req", method: "logs.tail" },
+      isWebchatConnect: logsNoop,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: llmLog,
+        source: "llm",
+        lines: ['{"stage":"prompt:before","prompt":"hello"}'],
+      }),
+      undefined,
+    );
+
+    if (previousOverride === undefined) {
+      delete process.env.OPENCLAW_CACHE_TRACE_FILE;
+    } else {
+      process.env.OPENCLAW_CACHE_TRACE_FILE = previousOverride;
+    }
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns a hint when llm logs are disabled", async () => {
+    const previousEnabled = process.env.OPENCLAW_CACHE_TRACE;
+    const previousFile = process.env.OPENCLAW_CACHE_TRACE_FILE;
+    process.env.OPENCLAW_CACHE_TRACE = "0";
+    delete process.env.OPENCLAW_CACHE_TRACE_FILE;
+
+    const respond = vi.fn();
+    await logsHandlers["logs.tail"]({
+      params: { source: "llm" },
+      respond,
+      context: {} as unknown as Parameters<(typeof logsHandlers)["logs.tail"]>[0]["context"],
+      client: null,
+      req: { id: "req-3", type: "req", method: "logs.tail" },
+      isWebchatConnect: logsNoop,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        source: "llm",
+        hint: expect.stringContaining("LLM logs are disabled"),
+      }),
+      undefined,
+    );
+
+    if (previousEnabled === undefined) {
+      delete process.env.OPENCLAW_CACHE_TRACE;
+    } else {
+      process.env.OPENCLAW_CACHE_TRACE = previousEnabled;
+    }
+    if (previousFile === undefined) {
+      delete process.env.OPENCLAW_CACHE_TRACE_FILE;
+    } else {
+      process.env.OPENCLAW_CACHE_TRACE_FILE = previousFile;
+    }
+  });
+
+  it("still returns a hint when disabled llm logs have historical trace contents", async () => {
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-llm-history-"));
+    const llmLog = path.join(tempDir, "cache-trace.jsonl");
+    const previousEnabled = process.env.OPENCLAW_CACHE_TRACE;
+    const previousFile = process.env.OPENCLAW_CACHE_TRACE_FILE;
+    process.env.OPENCLAW_CACHE_TRACE = "0";
+    process.env.OPENCLAW_CACHE_TRACE_FILE = llmLog;
+    await fsPromises.writeFile(
+      llmLog,
+      '{"stage":"session:after","messages":[{"role":"assistant","content":"old"}]}\n',
+    );
+
+    const respond = vi.fn();
+    await logsHandlers["logs.tail"]({
+      params: { source: "llm" },
+      respond,
+      context: {} as unknown as Parameters<(typeof logsHandlers)["logs.tail"]>[0]["context"],
+      client: null,
+      req: { id: "req-4", type: "req", method: "logs.tail" },
+      isWebchatConnect: logsNoop,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        file: llmLog,
+        source: "llm",
+        lines: ['{"stage":"session:after","messages":[{"role":"assistant","content":"old"}]}'],
+        hint: expect.stringContaining("historical"),
+      }),
+      undefined,
+    );
+
+    if (previousEnabled === undefined) {
+      delete process.env.OPENCLAW_CACHE_TRACE;
+    } else {
+      process.env.OPENCLAW_CACHE_TRACE = previousEnabled;
+    }
+    if (previousFile === undefined) {
+      delete process.env.OPENCLAW_CACHE_TRACE_FILE;
+    } else {
+      process.env.OPENCLAW_CACHE_TRACE_FILE = previousFile;
+    }
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary

This PR extends `openclaw logs` with an `llm` source so model request traces are visible through the CLI, while keeping the implementation aligned with existing `diagnostics.cacheTrace` behavior.

## What changed

- added `--source` support to `openclaw logs`
- exposed `gateway`, `llm`, and `all` as user-facing log sources
- extended `logs.tail` RPC to return source-aware metadata and optional hints
- reused `diagnostics.cacheTrace` for `llm` logs instead of introducing a separate LLM log file
- pretty-printed trace JSON in CLI output
- added ANSI coloring for pretty-printed JSON values in rich TTY mode
- clarified truncation wording so tail notices explain that older lines were omitted
- added explicit warnings when `cacheTrace` is disabled for the current gateway process, even if historical trace files still exist
- unified the default `max-bytes` window to `1000000`

## Why

`openclaw logs` previously only surfaced the main gateway log, which made it hard to investigate sudden token spikes or inspect what was sent to the model.

The repo already had `diagnostics.cacheTrace`, but that trace data was not accessible through the main logs command. This change exposes that existing diagnostic path through `openclaw logs --source llm` and makes the output much easier to inspect during debugging.

## Validation

- `pnpm test src/cli/logs-cli.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts`
- `pnpm build`

## Notes

- `openclaw logs --source llm` depends on `diagnostics.cacheTrace.enabled=true` or `OPENCLAW_CACHE_TRACE=1`
- if trace logging is disabled, the CLI now warns explicitly instead of silently showing stale historical trace data
- `all` includes gateway logs plus the unified `llm` view
