### PR TITLE
fix(google): return PLATFORM_UNSPECIFIED for macOS in resolvePlatform()

### DIFF
--- a/extensions/google/oauth.project.ts
+++ b/extensions/google/oauth.project.ts
@@ -12,9 +12,8 @@ function resolvePlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
   if (process.platform === "win32") {
     return "WINDOWS";
   }
-  if (process.platform === "darwin") {
-    return "MACOS";
-  }
+  // Google's loadCodeAssist API rejects "MACOS" and "LINUX" as invalid Platform enum values.
+  // Use "PLATFORM_UNSPECIFIED" for macOS, Linux and other platforms to match the pi-ai runtime.
   return "PLATFORM_UNSPECIFIED";
 }
 

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -252,10 +252,7 @@ describe("loginGeminiCliOAuth", () => {
     if (process.platform === "win32") {
       return "WINDOWS";
     }
-    if (process.platform === "darwin") {
-      return "MACOS";
-    }
-    // Matches updated resolvePlatform() which uses PLATFORM_UNSPECIFIED for Linux
+    // Matches updated resolvePlatform() which uses PLATFORM_UNSPECIFIED for macOS and Linux
     return "PLATFORM_UNSPECIFIED";
   }
 


### PR DESCRIPTION
## Problem

`loadCodeAssist` fails with `400 Bad Request` on macOS because `resolvePlatform()` returns `"MACOS"`, which Google's API rejects as an invalid Platform enum value.

The same issue was already known for Linux (comment in code), but the macOS case was not handled.

## Fix

Return `"PLATFORM_UNSPECIFIED"` for macOS (darwin), matching the pi-ai runtime behavior. Only Windows returns `"WINDOWS"` — all other platforms use `"PLATFORM_UNSPECIFIED"`.

## Files changed

- `extensions/google/oauth.project.ts` — remove darwin → MACOS branch
- `extensions/google/oauth.test.ts` — update test helper to match

## Testing

Tested on macOS 26.3.1 (M1 Max). After this fix, `loadCodeAssist` succeeds and Gemini CLI OAuth authentication completes normally.