### PR TITLE
fix(feishu): do not treat @_all as a bot-specific mention

### DIFF
--- a/extensions/feishu/src/bot-content.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot-content.checkBotMentioned.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { checkBotMentioned } from "./bot-content.js";
+
+function makeEvent(
+  content: string,
+  mentions?: Array<{ key: string; id: { open_id?: string }; name: string }>,
+  messageType = "text",
+) {
+  return {
+    message: {
+      content,
+      message_type: messageType,
+      mentions,
+      chat_id: "oc_group",
+    },
+  };
+}
+
+describe("checkBotMentioned", () => {
+  const botId = "ou_bot_123";
+
+  it("returns true when bot is explicitly mentioned", () => {
+    const event = makeEvent('{"text":"@_user_1 hello"}', [
+      { key: "@_user_1", id: { open_id: botId }, name: "Bot" },
+    ]);
+    expect(checkBotMentioned(event, botId)).toBe(true);
+  });
+
+  it("returns false when a different user is mentioned", () => {
+    const event = makeEvent('{"text":"@_user_1 hello"}', [
+      { key: "@_user_1", id: { open_id: "ou_other" }, name: "Other" },
+    ]);
+    expect(checkBotMentioned(event, botId)).toBe(false);
+  });
+
+  it("returns false when @_all is the only mention (#49761)", () => {
+    const event = makeEvent('{"text":"@_all hello everyone"}', [
+      { key: "@_all", id: { open_id: botId }, name: "所有人" },
+    ]);
+    expect(checkBotMentioned(event, botId)).toBe(false);
+  });
+
+  it("returns true when bot is mentioned alongside @_all", () => {
+    const event = makeEvent('{"text":"@_all @_user_1 hello"}', [
+      { key: "@_all", id: { open_id: botId }, name: "所有人" },
+      { key: "@_user_1", id: { open_id: botId }, name: "Bot" },
+    ]);
+    expect(checkBotMentioned(event, botId)).toBe(true);
+  });
+
+  it("returns false when no mentions and no bot open id in content", () => {
+    const event = makeEvent('{"text":"hello world"}');
+    expect(checkBotMentioned(event, botId)).toBe(false);
+  });
+
+  it("returns false when botOpenId is undefined", () => {
+    const event = makeEvent('{"text":"@_user_1 hello"}', [
+      { key: "@_user_1", id: { open_id: "ou_bot_123" }, name: "Bot" },
+    ]);
+    expect(checkBotMentioned(event, undefined)).toBe(false);
+  });
+});

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -248,12 +248,12 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
+  // @_all ("@所有人") mentions every group member, not a specific bot.
+  // Treating it as a bot mention causes all bots in the group to respond
+  // simultaneously (#49761). Only explicit per-bot mentions should trigger.
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
-    return mentions.some((mention) => mention.id.open_id === botOpenId);
+    return mentions.some((mention) => mention.id.open_id === botOpenId && mention.key !== "@_all");
   }
   if (event.message.message_type === "post") {
     return parsePostContent(event.message.content).mentionedOpenIds.some((id) => id === botOpenId);


### PR DESCRIPTION
## Summary

- **Problem:** When a user sends `@所有人` (@_all) in a Feishu group, **all bots** respond simultaneously, even with `requireMention: true`.
- **Root cause:** `checkBotMentioned()` checked if the raw content contains `"@_all"` and returned `true` unconditionally, treating a group-wide broadcast as a bot-specific mention.
- **Fix:** Remove the blanket `@_all` content check. Instead, filter `mention.key !== "@_all"` when checking the mentions array, so only explicit per-bot @mentions trigger a response.

## Change Type

- [x] Bug fix

## Scope

- [x] Feishu/Lark channel

## Linked Issue

- Closes #49761

## User-visible / Behavior Changes

**Before:** `@所有人` → all bots in the group respond simultaneously

**After:** `@所有人` → no bot responds (unless also explicitly @mentioned by name)

## Security Impact

None.

## Evidence

- [x] 6 new tests for `checkBotMentioned`:

```
✓ returns true when bot is explicitly mentioned
✓ returns false when a different user is mentioned
✓ returns false when @_all is the only mention (#49761)
✓ returns true when bot is mentioned alongside @_all
✓ returns false when no mentions and no bot open id in content
✓ returns false when botOpenId is undefined
```

## Compatibility

- Backward compatible for explicit @bot mentions (unchanged).
- **Behavior change** for `@所有人`: bots no longer auto-respond. Users who relied on `@所有人` to trigger a bot should explicitly @mention the bot instead.

## Risks

Minimal — only changes the @_all handling. All other mention patterns are unchanged.

[AI-assisted development by OpenClaw agent 虾干 🦐]