### PR TITLE
test: add SSRF guard coverage for URL credential bypass vectors

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -303,12 +303,13 @@ describe("fetchWithSsrFGuard hardening", () => {
 
   it("blocks redirect to a URL using credentials to obscure a private host", async () => {
     const lookupFn = createPublicLookup();
-    await expectRedirectFailure({
+    const fetchImpl = await expectRedirectFailure({
       url: "https://public.example/start",
       responses: [redirectResponse("http://public@127.0.0.1:6379/")],
       expectedError: /private|internal|blocked/i,
       lookupFn,
     });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("ignores env proxy by default to preserve DNS-pinned destination binding", async () => {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -278,6 +278,39 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
   });
 
+  it("blocks URLs that use credentials to obscure a private host", async () => {
+    const fetchImpl = vi.fn();
+    // http://attacker.com@127.0.0.1:8080/ — URL parser extracts hostname as 127.0.0.1
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://attacker.com@127.0.0.1:8080/internal",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("blocks private IPv6 addresses embedded in URLs with credentials", async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://user:pass@[::1]:8080/internal",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("blocks redirect to a URL using credentials to obscure a private host", async () => {
+    const lookupFn = createPublicLookup();
+    await expectRedirectFailure({
+      url: "https://public.example/start",
+      responses: [redirectResponse("http://public@127.0.0.1:6379/")],
+      expectedError: /private|internal|blocked/i,
+      lookupFn,
+    });
+  });
+
   it("ignores env proxy by default to preserve DNS-pinned destination binding", async () => {
     await runProxyModeDispatcherTest({
       mode: GUARDED_FETCH_MODE.STRICT,


### PR DESCRIPTION
## Summary

- Add 3 new test cases to `src/infra/net/fetch-guard.ssrf.test.ts` documenting that the SSRF guard correctly handles URL credential bypass attempts:
  1. `http://attacker.com@127.0.0.1:8080/internal` — URL parser extracts hostname as `127.0.0.1`, correctly blocked
  2. `http://user:pass@[::1]:8080/internal` — IPv6 loopback with credentials, correctly blocked
  3. Redirect to `http://public@127.0.0.1:6379/` — redirect chain credential bypass, correctly blocked

**Motivation:** The SSRF guard correctly blocks these vectors via JavaScript's `URL` constructor (which extracts the real hostname regardless of credentials), but this behavior was not documented in the test suite. Explicit test coverage prevents regressions if the URL parsing or hostname extraction logic changes, and documents expected behavior for security review.

## Test plan

- [x] All 17 SSRF guard tests pass (14 existing + 3 new)
- [x] No code changes — test-only PR