### PR TITLE
security: sanitize control characters in channel error logging

### DIFF
--- a/src/channels/logging.test.ts
+++ b/src/channels/logging.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { logAckFailure, logInboundDrop, logTypingFailure } from "./logging.js";
+
+describe("channel logging sanitization", () => {
+  it("strips newlines from error messages to prevent log injection", () => {
+    const log = vi.fn();
+    logTypingFailure({
+      log,
+      channel: "test",
+      error: "real error\nFAKE: admin logged in from 1.2.3.4",
+    });
+    expect(log).toHaveBeenCalledOnce();
+    const msg = log.mock.calls[0][0];
+    expect(msg).not.toContain("\n");
+    expect(msg).toContain("real error");
+    expect(msg).toContain("FAKE: admin logged in from 1.2.3.4");
+  });
+
+  it("strips carriage returns from error messages", () => {
+    const log = vi.fn();
+    logAckFailure({
+      log,
+      channel: "test",
+      error: "line1\r\nline2",
+    });
+    const msg = log.mock.calls[0][0];
+    expect(msg).not.toContain("\r");
+    expect(msg).not.toContain("\n");
+  });
+
+  it("strips control characters from target parameter", () => {
+    const log = vi.fn();
+    logInboundDrop({
+      log,
+      channel: "test",
+      reason: "rate-limit",
+      target: "user\x00\x1fid",
+    });
+    const msg = log.mock.calls[0][0];
+    // eslint-disable-next-line no-control-regex -- intentional: verify control chars are stripped
+    expect(msg).not.toMatch(/[\u0000-\u001f]/);
+    expect(msg).toContain("user");
+    expect(msg).toContain("id");
+  });
+
+  it("strips control characters from reason parameter", () => {
+    const log = vi.fn();
+    logInboundDrop({
+      log,
+      channel: "test",
+      reason: "bad\tinput\nhere",
+    });
+    const msg = log.mock.calls[0][0];
+    expect(msg).not.toContain("\t");
+    expect(msg).not.toContain("\n");
+  });
+
+  it("handles error objects with malicious toString()", () => {
+    const log = vi.fn();
+    const malicious = {
+      toString() {
+        return "ok\nCRITICAL: system compromised";
+      },
+    };
+    logTypingFailure({ log, channel: "test", error: malicious });
+    const msg = log.mock.calls[0][0];
+    expect(msg).not.toContain("\n");
+    expect(msg).toContain("ok");
+    expect(msg).toContain("CRITICAL: system compromised");
+  });
+
+  it("preserves normal log messages without modification", () => {
+    const log = vi.fn();
+    logTypingFailure({
+      log,
+      channel: "telegram",
+      target: "user123",
+      action: "start",
+      error: "timeout",
+    });
+    expect(log).toHaveBeenCalledWith("telegram typing action=start failed target=user123: timeout");
+  });
+});

--- a/src/channels/logging.ts
+++ b/src/channels/logging.ts
@@ -1,13 +1,19 @@
 export type LogFn = (message: string) => void;
 
+/** Replace control characters (newlines, tabs, etc.) with spaces to prevent log injection. */
+function sanitizeForLog(value: string): string {
+  // eslint-disable-next-line no-control-regex -- intentional: strip C0 controls + DEL to block log forging
+  return value.replace(/[\u0000-\u001f\u007f]/g, " ");
+}
+
 export function logInboundDrop(params: {
   log: LogFn;
   channel: string;
   reason: string;
   target?: string;
 }): void {
-  const target = params.target ? ` target=${params.target}` : "";
-  params.log(`${params.channel}: drop ${params.reason}${target}`);
+  const target = params.target ? ` target=${sanitizeForLog(params.target)}` : "";
+  params.log(`${params.channel}: drop ${sanitizeForLog(params.reason)}${target}`);
 }
 
 export function logTypingFailure(params: {
@@ -17,9 +23,11 @@ export function logTypingFailure(params: {
   action?: "start" | "stop";
   error: unknown;
 }): void {
-  const target = params.target ? ` target=${params.target}` : "";
+  const target = params.target ? ` target=${sanitizeForLog(params.target)}` : "";
   const action = params.action ? ` action=${params.action}` : "";
-  params.log(`${params.channel} typing${action} failed${target}: ${String(params.error)}`);
+  params.log(
+    `${params.channel} typing${action} failed${target}: ${sanitizeForLog(String(params.error))}`,
+  );
 }
 
 export function logAckFailure(params: {
@@ -28,6 +36,8 @@ export function logAckFailure(params: {
   target?: string;
   error: unknown;
 }): void {
-  const target = params.target ? ` target=${params.target}` : "";
-  params.log(`${params.channel} ack cleanup failed${target}: ${String(params.error)}`);
+  const target = params.target ? ` target=${sanitizeForLog(params.target)}` : "";
+  params.log(
+    `${params.channel} ack cleanup failed${target}: ${sanitizeForLog(String(params.error))}`,
+  );
 }


### PR DESCRIPTION
## Summary

- Add `sanitizeForLog()` helper that strips C0 control characters (`\u0000`–`\u001f`) and DEL (`\u007f`) from values before they reach the log sink
- Apply sanitization to `error`, `target`, and `reason` parameters in `logTypingFailure`, `logAckFailure`, and `logInboundDrop`
- Add comprehensive test coverage for log injection scenarios

**Motivation:** Error objects and external metadata (targets, reasons) flow into structured log lines. A crafted error `toString()` containing `\n` or `\r` can forge additional log entries, potentially misleading operators or triggering false alerts in log-monitoring pipelines. Replacing control characters with spaces preserves the diagnostic value while preventing log forging.

## Test plan

- [x] New `src/channels/logging.test.ts` with 6 test cases covering:
  - Newline stripping in error messages
  - Carriage return stripping
  - NUL and other control characters in target parameter
  - Control characters in reason parameter
  - Malicious `toString()` on error objects
  - Normal messages pass through unmodified
- [x] `pnpm test -- src/channels/logging.test.ts` passes