### PR TITLE
fix(slack): use dynamic import to fix ESM/CJS interop in bundled gateway

### DIFF
--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -1,16 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-// Dynamic import to avoid esbuild bundling issues with ESM/CJS interop
-let SlackBolt: unknown;
-let SlackBoltNamespace: Record<string, unknown> | undefined;
-
-async function loadSlackBolt() {
-  if (!SlackBolt) {
-    const slackModule = await import("@slack/bolt");
-    SlackBolt = slackModule.default ?? slackModule;
-    SlackBoltNamespace = slackModule as Record<string, unknown>;
-  }
-  return { SlackBolt, SlackBoltNamespace };
-}
+import type { App as SlackAppType, HTTPReceiver as SlackHTTPReceiverType } from "@slack/bolt";
 import {
   addAllowlistUserEntriesFromConfigEntry,
   buildAllowlistResolutionSummary,
@@ -56,6 +45,23 @@ import {
 } from "./reconnect-policy.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
+
+// Dynamic import to avoid esbuild bundling issues with ESM/CJS interop
+// Caches the Promise itself for concurrency safety
+let slackBoltLoadPromise: Promise<{
+  SlackBolt: unknown;
+  SlackBoltNamespace: Record<string, unknown>;
+}> | null = null;
+
+async function loadSlackBolt() {
+  if (!slackBoltLoadPromise) {
+    slackBoltLoadPromise = import("@slack/bolt").then((slackModule) => ({
+      SlackBolt: slackModule.default ?? slackModule,
+      SlackBoltNamespace: slackModule as Record<string, unknown>,
+    }));
+  }
+  return slackBoltLoadPromise;
+}
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
 type SlackHttpReceiverConstructor = typeof import("@slack/bolt").HTTPReceiver;
@@ -124,18 +130,19 @@ function resolveSlackBoltInterop(params: {
   throw new TypeError("Unable to resolve @slack/bolt App/HTTPReceiver exports");
 }
 
-// Lazy-loaded Slack Bolt exports (loaded dynamically to avoid bundling issues)
-let slackBoltExports: SlackBoltResolvedExports | null = null;
+// Lazy-loaded Slack Bolt exports (concurrency-safe via Promise caching)
+let slackBoltExportsPromise: Promise<SlackBoltResolvedExports> | null = null;
 
-async function getSlackBoltExports(): Promise<SlackBoltResolvedExports> {
-  if (!slackBoltExports) {
-    const { SlackBolt, SlackBoltNamespace } = await loadSlackBolt();
-    slackBoltExports = resolveSlackBoltInterop({
-      defaultImport: SlackBolt,
-      namespaceImport: SlackBoltNamespace,
-    });
+function getSlackBoltExports(): Promise<SlackBoltResolvedExports> {
+  if (!slackBoltExportsPromise) {
+    slackBoltExportsPromise = loadSlackBolt().then(({ SlackBolt, SlackBoltNamespace }) =>
+      resolveSlackBoltInterop({
+        defaultImport: SlackBolt,
+        namespaceImport: SlackBoltNamespace,
+      })
+    );
   }
-  return slackBoltExports;
+  return slackBoltExportsPromise;
 }
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -1,5 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import SlackBolt, * as SlackBoltNamespace from "@slack/bolt";
+// Dynamic import to avoid esbuild bundling issues with ESM/CJS interop
+let SlackBolt: unknown;
+let SlackBoltNamespace: Record<string, unknown> | undefined;
+
+async function loadSlackBolt() {
+  if (!SlackBolt) {
+    const slackModule = await import("@slack/bolt");
+    SlackBolt = slackModule.default ?? slackModule;
+    SlackBoltNamespace = slackModule as Record<string, unknown>;
+  }
+  return { SlackBolt, SlackBoltNamespace };
+}
 import {
   addAllowlistUserEntriesFromConfigEntry,
   buildAllowlistResolutionSummary,
@@ -113,10 +124,19 @@ function resolveSlackBoltInterop(params: {
   throw new TypeError("Unable to resolve @slack/bolt App/HTTPReceiver exports");
 }
 
-const { App, HTTPReceiver } = resolveSlackBoltInterop({
-  defaultImport: SlackBolt,
-  namespaceImport: SlackBoltNamespace,
-});
+// Lazy-loaded Slack Bolt exports (loaded dynamically to avoid bundling issues)
+let slackBoltExports: SlackBoltResolvedExports | null = null;
+
+async function getSlackBoltExports(): Promise<SlackBoltResolvedExports> {
+  if (!slackBoltExports) {
+    const { SlackBolt, SlackBoltNamespace } = await loadSlackBolt();
+    slackBoltExports = resolveSlackBoltInterop({
+      defaultImport: SlackBolt,
+      namespaceImport: SlackBoltNamespace,
+    });
+  }
+  return slackBoltExports;
+}
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
@@ -247,6 +267,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const typingReaction = slackCfg.typingReaction?.trim() ?? "";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+
+  // Load Slack Bolt exports dynamically
+  const { App, HTTPReceiver } = await getSlackBoltExports();
 
   const receiver =
     slackMode === "http"


### PR DESCRIPTION
## Problem
The Slack provider crashes with "App is not a constructor" when bundled in the gateway. This is caused by esbuild transforming the @slack/bolt module exports differently than Node.js runtime expects.

## Solution
Use dynamic import (await import()) instead of static imports. This:
1. Bypasses esbuild's static analysis and bundling
2. Preserves the original module structure at runtime  
3. Works with both ESM and CJS exports from @slack/bolt

## Changes
- Added async loadSlackBolt() function for dynamic import
- Added lazy-loaded getSlackBoltExports() to cache the resolved exports
- Updated monitorSlackProvider to await the dynamic import before using App/HTTPReceiver

## Testing
- [ ] Test with bundled gateway
- [ ] Test with source build
- [ ] Verify both socket mode and HTTP mode work

Fixes #50441