### PR TITLE
fix(ollama): detect vision models and set input to text+image

### DIFF
--- a/src/agents/models-config.providers.discovery.ts
+++ b/src/agents/models-config.providers.discovery.ts
@@ -76,7 +76,7 @@ async function discoverOllamaModels(
       id: model.name,
       name: model.name,
       reasoning: isReasoningModelHeuristic(model.name),
-      input: ["text"],
+      input: model.vision ? (["text", "image"] as const) : (["text"] as const),
       cost: OLLAMA_DEFAULT_COST,
       contextWindow: model.contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
       maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,

--- a/src/agents/ollama-models.test.ts
+++ b/src/agents/ollama-models.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { jsonResponse, requestBodyText, requestUrl } from "../test-helpers/http.js";
 import {
+  buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
+  isVisionModelHeuristic,
   resolveOllamaApiBase,
   type OllamaTagModel,
 } from "./ollama-models.js";
@@ -34,8 +36,67 @@ describe("ollama-models", () => {
     const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
 
     expect(enriched).toEqual([
-      { name: "llama3:8b", contextWindow: 65536 },
-      { name: "deepseek-r1:14b", contextWindow: undefined },
+      { name: "llama3:8b", contextWindow: 65536, vision: false },
+      { name: "deepseek-r1:14b", contextWindow: undefined, vision: false },
     ]);
+  });
+
+  it("detects vision models from /api/show projector keys", async () => {
+    const models: OllamaTagModel[] = [{ name: "llama3.2-vision:11b" }];
+    const fetchMock = vi.fn(async (_input: string | URL | Request) => {
+      return jsonResponse({
+        model_info: {
+          "general.architecture": "mllama",
+          "mllama.context_length": 131072,
+          "clip.block_count": 32,
+          "projector.type": "cross_attention",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched).toEqual([
+      { name: "llama3.2-vision:11b", contextWindow: 131072, vision: true },
+    ]);
+  });
+
+  describe("isVisionModelHeuristic", () => {
+    it.each([
+      "qwen3-vl:235b-cloud",
+      "llama3.2-vision:11b",
+      "llava:13b",
+      "bakllava:7b",
+      "moondream:1.8b",
+      "minicpm-v:8b",
+      "internvl2.5:78b",
+    ])("detects %s as a vision model", (modelId) => {
+      expect(isVisionModelHeuristic(modelId)).toBe(true);
+    });
+
+    it.each(["llama3:8b", "deepseek-r1:14b", "glm-4:9b", "qwen3:32b", "mistral:7b"])(
+      "does not flag %s as a vision model",
+      (modelId) => {
+        expect(isVisionModelHeuristic(modelId)).toBe(false);
+      },
+    );
+  });
+
+  describe("buildOllamaModelDefinition", () => {
+    it("sets input to text+image for vision models by name", () => {
+      const def = buildOllamaModelDefinition("qwen3-vl:235b-cloud");
+      expect(def.input).toEqual(["text", "image"]);
+    });
+
+    it("sets input to text+image when vision opt is true", () => {
+      const def = buildOllamaModelDefinition("custom-model:latest", undefined, { vision: true });
+      expect(def.input).toEqual(["text", "image"]);
+    });
+
+    it("sets input to text only for non-vision models", () => {
+      const def = buildOllamaModelDefinition("llama3:8b");
+      expect(def.input).toEqual(["text"]);
+    });
   });
 });

--- a/src/agents/ollama-models.ts
+++ b/src/agents/ollama-models.ts
@@ -28,6 +28,7 @@ export type OllamaTagsResponse = {
 
 export type OllamaModelWithContext = OllamaTagModel & {
   contextWindow?: number;
+  vision?: boolean;
 };
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
@@ -48,10 +49,15 @@ export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   return trimmed.replace(/\/v1$/i, "");
 }
 
-export async function queryOllamaContextWindow(
+export type OllamaShowInfo = {
+  contextWindow?: number;
+  vision?: boolean;
+};
+
+export async function queryOllamaModelInfo(
   apiBase: string,
   modelName: string,
-): Promise<number | undefined> {
+): Promise<OllamaShowInfo> {
   try {
     const response = await fetch(`${apiBase}/api/show`, {
       method: "POST",
@@ -60,24 +66,42 @@ export async function queryOllamaContextWindow(
       signal: AbortSignal.timeout(3000),
     });
     if (!response.ok) {
-      return undefined;
+      return {};
     }
     const data = (await response.json()) as { model_info?: Record<string, unknown> };
     if (!data.model_info) {
-      return undefined;
+      return {};
     }
-    for (const [key, value] of Object.entries(data.model_info)) {
-      if (key.endsWith(".context_length") && typeof value === "number" && Number.isFinite(value)) {
-        const contextWindow = Math.floor(value);
-        if (contextWindow > 0) {
-          return contextWindow;
+    let contextWindow: number | undefined;
+    let vision = false;
+    for (const key of Object.keys(data.model_info)) {
+      if (key.endsWith(".context_length") && !contextWindow) {
+        const value = data.model_info[key];
+        if (typeof value === "number" && Number.isFinite(value)) {
+          const ctx = Math.floor(value);
+          if (ctx > 0) {
+            contextWindow = ctx;
+          }
         }
       }
+      // Ollama vision models expose projector/clip architecture keys in model_info
+      if (key.startsWith("clip.") || key.startsWith("projector.")) {
+        vision = true;
+      }
     }
-    return undefined;
+    return { contextWindow, vision };
   } catch {
-    return undefined;
+    return {};
   }
+}
+
+/** @deprecated Use queryOllamaModelInfo instead. */
+export async function queryOllamaContextWindow(
+  apiBase: string,
+  modelName: string,
+): Promise<number | undefined> {
+  const info = await queryOllamaModelInfo(apiBase, modelName);
+  return info.contextWindow;
 }
 
 export async function enrichOllamaModelsWithContext(
@@ -90,10 +114,14 @@ export async function enrichOllamaModelsWithContext(
   for (let index = 0; index < models.length; index += concurrency) {
     const batch = models.slice(index, index + concurrency);
     const batchResults = await Promise.all(
-      batch.map(async (model) => ({
-        ...model,
-        contextWindow: await queryOllamaContextWindow(apiBase, model.name),
-      })),
+      batch.map(async (model) => {
+        const info = await queryOllamaModelInfo(apiBase, model.name);
+        return {
+          ...model,
+          contextWindow: info.contextWindow,
+          vision: info.vision || isVisionModelHeuristic(model.name),
+        };
+      }),
     );
     enriched.push(...batchResults);
   }
@@ -105,16 +133,31 @@ export function isReasoningModelHeuristic(modelId: string): boolean {
   return /r1|reasoning|think|reason/i.test(modelId);
 }
 
+/**
+ * Heuristic: detect vision/multimodal models by name.
+ * Covers common Ollama vision model naming patterns:
+ * - `-vl` / `_vl` suffix (qwen3-vl, internvl)
+ * - `vision` (llama3.2-vision)
+ * - `llava` / `bakllava` (LLaVA family)
+ * - `moondream` (small vision model)
+ * - `minicpm-v` (MiniCPM-V family)
+ */
+export function isVisionModelHeuristic(modelId: string): boolean {
+  return /[-_]vl\b|nvl\d|vision|llava|bakllava|moondream|minicpm-v/i.test(modelId);
+}
+
 /** Build a ModelDefinitionConfig for an Ollama model with default values. */
 export function buildOllamaModelDefinition(
   modelId: string,
   contextWindow?: number,
+  opts?: { vision?: boolean },
 ): ModelDefinitionConfig {
+  const vision = opts?.vision || isVisionModelHeuristic(modelId);
   return {
     id: modelId,
     name: modelId,
     reasoning: isReasoningModelHeuristic(modelId),
-    input: ["text"],
+    input: vision ? ["text", "image"] : ["text"],
     cost: OLLAMA_DEFAULT_COST,
     contextWindow: contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,

--- a/src/plugins/provider-ollama-setup.ts
+++ b/src/plugins/provider-ollama-setup.ts
@@ -249,9 +249,12 @@ function buildOllamaModelsConfig(
   modelNames: string[],
   discoveredModelsByName?: Map<string, OllamaModelWithContext>,
 ) {
-  return modelNames.map((name) =>
-    buildOllamaModelDefinition(name, discoveredModelsByName?.get(name)?.contextWindow),
-  );
+  return modelNames.map((name) => {
+    const discovered = discoveredModelsByName?.get(name);
+    return buildOllamaModelDefinition(name, discovered?.contextWindow, {
+      vision: discovered?.vision,
+    });
+  });
 }
 
 function applyOllamaProviderConfig(


### PR DESCRIPTION
## Problem

Ollama vision models like `qwen3-vl`, `llama3.2-vision`, `llava`, `internvl`, `moondream`, and `minicpm-v` are not recognized as supporting image input. Their `input` field is always set to `["text"]`, so the image tool rejects them even when correctly configured as the image model.

## Root Cause

Both `buildOllamaModelDefinition()` and `discoverOllamaModels()` hardcode `input: ["text"]` for all Ollama models without checking for vision capability.

## Fix

Two complementary detection strategies:

1. **Name-based heuristic** (`isVisionModelHeuristic`): matches common vision model naming patterns (`-vl`, `vision`, `llava`, `bakllava`, `moondream`, `minicpm-v`, `internvl`)
2. **/api/show inspection**: the existing `queryOllamaContextWindow` is generalized to `queryOllamaModelInfo`, which also checks for `clip.*` or `projector.*` keys in `model_info` — these are present in all Ollama vision model manifests

Both `buildOllamaModelDefinition` (used by provider-ollama-setup) and `discoverOllamaModels` (used by provider discovery) now set `input: ["text", "image"]` for detected vision models.

## Changes

- `src/agents/ollama-models.ts`: Add `isVisionModelHeuristic()`, `queryOllamaModelInfo()`, update `OllamaModelWithContext` type, update `buildOllamaModelDefinition()` signature
- `src/agents/models-config.providers.discovery.ts`: Use `model.vision` from enriched data
- `src/plugins/provider-ollama-setup.ts`: Pass vision info to `buildOllamaModelDefinition()`
- `src/agents/ollama-models.test.ts`: Add tests for vision detection (heuristic + /api/show), update existing test expectations

## Testing

All 18 tests pass:
- Existing context window enrichment test updated for new `vision` field
- New test: vision detection from `/api/show` projector keys
- New test suite: `isVisionModelHeuristic` with 12 model name cases
- New test suite: `buildOllamaModelDefinition` vision input behavior

Closes #50569