### PR TITLE
fix(agents): hint when unknown tools are skills

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -580,9 +580,15 @@ function hasVisibleSkillMatch(params: {
 function rewriteUnknownToolAsSkillHint(params: {
   raw: string;
   skillsSnapshot?: SkillSnapshot;
+  allowedToolNames?: ReadonlySet<string>;
 }): string | undefined {
   const toolName = resolveUnknownToolName(params.raw);
   if (!toolName) {
+    return undefined;
+  }
+  // If the tool name matches an actual tool in the run's tool set, don't
+  // redirect to a skill — the real fix is to enable/load the tool.
+  if (params.allowedToolNames?.has(toolName)) {
     return undefined;
   }
   if (!hasVisibleSkillMatch({ skillsSnapshot: params.skillsSnapshot, toolName })) {
@@ -599,16 +605,19 @@ function rewriteUnknownToolAsSkillHint(params: {
 /**
  * Rewrites an unknown-tool error message in a tool result to include a skill
  * hint when the tool name matches a visible skill.  Returns `undefined` when
- * the message does not look like an unknown-tool error or when no skill match
- * is found (caller should leave the result unchanged in that case).
+ * the message does not look like an unknown-tool error, when no skill match
+ * is found, or when the tool name collides with a real tool in the run's tool
+ * set (caller should leave the result unchanged in that case).
  */
 export function rewriteToolResultUnknownToolError(params: {
   errorText: string;
   skillsSnapshot?: SkillSnapshot;
+  allowedToolNames?: ReadonlySet<string>;
 }): string | undefined {
   return rewriteUnknownToolAsSkillHint({
     raw: params.errorText,
     skillsSnapshot: params.skillsSnapshot,
+    allowedToolNames: params.allowedToolNames,
   });
 }
 export function formatAssistantErrorText(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -13,6 +13,7 @@ export {
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
+import type { SkillSnapshot } from "../skills.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
   isAuthErrorMessage,
@@ -554,6 +555,62 @@ export function isRawApiErrorPayload(raw?: string): boolean {
   return getApiErrorPayloadFingerprint(raw) !== null;
 }
 
+function resolveUnknownToolName(raw: string): string | undefined {
+  return (
+    raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i)?.[1] ??
+    raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i)?.[1]
+  );
+}
+
+function hasVisibleSkillMatch(params: {
+  skillsSnapshot?: SkillSnapshot;
+  toolName: string;
+}): boolean {
+  const normalizedToolName = params.toolName.trim().toLowerCase();
+  if (!normalizedToolName) {
+    return false;
+  }
+  const resolvedSkills = params.skillsSnapshot?.resolvedSkills;
+  if (!resolvedSkills || resolvedSkills.length === 0) {
+    return false;
+  }
+  return resolvedSkills.some((s) => s.name.trim().toLowerCase() === normalizedToolName);
+}
+
+function rewriteUnknownToolAsSkillHint(params: {
+  raw: string;
+  skillsSnapshot?: SkillSnapshot;
+}): string | undefined {
+  const toolName = resolveUnknownToolName(params.raw);
+  if (!toolName) {
+    return undefined;
+  }
+  if (!hasVisibleSkillMatch({ skillsSnapshot: params.skillsSnapshot, toolName })) {
+    return undefined;
+  }
+  const normalizedToolName = toolName.trim().toLowerCase();
+  const canonicalName =
+    params.skillsSnapshot?.resolvedSkills?.find(
+      (s) => s.name.trim().toLowerCase() === normalizedToolName,
+    )?.name ?? toolName;
+  return `Tool "${toolName}" not found. "${canonicalName}" is a skill. Read its SKILL.md first.`;
+}
+
+/**
+ * Rewrites an unknown-tool error message in a tool result to include a skill
+ * hint when the tool name matches a visible skill.  Returns `undefined` when
+ * the message does not look like an unknown-tool error or when no skill match
+ * is found (caller should leave the result unchanged in that case).
+ */
+export function rewriteToolResultUnknownToolError(params: {
+  errorText: string;
+  skillsSnapshot?: SkillSnapshot;
+}): string | undefined {
+  return rewriteUnknownToolAsSkillHint({
+    raw: params.errorText,
+    skillsSnapshot: params.skillsSnapshot,
+  });
+}
 export function formatAssistantErrorText(
   msg: AssistantMessage,
   opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
@@ -567,14 +624,12 @@ export function formatAssistantErrorText(
     return "LLM request failed with an unknown error.";
   }
 
-  const unknownTool =
-    raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
-    raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
-  if (unknownTool?.[1]) {
+  const unknownTool = resolveUnknownToolName(raw);
+  if (unknownTool) {
     const rewritten = formatSandboxToolPolicyBlockedMessage({
       cfg: opts?.cfg,
       sessionKey: opts?.sessionKey,
-      toolName: unknownTool[1],
+      toolName: unknownTool,
     });
     if (rewritten) {
       return rewritten;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1954,6 +1954,7 @@ export async function runEmbeddedAttempt(
         const rewritten = rewriteToolResultUnknownToolError({
           errorText,
           skillsSnapshot: params.skillsSnapshot,
+          allowedToolNames,
         });
         if (!rewritten) {
           return prev;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type {
+  AfterToolCallContext,
+  AfterToolCallResult,
+  AgentMessage,
+  StreamFn,
+} from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
@@ -72,6 +77,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
+import { rewriteToolResultUnknownToolError } from "../../pi-embedded-helpers/errors.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
@@ -1919,6 +1925,47 @@ export async function runEmbeddedAttempt(
           ),
         ),
       });
+
+      // ── afterToolCall: rewrite unknown-tool errors with skill hints ──
+      // Compose with the existing handler installed by AgentSession (extension
+      // tool_result dispatch) so we don't silently drop it.
+      type AfterToolCallFn = (
+        ctx: AfterToolCallContext,
+        signal?: AbortSignal,
+      ) => Promise<AfterToolCallResult | undefined>;
+      // Read the private `_afterToolCall` field — no public getter exists.
+      const prevAfterToolCall = (
+        activeSession.agent as unknown as { _afterToolCall?: AfterToolCallFn }
+      )._afterToolCall;
+      activeSession.agent.setAfterToolCall(async (ctx, signal) => {
+        const prev = prevAfterToolCall ? await prevAfterToolCall(ctx, signal) : undefined;
+        if (!ctx.isError) {
+          return prev;
+        }
+        const content = prev?.content ?? ctx.result?.content;
+        if (!Array.isArray(content)) {
+          return prev;
+        }
+        const firstText = content.find((c) => c.type === "text" && "text" in c);
+        if (!firstText || firstText.type !== "text" || !("text" in firstText)) {
+          return prev;
+        }
+        const errorText = (firstText as { type: "text"; text: string }).text;
+        const rewritten = rewriteToolResultUnknownToolError({
+          errorText,
+          skillsSnapshot: params.skillsSnapshot,
+        });
+        if (!rewritten) {
+          return prev;
+        }
+        return {
+          ...prev,
+          content: content.map((c) =>
+            c === firstText ? { type: "text" as const, text: rewritten } : c,
+          ),
+        };
+      });
+
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,


### PR DESCRIPTION
## Summary

- **Problem:** When a model mistakenly calls a skill name as a tool (e.g. `my-skill`), the error message is a generic "Tool not found" with no guidance, so the model keeps retrying or gives up. This is especially common with weaker/smaller models that struggle to distinguish skills from tools in the system prompt.
- **Why it matters:** Skills are invoked differently from tools; without a hint the model has no way to self-correct, leading to repeated failed tool calls that waste tokens and frustrate users — particularly on cost-sensitive or lower-capability model configurations.
- **What changed:** Register an `afterToolCall` hook in `attempt.ts` that intercepts error tool results, detects unknown-tool errors matching a registered skill name, and rewrites the message to `Tool "X" not found. "X" is a skill. Read its SKILL.md first.` Also extracted `resolveUnknownToolName` helper in `errors.ts` (was inline regex) and exported `rewriteToolResultUnknownToolError` for the hook to call.
- **What did NOT change (scope boundary):** `formatAssistantErrorText` signature and all its callers are untouched. No new params threaded through `run.ts`, `payloads.ts`, `subscribe.types.ts`, or lifecycle handlers.

## Change Type (select all)

- [x] Feature
- [x] Refactor

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

None

## User-visible / Behavior Changes

- When a model calls a skill name as a tool and the skill is registered, the error tool result now says: `Tool "X" not found. "X" is a skill. Read its SKILL.md first.`
- When the tool name does not match any registered skill, behavior is unchanged (generic "Tool not found").

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0, arm64)
- Runtime/container: Node 22 + pnpm
- Model/provider: Claude (Anthropic)
- Relevant config: workspace with registered skills (e.g. `my-skill`, `another-skill`)

### Steps

1. Start an OpenClaw agent session with skills registered
2. Prompt the model to call a skill name as if it were a tool (e.g. "use tool my-skill")
3. Observe the error tool result returned to the model

### Expected

- Error message: `Tool "my-skill" not found. "my-skill" is a skill. Read its SKILL.md first.`

### Actual

- Confirmed: skill-matching errors get the hint; non-skill unknown tools get the generic error.

## Evidence

- [x] Trace/log snippets

Manually tested two scenarios:
1. Called skill names (`my-skill`, `another-skill`) as tools -> got skill hint message
2. Called nonexistent name (`banana123`) as tool -> got generic "Tool not found"

## Human Verification (required)

<img width="1172" height="703" alt="image" src="https://github.com/user-attachments/assets/1059fd30-c22f-45d5-8447-38e2fb261173" />

- **Verified scenarios:** Both skill-match and non-match unknown tool errors in a live OpenClaw agent session.
- **Edge cases checked:** Tool name that does not match any skill; empty skill snapshot; multiple registered skills.
- **What you did not verify:** Behavior with the upstream pi-agent-core `immediate` branch change (afterToolCall on prepareToolCall); that path is covered by the pi-agent-core MR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `e527e3c111`; the `afterToolCall` hook is additive and removing it restores default unknown-tool errors.
- Files/config to restore: `errors.ts`, `attempt.ts`
- Known bad symptoms reviewers should watch for: If `setAfterToolCall` is called before the agent session is fully initialized, the hook may not fire; watch for missing skill hints in logs.

## Risks and Mitigations

- **Risk:** `rewriteToolResultUnknownToolError` regex may not match all provider error formats.
  - **Mitigation:** Uses the same regex patterns already proven in `formatAssistantErrorText`; additional patterns can be added to `resolveUnknownToolName` without changing the hook wiring.
