### PR TITLE
fix(whatsapp): stabilize proactive sends across reconnects and gateway sends

### DIFF
--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveWebListener,
+  clearWebListenerRecovery,
+  getActiveWebListener,
+  requestWebListenerRecovery,
+  setActiveWebListener,
+  setWebListenerRecovery,
+  type ActiveWebListener,
+} from "./active-listener.js";
 
 type ActiveListenerModule = typeof import("./active-listener.js");
 
@@ -8,13 +17,33 @@ async function importActiveListenerModule(cacheBust: string): Promise<ActiveList
   return (await import(`${activeListenerModuleUrl}?t=${cacheBust}`)) as ActiveListenerModule;
 }
 
-afterEach(async () => {
-  const mod = await importActiveListenerModule(`cleanup-${Date.now()}`);
-  mod.setActiveWebListener(null);
-  mod.setActiveWebListener("work", null);
-});
+describe("active WhatsApp listener registry", () => {
+  const listenerA: ActiveWebListener = {
+    sendMessage: vi.fn(async () => ({ messageId: "a" })),
+    sendPoll: vi.fn(async () => ({ messageId: "a" })),
+    sendReaction: vi.fn(async () => {}),
+    sendComposingTo: vi.fn(async () => {}),
+  };
+  const listenerB: ActiveWebListener = {
+    sendMessage: vi.fn(async () => ({ messageId: "b" })),
+    sendPoll: vi.fn(async () => ({ messageId: "b" })),
+    sendReaction: vi.fn(async () => {}),
+    sendComposingTo: vi.fn(async () => {}),
+  };
 
-describe("active WhatsApp listener singleton", () => {
+  afterEach(async () => {
+    setActiveWebListener(null);
+    setActiveWebListener("work", null);
+    setWebListenerRecovery(null, null);
+    setWebListenerRecovery("work", null);
+
+    const mod = await importActiveListenerModule(`cleanup-${Date.now()}`);
+    mod.setActiveWebListener(null);
+    mod.setActiveWebListener("work", null);
+    mod.setWebListenerRecovery?.(null, null);
+    mod.setWebListenerRecovery?.("work", null);
+  });
+
   it("shares listeners across duplicate module instances", async () => {
     const first = await importActiveListenerModule(`first-${Date.now()}`);
     const second = await importActiveListenerModule(`second-${Date.now()}`);
@@ -32,5 +61,32 @@ describe("active WhatsApp listener singleton", () => {
       accountId: "work",
       listener,
     });
+  });
+
+  it("does not let a stale listener clear a newer listener", () => {
+    setActiveWebListener("work", listenerA);
+    setActiveWebListener("work", listenerB);
+
+    expect(clearActiveWebListener("work", listenerA)).toBe(false);
+    expect(getActiveWebListener("work")).toBe(listenerB);
+
+    expect(clearActiveWebListener("work", listenerB)).toBe(true);
+    expect(getActiveWebListener("work")).toBeNull();
+  });
+
+  it("does not let a stale recovery hook clear a newer recovery hook", async () => {
+    const recoveryA = vi.fn(async () => true);
+    const recoveryB = vi.fn(async () => true);
+
+    setWebListenerRecovery("work", recoveryA);
+    setWebListenerRecovery("work", recoveryB);
+
+    expect(clearWebListenerRecovery("work", recoveryA)).toBe(false);
+    await requestWebListenerRecovery("work", "probe");
+    expect(recoveryA).not.toHaveBeenCalled();
+    expect(recoveryB).toHaveBeenCalledWith({ accountId: "work", reason: "probe" });
+
+    expect(clearWebListenerRecovery("work", recoveryB)).toBe(true);
+    expect(await requestWebListenerRecovery("work", "probe-2")).toBe(false);
   });
 });

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -1,6 +1,7 @@
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
+import type { WebListenerCloseReason } from "./inbound/types.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
@@ -26,28 +27,38 @@ export type ActiveWebListener = {
   ) => Promise<void>;
   sendComposingTo: (to: string) => Promise<void>;
   close?: () => Promise<void>;
+  signalClose?: (reason?: WebListenerCloseReason) => void;
 };
+
+export type ActiveWebRecoveryRequest = {
+  accountId: string;
+  reason?: string;
+};
+
+export type ActiveWebRecoveryFn = (
+  request: ActiveWebRecoveryRequest,
+) => Promise<boolean | void> | boolean | void;
 
 // Use process-global symbol keys to survive bundler code-splitting and loader
 // cache splits without depending on fragile string property names.
 const GLOBAL_LISTENERS_KEY = Symbol.for("openclaw.whatsapp.activeListeners");
 const GLOBAL_CURRENT_KEY = Symbol.for("openclaw.whatsapp.currentListener");
+const GLOBAL_RECOVERY_KEY = Symbol.for("openclaw.whatsapp.recoveryHooks");
 
 type GlobalWithListeners = typeof globalThis & {
   [GLOBAL_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
   [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
+  [GLOBAL_RECOVERY_KEY]?: Map<string, ActiveWebRecoveryFn>;
 };
 
 const _global = globalThis as GlobalWithListeners;
 
 _global[GLOBAL_LISTENERS_KEY] ??= new Map<string, ActiveWebListener>();
 _global[GLOBAL_CURRENT_KEY] ??= null;
+_global[GLOBAL_RECOVERY_KEY] ??= new Map<string, ActiveWebRecoveryFn>();
 
 const listeners = _global[GLOBAL_LISTENERS_KEY];
-
-function getCurrentListener(): ActiveWebListener | null {
-  return _global[GLOBAL_CURRENT_KEY] ?? null;
-}
+const recoveryHooks = _global[GLOBAL_RECOVERY_KEY];
 
 function setCurrentListener(listener: ActiveWebListener | null): void {
   _global[GLOBAL_CURRENT_KEY] = listener;
@@ -99,7 +110,61 @@ export function setActiveWebListener(
   }
 }
 
+export function clearActiveWebListener(
+  accountId?: string | null,
+  expectedListener?: ActiveWebListener | null,
+): boolean {
+  const id = resolveWebAccountId(accountId);
+  const current = listeners.get(id) ?? null;
+  if (expectedListener && current !== expectedListener) {
+    return false;
+  }
+  listeners.delete(id);
+  if (id === DEFAULT_ACCOUNT_ID) {
+    setCurrentListener(listeners.get(id) ?? null);
+  }
+  return true;
+}
+
 export function getActiveWebListener(accountId?: string | null): ActiveWebListener | null {
   const id = resolveWebAccountId(accountId);
   return listeners.get(id) ?? null;
+}
+
+export function setWebListenerRecovery(
+  accountId: string | null | undefined,
+  recovery: ActiveWebRecoveryFn | null,
+): void {
+  const id = resolveWebAccountId(accountId);
+  if (!recovery) {
+    recoveryHooks.delete(id);
+    return;
+  }
+  recoveryHooks.set(id, recovery);
+}
+
+export function clearWebListenerRecovery(
+  accountId: string | null | undefined,
+  expectedRecovery?: ActiveWebRecoveryFn | null,
+): boolean {
+  const id = resolveWebAccountId(accountId);
+  const current = recoveryHooks.get(id);
+  if (expectedRecovery && current !== expectedRecovery) {
+    return false;
+  }
+  recoveryHooks.delete(id);
+  return true;
+}
+
+export async function requestWebListenerRecovery(
+  accountId?: string | null,
+  reason?: string,
+): Promise<boolean> {
+  const id = resolveWebAccountId(accountId);
+  const recovery = recoveryHooks.get(id);
+  if (!recovery) {
+    return false;
+  }
+  const result = await recovery({ accountId: id, reason });
+  return result !== false;
 }

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -14,7 +14,13 @@ import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-e
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { defaultRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } from "../accounts.js";
-import { setActiveWebListener } from "../active-listener.js";
+import type { ActiveWebRecoveryRequest } from "../active-listener.js";
+import {
+  clearActiveWebListener,
+  clearWebListenerRecovery,
+  setActiveWebListener,
+  setWebListenerRecovery,
+} from "../active-listener.js";
 import { monitorWebInbox } from "../inbound.js";
 import {
   computeBackoff,
@@ -141,6 +147,32 @@ export async function monitorWebChannel(
   process.once("SIGINT", handleSigint);
 
   let reconnectAttempts = 0;
+  let latestListener: Awaited<ReturnType<typeof monitorWebInbox>> | null = null;
+  let recoveryRequested = false;
+  let wakeReconnect: (() => void) | null = null;
+
+  const recoveryHandler = async ({ reason }: ActiveWebRecoveryRequest) => {
+    recoveryRequested = true;
+    reconnectLogger.info(
+      {
+        accountId: account.accountId,
+        reason: reason ?? "manual-recovery-request",
+        hasActiveListener: Boolean(latestListener),
+      },
+      "web reconnect: recovery requested",
+    );
+    if (latestListener?.signalClose) {
+      latestListener.signalClose({
+        status: 499,
+        isLoggedOut: false,
+        error: reason ?? "requested-recovery",
+      });
+    }
+    wakeReconnect?.();
+    return true;
+  };
+
+  setWebListenerRecovery(account.accountId, recoveryHandler);
 
   while (true) {
     if (stopRequested()) {
@@ -227,6 +259,7 @@ export async function monitorWebChannel(
     });
 
     setActiveWebListener(account.accountId, listener);
+    latestListener = listener;
     unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
       if (!isLikelyWhatsAppCryptoError(reason)) {
         return false;
@@ -245,7 +278,8 @@ export async function monitorWebChannel(
     });
 
     const closeListener = async () => {
-      setActiveWebListener(account.accountId, null);
+      clearActiveWebListener(account.accountId, listener);
+      latestListener = null;
       if (unregisterUnhandled) {
         unregisterUnhandled();
         unregisterUnhandled = null;
@@ -453,10 +487,20 @@ export async function monitorWebChannel(
       `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
     );
     await closeListener();
+    if (recoveryRequested) {
+      recoveryRequested = false;
+      continue;
+    }
+    const waitForWake = new Promise<void>((resolve) => {
+      wakeReconnect = () => resolve();
+    });
     try {
-      await sleep(delay, abortSignal);
+      await Promise.race([sleep(delay, abortSignal), waitForWake]);
     } catch {
       break;
+    } finally {
+      wakeReconnect = null;
+      recoveryRequested = false;
     }
   }
 
@@ -466,4 +510,5 @@ export async function monitorWebChannel(
   emitStatus();
 
   process.removeListener("SIGINT", handleSigint);
+  clearWebListenerRecovery(account.accountId, recoveryHandler);
 }

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
 import { redactIdentifier } from "../../../src/logging/redact-identifier.js";
-import { setActiveWebListener } from "./active-listener.js";
+import { setActiveWebListener, setWebListenerRecovery } from "./active-listener.js";
 
 const loadWebMediaMock = vi.fn();
 vi.mock("./media.js", () => ({
@@ -36,6 +36,8 @@ describe("web outbound", () => {
     setLoggerOverride(null);
     setActiveWebListener(null);
     setActiveWebListener("work", null);
+    setWebListenerRecovery(null, null);
+    setWebListenerRecovery("work", null);
   });
 
   it("sends message via active listener", async () => {
@@ -87,6 +89,35 @@ describe("web outbound", () => {
     await expect(
       sendMessageWhatsApp("+1555", "hi", { verbose: false, accountId: "work" }),
     ).rejects.toThrow(/account: work/);
+  });
+
+  it("requests listener recovery and retries once before failing", async () => {
+    setActiveWebListener(null);
+    setWebListenerRecovery("work", async () => {
+      setTimeout(() => {
+        setActiveWebListener("work", {
+          sendComposingTo,
+          sendMessage,
+          sendPoll,
+          sendReaction,
+        });
+      }, 0);
+      return true;
+    });
+
+    const result = await sendMessageWhatsApp("+1555", "hi", {
+      verbose: false,
+      accountId: "work",
+    });
+
+    expect(result).toEqual({
+      messageId: "msg123",
+      toJid: "1555@s.whatsapp.net",
+    });
+    expect(sendComposingTo).toHaveBeenCalledWith("+1555");
+    expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined, {
+      accountId: "work",
+    });
   });
 
   it("maps audio to PTT with opus mime when ogg", async () => {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -9,10 +9,58 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { markdownToWhatsApp } from "openclaw/plugin-sdk/text-runtime";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } from "./accounts.js";
-import { type ActiveWebSendOptions, requireActiveWebListener } from "./active-listener.js";
+import {
+  getActiveWebListener,
+  requestWebListenerRecovery,
+  resolveWebAccountId,
+  type ActiveWebListener,
+  type ActiveWebSendOptions,
+  requireActiveWebListener,
+} from "./active-listener.js";
 import { loadWebMedia } from "./media.js";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
+const LISTENER_RECOVERY_TIMEOUT_MS = 8_000;
+const LISTENER_RECOVERY_POLL_MS = 250;
+
+async function waitForRecoveredListener(
+  accountId: string,
+  timeoutMs = LISTENER_RECOVERY_TIMEOUT_MS,
+): Promise<ActiveWebListener | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const listener = getActiveWebListener(accountId);
+    if (listener) {
+      return listener;
+    }
+    await new Promise((resolve) => setTimeout(resolve, LISTENER_RECOVERY_POLL_MS));
+  }
+  return getActiveWebListener(accountId);
+}
+
+async function requireActiveWebListenerForSend(accountId?: string | null): Promise<{
+  accountId: string;
+  listener: ActiveWebListener;
+}> {
+  const resolvedAccountId = resolveWebAccountId(accountId);
+  const existing = getActiveWebListener(resolvedAccountId);
+  if (existing) {
+    return { accountId: resolvedAccountId, listener: existing };
+  }
+
+  const recoveryRequested = await requestWebListenerRecovery(
+    resolvedAccountId,
+    "send-path missing active listener",
+  );
+  if (recoveryRequested) {
+    const recovered = await waitForRecoveredListener(resolvedAccountId);
+    if (recovered) {
+      return { accountId: resolvedAccountId, listener: recovered };
+    }
+  }
+
+  return requireActiveWebListener(resolvedAccountId);
+}
 
 export async function sendMessageWhatsApp(
   to: string,
@@ -33,7 +81,7 @@ export async function sendMessageWhatsApp(
   }
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
-  const { listener: active, accountId: resolvedAccountId } = requireActiveWebListener(
+  const { listener: active, accountId: resolvedAccountId } = await requireActiveWebListenerForSend(
     options.accountId,
   );
   const cfg = options.cfg ?? loadConfig();
@@ -126,7 +174,7 @@ export async function sendReactionWhatsApp(
   },
 ): Promise<void> {
   const correlationId = generateSecureUuid();
-  const { listener: active } = requireActiveWebListener(options.accountId);
+  const { listener: active } = await requireActiveWebListenerForSend(options.accountId);
   const redactedChatJid = redactIdentifier(chatJid);
   const logger = getChildLogger({
     module: "web-outbound",
@@ -164,7 +212,7 @@ export async function sendPollWhatsApp(
 ): Promise<{ messageId: string; toJid: string }> {
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
-  const { listener: active } = requireActiveWebListener(options.accountId);
+  const { listener: active } = await requireActiveWebListenerForSend(options.accountId);
   const redactedTo = redactIdentifier(to);
   const logger = getChildLogger({
     module: "web-outbound",

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -89,17 +89,21 @@ vi.mock("../../config/sessions.js", async () => {
   };
 });
 
-const makeContext = (): GatewayRequestContext =>
+const makeContext = (overrides?: Partial<GatewayRequestContext>): GatewayRequestContext =>
   ({
     dedupe: new Map(),
+    ...overrides,
   }) as unknown as GatewayRequestContext;
 
-async function runSend(params: Record<string, unknown>) {
+async function runSend(
+  params: Record<string, unknown>,
+  contextOverrides?: Partial<GatewayRequestContext>,
+) {
   const respond = vi.fn();
   await sendHandlers.send({
     params: params as never,
     respond,
-    context: makeContext(),
+    context: makeContext(contextOverrides),
     req: { type: "req", id: "1", method: "send" },
     client: null,
     isWebchatConnect: () => false,
@@ -237,6 +241,31 @@ describe("gateway send mirroring", () => {
       expect.objectContaining({ messageId: "m-single-send" }),
       undefined,
       expect.objectContaining({ channel: "slack" }),
+    );
+  });
+
+  it("does not override WhatsApp outbound with gateway deps", async () => {
+    mockDeliverySuccess("m-wa");
+
+    await runSend(
+      {
+        to: "+601116417699",
+        message: "hi",
+        channel: "whatsapp",
+        idempotencyKey: "idem-wa-no-override",
+      },
+      {
+        deps: {
+          sendMessageWhatsApp: vi.fn(),
+        } as unknown as GatewayRequestContext["deps"],
+      },
+    );
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        deps: undefined,
+      }),
     );
   });
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -203,7 +203,10 @@ export const sendHandlers: GatewayRequestHandlers = {
           accountId,
         });
         const deliveryTarget = idLikeTarget?.to ?? resolved.to;
-        const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
+        const outboundDeps =
+          context.deps && outboundChannel !== "whatsapp"
+            ? createOutboundSendDeps(context.deps)
+            : undefined;
         const mirrorPayloads = normalizeReplyPayloadsForDelivery([
           { text: message, mediaUrl, mediaUrls },
         ]);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1017,16 +1017,57 @@ export async function startGatewayServer(
       : () => {};
 
   // Recover pending outbound deliveries from previous crash/restart.
+  let deliveryRecoveryDelayedTimer: NodeJS.Timeout | null = null;
+  let deliveryRecoveryCloseStarted = false;
   if (!minimalTestGateway) {
+    const deliveryRecoveryStartedAt = Date.now();
+    const transientStartupOnlyUntilMs = deliveryRecoveryStartedAt + 15_000;
     void (async () => {
       const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
       const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+      if (deliveryRecoveryCloseStarted) {
+        return;
+      }
+
+      let deliveryRecoveryInitialPassDone = false;
+      let deliveryRecoveryDelayedDue = false;
+      let deliveryRecoveryDelayedRan = false;
+      const runDelayedRecoveryIfReady = () => {
+        if (
+          deliveryRecoveryCloseStarted ||
+          !deliveryRecoveryInitialPassDone ||
+          !deliveryRecoveryDelayedDue ||
+          deliveryRecoveryDelayedRan
+        ) {
+          return;
+        }
+        deliveryRecoveryDelayedRan = true;
+        void recoverPendingDeliveries({
+          deliver: deliverOutboundPayloads,
+          log: log.child("delivery-recovery-delayed"),
+          cfg: cfgAtStart,
+          transientStartupOnlyUntilMs,
+        }).catch((err) => {
+          log.error(`Delivery recovery (delayed) failed: ${String(err)}`);
+        });
+      };
+
+      const delayedRecoveryDelayMs = Math.max(0, deliveryRecoveryStartedAt + 10_000 - Date.now());
+      deliveryRecoveryDelayedTimer = setTimeout(() => {
+        deliveryRecoveryDelayedTimer = null;
+        deliveryRecoveryDelayedDue = true;
+        runDelayedRecoveryIfReady();
+      }, delayedRecoveryDelayMs);
+
       const logRecovery = log.child("delivery-recovery");
       await recoverPendingDeliveries({
         deliver: deliverOutboundPayloads,
         log: logRecovery,
         cfg: cfgAtStart,
+        transientStartupOnlyUntilMs,
       });
+      deliveryRecoveryInitialPassDone = true;
+      runDelayedRecoveryIfReady();
     })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
   }
 
@@ -1329,6 +1370,7 @@ export async function startGatewayServer(
 
   return {
     close: async (opts) => {
+      deliveryRecoveryCloseStarted = true;
       // Run gateway_stop plugin hook before shutdown
       await runGlobalGatewayStopSafely({
         event: { reason: opts?.reason ?? "gateway stopping" },
@@ -1341,6 +1383,10 @@ export async function startGatewayServer(
       if (skillsRefreshTimer) {
         clearTimeout(skillsRefreshTimer);
         skillsRefreshTimer = null;
+      }
+      if (deliveryRecoveryDelayedTimer) {
+        clearTimeout(deliveryRecoveryDelayedTimer);
+        deliveryRecoveryDelayedTimer = null;
       }
       skillsChangeUnsub();
       authRateLimiter?.dispose();

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -342,6 +342,7 @@ describe("delivery-queue", () => {
       expect(result.failed).toBe(0);
       expect(result.skippedMaxRetries).toBe(0);
       expect(result.deferredBackoff).toBe(0);
+      expect(result.deferredTransient).toBe(0);
 
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(0);
@@ -360,6 +361,7 @@ describe("delivery-queue", () => {
       expect(deliver).not.toHaveBeenCalled();
       expect(result.skippedMaxRetries).toBe(1);
       expect(result.deferredBackoff).toBe(0);
+      expect(result.deferredTransient).toBe(0);
 
       const failedDir = path.join(tmpDir, "delivery-queue", "failed");
       expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
@@ -378,6 +380,33 @@ describe("delivery-queue", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0].retryCount).toBe(1);
       expect(entries[0].lastError).toBe("network down");
+    });
+
+    it("defers transient startup readiness errors without consuming retries", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] },
+        tmpDir,
+      );
+
+      const deliver = vi
+        .fn()
+        .mockRejectedValue(new Error("No active WhatsApp Web listener (account: default)"));
+      const { result } = await runRecovery({ deliver });
+
+      expect(result).toEqual({
+        recovered: 0,
+        failed: 0,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+        deferredTransient: 1,
+      });
+
+      const entries = await loadPendingDeliveries(tmpDir);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].id).toBe(id);
+      expect(entries[0].retryCount).toBe(0);
+      expect(entries[0].lastError).toContain("No active WhatsApp Web listener");
+      expect(entries[0].lastAttemptAt).toBeTypeOf("number");
     });
 
     it("moves entries to failed/ immediately on permanent delivery errors", async () => {
@@ -485,6 +514,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        deferredTransient: 0,
       });
 
       const remaining = await loadPendingDeliveries(tmpDir);
@@ -515,6 +545,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        deferredTransient: 0,
       });
       expect(deliver).toHaveBeenCalledTimes(1);
       expect(deliver).toHaveBeenCalledWith(
@@ -544,6 +575,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        deferredTransient: 0,
       });
       expect(firstDeliver).not.toHaveBeenCalled();
 
@@ -555,6 +587,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 0,
+        deferredTransient: 0,
       });
       expect(secondDeliver).toHaveBeenCalledTimes(1);
 
@@ -562,6 +595,63 @@ describe("delivery-queue", () => {
       expect(remaining).toHaveLength(0);
 
       vi.useRealTimers();
+    });
+
+    it("stops deferring transient startup errors once the startup window expires", async () => {
+      vi.useFakeTimers();
+      const start = new Date("2026-01-01T00:00:00.000Z");
+      vi.setSystemTime(start);
+
+      try {
+        await enqueueDelivery(
+          { channel: "whatsapp", to: "+1", payloads: [{ text: "later" }] },
+          tmpDir,
+        );
+
+        const firstDeliver = vi
+          .fn()
+          .mockRejectedValue(new Error("No active WhatsApp Web listener"));
+        const firstRun = await recoverPendingDeliveries({
+          deliver: firstDeliver as DeliverFn,
+          log: createLog(),
+          cfg: baseCfg,
+          stateDir: tmpDir,
+          transientStartupOnlyUntilMs: start.getTime() + 10_000,
+        });
+        expect(firstRun).toEqual({
+          recovered: 0,
+          failed: 0,
+          skippedMaxRetries: 0,
+          deferredBackoff: 0,
+          deferredTransient: 1,
+        });
+
+        vi.setSystemTime(new Date(start.getTime() + 10_001));
+        const secondDeliver = vi
+          .fn()
+          .mockRejectedValue(new Error("No active WhatsApp Web listener"));
+        const secondRun = await recoverPendingDeliveries({
+          deliver: secondDeliver as DeliverFn,
+          log: createLog(),
+          cfg: baseCfg,
+          stateDir: tmpDir,
+          transientStartupOnlyUntilMs: start.getTime() + 10_000,
+        });
+        expect(secondRun).toEqual({
+          recovered: 0,
+          failed: 1,
+          skippedMaxRetries: 0,
+          deferredBackoff: 0,
+          deferredTransient: 0,
+        });
+
+        const entries = await loadPendingDeliveries(tmpDir);
+        expect(entries).toHaveLength(1);
+        expect(entries[0]?.retryCount).toBe(1);
+        expect(entries[0]?.lastError).toBe("No active WhatsApp Web listener");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("returns zeros when queue is empty", async () => {
@@ -573,6 +663,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 0,
+        deferredTransient: 0,
       });
       expect(deliver).not.toHaveBeenCalled();
     });

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -317,10 +317,12 @@ describe("delivery-queue", () => {
       deliver,
       log = createLog(),
       maxRecoveryMs,
+      transientStartupOnlyUntilMs,
     }: {
       deliver: ReturnType<typeof vi.fn>;
       log?: ReturnType<typeof createLog>;
       maxRecoveryMs?: number;
+      transientStartupOnlyUntilMs?: number;
     }) => {
       const result = await recoverPendingDeliveries({
         deliver: deliver as DeliverFn,
@@ -328,6 +330,7 @@ describe("delivery-queue", () => {
         cfg: baseCfg,
         stateDir: tmpDir,
         ...(maxRecoveryMs === undefined ? {} : { maxRecoveryMs }),
+        ...(transientStartupOnlyUntilMs === undefined ? {} : { transientStartupOnlyUntilMs }),
       });
       return { result, log };
     };
@@ -391,7 +394,10 @@ describe("delivery-queue", () => {
       const deliver = vi
         .fn()
         .mockRejectedValue(new Error("No active WhatsApp Web listener (account: default)"));
-      const { result } = await runRecovery({ deliver });
+      const { result } = await runRecovery({
+        deliver,
+        transientStartupOnlyUntilMs: Number.MAX_SAFE_INTEGER,
+      });
 
       expect(result).toEqual({
         recovered: 0,
@@ -407,6 +413,28 @@ describe("delivery-queue", () => {
       expect(entries[0].retryCount).toBe(0);
       expect(entries[0].lastError).toContain("No active WhatsApp Web listener");
       expect(entries[0].lastAttemptAt).toBeTypeOf("number");
+    });
+
+    it("treats transient startup errors as ordinary failures when no startup window is provided", async () => {
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir);
+
+      const deliver = vi
+        .fn()
+        .mockRejectedValue(new Error("No active WhatsApp Web listener (account: default)"));
+      const { result } = await runRecovery({ deliver });
+
+      expect(result).toEqual({
+        recovered: 0,
+        failed: 1,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+        deferredTransient: 0,
+      });
+
+      const entries = await loadPendingDeliveries(tmpDir);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].retryCount).toBe(1);
+      expect(entries[0].lastError).toContain("No active WhatsApp Web listener");
     });
 
     it("moves entries to failed/ immediately on permanent delivery errors", async () => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -381,7 +381,13 @@ export async function recoverPendingDeliveries(opts: {
   for (const entry of pending) {
     const now = Date.now();
     if (now >= deadline) {
-      const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff;
+      const deferred =
+        pending.length -
+        recovered -
+        failed -
+        skippedMaxRetries -
+        deferredBackoff -
+        deferredTransient;
       opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
       break;
     }
@@ -430,7 +436,7 @@ export async function recoverPendingDeliveries(opts: {
       const errMsg = err instanceof Error ? err.message : String(err);
 
       const withinTransientStartupWindow =
-        opts.transientStartupOnlyUntilMs === undefined ||
+        opts.transientStartupOnlyUntilMs !== undefined &&
         Date.now() <= opts.transientStartupOnlyUntilMs;
       if (withinTransientStartupWindow && isTransientStartupDeliveryError(entry.channel, errMsg)) {
         deferredTransient += 1;

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -51,6 +51,7 @@ export type RecoverySummary = {
   failed: number;
   skippedMaxRetries: number;
   deferredBackoff: number;
+  deferredTransient: number;
 };
 
 function resolveQueueDir(stateDir?: string): string {
@@ -165,6 +166,30 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   const raw = await fs.promises.readFile(filePath, "utf-8");
   const entry: QueuedDelivery = JSON.parse(raw);
   entry.retryCount += 1;
+  entry.lastAttemptAt = Date.now();
+  entry.lastError = error;
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.promises.rename(tmp, filePath);
+}
+
+/**
+ * Update a queue entry after an attempt that should NOT consume a retry.
+ *
+ * Used for transient startup readiness errors so recovery does not burn
+ * through MAX_RETRIES while a channel is still connecting.
+ */
+async function noteDeliveryAttemptNoRetry(
+  id: string,
+  error: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+  const raw = await fs.promises.readFile(filePath, "utf-8");
+  const entry: QueuedDelivery = JSON.parse(raw);
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;
   const tmp = `${filePath}.${process.pid}.tmp`;
@@ -323,10 +348,21 @@ export async function recoverPendingDeliveries(opts: {
   stateDir?: string;
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next restart. Default: 60 000. */
   maxRecoveryMs?: number;
+  /**
+   * Until this timestamp, startup/transient delivery errors do not consume a retry.
+   * After this window they fall back to normal retry accounting.
+   */
+  transientStartupOnlyUntilMs?: number;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
-    return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    return {
+      recovered: 0,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+      deferredTransient: 0,
+    };
   }
 
   // Process oldest first.
@@ -340,6 +376,7 @@ export async function recoverPendingDeliveries(opts: {
   let failed = 0;
   let skippedMaxRetries = 0;
   let deferredBackoff = 0;
+  let deferredTransient = 0;
 
   for (const entry of pending) {
     const now = Date.now();
@@ -391,6 +428,21 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.info(`Recovered delivery ${entry.id} to ${entry.channel}:${entry.to}`);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
+
+      const withinTransientStartupWindow =
+        opts.transientStartupOnlyUntilMs === undefined ||
+        Date.now() <= opts.transientStartupOnlyUntilMs;
+      if (withinTransientStartupWindow && isTransientStartupDeliveryError(entry.channel, errMsg)) {
+        deferredTransient += 1;
+        try {
+          await noteDeliveryAttemptNoRetry(entry.id, errMsg, opts.stateDir);
+        } catch {
+          // Best-effort update.
+        }
+        opts.log.info(`Delivery ${entry.id} deferred (startup/transient): ${errMsg}`);
+        continue;
+      }
+
       if (isPermanentDeliveryError(errMsg)) {
         opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
         try {
@@ -412,9 +464,9 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${deferredBackoff} deferred (backoff), ${deferredTransient} deferred (startup/transient)`,
   );
-  return { recovered, failed, skippedMaxRetries, deferredBackoff };
+  return { recovered, failed, skippedMaxRetries, deferredBackoff, deferredTransient };
 }
 
 export { MAX_RETRIES };
@@ -430,6 +482,18 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
 ];
+
+const TRANSIENT_STARTUP_ERROR_PATTERNS_BY_CHANNEL: Partial<Record<string, readonly RegExp[]>> = {
+  whatsapp: [/no active whatsapp web listener/i, /whatsapp.*not (connected|ready)/i],
+};
+
+function isTransientStartupDeliveryError(channel: string, error: string): boolean {
+  const patterns = TRANSIENT_STARTUP_ERROR_PATTERNS_BY_CHANNEL[channel];
+  if (!patterns) {
+    return false;
+  }
+  return patterns.some((re) => re.test(error));
+}
 
 export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));


### PR DESCRIPTION
## Summary

- make WhatsApp active-listener / recovery-hook cleanup owner-aware so stale monitor instances cannot clear a newer live listener
- keep gateway `send` for WhatsApp on the active plugin-local sender path instead of overriding into a different bundled runtime graph
- defer transient WhatsApp startup-readiness delivery-recovery errors during the startup window, then run a delayed recovery pass after startup without racing shutdown

Fixes #37428.
Supersedes #37429.
Related operational context: #47513.

## Root cause

The affected deployment ended up with two overlapping failure modes:

1. **stale listener ownership cleanup**
   - an older `monitorWebChannel` instance could shut down after a newer one had already registered itself
   - the older instance would then clear the shared active listener / recovery hook
   - result: inbound could still look alive, but proactive sends would intermittently report `No active WhatsApp Web listener`

2. **gateway/tool send path overriding into the wrong runtime graph**
   - gateway `send` was overriding WhatsApp outbound through `createDefaultDeps()`
   - in the affected build this resolved onto a different bundled WhatsApp runtime graph from the one holding the active listener
   - result: some real sends could succeed while later tool-side `message.send` still failed against an empty listener registry

There was also a **startup delivery-recovery** problem already captured in #37428 / #37429:
- queued WhatsApp deliveries could retry before the listener was ready after restart
- those transient startup failures consumed retry budget too early

## What changed

### 1) Make listener cleanup owner-aware
- add conditional clear helpers for active listeners and recovery hooks
- only let a monitor instance clear the listener / hook it actually owns
- add focused regression coverage for stale-instance cleanup

### 2) Keep gateway WhatsApp sends on the active sender path
- stop overriding WhatsApp outbound in `gateway send` with `createOutboundSendDeps(context.deps)`
- let WhatsApp delivery use the plugin-local sender path that shares the working runtime graph with the active listener
- add a regression test to assert WhatsApp gateway sends do not inject the gateway deps override

### 3) Fold in the startup recovery fix from #37429 on current main
- treat `No active WhatsApp Web listener`-style startup readiness errors as transient during the startup window
- record the attempt without consuming retry budget
- schedule a delayed second recovery pass anchored to startup time
- avoid running that delayed pass concurrently with the initial pass or after shutdown has started

## Why a new PR instead of updating #37429 directly?

I tried applying the current hotfix onto the old PR branch in an isolated worktree. It failed immediately because the older branch predates the newer WhatsApp source layout (`src/web/active-listener.ts`, `src/web/outbound.ts`, etc.).

So this PR carries the same intent as #37429, but rebased onto current `main` with the newer WhatsApp runtime split fixes included.

## Validation

- `pnpm vitest run src/web/active-listener.test.ts src/web/outbound.test.ts src/gateway/server-methods/send.test.ts src/infra/outbound/delivery-queue.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- `NODE_OPTIONS='--max-old-space-size=6144' pnpm exec tsc --noEmit`
- `NODE_OPTIONS='--max-old-space-size=6144' pnpm build`

## Live repro validation on the affected deployment

After applying the staged version of this fix locally on the affected deployment and restarting the gateway:
- proactive WhatsApp ZIP send succeeded via the normal tool path
- representative attachment matrix succeeded across document / media / archive types (`txt/json/csv/pdf/zip/docx/xlsx/png/gif/wav/ogg/mp4/webp/webm/pptx/doc/7z/rar`)
- no new `No active WhatsApp Web listener` errors appeared during the verification sweep
