### PR TITLE
CLI: prune inactive gateway auth credentials on mode set

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -209,6 +209,94 @@ describe("config cli", () => {
         apiKey: "ollama-local", // pragma: allowlist secret
       });
     });
+
+    it("drops gateway.auth.password when switching mode to token", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            mode: "password",
+            token: "token-keep",
+            password: "password-drop", // pragma: allowlist secret
+            allowTailscale: true,
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.auth.mode", "token"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.auth).toEqual({
+        mode: "token",
+        token: "token-keep",
+        allowTailscale: true,
+      });
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Removed inactive gateway.auth.password for gateway.auth.mode=token",
+        ),
+      );
+    });
+
+    it("drops gateway.auth.token when switching mode to password", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: "token-drop",
+            password: "password-keep", // pragma: allowlist secret
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.auth.mode", "password"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.auth).toEqual({
+        mode: "password",
+        password: "password-keep", // pragma: allowlist secret
+      });
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Removed inactive gateway.auth.token for gateway.auth.mode=password",
+        ),
+      );
+    });
+
+    it("applies mode-based credential cleanup using the final batch result", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: {
+          auth: {
+            mode: "password",
+            token: "token-keep",
+            password: "password-drop", // pragma: allowlist secret
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "--batch-json",
+        '[{"path":"gateway.auth.password","value":"password-updated"},{"path":"gateway.auth.mode","value":"token"}]',
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.gateway?.auth).toEqual({
+        mode: "token",
+        token: "token-keep",
+      });
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Removed inactive gateway.auth.password for gateway.auth.mode=token",
+        ),
+      );
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -69,6 +69,7 @@ type ConfigSetOperation = {
 
 const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "apiKey"];
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
+const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
@@ -350,6 +351,48 @@ function ensureValidOllamaProviderForApiKeySet(
     api: "ollama",
     models: [],
   });
+}
+
+function pruneInactiveGatewayAuthCredentials(params: {
+  root: Record<string, unknown>;
+  operations: ConfigSetOperation[];
+}): string[] {
+  const touchedGatewayAuthMode = params.operations.some((operation) =>
+    pathEquals(operation.requestedPath, GATEWAY_AUTH_MODE_PATH),
+  );
+  if (!touchedGatewayAuthMode) {
+    return [];
+  }
+
+  const gatewayRaw = params.root.gateway;
+  if (!gatewayRaw || typeof gatewayRaw !== "object" || Array.isArray(gatewayRaw)) {
+    return [];
+  }
+  const gateway = gatewayRaw as Record<string, unknown>;
+  const authRaw = gateway.auth;
+  if (!authRaw || typeof authRaw !== "object" || Array.isArray(authRaw)) {
+    return [];
+  }
+  const auth = authRaw as Record<string, unknown>;
+  const mode = typeof auth.mode === "string" ? auth.mode.trim() : "";
+
+  const removedPaths: string[] = [];
+  const remove = (key: "token" | "password") => {
+    if (Object.hasOwn(auth, key)) {
+      delete auth[key];
+      removedPaths.push(`gateway.auth.${key}`);
+    }
+  };
+
+  if (mode === "token") {
+    remove("password");
+  } else if (mode === "password") {
+    remove("token");
+  } else if (mode === "trusted-proxy") {
+    remove("token");
+    remove("password");
+  }
+  return removedPaths;
 }
 
 function toDotPath(path: PathSegment[]): string {
@@ -964,6 +1007,10 @@ export async function runConfigSet(opts: {
       ensureValidOllamaProviderForApiKeySet(next, operation.setPath);
       setAtPath(next, operation.setPath, operation.value);
     }
+    const removedGatewayAuthPaths = pruneInactiveGatewayAuthCredentials({
+      root: next,
+      operations,
+    });
     const nextConfig = next as OpenClawConfig;
 
     if (opts.cliOptions.dryRun) {
@@ -1051,6 +1098,13 @@ export async function runConfigSet(opts: {
     }
 
     await writeConfigFile(next);
+    if (removedGatewayAuthPaths.length > 0) {
+      runtime.log(
+        info(
+          `Removed inactive ${removedGatewayAuthPaths.join(", ")} for gateway.auth.mode=${String(nextConfig.gateway?.auth?.mode ?? "<unset>")}.`,
+        ),
+      );
+    }
     if (operations.length === 1) {
       runtime.log(
         info(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw config set gateway.auth.mode ...` could leave inactive credentials (`gateway.auth.password` or `gateway.auth.token`) in config.
- Why it matters: residual credentials increase secret persistence risk and can be accidentally reactivated later.
- What changed: `config set` now prunes inactive gateway auth credentials when `gateway.auth.mode` is set (single or batch mode), based on final mode.
- What did NOT change (scope boundary): gateway runtime auth enforcement logic was not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`openclaw config set gateway.auth.mode token` now removes `gateway.auth.password` from config.
`openclaw config set gateway.auth.mode password` now removes `gateway.auth.token` from config.
`openclaw config set gateway.auth.mode trusted-proxy` now removes both `gateway.auth.token` and `gateway.auth.password`.
CLI prints an info line when cleanup occurs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - This reduces residual credential persistence by removing inactive gateway auth secrets when auth mode is explicitly set.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/Bun local dev
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `gateway.auth.mode`, `gateway.auth.token`, `gateway.auth.password`

### Steps

1. Start with config containing both `gateway.auth.token` and `gateway.auth.password`.
2. Run `openclaw config set gateway.auth.mode token` (and similarly for `password` / `trusted-proxy`).
3. Inspect written config.

### Expected

- Inactive credentials are removed based on mode.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/cli/config-cli.test.ts`
  - `pnpm test -- src/cli/config-cli.integration.test.ts`
  - Manual local repro of `config set gateway.auth.mode token` behavior before/after in temp config.
- Edge cases checked:
  - Batch mode cleanup applies to final mode result.
  - Existing unrelated fields under `gateway.auth` are preserved.
- What you did **not** verify:
  - Full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit on this branch.
- Files/config to restore:
  - `src/cli/config-cli.ts`
  - `src/cli/config-cli.test.ts`
- Known bad symptoms reviewers should watch for:
  - `config set gateway.auth.mode ...` unexpectedly deleting fields outside token/password.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Cleanup could run when not intended.
  - Mitigation:
    - Cleanup is gated to operations that explicitly set `gateway.auth.mode`.
