### PR TITLE
fix(feishu): fall back to plain text when card delivery fails

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -715,4 +715,82 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       streamingInstances.push = origPush;
     }
   });
+
+  it("falls back to plain text when card send fails (e.g. table limit exceeded)", async () => {
+    const convertMock = vi.fn((text: string) => text.replace(/\|/g, "-"));
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 4000),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "bullet"),
+          convertMarkdownTables: convertMock,
+          chunkTextWithMode: vi.fn((text: string) => [text]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+    });
+
+    // Simulate non-streaming card mode
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: false,
+      },
+    });
+
+    const logMock = vi.fn();
+    const { options } = createDispatcherHarness({
+      runtime: { log: logMock, error: vi.fn() } as never,
+    });
+
+    // First call to sendStructuredCardFeishu fails (card table limit)
+    sendStructuredCardFeishuMock.mockRejectedValueOnce(new Error("card table number over limit"));
+
+    const tableMarkdown = "| Col1 | Col2 |\n|------|------|\n| a | b |";
+    await options.deliver({ text: tableMarkdown }, { kind: "final" });
+
+    // Card was attempted and failed
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+
+    // Fallback to plain text was used
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+
+    // Markdown tables were converted before fallback send
+    expect(convertMock).toHaveBeenCalled();
+
+    // Warning was logged
+    expect(logMock).toHaveBeenCalledWith(
+      expect.stringContaining("card send failed, falling back to text"),
+    );
+  });
+
+  it("card fallback does not trigger when card send succeeds", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: false,
+      },
+    });
+
+    const { options } = createDispatcherHarness();
+
+    await options.deliver({ text: "```js\ncode\n```" }, { kind: "final" });
+
+    // Card send should succeed normally
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+    // No fallback to plain text
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -763,8 +763,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     // Fallback to plain text was used
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
 
-    // Markdown tables were converted before fallback send
-    expect(convertMock).toHaveBeenCalled();
+    // Markdown tables were converted exactly once (inside sendChunkedTextReply)
+    expect(convertMock).toHaveBeenCalledTimes(1);
 
     // Warning was logged
     expect(logMock).toHaveBeenCalledWith(

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -442,9 +442,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               params.runtime.log?.(
                 `feishu[${account.accountId}]: card send failed, falling back to text: ${String(cardError)}`,
               );
-              const fallbackText = core.channel.text.convertMarkdownTables(text, tableMode);
               await sendChunkedTextReply({
-                text: fallbackText,
+                text,
                 useCard: false,
                 infoKind: info?.kind,
                 sendChunk: async ({ chunk, isFirst }) => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -416,24 +416,50 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (useCard) {
             const cardHeader = resolveCardHeader(agentId, identity);
             const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: chatId,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  mentions: isFirst ? mentionTargets : undefined,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                });
-              },
-            });
+            try {
+              await sendChunkedTextReply({
+                text,
+                useCard: true,
+                infoKind: info?.kind,
+                sendChunk: async ({ chunk, isFirst }) => {
+                  await sendStructuredCardFeishu({
+                    cfg,
+                    to: chatId,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    mentions: isFirst ? mentionTargets : undefined,
+                    accountId,
+                    header: cardHeader,
+                    note: cardNote,
+                  });
+                },
+              });
+            } catch (cardError) {
+              // Card delivery can fail when the content exceeds Feishu card
+              // limitations (e.g. "card table number over limit"). Fall back
+              // to plain-text delivery so the user still receives the reply.
+              params.runtime.log?.(
+                `feishu[${account.accountId}]: card send failed, falling back to text: ${String(cardError)}`,
+              );
+              const fallbackText = core.channel.text.convertMarkdownTables(text, tableMode);
+              await sendChunkedTextReply({
+                text: fallbackText,
+                useCard: false,
+                infoKind: info?.kind,
+                sendChunk: async ({ chunk, isFirst }) => {
+                  await sendMessageFeishu({
+                    cfg,
+                    to: chatId,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    mentions: isFirst ? mentionTargets : undefined,
+                    accountId,
+                  });
+                },
+              });
+            }
           } else {
             await sendChunkedTextReply({
               text,


### PR DESCRIPTION
## Summary

- **Problem:** When the agent response contains many markdown tables, Feishu rejects the interactive card with `"card table number over limit"` (HTTP 400 / code 230099). The reply is silently dropped and the user receives nothing in Feishu, even though the response is visible in the control UI.
- **Root cause:** In `reply-dispatcher.ts`, the card delivery path (`sendStructuredCardFeishu`) does not catch errors. When the Feishu API rejects the card, the error propagates up and the reply is lost.
- **Fix:** Wrap the card delivery in a try/catch. On failure, log a warning and retry as plain text via `sendMessageFeishu()`, applying `convertMarkdownTables()` to transform tables into a text-friendly format before sending.
- **What did NOT change:** Streaming card path (CardKit API) is not affected — it updates individual card elements rather than creating full cards, so it does not hit the table limit.

## Change Type

- [x] Bug fix

## Scope

- [x] Feishu/Lark channel

## Linked Issue

- Closes #43690

## User-visible / Behavior Changes

**Before:** Agent response with many tables → Feishu card fails silently → user sees nothing:
```
[feishu] streaming start failed: Error: Create card request failed with HTTP 400
[feishu] feishu[default] final reply failed: AxiosError: Request failed with status code 400
```

**After:** Card fails → automatic fallback to plain text with tables converted:
```
feishu[main]: card send failed, falling back to text: Error: card table number over limit
```
User receives the response as a regular text message with tables rendered as bullet lists or code blocks (depending on `markdownTableMode` config).

## Security Impact

None. No new permissions, no network changes, no secrets handling.

## Evidence

- [x] 31 tests passing (29 existing + 2 new fallback-specific tests)

```
✓ extensions/feishu/src/reply-dispatcher.test.ts (31 tests) 10ms
  ✓ falls back to plain text when card send fails (e.g. table limit exceeded)
  ✓ card fallback does not trigger when card send succeeds
```

## Compatibility

- Backward compatible. Only adds error handling around existing card delivery.
- No config changes needed. Fallback uses existing `markdownTableMode` setting.

## Failure Recovery

- Revert: Remove the try/catch block around `sendStructuredCardFeishu` in `deliver()`.

## Risks

Minimal — the fallback path uses the same `sendMessageFeishu` function already used for non-card delivery.

[AI-assisted development by OpenClaw agent 虾干 🦐]