### PR TITLE
fix(exec): propagate skills.entries.env vars into sandbox subprocess environment

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -27,6 +27,7 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  skillEnv?: Record<string, string>;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -375,6 +375,7 @@ export function createExecTool(
         ? buildSandboxEnv({
             defaultPath: DEFAULT_PATH,
             paramsEnv: params.env,
+            skillEnv: defaults?.skillEnv,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
           })

--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildSandboxEnv } from "./bash-tools.shared.js";
+
+describe("buildSandboxEnv", () => {
+  it("includes skillEnv in sandbox environment", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      skillEnv: { MY_API_KEY: "secret-123", CUSTOM_VAR: "value" },
+      containerWorkdir: "/workspace",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/workspace");
+    expect(env.MY_API_KEY).toBe("secret-123");
+    expect(env.CUSTOM_VAR).toBe("value");
+  });
+
+  it("sandboxEnv overrides skillEnv", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      skillEnv: { SHARED: "from-skill" },
+      sandboxEnv: { SHARED: "from-sandbox" },
+      containerWorkdir: "/workspace",
+    });
+
+    expect(env.SHARED).toBe("from-sandbox");
+  });
+
+  it("paramsEnv overrides both skillEnv and sandboxEnv", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      skillEnv: { SHARED: "from-skill" },
+      sandboxEnv: { SHARED: "from-sandbox" },
+      paramsEnv: { SHARED: "from-params" },
+      containerWorkdir: "/workspace",
+    });
+
+    expect(env.SHARED).toBe("from-params");
+  });
+
+  it("works without skillEnv", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      containerWorkdir: "/workspace",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/workspace");
+    expect(Object.keys(env)).toHaveLength(2);
+  });
+});

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -18,12 +18,17 @@ export function buildSandboxEnv(params: {
   defaultPath: string;
   paramsEnv?: Record<string, string>;
   sandboxEnv?: Record<string, string>;
+  skillEnv?: Record<string, string>;
   containerWorkdir: string;
 }) {
   const env: Record<string, string> = {
     PATH: params.defaultPath,
     HOME: params.containerWorkdir,
   };
+  // Merge order: base (PATH/HOME) → skillEnv → sandboxEnv → paramsEnv (highest priority)
+  for (const [key, value] of Object.entries(params.skillEnv ?? {})) {
+    env[key] = value;
+  }
   for (const [key, value] of Object.entries(params.sandboxEnv ?? {})) {
     env[key] = value;
   }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -337,7 +337,7 @@ export async function compactEmbeddedPiSessionDirect(
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
+    const skillEnvResult = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
@@ -346,6 +346,7 @@ export async function compactEmbeddedPiSessionDirect(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvResult.revert;
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -515,7 +515,7 @@ export async function runEmbeddedAttempt(
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
+    const skillEnvResult = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
@@ -524,6 +524,8 @@ export async function runEmbeddedAttempt(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvResult.revert;
+    const skillEnv = skillEnvResult.appliedEnv;
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
@@ -569,6 +571,7 @@ export async function runEmbeddedAttempt(
           exec: {
             ...params.execOverrides,
             elevated: params.bashElevated,
+            skillEnv,
           },
           sandbox,
           messageProvider: params.messageChannel ?? params.messageProvider,

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -255,7 +255,7 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["ENV_KEY"], () => {
-      const restore = applySkillEnvOverrides({
+      const { revert: restore } = applySkillEnvOverrides({
         skills: entries,
         config: { skills: { entries: { "env-skill": { apiKey: "injected" } } } },
       });
@@ -285,7 +285,7 @@ describe("applySkillEnvOverrides", () => {
     });
 
     withClearedEnv(["ENV_KEY"], () => {
-      const restore = applySkillEnvOverridesFromSnapshot({
+      const { revert: restore } = applySkillEnvOverridesFromSnapshot({
         snapshot,
         config: { skills: { entries: { "env-skill": { apiKey: "snap-key" } } } },
       });
@@ -313,7 +313,7 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["OPENAI_API_KEY", "NODE_OPTIONS"], () => {
-      const restore = applySkillEnvOverrides({
+      const { revert: restore } = applySkillEnvOverrides({
         skills: entries,
         config: {
           skills: {
@@ -353,7 +353,7 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["BASH_ENV", "SHELL"], () => {
-      const restore = applySkillEnvOverrides({
+      const { revert: restore } = applySkillEnvOverrides({
         skills: entries,
         config: {
           skills: {
@@ -407,7 +407,7 @@ describe("applySkillEnvOverrides", () => {
     });
 
     withClearedEnv(["OPENAI_API_KEY"], () => {
-      const restore = applySkillEnvOverridesFromSnapshot({
+      const { revert: restore } = applySkillEnvOverridesFromSnapshot({
         snapshot,
         config,
       });

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -14,6 +14,7 @@ export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
 } from "./skills/env-overrides.js";
+export type { SkillEnvOverridesResult } from "./skills/env-overrides.js";
 export type {
   OpenClawSkillMetadata,
   SkillEligibilityContext,

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -145,7 +145,15 @@ function createEnvReverter(updates: EnvUpdate[]) {
   };
 }
 
-export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+export type SkillEnvOverridesResult = {
+  revert: () => void;
+  appliedEnv: Record<string, string>;
+};
+
+export function applySkillEnvOverrides(params: {
+  skills: SkillEntry[];
+  config?: OpenClawConfig;
+}): SkillEnvOverridesResult {
   const { skills, config } = params;
   const updates: EnvUpdate[] = [];
 
@@ -165,16 +173,24 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
     });
   }
 
-  return createEnvReverter(updates);
+  const appliedEnv: Record<string, string> = {};
+  for (const update of updates) {
+    const value = process.env[update.key];
+    if (value !== undefined) {
+      appliedEnv[update.key] = value;
+    }
+  }
+
+  return { revert: createEnvReverter(updates), appliedEnv };
 }
 
 export function applySkillEnvOverridesFromSnapshot(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
-}) {
+}): SkillEnvOverridesResult {
   const { snapshot, config } = params;
   if (!snapshot) {
-    return () => {};
+    return { revert: () => {}, appliedEnv: {} };
   }
   const updates: EnvUpdate[] = [];
 
@@ -193,5 +209,13 @@ export function applySkillEnvOverridesFromSnapshot(params: {
     });
   }
 
-  return createEnvReverter(updates);
+  const appliedEnv: Record<string, string> = {};
+  for (const update of updates) {
+    const value = process.env[update.key];
+    if (value !== undefined) {
+      appliedEnv[update.key] = value;
+    }
+  }
+
+  return { revert: createEnvReverter(updates), appliedEnv };
 }


### PR DESCRIPTION
## Summary

- Environment variables configured under `skills.entries.<skill>.env` in `openclaw.json` were not passed to subprocesses spawned by the `exec` tool in sandbox mode
- `buildSandboxEnv()` constructed a clean environment (PATH + HOME + docker config + tool-call env) that deliberately excluded `process.env`, so skill env overrides applied via `applySkillEnvOverrides()` were silently dropped for sandbox subprocesses
- Gateway mode was unaffected (it starts from `process.env`); only sandbox mode had the gap

## Changes

- `src/agents/skills/env-overrides.ts`: `applySkillEnvOverrides` and `applySkillEnvOverridesFromSnapshot` now return `{ revert: () => void; appliedEnv: Record<string, string> }` so callers can capture the applied env map
- `src/agents/bash-tools.shared.ts`: `buildSandboxEnv()` accepts optional `skillEnv` and merges it between base env and `sandboxEnv` (merge order: base → skillEnv → sandboxEnv → paramsEnv, highest priority last)
- `src/agents/bash-tools.exec-types.ts`: Added `skillEnv?: Record<string, string>` to `ExecToolDefaults`
- `src/agents/bash-tools.exec.ts`: Passes `defaults?.skillEnv` into `buildSandboxEnv()` for sandbox path
- `src/agents/pi-embedded-runner/run/attempt.ts`: Captures `appliedEnv` from skill env result and threads it into exec tool defaults as `skillEnv`
- `src/agents/pi-embedded-runner/compact.ts`: Updated to handle new return type (uses `.revert` for cleanup)
- `src/agents/skills.ts`: Exports new `SkillEnvOverridesResult` type
- `src/agents/bash-tools.shared.test.ts`: New tests covering `skillEnv` merge priority in `buildSandboxEnv`
- `src/agents/skills.test.ts`: Updated callers to destructure `{ revert }` from new return type

## Test plan

- [x] `pnpm tsgo` — no type errors
- [x] `pnpm test -- src/agents/bash-tools.shared.test.ts src/agents/skills.test.ts` — 16/16 pass
- [x] New tests in `bash-tools.shared.test.ts` verify `skillEnv` appears in sandbox env and that `sandboxEnv`/`paramsEnv` still override it

Fixes #31583

Generated with Ship