### PR TITLE
fix: recognize snake_case tool call types in session history repair

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -8,7 +8,14 @@ import {
 } from "./session-transcript-repair.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 
-const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
 
 function getAssistantToolCallBlocks(messages: AgentMessage[]) {
   const assistant = messages[0] as Extract<AgentMessage, { role: "assistant" }> | undefined;
@@ -272,6 +279,43 @@ describe("sanitizeToolCallInputs", () => {
     ]);
 
     const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
+  it("recognizes snake_case tool call block types (tool_use, tool_call, function_call)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "read", input: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    // Both messages should be preserved (tool_use is recognized)
+    expect(out).toHaveLength(2);
+    expect(out[0]?.role).toBe("assistant");
+    const blocks = getAssistantToolCallBlocks(out);
+    expect(blocks).toHaveLength(1);
+  });
+
+  it("drops snake_case tool_use blocks missing input", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "read" }],
+      },
+      { role: "user", content: "hello" },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    // The broken tool_use block should be dropped
     expect(out.map((m) => m.role)).toEqual(["user"]);
   });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -19,7 +19,12 @@ function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   const type = (block as { type?: unknown }).type;
   return (
     typeof type === "string" &&
-    (type === "toolCall" || type === "toolUse" || type === "functionCall")
+    (type === "toolCall" ||
+      type === "toolUse" ||
+      type === "functionCall" ||
+      type === "tool_call" ||
+      type === "tool_use" ||
+      type === "function_call")
   );
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** After an interrupted Anthropic tool call, users get persistent "Session history looks corrupted (tool call input missing)" errors that `/new` cannot reliably resolve.
- **Root cause:** `isRawToolCallBlock()` in `session-transcript-repair.ts` only recognizes camelCase block types (`toolCall`, `toolUse`, `functionCall`) but Anthropic persists `tool_use` (snake_case). The broken block survives `repairToolCallInputs()` sanitization, and Anthropic rejects the request with `"tool_use.input: field required"`.
- **Fix:** Add `tool_call`, `tool_use`, and `function_call` to the type check so the repair logic can detect and fix (or drop) broken snake_case blocks.

## Change Type

- [x] Bug fix

## Scope

- [x] Session history / transcript repair

## Linked Issue

- Closes #48915

## User-visible / Behavior Changes

**Before:** Interrupted Anthropic tool call → persistent "session history corrupted" error → `/new` doesn't fix it

**After:** Broken `tool_use` blocks are detected and dropped by the sanitizer → session recovers automatically

## Security Impact

None.

## Evidence

- [x] 25 tests passing (23 existing + 2 new snake_case tests)

```
✓ recognizes snake_case tool call block types (tool_use, tool_call, function_call)
✓ drops snake_case tool_use blocks missing input
```

## Compatibility

- Backward compatible. Only adds more type strings to an existing check.

## Risks

None — the added types follow the exact same repair logic as the existing camelCase types.

[AI-assisted development by OpenClaw agent 虾干 🦐]