### PR TITLE
style: reorder type imports in provider-self-hosted-setup for oxfmt compliance

### DIFF
--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -10,9 +10,9 @@ import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthProfileConfig } from "./provider-auth-helpers.js";
 import type {
-  ProviderDiscoveryContext,
-  ProviderAuthResult,
   ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+  ProviderDiscoveryContext,
   ProviderNonInteractiveApiKeyResult,
 } from "./types.js";
 


### PR DESCRIPTION
The \`src/plugins/provider-self-hosted-setup.ts\` file had type imports in incorrect order according to the project's \`oxfmt\` style guide.

Changes:
- Reordered \`ProviderAuthResult\` before \`ProviderDiscoveryContext\`
- Follows oxfmt style guide for type import ordering
- No semantic changes—only import reordering

Pattern from PR #48758