### PR TITLE
fix: load matrix legacy helper through native ESM when possible

### DIFF
--- a/src/infra/matrix-plugin-helper.test.ts
+++ b/src/infra/matrix-plugin-helper.test.ts
@@ -25,6 +25,22 @@ function writeMatrixPluginFixture(rootDir: string, helperBody: string): void {
   fs.writeFileSync(path.join(rootDir, "legacy-crypto-inspector.js"), helperBody, "utf8");
 }
 
+function writeMatrixPluginManifest(rootDir: string): void {
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "matrix",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+      },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(rootDir, "index.js"), "export default {};\n", "utf8");
+}
+
 describe("matrix plugin helper resolution", () => {
   it("loads the legacy crypto inspector from the bundled matrix plugin", async () => {
     await withTempHome(
@@ -120,6 +136,62 @@ describe("matrix plugin helper resolution", () => {
       {
         env: {
           OPENCLAW_BUNDLED_PLUGINS_DIR: (home) => path.join(home, "bundled"),
+        },
+      },
+    );
+  });
+
+  it("keeps source-style root helper shims on the Jiti fallback path", async () => {
+    await withTempHome(
+      async (home) => {
+        const customRoot = path.join(home, "plugins", "matrix-local");
+        writeMatrixPluginManifest(customRoot);
+        fs.mkdirSync(path.join(customRoot, "src", "matrix"), { recursive: true });
+        fs.writeFileSync(
+          path.join(customRoot, "legacy-crypto-inspector.js"),
+          'export { inspectLegacyMatrixCryptoStore } from "./src/matrix/legacy-crypto-inspector.js";\n',
+          "utf8",
+        );
+        fs.writeFileSync(
+          path.join(customRoot, "src", "matrix", "legacy-crypto-inspector.ts"),
+          [
+            "export async function inspectLegacyMatrixCryptoStore() {",
+            '  return { deviceId: "SRCJS", roomKeyCounts: null, backupVersion: null, decryptionKeyBase64: null };',
+            "}",
+          ].join("\n"),
+          "utf8",
+        );
+
+        const cfg: OpenClawConfig = {
+          plugins: {
+            load: {
+              paths: [customRoot],
+            },
+          },
+        };
+
+        expect(isMatrixLegacyCryptoInspectorAvailable({ cfg, env: process.env })).toBe(true);
+        const inspectLegacyStore = await loadMatrixLegacyCryptoInspector({
+          cfg,
+          env: process.env,
+        });
+
+        await expect(
+          inspectLegacyStore({
+            cryptoRootDir: "/tmp/legacy",
+            userId: "@bot:example.org",
+            deviceId: "DEVICE123",
+          }),
+        ).resolves.toEqual({
+          deviceId: "SRCJS",
+          roomKeyCounts: null,
+          backupVersion: null,
+          decryptionKeyBase64: null,
+        });
+      },
+      {
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: (home) => path.join(home, "empty-bundled"),
         },
       },
     );

--- a/src/infra/matrix-plugin-helper.ts
+++ b/src/infra/matrix-plugin-helper.ts
@@ -112,6 +112,14 @@ function getJiti() {
   return jitiLoader;
 }
 
+function canRetryWithJiti(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "ERR_UNKNOWN_FILE_EXTENSION";
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -159,9 +167,19 @@ export async function loadMatrixLegacyCryptoInspector(params: {
   }
 
   const pending = (async () => {
-    const loaded: unknown = shouldPreferNativeJiti(helperPath)
-      ? await import(pathToFileURL(helperPath).href)
-      : getJiti()(helperPath);
+    let loaded: unknown;
+    if (shouldPreferNativeJiti(helperPath)) {
+      try {
+        loaded = await import(pathToFileURL(helperPath).href);
+      } catch (error) {
+        if (!canRetryWithJiti(error)) {
+          throw error;
+        }
+        loaded = getJiti()(helperPath);
+      }
+    } else {
+      loaded = getJiti()(helperPath);
+    }
     const inspectLegacyMatrixCryptoStore = resolveInspectorExport(loaded);
     if (!inspectLegacyMatrixCryptoStore) {
       throw new Error(

--- a/src/infra/matrix-plugin-helper.ts
+++ b/src/infra/matrix-plugin-helper.ts
@@ -7,7 +7,7 @@ import {
   loadPluginManifestRegistry,
   type PluginManifestRecord,
 } from "../plugins/manifest-registry.js";
-import { buildPluginLoaderJitiOptions, shouldPreferNativeJiti } from "../plugins/sdk-alias.js";
+import { shouldPreferNativeJiti } from "../plugins/sdk-alias.js";
 import { openBoundaryFileSync } from "./boundary-file-read.js";
 
 const MATRIX_PLUGIN_ID = "matrix";
@@ -96,22 +96,20 @@ export function isMatrixLegacyCryptoInspectorAvailable(params: {
   return resolveMatrixLegacyCryptoInspectorPath(params).status === "ok";
 }
 
-const jitiLoaders = new Map<boolean, ReturnType<typeof createJiti>>();
+let jitiLoader: ReturnType<typeof createJiti> | null = null;
 const inspectorCache = new Map<string, Promise<MatrixLegacyCryptoInspector>>();
 
-function getJiti(modulePath: string) {
-  const tryNative = shouldPreferNativeJiti(modulePath);
-  const cached = jitiLoaders.get(tryNative);
-  if (cached) {
-    return cached;
+function getJiti() {
+  if (jitiLoader) {
+    return jitiLoader;
   }
 
-  const loader = createJiti(import.meta.url, {
-    ...buildPluginLoaderJitiOptions({}),
-    tryNative,
+  jitiLoader = createJiti(import.meta.url, {
+    interopDefault: false,
+    tryNative: false,
+    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
-  jitiLoaders.set(tryNative, loader);
-  return loader;
+  return jitiLoader;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -163,7 +161,7 @@ export async function loadMatrixLegacyCryptoInspector(params: {
   const pending = (async () => {
     const loaded: unknown = shouldPreferNativeJiti(helperPath)
       ? await import(pathToFileURL(helperPath).href)
-      : getJiti(helperPath)(helperPath);
+      : getJiti()(helperPath);
     const inspectLegacyMatrixCryptoStore = resolveInspectorExport(loaded);
     if (!inspectLegacyMatrixCryptoStore) {
       throw new Error(

--- a/src/infra/matrix-plugin-helper.ts
+++ b/src/infra/matrix-plugin-helper.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadPluginManifestRegistry,
   type PluginManifestRecord,
 } from "../plugins/manifest-registry.js";
+import { buildPluginLoaderJitiOptions, shouldPreferNativeJiti } from "../plugins/sdk-alias.js";
 import { openBoundaryFileSync } from "./boundary-file-read.js";
 
 const MATRIX_PLUGIN_ID = "matrix";
@@ -94,17 +96,22 @@ export function isMatrixLegacyCryptoInspectorAvailable(params: {
   return resolveMatrixLegacyCryptoInspectorPath(params).status === "ok";
 }
 
-let jitiLoader: ReturnType<typeof createJiti> | null = null;
+const jitiLoaders = new Map<boolean, ReturnType<typeof createJiti>>();
 const inspectorCache = new Map<string, Promise<MatrixLegacyCryptoInspector>>();
 
-function getJiti() {
-  if (!jitiLoader) {
-    jitiLoader = createJiti(import.meta.url, {
-      interopDefault: false,
-      extensions: [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs", ".json"],
-    });
+function getJiti(modulePath: string) {
+  const tryNative = shouldPreferNativeJiti(modulePath);
+  const cached = jitiLoaders.get(tryNative);
+  if (cached) {
+    return cached;
   }
-  return jitiLoader;
+
+  const loader = createJiti(import.meta.url, {
+    ...buildPluginLoaderJitiOptions({}),
+    tryNative,
+  });
+  jitiLoaders.set(tryNative, loader);
+  return loader;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -154,7 +161,9 @@ export async function loadMatrixLegacyCryptoInspector(params: {
   }
 
   const pending = (async () => {
-    const loaded: unknown = await getJiti().import(helperPath);
+    const loaded: unknown = shouldPreferNativeJiti(helperPath)
+      ? await import(pathToFileURL(helperPath).href)
+      : getJiti(helperPath)(helperPath);
     const inspectLegacyMatrixCryptoStore = resolveInspectorExport(loaded);
     if (!inspectLegacyMatrixCryptoStore) {
       throw new Error(


### PR DESCRIPTION
## Summary

- Problem: `src/infra/matrix-plugin-helper.test.ts` was failing on `main` with a Jiti runtime error when loading `legacy-crypto-inspector.js`.
- Why it matters: Matrix legacy encrypted-state inspection is a plugin boundary, and the current helper was loading built plugin code through the wrong module path.
- What changed: aligned `src/infra/matrix-plugin-helper.ts` with the newer plugin-loader pattern by preferring native ESM import for native-loadable helper files and keeping Jiti only for source helper files.
- What did NOT change (scope boundary): path safety checks, helper export resolution, plugin manifest resolution, and the Matrix plugin helper implementation itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra


## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin helper loading
- Relevant config (redacted): default config plus temp bundled/custom Matrix plugin fixtures from the existing tests

### Steps

1. Check out current `main`.
2. Run `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/infra/matrix-plugin-helper.test.ts src/cli/qr-dashboard.integration.test.ts`.
3. Observe `src/infra/matrix-plugin-helper.test.ts` fail with `TypeError: Cannot set property require of [object Object] which has only a getter`.
4. Apply this change and rerun the same targeted command.

### Expected

- The Matrix helper test loads built `.js` helpers through the native module path and passes.
- The targeted slice stays green.

### Actual

- Before the fix, the Matrix helper test failed on `main` due to the Jiti runtime error above.
- After the fix, the targeted slice passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `src/infra/matrix-plugin-helper.test.ts`; `src/infra/matrix-plugin-helper.test.ts src/cli/qr-dashboard.integration.test.ts`
- Edge cases checked: bundled helper fixture, configured plugin-load-path fixture, unsafe helper path fixture
- What you did **not** verify: full repo `pnpm test`; plugin helper behavior in a live Matrix install

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `6d91224705`
- Files/config to restore: `src/infra/matrix-plugin-helper.ts`
- Known bad symptoms reviewers should watch for: Matrix legacy helper failing to load source `.ts` helpers or built `.js` helpers

## Risks and Mitigations

- Risk: Native-vs-Jiti selection could regress one helper path while fixing the other.
  - Mitigation: kept the existing path safety and export resolution logic intact, and verified bundled, configured-path, and unsafe-path cases through the existing targeted tests.
