### PR TITLE
fix(usage): treat MiniMax current_interval_usage_count as remaining

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -67,8 +67,6 @@ const USED_KEYS = [
   "usedPrompt",
   "prompts_used",
   "promptsUsed",
-  "current_interval_usage_count",
-  "currentIntervalUsageCount",
   "consumed",
 ] as const;
 
@@ -132,6 +130,10 @@ const REMAINING_KEYS = [
   "promptLeft",
   "prompts_left",
   "promptsLeft",
+  "current_interval_usage_count",
+  "currentIntervalUsageCount",
+  "current_interval_remaining_count",
+  "currentIntervalRemainingCount",
   "left",
 ] as const;
 

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -219,7 +219,7 @@ describe("provider usage loading", () => {
           },
         ],
       },
-      expected: { usedPercent: 25 },
+      expected: { usedPercent: 75 },
     },
     {
       name: "keeps payload-level MiniMax plan metadata when the usage candidate is nested",


### PR DESCRIPTION
## Summary
- Move `current_interval_usage_count` / `currentIntervalUsageCount` from `USED_KEYS` to `REMAINING_KEYS` — despite the name, this field represents remaining prompts (confirmed by 3 independent third-party implementations)
- Add `current_interval_remaining_count` / `currentIntervalRemainingCount` as additional remaining key variants
- Fix test expectation to match corrected interpretation

Fixes #50372

## Test plan
- [x] `pnpm test -- src/infra/provider-usage.fetch.minimax.test.ts src/infra/provider-usage.test.ts` — 21 tests pass
- [x] `pnpm check` — no new errors (pre-existing TS errors unrelated)