### PR TITLE
fix(usage): include reset archive transcripts in usage calculations

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -71,8 +71,9 @@ const sessionIdFromFilename = (name: string): string => {
   if (name.endsWith(".jsonl")) {
     return name.slice(0, -6);
   }
-  // Strip `.jsonl.reset.<timestamp>` suffix
-  const resetIdx = name.indexOf(".jsonl.reset.");
+  // Strip `.jsonl.reset.<timestamp>` suffix — use lastIndexOf so session IDs
+  // that happen to contain ".jsonl.reset." are handled correctly.
+  const resetIdx = name.lastIndexOf(".jsonl.reset.");
   return resetIdx !== -1 ? name.slice(0, resetIdx) : name;
 };
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -53,6 +53,29 @@ export type {
   SessionUsageTimeSeries,
 } from "./session-cost-usage.types.js";
 
+/** Matches reset archive filenames: `<sessionId>.jsonl.reset.<ISO-timestamp>` */
+const RESET_ARCHIVE_RE = /\.jsonl\.reset\.\d{4}-\d{2}-\d{2}T[\d\-]+\.\d+Z$/;
+
+/**
+ * Returns true for both regular transcript files (`.jsonl`) and reset archives
+ * (`.jsonl.reset.<timestamp>`), so both are included in usage calculations.
+ */
+const isTranscriptFile = (name: string): boolean =>
+  name.endsWith(".jsonl") || RESET_ARCHIVE_RE.test(name);
+
+/**
+ * Extracts the session ID from a transcript filename.
+ * Handles both `.jsonl` and `.jsonl.reset.<timestamp>` formats.
+ */
+const sessionIdFromFilename = (name: string): string => {
+  if (name.endsWith(".jsonl")) {
+    return name.slice(0, -6);
+  }
+  // Strip `.jsonl.reset.<timestamp>` suffix
+  const resetIdx = name.indexOf(".jsonl.reset.");
+  return resetIdx !== -1 ? name.slice(0, resetIdx) : name;
+};
+
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
   output: 0,
@@ -318,7 +341,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isTranscriptFile(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -393,7 +416,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isTranscriptFile(entry.name)) {
       continue;
     }
 
@@ -409,8 +432,8 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename (handles both .jsonl and .jsonl.reset.<timestamp>)
+    const sessionId = sessionIdFromFilename(entry.name);
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -54,7 +54,7 @@ export type {
 } from "./session-cost-usage.types.js";
 
 /** Matches reset archive filenames: `<sessionId>.jsonl.reset.<ISO-timestamp>` */
-const RESET_ARCHIVE_RE = /\.jsonl\.reset\.\d{4}-\d{2}-\d{2}T[\d\-]+\.\d+Z$/;
+const RESET_ARCHIVE_RE = /\.jsonl\.reset\.\d{4}-\d{2}-\d{2}T[\d\-:]+\.\d+Z$/;
 
 /**
  * Returns true for both regular transcript files (`.jsonl`) and reset archives
@@ -475,6 +475,7 @@ export async function discoverAllSessions(params?: {
       sessionFile: filePath,
       mtime: stats.mtimeMs,
       firstUserMessage,
+      isResetArchive: RESET_ARCHIVE_RE.test(entry.name),
     });
   }
 

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -143,6 +143,8 @@ export type DiscoveredSession = {
   sessionFile: string;
   mtime: number;
   firstUserMessage?: string;
+  /** True when this entry is a reset archive (`*.jsonl.reset.<timestamp>`), not the active transcript. */
+  isResetArchive?: boolean;
 };
 
 export type SessionUsageTimePoint = SharedSessionUsageTimePoint;


### PR DESCRIPTION
Fixes #40870

## Problem

Reset archives follow the naming pattern `<sessionId>.jsonl.reset.<ISO-timestamp>`, but the usage tracking code only scanned files ending in `.jsonl`. This caused significant undercounting of token usage and cost — in practice, **85% of all token usage** was hidden in reset archives.

## Root cause

Three issues in `src/infra/session-cost-usage.ts`:

1. `loadCostUsageSummary` filtered entries with `entry.name.endsWith(".jsonl")`
2. `discoverAllSessions` had the same filter
3. `discoverAllSessions` used `entry.name.slice(0, -6)` to extract session ID, which produces garbage for reset archive filenames

## Fix

- Add `RESET_ARCHIVE_RE` constant matching `*.jsonl.reset.<ISO-timestamp>` filenames
- Add `isTranscriptFile(name)` helper: matches both `.jsonl` and reset archives
- Add `sessionIdFromFilename(name)` helper: correctly extracts session ID from both filename formats
- Apply both helpers in the two affected functions

## Testing

Verified locally with 64 reset archives present — usage dashboard now correctly reflects all historical token usage.