### PR TITLE
feat(gateway): add default reasoning config, defaulting to off when unset

### DIFF
--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -33,4 +33,41 @@ describe("resolveCurrentDirectiveLevels", () => {
     expect(result.currentThinkLevel).toBe("minimal");
     expect(resolveDefaultThinkingLevel).not.toHaveBeenCalled();
   });
+
+  // reasoningDefault tests
+  it("uses agent reasoningDefault when session reasoningLevel is absent", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {
+        reasoningDefault: "on",
+      },
+      resolveDefaultThinkingLevel: vi.fn(),
+    });
+
+    expect(result.currentReasoningLevel).toBe("on");
+  });
+
+  it("session reasoningLevel overrides agent reasoningDefault", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {
+        reasoningLevel: "off",
+      },
+      agentCfg: {
+        reasoningDefault: "on",
+      },
+      resolveDefaultThinkingLevel: vi.fn(),
+    });
+
+    expect(result.currentReasoningLevel).toBe("off");
+  });
+
+  it("defaults reasoningLevel to off when neither session nor config is set", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {},
+      resolveDefaultThinkingLevel: vi.fn(),
+    });
+
+    expect(result.currentReasoningLevel).toBe("off");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -10,6 +10,7 @@ export async function resolveCurrentDirectiveLevels(params: {
   };
   agentCfg?: {
     thinkingDefault?: unknown;
+    reasoningDefault?: unknown;
     verboseDefault?: unknown;
     elevatedDefault?: unknown;
   };
@@ -32,7 +33,9 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -360,6 +360,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -413,7 +413,8 @@ export async function resolveReplyDirectives(params: {
   // be emitted as visible "Reasoning:" messages.
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
+    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null) ||
+    agentCfg?.reasoningDefault !== undefined;
   const thinkingActive = resolvedThinkLevelWithDefault !== "off";
   if (!reasoningExplicitlySet && resolvedReasoningLevel === "off" && !thinkingActive) {
     resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -512,7 +512,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const verboseLevel =
     args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
   const fastMode = args.resolvedFast ?? args.sessionEntry?.fastMode ?? false;
-  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? args.agent?.reasoningDefault ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -187,6 +187,8 @@ export type AgentDefaultsConfig = {
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+  /** Default reasoning display level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -148,6 +148,9 @@ export const AgentDefaultsSchema = z
         z.literal("adaptive"),
       ])
       .optional(),
+    reasoningDefault: z
+      .union([z.literal("off"), z.literal("on"), z.literal("stream")])
+      .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])


### PR DESCRIPTION
## Summary

- **Problem:** The `/reasoning` directive level had no persistent default — it always fell back to `"off"` at session startup with no way to configure a different baseline via `openclaw.json`.
- **Why it matters:** Users who always want reasoning output visible (e.g. `"on"` or `"stream"`) had to issue `/reasoning on` manually every session; there was no config-driven default.
- **What changed:** Added `reasoningDefault` to `AgentDefaultsConfig` (type), `AgentDefaultsSchema` (Zod validation), and `resolveCurrentDirectiveLevels` (runtime resolution) so the config key `agents.defaults.reasoningDefault` is respected as the fallback before the hardcoded `"off"`.
- **What did NOT change:** Session-level `/reasoning` directive overrides are unaffected; the hardcoded `"off"` floor is preserved when neither session nor config supplies a value.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50812
- Related #50812

## User-visible / Behavior Changes

- New config key: `agents.defaults.reasoningDefault` — accepted values: `"off"` (default), `"on"`, `"stream"`.
- When set, this value is applied as the reasoning display level at session start, before any per-session `/reasoning` directive override.
- No change to existing behavior when the key is absent (continues to default to `"off"`).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+ / Bun
- Model/provider: Any
- Integration/channel (if any): Any
- Relevant config (redacted):
  ```json
  {
    "agents": {
      "defaults": {
        "reasoningDefault": "on"
      }
    }
  }
  ```

### Steps

1. Set `agents.defaults.reasoningDefault` to `"on"` (or `"stream"`) in `openclaw.json`.
2. Start a new agent session without issuing any `/reasoning` directive.
3. Observe that reasoning output is shown by default.

### Expected

- Reasoning is displayed according to the configured default without requiring a manual directive.

### Actual

- (Before fix) Reasoning always defaulted to `"off"` regardless of config.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Config key absent → behavior unchanged (`"off"`); config key `"on"` → reasoning shown by default; config key `"stream"` → streaming reasoning shown by default.
- Edge cases checked: Session-level `/reasoning off` still overrides a `"on"` default correctly (session entry takes priority over config default in `resolveCurrentDirectiveLevels`).
- What you did **not** verify: Live end-to-end roundtrip across all channel types.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — key is optional; omitting it preserves the existing `"off"` default.
- Config/env changes? `Yes` — new optional config key `agents.defaults.reasoningDefault`.
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove or unset `agents.defaults.reasoningDefault` from `openclaw.json` (or set it to `"off"`).
- Files/config to restore: `src/config/types.agent-defaults.ts`, `src/config/zod-schema.agent-defaults.ts`, `src/auto-reply/reply/directive-handling.levels.ts`.
- Known bad symptoms reviewers should watch for: Unexpected reasoning output appearing in sessions where it was not previously shown (only if `reasoningDefault` was explicitly set).

## Risks and Mitigations

- Risk: A misconfigured value (e.g. a typo) is accepted silently and applied as `"off"` fallback.
  - Mitigation: Zod schema enforces a strict `union` of `"off" | "on" | "stream"`; invalid values will fail config validation at load time.

written by cursor