### PR TITLE
fix: resolve typecheck regressions on main (non-matrix)

### DIFF
--- a/extensions/googlechat/runtime-api.ts
+++ b/extensions/googlechat/runtime-api.ts
@@ -1,4 +1,1 @@
-// Private runtime barrel for the bundled Google Chat extension.
-// Keep this barrel thin and aligned with the curated plugin-sdk/googlechat surface.
-
-export * from "../../src/plugin-sdk/googlechat.js";
+export * from "openclaw/plugin-sdk/googlechat";

--- a/extensions/nextcloud-talk/runtime-api.ts
+++ b/extensions/nextcloud-talk/runtime-api.ts
@@ -1,1 +1,1 @@
-export * from "../../src/plugin-sdk/nextcloud-talk.js";
+export * from "openclaw/plugin-sdk/nextcloud-talk";

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -102,7 +102,6 @@ function replaceSpawnConfig(next: OpenClawConfig): void {
 
 function createSessionBindingCapabilities() {
   return {
-    adapterAvailable: true,
     bindSupported: true,
     unbindSupported: true,
     placements: ["current", "child"] satisfies SessionBindingPlacement[],

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   type OpenClawConfig,
 } from "../config/config.js";
 import * as configSessions from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions.js";
 import * as gatewayCall from "../gateway/call.js";
 import {
   __testing as sessionBindingServiceTesting,
@@ -66,10 +67,10 @@ const readLatestAssistantReplyMock = vi.fn(
   async (_sessionKey?: string): Promise<string | undefined> => "raw subagent reply",
 );
 const embeddedRunMock = {
-  isEmbeddedPiRunActive: vi.fn(() => false),
-  isEmbeddedPiRunStreaming: vi.fn(() => false),
-  queueEmbeddedPiMessage: vi.fn((_: string, __: string) => false),
-  waitForEmbeddedPiRunEnd: vi.fn(async (_: string, __?: number) => true),
+  isEmbeddedPiRunActive: vi.fn((_sessionId?: string) => false),
+  isEmbeddedPiRunStreaming: vi.fn((_sessionId?: string) => false),
+  queueEmbeddedPiMessage: vi.fn((_sessionId: string, _text: string) => false),
+  waitForEmbeddedPiRunEnd: vi.fn(async (_sessionId: string, _timeoutMs?: number) => true),
 };
 const { subagentRegistryMock } = vi.hoisted(() => ({
   subagentRegistryMock: {
@@ -131,8 +132,8 @@ function setConfigOverride(next: OpenClawConfig): void {
   setRuntimeConfigSnapshot(configOverride);
 }
 
-function loadSessionStoreFixture(): ReturnType<typeof configSessions.loadSessionStore> {
-  return new Proxy(sessionStore as ReturnType<typeof configSessions.loadSessionStore>, {
+function loadSessionStoreFixture(): Record<string, SessionEntry> {
+  return new Proxy(sessionStore as Record<string, SessionEntry>, {
     get(target, key: string | symbol) {
       if (typeof key === "string" && !(key in target) && key.includes(":subagent:")) {
         return {

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -108,7 +108,7 @@ export async function channelsRemoveCommand(
   }
   channel = resolvedPluginState?.channelId ?? channel;
   const plugin = resolvedPluginState?.plugin ?? (channel ? getChannelPlugin(channel) : undefined);
-  if (!plugin) {
+  if (!plugin || !channel) {
     runtime.error(`Unknown channel: ${channel}`);
     runtime.exit(1);
     return;

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -100,6 +100,16 @@ export type SessionThreadBindingsConfig = {
    * Session auto-unfocuses once this age is reached even if active. Set to 0 to disable. Default: 0.
    */
   maxAgeHours?: number;
+  /**
+   * Allow subagent spawns with thread=true to auto-bind conversations
+   * when supported. Default: false (opt-in).
+   */
+  spawnSubagentSessions?: boolean;
+  /**
+   * Allow ACP spawns with thread=true to auto-bind conversations
+   * when supported. Default: false (opt-in).
+   */
+  spawnAcpSessions?: boolean;
 };
 
 export type SessionConfig = {

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -52,6 +52,7 @@ export type {
   ProviderAuthResult,
   OpenClawPluginCommandDefinition,
   OpenClawPluginDefinition,
+  PluginCommandContext,
   PluginLogger,
   PluginInteractiveTelegramHandlerContext,
 } from "../plugins/types.js";


### PR DESCRIPTION
## Summary

- Export missing `PluginCommandContext` from `plugin-sdk/core`, fixing `extensions/phone-control` build
- Fix readonly array assignability in `acp-spawn.test.ts` and `matrix-plugin-helper.test.ts`
- Add `spawnSubagentSessions` / `spawnAcpSessions` to `SessionThreadBindingsConfig` type (already in Zod schema)
- Fix mock types and function signatures in `subagent-announce.format.e2e.test.ts`
- Add null guards in `channels/add.ts` and `channels/remove.ts`
- Fix `googlechat` and `nextcloud-talk` runtime-api to use `openclaw/plugin-sdk/*` subpath imports instead of relative paths

Remaining known upstream `main` failures not addressed:
- `extensions/matrix/*` typecheck errors (54) — from in-progress matrix refactor
- `registry.contract.test.ts` — matrix session binding entry missing from contract registry (matrix-specific)
- `@tloncorp/tlon-skill` npm build errors (third-party dep)

## Test plan

- [x] `pnpm tsgo --noEmit` — only `extensions/matrix/*` errors remain
- [x] `acp-spawn.test.ts` — 24/24 passed
- [x] `subagent-announce.format.e2e.test.ts` — 70/70 passed
- [x] `matrix-plugin-helper.test.ts` — 3/3 passed
- [x] Verified on Linux (bigbox) with Node 24