### PR TITLE
fix(agents): throw FailoverError at retry limit when fallback is configured

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -532,4 +532,102 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expect(firstCall?.provider).toBe("openai");
     });
   });
+
+  it("falls back to next model when rate-limit retries exhaust the run loop limit", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      const RATE_LIMIT_ERROR =
+        '{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}';
+
+      // Set up many profiles so profile rotation cycles through them
+      // without exhausting advanceAuthProfile before the retry limit.
+      // With 4 profiles: retry limit = max(32, 24 + 4*8) = 56.
+      // Each profile cycles once per 4 iterations, so after 4 rotations
+      // the profiles re-enter cooldown and the loop continues until the
+      // retry limit is hit.
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openai:p1": { type: "api_key", provider: "openai", key: "sk-1" },
+            "openai:p2": { type: "api_key", provider: "openai", key: "sk-2" },
+            "openai:p3": { type: "api_key", provider: "openai", key: "sk-3" },
+            "openai:p4": { type: "api_key", provider: "openai", key: "sk-4" },
+            "groq:p1": { type: "api_key", provider: "groq", key: "sk-groq" },
+          },
+          usageStats: {
+            "openai:p1": { lastUsed: 1 },
+            "openai:p2": { lastUsed: 2 },
+            "openai:p3": { lastUsed: 3 },
+            "openai:p4": { lastUsed: 4 },
+            "groq:p1": { lastUsed: 5 },
+          },
+        }),
+      );
+
+      // Primary provider always returns rate-limit errors.
+      // Fallback provider succeeds.
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const attemptParams = params as {
+          provider: string;
+          modelId: string;
+          authProfileId?: string;
+        };
+        if (attemptParams.provider === "openai") {
+          return makeAttempt({
+            assistantTexts: [],
+            lastAssistant: buildAssistant({
+              provider: "openai",
+              model: "mock-1",
+              stopReason: "error",
+              errorMessage: RATE_LIMIT_ERROR,
+            }),
+          });
+        }
+        if (attemptParams.provider === "groq") {
+          return makeAttempt({
+            assistantTexts: ["fallback ok"],
+            lastAssistant: buildAssistant({
+              provider: "groq",
+              model: "mock-2",
+              stopReason: "stop",
+              content: [{ type: "text", text: "fallback ok" }],
+            }),
+          });
+        }
+        throw new Error(`Unexpected provider ${attemptParams.provider}`);
+      });
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:rate-limit-retry-exhaustion",
+        runId: "run:rate-limit-retry-exhaustion",
+      });
+
+      // The key assertion: the fallback model must be used, not a
+      // "Request failed after repeated internal retries" error result.
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+
+      // Verify the primary was attempted first (at least once).
+      const firstCall = runEmbeddedAttemptMock.mock.calls[0]?.[0] as
+        | { provider?: string }
+        | undefined;
+      expect(firstCall?.provider).toBe("openai");
+
+      // Verify the fallback was actually invoked.
+      const allProviders = runEmbeddedAttemptMock.mock.calls.map(
+        (call) => (call[0] as { provider?: string })?.provider,
+      );
+      expect(allProviders).toContain("groq");
+
+      // The primary attempt should be recorded as a failed attempt.
+      expect(result.attempts.length).toBeGreaterThan(0);
+      const primaryAttempt = result.attempts.find((a) => a.provider === "openai");
+      expect(primaryAttempt).toBeDefined();
+      expect(primaryAttempt?.reason).toMatch(/rate_limit|overloaded|unknown/);
+    });
+  });
 });

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -538,12 +538,10 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       const RATE_LIMIT_ERROR =
         '{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}';
 
-      // Set up many profiles so profile rotation cycles through them
-      // without exhausting advanceAuthProfile before the retry limit.
-      // With 4 profiles: retry limit = max(32, 24 + 4*8) = 56.
-      // Each profile cycles once per 4 iterations, so after 4 rotations
-      // the profiles re-enter cooldown and the loop continues until the
-      // retry limit is hit.
+      // Set up enough profiles that profile rotation keeps cycling without
+      // exhausting advanceAuthProfile before MAX_RUN_LOOP_ITERATIONS is reached.
+      // With 4 primary profiles the retry limit is well above the number of
+      // per-profile rotation slots, so the loop will always hit the ceiling.
       await fs.writeFile(
         path.join(agentDir, "auth-profiles.json"),
         JSON.stringify({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1512,7 +1512,8 @@ export async function runEmbeddedPiAgent(
             const rotated = await advanceAuthProfile();
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
-              lastRetryFailoverReason = (assistantFailoverReason ?? (timedOut ? "timeout" : null)) ?? lastRetryFailoverReason;
+              lastRetryFailoverReason =
+                assistantFailoverReason ?? (timedOut ? "timeout" : null) ?? lastRetryFailoverReason;
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;
             }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -768,6 +768,7 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      let lastRetryFailoverReason: FailoverReason | null = null;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -835,6 +836,26 @@ export async function runEmbeddedPiAgent(
                 `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
                 `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
             );
+            // When fallback models are configured and the retries were exhausted
+            // by a failover-worthy reason (rate_limit, overloaded, auth, billing),
+            // throw a FailoverError so runWithModelFallback() can try the next
+            // candidate instead of silently returning an error result.
+            if (
+              fallbackConfigured &&
+              lastRetryFailoverReason &&
+              lastRetryFailoverReason !== "timeout" &&
+              lastRetryFailoverReason !== "model_not_found" &&
+              lastRetryFailoverReason !== "format" &&
+              lastRetryFailoverReason !== "session_expired"
+            ) {
+              throw new FailoverError(message, {
+                reason: lastRetryFailoverReason,
+                provider,
+                model: modelId,
+                profileId: lastProfileId,
+                status: resolveFailoverStatus(lastRetryFailoverReason),
+              });
+            }
             return {
               payloads: [
                 {
@@ -1358,6 +1379,7 @@ export async function runEmbeddedPiAgent(
               (await advanceAuthProfile())
             ) {
               logPromptFailoverDecision("rotate_profile");
+              lastRetryFailoverReason = promptFailoverReason;
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
             }
@@ -1490,6 +1512,7 @@ export async function runEmbeddedPiAgent(
             const rotated = await advanceAuthProfile();
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
+              lastRetryFailoverReason = assistantFailoverReason ?? (timedOut ? "timeout" : null);
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;
             }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1379,7 +1379,7 @@ export async function runEmbeddedPiAgent(
               (await advanceAuthProfile())
             ) {
               logPromptFailoverDecision("rotate_profile");
-              lastRetryFailoverReason = promptFailoverReason;
+              lastRetryFailoverReason = promptFailoverReason ?? lastRetryFailoverReason;
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
             }
@@ -1512,7 +1512,7 @@ export async function runEmbeddedPiAgent(
             const rotated = await advanceAuthProfile();
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
-              lastRetryFailoverReason = assistantFailoverReason ?? (timedOut ? "timeout" : null);
+              lastRetryFailoverReason = (assistantFailoverReason ?? (timedOut ? "timeout" : null)) ?? lastRetryFailoverReason;
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;
             }


### PR DESCRIPTION
## Summary

- When mid-conversation rate limits exhaust all auth profile rotations and hit `MAX_RUN_LOOP_ITERATIONS`, throw a `FailoverError` instead of returning an error result, so `runWithModelFallback()` can try the next model candidate
- Track the last failover reason across retry loop iterations via `lastRetryFailoverReason`
- Add regression test verifying that rate-limit retry exhaustion falls back to the next configured model

## Problem

When a model succeeds on turn N but gets rate-limited on turn N+1, the embedded runner cycles through auth profiles via `advanceAuthProfile()` → `continue`. Each retry increments `runLoopIterations`. Once `MAX_RUN_LOOP_ITERATIONS` is exceeded (`run.ts:887`), the code **returns** an error result payload instead of **throwing** a `FailoverError`.

Since `runFallbackCandidate()` in `model-fallback.ts` only treats thrown errors as failures, this returned result is wrapped as `{ ok: true, result }` — a "success." The fallback loop exits without trying the next model. The user sees "Request failed after repeated internal retries" instead of a response from the fallback model.

## Fix

The retry-limit exit now checks whether:
- `fallbackConfigured` is true, AND
- `lastRetryFailoverReason` is failover-worthy (`rate_limit`, `overloaded`, `auth`, `billing`, `unknown`)

If both conditions are met, it throws a `FailoverError` that propagates to `runWithModelFallback()`, which catches it and tries the next candidate.

## Test plan

- [ ] New e2e test: "falls back to next model when rate-limit retries exhaust the run loop limit" — sets up 4 primary profiles that all return rate-limit errors, verifies fallback model (`groq/mock-2`) is used
- [ ] Existing overload/fallback tests continue to pass
- [ ] `pnpm build && pnpm check && pnpm test`

Closes #50421

🤖 Generated with [Claude Code](https://claude.com/claude-code)