### PR TITLE
fix(agents): enable tool calling for deepseek-v3.2 on Venice

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -168,7 +168,6 @@ export const VENICE_MODEL_CATALOG = [
     input: ["text"],
     contextWindow: 160000,
     maxTokens: 32768,
-    supportsTools: false,
     privacy: "private",
   },
 


### PR DESCRIPTION
## Problem

The Venice provider model catalog marks `deepseek-v3.2` with `supportsTools: false`, but the model supports tool/function calling correctly. This makes DeepSeek V3.2 unusable for any agentic workflow requiring tools when routed through Venice.

## Root Cause

`src/agents/venice-models.ts` line 171: explicit `supportsTools: false` on the `deepseek-v3.2` catalog entry.

The Venice catalog builder at line 477 forwards this flag into the compat object:
```ts
...('supportsTools' in entry && !entry.supportsTools ? { supportsTools: false } : {})
```

So omitting the field = tools enabled (the default for all other tool-capable Venice models).

## Fix

Remove the `supportsTools: false` line from the `deepseek-v3.2` entry. This follows the existing pattern — no other Venice model explicitly sets `supportsTools: true`; they either omit it (tools enabled) or set `false` (tools disabled).

1 file changed, 1 deletion.

## Evidence

Issue reporter confirmed tool calling works via direct API test (correct `tool_calls` response). Community comment on #50476 confirmed the exact source location.

Fixes #50476