### PR TITLE
fix: *.ts.net Host header accepted as local-direct request...

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -5,6 +5,7 @@ import {
   authorizeGatewayConnect,
   authorizeHttpGatewayConnect,
   authorizeWsControlUiGatewayConnect,
+  isLocalDirectRequest,
   resolveGatewayAuth,
 } from "./auth.js";
 
@@ -631,5 +632,50 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.user).toBe("nick@example.com");
+  });
+});
+
+describe("isLocalDirectRequest — ts.net host-header gate (AA-ala regression)", () => {
+  function makeReq(
+    host: string,
+    remoteAddress = "127.0.0.1",
+    headers: Record<string, string> = {},
+  ) {
+    return {
+      socket: { remoteAddress },
+      headers: { host, ...headers },
+    } as never;
+  }
+
+  it("rejects ts.net host when allowTailscale is not set", () => {
+    const req = makeReq("gateway.tailnet.ts.net");
+    expect(isLocalDirectRequest(req)).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false)).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false, {})).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: false })).toBe(false);
+  });
+
+  it("accepts ts.net host when allowTailscale is true", () => {
+    const req = makeReq("gateway.tailnet.ts.net");
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(true);
+  });
+
+  it("rejects ts.net host from non-loopback even with allowTailscale", () => {
+    const req = makeReq("gateway.tailnet.ts.net", "192.168.1.50");
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(false);
+  });
+
+  it("accepts loopback host regardless of allowTailscale", () => {
+    const req = makeReq("localhost");
+    expect(isLocalDirectRequest(req)).toBe(true);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: false })).toBe(true);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(true);
+  });
+
+  it("rejects ts.net host when forwarding headers present and remote is not trusted proxy", () => {
+    const req = makeReq("gateway.tailnet.ts.net", "127.0.0.1", {
+      "x-forwarded-for": "10.0.0.1",
+    });
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(false);
   });
 });

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -117,6 +117,7 @@ export function isLocalDirectRequest(
   req?: IncomingMessage,
   trustedProxies?: string[],
   allowRealIpFallback = false,
+  opts?: { allowTailscale?: boolean },
 ): boolean {
   if (!req) {
     return false;
@@ -133,7 +134,10 @@ export function isLocalDirectRequest(
   );
 
   const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
-  return isLocalishHost(req.headers?.host) && (!hasForwarded || remoteIsTrustedProxy);
+  return (
+    isLocalishHost(req.headers?.host, { allowTailscale: opts?.allowTailscale }) &&
+    (!hasForwarded || remoteIsTrustedProxy)
+  );
 }
 
 function getTailscaleUser(req?: IncomingMessage): TailscaleUser | null {
@@ -376,6 +380,7 @@ export async function authorizeGatewayConnect(
     req,
     trustedProxies,
     params.allowRealIpFallback === true,
+    { allowTailscale: auth.allowTailscale },
   );
 
   if (auth.mode === "trusted-proxy") {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -28,16 +28,29 @@ describe("resolveHostName", () => {
 });
 
 describe("isLocalishHost", () => {
-  it("accepts loopback and tailscale serve/funnel host headers", () => {
-    const accepted = [
-      "localhost",
-      "127.0.0.1:18789",
-      "[::1]:18789",
-      "[::ffff:127.0.0.1]:18789",
-      "gateway.tailnet.ts.net",
-    ];
+  it("accepts loopback hosts without allowTailscale", () => {
+    const accepted = ["localhost", "127.0.0.1:18789", "[::1]:18789", "[::ffff:127.0.0.1]:18789"];
     for (const host of accepted) {
       expect(isLocalishHost(host), host).toBe(true);
+    }
+  });
+
+  it("rejects *.ts.net hosts when allowTailscale is not set (default)", () => {
+    expect(isLocalishHost("gateway.tailnet.ts.net")).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", {})).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: false })).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: undefined })).toBe(false);
+  });
+
+  it("accepts *.ts.net hosts when allowTailscale is true", () => {
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: true })).toBe(true);
+    expect(isLocalishHost("machine.example.ts.net", { allowTailscale: true })).toBe(true);
+  });
+
+  it("loopback hosts pass regardless of allowTailscale flag", () => {
+    for (const host of ["localhost", "127.0.0.1:18789", "[::1]:18789"]) {
+      expect(isLocalishHost(host, { allowTailscale: false }), host).toBe(true);
+      expect(isLocalishHost(host, { allowTailscale: true }), host).toBe(true);
     }
   });
 
@@ -45,6 +58,13 @@ describe("isLocalishHost", () => {
     const rejected = ["example.com", "192.168.1.10", "203.0.113.5:18789"];
     for (const host of rejected) {
       expect(isLocalishHost(host), host).toBe(false);
+    }
+  });
+
+  it("rejects non-local hosts even with allowTailscale", () => {
+    const rejected = ["example.com", "192.168.1.10", "attacker.ts.net.evil.com"];
+    for (const host of rejected) {
+      expect(isLocalishHost(host, { allowTailscale: true }), host).toBe(false);
     }
   });
 });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -351,14 +351,22 @@ export function isLoopbackHost(host: string): boolean {
 /**
  * Local-facing host check for inbound requests:
  * - loopback hosts (localhost/127.x/::1 and mapped forms)
- * - Tailscale Serve/Funnel hostnames (*.ts.net)
+ * - Tailscale Serve/Funnel hostnames (*.ts.net) — only when Tailscale is active
+ *
+ * The `allowTailscale` flag gates the `.ts.net` Host-header branch so that
+ * a co-resident process cannot spoof a Tailscale hostname when Tailscale is
+ * not configured.  Callers that do not pass the flag get loopback-only
+ * behaviour (safe default).
  */
-export function isLocalishHost(hostHeader?: string): boolean {
+export function isLocalishHost(hostHeader?: string, opts?: { allowTailscale?: boolean }): boolean {
   const host = resolveHostName(hostHeader);
   if (!host) {
     return false;
   }
-  return isLoopbackHost(host) || host.endsWith(".ts.net");
+  if (isLoopbackHost(host)) {
+    return true;
+  }
+  return opts?.allowTailscale === true && host.endsWith(".ts.net");
 }
 
 /**

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -200,7 +200,11 @@ async function canRevealReadinessDetails(params: {
   trustedProxies: string[];
   allowRealIpFallback: boolean;
 }): Promise<boolean> {
-  if (isLocalDirectRequest(params.req, params.trustedProxies, params.allowRealIpFallback)) {
+  if (
+    isLocalDirectRequest(params.req, params.trustedProxies, params.allowRealIpFallback, {
+      allowTailscale: params.resolvedAuth.allowTailscale,
+    })
+  ) {
     return true;
   }
   if (params.resolvedAuth.mode === "none") {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -216,8 +216,12 @@ export function attachGatewayWsMessageHandler(params: {
   const hasProxyHeaders = Boolean(forwardedFor || realIp);
   const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
   const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
-  const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
+  const hostIsLocalish = isLocalishHost(requestHost, {
+    allowTailscale: resolvedAuth.allowTailscale,
+  });
+  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback, {
+    allowTailscale: resolvedAuth.allowTailscale,
+  });
   const reportedClientIp =
     isLocalClient || hasUntrustedProxyHeaders
       ? undefined

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -97,7 +97,9 @@ export async function handleSessionKillHttpRequest(
   const trustedProxies = opts.trustedProxies ?? cfg.gateway?.trustedProxies;
   const allowRealIpFallback = opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback;
   const requesterSessionKey = req.headers[REQUESTER_SESSION_KEY_HEADER]?.toString().trim();
-  const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+  const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback, {
+    allowTailscale: opts.auth.allowTailscale,
+  });
   const allowBearerOperatorKill = canBearerTokenKillSessions(token, authResult.ok);
 
   if (!requesterSessionKey && !allowLocalAdminKill && !allowBearerOperatorKill) {


### PR DESCRIPTION
## Fix Summary
A local attacker (any co-resident process, container sharing the host network, or SSH port-forward) can bypass gateway token or password authentication on the canvas, a2ui, and readiness detail endpoints by sending an HTTP request to the loopback gateway port with `Host: anything.ts.net` and no forwarding headers. This grants unauthenticated access to session canvas content and readiness metadata protected by `gateway.auth`.

## Issue Linkage
Fixes #50635

## Security Snapshot
- CVSS v3.1: 9.1 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/auth.test.ts` (+46/-0)
- `src/gateway/auth.ts` (+6/-1)
- `src/gateway/net.test.ts` (+28/-8)
- `src/gateway/net.ts` (+11/-3)
- `src/gateway/server-http.ts` (+5/-1)
- `src/gateway/server/http-auth.ts` (+5/-1)
- `src/gateway/server/ws-connection/message-handler.ts` (+6/-2)
- `src/gateway/session-kill-http.ts` (+3/-1)

### Technical Analysis
1. Start the gateway in `loopback` bind mode (the default) with `auth.mode=token` and a configured token. Tailscale is not configured (`tailscale.mode=off`, `auth.allowTailscale=false`).
2. From any process on the same host, send a canvas HTTP request with a crafted Host header and no Authorization header:
   ```
   curl -s http://127.0.0.1:<port>/__openclaw__/canvas/ \
     -H "Host: attacker.ts.net" \
     --no-proxy ""
   ```
   Omit all `X-Forwarded-For`, `X-Real-IP`, and `X-Forwarded-Host` headers.
3. `isLocalDirectRequest` evaluates: socket `remoteAddress` is `127.0.0.1` (loopback passes), `Host: attacker.ts.net` causes `isLocalishHost` to return `true` via the `host.endsWith(".ts.net")` branch, no forwarding headers are present. Result: `{ ok: true }` — the canvas request is granted without any token check.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/gpt-5.4
