### PR TITLE
fix: Tailscale serve + auth.mode=none exposes gateway to full...

### DIFF
--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -250,6 +250,55 @@ describe("resolveGatewayRuntimeConfig", () => {
     });
   });
 
+  describe("tailscale auth.mode=none guard", () => {
+    it("rejects tailscale serve with auth.mode=none", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "loopback" as const,
+              auth: { mode: "none" as const },
+            },
+          },
+          port: 18789,
+          tailscale: { mode: "serve" },
+        }),
+      ).rejects.toThrow(
+        "tailscale serve/funnel requires gateway auth — refusing to start with auth.mode=none when tailscale is active",
+      );
+    });
+
+    it("rejects tailscale funnel with auth.mode=none", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "loopback" as const,
+              auth: { mode: "none" as const },
+            },
+          },
+          port: 18789,
+          tailscale: { mode: "funnel" },
+        }),
+      ).rejects.toThrow("tailscale funnel requires gateway auth mode=password");
+    });
+
+    it("allows tailscale serve with auth.mode=token", async () => {
+      const result = await resolveGatewayRuntimeConfig({
+        cfg: {
+          gateway: {
+            bind: "loopback" as const,
+            auth: TOKEN_AUTH,
+          },
+        },
+        port: 18789,
+        tailscale: { mode: "serve" },
+      });
+      expect(result.authMode).toBe("token");
+      expect(result.tailscaleMode).toBe("serve");
+    });
+  });
+
   describe("HTTP security headers", () => {
     const cases = [
       {

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -264,7 +264,7 @@ describe("resolveGatewayRuntimeConfig", () => {
           tailscale: { mode: "serve" },
         }),
       ).rejects.toThrow(
-        "tailscale serve/funnel requires gateway auth — refusing to start with auth.mode=none when tailscale is active",
+        "tailscale serve requires gateway auth — refusing to start with auth.mode=none when tailscale serve is active",
       );
     });
 

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -127,6 +127,11 @@ export async function resolveGatewayRuntimeConfig(params: {
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
     );
   }
+  if (tailscaleMode !== "off" && authMode === "none") {
+    throw new Error(
+      "tailscale serve/funnel requires gateway auth — refusing to start with auth.mode=none when tailscale is active",
+    );
+  }
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
     throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
   }

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -127,9 +127,9 @@ export async function resolveGatewayRuntimeConfig(params: {
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
     );
   }
-  if (tailscaleMode !== "off" && authMode === "none") {
+  if (tailscaleMode === "serve" && authMode === "none") {
     throw new Error(
-      "tailscale serve/funnel requires gateway auth — refusing to start with auth.mode=none when tailscale is active",
+      "tailscale serve requires gateway auth — refusing to start with auth.mode=none when tailscale serve is active",
     );
   }
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {


### PR DESCRIPTION
## Fix Summary
When `gateway.auth.mode` is set to `"none"` and `gateway.tailscale.mode` is set to `"serve"`, the gateway is reachable over the user's entire Tailnet with zero authentication. Any Tailnet peer connecting through the Tailscale serve URL receives `{ ok: true, method: "none" }` from `authorizeGatewayConnect` without presenting any credential, gaining full operator-level access to the gateway control plane.

## Issue Linkage
Fixes #50630

## Security Snapshot
- CVSS v3.1: 9.3 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/server-runtime-config.test.ts` (+49/-0)
- `src/gateway/server-runtime-config.ts` (+5/-0)

### Technical Analysis
The startup validation chain in `resolveGatewayRuntimeConfig` has three relevant guards:

1. `assertGatewayAuthConfigured` (`auth.ts:285`) — validates token/password/trusted-proxy preconditions but has no branch for `mode === "none"`. Passes silently for any tailscale configuration.
2. The funnel guard (`server-runtime-config.ts:125`) — blocks `authMode !== "password"` when `tailscaleMode === "funnel"`. Does not apply to `tailscaleMode === "serve"`.
3. The non-loopback LAN guard (`server-runtime-config.ts:133`) — blocks `mode: "none"` on LAN/custom binds by requiring `hasSharedSecret || authMode === "trusted-proxy"`. Does not apply here because Tailscale serve enforces loopback bind (`server-runtime-config.ts:130`), so `isLoopbackHost(bindHost)` is `true`.

The combination `tailscaleMode === "serve"` + `authMode === "none"` satisfies all three guards:
- Guard at line 130 passes because serve mode enforces loopback — which then exempts the connection from the non-loopback guard at line 133.
- The funnel-only guard at line 125 does not apply to serve.
- `assertGatewayAuthConfigured` passes silently for `mode: "none"`.

`resolveGatewayRuntimeConfig` succeeds, the gateway starts, and `authorizeGatewayConnect` unconditionally returns `{ ok: true, method: "none" }` (auth.ts:402-404) for every incoming connection. Tailscale's local proxy relays requests from any Tailnet peer to the loopback gateway port, bypassing the auth check entirely.

Additionally, `resolveGatewayAuth` at `auth.ts:271-273` auto-enables `allowTailscale` when `tailscaleMode === "serve"` and `mode !== "password" && mode !== "trusted-proxy"` — this sets `allowTailscale: true` for `mode: "none"` + serve, though the `mode: "none"` early return in `authorizeGatewayConnect` fires before the Tailscale header auth path is reached.

**Deterministic repro config:**
```yaml
gateway:
  auth:
    mode: none
  tailscale:
    mode: serve
```

Steps:
1. Set `gateway.auth.mode = "none"` and `gateway.tailscale.mode = "serve"` in `~/.openclaw/openclaw.json`.
2. Start the gateway: `openclaw gateway run`.
3. From any other device on the same Tailnet, connect to the Tailscale serve URL (e.g., `https://<hostname>.ts.net`).
4. Observe: connection is accepted with `authMethod: "none"` — no token, password, or device pairing required.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/claude-sonnet-4-6
