### PR TITLE
feat(skills): warn when skill descriptions exceed configurable length limit

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -30,6 +30,7 @@ export type SkillInstallOption = {
 export type SkillStatusEntry = {
   name: string;
   description: string;
+  descriptionLength: number;
   source: string;
   bundled: boolean;
   filePath: string;
@@ -46,6 +47,7 @@ export type SkillStatusEntry = {
   missing: Requirements;
   configChecks: SkillStatusConfigCheck[];
   install: SkillInstallOption[];
+  warnings?: string[];
 };
 
 export type SkillStatusReport = {
@@ -202,9 +204,18 @@ function buildSkillStatus(
     });
   const eligible = !disabled && !blockedByAllowlist && requirementsSatisfied;
 
+  const descriptionLength = entry.skill.description?.length ?? 0;
+  const warnings: string[] = [];
+  if (descriptionLength > 200) {
+    warnings.push(
+      `description is verbose (${descriptionLength} chars) — shorten to reduce system prompt bloat`,
+    );
+  }
+
   return {
     name: entry.skill.name,
     description: entry.skill.description,
+    descriptionLength,
     source: entry.skill.source,
     bundled,
     filePath: entry.skill.filePath,
@@ -221,6 +232,7 @@ function buildSkillStatus(
     missing,
     configChecks,
     install: normalizeInstallOptions(entry, prefs ?? resolveSkillsInstallPreferences(config)),
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -99,6 +99,7 @@ const DEFAULT_MAX_SKILLS_LOADED_PER_SOURCE = 200;
 const DEFAULT_MAX_SKILLS_IN_PROMPT = 150;
 const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 30_000;
 const DEFAULT_MAX_SKILL_FILE_BYTES = 256_000;
+const DEFAULT_MAX_SKILL_DESCRIPTION_CHARS = 200;
 
 function sanitizeSkillCommandName(raw: string): string {
   const normalized = raw
@@ -135,6 +136,7 @@ type ResolvedSkillsLimits = {
   maxSkillsInPrompt: number;
   maxSkillsPromptChars: number;
   maxSkillFileBytes: number;
+  maxSkillDescriptionChars: number;
 };
 
 function resolveSkillsLimits(config?: OpenClawConfig): ResolvedSkillsLimits {
@@ -146,6 +148,8 @@ function resolveSkillsLimits(config?: OpenClawConfig): ResolvedSkillsLimits {
     maxSkillsInPrompt: limits?.maxSkillsInPrompt ?? DEFAULT_MAX_SKILLS_IN_PROMPT,
     maxSkillsPromptChars: limits?.maxSkillsPromptChars ?? DEFAULT_MAX_SKILLS_PROMPT_CHARS,
     maxSkillFileBytes: limits?.maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES,
+    maxSkillDescriptionChars:
+      limits?.maxSkillDescriptionChars ?? DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
   };
 }
 
@@ -524,6 +528,18 @@ function loadSkillEntries(
       invocation: resolveSkillInvocationPolicy(frontmatter),
     };
   });
+
+  // Warn about verbose skill descriptions that bloat the system prompt.
+  for (const entry of skillEntries) {
+    const descLen = entry.skill.description?.length ?? 0;
+    if (descLen > limits.maxSkillDescriptionChars) {
+      skillsLogger.warn(
+        `Skill "${entry.skill.name}" has a verbose description (${descLen} chars, limit ${limits.maxSkillDescriptionChars}). ` +
+          `Shorten it to reduce system prompt bloat. Run \`openclaw skills check\` to audit.`,
+      );
+    }
+  }
+
   return skillEntries;
 }
 

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -35,6 +35,12 @@ export type SkillsLimitsConfig = {
   maxSkillsPromptChars?: number;
   /** Max size (bytes) allowed for a SKILL.md file to be considered. */
   maxSkillFileBytes?: number;
+  /**
+   * Warn when a skill description exceeds this many characters.
+   * Verbose descriptions bloat the system prompt on every turn.
+   * Default: 200.
+   */
+  maxSkillDescriptionChars?: number;
 };
 
 export type SkillsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -905,6 +905,7 @@ export const OpenClawSchema = z
             maxSkillsInPrompt: z.number().int().min(0).optional(),
             maxSkillsPromptChars: z.number().int().min(0).optional(),
             maxSkillFileBytes: z.number().int().min(0).optional(),
+            maxSkillDescriptionChars: z.number().int().min(0).optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Problem

No guardrails on skill description length. Verbose descriptions (600+ chars) effectively inject API documentation into every request, bloating the system prompt and increasing token usage/cost on every turn.

## Fix

Add a configurable `skills.limits.maxSkillDescriptionChars` option (default: 200) that emits a warning during skill loading when descriptions exceed the threshold.

### Changes

- `src/config/types.skills.ts`: Add `maxSkillDescriptionChars` to `SkillsLimitsConfig`
- `src/config/zod-schema.ts`: Add zod validation for the new field
- `src/agents/skills/workspace.ts`: Emit warning via skills logger during `loadSkillEntries()` for verbose descriptions
- `src/agents/skills-status.ts`: Surface `descriptionLength` and `warnings` in `SkillStatusEntry` for `openclaw skills check`

### Behavior

- Soft warning only — skills still load normally
- Default threshold: 200 chars (configurable via `skills.limits.maxSkillDescriptionChars`)
- Warning message includes skill name, current length, limit, and suggests running `openclaw skills check`
- `openclaw skills check` now surfaces description length warnings per skill

### Configuration

```json
{
  "skills": {
    "limits": {
      "maxSkillDescriptionChars": 200
    }
  }
}
```

## Testing

All existing tests pass (34 skills tests, 1 skills-status test, 25 config schema tests).

Closes #50564