### PR TITLE
fix(plugins): share split-load singleton state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,6 @@ Docs: https://docs.openclaw.ai
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
-- Plugins/WhatsApp: share split-load singleton state for plugin command registration and active WhatsApp listeners so duplicate module graphs no longer lose native plugin commands or outbound listener state. (#50418) Thanks @huntharo.
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
 - Gateway/auth: add regression coverage that keeps device-less trusted-proxy Control UI sessions off privileged pairing approval RPCs. Thanks @vincentkoc.
 - Plugins/runtime-api: pin extension runtime-api export surfaces with explicit guardrail coverage so future surface creep becomes a deliberate diff. Thanks @vincentkoc.
@@ -162,6 +161,7 @@ Docs: https://docs.openclaw.ai
 - Matrix: make onboarding status runtime-safe (#49995) Thanks @joshavant.
 - Channels: stabilize lane harness and monitor tests (#50167) Thanks @joshavant.
 - WhatsApp/active-listener: pin the active listener registry to a `globalThis` singleton so split WhatsApp bundle chunks share one listener map and outbound sends stop missing the registered session. (#47433) Thanks @clawdia67.
+- Plugins/WhatsApp: share split-load singleton state for plugin command registration and active WhatsApp listeners so duplicate module graphs no longer lose native plugin commands or outbound listener state. (#50418) Thanks @huntharo.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.
 - Mattermost/DM send: retry transient direct-channel creation failures for DM deliveries, with configurable backoff and per-request timeout. (#42398) Thanks @JonathanJing.
 - Telegram/network: unify API and media fetches under the same sticky IPv4 and pinned-IP fallback chain, and re-validate pinned override addresses against SSRF policy. (#49148) Thanks @obviyus.
+- Plugins/WhatsApp: share split-load singleton state for plugin command registration and active WhatsApp listeners so duplicate module graphs no longer lose native plugin commands or outbound listener state. (#50418) Thanks @huntharo.
 - Agents/prompt composition: append bootstrap truncation warnings to the current-turn prompt and add regression coverage for stable system-prompt cache invariants. (#49237) Thanks @scoootscooob.
 - Gateway/auth: add regression coverage that keeps device-less trusted-proxy Control UI sessions off privileged pairing approval RPCs. Thanks @vincentkoc.
 - Plugins/runtime-api: pin extension runtime-api export surfaces with explicit guardrail coverage so future surface creep becomes a deliberate diff. Thanks @vincentkoc.

--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type ActiveListenerModule = typeof import("./active-listener.js");
+
+const activeListenerModuleUrl = new URL("./active-listener.ts", import.meta.url).href;
+
+async function importActiveListenerModule(cacheBust: string): Promise<ActiveListenerModule> {
+  return (await import(`${activeListenerModuleUrl}?t=${cacheBust}`)) as ActiveListenerModule;
+}
+
+afterEach(async () => {
+  const mod = await importActiveListenerModule(`cleanup-${Date.now()}`);
+  mod.setActiveWebListener(null);
+  mod.setActiveWebListener("work", null);
+});
+
+describe("active WhatsApp listener singleton", () => {
+  it("shares listeners across duplicate module instances", async () => {
+    const first = await importActiveListenerModule(`first-${Date.now()}`);
+    const second = await importActiveListenerModule(`second-${Date.now()}`);
+    const listener = {
+      sendMessage: vi.fn(async () => ({ messageId: "msg-1" })),
+      sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
+      sendReaction: vi.fn(async () => {}),
+      sendComposingTo: vi.fn(async () => {}),
+    };
+
+    first.setActiveWebListener("work", listener);
+
+    expect(second.getActiveWebListener("work")).toBe(listener);
+    expect(second.requireActiveWebListener("work")).toEqual({
+      accountId: "work",
+      listener,
+    });
+  });
+});

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,27 +28,22 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-// Use a process-level singleton to survive bundler code-splitting.
-// Rolldown duplicates this module across multiple output chunks, each with its
-// own module-scoped `listeners` Map. The WhatsApp provider writes to one chunk's
-// Map via setActiveWebListener(), but the outbound send path reads from a
-// different chunk's Map via requireActiveWebListener() — so the listener is
-// never found. Pinning the Map to globalThis ensures all chunks share one
-// instance.  See: https://github.com/openclaw/openclaw/issues/14406
-const GLOBAL_KEY = "__openclaw_wa_listeners" as const;
-const GLOBAL_CURRENT_KEY = "__openclaw_wa_current_listener" as const;
+// Use process-global symbol keys to survive bundler code-splitting and loader
+// cache splits without depending on fragile string property names.
+const GLOBAL_LISTENERS_KEY = Symbol.for("openclaw.whatsapp.activeListeners");
+const GLOBAL_CURRENT_KEY = Symbol.for("openclaw.whatsapp.currentListener");
 
 type GlobalWithListeners = typeof globalThis & {
-  [GLOBAL_KEY]?: Map<string, ActiveWebListener>;
+  [GLOBAL_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
   [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
 };
 
 const _global = globalThis as GlobalWithListeners;
 
-_global[GLOBAL_KEY] ??= new Map<string, ActiveWebListener>();
+_global[GLOBAL_LISTENERS_KEY] ??= new Map<string, ActiveWebListener>();
 _global[GLOBAL_CURRENT_KEY] ??= null;
 
-const listeners = _global[GLOBAL_KEY];
+const listeners = _global[GLOBAL_LISTENERS_KEY];
 
 function getCurrentListener(): ActiveWebListener | null {
   return _global[GLOBAL_CURRENT_KEY] ?? null;

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -12,6 +12,14 @@ import {
 } from "./commands.js";
 import { setActivePluginRegistry } from "./runtime.js";
 
+type CommandsModule = typeof import("./commands.js");
+
+const commandsModuleUrl = new URL("./commands.ts", import.meta.url).href;
+
+async function importCommandsModule(cacheBust: string): Promise<CommandsModule> {
+  return (await import(`${commandsModuleUrl}?t=${cacheBust}`)) as CommandsModule;
+}
+
 beforeEach(() => {
   setActivePluginRegistry(
     createTestRegistry([{ pluginId: "discord", source: "test", plugin: discordPlugin }]),
@@ -106,6 +114,40 @@ describe("registerPluginCommand", () => {
       },
     ]);
     expect(getPluginCommandSpecs("slack")).toEqual([]);
+  });
+
+  it("shares plugin commands across duplicate module instances", async () => {
+    const first = await importCommandsModule(`first-${Date.now()}`);
+    const second = await importCommandsModule(`second-${Date.now()}`);
+
+    first.clearPluginCommands();
+
+    expect(
+      first.registerPluginCommand("demo-plugin", {
+        name: "voice",
+        nativeNames: {
+          telegram: "voice",
+        },
+        description: "Voice command",
+        handler: async () => ({ text: "ok" }),
+      }),
+    ).toEqual({ ok: true });
+
+    expect(second.getPluginCommandSpecs("telegram")).toEqual([
+      {
+        name: "voice",
+        description: "Voice command",
+        acceptsArgs: false,
+      },
+    ]);
+    expect(second.matchPluginCommand("/voice")).toMatchObject({
+      command: expect.objectContaining({
+        name: "voice",
+        pluginId: "demo-plugin",
+      }),
+    });
+
+    second.clearPluginCommands();
   });
 
   it("matches provider-specific native aliases back to the canonical command", () => {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -8,6 +8,7 @@
 import { parseExplicitTargetForChannel } from "../channels/plugins/target-parsing.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   detachPluginConversationBinding,
   getCurrentPluginConversationBinding,
@@ -25,11 +26,19 @@ type RegisteredPluginCommand = OpenClawPluginCommandDefinition & {
   pluginRoot?: string;
 };
 
-// Registry of plugin commands
-const pluginCommands: Map<string, RegisteredPluginCommand> = new Map();
+type PluginCommandState = {
+  pluginCommands: Map<string, RegisteredPluginCommand>;
+  registryLocked: boolean;
+};
 
-// Lock to prevent modifications during command execution
-let registryLocked = false;
+const PLUGIN_COMMAND_STATE_KEY = Symbol.for("openclaw.pluginCommandsState");
+
+const state = resolveGlobalSingleton<PluginCommandState>(PLUGIN_COMMAND_STATE_KEY, () => ({
+  pluginCommands: new Map<string, RegisteredPluginCommand>(),
+  registryLocked: false,
+}));
+
+const pluginCommands = state.pluginCommands;
 
 // Maximum allowed length for command arguments (defense in depth)
 const MAX_ARGS_LENGTH = 4096;
@@ -172,7 +181,7 @@ export function registerPluginCommand(
   opts?: { pluginName?: string; pluginRoot?: string },
 ): CommandRegistrationResult {
   // Prevent registration while commands are being processed
-  if (registryLocked) {
+  if (state.registryLocked) {
     return { ok: false, error: "Cannot register commands while processing is in progress" };
   }
 
@@ -451,7 +460,7 @@ export async function executePluginCommand(params: {
   };
 
   // Lock registry during execution to prevent concurrent modifications
-  registryLocked = true;
+  state.registryLocked = true;
   try {
     const result = await command.handler(ctx);
     logVerbose(
@@ -464,7 +473,7 @@ export async function executePluginCommand(params: {
     // Don't leak internal error details - return a safe generic message
     return { text: "⚠️ Command failed. Please try again later." };
   } finally {
-    registryLocked = false;
+    state.registryLocked = false;
   }
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: split module graphs can create duplicate mutable plugin/core state, so one copy registers state and another copy reads an empty copy later.
- Why it matters: this already showed up in practice as WhatsApp listener state diverging and plugin-registered slash commands like `/voice`, `/phone`, and `/pair` disappearing from Telegram/Discord.
- What changed: moved the WhatsApp active listener store and the plugin command registry onto process-global singleton state using `globalThis + Symbol.for(...)`, and added regression tests that import duplicate module instances and prove the state stays shared.
- What did NOT change (scope boundary): this does not eliminate the underlying duplicate-load trigger in `gateway:watch` or convert every mutable runtime singleton in the repo to global singleton storage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #47433

## User-visible / Behavior Changes

- Plugin-registered commands remain visible even if runtime code is loaded through duplicate module instances.
- WhatsApp active listener state remains shared across duplicate module instances instead of silently diverging.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp, Telegram, Discord plugin runtime paths
- Relevant config (redacted): local dev checkout with duplicate module-instance repro via cache-busted imports

### Steps

1. Import the same runtime module twice through distinct module URLs so it evaluates into two module instances.
2. Write mutable state through one instance.
3. Read the same state through the second instance.

### Expected

- Both module instances observe the same process-global state.

### Actual

- Before this change, module-local mutable state split, so one graph could register data and another graph would observe an empty copy.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `extensions/whatsapp/src/active-listener.test.ts` proves duplicate module instances share the active listener.
  - `src/plugins/commands.test.ts` proves duplicate module instances share plugin command registration and lookup for `/voice`.
  - a full live `pnpm gateway:watch` end-to-end command publish flow on Telegram after this exact patch
- Edge cases checked:
  - cleanup after each duplicate-load test run
  - command lookup through the second module instance, not just direct map inspection
- What you did **not** verify:
  - other mutable runtime singletons outside WhatsApp active listeners and plugin commands

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits in this PR.
- Files/config to restore: `extensions/whatsapp/src/active-listener.ts`, `src/plugins/commands.ts`
- Known bad symptoms reviewers should watch for: WhatsApp runtime losing the active listener unexpectedly, or plugin-native commands vanishing again from Telegram/Discord after plugin startup.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: other mutable plugin-facing state is still module-local elsewhere, so this PR fixes only the two confirmed breakages.
  - Mitigation: scope is explicit, and the tests pin the two known failures so they cannot silently regress again.
