### PR TITLE
Tests: trim command secret gateway imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/WhatsApp: share split-load singleton state for plugin command registration and active WhatsApp listeners so duplicate module graphs no longer lose native plugin commands or outbound listener state. (#50418) Thanks @huntharo.
 - Onboarding/custom providers: keep Azure AI Foundry `*.services.ai.azure.com` custom endpoints on the selected compatibility path instead of forcing Responses, so chat-completions Foundry models still work after setup. Fixes #50528. (#50535) Thanks @obviyus.
 - Plugins/update: let `openclaw plugins update <npm-spec>` target tracked npm installs by dist-tag or exact version, and preserve the recorded npm spec for later id-based updates. (#49998) Thanks @huntharo.
+- Tests/CLI: reduce command-secret gateway test import pressure while keeping the real protocol payload validator in place, so the isolated lane no longer carries the heavier runtime-web and message-channel graphs. (#50663) Thanks @huntharo.
 
 ### Breaking
 

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -7,6 +7,33 @@ vi.mock("../gateway/call.js", () => ({
   callGateway,
 }));
 
+vi.mock("../gateway/protocol/index.js", () => ({
+  validateSecretsResolveResult: (payload: unknown) => {
+    if (typeof payload !== "object" || payload === null) {
+      return false;
+    }
+    const candidate = payload as {
+      assignments?: unknown;
+      diagnostics?: unknown;
+      inactiveRefPaths?: unknown;
+    };
+    return (
+      Array.isArray(candidate.assignments) &&
+      Array.isArray(candidate.diagnostics) &&
+      (candidate.inactiveRefPaths === undefined || Array.isArray(candidate.inactiveRefPaths))
+    );
+  },
+}));
+
+vi.mock("../secrets/runtime-web-tools.js", () => ({
+  resolveRuntimeWebTools: vi.fn(async () => ({})),
+}));
+
+vi.mock("../utils/message-channel.js", () => ({
+  GATEWAY_CLIENT_MODES: { CLI: "cli" },
+  GATEWAY_CLIENT_NAMES: { CLI: "cli" },
+}));
+
 let resolveCommandSecretRefsViaGateway: typeof import("./command-secret-gateway.js").resolveCommandSecretRefsViaGateway;
 
 beforeAll(async () => {

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -7,24 +7,6 @@ vi.mock("../gateway/call.js", () => ({
   callGateway,
 }));
 
-vi.mock("../gateway/protocol/index.js", () => ({
-  validateSecretsResolveResult: (payload: unknown) => {
-    if (typeof payload !== "object" || payload === null) {
-      return false;
-    }
-    const candidate = payload as {
-      assignments?: unknown;
-      diagnostics?: unknown;
-      inactiveRefPaths?: unknown;
-    };
-    return (
-      Array.isArray(candidate.assignments) &&
-      Array.isArray(candidate.diagnostics) &&
-      (candidate.inactiveRefPaths === undefined || Array.isArray(candidate.inactiveRefPaths))
-    );
-  },
-}));
-
 vi.mock("../secrets/runtime-web-tools.js", () => ({
   resolveRuntimeWebTools: vi.fn(async () => ({})),
 }));


### PR DESCRIPTION
## Summary

- `src/cli/command-secret-gateway.test.ts` imported a much broader protocol and runtime graph than the assertions in this file actually need.
- Under the test heap-snapshot tooling from #50654, the pre-fix scoped run kept a large worker heap alive long enough to emit a 5s snapshot, and that snapshot was dominated by transformed-module source strings rather than runtime data objects.
- This PR narrows the test seam by mocking the runtime web-tool resolver and gateway client-name constants directly in the test, while keeping the real protocol payload validator in place.
- Scope boundary: no production code, no heap tooling, and no `test/fixtures/test-parallel.behavior.json` changes are included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #50654

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.13.0
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): none

### Run Just This Test

Functional check:

```bash
pnpm exec vitest run --config vitest.unit.config.ts --pool=forks src/cli/command-secret-gateway.test.ts
```

Scoped wrapper check:

```bash
pnpm test -- src/cli/command-secret-gateway.test.ts
```

Heap-snapshot diagnostic form:

```bash
OPENCLAW_TEST_MEMORY_TRACE=1 \
OPENCLAW_TEST_HEAPSNAPSHOT_INTERVAL_MS=5000 \
OPENCLAW_TEST_HEAPSNAPSHOT_DIR=.tmp/pr-50663-heapsnap \
OPENCLAW_TEST_WORKERS=1 \
OPENCLAW_TEST_SERIAL_GATEWAY=1 \
pnpm test -- src/cli/command-secret-gateway.test.ts
```

### Expected

- `src/cli/command-secret-gateway.test.ts` still validates the same command-secret gateway behaviors.
- The invalid-payload case still rejects malformed gateway responses.
- The scoped run should avoid loading the broad protocol/runtime graph that this test does not exercise.

### Actual

- `pnpm exec vitest run --config vitest.unit.config.ts --pool=forks src/cli/command-secret-gateway.test.ts` passed: 23/23 tests.
- `pnpm test -- src/cli/command-secret-gateway.test.ts` also passed after the rebase onto current `upstream/main`.

## Evidence

### Before / After

Measured with:

```bash
/usr/bin/time -l env OPENCLAW_TEST_MEMORY_TRACE=1 OPENCLAW_TEST_HEAPSNAPSHOT_INTERVAL_MS=5000 OPENCLAW_TEST_HEAPSNAPSHOT_DIR=.tmp/pr-50663-<rev>/heapsnap OPENCLAW_TEST_WORKERS=1 OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/cli/command-secret-gateway.test.ts
```

| Revision | Wrapper elapsed | Vitest duration | Max RSS (`time -l`) | Heap snapshots | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| `20001a50c5` (`upstream/main` parent) | 8.6s | 7.65s | 967.4 MiB | 1 | First periodic snapshot fired at 5s |
| `85592cd8ce` (this PR) | 850ms | 445ms | 191.4 MiB | 0 | Finished before the first 5s snapshot interval |

Observed reduction from the same scoped wrapper command:

- Wrapper elapsed: 8.6s -> 850ms (`-90.1%`)
- Max RSS: 967.4 MiB -> 191.4 MiB (`-80.2%`)

### Heap Snapshot Summary

The pre-fix diagnostic run emitted three `.heapsnapshot` files under `.tmp/pr-50663-before/heapsnap/unit/`; the inspected worker snapshot was dominated by transformed-module state rather than application data:

| Snapshot stat | Value |
| --- | ---: |
| Snapshot inspected | `Heap.20260319.185647.76387.0.001.heapsnapshot` |
| Snapshot file size | 29 MiB |
| Top retained node type | `string` at 49.1 MiB |
| Next largest types | `code` 8.1 MiB, `array` 5.4 MiB, `object` 1.9 MiB, `object shape` 1.7 MiB |
| Largest retained string entry | 2.4 MiB of transformed bundled module source |

Interpretation:

- The retained heap in the pre-fix run looked like Vite/Vitest transformed module source and scaffolding, not command-secret runtime objects.
- After the test-only mock reduction, the same scoped command exits before the first periodic snapshot interval, which is consistent with the import-graph cost being the dominant problem here.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.unit.config.ts --pool=forks src/cli/command-secret-gateway.test.ts`
  - `pnpm test -- src/cli/command-secret-gateway.test.ts`
  - Diagnostic wrapper run with `OPENCLAW_TEST_MEMORY_TRACE=1` and periodic heap snapshots on the pre-fix parent revision
- Edge cases checked: the invalid-payload test still rejects malformed gateway results with the real `validateSecretsResolveResult` seam intact.
- What I did **not** verify: I did not re-run the entire full suite in this PR branch; the evidence here is scoped to the single-file repro and the heap-snapshot diagnostic command above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/cli/command-secret-gateway.test.ts`
- Known bad symptoms reviewers should watch for: if the mocks get too permissive, the invalid-payload assertion could stop protecting malformed `secrets.resolve` responses.

## Risks and Mitigations

- Risk: the test could stop covering runtime web-tool integration behavior.
  - Mitigation: this file only exercises command-secret resolution behavior; broader runtime-web coverage remains in the dedicated runtime-web tests.
