### PR TITLE
fix(gateway): retry local probe with device auth

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -60,6 +60,7 @@ async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void>
       password: process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined,
     },
     timeoutMs: 1_000,
+    allowLocalDeviceAuthRetry: true,
   }).catch(() => null);
 
   if (!probe?.ok) {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -67,6 +67,7 @@ async function confirmGatewayReachable(port: number): Promise<boolean> {
     auth: token || password ? { token, password } : undefined,
     timeoutMs: 3_000,
     includeDetails: false,
+    allowLocalDeviceAuthRetry: true,
   });
   return probe.ok || looksLikeAuthClose(probe.close?.code, probe.close?.reason);
 }

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -558,8 +558,14 @@ describe("gateway-status command", () => {
     expect(probeGateway).toHaveBeenCalled();
     const tunnelCall = probeGateway.mock.calls.find(
       (call) => typeof call?.[0]?.url === "string" && call[0].url.startsWith("ws://127.0.0.1:"),
-    )?.[0] as { auth?: { token?: string } } | undefined;
+    )?.[0] as
+      | {
+          auth?: { token?: string };
+          allowLocalDeviceAuthRetry?: boolean;
+        }
+      | undefined;
     expect(tunnelCall?.auth?.token).toBe("rtok");
+    expect(tunnelCall?.allowLocalDeviceAuthRetry).toBe(false);
     expect(sshStop).toHaveBeenCalledTimes(1);
 
     const parsed = JSON.parse(runtimeLogs.join("\n")) as Record<string, unknown>;

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -181,6 +181,7 @@ export async function gatewayStatusCommand(
               url: target.url,
               auth,
               timeoutMs,
+              allowLocalDeviceAuthRetry: target.kind === "localLoopback",
             });
             const configSummary = probe.configSnapshot
               ? extractConfigSummary(probe.configSnapshot)

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -134,6 +134,7 @@ export async function statusAllCommand(
       url: connection.url,
       auth: probeAuth,
       timeoutMs: Math.min(5000, opts?.timeoutMs ?? 10_000),
+      allowLocalDeviceAuthRetry: !isRemoteMode || remoteUrlMissing,
     }).catch(() => null);
     const gatewayReachable = gatewayProbe?.ok === true;
     const gatewaySelf = pickGatewaySelfPresence(gatewayProbe?.presence ?? null);

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -77,6 +77,7 @@ export async function resolveGatewayProbeSnapshot(params: {
           auth: gatewayProbeAuthResolution.auth,
           timeoutMs: Math.min(params.opts.all ? 5000 : 2500, params.opts.timeoutMs ?? 10_000),
           detailLevel: "presence",
+          allowLocalDeviceAuthRetry: gatewayMode === "local" || remoteUrlMissing,
         }).catch(() => null);
   if (gatewayProbeAuthWarning && gatewayProbe?.ok === false) {
     gatewayProbe.error = gatewayProbe.error

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -98,6 +98,7 @@ export type GatewayClientOptions = {
   permissions?: Record<string, boolean>;
   pathEnv?: string;
   deviceIdentity?: DeviceIdentity | null;
+  clearDeviceAuthTokenOnMismatch?: boolean;
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
@@ -254,6 +255,7 @@ export class GatewayClient {
       if (
         code === 1008 &&
         reasonText.toLowerCase().includes("device token mismatch") &&
+        this.opts.clearDeviceAuthTokenOnMismatch !== false &&
         !this.opts.token &&
         !this.opts.password &&
         this.opts.deviceIdentity

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -1,34 +1,67 @@
 import { describe, expect, it, vi } from "vitest";
 
 const gatewayClientState = vi.hoisted(() => ({
-  options: null as Record<string, unknown> | null,
+  options: [] as Record<string, unknown>[],
   requests: [] as string[],
+  plans: [] as Array<Record<string, unknown>>,
 }));
 
 class MockGatewayClient {
   private readonly opts: Record<string, unknown>;
+  private readonly plan: Record<string, unknown>;
 
   constructor(opts: Record<string, unknown>) {
     this.opts = opts;
-    gatewayClientState.options = opts;
+    this.plan = gatewayClientState.plans.shift() ?? {};
+    gatewayClientState.options.push(opts);
     gatewayClientState.requests = [];
   }
 
   start(): void {
-    void Promise.resolve()
-      .then(async () => {
-        const onHelloOk = this.opts.onHelloOk;
-        if (typeof onHelloOk === "function") {
+    const onHelloOk = this.opts.onHelloOk;
+    if (typeof onHelloOk !== "function" || this.plan.skipHelloOk === true) {
+      return;
+    }
+    const helloDelayMs =
+      typeof this.plan.helloDelayMs === "number" && Number.isFinite(this.plan.helloDelayMs)
+        ? Math.max(0, this.plan.helloDelayMs)
+        : 0;
+    const runHelloOk = () => {
+      void Promise.resolve()
+        .then(async () => {
           await onHelloOk();
-        }
-      })
-      .catch(() => {});
+        })
+        .catch(() => {});
+    };
+    if (helloDelayMs > 0) {
+      setTimeout(runHelloOk, helloDelayMs);
+      return;
+    }
+    runHelloOk();
   }
 
   stop(): void {}
 
   async request(method: string): Promise<unknown> {
     gatewayClientState.requests.push(method);
+    const requests =
+      (this.plan.requests as
+        | Record<string, { error?: string; result?: unknown; delayMs?: number }>
+        | undefined) ?? {};
+    const planned = requests[method];
+    if (
+      typeof planned?.delayMs === "number" &&
+      Number.isFinite(planned.delayMs) &&
+      planned.delayMs > 0
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, planned.delayMs));
+    }
+    if (planned?.error) {
+      throw new Error(planned.error);
+    }
+    if (planned && "result" in planned) {
+      return planned.result;
+    }
     if (method === "system-presence") {
       return [];
     }
@@ -49,15 +82,128 @@ describe("probeGateway", () => {
     expect(clampProbeTimeoutMs(3_000_000_000)).toBe(2_147_483_647);
   });
 
+  it("retries local probes without explicit auth when shared auth loses operator.read", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.splice(0, gatewayClientState.plans.length, {
+      requests: {
+        status: { error: "missing scope: operator.read" },
+      },
+    });
+    gatewayClientState.plans.push({
+      requests: {
+        health: { result: { ok: true } },
+        status: { result: { ok: true } },
+        "system-presence": { result: [] },
+        "config.get": { result: { ok: true } },
+      },
+    });
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      allowLocalDeviceAuthRetry: true,
+    });
+
+    expect(gatewayClientState.options).toHaveLength(2);
+    expect(gatewayClientState.options[0]?.token).toBe("secret");
+    expect(gatewayClientState.options[1]?.token).toBeUndefined();
+    // Retry enables device identity (undefined = use default, not null = disabled)
+    expect(gatewayClientState.options[1]?.deviceIdentity).toBeUndefined();
+    expect(gatewayClientState.options[1]?.clearDeviceAuthTokenOnMismatch).toBe(false);
+    expect(result.ok).toBe(true);
+  });
+
+  it("keeps the original scope-limited result when the local retry still fails", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.splice(0, gatewayClientState.plans.length, {
+      requests: {
+        status: { error: "missing scope: operator.read" },
+      },
+    });
+    gatewayClientState.plans.push({
+      requests: {
+        health: { error: "pairing required" },
+      },
+    });
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      allowLocalDeviceAuthRetry: true,
+    });
+
+    expect(gatewayClientState.options).toHaveLength(2);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("missing scope: operator.read");
+  });
+
+  it("can suppress local device-auth fallback for tunneled loopback targets", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.splice(0, gatewayClientState.plans.length, {
+      requests: {
+        status: { error: "missing scope: operator.read" },
+      },
+    });
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      allowLocalDeviceAuthRetry: false,
+    });
+
+    expect(gatewayClientState.options).toHaveLength(1);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("missing scope: operator.read");
+  });
+
+  it("keeps one timeout budget across the retry path", async () => {
+    vi.useFakeTimers();
+    try {
+      gatewayClientState.options.length = 0;
+      gatewayClientState.plans.splice(0, gatewayClientState.plans.length, {
+        requests: {
+          status: { error: "missing scope: operator.read", delayMs: 200 },
+        },
+      });
+      gatewayClientState.plans.push({
+        helloDelayMs: 400,
+      });
+
+      let settled = false;
+      const resultPromise = probeGateway({
+        url: "ws://127.0.0.1:18789",
+        auth: { token: "secret" },
+        timeoutMs: 500,
+        allowLocalDeviceAuthRetry: true,
+      }).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(settled).toBe(true);
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("missing scope: operator.read");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("connects with operator.read scope", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.length = 0;
     const result = await probeGateway({
       url: "ws://127.0.0.1:18789",
       auth: { token: "secret" },
       timeoutMs: 1_000,
     });
 
-    expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
-    expect(gatewayClientState.options?.deviceIdentity).toBeUndefined();
+    expect(gatewayClientState.options[0]?.scopes).toEqual(["operator.read"]);
+    expect(gatewayClientState.options[0]?.deviceIdentity).toBeUndefined();
     expect(gatewayClientState.requests).toEqual([
       "health",
       "status",
@@ -68,25 +214,31 @@ describe("probeGateway", () => {
   });
 
   it("keeps device identity enabled for remote probes", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.length = 0;
     await probeGateway({
       url: "wss://gateway.example/ws",
       auth: { token: "secret" },
       timeoutMs: 1_000,
     });
 
-    expect(gatewayClientState.options?.deviceIdentity).toBeUndefined();
+    expect(gatewayClientState.options[0]?.deviceIdentity).toBeUndefined();
   });
 
   it("keeps device identity disabled for unauthenticated loopback probes", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.length = 0;
     await probeGateway({
       url: "ws://127.0.0.1:18789",
       timeoutMs: 1_000,
     });
 
-    expect(gatewayClientState.options?.deviceIdentity).toBeNull();
+    expect(gatewayClientState.options[0]?.deviceIdentity).toBeNull();
   });
 
   it("skips detail RPCs for lightweight reachability probes", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.length = 0;
     const result = await probeGateway({
       url: "ws://127.0.0.1:18789",
       timeoutMs: 1_000,
@@ -98,6 +250,8 @@ describe("probeGateway", () => {
   });
 
   it("fetches only presence for presence-only probes", async () => {
+    gatewayClientState.options.length = 0;
+    gatewayClientState.plans.length = 0;
     const result = await probeGateway({
       url: "ws://127.0.0.1:18789",
       timeoutMs: 1_000,

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -36,78 +36,111 @@ export function clampProbeTimeoutMs(timeoutMs: number): number {
   return Math.min(MAX_TIMER_DELAY_MS, Math.max(MIN_PROBE_TIMEOUT_MS, timeoutMs));
 }
 
+function isLocalSharedAuthScopeFailure(opts: {
+  url: string;
+  auth?: GatewayProbeAuth;
+  result: GatewayProbeResult;
+  allowLocalDeviceAuthRetry?: boolean;
+}): boolean {
+  if (opts.allowLocalDeviceAuthRetry !== true) {
+    return false;
+  }
+  if (!opts.auth?.token && !opts.auth?.password) {
+    return false;
+  }
+  if (!opts.result.error?.includes(`missing scope: ${READ_SCOPE}`)) {
+    return false;
+  }
+  try {
+    const hostname = new URL(opts.url).hostname;
+    return isLoopbackHost(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe a gateway endpoint for connectivity and optional health/status details.
+ *
+ * When `allowLocalDeviceAuthRetry` is true and the first attempt fails with a
+ * scope-stripping error on a loopback URL, the probe retries without explicit
+ * auth so device-identity pairing can satisfy the scope requirement. Both
+ * attempts share a single deadline computed from `timeoutMs`, so the total
+ * wall-clock time never exceeds the caller's budget.
+ */
 export async function probeGateway(opts: {
   url: string;
   auth?: GatewayProbeAuth;
   timeoutMs: number;
   includeDetails?: boolean;
   detailLevel?: "none" | "presence" | "full";
+  allowLocalDeviceAuthRetry?: boolean;
 }): Promise<GatewayProbeResult> {
-  const startedAt = Date.now();
-  const instanceId = randomUUID();
-  let connectLatencyMs: number | null = null;
-  let connectError: string | null = null;
-  let close: GatewayProbeClose | null = null;
-
-  const disableDeviceIdentity = (() => {
-    try {
-      const hostname = new URL(opts.url).hostname;
-      // Local authenticated probes should stay device-bound so read/detail RPCs
-      // are not scope-limited by the shared-auth scope stripping hardening.
-      return isLoopbackHost(hostname) && !(opts.auth?.token || opts.auth?.password);
-    } catch {
-      return false;
-    }
-  })();
-
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
+  // A single deadline governs both the initial attempt and any device-auth
+  // retry so the caller's timeout budget is never exceeded.
+  const deadlineAt = Date.now() + clampProbeTimeoutMs(opts.timeoutMs);
+  const attemptProbe = async (
+    auth?: GatewayProbeAuth,
+    attemptOpts?: {
+      forceDeviceIdentity?: boolean;
+      clearDeviceAuthTokenOnMismatch?: boolean;
+    },
+  ): Promise<GatewayProbeResult> => {
+    const startedAt = Date.now();
+    const instanceId = randomUUID();
+    let connectLatencyMs: number | null = null;
+    let connectError: string | null = null;
+    let close: GatewayProbeClose | null = null;
 
-  return await new Promise<GatewayProbeResult>((resolve) => {
-    let settled = false;
-    const settle = (result: Omit<GatewayProbeResult, "url">) => {
-      if (settled) {
-        return;
+    const disableDeviceIdentity = (() => {
+      try {
+        const hostname = new URL(opts.url).hostname;
+        // Local authenticated probes should stay device-bound so read/detail RPCs
+        // are not scope-limited by the shared-auth scope stripping hardening.
+        return (
+          isLoopbackHost(hostname) &&
+          !(auth?.token || auth?.password) &&
+          attemptOpts?.forceDeviceIdentity !== true
+        );
+      } catch {
+        return false;
       }
-      settled = true;
-      clearTimeout(timer);
-      client.stop();
-      resolve({ url: opts.url, ...result });
-    };
+    })();
 
-    const client = new GatewayClient({
-      url: opts.url,
-      token: opts.auth?.token,
-      password: opts.auth?.password,
-      scopes: [READ_SCOPE],
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      clientVersion: "dev",
-      mode: GATEWAY_CLIENT_MODES.PROBE,
-      instanceId,
-      deviceIdentity: disableDeviceIdentity ? null : undefined,
-      onConnectError: (err) => {
-        connectError = formatErrorMessage(err);
-      },
-      onClose: (code, reason) => {
-        close = { code, reason };
-      },
-      onHelloOk: async () => {
-        connectLatencyMs = Date.now() - startedAt;
-        if (detailLevel === "none") {
-          settle({
-            ok: true,
-            connectLatencyMs,
-            error: null,
-            close,
-            health: null,
-            status: null,
-            presence: null,
-            configSnapshot: null,
-          });
+    return await new Promise<GatewayProbeResult>((resolve) => {
+      const remainingBudgetMs = Math.max(1, deadlineAt - Date.now());
+      let settled = false;
+      const settle = (result: Omit<GatewayProbeResult, "url">) => {
+        if (settled) {
           return;
         }
-        try {
-          if (detailLevel === "presence") {
-            const presence = await client.request("system-presence");
+        settled = true;
+        clearTimeout(timer);
+        client.stop();
+        resolve({ url: opts.url, ...result });
+      };
+
+      const client = new GatewayClient({
+        url: opts.url,
+        token: auth?.token,
+        password: auth?.password,
+        scopes: [READ_SCOPE],
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        clientVersion: "dev",
+        mode: GATEWAY_CLIENT_MODES.PROBE,
+        instanceId,
+        deviceIdentity: disableDeviceIdentity ? null : undefined,
+        clearDeviceAuthTokenOnMismatch: attemptOpts?.clearDeviceAuthTokenOnMismatch,
+        onConnectError: (err) => {
+          connectError = formatErrorMessage(err);
+        },
+        onClose: (code, reason) => {
+          close = { code, reason };
+        },
+        onHelloOk: async () => {
+          connectLatencyMs = Date.now() - startedAt;
+          if (detailLevel === "none") {
             settle({
               ok: true,
               connectLatencyMs,
@@ -115,55 +148,88 @@ export async function probeGateway(opts: {
               close,
               health: null,
               status: null,
-              presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
+              presence: null,
               configSnapshot: null,
             });
             return;
           }
-          const [health, status, presence, configSnapshot] = await Promise.all([
-            client.request("health"),
-            client.request("status"),
-            client.request("system-presence"),
-            client.request("config.get", {}),
-          ]);
-          settle({
-            ok: true,
-            connectLatencyMs,
-            error: null,
-            close,
-            health,
-            status,
-            presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
-            configSnapshot,
-          });
-        } catch (err) {
-          settle({
-            ok: false,
-            connectLatencyMs,
-            error: formatErrorMessage(err),
-            close,
-            health: null,
-            status: null,
-            presence: null,
-            configSnapshot: null,
-          });
-        }
-      },
-    });
-
-    const timer = setTimeout(() => {
-      settle({
-        ok: false,
-        connectLatencyMs,
-        error: connectError ? `connect failed: ${connectError}` : "timeout",
-        close,
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
+          try {
+            if (detailLevel === "presence") {
+              const presence = await client.request("system-presence");
+              settle({
+                ok: true,
+                connectLatencyMs,
+                error: null,
+                close,
+                health: null,
+                status: null,
+                presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
+                configSnapshot: null,
+              });
+              return;
+            }
+            const [health, status, presence, configSnapshot] = await Promise.all([
+              client.request("health"),
+              client.request("status"),
+              client.request("system-presence"),
+              client.request("config.get", {}),
+            ]);
+            settle({
+              ok: true,
+              connectLatencyMs,
+              error: null,
+              close,
+              health,
+              status,
+              presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
+              configSnapshot,
+            });
+          } catch (err) {
+            settle({
+              ok: false,
+              connectLatencyMs,
+              error: formatErrorMessage(err),
+              close,
+              health: null,
+              status: null,
+              presence: null,
+              configSnapshot: null,
+            });
+          }
+        },
       });
-    }, clampProbeTimeoutMs(opts.timeoutMs));
 
-    client.start();
+      const timer = setTimeout(() => {
+        settle({
+          ok: false,
+          connectLatencyMs,
+          error: connectError ? `connect failed: ${connectError}` : "timeout",
+          close,
+          health: null,
+          status: null,
+          presence: null,
+          configSnapshot: null,
+        });
+      }, remainingBudgetMs);
+
+      client.start();
+    });
+  };
+
+  const first = await attemptProbe(opts.auth);
+  if (
+    !isLocalSharedAuthScopeFailure({
+      url: opts.url,
+      auth: opts.auth,
+      result: first,
+      allowLocalDeviceAuthRetry: opts.allowLocalDeviceAuthRetry,
+    })
+  ) {
+    return first;
+  }
+  const retry = await attemptProbe(undefined, {
+    forceDeviceIdentity: true,
+    clearDeviceAuthTokenOnMismatch: false,
   });
+  return retry.ok ? retry : first;
 }


### PR DESCRIPTION
## Summary

- retry loopback gateway probes without explicit shared auth when the first probe fails with `missing scope: operator.read`
- keep the fallback local-only so remote auth precedence stays unchanged
- add regression coverage for the retry path in `src/gateway/probe.test.ts`

## Linked Issue

- Closes #50514

## Verification

- `pnpm test -- src/gateway/probe.test.ts`
- `pnpm exec oxfmt --check src/gateway/probe.ts src/gateway/probe.test.ts`
