### PR TITLE
Cron: add GitHub checks Slack path and Sentry diagnostics

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -602,6 +602,22 @@ openclaw cron add \
   --to "+15551234567"
 ```
 
+Recurring isolated job (watch GitHub checks and announce to Slack):
+
+```bash
+openclaw cron add \
+  --name "OpenClaw main CI watch" \
+  --cron "*/15 * * * *" \
+  --tz "UTC" \
+  --session isolated \
+  --message "Use github_checks for openclaw/openclaw on ref main. If any checks are failing or pending, summarize the important ones in a short operator update. If everything is green, say that clearly and keep it brief." \
+  --announce \
+  --channel slack \
+  --to "channel:C12345678"
+```
+
+For Sentry-backed cron failure reporting, enable the optional `diagnostics-sentry` plugin under `plugins.entries.diagnostics-sentry.config` and set its DSN.
+
 Recurring cron job with explicit 30-second stagger:
 
 ```bash

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,5 +1,5 @@
 ---
-summary: "Agent tool surface for OpenClaw (browser, canvas, nodes, message, cron) replacing legacy `openclaw-*` skills"
+summary: "Agent tool surface for OpenClaw (browser, canvas, nodes, message, cron, GitHub checks) replacing legacy `openclaw-*` skills"
 read_when:
   - Adding or modifying agent tools
   - Retiring or changing `openclaw-*` skills
@@ -8,7 +8,7 @@ title: "Tools"
 
 # Tools (OpenClaw)
 
-OpenClaw exposes **first-class agent tools** for browser, canvas, nodes, and cron.
+OpenClaw exposes **first-class agent tools** for browser, canvas, nodes, cron, GitHub checks, and messaging.
 These replace the old `openclaw-*` skills: the tools are typed, no shelling,
 and the agent should rely on them directly.
 
@@ -148,7 +148,7 @@ Available groups:
 - `group:memory`: `memory_search`, `memory_get`
 - `group:web`: `web_search`, `web_fetch`
 - `group:ui`: `browser`, `canvas`
-- `group:automation`: `cron`, `gateway`
+- `group:automation`: `cron`, `gateway`, `github_checks`
 - `group:messaging`: `message`
 - `group:nodes`: `nodes`
 - `group:openclaw`: all built-in OpenClaw tools (excludes provider plugins)
@@ -488,6 +488,23 @@ Notes:
 
 - `add` expects a full cron job object (same schema as `cron.add` RPC).
 - `update` uses `{ jobId, patch }` (`id` accepted for compatibility).
+
+### `github_checks`
+
+Fetch GitHub check runs and commit statuses for a repository ref.
+
+Core parameters:
+
+- `repo` (required, `owner/repo`)
+- `ref` (required, branch, tag, or commit SHA)
+- `checkName` (optional server-side filter)
+- `maxCheckRuns`, `maxStatuses`, `timeoutMs`
+
+Notes:
+
+- Uses `GH_TOKEN`, `GITHUB_TOKEN`, or an explicit `token` parameter.
+- Returns both GitHub Check Runs and legacy commit statuses, plus a combined summary (`failure`, `pending`, `success`, or `no_data`).
+- Useful in isolated cron jobs that announce concise CI updates back to Slack, Discord, or other channels.
 
 ### `gateway`
 

--- a/extensions/diagnostics-sentry/api.ts
+++ b/extensions/diagnostics-sentry/api.ts
@@ -1,0 +1,1 @@
+export * from "openclaw/plugin-sdk/diagnostics-sentry";

--- a/extensions/diagnostics-sentry/index.ts
+++ b/extensions/diagnostics-sentry/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createDiagnosticsSentryService, parseDiagnosticsSentryConfig } from "./src/service.js";
+
+export default definePluginEntry({
+  id: "diagnostics-sentry",
+  name: "Diagnostics Sentry",
+  description: "Report cron failures to Sentry",
+  register(api) {
+    api.registerService(
+      createDiagnosticsSentryService(parseDiagnosticsSentryConfig(api.pluginConfig)),
+    );
+  },
+});

--- a/extensions/diagnostics-sentry/openclaw.plugin.json
+++ b/extensions/diagnostics-sentry/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "diagnostics-sentry",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "dsn": {
+        "type": "string"
+      },
+      "environment": {
+        "type": "string"
+      },
+      "release": {
+        "type": "string"
+      },
+      "serverName": {
+        "type": "string"
+      },
+      "flushTimeoutMs": {
+        "type": "number",
+        "minimum": 1
+      }
+    }
+  }
+}

--- a/extensions/diagnostics-sentry/package.json
+++ b/extensions/diagnostics-sentry/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/diagnostics-sentry",
+  "version": "2026.3.14",
+  "description": "OpenClaw diagnostics Sentry exporter",
+  "type": "module",
+  "dependencies": {
+    "@sentry/node": "^10.22.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "release": {
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/diagnostics-sentry/src/service.test.ts
+++ b/extensions/diagnostics-sentry/src/service.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryState = vi.hoisted(() => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  close: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@sentry/node", () => ({
+  init: sentryState.init,
+  captureException: sentryState.captureException,
+  close: sentryState.close,
+}));
+
+import type { OpenClawPluginServiceContext } from "../api.js";
+import { emitDiagnosticEvent } from "../api.js";
+import { createDiagnosticsSentryService, parseDiagnosticsSentryConfig } from "./service.js";
+
+function createContext(): OpenClawPluginServiceContext {
+  return {
+    config: {},
+    stateDir: "/tmp/openclaw-diagnostics-sentry-test",
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+
+describe("diagnostics-sentry service", () => {
+  beforeEach(() => {
+    sentryState.init.mockClear();
+    sentryState.captureException.mockClear();
+    sentryState.close.mockClear();
+  });
+
+  it("normalizes plugin config safely", () => {
+    expect(
+      parseDiagnosticsSentryConfig({ enabled: true, dsn: " https://dsn ", flushTimeoutMs: 900 }),
+    ).toEqual({
+      enabled: true,
+      dsn: "https://dsn",
+      environment: undefined,
+      release: undefined,
+      serverName: undefined,
+      flushTimeoutMs: 900,
+    });
+  });
+
+  it("captures cron failures and ignores successful runs", async () => {
+    const ctx = createContext();
+    const service = createDiagnosticsSentryService({
+      enabled: true,
+      dsn: "https://dsn.ingest.sentry.io/1",
+    });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "cron.finished",
+      jobId: "job-ok",
+      jobName: "Healthy job",
+      status: "ok",
+    });
+    emitDiagnosticEvent({
+      type: "cron.finished",
+      jobId: "job-fail",
+      jobName: "Broken job",
+      status: "error",
+      error: "boom",
+      deliveryStatus: "not-delivered",
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    expect(sentryState.init).toHaveBeenCalledTimes(1);
+    expect(sentryState.captureException).toHaveBeenCalledTimes(1);
+    const captureArgs = sentryState.captureException.mock.calls[0];
+    expect(captureArgs?.[0]).toBeInstanceOf(Error);
+    expect(captureArgs?.[1]).toMatchObject({
+      tags: {
+        subsystem: "cron",
+        job_id: "job-fail",
+        job_name: "Broken job",
+        delivery_status: "not-delivered",
+      },
+    });
+
+    await service.stop?.(ctx);
+    expect(sentryState.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/diagnostics-sentry/src/service.ts
+++ b/extensions/diagnostics-sentry/src/service.ts
@@ -1,0 +1,128 @@
+import * as Sentry from "@sentry/node";
+import type { DiagnosticCronFinishedEvent, OpenClawPluginService } from "../api.js";
+import { onDiagnosticEvent, redactSensitiveText } from "../api.js";
+
+const DEFAULT_FLUSH_TIMEOUT_MS = 2_000;
+
+export type DiagnosticsSentryConfig = {
+  enabled?: boolean;
+  dsn?: string;
+  environment?: string;
+  release?: string;
+  serverName?: string;
+  flushTimeoutMs?: number;
+};
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function parseDiagnosticsSentryConfig(value: unknown): DiagnosticsSentryConfig {
+  const record = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  return {
+    enabled:
+      typeof (record as { enabled?: unknown }).enabled === "boolean"
+        ? (record as { enabled: boolean }).enabled
+        : undefined,
+    dsn: asNonEmptyString((record as { dsn?: unknown }).dsn),
+    environment: asNonEmptyString((record as { environment?: unknown }).environment),
+    release: asNonEmptyString((record as { release?: unknown }).release),
+    serverName: asNonEmptyString((record as { serverName?: unknown }).serverName),
+    flushTimeoutMs:
+      typeof (record as { flushTimeoutMs?: unknown }).flushTimeoutMs === "number" &&
+      Number.isFinite((record as { flushTimeoutMs: number }).flushTimeoutMs)
+        ? Math.max(1, Math.floor((record as { flushTimeoutMs: number }).flushTimeoutMs))
+        : undefined,
+  };
+}
+
+function buildCronFailureFingerprint(event: DiagnosticCronFinishedEvent): string[] {
+  const fingerprint = ["openclaw", "cron", "job-failure", event.jobId];
+  if (event.provider) {
+    fingerprint.push(event.provider);
+  }
+  return fingerprint;
+}
+
+function normalizeCronFailureError(event: DiagnosticCronFinishedEvent): Error {
+  const base = event.error?.trim() || `Cron job "${event.jobName ?? event.jobId}" failed`;
+  const error = new Error(base);
+  error.name = "OpenClawCronFailureError";
+  return error;
+}
+
+export function createDiagnosticsSentryService(
+  config: DiagnosticsSentryConfig,
+): OpenClawPluginService {
+  let unsubscribe: (() => void) | null = null;
+  let active = false;
+
+  return {
+    id: "diagnostics-sentry",
+    async start(ctx) {
+      if (config.enabled === false) {
+        return;
+      }
+      if (!config.dsn) {
+        return;
+      }
+
+      Sentry.init({
+        dsn: config.dsn,
+        environment: config.environment,
+        release: config.release,
+        serverName: config.serverName,
+        sendDefaultPii: false,
+      });
+      active = true;
+
+      unsubscribe = onDiagnosticEvent((event) => {
+        if (event.type !== "cron.finished" || event.status !== "error") {
+          return;
+        }
+        const error = normalizeCronFailureError(event);
+        try {
+          Sentry.captureException(error, {
+            level: "error",
+            tags: {
+              subsystem: "cron",
+              job_id: event.jobId,
+              job_name: event.jobName ?? event.jobId,
+              status: event.status,
+              delivery_status: event.deliveryStatus ?? "unknown",
+              provider: event.provider ?? "unknown",
+              model: event.model ?? "unknown",
+            },
+            extra: {
+              summary: event.summary ? redactSensitiveText(event.summary) : undefined,
+              error: event.error ? redactSensitiveText(event.error) : undefined,
+              sessionId: event.sessionId,
+              sessionKey: event.sessionKey,
+              runAtMs: event.runAtMs,
+              durationMs: event.durationMs,
+              nextRunAtMs: event.nextRunAtMs,
+              delivered: event.delivered,
+              deliveryError: event.deliveryError
+                ? redactSensitiveText(event.deliveryError)
+                : undefined,
+            },
+            fingerprint: buildCronFailureFingerprint(event),
+          });
+        } catch (err) {
+          ctx.logger.error(
+            `diagnostics-sentry: failed to capture cron event: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      });
+    },
+    async stop() {
+      unsubscribe?.();
+      unsubscribe = null;
+      if (!active) {
+        return;
+      }
+      active = false;
+      await Sentry.close(config.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS).catch(() => undefined);
+    },
+  } satisfies OpenClawPluginService;
+}

--- a/extensions/discord/src/account-inspect.ts
+++ b/extensions/discord/src/account-inspect.ts
@@ -1,9 +1,9 @@
-import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/discord-core";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   hasConfiguredSecretInput,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/config-runtime";
+import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/discord-core";
 import {
   mergeDiscordAccountConfig,
   resolveDefaultDiscordAccountId,

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -1,13 +1,13 @@
-import type {
-  DiscordAccountConfig,
-  DiscordActionConfig,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/discord-core";
 import {
   createAccountActionGate,
   createAccountListHelpers,
 } from "openclaw/plugin-sdk/account-helpers";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type {
+  DiscordAccountConfig,
+  DiscordActionConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/discord-core";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
 import { resolveDiscordToken } from "./token.js";
 

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
-import type { SignalDaemonExitEvent } from "./daemon.js";
 import { resolveAgentRoute } from "../../../src/routing/resolve-route.js";
 import { normalizeE164 } from "../../../src/utils.js";
+import type { SignalDaemonExitEvent } from "./daemon.js";
 import {
   createMockSignalDaemonHandle,
   config,

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -1,19 +1,19 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { SignalReactionNotificationMode } from "openclaw/plugin-sdk/config-runtime";
-import type { BackoffPolicy } from "openclaw/plugin-sdk/infra-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/config-runtime";
+import type { BackoffPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/infra-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import {
   deliverTextOrMediaReply,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import {
   chunkTextWithMode,
   resolveChunkMode,
@@ -23,16 +23,16 @@ import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
-import type {
-  SignalAttachment,
-  SignalReactionMessage,
-  SignalReactionTarget,
-} from "./monitor/event-handler.types.js";
 import { resolveSignalAccount } from "./accounts.js";
 import { signalCheck, signalRpcRequest } from "./client.js";
 import { formatSignalDaemonExit, spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
+import type {
+  SignalAttachment,
+  SignalReactionMessage,
+  SignalReactionTarget,
+} from "./monitor/event-handler.types.js";
 import { sendMessageSignal } from "./send.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
 

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -1,8 +1,6 @@
+import { type Bot, GrammyError, InputFile } from "grammy";
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-runtime";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { type Bot, GrammyError, InputFile } from "grammy";
 import { fireAndForgetHook } from "openclaw/plugin-sdk/hook-runtime";
 import { createInternalHookEvent, triggerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
 import {
@@ -15,7 +13,9 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { buildOutboundMediaLoadOptions } from "openclaw/plugin-sdk/media-runtime";
 import { isGifMedia, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import type { TelegramInlineButtons } from "../button-types.js";

--- a/package.json
+++ b/package.json
@@ -313,6 +313,10 @@
       "types": "./dist/plugin-sdk/diagnostics-otel.d.ts",
       "default": "./dist/plugin-sdk/diagnostics-otel.js"
     },
+    "./plugin-sdk/diagnostics-sentry": {
+      "types": "./dist/plugin-sdk/diagnostics-sentry.d.ts",
+      "default": "./dist/plugin-sdk/diagnostics-sentry.js"
+    },
     "./plugin-sdk/diffs": {
       "types": "./dist/plugin-sdk/diffs.d.ts",
       "default": "./dist/plugin-sdk/diffs.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,12 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
 
+  extensions/diagnostics-sentry:
+    dependencies:
+      '@sentry/node':
+        specifier: ^10.22.0
+        version: 10.45.0
+
   extensions/diffs:
     dependencies:
       '@pierre/diffs':
@@ -1275,6 +1281,11 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/otel@0.17.1':
+    resolution: {integrity: sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
     engines: {node: '>=20.0.0'}
@@ -2163,6 +2174,14 @@ packages:
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.213.0':
     resolution: {integrity: sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==}
     engines: {node: '>=8.0.0'}
@@ -2255,6 +2274,150 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/instrumentation-amqplib@0.60.0':
+    resolution: {integrity: sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.56.0':
+    resolution: {integrity: sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.30.0':
+    resolution: {integrity: sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.61.0':
+    resolution: {integrity: sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.32.0':
+    resolution: {integrity: sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.56.0':
+    resolution: {integrity: sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.61.0':
+    resolution: {integrity: sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.59.0':
+    resolution: {integrity: sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.213.0':
+    resolution: {integrity: sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.61.0':
+    resolution: {integrity: sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.22.0':
+    resolution: {integrity: sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.57.0':
+    resolution: {integrity: sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.61.0':
+    resolution: {integrity: sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.57.0':
+    resolution: {integrity: sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.66.0':
+    resolution: {integrity: sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.59.0':
+    resolution: {integrity: sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.59.0':
+    resolution: {integrity: sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.59.0':
+    resolution: {integrity: sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.65.0':
+    resolution: {integrity: sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.61.0':
+    resolution: {integrity: sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.32.0':
+    resolution: {integrity: sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.23.0':
+    resolution: {integrity: sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.213.0':
     resolution: {integrity: sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2290,6 +2453,10 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/redis-common@0.38.2':
+    resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
 
   '@opentelemetry/resources@2.6.0':
     resolution: {integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==}
@@ -2330,6 +2497,12 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@oxc-project/runtime@0.115.0':
     resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
@@ -2616,6 +2789,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@prisma/instrumentation@7.4.2':
+    resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2801,6 +2979,51 @@ packages:
 
   '@scure/bip39@2.0.1':
     resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
+
+  '@sentry/core@10.45.0':
+    resolution: {integrity: sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.45.0':
+    resolution: {integrity: sha512-KQZEvLKM344+EqXiA9HIzWbW5hzq6/9nnFUQ8niaBPoOgR9AiJhrccfIscfgb8vjkriiEtzE03OW/4h1CTgZ3Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/context-async-hooks':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.45.0':
+    resolution: {integrity: sha512-Kpiq9lRGnJc1ex8SwxOBl+FLQNl4Y137BydVooP7AFiAYZ6ftwHsIEF1bcYXaipHMT1YHS2bdhC2UQaaB2jkuQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.45.0':
+    resolution: {integrity: sha512-PmuGO+p/gC3ZQ8ddOeJ5P9ApnTTm35i12Bpuyb13AckCbNSJFvG2ggZda35JQOmiFU0kKYiwkoFAa8Mvj9od3Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -3368,6 +3591,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mysql@2.15.27':
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
@@ -3382,6 +3608,12 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/pg-pool@2.0.7':
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.15.6':
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
@@ -3403,6 +3635,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -4409,6 +4644,9 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4638,6 +4876,9 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
   import-in-the-middle@3.0.0:
     resolution: {integrity: sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==}
@@ -5547,6 +5788,17 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5597,6 +5849,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
@@ -6643,6 +6911,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -7832,6 +8104,16 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
+  '@fastify/otel@0.17.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      minimatch: 10.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@google/genai@1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.1
@@ -8950,6 +9232,14 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.213.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9077,6 +9367,215 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/instrumentation-amqplib@0.60.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.30.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.61.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.32.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.61.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.61.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.61.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.66.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.65.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.61.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.32.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.23.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9120,6 +9619,8 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/redis-common@0.38.2': {}
 
   '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9186,6 +9687,11 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
 
   '@oxc-project/runtime@0.115.0': {}
 
@@ -9343,6 +9849,13 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -9467,6 +9980,71 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
+
+  '@sentry/core@10.45.0': {}
+
+  '@sentry/node-core@10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.45.0
+      '@sentry/opentelemetry': 10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@sentry/node@10.45.0':
+    dependencies:
+      '@fastify/otel': 0.17.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-amqplib': 0.60.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-connect': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-dataloader': 0.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-express': 0.61.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fs': 0.32.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-generic-pool': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-graphql': 0.61.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-hapi': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-ioredis': 0.61.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-kafkajs': 0.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-knex': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-koa': 0.61.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongodb': 0.66.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongoose': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql2': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pg': 0.65.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-redis': 0.61.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-tedious': 0.32.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici': 0.23.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 7.4.2(@opentelemetry/api@1.9.0)
+      '@sentry/core': 10.45.0
+      '@sentry/node-core': 10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/opentelemetry@10.45.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.45.0
 
   '@shikijs/core@3.23.0':
     dependencies:
@@ -10292,6 +10870,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/node@10.17.60': {}
 
   '@types/node@16.9.1':
@@ -10308,6 +10890,16 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.15.6
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.5.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/qrcode-terminal@0.12.2': {}
 
@@ -10326,6 +10918,10 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
+      '@types/node': 25.5.0
+
+  '@types/tedious@4.0.14':
+    dependencies:
       '@types/node': 25.5.0
 
   '@types/trusted-types@2.0.7': {}
@@ -11385,6 +11981,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -11686,6 +12284,13 @@ snapshots:
     optional: true
 
   immediate@3.0.6: {}
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   import-in-the-middle@3.0.0:
     dependencies:
@@ -12795,6 +13400,18 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -12846,6 +13463,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   pretty-bytes@6.1.1: {}
 
@@ -13931,6 +14558,8 @@ snapshots:
     optional: true
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -68,6 +68,7 @@
   "boolean-param",
   "device-pair",
   "diagnostics-otel",
+  "diagnostics-sentry",
   "diffs",
   "extension-shared",
   "channel-config-helpers",

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -12,6 +12,7 @@ import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
+import { createGitHubChecksTool } from "./tools/github-checks-tool.js";
 import { createImageGenerateTool } from "./tools/image-generate-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
@@ -167,6 +168,7 @@ export function createOpenClawTools(
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
     }),
+    createGitHubChecksTool(),
     ...(messageTool ? [messageTool] : []),
     createTtsTool({
       agentChannel: options?.agentChannel,

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts
@@ -108,6 +108,9 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("write")).toBe(true);
     expect(names.has("edit")).toBe(true);
     expect(names.has("apply_patch")).toBe(false);
+
+    const ownerTools = createOpenClawCodingTools({ senderIsOwner: true });
+    expect(ownerTools.some((tool) => tool.name === "github_checks")).toBe(true);
   });
   it("provides top-level object schemas for all tools", () => {
     const tools = createOpenClawCodingTools();

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -202,6 +202,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "github_checks",
+    label: "github_checks",
+    description: "Inspect GitHub checks",
+    sectionId: "automation",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "gateway",
     label: "gateway",
     description: "Gateway control",

--- a/src/agents/tools/github-checks-tool.test.ts
+++ b/src/agents/tools/github-checks-tool.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadGitHubChecksMock } = vi.hoisted(() => ({
+  loadGitHubChecksMock: vi.fn(),
+}));
+
+vi.mock("../../github/checks.js", () => ({
+  loadGitHubChecks: (opts: unknown) => loadGitHubChecksMock(opts),
+}));
+
+import { createGitHubChecksTool } from "./github-checks-tool.js";
+
+describe("github checks tool", () => {
+  beforeEach(() => {
+    loadGitHubChecksMock.mockReset();
+    loadGitHubChecksMock.mockResolvedValue({ overallState: "success" });
+  });
+
+  it("is owner-only", () => {
+    const tool = createGitHubChecksTool();
+    expect(tool.ownerOnly).toBe(true);
+  });
+
+  it("passes validated params to the github checks loader", async () => {
+    const tool = createGitHubChecksTool();
+    await tool.execute("call-1", {
+      repo: "openclaw/openclaw",
+      ref: "main",
+      checkName: "CI / test",
+      maxCheckRuns: 25,
+      maxStatuses: 10,
+      timeoutMs: 12000,
+      token: "ghp_test",
+    });
+
+    expect(loadGitHubChecksMock).toHaveBeenCalledWith({
+      repo: "openclaw/openclaw",
+      ref: "main",
+      checkName: "CI / test",
+      token: "ghp_test",
+      maxCheckRuns: 25,
+      maxStatuses: 10,
+      timeoutMs: 12000,
+    });
+  });
+
+  it("requires repo and ref", async () => {
+    const tool = createGitHubChecksTool();
+    await expect(tool.execute("call-1", { repo: "openclaw/openclaw" })).rejects.toThrow(
+      /ref required/i,
+    );
+  });
+});

--- a/src/agents/tools/github-checks-tool.ts
+++ b/src/agents/tools/github-checks-tool.ts
@@ -1,0 +1,45 @@
+import { Type } from "@sinclair/typebox";
+import { loadGitHubChecks } from "../../github/checks.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const GitHubChecksToolSchema = Type.Object({
+  repo: Type.String({ description: "GitHub repository in owner/repo form" }),
+  ref: Type.String({ description: "Git reference: branch, tag, or commit SHA" }),
+  checkName: Type.Optional(Type.String()),
+  maxCheckRuns: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
+  maxStatuses: Type.Optional(Type.Number({ minimum: 1, maximum: 100 })),
+  timeoutMs: Type.Optional(Type.Number({ minimum: 1 })),
+  token: Type.Optional(Type.String()),
+});
+
+export function createGitHubChecksTool(): AnyAgentTool {
+  return {
+    label: "GitHub Checks",
+    name: "github_checks",
+    ownerOnly: true,
+    description:
+      "Fetch GitHub check runs and commit statuses for a repo ref. Good for cron jobs that watch CI and announce concise Slack summaries.",
+    parameters: GitHubChecksToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const repo = readStringParam(params, "repo", { required: true });
+      const ref = readStringParam(params, "ref", { required: true });
+      const checkName = readStringParam(params, "checkName");
+      const token = readStringParam(params, "token", { trim: false });
+      const maxCheckRuns = readNumberParam(params, "maxCheckRuns", { integer: true });
+      const maxStatuses = readNumberParam(params, "maxStatuses", { integer: true });
+      const timeoutMs = readNumberParam(params, "timeoutMs", { integer: true });
+      const result = await loadGitHubChecks({
+        repo,
+        ref,
+        checkName,
+        token,
+        maxCheckRuns,
+        maxStatuses,
+        timeoutMs,
+      });
+      return jsonResult(result);
+    },
+  };
+}

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -19,6 +19,7 @@ import {
 import { CronService } from "../cron/service.js";
 import { resolveCronStorePath } from "../cron/store.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
@@ -368,6 +369,24 @@ export function buildGatewayCronService(params: {
         const webhookToken = trimToOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = trimToOptionalString(params.cfg.cron?.webhook);
         const job = cron.getJob(evt.jobId);
+        emitDiagnosticEvent({
+          type: "cron.finished",
+          jobId: evt.jobId,
+          jobName: job?.name,
+          status: evt.status ?? "error",
+          error: evt.error,
+          summary: evt.summary,
+          delivered: evt.delivered,
+          deliveryStatus: evt.deliveryStatus,
+          deliveryError: evt.deliveryError,
+          sessionId: evt.sessionId,
+          sessionKey: evt.sessionKey,
+          runAtMs: evt.runAtMs,
+          durationMs: evt.durationMs,
+          nextRunAtMs: evt.nextRunAtMs,
+          model: evt.model,
+          provider: evt.provider,
+        });
         const legacyNotify = (job as { notify?: unknown } | undefined)?.notify === true;
         const webhookTarget = resolveCronWebhookTarget({
           delivery:

--- a/src/github/checks.test.ts
+++ b/src/github/checks.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { loadGitHubChecks, parseGitHubRepo, resolveGitHubToken } from "./checks.js";
+
+describe("github checks", () => {
+  it("parses owner/repo inputs", () => {
+    expect(parseGitHubRepo("openclaw/openclaw")).toEqual({
+      owner: "openclaw",
+      repo: "openclaw",
+      repository: "openclaw/openclaw",
+    });
+    expect(parseGitHubRepo("https://github.com/openclaw/openclaw.git")).toEqual({
+      owner: "openclaw",
+      repo: "openclaw",
+      repository: "openclaw/openclaw",
+    });
+  });
+
+  it("prefers explicit token before env fallbacks", () => {
+    expect(resolveGitHubToken("  abc123  ")).toBe("abc123");
+  });
+
+  it("loads and summarizes failing checks and statuses", async () => {
+    const responses = [
+      {
+        total_count: 2,
+        check_runs: [
+          {
+            id: 1,
+            name: "CI / test",
+            status: "completed",
+            conclusion: "failure",
+            details_url: "https://example.invalid/runs/1",
+          },
+          {
+            id: 2,
+            name: "CI / lint",
+            status: "in_progress",
+            conclusion: null,
+            details_url: "https://example.invalid/runs/2",
+          },
+        ],
+      },
+      {
+        state: "failure",
+        sha: "abc123",
+        statuses: [
+          {
+            id: 10,
+            context: "deploy/preview",
+            state: "pending",
+            target_url: "https://example.invalid/status/10",
+          },
+        ],
+      },
+    ];
+    const fetchCalls: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      fetchCalls.push(
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+      );
+      const body = responses.shift();
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const result = await loadGitHubChecks({
+      repo: "openclaw/openclaw",
+      ref: "main",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchCalls[0]).toContain("/repos/openclaw/openclaw/commits/main/check-runs");
+    expect(fetchCalls[1]).toContain("/repos/openclaw/openclaw/commits/main/status");
+    expect(result.overallState).toBe("failure");
+    expect(result.summary).toMatchObject({ failing: 1, pending: 2, total: 3 });
+    expect(result.failing).toEqual([
+      {
+        kind: "check_run",
+        name: "CI / test",
+        status: "completed",
+        conclusion: "failure",
+        detailsUrl: "https://example.invalid/runs/1",
+      },
+    ]);
+    expect(result.pending).toEqual([
+      {
+        kind: "check_run",
+        name: "CI / lint",
+        status: "in_progress",
+        detailsUrl: "https://example.invalid/runs/2",
+      },
+      {
+        kind: "status",
+        context: "deploy/preview",
+        state: "pending",
+        description: undefined,
+        targetUrl: "https://example.invalid/status/10",
+      },
+    ]);
+  });
+
+  it("returns no_data when a ref has no checks or statuses", async () => {
+    const responses = [
+      { total_count: 0, check_runs: [] },
+      { state: "success", sha: "abc", statuses: [] },
+    ];
+    const fetchImpl = async () =>
+      new Response(JSON.stringify(responses.shift()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const result = await loadGitHubChecks({
+      repo: "openclaw/openclaw",
+      ref: "main",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.overallState).toBe("no_data");
+    expect(result.summary.total).toBe(0);
+  });
+});

--- a/src/github/checks.ts
+++ b/src/github/checks.ts
@@ -1,0 +1,475 @@
+import { resolveFetch } from "../infra/fetch.js";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_CHECK_RUNS = 20;
+const DEFAULT_MAX_STATUSES = 20;
+const MAX_PAGE_SIZE = 100;
+
+export type GitHubCheckRunStatus = "queued" | "in_progress" | "completed";
+
+export type GitHubCheckRunConclusion =
+  | "action_required"
+  | "cancelled"
+  | "failure"
+  | "neutral"
+  | "skipped"
+  | "stale"
+  | "success"
+  | "timed_out"
+  | "startup_failure"
+  | null;
+
+export type GitHubCheckRun = {
+  id: number;
+  name: string;
+  status: GitHubCheckRunStatus;
+  conclusion: GitHubCheckRunConclusion;
+  detailsUrl?: string;
+  htmlUrl?: string;
+  startedAt?: string;
+  completedAt?: string;
+  app?: {
+    id?: number;
+    slug?: string;
+    name?: string;
+  };
+  output?: {
+    title?: string;
+    summary?: string;
+    text?: string;
+    annotationsCount?: number;
+  };
+};
+
+export type GitHubCommitStatusState = "error" | "failure" | "pending" | "success";
+
+export type GitHubCommitStatus = {
+  id: number;
+  context: string;
+  state: GitHubCommitStatusState;
+  description?: string;
+  targetUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type GitHubChecksOverallState = "failure" | "pending" | "success" | "no_data";
+
+export type GitHubChecksSnapshot = {
+  repository: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  sha?: string;
+  overallState: GitHubChecksOverallState;
+  combinedStatusState?: "failure" | "pending" | "success";
+  summary: {
+    failing: number;
+    pending: number;
+    successful: number;
+    neutral: number;
+    skipped: number;
+    total: number;
+  };
+  checkRuns: GitHubCheckRun[];
+  statuses: GitHubCommitStatus[];
+  failing: Array<
+    | {
+        kind: "check_run";
+        name: string;
+        status: GitHubCheckRunStatus;
+        conclusion: GitHubCheckRunConclusion;
+        detailsUrl?: string;
+      }
+    | {
+        kind: "status";
+        context: string;
+        state: GitHubCommitStatusState;
+        description?: string;
+        targetUrl?: string;
+      }
+  >;
+  pending: Array<
+    | {
+        kind: "check_run";
+        name: string;
+        status: GitHubCheckRunStatus;
+        detailsUrl?: string;
+      }
+    | {
+        kind: "status";
+        context: string;
+        state: GitHubCommitStatusState;
+        description?: string;
+        targetUrl?: string;
+      }
+  >;
+};
+
+export type LoadGitHubChecksOptions = {
+  repo: string;
+  ref: string;
+  token?: string;
+  timeoutMs?: number;
+  maxCheckRuns?: number;
+  maxStatuses?: number;
+  checkName?: string;
+  fetchImpl?: typeof fetch;
+};
+
+type GitHubCheckRunsResponse = {
+  total_count?: number;
+  check_runs?: Array<{
+    id?: number;
+    name?: string;
+    status?: GitHubCheckRunStatus;
+    conclusion?: GitHubCheckRunConclusion;
+    details_url?: string;
+    html_url?: string;
+    started_at?: string;
+    completed_at?: string;
+    app?: {
+      id?: number;
+      slug?: string;
+      name?: string;
+    };
+    output?: {
+      title?: string;
+      summary?: string;
+      text?: string;
+      annotations_count?: number;
+    };
+  }>;
+};
+
+type GitHubCombinedStatusResponse = {
+  state?: "failure" | "pending" | "success";
+  sha?: string;
+  statuses?: Array<{
+    id?: number;
+    context?: string;
+    state?: GitHubCommitStatusState;
+    description?: string;
+    target_url?: string;
+    created_at?: string;
+    updated_at?: string;
+  }>;
+};
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value != null;
+}
+
+function normalizeToken(token?: string): string | undefined {
+  const trimmed = token?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveGitHubToken(explicitToken?: string): string | undefined {
+  const direct = normalizeToken(explicitToken);
+  if (direct) {
+    return direct;
+  }
+  return (
+    normalizeToken(process.env.GH_TOKEN) ??
+    normalizeToken(process.env.GITHUB_TOKEN) ??
+    normalizeToken(process.env.COPILOT_GITHUB_TOKEN)
+  );
+}
+
+export function parseGitHubRepo(input: string): {
+  owner: string;
+  repo: string;
+  repository: string;
+} {
+  const trimmed = input
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/\.git$/i, "");
+  const parts = trimmed.split("/").filter(Boolean);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid GitHub repository "${input}". Expected "owner/repo".`);
+  }
+  return {
+    owner: parts[0],
+    repo: parts[1],
+    repository: `${parts[0]}/${parts[1]}`,
+  };
+}
+
+function clampPageSize(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(MAX_PAGE_SIZE, Math.floor(value)));
+}
+
+function buildGitHubHeaders(token?: string): HeadersInit {
+  const normalizedToken = resolveGitHubToken(token);
+  return {
+    Accept: "application/vnd.github+json",
+    ...(normalizedToken ? { Authorization: `Bearer ${normalizedToken}` } : {}),
+    "User-Agent": "OpenClaw GitHub Checks Tool",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+}
+
+async function fetchGitHubJson<T>(params: {
+  path: string;
+  token?: string;
+  timeoutMs: number;
+  fetchImpl?: typeof fetch;
+}): Promise<T> {
+  const fetchFn = resolveFetch(params.fetchImpl);
+  if (!fetchFn) {
+    throw new Error("fetch is not available");
+  }
+  const response = await fetchFn(`${GITHUB_API_BASE_URL}${params.path}`, {
+    method: "GET",
+    headers: buildGitHubHeaders(params.token),
+    signal: AbortSignal.timeout(params.timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    const suffix = body.trim() ? `: ${body.trim()}` : "";
+    throw new Error(`GitHub API ${response.status} ${response.statusText}${suffix}`);
+  }
+  return (await response.json()) as T;
+}
+
+function normalizeCheckRun(
+  input: NonNullable<GitHubCheckRunsResponse["check_runs"]>[number],
+): GitHubCheckRun | null {
+  if (typeof input.id !== "number" || !Number.isFinite(input.id)) {
+    return null;
+  }
+  const name = typeof input.name === "string" && input.name.trim() ? input.name.trim() : undefined;
+  const status = input.status;
+  if (!name || (status !== "queued" && status !== "in_progress" && status !== "completed")) {
+    return null;
+  }
+  return {
+    id: input.id,
+    name,
+    status,
+    conclusion: input.conclusion ?? null,
+    detailsUrl: typeof input.details_url === "string" ? input.details_url : undefined,
+    htmlUrl: typeof input.html_url === "string" ? input.html_url : undefined,
+    startedAt: typeof input.started_at === "string" ? input.started_at : undefined,
+    completedAt: typeof input.completed_at === "string" ? input.completed_at : undefined,
+    app: input.app
+      ? {
+          id: input.app.id,
+          slug: typeof input.app.slug === "string" ? input.app.slug : undefined,
+          name: typeof input.app.name === "string" ? input.app.name : undefined,
+        }
+      : undefined,
+    output: input.output
+      ? {
+          title: typeof input.output.title === "string" ? input.output.title : undefined,
+          summary: typeof input.output.summary === "string" ? input.output.summary : undefined,
+          text: typeof input.output.text === "string" ? input.output.text : undefined,
+          annotationsCount:
+            typeof input.output.annotations_count === "number" &&
+            Number.isFinite(input.output.annotations_count)
+              ? input.output.annotations_count
+              : undefined,
+        }
+      : undefined,
+  };
+}
+
+function normalizeCommitStatus(
+  input: NonNullable<GitHubCombinedStatusResponse["statuses"]>[number],
+): GitHubCommitStatus | null {
+  if (typeof input.id !== "number" || !Number.isFinite(input.id)) {
+    return null;
+  }
+  const context =
+    typeof input.context === "string" && input.context.trim() ? input.context.trim() : undefined;
+  const state = input.state;
+  if (
+    !context ||
+    (state !== "error" && state !== "failure" && state !== "pending" && state !== "success")
+  ) {
+    return null;
+  }
+  return {
+    id: input.id,
+    context,
+    state,
+    description: typeof input.description === "string" ? input.description : undefined,
+    targetUrl: typeof input.target_url === "string" ? input.target_url : undefined,
+    createdAt: typeof input.created_at === "string" ? input.created_at : undefined,
+    updatedAt: typeof input.updated_at === "string" ? input.updated_at : undefined,
+  };
+}
+
+function isFailingCheckRun(run: GitHubCheckRun): boolean {
+  return (
+    run.status === "completed" &&
+    ["action_required", "cancelled", "failure", "stale", "timed_out", "startup_failure"].includes(
+      run.conclusion ?? "",
+    )
+  );
+}
+
+function isPendingCheckRun(run: GitHubCheckRun): boolean {
+  return run.status === "queued" || run.status === "in_progress";
+}
+
+function isSuccessfulCheckRun(run: GitHubCheckRun): boolean {
+  return run.status === "completed" && run.conclusion === "success";
+}
+
+function isNeutralCheckRun(run: GitHubCheckRun): boolean {
+  return run.status === "completed" && run.conclusion === "neutral";
+}
+
+function isSkippedCheckRun(run: GitHubCheckRun): boolean {
+  return run.status === "completed" && run.conclusion === "skipped";
+}
+
+function resolveOverallState(params: {
+  checkRuns: GitHubCheckRun[];
+  statuses: GitHubCommitStatus[];
+  combinedStatusState?: "failure" | "pending" | "success";
+}): GitHubChecksOverallState {
+  if (
+    params.combinedStatusState === "failure" ||
+    params.checkRuns.some(isFailingCheckRun) ||
+    params.statuses.some((status) => status.state === "error" || status.state === "failure")
+  ) {
+    return "failure";
+  }
+  if (
+    params.combinedStatusState === "pending" ||
+    params.checkRuns.some(isPendingCheckRun) ||
+    params.statuses.some((status) => status.state === "pending")
+  ) {
+    return "pending";
+  }
+  if (params.checkRuns.length === 0 && params.statuses.length === 0) {
+    return "no_data";
+  }
+  return "success";
+}
+
+export async function loadGitHubChecks(
+  options: LoadGitHubChecksOptions,
+): Promise<GitHubChecksSnapshot> {
+  const parsedRepo = parseGitHubRepo(options.repo);
+  const ref = options.ref.trim();
+  if (!ref) {
+    throw new Error("GitHub ref is required.");
+  }
+  const timeoutMs =
+    typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
+      ? Math.max(1, Math.floor(options.timeoutMs))
+      : DEFAULT_TIMEOUT_MS;
+  const maxCheckRuns = clampPageSize(options.maxCheckRuns, DEFAULT_MAX_CHECK_RUNS);
+  const maxStatuses = clampPageSize(options.maxStatuses, DEFAULT_MAX_STATUSES);
+
+  const checkRunsPath = new URL(
+    `/repos/${encodeURIComponent(parsedRepo.owner)}/${encodeURIComponent(parsedRepo.repo)}/commits/${encodeURIComponent(ref)}/check-runs`,
+    GITHUB_API_BASE_URL,
+  );
+  checkRunsPath.searchParams.set("filter", "latest");
+  checkRunsPath.searchParams.set("per_page", String(maxCheckRuns));
+  if (options.checkName?.trim()) {
+    checkRunsPath.searchParams.set("check_name", options.checkName.trim());
+  }
+
+  const statusPath = new URL(
+    `/repos/${encodeURIComponent(parsedRepo.owner)}/${encodeURIComponent(parsedRepo.repo)}/commits/${encodeURIComponent(ref)}/status`,
+    GITHUB_API_BASE_URL,
+  );
+  statusPath.searchParams.set("per_page", String(maxStatuses));
+
+  const [checkRunsResponse, combinedStatusResponse] = await Promise.all([
+    fetchGitHubJson<GitHubCheckRunsResponse>({
+      path: `${checkRunsPath.pathname}${checkRunsPath.search}`,
+      token: options.token,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+    }),
+    fetchGitHubJson<GitHubCombinedStatusResponse>({
+      path: `${statusPath.pathname}${statusPath.search}`,
+      token: options.token,
+      timeoutMs,
+      fetchImpl: options.fetchImpl,
+    }),
+  ]);
+
+  const checkRuns = (checkRunsResponse.check_runs ?? []).map(normalizeCheckRun).filter(isDefined);
+  const statuses = (combinedStatusResponse.statuses ?? [])
+    .map(normalizeCommitStatus)
+    .filter(isDefined);
+
+  const failing = [
+    ...checkRuns.filter(isFailingCheckRun).map((run) => ({
+      kind: "check_run" as const,
+      name: run.name,
+      status: run.status,
+      conclusion: run.conclusion,
+      detailsUrl: run.detailsUrl ?? run.htmlUrl,
+    })),
+    ...statuses
+      .filter((status) => status.state === "error" || status.state === "failure")
+      .map((status) => ({
+        kind: "status" as const,
+        context: status.context,
+        state: status.state,
+        description: status.description,
+        targetUrl: status.targetUrl,
+      })),
+  ];
+
+  const pending = [
+    ...checkRuns.filter(isPendingCheckRun).map((run) => ({
+      kind: "check_run" as const,
+      name: run.name,
+      status: run.status,
+      detailsUrl: run.detailsUrl ?? run.htmlUrl,
+    })),
+    ...statuses
+      .filter((status) => status.state === "pending")
+      .map((status) => ({
+        kind: "status" as const,
+        context: status.context,
+        state: status.state,
+        description: status.description,
+        targetUrl: status.targetUrl,
+      })),
+  ];
+
+  return {
+    repository: parsedRepo.repository,
+    owner: parsedRepo.owner,
+    repo: parsedRepo.repo,
+    ref,
+    sha: typeof combinedStatusResponse.sha === "string" ? combinedStatusResponse.sha : undefined,
+    overallState: resolveOverallState({
+      checkRuns,
+      statuses,
+      combinedStatusState: combinedStatusResponse.state,
+    }),
+    combinedStatusState: combinedStatusResponse.state,
+    summary: {
+      failing: failing.length,
+      pending: pending.length,
+      successful:
+        checkRuns.filter(isSuccessfulCheckRun).length +
+        statuses.filter((status) => status.state === "success").length,
+      neutral: checkRuns.filter(isNeutralCheckRun).length,
+      skipped: checkRuns.filter(isSkippedCheckRun).length,
+      total: checkRuns.length + statuses.length,
+    },
+    checkRuns,
+    statuses,
+    failing,
+    pending,
+  };
+}

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -147,6 +147,25 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticCronFinishedEvent = DiagnosticBaseEvent & {
+  type: "cron.finished";
+  jobId: string;
+  jobName?: string;
+  status: "ok" | "error" | "skipped";
+  error?: string;
+  summary?: string;
+  delivered?: boolean;
+  deliveryStatus?: "delivered" | "not-delivered" | "unknown" | "not-requested";
+  deliveryError?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  runAtMs?: number;
+  durationMs?: number;
+  nextRunAtMs?: number;
+  model?: string;
+  provider?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -160,7 +179,8 @@ export type DiagnosticEventPayload =
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
-  | DiagnosticToolLoopEvent;
+  | DiagnosticToolLoopEvent
+  | DiagnosticCronFinishedEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload
@@ -201,9 +221,10 @@ export function emitDiagnosticEvent(event: DiagnosticEventInput) {
     return;
   }
 
+  state.seq += 1;
   const enriched = {
     ...event,
-    seq: (state.seq += 1),
+    seq: state.seq,
     ts: Date.now(),
   } satisfies DiagnosticEventPayload;
   state.dispatchDepth += 1;

--- a/src/plugin-sdk/channel-import-guardrails.test.ts
+++ b/src/plugin-sdk/channel-import-guardrails.test.ts
@@ -128,6 +128,7 @@ const LOCAL_EXTENSION_API_BARREL_GUARDS = [
   "bluebubbles",
   "device-pair",
   "diagnostics-otel",
+  "diagnostics-sentry",
   "discord",
   "diffs",
   "feishu",

--- a/src/plugin-sdk/diagnostics-sentry.ts
+++ b/src/plugin-sdk/diagnostics-sentry.ts
@@ -1,0 +1,11 @@
+export type {
+  DiagnosticCronFinishedEvent,
+  DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+export { emitDiagnosticEvent, onDiagnosticEvent } from "../infra/diagnostic-events.js";
+export { redactSensitiveText } from "../logging/redact.js";
+export type {
+  OpenClawPluginApi,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "../plugins/types.js";


### PR DESCRIPTION
## Summary
- add a new owner-only `github_checks` agent tool so isolated OpenClaw cron jobs can poll GitHub check runs and commit statuses, then announce concise results to Slack or other channels
- emit structured `cron.finished` diagnostic events from the gateway cron service and add a new `diagnostics-sentry` extension that captures cron failures in Sentry
- document the GitHub-checks-to-Slack cron flow, export the new plugin-sdk surface, and keep the repo green with targeted tests plus formatting drift fixes required by `pnpm check`

## Testing
- `pnpm test -- src/github/checks.test.ts src/agents/tools/github-checks-tool.test.ts extensions/diagnostics-sentry/src/service.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts src/agents/tool-policy.test.ts`
- `pnpm check`