### PR TITLE
security: reject null bytes in archive entry paths

### DIFF
--- a/src/infra/archive-path.test.ts
+++ b/src/infra/archive-path.test.ts
@@ -50,6 +50,16 @@ describe("archive path helpers", () => {
       entryPath: "\\\\server\\share.txt",
       message: "archive entry is absolute: \\\\server\\share.txt",
     },
+    {
+      name: "rejects entry names containing null bytes",
+      entryPath: "safe.txt\0.malicious",
+      message: "archive entry contains a null byte",
+    },
+    {
+      name: "rejects entry names with embedded null bytes in directory",
+      entryPath: "dir\0evil/file.txt",
+      message: "archive entry contains a null byte",
+    },
   ])("$name", ({ entryPath, message }) => {
     expect(() =>
       validateArchiveEntryPath(entryPath, {

--- a/src/infra/archive-path.ts
+++ b/src/infra/archive-path.ts
@@ -16,6 +16,11 @@ export function validateArchiveEntryPath(
   if (!entryPath || entryPath === "." || entryPath === "./") {
     return;
   }
+  // Null bytes can truncate filenames at the OS level, potentially bypassing
+  // path-based security checks that operate on the full string.
+  if (entryPath.includes("\0")) {
+    throw new Error("archive entry contains a null byte");
+  }
   if (isWindowsDrivePath(entryPath)) {
     throw new Error(`archive entry uses a drive path: ${entryPath}`);
   }


### PR DESCRIPTION
## Summary

- Add explicit null byte (`\0`) validation in `validateArchiveEntryPath()` before any other path checks
- Reject archive entries containing null bytes with a clear error message

**Motivation:** Null bytes can truncate filenames at the OS/syscall level while path-based security checks operate on the full string. For example, an archive entry named `safe.txt\0../../etc/passwd` could pass string-based traversal checks (which see a safe relative path) but be interpreted by the filesystem as `safe.txt`. While Node.js `fs` APIs generally reject null bytes at the syscall level, adding explicit validation in the path validation layer provides defense-in-depth and a clear, descriptive error instead of a low-level EINVAL.

## Test plan

- [x] Two new test cases in `src/infra/archive-path.test.ts`:
  - Null byte in filename (`safe.txt\0.malicious`)
  - Null byte in directory component (`dir\0evil/file.txt`)
- [x] All 23 existing + new archive-path tests pass
- [x] No functional change to valid archive entries