### PR TITLE
style: reorder export statements in plugin-sdk compat for oxfmt compliance

### DIFF
--- a/src/plugin-sdk/compat.ts
+++ b/src/plugin-sdk/compat.ts
@@ -24,6 +24,7 @@ export { delegateCompactionToRuntime } from "../context-engine/delegate.js";
 export { createAccountStatusSink } from "./channel-lifecycle.js";
 export { createPluginRuntimeStore } from "./runtime-store.js";
 export { KeyedAsyncQueue } from "./keyed-async-queue.js";
+export { formatAllowFromLowercase, formatNormalizedAllowFromEntries } from "./allow-from.js";
 
 export {
   createHybridChannelConfigAdapter,
@@ -36,7 +37,7 @@ export {
   createTopLevelChannelConfigBase,
   mapAllowFromEntries,
 } from "./channel-config-helpers.js";
-export { formatAllowFromLowercase, formatNormalizedAllowFromEntries } from "./allow-from.js";
+
 export * from "./channel-config-schema.js";
 export * from "./channel-policy.js";
 export * from "./reply-history.js";


### PR DESCRIPTION
The \`src/plugin-sdk/compat.ts\` barrel file had export statements in an incorrect order according to the project's \`oxfmt\` style guide.

Changes:
- Moved \`export { formatAllowFromLowercase, formatNormalizedAllowFromEntries }\` from line 40 to line 27
- Ensures parent imports come before local imports
- Places star exports (\`export *\`) at the bottom as per style guide
- No semantic changes—only reordering for style compliance

Pattern from PR #48758