### PR TITLE
fix: Silent auto-approval of scope-upgrade pairing requests for...

### DIFF
--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -68,16 +68,43 @@ describe("handshake auth helpers", () => {
     });
   });
 
-  it("allows silent local pairing only for not-paired and scope upgrades", () => {
+  it("allows silent local pairing for not-paired reason", () => {
     expect(
       shouldAllowSilentLocalPairing({
         isLocalClient: true,
         hasBrowserOriginHeader: false,
-        isControlUi: false,
+        isControlUi: true,
         isWebchat: false,
         reason: "not-paired",
       }),
     ).toBe(true);
+  });
+
+  it("rejects silent local pairing for scope-upgrade even from local ControlUI", () => {
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: true,
+        isWebchat: false,
+        reason: "scope-upgrade",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects silent local pairing for role-upgrade", () => {
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: true,
+        isWebchat: false,
+        reason: "role-upgrade",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects silent local pairing for metadata-upgrade", () => {
     expect(
       shouldAllowSilentLocalPairing({
         isLocalClient: true,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -56,7 +56,7 @@ export function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
+    params.reason === "not-paired"
   );
 }
 


### PR DESCRIPTION
## Fix Summary
A local browser page connecting as the Control UI (or Webchat) client can request scopes beyond its originally approved set and receive silent auto-approval without any prompt to the gateway operator. Any local JavaScript that can initiate a Control UI WebSocket connection — including a page already on the trusted-origin allowlist, or any page with XSS access to a trusted origin — can permanently escalate the paired device's scopes. Because `approveDevicePairing` persists the upgraded scopes to the pairing file, the escalation survives gateway restarts and subsequent reconnects use the elevated scopes unconditionally.

## Issue Linkage
Fixes #50640

## Security Snapshot
- CVSS v3.1: 9.2 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts` (+29/-2)
- `src/gateway/server/ws-connection/handshake-auth-helpers.ts` (+1/-1)

### Technical Analysis
1. Start the gateway in any auth mode (`token` or `password`) with the Control UI accessible on localhost. Pair a device (the Control UI browser) with `role=operator` and `scopes=["operator.read"]`.
2. From the same browser (or any local client that can claim `client.id = GATEWAY_CLIENT_IDS.CONTROL_UI`), open a new WebSocket connection sending a `connect` frame with the same device identity (keypair) but requesting `scopes=["operator.admin"]`.
3. The gateway detects the scope mismatch, calls `requirePairing("scope-upgrade")`, and `shouldAllowSilentLocalPairing` returns `true` (`isLocalClient=true`, `isControlUi=true`, `reason="scope-upgrade"`).
4. `requestDevicePairing` is invoked with `silent: true` and `approveDevicePairing` is called immediately without surfacing any operator prompt.
5. The device is now paired with `operator.admin` scope, persisted to the pairing file. All subsequent connections by that device carry full admin access.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/github-copilot/gpt-5.4
