### PR TITLE
test: reduce low-memory Vitest pressure

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -47,17 +47,6 @@ const hostMemoryGiB = Math.floor(os.totalmem() / 1024 ** 3);
 const highMemLocalHost = !isCI && hostMemoryGiB >= 96;
 const lowMemLocalHost = !isCI && hostMemoryGiB < 64;
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
-// vmForks is a big win for transform/import heavy suites. Node 24 is stable again
-// for the default unit-fast lane after moving the known flaky files to fork-only
-// isolation, but Node 25+ still falls back to process forks until re-validated.
-// Keep it opt-out via OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
-const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor <= 24 : true;
-const useVmForks =
-  process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
-  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks && !lowMemLocalHost);
-const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
-const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
-const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";
 const rawTestProfile = process.env.OPENCLAW_TEST_PROFILE?.trim().toLowerCase();
 const testProfile =
   rawTestProfile === "low" ||
@@ -68,6 +57,21 @@ const testProfile =
     ? rawTestProfile
     : "normal";
 const isMacMiniProfile = testProfile === "macmini";
+// vmForks is a big win for transform/import heavy suites. Node 24 is stable again
+// for the default unit-fast lane after moving the known flaky files to fork-only
+// isolation, but Node 25+ still falls back to process forks until re-validated.
+// Keep it opt-out via OPENCLAW_TEST_VM_FORKS=0, and let users force-enable with =1.
+const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor <= 24 : true;
+const useVmForks =
+  process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
+  (process.env.OPENCLAW_TEST_VM_FORKS !== "0" &&
+    !isWindows &&
+    supportsVmForks &&
+    !lowMemLocalHost &&
+    testProfile !== "low");
+const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
+const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
+const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";
 // Even on low-memory hosts, keep the isolated lane split so files like
 // git-commit.test.ts still get the worker/process isolation they require.
 const shouldSplitUnitRuns = testProfile !== "serial";

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -68,7 +68,7 @@ const useVmForks =
     !isWindows &&
     supportsVmForks &&
     !lowMemLocalHost &&
-    testProfile !== "low");
+    (isCI || testProfile !== "low"));
 const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
 const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
 const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";

--- a/src/config/doc-baseline.test.ts
+++ b/src/config/doc-baseline.test.ts
@@ -13,6 +13,21 @@ import {
 
 describe("config doc baseline", () => {
   const tempRoots: string[] = [];
+  let sharedBaselinePromise: Promise<Awaited<ReturnType<typeof buildConfigDocBaseline>>> | null =
+    null;
+  let sharedRenderedPromise: Promise<
+    Awaited<ReturnType<typeof renderConfigDocBaselineStatefile>>
+  > | null = null;
+
+  function getSharedBaseline() {
+    sharedBaselinePromise ??= buildConfigDocBaseline();
+    return sharedBaselinePromise;
+  }
+
+  function getSharedRendered() {
+    sharedRenderedPromise ??= renderConfigDocBaselineStatefile(getSharedBaseline());
+    return sharedRenderedPromise;
+  }
 
   afterEach(async () => {
     await Promise.all(
@@ -31,7 +46,7 @@ describe("config doc baseline", () => {
   });
 
   it("normalizes array and record paths to wildcard form", async () => {
-    const baseline = await buildConfigDocBaseline();
+    const baseline = await getSharedBaseline();
     const paths = new Set(baseline.entries.map((entry) => entry.path));
 
     expect(paths.has("session.sendPolicy.rules.*.match.keyPrefix")).toBe(true);
@@ -40,7 +55,7 @@ describe("config doc baseline", () => {
   });
 
   it("includes core, channel, and plugin config metadata", async () => {
-    const baseline = await buildConfigDocBaseline();
+    const baseline = await getSharedBaseline();
     const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));
 
     expect(byPath.get("gateway.auth.token")).toMatchObject({
@@ -58,7 +73,7 @@ describe("config doc baseline", () => {
   });
 
   it("preserves help text and tags from merged schema hints", async () => {
-    const baseline = await buildConfigDocBaseline();
+    const baseline = await getSharedBaseline();
     const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));
     const tokenEntry = byPath.get("gateway.auth.token");
 
@@ -68,7 +83,7 @@ describe("config doc baseline", () => {
   });
 
   it("matches array help hints that still use [] notation", async () => {
-    const baseline = await buildConfigDocBaseline();
+    const baseline = await getSharedBaseline();
     const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));
 
     expect(byPath.get("session.sendPolicy.rules.*.match.keyPrefix")).toMatchObject({
@@ -78,7 +93,7 @@ describe("config doc baseline", () => {
   });
 
   it("walks union branches for nested config keys", async () => {
-    const baseline = await buildConfigDocBaseline();
+    const baseline = await getSharedBaseline();
     const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));
 
     expect(byPath.get("bindings.*")).toMatchObject({
@@ -121,11 +136,13 @@ describe("config doc baseline", () => {
   it("supports check mode for stale generated artifacts", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-doc-baseline-"));
     tempRoots.push(tempRoot);
+    const rendered = getSharedRendered();
 
     const initial = await writeConfigDocBaselineStatefile({
       repoRoot: tempRoot,
       jsonPath: "docs/.generated/config-baseline.json",
       statefilePath: "docs/.generated/config-baseline.jsonl",
+      rendered,
     });
     expect(initial.wrote).toBe(true);
 
@@ -134,6 +151,7 @@ describe("config doc baseline", () => {
       jsonPath: "docs/.generated/config-baseline.json",
       statefilePath: "docs/.generated/config-baseline.jsonl",
       check: true,
+      rendered,
     });
     expect(current.changed).toBe(false);
 
@@ -153,6 +171,7 @@ describe("config doc baseline", () => {
       jsonPath: "docs/.generated/config-baseline.json",
       statefilePath: "docs/.generated/config-baseline.jsonl",
       check: true,
+      rendered,
     });
     expect(stale.changed).toBe(true);
     expect(stale.wrote).toBe(false);

--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -658,11 +658,11 @@ export async function buildConfigDocBaseline(): Promise<ConfigDocBaseline> {
 }
 
 export async function renderConfigDocBaselineStatefile(
-  baseline?: ConfigDocBaseline,
+  baseline?: ConfigDocBaseline | Promise<ConfigDocBaseline>,
 ): Promise<ConfigDocBaselineStatefileRender> {
   const start = Date.now();
   logConfigDocBaselineDebug("render statefile start");
-  const resolvedBaseline = baseline ?? (await buildConfigDocBaseline());
+  const resolvedBaseline = baseline ? await baseline : await buildConfigDocBaseline();
   const json = `${JSON.stringify(resolvedBaseline, null, 2)}\n`;
   const metadataLine = JSON.stringify({
     generatedBy: GENERATED_BY,
@@ -706,13 +706,16 @@ export async function writeConfigDocBaselineStatefile(params?: {
   check?: boolean;
   jsonPath?: string;
   statefilePath?: string;
+  rendered?: ConfigDocBaselineStatefileRender | Promise<ConfigDocBaselineStatefileRender>;
 }): Promise<ConfigDocBaselineStatefileWriteResult> {
   const start = Date.now();
   logConfigDocBaselineDebug("write statefile start");
   const repoRoot = params?.repoRoot ?? resolveRepoRoot();
   const jsonPath = path.resolve(repoRoot, params?.jsonPath ?? DEFAULT_JSON_OUTPUT);
   const statefilePath = path.resolve(repoRoot, params?.statefilePath ?? DEFAULT_STATEFILE_OUTPUT);
-  const rendered = await renderConfigDocBaselineStatefile();
+  const rendered = params?.rendered
+    ? await params.rendered
+    : await renderConfigDocBaselineStatefile();
   logConfigDocBaselineDebug(`render statefile done elapsedMs=${Date.now() - start}`);
   logConfigDocBaselineDebug(`read current json start ${jsonPath}`);
   const currentJson = await readIfExists(jsonPath);

--- a/test/fixtures/test-parallel.behavior.json
+++ b/test/fixtures/test-parallel.behavior.json
@@ -14,6 +14,10 @@
         "reason": "Mutates process.cwd() and core loader seams."
       },
       {
+        "file": "src/config/doc-baseline.test.ts",
+        "reason": "Rebuilds bundled config baselines through many channel schema subprocesses; keep out of the shared lane."
+      },
+      {
         "file": "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
         "reason": "Touches process-level unhandledRejection listeners."
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm test` could drive low-memory Vitest runs into multi-GB worker heap growth and OOM under the shared `unit-fast` lane.
- Why it matters: the repo's documented low-memory profile was still selecting `vmForks`, and one bundled config-baseline test repeatedly rebuilt a very expensive 21-channel schema surface inside the shared lane.
- What changed: `OPENCLAW_TEST_PROFILE=low` now defaults to `forks`, `src/config/doc-baseline.test.ts` reuses a shared built/rendered baseline where freshness is not required, and that file is routed out of `unit-fast` into the isolated lane.
- What did NOT change (scope boundary): this PR does not fix the separate `openclaw/plugin-sdk/imessage-core` alias failure surfaced by `src/security/dm-policy-channel-smoke.test.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `OPENCLAW_TEST_PROFILE=low` now uses `forks` by default instead of `vmForks` unless `OPENCLAW_TEST_VM_FORKS=1` is explicitly set.
- `src/config/doc-baseline.test.ts` no longer runs inside the shared `unit-fast` lane.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.17.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low`, `OPENCLAW_TEST_SERIAL_GATEWAY=1`

### Steps

1. Run `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 /usr/bin/time -l pnpm test` on `main`.
2. Observe `unit-fast` launch with `vmForks` and workers grow toward ~4 GB V8 heap before OOM.
3. Apply this branch and rerun the same command or inspect `ps` during the run.

### Expected

- Low-memory mode should use the safer worker pool.
- The bundled config baseline hotspot should not live in `unit-fast`.

### Actual

- Before this PR, low-memory mode still chose `vmForks` and could OOM.
- After this PR, low-memory mode chooses `forks`, and the config baseline hotspot is isolated.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Perf numbers (if relevant)
- [ ] Screenshot/recording

Key measurements:

- Before: low-profile `unit-fast` under `vmForks` hit ~4 GB worker heap and OOMed.
- After forcing `forks` on the same profile, workers stayed in the hundreds of MB during the same observation window.
- `OPENCLAW_TEST_PROFILE=low pnpm test -- src/config/doc-baseline.test.ts` now passes in `unit-isolated` (8 tests, ~98s, max RSS ~670 MB).
- Standalone `buildConfigDocBaseline()` stabilized around ~560 MB RSS / ~281 MB heap-used, which pointed to an expensive hotspot rather than an obviously unbounded leak in that builder alone.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the OOM shape on low-profile `vmForks`, compared it against `forks`, confirmed `src/config/doc-baseline.test.ts` routes to `unit-isolated`, and verified the focused file passes after the test changes.
- Edge cases checked: confirmed the low profile still honors explicit `OPENCLAW_TEST_VM_FORKS=1` escape hatch in code, and typechecked the changed signatures with `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`.
- What you did **not** verify: I did not wait for the entire full-suite `pnpm test` run to complete end-to-end after the pool switch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `OPENCLAW_TEST_VM_FORKS=1` to restore the old low-profile pool selection, or revert this branch.
- Files/config to restore: `scripts/test-parallel.mjs`, `src/config/doc-baseline.test.ts`, `src/config/doc-baseline.ts`, `test/fixtures/test-parallel.behavior.json`
- Known bad symptoms reviewers should watch for: low-memory runs still climbing rapidly toward multi-GB heap, or doc-baseline tests no longer exercising stale-file check mode correctly.

## Risks and Mitigations

- Risk: low-profile `forks` may be slower than `vmForks` on some hosts.
  - Mitigation: the change is limited to `OPENCLAW_TEST_PROFILE=low`, and operators can still force `OPENCLAW_TEST_VM_FORKS=1`.
- Risk: reusing a shared baseline in `src/config/doc-baseline.test.ts` could hide test coupling if the builder becomes stateful later.
  - Mitigation: the determinism test still performs two independent renders, and the shared cache is limited to this one test file.
