### PR TITLE
security: add input length limits to hook agent payload metadata fields

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -323,6 +323,55 @@ describe("gateway hooks helpers", () => {
       "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset",
     );
   });
+
+  test("normalizeAgentPayload rejects oversized metadata fields", () => {
+    const longName = "x".repeat(1001);
+    expect(normalizeAgentPayload({ message: "hello", name: longName })).toEqual({
+      ok: false,
+      error: "name exceeds maximum length of 1000",
+    });
+
+    const longTo = "x".repeat(1001);
+    expect(normalizeAgentPayload({ message: "hello", to: longTo })).toEqual({
+      ok: false,
+      error: "to exceeds maximum length of 1000",
+    });
+
+    const longModel = "x".repeat(257);
+    expect(normalizeAgentPayload({ message: "hello", model: longModel })).toEqual({
+      ok: false,
+      error: "model exceeds maximum length of 256",
+    });
+
+    const longThinking = "x".repeat(65);
+    expect(normalizeAgentPayload({ message: "hello", thinking: longThinking })).toEqual({
+      ok: false,
+      error: "thinking exceeds maximum length of 64",
+    });
+
+    const longAgentId = "x".repeat(257);
+    expect(normalizeAgentPayload({ message: "hello", agentId: longAgentId })).toEqual({
+      ok: false,
+      error: "agentId exceeds maximum length of 256",
+    });
+
+    const longSessionKey = "x".repeat(1001);
+    expect(normalizeAgentPayload({ message: "hello", sessionKey: longSessionKey })).toEqual({
+      ok: false,
+      error: "sessionKey exceeds maximum length of 1000",
+    });
+  });
+
+  test("normalizeAgentPayload accepts fields at exact max length", () => {
+    const result = normalizeAgentPayload({
+      message: "hello",
+      name: "x".repeat(1000),
+      to: "x".repeat(1000),
+      model: "x".repeat(256),
+      thinking: "x".repeat(64),
+    });
+    expect(result.ok).toBe(true);
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -13,6 +13,12 @@ import { resolveAllowedAgentIds } from "./hooks-policy.js";
 const DEFAULT_HOOKS_PATH = "/hooks";
 const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
 const MAX_HOOK_IDEMPOTENCY_KEY_LENGTH = 256;
+const MAX_HOOK_NAME_LENGTH = 1000;
+const MAX_HOOK_TO_LENGTH = 1000;
+const MAX_HOOK_MODEL_LENGTH = 256;
+const MAX_HOOK_THINKING_LENGTH = 64;
+const MAX_HOOK_AGENT_ID_LENGTH = 256;
+const MAX_HOOK_SESSION_KEY_LENGTH = 1000;
 
 export type HooksConfigResolved = {
   basePath: string;
@@ -365,29 +371,50 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
   }
   const nameRaw = payload.name;
   const name = typeof nameRaw === "string" && nameRaw.trim() ? nameRaw.trim() : "Hook";
+  if (name.length > MAX_HOOK_NAME_LENGTH) {
+    return { ok: false, error: `name exceeds maximum length of ${MAX_HOOK_NAME_LENGTH}` };
+  }
   const agentIdRaw = payload.agentId;
   const agentId =
     typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
+  if (agentId && agentId.length > MAX_HOOK_AGENT_ID_LENGTH) {
+    return { ok: false, error: `agentId exceeds maximum length of ${MAX_HOOK_AGENT_ID_LENGTH}` };
+  }
   const idempotencyKey = resolveOptionalHookIdempotencyKey(payload.idempotencyKey);
   const wakeMode = payload.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const sessionKeyRaw = payload.sessionKey;
   const sessionKey =
     typeof sessionKeyRaw === "string" && sessionKeyRaw.trim() ? sessionKeyRaw.trim() : undefined;
+  if (sessionKey && sessionKey.length > MAX_HOOK_SESSION_KEY_LENGTH) {
+    return {
+      ok: false,
+      error: `sessionKey exceeds maximum length of ${MAX_HOOK_SESSION_KEY_LENGTH}`,
+    };
+  }
   const channel = resolveHookChannel(payload.channel);
   if (!channel) {
     return { ok: false, error: getHookChannelError() };
   }
   const toRaw = payload.to;
   const to = typeof toRaw === "string" && toRaw.trim() ? toRaw.trim() : undefined;
+  if (to && to.length > MAX_HOOK_TO_LENGTH) {
+    return { ok: false, error: `to exceeds maximum length of ${MAX_HOOK_TO_LENGTH}` };
+  }
   const modelRaw = payload.model;
   const model = typeof modelRaw === "string" && modelRaw.trim() ? modelRaw.trim() : undefined;
   if (modelRaw !== undefined && !model) {
     return { ok: false, error: "model required" };
   }
+  if (model && model.length > MAX_HOOK_MODEL_LENGTH) {
+    return { ok: false, error: `model exceeds maximum length of ${MAX_HOOK_MODEL_LENGTH}` };
+  }
   const deliver = resolveHookDeliver(payload.deliver);
   const thinkingRaw = payload.thinking;
   const thinking =
     typeof thinkingRaw === "string" && thinkingRaw.trim() ? thinkingRaw.trim() : undefined;
+  if (thinking && thinking.length > MAX_HOOK_THINKING_LENGTH) {
+    return { ok: false, error: `thinking exceeds maximum length of ${MAX_HOOK_THINKING_LENGTH}` };
+  }
   const timeoutRaw = payload.timeoutSeconds;
   const timeoutSeconds =
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0


### PR DESCRIPTION
## Summary

- Add per-field maximum length constants for hook agent payload metadata fields in `normalizeAgentPayload()`:
  - `name`: 1,000 chars
  - `to`: 1,000 chars
  - `model`: 256 chars
  - `thinking`: 64 chars
  - `agentId`: 256 chars
  - `sessionKey`: 1,000 chars
- Return descriptive error messages when limits are exceeded
- `message` is intentionally left unconstrained (bounded by `DEFAULT_HOOKS_MAX_BODY_BYTES` = 256 KB at the HTTP layer)

**Motivation:** While the overall HTTP body is limited to 256 KB, individual metadata fields within the hook payload had no per-field length validation (except `idempotencyKey` which already had a 256-char limit). Oversized metadata values could cause disproportionate resource consumption in downstream processing (message formatting, storage, logging). This adds defense-in-depth without affecting normal usage — the limits are generous enough to accommodate any reasonable input.

## Test plan

- [x] All 19 hooks tests pass (17 existing + 2 new)
- [x] New test: rejects oversized values for all 6 metadata fields
- [x] New test: accepts values at exact maximum length boundary
- [x] `message` field remains unconstrained within the body limit