### PR TITLE
Fix WhatsApp duplicated active-listener state across bundled runtime chunks

### DIFF
--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type ActiveListenerModule = typeof import("./active-listener.js");
 
@@ -8,13 +8,21 @@ async function importActiveListenerModule(cacheBust: string): Promise<ActiveList
   return (await import(`${activeListenerModuleUrl}?t=${cacheBust}`)) as ActiveListenerModule;
 }
 
-afterEach(async () => {
+async function resetGlobalListenerState(): Promise<void> {
   const mod = await importActiveListenerModule(`cleanup-${Date.now()}`);
   mod.setActiveWebListener(null);
   mod.setActiveWebListener("work", null);
-});
+}
 
 describe("active WhatsApp listener singleton", () => {
+  beforeEach(async () => {
+    await resetGlobalListenerState();
+  });
+
+  afterEach(async () => {
+    await resetGlobalListenerState();
+  });
+
   it("shares listeners across duplicate module instances", async () => {
     const first = await importActiveListenerModule(`first-${Date.now()}`);
     const second = await importActiveListenerModule(`second-${Date.now()}`);

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -31,27 +31,16 @@ export type ActiveWebListener = {
 // Use process-global symbol keys to survive bundler code-splitting and loader
 // cache splits without depending on fragile string property names.
 const GLOBAL_LISTENERS_KEY = Symbol.for("openclaw.whatsapp.activeListeners");
-const GLOBAL_CURRENT_KEY = Symbol.for("openclaw.whatsapp.currentListener");
 
 type GlobalWithListeners = typeof globalThis & {
   [GLOBAL_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
-  [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
 };
 
 const _global = globalThis as GlobalWithListeners;
 
 _global[GLOBAL_LISTENERS_KEY] ??= new Map<string, ActiveWebListener>();
-_global[GLOBAL_CURRENT_KEY] ??= null;
 
 const listeners = _global[GLOBAL_LISTENERS_KEY];
-
-function getCurrentListener(): ActiveWebListener | null {
-  return _global[GLOBAL_CURRENT_KEY] ?? null;
-}
-
-function setCurrentListener(listener: ActiveWebListener | null): void {
-  _global[GLOBAL_CURRENT_KEY] = listener;
-}
 
 export function resolveWebAccountId(accountId?: string | null): string {
   return (accountId ?? "").trim() || DEFAULT_ACCOUNT_ID;
@@ -93,9 +82,6 @@ export function setActiveWebListener(
     listeners.delete(id);
   } else {
     listeners.set(id, listener);
-  }
-  if (id === DEFAULT_ACCOUNT_ID) {
-    setCurrentListener(listener);
   }
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp outbound sends can fail with `No active WhatsApp Web listener` even while WhatsApp is connected and inbound messaging still works, because the active listener registry is duplicated across bundled runtime chunks.
- Why it matters: `message send`, proactive outbound delivery, and some recovery/retry paths can fail while the channel still appears healthy and other WhatsApp flows continue to work.
- What changed: moved the active WhatsApp listener registry to a process-wide `globalThis` singleton so all chunks share the same listener state instead of maintaining separate module-scoped `Map` instances.
- What did NOT change (scope boundary): this PR does not add a fallback transport, does not change channel health/status policy, and does not introduce any new delivery path beyond fixing the existing listener lookup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49345
- Closes #49209
- Closes #49149
- Closes #50166
- Closes #49217

## User-visible / Behavior Changes

- WhatsApp outbound sends are able to resolve the active listener consistently across bundled runtime chunks.
- This removes a class of failures where outbound sends report `No active WhatsApp Web listener` even though WhatsApp inbound and other outbound paths are still functioning.
- No config or default changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

None.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw source checkout
- Model/provider: Any
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): standard WhatsApp account config with active listener registration

### Steps

1. Run a build where WhatsApp listener state is written from one bundled chunk and read from another.
2. Connect WhatsApp successfully so inbound messaging is active.
3. Trigger an outbound send path that resolves the listener through a different bundled runtime chunk.

### Expected

- Outbound send paths should resolve the same active WhatsApp listener state used by the connected runtime.

### Actual

- Before this change, different chunks can hold different module-scoped listener `Map` instances, causing outbound sends to fail with `No active WhatsApp Web listener`.
- After this change, all chunks share a single process-wide listener registry via `globalThis`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Ran targeted test file `extensions/whatsapp/src/send.test.ts`
- Added and ran `extensions/whatsapp/src/active-listener.test.ts`
- Confirmed listener storage is pinned to a shared `globalThis` registry
- Confirmed existing targeted WhatsApp send tests still pass after the registry change
- Confirmed from live logs that WhatsApp inbound and some outbound paths succeed while other outbound paths fail with `No active WhatsApp Web listener`, matching the duplicated-state diagnosis
- Edge cases checked:
- normal in-process listener send path still works
- no-listener case still throws the same helpful error
- account-scoped listener registration and lookup still work
- poll/reaction/send targeted tests still pass under the shared registry implementation
- What you did **not** verify:
- full end-to-end validation of the patched build on the production-style packaged install
- broader health/status reconciliation beyond the listener registry itself
- every possible bundled runtime path outside the targeted WhatsApp tests and log-based diagnosis

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- revert this PR/commit
- Files/config to restore:
- `extensions/whatsapp/src/active-listener.ts`
- `extensions/whatsapp/src/active-listener.test.ts`
- `extensions/whatsapp/src/send.test.ts`
- Known bad symptoms reviewers should watch for:
- listener lookups still diverging between chunks
- unexpected listener leakage across accounts
- outbound WhatsApp sends failing despite successful listener registration

## Risks and Mitigations

- Risk: this change makes the active WhatsApp listener registry process-global via `globalThis`, so if that registry contract is wrong, multiple WhatsApp runtime paths could now share incorrect state instead of isolated incorrect state.
- Mitigation: the current behavior already fails in real usage because the listener state is unintentionally split across bundled chunks; this PR replaces those accidental duplicate stores with one explicit shared registry, while preserving the same public behavior and listener API.