### PR TITLE
fix(whatsapp): use lazy-init getListeners() for cross-chunk singleton

### DIFF
--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -28,29 +28,19 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-// Use process-global symbol keys to survive bundler code-splitting and loader
-// cache splits without depending on fragile string property names.
-const GLOBAL_LISTENERS_KEY = Symbol.for("openclaw.whatsapp.activeListeners");
-const GLOBAL_CURRENT_KEY = Symbol.for("openclaw.whatsapp.currentListener");
+// Use process-global symbol key with lazy initialization to survive bundler
+// code-splitting and loader cache splits. The getListeners() function ensures
+// we always access the same Map regardless of which chunk loads first.
+const LISTENERS_KEY = Symbol.for("openclaw:whatsapp:active-listeners");
 
-type GlobalWithListeners = typeof globalThis & {
-  [GLOBAL_LISTENERS_KEY]?: Map<string, ActiveWebListener>;
-  [GLOBAL_CURRENT_KEY]?: ActiveWebListener | null;
-};
-
-const _global = globalThis as GlobalWithListeners;
-
-_global[GLOBAL_LISTENERS_KEY] ??= new Map<string, ActiveWebListener>();
-_global[GLOBAL_CURRENT_KEY] ??= null;
-
-const listeners = _global[GLOBAL_LISTENERS_KEY];
-
-function getCurrentListener(): ActiveWebListener | null {
-  return _global[GLOBAL_CURRENT_KEY] ?? null;
-}
-
-function setCurrentListener(listener: ActiveWebListener | null): void {
-  _global[GLOBAL_CURRENT_KEY] = listener;
+function getListeners(): Map<string, ActiveWebListener> {
+  const g = globalThis as Record<symbol, unknown>;
+  let map = g[LISTENERS_KEY] as Map<string, ActiveWebListener> | undefined;
+  if (!map) {
+    map = new Map<string, ActiveWebListener>();
+    g[LISTENERS_KEY] = map;
+  }
+  return map;
 }
 
 export function resolveWebAccountId(accountId?: string | null): string {
@@ -62,7 +52,7 @@ export function requireActiveWebListener(accountId?: string | null): {
   listener: ActiveWebListener;
 } {
   const id = resolveWebAccountId(accountId);
-  const listener = listeners.get(id) ?? null;
+  const listener = getListeners().get(id) ?? null;
   if (!listener) {
     throw new Error(
       `No active WhatsApp Web listener (account: ${id}). Start the gateway, then link WhatsApp with: ${formatCliCommand(`openclaw channels login --channel whatsapp --account ${id}`)}.`,
@@ -90,16 +80,13 @@ export function setActiveWebListener(
 
   const id = resolveWebAccountId(accountId);
   if (!listener) {
-    listeners.delete(id);
+    getListeners().delete(id);
   } else {
-    listeners.set(id, listener);
-  }
-  if (id === DEFAULT_ACCOUNT_ID) {
-    setCurrentListener(listener);
+    getListeners().set(id, listener);
   }
 }
 
 export function getActiveWebListener(accountId?: string | null): ActiveWebListener | null {
   const id = resolveWebAccountId(accountId);
-  return listeners.get(id) ?? null;
+  return getListeners().get(id) ?? null;
 }


### PR DESCRIPTION
## Problem

The previous `Symbol.for()` approach for sharing the WhatsApp listener Map across bundler chunks still failed intermittently. Module-level initialization (`_global[KEY] ??= new Map()`) could race between chunks, resulting in multiple Map instances.

This caused outbound WhatsApp messages to fail with:
```
Error: No active WhatsApp Web listener (account: default)
```

Even after successful gateway reconnects and re-linking.

## Solution

Replace module-level initialization with a `getListeners()` function that lazily initializes the Map on every access. This ensures all chunks share the same instance regardless of load order.

**Before:**
```typescript
_global[GLOBAL_LISTENERS_KEY] ??= new Map<string, ActiveWebListener>();
const listeners = _global[GLOBAL_LISTENERS_KEY];
```

**After:**
```typescript
function getListeners(): Map<string, ActiveWebListener> {
  const g = globalThis as Record<symbol, unknown>;
  let map = g[LISTENERS_KEY] as Map<string, ActiveWebListener> | undefined;
  if (!map) {
    map = new Map<string, ActiveWebListener>();
    g[LISTENERS_KEY] = map;
  }
  return map;
}
```

## Testing

Verified fix resolves the issue after multiple gateway disconnects/reconnects:
- Outbound messages to direct chats ✅
- Outbound messages to groups ✅
- 12+ cron jobs that were failing now work ✅

## Additional Changes

- Removed unused `_currentListener` variable and `getCurrentListener()`/`setCurrentListener()` functions
- Simplified Symbol key name to `openclaw:whatsapp:active-listeners`