### PR TITLE
style: merge SDK imports in qwen-portal-auth for oxfmt compliance

### DIFF
--- a/extensions/qwen-portal-auth/index.ts
+++ b/extensions/qwen-portal-auth/index.ts
@@ -1,5 +1,8 @@
-import { ensureAuthProfileStore, listProfilesForProvider } from "openclaw/plugin-sdk/agent-runtime";
-import { QWEN_OAUTH_MARKER } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  QWEN_OAUTH_MARKER,
+} from "openclaw/plugin-sdk/agent-runtime";
 import { buildQwenPortalProvider, QWEN_PORTAL_BASE_URL } from "./provider-catalog.js";
 import {
   buildOauthProviderAuthResult,


### PR DESCRIPTION
The \`extensions/qwen-portal-auth/index.ts\` file had SDK imports split across multiple statements instead of being merged according to the project's \`oxfmt\` style guide.

Changes:
- Merged \`ensureAuthProfileStore\`, \`listProfilesForProvider\`, and \`QWEN_OAUTH_MARKER\` imports into a single statement
- Follows oxfmt style guide for parent import grouping
- No semantic changes—only import reordering

Pattern from PR #48758