### PR TITLE
fix(whatsapp): reduce stale-socket message loss with active health ping

### DIFF
--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -243,9 +243,25 @@ export async function monitorWebChannel(
     };
     const wrapOutbound = <F extends (...args: never[]) => Promise<unknown>>(fn: F): F =>
       (async (...args: Parameters<F>) => {
-        const result = await fn(...args);
-        updateLastActivity();
-        return result;
+        try {
+          const result = await fn(...args);
+          updateLastActivity();
+          return result;
+        } catch (err) {
+          // A failed outbound send may indicate a stale socket. Log it and
+          // trigger a proactive reconnect rather than silently aging the
+          // watchdog timer. The caller still receives the error.
+          reconnectLogger.warn(
+            { connectionId, error: formatError(err) },
+            "outbound send failed — may indicate stale socket",
+          );
+          listener.signalClose?.({
+            status: 499,
+            isLoggedOut: false,
+            error: err,
+          });
+          throw err;
+        }
       }) as unknown as F;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- need mutable access
     const mutableListener = listener as any;

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -198,6 +198,8 @@ export async function monitorWebChannel(
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
+      pingIntervalMs: tuning.pingIntervalMs,
+      pingTimeoutMs: tuning.pingTimeoutMs,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;
         lastMessageAt = Date.now();
@@ -227,6 +229,48 @@ export async function monitorWebChannel(
     });
 
     setActiveWebListener(account.accountId, listener);
+
+    // Wrap outbound methods so that send activity also resets the watchdog timer.
+    // Without this, an outbound-only channel (e.g., cron sending but no human replies)
+    // would falsely trigger the watchdog after MESSAGE_TIMEOUT_MS.
+    // The listener object is returned as `const` (readonly), so we need a mutable
+    // handle to patch outbound methods.
+    const updateLastActivity = () => {
+      lastMessageAt = Date.now();
+      status.lastMessageAt = lastMessageAt;
+      status.lastEventAt = lastMessageAt;
+      emitStatus();
+    };
+    const wrapOutbound = <F extends (...args: never[]) => Promise<unknown>>(fn: F): F =>
+      (async (...args: Parameters<F>) => {
+        const result = await fn(...args);
+        updateLastActivity();
+        return result;
+      }) as unknown as F;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- need mutable access
+    const mutableListener = listener as any;
+    if (typeof mutableListener.sendMessage === "function") {
+      mutableListener.sendMessage = wrapOutbound(mutableListener.sendMessage);
+    }
+    if (typeof mutableListener.sendPoll === "function") {
+      mutableListener.sendPoll = wrapOutbound(mutableListener.sendPoll);
+    }
+    if (typeof mutableListener.sendReaction === "function") {
+      mutableListener.sendReaction = wrapOutbound(mutableListener.sendReaction);
+    }
+    if (typeof mutableListener.sendComposingTo === "function") {
+      mutableListener.sendComposingTo = wrapOutbound(mutableListener.sendComposingTo);
+    }
+
+    // Log reconnect gap duration for debugging (only on subsequent connections).
+    if (status.lastDisconnect?.at) {
+      const gapMs = Date.now() - status.lastDisconnect.at;
+      reconnectLogger.info(
+        { gapMs, gapSeconds: Math.round(gapMs / 1000) },
+        "web reconnect: gap duration since last disconnect",
+      );
+    }
+
     unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
       if (!isLikelyWhatsAppCryptoError(reason)) {
         return false;

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -245,7 +245,9 @@ export async function monitorWebChannel(
     // Application-level send failures (bad JID, content errors) should NOT
     // trigger a reconnect — only connection/socket issues should.
     const isTransportError = (err: unknown): boolean => {
-      const msg = String(err).toLowerCase();
+      // Use formatError() to handle Boom-style wrappers and nested error
+      // objects that stringify as "[object Object]" with plain String().
+      const msg = formatError(err).toLowerCase();
       return (
         msg.includes("connection") ||
         msg.includes("socket") ||

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -241,6 +241,24 @@ export async function monitorWebChannel(
       status.lastEventAt = lastMessageAt;
       emitStatus();
     };
+    // Heuristic: detect transport-level errors that suggest a dead socket.
+    // Application-level send failures (bad JID, content errors) should NOT
+    // trigger a reconnect — only connection/socket issues should.
+    const isTransportError = (err: unknown): boolean => {
+      const msg = String(err).toLowerCase();
+      return (
+        msg.includes("connection") ||
+        msg.includes("socket") ||
+        msg.includes("timed out") ||
+        msg.includes("timeout") ||
+        msg.includes("closed") ||
+        msg.includes("econnreset") ||
+        msg.includes("epipe") ||
+        msg.includes("not open") ||
+        msg.includes("disconnected")
+      );
+    };
+
     const wrapOutbound = <F extends (...args: never[]) => Promise<unknown>>(fn: F): F =>
       (async (...args: Parameters<F>) => {
         try {
@@ -248,18 +266,26 @@ export async function monitorWebChannel(
           updateLastActivity();
           return result;
         } catch (err) {
-          // A failed outbound send may indicate a stale socket. Log it and
-          // trigger a proactive reconnect rather than silently aging the
-          // watchdog timer. The caller still receives the error.
-          reconnectLogger.warn(
-            { connectionId, error: formatError(err) },
-            "outbound send failed — may indicate stale socket",
-          );
-          listener.signalClose?.({
-            status: 499,
-            isLoggedOut: false,
-            error: err,
-          });
+          if (isTransportError(err)) {
+            // Transport-level failure likely means a stale socket.
+            // Trigger proactive reconnect. The caller still receives the error.
+            reconnectLogger.warn(
+              { connectionId, error: formatError(err) },
+              "outbound send failed (transport error) — forcing reconnect",
+            );
+            listener.signalClose?.({
+              status: 499,
+              isLoggedOut: false,
+              error: err,
+            });
+          } else {
+            // Application-level error (bad JID, invalid content, etc.)
+            // — don't tear down a healthy connection.
+            reconnectLogger.info(
+              { connectionId, error: formatError(err) },
+              "outbound send failed (application error) — not reconnecting",
+            );
+          }
           throw err;
         }
       }) as unknown as F;

--- a/src/web/auto-reply/types.ts
+++ b/src/web/auto-reply/types.ts
@@ -34,4 +34,8 @@ export type WebMonitorTuning = {
   accountId?: string;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender. */
   debounceMs?: number;
+  /** Interval (ms) between active socket health pings (default 25000). */
+  pingIntervalMs?: number;
+  /** Timeout (ms) for each health ping before declaring the socket stale (default 10000). */
+  pingTimeoutMs?: number;
 };

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -76,20 +76,67 @@ export async function monitorWebInbox(options: {
   }
 
   // Periodically ping the socket to detect stale connections within seconds.
+  // Prefers WebSocket-level ping/pong (transport-layer, no side-effects) over
+  // sendPresenceUpdate which broadcasts "online" status to contacts every interval.
+  // Falls back to presence update only when the raw WebSocket is inaccessible.
   // A PING_INTERVAL_MS of 0 disables the health ping entirely.
+  //
+  // Note: Baileys has its own keepAlive (<iq><ping/></iq> every 30s) but it may
+  // not catch all stale-socket scenarios. This is an additional safety layer.
+  const rawWs = (sock.ws as unknown as { socket?: { ping?: (cb?: (err?: Error) => void) => void } })?.socket;
+  const canWsPing = typeof rawWs?.ping === "function";
+
   if (PING_INTERVAL_MS > 0) pingTimer = setInterval(() => {
-    const timeout = setTimeout(() => {
-      logVerbose("Health ping timed out — forcing reconnect");
-      resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
-    }, PING_TIMEOUT_MS);
-    sock
-      .sendPresenceUpdate("available")
-      .then(() => clearTimeout(timeout))
-      .catch((err: unknown) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return false;
+      settled = true;
+      return true;
+    };
+
+    if (canWsPing) {
+      // WebSocket-level ping/pong: no presence side-effect.
+      const onPong = () => {
+        if (!settle()) return;
         clearTimeout(timeout);
-        logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
-        resolveClose({ status: 499, isLoggedOut: false, error: err });
-      });
+      };
+      const timeout = setTimeout(() => {
+        if (!settle()) return;
+        sock.ws.removeListener("pong", onPong);
+        if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+        logVerbose("Health ping timed out — forcing reconnect");
+        resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
+      }, PING_TIMEOUT_MS);
+
+      sock.ws.once("pong", onPong);
+      try {
+        rawWs!.ping!();
+      } catch (err: unknown) {
+        if (settle()) {
+          sock.ws.removeListener("pong", onPong);
+          clearTimeout(timeout);
+          if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+          logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
+          resolveClose({ status: 499, isLoggedOut: false, error: err });
+        }
+      }
+    } else {
+      // Fallback: presence update when raw WebSocket ping is unavailable.
+      const timeout = setTimeout(() => {
+        if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+        logVerbose("Health ping timed out — forcing reconnect");
+        resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
+      }, PING_TIMEOUT_MS);
+      sock
+        .sendPresenceUpdate("available")
+        .then(() => clearTimeout(timeout))
+        .catch((err: unknown) => {
+          clearTimeout(timeout);
+          if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+          logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
+          resolveClose({ status: 499, isLoggedOut: false, error: err });
+        });
+    }
   }, PING_INTERVAL_MS);
 
   // If ping is disabled, log it for clarity.

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -52,6 +52,7 @@ export async function monitorWebInbox(options: {
   const PING_INTERVAL_MS = options.pingIntervalMs ?? 25_000;
   const PING_TIMEOUT_MS = options.pingTimeoutMs ?? 10_000;
   let pingTimer: ReturnType<typeof setInterval> | null = null;
+  let activePingTimeout: ReturnType<typeof setTimeout> | null = null;
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
   const onClose = new Promise<WebListenerCloseReason>((resolve) => {
@@ -94,14 +95,19 @@ export async function monitorWebInbox(options: {
       return true;
     };
 
+    const clearPingTimeout = () => {
+      if (activePingTimeout) { clearTimeout(activePingTimeout); activePingTimeout = null; }
+    };
+
     if (canWsPing) {
       // WebSocket-level ping/pong: no presence side-effect.
       const onPong = () => {
         if (!settle()) return;
-        clearTimeout(timeout);
+        clearPingTimeout();
       };
-      const timeout = setTimeout(() => {
+      activePingTimeout = setTimeout(() => {
         if (!settle()) return;
+        activePingTimeout = null;
         sock.ws.removeListener("pong", onPong);
         if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
         logVerbose("Health ping timed out — forcing reconnect");
@@ -114,7 +120,7 @@ export async function monitorWebInbox(options: {
       } catch (err: unknown) {
         if (settle()) {
           sock.ws.removeListener("pong", onPong);
-          clearTimeout(timeout);
+          clearPingTimeout();
           if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
           logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
           resolveClose({ status: 499, isLoggedOut: false, error: err });
@@ -122,16 +128,17 @@ export async function monitorWebInbox(options: {
       }
     } else {
       // Fallback: presence update when raw WebSocket ping is unavailable.
-      const timeout = setTimeout(() => {
+      activePingTimeout = setTimeout(() => {
+        activePingTimeout = null;
         if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
         logVerbose("Health ping timed out — forcing reconnect");
         resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
       }, PING_TIMEOUT_MS);
       sock
         .sendPresenceUpdate("available")
-        .then(() => clearTimeout(timeout))
+        .then(() => clearPingTimeout())
         .catch((err: unknown) => {
-          clearTimeout(timeout);
+          clearPingTimeout();
           if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
           logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
           resolveClose({ status: 499, isLoggedOut: false, error: err });
@@ -456,6 +463,10 @@ export async function monitorWebInbox(options: {
       if (pingTimer) {
         clearInterval(pingTimer);
         pingTimer = null;
+      }
+      if (activePingTimeout) {
+        clearTimeout(activePingTimeout);
+        activePingTimeout = null;
       }
       try {
         const ev = sock.ev as unknown as {

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -34,6 +34,10 @@ export async function monitorWebInbox(options: {
   debounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  /** Active socket health ping interval (ms). Set 0 to disable. Default: 25000. */
+  pingIntervalMs?: number;
+  /** Active socket health ping timeout (ms). Default: 10000. */
+  pingTimeoutMs?: number;
 }) {
   const inboundLogger = getChildLogger({ module: "web-inbound" });
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
@@ -42,6 +46,12 @@ export async function monitorWebInbox(options: {
   });
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();
+
+  // Active health ping to detect stale sockets quickly.
+  // Configurable via options; 0 disables the ping entirely.
+  const PING_INTERVAL_MS = options.pingIntervalMs ?? 25_000;
+  const PING_TIMEOUT_MS = options.pingTimeoutMs ?? 10_000;
+  let pingTimer: ReturnType<typeof setInterval> | null = null;
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
   const onClose = new Promise<WebListenerCloseReason>((resolve) => {
@@ -63,6 +73,28 @@ export async function monitorWebInbox(options: {
     }
   } catch (err) {
     logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+  }
+
+  // Periodically ping the socket to detect stale connections within seconds.
+  // A PING_INTERVAL_MS of 0 disables the health ping entirely.
+  if (PING_INTERVAL_MS > 0) pingTimer = setInterval(() => {
+    const timeout = setTimeout(() => {
+      logVerbose("Health ping timed out — forcing reconnect");
+      resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
+    }, PING_TIMEOUT_MS);
+    sock
+      .sendPresenceUpdate("available")
+      .then(() => clearTimeout(timeout))
+      .catch((err: unknown) => {
+        clearTimeout(timeout);
+        logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
+        resolveClose({ status: 499, isLoggedOut: false, error: err });
+      });
+  }, PING_INTERVAL_MS);
+
+  // If ping is disabled, log it for clarity.
+  if (PING_INTERVAL_MS <= 0) {
+    logVerbose("Active health ping disabled (pingIntervalMs=0)");
   }
 
   const selfJid = sock.user?.id;
@@ -374,6 +406,10 @@ export async function monitorWebInbox(options: {
 
   return {
     close: async () => {
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
       try {
         const ev = sock.ev as unknown as {
           off?: (event: string, listener: (...args: unknown[]) => void) => void;

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -128,17 +128,28 @@ export async function monitorWebInbox(options: {
       }
     } else {
       // Fallback: presence update when raw WebSocket ping is unavailable.
-      activePingTimeout = setTimeout(() => {
-        activePingTimeout = null;
+      // Each tick gets its own local timeout handle to prevent cross-tick
+      // interference when a slow presence response from tick N resolves
+      // after tick N+1's timeout has been stored in activePingTimeout.
+      const localTimeout = setTimeout(() => {
+        if (!settle()) return;
+        if (activePingTimeout === localTimeout) activePingTimeout = null;
         if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
         logVerbose("Health ping timed out — forcing reconnect");
         resolveClose({ status: 499, isLoggedOut: false, error: "health-ping-timeout" });
       }, PING_TIMEOUT_MS);
+      activePingTimeout = localTimeout;
       sock
         .sendPresenceUpdate("available")
-        .then(() => clearPingTimeout())
+        .then(() => {
+          if (!settle()) return;
+          clearTimeout(localTimeout);
+          if (activePingTimeout === localTimeout) activePingTimeout = null;
+        })
         .catch((err: unknown) => {
-          clearPingTimeout();
+          if (!settle()) return;
+          clearTimeout(localTimeout);
+          if (activePingTimeout === localTimeout) activePingTimeout = null;
           if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
           logVerbose(`Health ping failed: ${String(err)} — forcing reconnect`);
           resolveClose({ status: 499, isLoggedOut: false, error: err });


### PR DESCRIPTION
## Summary

Reduces the window for silent inbound message loss during WhatsApp stale-socket reconnects.

Fixes #50428

## Changes

### 1. Configurable health ping passthrough (`src/web/inbound/monitor.ts`)
- Accept `pingIntervalMs` and `pingTimeoutMs` options in `monitorWebInbox()`
- Use tuning values instead of hardcoded constants (default: 25s interval, 10s timeout)
- Set `pingIntervalMs=0` to disable the health ping entirely
- Log when ping is disabled for clarity

### 2. Outbound activity resets watchdog (`src/web/auto-reply/monitor.ts`)
- Wrap `sendMessage`, `sendPoll`, `sendReaction`, and `sendComposingTo` so outbound traffic also updates `lastMessageAt`
- Prevents false-positive watchdog reconnects on outbound-only channels (e.g., cron sending with no human replies)
- This fix was present in the compiled dist but missing from TypeScript source

### 3. Reconnect gap logging (`src/web/auto-reply/monitor.ts`)
- After reconnect, log the duration of the gap since the last disconnect
- Helps diagnose how long message loss windows actually are in production

### 4. Tuning types (`src/web/auto-reply/types.ts`)
- Pass `pingIntervalMs`/`pingTimeoutMs` from `WebMonitorTuning` through to the inbound monitor

## How it helps

| Before | After |
|--------|-------|
| Stale socket detected after 30 min watchdog timeout | Health ping detects staleness within ~35 seconds |
| Outbound-only traffic triggers false watchdog reconnects | Outbound activity resets the timer |
| No visibility into reconnect gap duration | Gap logged for debugging |

## Testing

- TypeScript compilation: `npx tsc --noEmit` passes with 0 errors in modified files
- Existing tests unaffected (changes are additive)
- Verified on personal OpenClaw instance (WSL2, v2026.3.13) where status 499 disconnects occur every ~2 hours

## Related

- #22511 — my earlier analysis of WhatsApp disconnection root causes
- [Issue comment with full root cause analysis](https://github.com/openclaw/openclaw/issues/50428#issuecomment-4091836574)