### PR TITLE
feat(hooks): add LLM synthesis mode and canonical daily file for session-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Hooks/session-memory: add opt-in LLM synthesis and append saved sessions to the canonical daily memory file while keeping raw-message fallback behavior. Carries forward #50584. Thanks @amart19D.
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
 - Android: publish authenticated `node.presence.alive` events after node connect and background transitions so paired Android nodes retain durable last-seen metadata after disconnects. Carries forward #63123. Thanks @ngutman.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -177,7 +177,7 @@ openclaw hooks enable <hook-name>
 
 ### session-memory details
 
-Extracts the last 15 user/assistant messages, generates a descriptive filename slug via LLM, and saves to `<workspace>/memory/YYYY-MM-DD-slug.md` using the host local date. Requires `workspace.dir` to be configured.
+Extracts the last 15 user/assistant messages, generates a descriptive filename slug via LLM, saves to `<workspace>/memory/YYYY-MM-DD-slug.md`, and appends the same entry to `<workspace>/memory/YYYY-MM-DD.md` using the host local date. Set `hooks.internal.entries.session-memory.synthesis: true` to ask the configured LLM to distill durable decisions and outcomes before writing, with raw-message fallback. Requires `workspace.dir` to be configured.
 
 <a id="bootstrap-extra-files"></a>
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -25,7 +25,8 @@ When you run `/new` or `/reset` to start a fresh session:
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)
 3. **Generates descriptive slug** - Uses LLM to create a meaningful filename slug based on conversation content
-4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-slug.md`
+4. **Optionally synthesizes** - When `synthesis: true`, runs conversation through LLM to distill decisions, outcomes, and durable context (instead of saving raw messages)
+5. **Saves to memory** - Creates a slug-named file at `<workspace>/memory/YYYY-MM-DD-slug.md` **and** appends to the canonical daily file at `<workspace>/memory/YYYY-MM-DD.md`
 
 ## Output Format
 
@@ -37,7 +38,15 @@ Memory files are created with the following format:
 - **Session Key**: agent:main:main
 - **Session ID**: abc123def456
 - **Source**: telegram
+
+## Summary
+
+- Decided to use Redis for session caching (rationale: low latency, built-in TTL)
+- Fixed auth bug: token refresh was using expired client secret
+- Next step: add rate limiting to the /api/users endpoint
 ```
+
+When synthesis is disabled (default), the section is titled "Conversation Summary" and contains raw messages.
 
 ## Filename Examples
 
@@ -48,21 +57,45 @@ The LLM generates descriptive slugs based on your conversation:
 - `2026-01-16-bug-fix.md` - Debugging session
 - `2026-01-16-1430.md` - Fallback local timestamp if slug generation fails
 
+## Canonical Daily File
+
+In addition to the slug-named file, the hook appends the same entry to the canonical `memory/YYYY-MM-DD.md` file. This ensures agents can find session memories on boot (which reads `memory/YYYY-MM-DD.md`) without relying on `memory_search`.
+
+Multiple sessions on the same day are separated by `---` markers in the canonical file.
+
+## Date Handling
+
+Filenames use the user's local timezone rather than UTC. This prevents sessions from being filed under the wrong date when working across midnight in local time.
+
 ## Requirements
 
 - **Config**: `workspace.dir` must be set (automatically configured during setup)
 
-The hook uses your configured LLM provider to generate slugs, so it works with any provider (Anthropic, OpenAI, etc.).
+The hook uses your configured LLM provider for slug generation and synthesis.
 
 ## Configuration
 
 The hook supports optional configuration:
 
-| Option     | Type   | Default | Description                                                     |
-| ---------- | ------ | ------- | --------------------------------------------------------------- |
-| `messages` | number | 15      | Number of user/assistant messages to include in the memory file |
+| Option      | Type    | Default | Description                                                                              |
+| ----------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
+| `messages`  | number  | 15      | Number of user/assistant messages to include in the memory file                          |
+| `llmSlug`   | boolean | true    | Whether to use LLM for generating descriptive filename slugs                             |
+| `synthesis` | boolean | false   | When true, distill conversation through LLM before saving (decisions, outcomes, context) |
 
-Example configuration:
+### Synthesis Mode
+
+When `synthesis: true`, the hook runs the conversation through an LLM to produce a concise summary focused on:
+
+- Decisions made and their rationale
+- Actions taken and their outcomes
+- Key facts, configurations, or state changes
+- Problems solved and how
+- Open questions or next steps
+
+Trivial conversations (test messages, greetings) produce no output — the LLM returns `NO_SUMMARY` and the raw content is used as a fallback.
+
+Example configuration with synthesis:
 
 ```json
 {
@@ -71,6 +104,7 @@ Example configuration:
       "entries": {
         "session-memory": {
           "enabled": true,
+          "synthesis": true,
           "messages": 25
         }
       }
@@ -82,8 +116,9 @@ Example configuration:
 The hook automatically:
 
 - Uses your workspace directory (`~/.openclaw/workspace` by default)
-- Uses your configured LLM for slug generation
+- Uses your configured LLM for slug generation and synthesis
 - Falls back to timestamp slugs if LLM is unavailable
+- Falls back to raw content if synthesis fails
 
 ## Disabling
 

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
 import { createHookEvent } from "../../hooks.js";
+import { synthesizeSessionContent } from "../../session-synthesizer.js";
 import {
   findPreviousSessionFile,
   getRecentSessionContent,
@@ -37,6 +38,12 @@ async function createCaseWorkspace(prefix = "case"): Promise<string> {
 beforeAll(async () => {
   ({ default: handler } = await import("./handler.js"));
   suiteWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-memory-"));
+});
+
+beforeEach(() => {
+  vi.mocked(synthesizeSessionContent)
+    .mockReset()
+    .mockResolvedValue("- Discussed simple math operations\n- Confirmed 2+2 = 4");
 });
 
 afterAll(async () => {
@@ -708,9 +715,7 @@ describe("session-memory hook", () => {
     expect(canonicalContent).toContain("---"); // separator between sessions
   });
 
-  it("uses synthesis when enabled in config (test env skips LLM call)", async () => {
-    // In test env, synthesis is skipped (isTestEnv check), so the raw content is used.
-    // This test verifies the code path doesn't crash and falls back gracefully.
+  it("uses synthesis when enabled in config", async () => {
     const sessionContent = createMockSessionContent([
       { role: "user", content: "Synthesized session test" },
       { role: "assistant", content: "This should be synthesized" },
@@ -720,8 +725,28 @@ describe("session-memory hook", () => {
       cfg: (tempDir) => makeSessionMemoryConfigWithSynthesis(tempDir),
     });
 
-    // In test env, synthesis LLM call is skipped, so raw content is preserved
-    expect(memoryContent).toContain("Synthesized session test");
+    expect(synthesizeSessionContent).toHaveBeenCalledOnce();
+    expect(memoryContent).toContain("## Summary");
+    expect(memoryContent).toContain("- Discussed simple math operations");
+    expect(memoryContent).not.toContain("Synthesized session test");
+  });
+
+  it("falls back to raw content when synthesis produces no summary", async () => {
+    vi.mocked(synthesizeSessionContent).mockResolvedValueOnce(null);
+
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Keep the original transcript" },
+      { role: "assistant", content: "No durable summary was produced" },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({
+      sessionContent,
+      cfg: (tempDir) => makeSessionMemoryConfigWithSynthesis(tempDir),
+    });
+
+    expect(synthesizeSessionContent).toHaveBeenCalledOnce();
+    expect(memoryContent).toContain("## Conversation Summary");
+    expect(memoryContent).toContain("user: Keep the original transcript");
+    expect(memoryContent).toContain("assistant: No durable summary was produced");
   });
 
   it("uses raw content by default (synthesis disabled)", async () => {
@@ -732,6 +757,7 @@ describe("session-memory hook", () => {
     const { memoryContent } = await runNewWithPreviousSession({ sessionContent });
 
     // Default behavior: raw messages in "Conversation Summary" section
+    expect(synthesizeSessionContent).not.toHaveBeenCalled();
     expect(memoryContent).toContain("## Conversation Summary");
     expect(memoryContent).toContain("user: Raw content test");
     expect(memoryContent).toContain("assistant: Should not be synthesized");

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -17,6 +17,12 @@ vi.mock("../../llm-slug-generator.js", () => ({
   generateSlugViaLLM: vi.fn().mockResolvedValue("simple-math"),
 }));
 
+vi.mock("../../session-synthesizer.js", () => ({
+  synthesizeSessionContent: vi
+    .fn()
+    .mockResolvedValue("- Discussed simple math operations\n- Confirmed 2+2 = 4"),
+}));
+
 let handler: typeof import("./handler.js").default;
 let suiteWorkspaceRoot = "";
 let workspaceCaseCounter = 0;
@@ -95,7 +101,7 @@ async function runNewWithPreviousSessionEntry(params: {
   await handler(event);
 
   const memoryDir = path.join(params.tempDir, "memory");
-  const files = await fs.readdir(memoryDir);
+  const files = (await fs.readdir(memoryDir)).toSorted();
   const memoryContent =
     files.length > 0 ? await fs.readFile(path.join(memoryDir, files[0]), "utf-8") : "";
   return { files, memoryContent };
@@ -132,6 +138,19 @@ async function runNewWithPreviousSession(params: {
     },
   });
   return { tempDir, files, memoryContent };
+}
+
+function makeSessionMemoryConfigWithSynthesis(tempDir: string): OpenClawConfig {
+  return {
+    agents: { defaults: { workspace: tempDir } },
+    hooks: {
+      internal: {
+        entries: {
+          "session-memory": { enabled: true, synthesis: true },
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
 }
 
 async function createSessionMemoryWorkspace(params?: {
@@ -228,7 +247,7 @@ describe("session-memory hook", () => {
       { role: "assistant", content: "2+2 equals 4" },
     ]);
     const { files, memoryContent } = await runNewWithPreviousSession({ sessionContent });
-    expect(files.length).toBe(1);
+    expect(files.length).toBeGreaterThanOrEqual(1);
 
     // Read the memory file and verify content
     expect(memoryContent).toContain("user: Hello there");
@@ -247,7 +266,7 @@ describe("session-memory hook", () => {
       action: "reset",
     });
 
-    expect(files.length).toBe(1);
+    expect(files.length).toBeGreaterThanOrEqual(1);
     expect(memoryContent).toContain("user: Please reset and keep notes");
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
@@ -264,7 +283,7 @@ describe("session-memory hook", () => {
         },
       });
 
-      expect(files).toEqual(["2025-12-31-2330.md"]);
+      expect(files).toEqual(["2025-12-31-2330.md", "2025-12-31.md"]);
       expect(memoryContent).toMatch(/^# Session: 2025-12-31 23:30:15(?: EST| GMT-5)?/);
       expect(memoryContent).not.toContain("# Session: 2026-01-01 04:30:15 UTC");
     });
@@ -301,7 +320,7 @@ describe("session-memory hook", () => {
       },
     });
 
-    expect(files.length).toBe(1);
+    expect(files.length).toBeGreaterThanOrEqual(1);
     expect(memoryContent).toContain("user: Remember this under Navi");
     expect(memoryContent).toContain("assistant: Stored in the bound workspace");
     expect(memoryContent).toContain("- **Session Key**: agent:navi:main");
@@ -553,7 +572,7 @@ describe("session-memory hook", () => {
   it("handles empty session files gracefully", async () => {
     // Should not throw
     const { files } = await runNewWithPreviousSession({ sessionContent: "" });
-    expect(files.length).toBe(1);
+    expect(files.length).toBeGreaterThanOrEqual(1);
   });
 
   it("uses agent-specific workspace when workspaceDir is provided for non-default agent (gateway path regression)", async () => {
@@ -592,7 +611,7 @@ describe("session-memory hook", () => {
       },
     });
 
-    expect(files.length).toBe(1);
+    expect(files.length).toBeGreaterThanOrEqual(1);
     expect(memoryContent).toContain("user: Custom agent conversation");
     expect(memoryContent).toContain("assistant: Stored in agent workspace");
     // Verify memory did NOT leak to the default workspace
@@ -608,5 +627,111 @@ describe("session-memory hook", () => {
 
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
+  });
+
+  it("also appends to canonical daily file", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Canonical test message" },
+      { role: "assistant", content: "Canonical test reply" },
+    ]);
+    const { tempDir } = await runNewWithPreviousSession({ sessionContent });
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+
+    // Should have at least 2 files: the slug file and the canonical daily file
+    const canonicalFile = files.find((file) => /^\d{4}-\d{2}-\d{2}\.md$/.test(file));
+    const slugFile = files.find((file) => file !== canonicalFile && file.endsWith(".md"));
+
+    expect(canonicalFile).toBeDefined();
+    expect(slugFile).toBeDefined();
+
+    // Canonical file should contain the same content
+    const canonicalContent = await fs.readFile(path.join(memoryDir, canonicalFile!), "utf-8");
+    expect(canonicalContent).toContain("Canonical test message");
+    expect(canonicalContent).toContain("Canonical test reply");
+  });
+
+  it("appends multiple sessions to canonical daily file with separator", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const cfg = {
+      agents: { defaults: { workspace: tempDir } },
+    } satisfies OpenClawConfig;
+
+    // First session
+    const sessionFile1 = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "session-1.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "First session content" },
+        { role: "assistant", content: "First session reply" },
+      ]),
+    });
+
+    await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      previousSessionEntry: { sessionId: "session-1", sessionFile: sessionFile1 },
+    });
+
+    // Second session
+    const sessionFile2 = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "session-2.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Second session content" },
+        { role: "assistant", content: "Second session reply" },
+      ]),
+    });
+
+    await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      previousSessionEntry: { sessionId: "session-2", sessionFile: sessionFile2 },
+    });
+
+    // Check canonical file has both sessions separated
+    const memoryDir = path.join(tempDir, "memory");
+    const canonicalFile = (await fs.readdir(memoryDir)).find((file) =>
+      /^\d{4}-\d{2}-\d{2}\.md$/.test(file),
+    );
+    expect(canonicalFile).toBeDefined();
+    const canonicalContent = await fs.readFile(path.join(memoryDir, canonicalFile!), "utf-8");
+
+    expect(canonicalContent).toContain("First session content");
+    expect(canonicalContent).toContain("Second session content");
+    expect(canonicalContent).toContain("---"); // separator between sessions
+  });
+
+  it("uses synthesis when enabled in config (test env skips LLM call)", async () => {
+    // In test env, synthesis is skipped (isTestEnv check), so the raw content is used.
+    // This test verifies the code path doesn't crash and falls back gracefully.
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Synthesized session test" },
+      { role: "assistant", content: "This should be synthesized" },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({
+      sessionContent,
+      cfg: (tempDir) => makeSessionMemoryConfigWithSynthesis(tempDir),
+    });
+
+    // In test env, synthesis LLM call is skipped, so raw content is preserved
+    expect(memoryContent).toContain("Synthesized session test");
+  });
+
+  it("uses raw content by default (synthesis disabled)", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Raw content test" },
+      { role: "assistant", content: "Should not be synthesized" },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({ sessionContent });
+
+    // Default behavior: raw messages in "Conversation Summary" section
+    expect(memoryContent).toContain("## Conversation Summary");
+    expect(memoryContent).toContain("user: Raw content test");
+    expect(memoryContent).toContain("assistant: Should not be synthesized");
   });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -284,7 +284,7 @@ describe("session-memory hook", () => {
       });
 
       expect(files).toEqual(["2025-12-31-2330.md", "2025-12-31.md"]);
-      expect(memoryContent).toMatch(/^# Session: 2025-12-31 23:30:15(?: EST| GMT-5)?/);
+      expect(memoryContent).toMatch(/^# Session: 2025-12-31 23:30:15 \(America\/New_York\)/);
       expect(memoryContent).not.toContain("# Session: 2026-01-01 04:30:15 UTC");
     });
   });
@@ -639,9 +639,11 @@ describe("session-memory hook", () => {
     const memoryDir = path.join(tempDir, "memory");
     const files = await fs.readdir(memoryDir);
 
-    // Should have at least 2 files: the slug file and the canonical daily file
-    const canonicalFile = files.find((file) => /^\d{4}-\d{2}-\d{2}\.md$/.test(file));
-    const slugFile = files.find((file) => file !== canonicalFile && file.endsWith(".md"));
+    // Find canonical file (YYYY-MM-DD.md — no slug suffix) and slug file
+    const canonicalFile = files.find((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f));
+    const slugFile = files.find(
+      (f) => f.endsWith(".md") && f !== canonicalFile && /^\d{4}-\d{2}-\d{2}-.+\.md$/.test(f),
+    );
 
     expect(canonicalFile).toBeDefined();
     expect(slugFile).toBeDefined();
@@ -693,13 +695,13 @@ describe("session-memory hook", () => {
       previousSessionEntry: { sessionId: "session-2", sessionFile: sessionFile2 },
     });
 
-    // Check canonical file has both sessions separated
+    // Check canonical file has both sessions separated — find by pattern,
+    // not by constructing the date (which could differ from handler's timezone)
     const memoryDir = path.join(tempDir, "memory");
-    const canonicalFile = (await fs.readdir(memoryDir)).find((file) =>
-      /^\d{4}-\d{2}-\d{2}\.md$/.test(file),
-    );
-    expect(canonicalFile).toBeDefined();
-    const canonicalContent = await fs.readFile(path.join(memoryDir, canonicalFile!), "utf-8");
+    const allFiles = await fs.readdir(memoryDir);
+    const canonFile = allFiles.find((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f));
+    expect(canonFile).toBeDefined();
+    const canonicalContent = await fs.readFile(path.join(memoryDir, canonFile!), "utf-8");
 
     expect(canonicalContent).toContain("First session content");
     expect(canonicalContent).toContain("Second session content");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -20,9 +20,10 @@ import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
+import { resolveUserTimezone } from "../../../agents/date-time.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
+import { appendFileWithinRoot, writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   parseAgentSessionKey,
@@ -37,34 +38,14 @@ import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } fro
 
 const log = createSubsystemLogger("hooks/session-memory");
 
-function pickDateTimePart(
-  parts: Intl.DateTimeFormatPart[],
-  type: Intl.DateTimeFormatPartTypes,
-): string | undefined {
-  return parts.find((part) => part.type === type)?.value;
-}
-
-function resolveLocalTimeZone(): string | undefined {
-  const timeZone = process.env.TZ?.trim();
-  if (!timeZone) {
-    return undefined;
-  }
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
-    return timeZone;
-  } catch {
-    return undefined;
-  }
-}
-
-function formatLocalSessionTimestamp(date: Date): {
-  date: string;
-  time: string;
-  timeSlug: string;
-  timeZoneName?: string;
-} {
+function resolveSessionTimestamp(
+  timestamp: number,
+  cfg?: OpenClawConfig,
+): { dateStr: string; timeStr: string; timeSlug: string; timezone: string } {
+  const timezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone ?? process.env.TZ);
+  const date = new Date(timestamp);
   const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: resolveLocalTimeZone(),
+    timeZone: timezone,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -72,25 +53,22 @@ function formatLocalSessionTimestamp(date: Date): {
     minute: "2-digit",
     second: "2-digit",
     hourCycle: "h23",
-    timeZoneName: "short",
   }).formatToParts(date);
 
-  const year = pickDateTimePart(parts, "year") ?? String(date.getFullYear()).padStart(4, "0");
-  const month = pickDateTimePart(parts, "month") ?? String(date.getMonth() + 1).padStart(2, "0");
-  const day = pickDateTimePart(parts, "day") ?? String(date.getDate()).padStart(2, "0");
-  const hour = pickDateTimePart(parts, "hour") ?? String(date.getHours()).padStart(2, "0");
-  const minute = pickDateTimePart(parts, "minute") ?? String(date.getMinutes()).padStart(2, "0");
-  const second = pickDateTimePart(parts, "second") ?? String(date.getSeconds()).padStart(2, "0");
-  const timeZoneName = [...parts]
-    .toReversed()
-    .find((part) => part.type === "timeZoneName")
-    ?.value?.trim();
+  const value = (type: Intl.DateTimeFormatPartTypes): string | undefined =>
+    parts.find((part) => part.type === type)?.value;
+  const year = value("year") ?? String(date.getUTCFullYear()).padStart(4, "0");
+  const month = value("month") ?? String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = value("day") ?? String(date.getUTCDate()).padStart(2, "0");
+  const hour = value("hour") ?? String(date.getUTCHours()).padStart(2, "0");
+  const minute = value("minute") ?? String(date.getUTCMinutes()).padStart(2, "0");
+  const second = value("second") ?? String(date.getUTCSeconds()).padStart(2, "0");
 
   return {
-    date: `${year}-${month}-${day}`,
-    time: `${hour}:${minute}:${second}`,
+    dateStr: `${year}-${month}-${day}`,
+    timeStr: `${hour}:${minute}:${second}`,
     timeSlug: `${hour}${minute}`,
-    timeZoneName,
+    timezone,
   };
 }
 
@@ -146,10 +124,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Use the user's local timezone for memory artifact names and headings.
-    const now = new Date(event.timestamp);
-    const localTimestamp = formatLocalSessionTimestamp(now);
-    const dateStr = localTimestamp.date;
+    const { dateStr, timeStr, timeSlug, timezone } = resolveSessionTimestamp(event.timestamp, cfg);
 
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
@@ -227,7 +202,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // If no slug, use timestamp
     if (!slug) {
-      slug = localTimestamp.timeSlug;
+      slug = timeSlug;
       log.debug("Using fallback timestamp slug", { slug });
     }
 
@@ -239,9 +214,6 @@ const saveSessionToMemory: HookHandler = async (event) => {
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
 
-    const timeStr = localTimestamp.time;
-    const timeZoneSuffix = localTimestamp.timeZoneName ? ` ${localTimestamp.timeZoneName}` : "";
-
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
     const source = (context.commandSource as string) || "unknown";
@@ -250,6 +222,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     // it into a concise summary. Falls back to raw content on failure.
     const synthesisEnabled = hookConfig?.synthesis === true;
     let outputContent = sessionContent;
+    let synthesisSucceeded = false;
 
     if (synthesisEnabled && sessionContent && cfg) {
       const isTestEnv =
@@ -267,6 +240,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
         });
         if (synthesized) {
           outputContent = synthesized;
+          synthesisSucceeded = true;
           log.debug("Synthesis complete", { length: synthesized.length });
         } else {
           log.debug("Synthesis returned empty or failed, using raw content");
@@ -274,9 +248,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
       }
     }
 
-    // Build Markdown entry
+    // Build Markdown entry — date and time use the same timezone
+    const timezoneLabel = timezone === "UTC" ? "UTC" : timezone;
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr}${timeZoneSuffix}`,
+      `# Session: ${dateStr} ${timeStr} (${timezoneLabel})`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,
@@ -286,7 +261,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Include conversation content if available
     if (outputContent) {
-      if (synthesisEnabled && outputContent !== sessionContent) {
+      if (synthesisEnabled && synthesisSucceeded) {
         entryParts.push("## Summary", "", outputContent, "");
       } else {
         entryParts.push("## Conversation Summary", "", outputContent, "");
@@ -306,26 +281,16 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Also append to canonical daily file (memory/YYYY-MM-DD.md) so the boot
     // sequence can find session memories without relying on memory_search.
+    // Uses atomic appendFileWithinRoot to avoid TOCTOU races when multiple
+    // /new commands fire in rapid succession on the same day.
     const canonicalFilename = `${dateStr}.md`;
-    const canonicalPath = path.join(memoryDir, canonicalFilename);
     try {
-      const separator = "\n---\n\n";
-      let existingContent = "";
-      try {
-        existingContent = await fs.readFile(canonicalPath, "utf-8");
-      } catch {
-        // File doesn't exist yet — will be created.
-      }
-
-      const appendContent = existingContent
-        ? `${existingContent.trimEnd()}${separator}${entry}`
-        : entry;
-
-      await writeFileWithinRoot({
+      await appendFileWithinRoot({
         rootDir: memoryDir,
         relativePath: canonicalFilename,
-        data: appendContent,
+        data: `\n---\n\n${entry}`,
         encoding: "utf-8",
+        prependNewlineIfNeeded: false,
       });
       log.debug("Appended to canonical daily file", { canonicalFilename });
     } catch (err) {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -1,8 +1,16 @@
 /**
  * Session memory hook handler
  *
- * Saves session context to memory when /new or /reset command is triggered
- * Creates a new dated memory file with LLM-generated slug
+ * Saves session context to memory when /new or /reset command is triggered.
+ *
+ * When `synthesis` is enabled (opt-in), session content is distilled through
+ * an LLM pass before writing — producing a concise summary of decisions,
+ * outcomes, and context worth remembering. When disabled (default), the raw
+ * conversation messages are saved verbatim (legacy behavior).
+ *
+ * Output is always appended to the canonical daily file `memory/YYYY-MM-DD.md`
+ * to align with the boot sequence (which reads that file on startup). A separate
+ * slug-named file is also written for per-session granularity.
  */
 
 import fs from "node:fs/promises";
@@ -24,6 +32,7 @@ import {
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
+import { synthesizeSessionContent } from "../../session-synthesizer.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
@@ -237,6 +246,34 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
     const source = (context.commandSource as string) || "unknown";
 
+    // When synthesis is enabled, run the session content through an LLM to distill
+    // it into a concise summary. Falls back to raw content on failure.
+    const synthesisEnabled = hookConfig?.synthesis === true;
+    let outputContent = sessionContent;
+
+    if (synthesisEnabled && sessionContent && cfg) {
+      const isTestEnv =
+        process.env.OPENCLAW_TEST_FAST === "1" ||
+        process.env.VITEST === "true" ||
+        process.env.VITEST === "1" ||
+        process.env.NODE_ENV === "test";
+
+      if (!isTestEnv) {
+        log.debug("Running LLM synthesis on session content");
+        const synthesized = await synthesizeSessionContent({
+          sessionContent,
+          cfg,
+          sessionKey: displaySessionKey,
+        });
+        if (synthesized) {
+          outputContent = synthesized;
+          log.debug("Synthesis complete", { length: synthesized.length });
+        } else {
+          log.debug("Synthesis returned empty or failed, using raw content");
+        }
+      }
+    }
+
     // Build Markdown entry
     const entryParts = [
       `# Session: ${dateStr} ${timeStr}${timeZoneSuffix}`,
@@ -248,13 +285,17 @@ const saveSessionToMemory: HookHandler = async (event) => {
     ];
 
     // Include conversation content if available
-    if (sessionContent) {
-      entryParts.push("## Conversation Summary", "", sessionContent, "");
+    if (outputContent) {
+      if (synthesisEnabled && outputContent !== sessionContent) {
+        entryParts.push("## Summary", "", outputContent, "");
+      } else {
+        entryParts.push("## Conversation Summary", "", outputContent, "");
+      }
     }
 
     const entry = entryParts.join("\n");
 
-    // Write under memory root with alias-safe file validation.
+    // Write slug-named file for per-session granularity.
     await writeFileWithinRoot({
       rootDir: memoryDir,
       relativePath: filename,
@@ -262,6 +303,35 @@ const saveSessionToMemory: HookHandler = async (event) => {
       encoding: "utf-8",
     });
     log.debug("Memory file written successfully");
+
+    // Also append to canonical daily file (memory/YYYY-MM-DD.md) so the boot
+    // sequence can find session memories without relying on memory_search.
+    const canonicalFilename = `${dateStr}.md`;
+    const canonicalPath = path.join(memoryDir, canonicalFilename);
+    try {
+      const separator = "\n---\n\n";
+      let existingContent = "";
+      try {
+        existingContent = await fs.readFile(canonicalPath, "utf-8");
+      } catch {
+        // File doesn't exist yet — will be created.
+      }
+
+      const appendContent = existingContent
+        ? `${existingContent.trimEnd()}${separator}${entry}`
+        : entry;
+
+      await writeFileWithinRoot({
+        rootDir: memoryDir,
+        relativePath: canonicalFilename,
+        data: appendContent,
+        encoding: "utf-8",
+      });
+      log.debug("Appended to canonical daily file", { canonicalFilename });
+    } catch (err) {
+      // Non-fatal — the slug file was already written.
+      log.warn(`Failed to append to canonical daily file: ${String(err)}`);
+    }
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
     const relPath = memoryFilePath.replace(os.homedir(), "~");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -39,11 +39,11 @@ import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } fro
 const log = createSubsystemLogger("hooks/session-memory");
 
 function resolveSessionTimestamp(
-  timestamp: number,
+  timestamp: Date | number,
   cfg?: OpenClawConfig,
 ): { dateStr: string; timeStr: string; timeSlug: string; timezone: string } {
   const timezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone ?? process.env.TZ);
-  const date = new Date(timestamp);
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     year: "numeric",

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -225,26 +225,18 @@ const saveSessionToMemory: HookHandler = async (event) => {
     let synthesisSucceeded = false;
 
     if (synthesisEnabled && sessionContent && cfg) {
-      const isTestEnv =
-        process.env.OPENCLAW_TEST_FAST === "1" ||
-        process.env.VITEST === "true" ||
-        process.env.VITEST === "1" ||
-        process.env.NODE_ENV === "test";
-
-      if (!isTestEnv) {
-        log.debug("Running LLM synthesis on session content");
-        const synthesized = await synthesizeSessionContent({
-          sessionContent,
-          cfg,
-          sessionKey: displaySessionKey,
-        });
-        if (synthesized) {
-          outputContent = synthesized;
-          synthesisSucceeded = true;
-          log.debug("Synthesis complete", { length: synthesized.length });
-        } else {
-          log.debug("Synthesis returned empty or failed, using raw content");
-        }
+      log.debug("Running LLM synthesis on session content");
+      const synthesized = await synthesizeSessionContent({
+        sessionContent,
+        cfg,
+        sessionKey: displaySessionKey,
+      });
+      if (synthesized) {
+        outputContent = synthesized;
+        synthesisSucceeded = true;
+        log.debug("Synthesis complete", { length: synthesized.length });
+      } else {
+        log.debug("Synthesis returned empty or failed, using raw content");
       }
     }
 

--- a/src/hooks/session-synthesizer.ts
+++ b/src/hooks/session-synthesizer.ts
@@ -91,9 +91,11 @@ export async function synthesizeSessionContent(params: {
       cleanupBundleMcpOnRunEnd: true,
     });
 
-    // Extract text from payloads
+    // Extract text from payloads, skipping error payloads (e.g., timeout/auth failures)
+    // so we fall back to raw content instead of storing an error message as the summary.
     if (result.payloads && result.payloads.length > 0) {
-      const text = result.payloads[0]?.text?.trim();
+      const successPayload = result.payloads.find((p) => p.text?.trim() && !p.isError);
+      const text = successPayload?.text?.trim();
       if (text) {
         // If the LLM determined nothing worth remembering, return null
         if (text === "NO_SUMMARY" || text.startsWith("NO_SUMMARY")) {

--- a/src/hooks/session-synthesizer.ts
+++ b/src/hooks/session-synthesizer.ts
@@ -9,15 +9,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import {
-  resolveDefaultAgentId,
-  resolveAgentWorkspaceDir,
-  resolveAgentDir,
-} from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveAgentDir } from "../agents/agent-scope.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 
 const log = createSubsystemLogger("session-synthesizer");
 
@@ -52,12 +49,15 @@ Conversation:
 export async function synthesizeSessionContent(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
-  sessionKey?: string;
+  /** Session key used to resolve the correct agent scope in multi-agent setups. */
+  sessionKey: string;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
   try {
-    const agentId = resolveDefaultAgentId(params.cfg);
+    // Resolve the agent from the session key so multi-agent setups use the
+    // correct workspace, model, and provider (not always the default agent).
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
 
@@ -77,7 +77,7 @@ export async function synthesizeSessionContent(params: {
 
     const result = await runEmbeddedPiAgent({
       sessionId: `session-synthesis-${Date.now()}`,
-      sessionKey: "temp:session-synthesis",
+      sessionKey: params.sessionKey,
       agentId,
       sessionFile: tempSessionFile,
       workspaceDir,

--- a/src/hooks/session-synthesizer.ts
+++ b/src/hooks/session-synthesizer.ts
@@ -1,0 +1,122 @@
+/**
+ * LLM-based session content synthesizer for session-memory hook.
+ *
+ * Distills raw conversation messages into a concise summary of decisions,
+ * outcomes, and durable context — similar to the pre-compaction memory flush
+ * but triggered on /new or /reset.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveDefaultAgentId,
+  resolveAgentWorkspaceDir,
+  resolveAgentDir,
+} from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("session-synthesizer");
+
+const DEFAULT_SYNTHESIS_PROMPT = `You are summarizing a conversation session that is about to be saved to long-term memory.
+
+Distill the following conversation into a concise summary. Focus on:
+- Decisions made and their rationale
+- Actions taken and their outcomes
+- Key facts, configurations, or state changes
+- Problems solved and how
+- Open questions or next steps
+
+Omit:
+- Greetings, small talk, and filler
+- Raw tool output or verbose logs
+- Exploratory back-and-forth that led nowhere
+- Messages that are just "test", "ok", acknowledgments, or reactions
+
+If the conversation contains nothing worth remembering (e.g., only test messages, greetings, or trivial exchanges), reply with exactly: NO_SUMMARY
+
+Otherwise, write a clean markdown summary (no code fences around the whole thing). Use bullet points for individual items. Be concise — aim for roughly 20-50% of the original length.
+
+Conversation:
+`;
+
+/**
+ * Synthesize raw session messages into a concise summary using an LLM.
+ *
+ * Returns the synthesized text, or null if synthesis fails or produces
+ * no meaningful output (e.g., trivial conversations).
+ */
+export async function synthesizeSessionContent(params: {
+  sessionContent: string;
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+}): Promise<string | null> {
+  let tempSessionFile: string | null = null;
+
+  try {
+    const agentId = resolveDefaultAgentId(params.cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+    const agentDir = resolveAgentDir(params.cfg, agentId);
+
+    // Create a temporary session file for this one-off LLM call
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-synthesis-"));
+    tempSessionFile = path.join(tempDir, "session.jsonl");
+
+    // Cap input to avoid blowing context windows on very long sessions
+    const truncatedContent = params.sessionContent.slice(0, 12_000);
+
+    const prompt = `${DEFAULT_SYNTHESIS_PROMPT}${truncatedContent}`;
+
+    const { provider, model } = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId,
+    });
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: `session-synthesis-${Date.now()}`,
+      sessionKey: "temp:session-synthesis",
+      agentId,
+      sessionFile: tempSessionFile,
+      workspaceDir,
+      agentDir,
+      config: params.cfg,
+      prompt,
+      provider,
+      model,
+      timeoutMs: 30_000, // 30 second timeout (synthesis is heavier than slug gen)
+      runId: `synthesis-${Date.now()}`,
+      cleanupBundleMcpOnRunEnd: true,
+    });
+
+    // Extract text from payloads
+    if (result.payloads && result.payloads.length > 0) {
+      const text = result.payloads[0]?.text?.trim();
+      if (text) {
+        // If the LLM determined nothing worth remembering, return null
+        if (text === "NO_SUMMARY" || text.startsWith("NO_SUMMARY")) {
+          log.debug("LLM determined session has nothing worth summarizing");
+          return null;
+        }
+        return text;
+      }
+    }
+
+    return null;
+  } catch (err) {
+    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    log.error(`Failed to synthesize session content: ${message}`);
+    return null;
+  } finally {
+    // Clean up temporary session file
+    if (tempSessionFile) {
+      try {
+        await fs.rm(path.dirname(tempSessionFile), { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The session-memory hook saves conversation context when `/new` or `/reset` is triggered, but the current implementation has three issues that reduce its usefulness:

1. **Raw dumps, not summaries** — It saves the last 15 messages verbatim, including trivial exchanges (`test`, `are you still there?`, `🫡`). The pre-compaction memory flush already solves this with LLM synthesis, but the session-memory hook doesn't use it.

2. **Slug files the boot sequence never reads** (#45607, #46687) — The hook writes to `memory/YYYY-MM-DD-slug.md`, but `AGENTS.md` instructs agents to read `memory/YYYY-MM-DD.md`. The output is invisible unless `memory_search` happens to surface it.

3. **UTC dates cross midnight boundaries** (#46703) — A session at 11 PM CST gets filed as the next day's UTC date.

## Changes

### 1. LLM synthesis mode (opt-in)

New `synthesis: true` config option. When enabled, session content is run through an LLM before writing — distilling decisions, outcomes, and durable context into a concise summary. Trivial conversations return `NO_SUMMARY` and fall back to raw content.

Uses the same `runEmbeddedPiAgent` pattern as the existing slug generator. New module: `src/hooks/session-synthesizer.ts`.

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "session-memory": {
          "enabled": true,
          "synthesis": true
        }
      }
    }
  }
}
```

### 2. Canonical daily file append

After writing the slug-named file (preserved for per-session granularity), the hook now also appends to the canonical `memory/YYYY-MM-DD.md` file. Multiple sessions per day are separated by `---` markers. The canonical append is non-fatal — if it fails, the slug file was already written.

### 3. User timezone for dates

Filenames now use `agents.defaults.userTimezone` (via `resolveUserTimezone`) instead of UTC `toISOString()`. This matches the pre-compaction memory flush's behavior (`formatDateStampInTimezone` in `memory-flush.ts`).

## Backward compatibility

All changes are non-breaking:
- Synthesis is opt-in (`synthesis: false` is the default)
- Slug-named files continue to be written
- Canonical file append is additive and non-fatal
- Synthesis failure falls back to raw content gracefully

## Testing

- All 21 existing tests pass (updated file count assertions for canonical file)
- New tests added for canonical daily file append (single + multiple sessions)
- New tests for synthesis config path
- Build passes: `pnpm build && pnpm vitest run src/hooks/bundled/session-memory/handler.test.ts`

## AI disclosure

🤖 Built with AI assistance (Claude, via OpenClaw). The changes were designed by reviewing the existing codebase patterns (`memory-flush.ts`, `llm-slug-generator.ts`, `pi-embedded.ts`) and following the same conventions. All code reviewed and understood by the submitter.

Closes #45607
Refs #46703, #46687, #38478, #40418
