### PR TITLE
fix: WS handshake rate-limiter bypassed by synthetic device identity...

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -1,6 +1,36 @@
+import type { IncomingMessage } from "node:http";
 import { describe, expect, it, vi } from "vitest";
-import type { AuthRateLimiter } from "../../auth-rate-limit.js";
-import { resolveConnectAuthDecision, type ConnectAuthState } from "./auth-context.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+  type AuthRateLimiter,
+} from "../../auth-rate-limit.js";
+import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
+import {
+  resolveConnectAuthDecision,
+  resolveConnectAuthState,
+  type ConnectAuthState,
+} from "./auth-context.js";
+
+vi.mock("../../auth.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../auth.js")>();
+  return {
+    ...original,
+    authorizeWsControlUiGatewayConnect: vi.fn<() => Promise<GatewayAuthResult>>(),
+    authorizeHttpGatewayConnect: vi.fn<() => Promise<GatewayAuthResult>>(),
+  };
+});
+
+async function importMockedAuth() {
+  const mod = await import("../../auth.js");
+  return {
+    authorizeWsControlUiGatewayConnect: mod.authorizeWsControlUiGatewayConnect as ReturnType<
+      typeof vi.fn<() => Promise<GatewayAuthResult>>
+    >,
+    authorizeHttpGatewayConnect: mod.authorizeHttpGatewayConnect as ReturnType<
+      typeof vi.fn<() => Promise<GatewayAuthResult>>
+    >,
+  };
+}
 
 type VerifyDeviceTokenFn = Parameters<typeof resolveConnectAuthDecision>[0]["verifyDeviceToken"];
 type VerifyBootstrapTokenFn = Parameters<
@@ -187,5 +217,157 @@ describe("resolveConnectAuthDecision", () => {
     expect(decision.authOk).toBe(true);
     expect(decision.authMethod).toBe("token");
     expect(verifyDeviceToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveConnectAuthState – shared-secret rate limiting with device identity", () => {
+  const fakeReq = {} as IncomingMessage;
+  const fakeResolvedAuth: ResolvedGatewayAuth = {
+    mode: "token",
+    token: "real-token",
+    allowTailscale: false,
+  };
+
+  function createMockRateLimiter(): {
+    limiter: AuthRateLimiter;
+    recordFailure: ReturnType<typeof vi.fn>;
+    check: ReturnType<typeof vi.fn>;
+    reset: ReturnType<typeof vi.fn>;
+  } {
+    const recordFailure = vi.fn();
+    const check = vi.fn(() => ({ allowed: true, remaining: 10, retryAfterMs: 0 }));
+    const reset = vi.fn();
+    return {
+      limiter: { check, recordFailure, reset, size: () => 0, prune: () => {}, dispose: () => {} },
+      recordFailure,
+      check,
+      reset,
+    };
+  }
+
+  it("records shared-secret failure when hasDeviceIdentity is true and auth fails", async () => {
+    const { authorizeWsControlUiGatewayConnect, authorizeHttpGatewayConnect } =
+      await importMockedAuth();
+
+    authorizeWsControlUiGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+    authorizeHttpGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+
+    const mock = createMockRateLimiter();
+    const state = await resolveConnectAuthState({
+      resolvedAuth: fakeResolvedAuth,
+      connectAuth: { token: "wrong-token", deviceToken: "some-device-token" },
+      hasDeviceIdentity: true,
+      req: fakeReq,
+      trustedProxies: [],
+      allowRealIpFallback: false,
+      rateLimiter: mock.limiter,
+      clientIp: "203.0.113.50",
+    });
+
+    expect(state.authOk).toBe(false);
+    expect(mock.recordFailure).toHaveBeenCalledWith(
+      "203.0.113.50",
+      AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+    );
+  });
+
+  it("does NOT record failure when hasDeviceIdentity is false (normal path)", async () => {
+    const { authorizeWsControlUiGatewayConnect, authorizeHttpGatewayConnect } =
+      await importMockedAuth();
+
+    authorizeWsControlUiGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+    authorizeHttpGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+
+    const mock = createMockRateLimiter();
+    await resolveConnectAuthState({
+      resolvedAuth: fakeResolvedAuth,
+      connectAuth: { token: "wrong-token" },
+      hasDeviceIdentity: false,
+      req: fakeReq,
+      trustedProxies: [],
+      allowRealIpFallback: false,
+      rateLimiter: mock.limiter,
+      clientIp: "203.0.113.51",
+    });
+
+    // The rate limiter was passed directly to authorizeWsControlUiGatewayConnect,
+    // so recordFailure is handled inside that function, not in the else branch.
+    expect(mock.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("resets rate limiter on success with device identity (existing behavior preserved)", async () => {
+    const { authorizeWsControlUiGatewayConnect, authorizeHttpGatewayConnect } =
+      await importMockedAuth();
+
+    authorizeWsControlUiGatewayConnect.mockResolvedValue({
+      ok: true,
+      method: "token",
+    });
+    authorizeHttpGatewayConnect.mockResolvedValue({
+      ok: true,
+      method: "token",
+    });
+
+    const mock = createMockRateLimiter();
+    const state = await resolveConnectAuthState({
+      resolvedAuth: fakeResolvedAuth,
+      connectAuth: { token: "real-token", deviceToken: "some-device-token" },
+      hasDeviceIdentity: true,
+      req: fakeReq,
+      trustedProxies: [],
+      allowRealIpFallback: false,
+      rateLimiter: mock.limiter,
+      clientIp: "203.0.113.52",
+    });
+
+    expect(state.authOk).toBe(true);
+    expect(mock.recordFailure).not.toHaveBeenCalled();
+    expect(mock.reset).toHaveBeenCalledWith("203.0.113.52", AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+  });
+
+  it("records failure with shared-token-fallback device candidate", async () => {
+    const { authorizeWsControlUiGatewayConnect, authorizeHttpGatewayConnect } =
+      await importMockedAuth();
+
+    // When only token is provided (no explicit deviceToken), the token is reused
+    // as a shared-token-fallback device candidate.
+    authorizeWsControlUiGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+    authorizeHttpGatewayConnect.mockResolvedValue({
+      ok: false,
+      reason: "token_mismatch",
+    });
+
+    const mock = createMockRateLimiter();
+    const state = await resolveConnectAuthState({
+      resolvedAuth: fakeResolvedAuth,
+      connectAuth: { token: "wrong-token" },
+      hasDeviceIdentity: true,
+      req: fakeReq,
+      trustedProxies: [],
+      allowRealIpFallback: false,
+      rateLimiter: mock.limiter,
+      clientIp: "203.0.113.53",
+    });
+
+    expect(state.authOk).toBe(false);
+    expect(mock.recordFailure).toHaveBeenCalledWith(
+      "203.0.113.53",
+      AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+    );
   });
 });

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -131,6 +131,12 @@ export async function resolveConnectAuthState(params: {
     } else {
       params.rateLimiter.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
     }
+  } else if (hasDeviceTokenCandidate && !authResult.ok && params.rateLimiter) {
+    // Record shared-secret failures that were missed because the rate limiter
+    // was not passed to the primary auth call (deferred for device-token flows).
+    // Without this, an attacker including a device field bypasses brute-force
+    // protection on the shared secret entirely.
+    params.rateLimiter.recordFailure(params.clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
   }
 
   const sharedAuthResult =


### PR DESCRIPTION
## Fix Summary
Any unauthenticated remote caller can disable the shared-secret brute-force rate-limiter by including a syntactically valid device identity object in the WebSocket `connect` handshake, allowing unlimited token/password guesses without triggering lockout. For any gateway with a non-loopback bind address (LAN, Tailscale, or public reverse proxy), rate-limit protection on the shared secret is wholly absent when the attacker includes a device field. The attacker can iterate credential guesses at network speed until the correct token or password is found.

## Issue Linkage
Fixes #50637

## Security Snapshot
- CVSS v3.1: 9.1 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/server/ws-connection/auth-context.test.ts` (+184/-2)
- `src/gateway/server/ws-connection/auth-context.ts` (+6/-0)

### Technical Analysis
1. Start an OpenClaw gateway with a non-loopback bind address (e.g., `--bind 0.0.0.0`) and token/password auth.
2. Connect to the gateway WebSocket endpoint from a remote host.
3. Send a `connect` request frame including a `device` object (any syntactically valid public key, nonce, and signature) alongside `auth.token` with an incorrect value:
   ```json
   {
     "type": "req", "id": "1", "method": "connect",
     "params": {
       "minProtocol": 1, "maxProtocol": 1,
       "role": "operator", "scopes": [],
       "client": { "id": "test-client", "mode": "cli", "version": "0.0.1" },
       "device": {
         "id": "<any-derived-id>",
         "publicKey": "<any-ed25519-public-key-base64url>",
         "signature": "<any-signature>",
         "signedAt": 1234567890,
         "nonce": "<any-nonce>"
       },
       "auth": { "token": "<WRONG_TOKEN>" }
     }
   }
   ```
4. Observe: connection is rejected (wrong token), but no rate-limit failure is recorded for the source IP.
5. Repeat step 3 thousands of times with different token guesses. The gateway never returns a rate-limit error and never locks out the IP.

Device signature validation happens after `resolveConnectAuthState` returns; providing a bogus device object is sufficient to suppress the rate limiter.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/claude-sonnet-4-6
