### PR TITLE
fix(openai-http): preserve image_url parts in extractTextContent() for vision models

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -176,6 +176,13 @@ function extractTextContent(content: unknown): string {
         if (typeof inputText === "string") {
           return inputText;
         }
+        // Preserve image_url parts as text references so the model sees them
+        if (type === "image_url") {
+          const url = resolveImageUrlPart(part);
+          if (url) {
+            return `[image: ${url}]`;
+          }
+        }
         return "";
       })
       .filter(Boolean)


### PR DESCRIPTION
## Summary

`extractTextContent()` in `src/gateway/openai-http.ts` was discarding `image_url` content parts, causing images to be invisible to vision-capable models when using the `/v1/chat/completions` endpoint.

## Root Cause

The function only handled `text` and `input_text` content types. When an `image_url` part was encountered, it returned an empty string, effectively dropping the image from the conversation.

## Fix

Added handling for `image_url` parts to preserve them as `[image: <url>]` text references in the output, so models that support vision can receive both the image data (via the `images` array) AND see a textual reference to the image in the prompt.

**Changed file:** `src/gateway/openai-http.ts`

```typescript
// Preserve image_url parts as text references so the model sees them
if (type === "image_url") {
  const url = resolveImageUrlPart(part);
  if (url) {
    return `[image: ${url}]`;
  }
}
```

## Testing

After this change, Telegram images should be:
1. Downloaded and extracted as `ImageContent` (already working)
2. Passed to the vision model via the `images` parameter (already working)
3. **NEW:** Referenced in the text prompt so the model knows images are present

## Related Issues

- Fixes openclaw/openclaw#23452
- Fixes openclaw/openclaw#18583
- Related: openclaw/openclaw#7564 (Telegram images not passed to vision model)