### PR TITLE
fix(telegram): add type guard for reply context text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Docs: https://docs.openclaw.ai
 - Android/camera: recycle intermediate and final snap bitmaps in `camera.snap` so repeated captures do not leak native image memory. (#41902) Thanks @Kaneki-x.
 - Control UI/logging: make browser-safe logger imports avoid eager temp-dir resolution so the bundled Control UI no longer crashes to a blank screen when logging reaches `tmp-openclaw-dir`. (#48469) Fixes #48062. Thanks @7inspire.
 - Control UI/chat sessions: show human-readable labels in the grouped session dropdown again, keep unique scoped fallbacks when metadata is missing, and disambiguate duplicate labels only when needed. (#45130) Thanks @luzhidong.
+- Telegram/replies: ignore malformed non-string reply text and caption fields when describing reply context, so unexpected Telegram reply payloads no longer break inbound context assembly. (#50500) Thanks @p3nchan.
 - Control UI/dashboard: preserve structured gateway shutdown reasons across restart disconnects so config-triggered restarts no longer fall back to `disconnected (1006): no reason`. (#46580) Fixes #46532. Thanks @vincentkoc.
 - Android/chat: theme the thinking dropdown and TLS trust dialogs explicitly so popup surfaces match the active app theme instead of falling back to mismatched Material defaults.
 - Node/startup: remove leftover debug `console.log("node host PATH: ...")` that printed the resolved PATH on every `openclaw node run` invocation. (#46515) Fixes #46411. Thanks @ademczuk.

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -263,8 +263,27 @@ describe("describeReplyTarget", () => {
       },
       // oxlint-disable-next-line typescript/no-explicit-any
     } as any);
-    // Should not produce "[object Object]" — should return null (no valid body)
+    // Should not throw when reply text is malformed; return null instead.
     expect(result).toBeNull();
+  });
+
+  it("falls back to caption when reply text is malformed", () => {
+    const result = describeReplyTarget({
+      message_id: 2,
+      date: 1000,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 1,
+        date: 900,
+        chat: { id: 1, type: "private" },
+        text: { some: "object" },
+        caption: "Caption body",
+        from: { id: 42, first_name: "Alice", is_bot: false },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(result?.body).toBe("Caption body");
+    expect(result?.kind).toBe("reply");
   });
 
   it("extracts forwarded context from reply_to_message (issue #9619)", () => {

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -406,8 +406,13 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
 
   const replyLike = reply ?? externalReply;
   if (!body && replyLike) {
-    const rawText = replyLike.text ?? replyLike.caption ?? "";
-    const replyBody = (typeof rawText === "string" ? rawText : "").trim();
+    const replyBody = (
+      typeof replyLike.text === "string"
+        ? replyLike.text
+        : typeof replyLike.caption === "string"
+          ? replyLike.caption
+          : ""
+    ).trim();
     body = replyBody;
     if (!body) {
       body = resolveTelegramMediaPlaceholder(replyLike) ?? "";


### PR DESCRIPTION
## Summary

Fixes #27201.

When `replyLike.text` or `replyLike.caption` is an unexpected non-string value (edge case from certain Telegram API responses, particularly `ExternalReplyInfo`), the reply body was coerced to `"[object Object]"` via implicit string concatenation.

This adds a `typeof === "string"` guard before `.trim()`, matching the existing pattern already used for `quoteText` on [line 400](https://github.com/openclaw/openclaw/blob/main/extensions/telegram/src/bot/helpers.ts#L400) of the same function.

## Changes

- `extensions/telegram/src/bot/helpers.ts` — 1 line: add type guard for reply text
- `extensions/telegram/src/bot/helpers.test.ts` — add test case for non-string reply text

## Test plan

- [x] Added test: non-string `.text` value returns `null` instead of `"[object Object]"`
- [x] All 48 existing tests in `helpers.test.ts` pass
- [x] `pnpm build && pnpm check && pnpm test` — clean

> AI-assisted: test case co-authored with Claude (Anthropic).