### PR TITLE
fix(telegram): make buttons schema contribution Optional

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { formatNormalizedAllowFromEntries } from "openclaw/plugin-sdk/allow-from";
 import {
   createScopedChannelConfigAdapter,
@@ -91,7 +92,7 @@ function describeMattermostMessageTool({
       enabledAccounts.length > 0
         ? {
             properties: {
-              buttons: createMessageToolButtonsSchema(),
+              buttons: Type.Optional(createMessageToolButtonsSchema()),
             },
           }
         : null,

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import {
   createMessageToolButtonsSchema,
   createUnionActionGate,
@@ -108,7 +109,7 @@ function describeTelegramMessageTool({
   if (discovery.buttonsEnabled) {
     schema.push({
       properties: {
-        buttons: createMessageToolButtonsSchema(),
+        buttons: Type.Optional(createMessageToolButtonsSchema()),
       },
     });
   }


### PR DESCRIPTION
## Summary

The Telegram channel plugin contributes `buttons` to the message tool send schema via `createMessageToolButtonsSchema()`, but the field is not wrapped in `Type.Optional()`. This causes TypeBox to include `buttons` in the JSON Schema `required` array, which makes AJV reject any `message(action="send")` call that omits the field — including plain text sends with no inline keyboard intended.

## Root Cause

In `extensions/telegram/src/channel-actions.ts`:

```ts
schema.push({
  properties: {
    buttons: createMessageToolButtonsSchema(), // ← not Optional
  },
});
```

`createMessageToolButtonsSchema()` returns `Type.Array(...)` — a required TypeBox field. When TypeBox serialises the merged tool schema to JSON Schema, `buttons` appears in the `required` array. AJV then rejects any tool call missing it.

## Impact

Any agent (particularly cron/isolated sessions) that calls `message(action="send")` without explicitly including `buttons` gets a validation error and the message silently fails to deliver. This affects all Telegram setups with `inlineButtons` enabled (the default).

This is especially acute for scheduled cron agents generating briefs, alerts, or notifications — they have no reason to know that `buttons` is contextually required.

## Fix

One line: wrap the contribution in `Type.Optional()` and import `Type` from `@sinclair/typebox`:

```ts
buttons: Type.Optional(createMessageToolButtonsSchema())
```

This correctly marks `buttons` as optional in the generated JSON Schema. Omitting `buttons` or passing `buttons: []` both work — the Telegram action runtime already handles empty arrays gracefully (returns `undefined` for `reply_markup`, no keyboard sent).

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Telegram channel plugin)

## User-visible / Behavior Changes

- `message(action="send")` no longer requires `buttons` to be passed when Telegram inline buttons are enabled
- Existing callers that pass `buttons` are unaffected
- Cron/isolated sessions that send plain text messages to Telegram threads now work correctly without workarounds

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No

## Related

- History: #18567 originally added `buttons` to the schema (pre-plugin-SDK era). The `b48194a07e` refactor ("Plugins: move message tool schemas into channel plugins") moved it into the plugin but carried over the non-optional pattern.
- Complementary: #38413 strips inert empty-array fields from send params — different scope but related problem surface.