### PR TITLE
fix(plugins): share command registry across module graphs

### DIFF
--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -108,6 +108,64 @@ describe("registerPluginCommand", () => {
     expect(getPluginCommandSpecs("slack")).toEqual([]);
   });
 
+  it("shares plugin commands across duplicated module instances", async () => {
+    const duplicateCommands = (await import("./commands.js?duplicate=1")) as {
+      clearPluginCommands: () => void;
+      getPluginCommandSpecs: (provider?: string) => Array<{
+        name: string;
+        description: string;
+        acceptsArgs: boolean;
+      }>;
+      registerPluginCommand: typeof registerPluginCommand;
+    };
+
+    clearPluginCommands();
+    duplicateCommands.clearPluginCommands();
+
+    expect(
+      duplicateCommands.registerPluginCommand("demo-plugin", {
+        name: "phone",
+        description: "Phone control",
+        acceptsArgs: true,
+        nativeNames: {
+          telegram: "phone",
+        },
+        handler: async () => ({ text: "ok" }),
+      }),
+    ).toEqual({ ok: true });
+
+    expect(getPluginCommandSpecs("telegram")).toEqual([
+      {
+        name: "phone",
+        description: "Phone control",
+        acceptsArgs: true,
+      },
+    ]);
+
+    clearPluginCommands();
+    expect(duplicateCommands.getPluginCommandSpecs("telegram")).toEqual([]);
+
+    expect(
+      registerPluginCommand("demo-plugin", {
+        name: "voice",
+        description: "Voice control",
+        acceptsArgs: false,
+        nativeNames: {
+          telegram: "voice",
+        },
+        handler: async () => ({ text: "ok" }),
+      }),
+    ).toEqual({ ok: true });
+
+    expect(duplicateCommands.getPluginCommandSpecs("telegram")).toEqual([
+      {
+        name: "voice",
+        description: "Voice control",
+        acceptsArgs: false,
+      },
+    ]);
+  });
+
   it("matches provider-specific native aliases back to the canonical command", () => {
     const result = registerPluginCommand("demo-plugin", {
       name: "voice",

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -109,7 +109,8 @@ describe("registerPluginCommand", () => {
   });
 
   it("shares plugin commands across duplicated module instances", async () => {
-    const duplicateCommands = (await import("./commands.js?duplicate=1")) as {
+    const duplicateSpecifier = "./commands.js?duplicate=1";
+    const duplicateCommands = (await import(duplicateSpecifier)) as {
       clearPluginCommands: () => void;
       getPluginCommandSpecs: (provider?: string) => Array<{
         name: string;

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -8,6 +8,7 @@
 import { parseExplicitTargetForChannel } from "../channels/plugins/target-parsing.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   detachPluginConversationBinding,
   getCurrentPluginConversationBinding,
@@ -25,11 +26,28 @@ type RegisteredPluginCommand = OpenClawPluginCommandDefinition & {
   pluginRoot?: string;
 };
 
-// Registry of plugin commands
-const pluginCommands: Map<string, RegisteredPluginCommand> = new Map();
+type PluginCommandRegistryState = {
+  pluginCommands: Map<string, RegisteredPluginCommand>;
+  registryLocked: boolean;
+};
 
-// Lock to prevent modifications during command execution
-let registryLocked = false;
+const PLUGIN_COMMAND_REGISTRY_STATE_KEY = Symbol.for("openclaw.plugins.command-registry-state");
+
+/**
+ * Keep plugin command state on globalThis so source-loaded plugin-sdk shims,
+ * bundled dist extensions, and Jiti-transpiled copies all share one registry.
+ * Without this, plugin registration can succeed in one module graph while
+ * Telegram/Discord read commands from a different copy and see an empty set.
+ */
+const registryState = resolveGlobalSingleton<PluginCommandRegistryState>(
+  PLUGIN_COMMAND_REGISTRY_STATE_KEY,
+  () => ({
+    pluginCommands: new Map<string, RegisteredPluginCommand>(),
+    registryLocked: false,
+  }),
+);
+
+const pluginCommands = registryState.pluginCommands;
 
 // Maximum allowed length for command arguments (defense in depth)
 const MAX_ARGS_LENGTH = 4096;
@@ -172,7 +190,7 @@ export function registerPluginCommand(
   opts?: { pluginName?: string; pluginRoot?: string },
 ): CommandRegistrationResult {
   // Prevent registration while commands are being processed
-  if (registryLocked) {
+  if (registryState.registryLocked) {
     return { ok: false, error: "Cannot register commands while processing is in progress" };
   }
 
@@ -451,7 +469,7 @@ export async function executePluginCommand(params: {
   };
 
   // Lock registry during execution to prevent concurrent modifications
-  registryLocked = true;
+  registryState.registryLocked = true;
   try {
     const result = await command.handler(ctx);
     logVerbose(
@@ -464,7 +482,7 @@ export async function executePluginCommand(params: {
     // Don't leak internal error details - return a safe generic message
     return { text: "⚠️ Command failed. Please try again later." };
   } finally {
-    registryLocked = false;
+    registryState.registryLocked = false;
   }
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled plugin commands were stored in a module-local registry, so mixed source, bundled, and Jiti-transpiled module graphs could each see a different command map.
- Why it matters: Telegram native command registration under `pnpm gateway:watch` could read an empty plugin command set even when plugins had already registered `/pair`, `/phone`, and `/voice`.
- What changed: move the plugin command registry state and lock onto a `globalThis` singleton, and add a regression test that imports a duplicate copy of `src/plugins/commands.ts` and verifies both copies share command visibility.
- What did NOT change (scope boundary): plugin command semantics, provider-specific aliases, and Telegram menu-building logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Bundled plugin Telegram slash commands now stay registered under `pnpm gateway:watch` and other mixed module-graph runtimes. In the reproduced case, `/pair`, `/phone`, and `/voice` now appear again.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Mac mini host)
- Runtime/container: local source checkout plus remote `pnpm gateway:watch` rebuild
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram bot token configured in `~/.openclaw/openclaw.json`; bundled `device-pair`, `phone-control`, and `talk-voice` plugins enabled

### Steps

1. Start the gateway from a source checkout with `pnpm gateway:watch`.
2. Let bundled plugins register commands, then let Telegram build native menu commands.
3. Query the live bot command menu with Telegram `getMyCommands`.

### Expected

- Telegram native commands include plugin commands from loaded bundled plugins.

### Actual

- Before this fix, the plugin loader saw `pair`, `phone`, and `voice`, while Telegram later read `pluginSpecs=[]` from a different registry instance.
- After this fix, the live bot command menu includes `tts`, `pair`, `phone`, and `voice`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/plugins/commands.test.ts`
  - `pnpm test -- extensions/telegram/src/bot-native-commands.registry.test.ts`
  - Rebuilt on the Mac mini and ran `pnpm gateway:watch`
  - Queried the live Telegram Bot API `getMyCommands`; the relevant commands were `tts`, `pair`, `phone`, and `voice`
- Edge cases checked:
  - Duplicate module imports share registry state in both directions
  - Clearing the registry from either module instance is visible to the other
- What you did **not** verify:
  - Discord native plugin command registration under the same mixed module-graph runtime
  - Full end-to-end menu refresh behavior for every provider

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e530563375`
- Files/config to restore: `src/plugins/commands.ts`, `src/plugins/commands.test.ts`
- Known bad symptoms reviewers should watch for: plugin slash commands disappearing again in watch/source runtimes

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a process-global registry could leak state between test phases that expect isolation.
  - Mitigation: `clearPluginCommands()` remains the test reset path, and the new regression test covers the shared-state behavior directly.
