### PR TITLE
fix(memory): fix mcporter/qmd MCP bridge

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1624,6 +1624,19 @@ describe("QmdMemoryManager", () => {
     );
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("cold-start"));
 
+    // Verify mcporter calls use `qmd.query` (the actual MCP tool name) with
+    // a `searches` array instead of the legacy `search`/`vector_search` tools.
+    const callCmds = mcporterCalls.filter((call: unknown[]) => (call[1] as string[])[0] === "call");
+    for (const call of callCmds) {
+      const args = call[1] as string[];
+      expect(args[1]).toBe("qmd.query");
+      const argsJsonIdx = args.indexOf("--args");
+      expect(argsJsonIdx).toBeGreaterThan(-1);
+      const parsed = JSON.parse(args[argsJsonIdx + 1]) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("searches");
+      expect(Array.isArray(parsed.searches)).toBe(true);
+    }
+
     await manager.close();
   });
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1281,16 +1281,15 @@ export class QmdMemoryManager implements MemorySearchManager {
     const searchTypeMap: Record<string, string> = {
       search: "lex",
       vector_search: "vec",
-      // deep_search → hybrid lex+vec for best recall
-      deep_search: "lex",
     };
 
     const selector = `${params.mcporter.serverName}.query`;
+    // deep_search → hybrid: vec first (2× weight from qmd) + lex for best recall
     const searches: Array<{ type: string; query: string }> =
       params.tool === "deep_search"
         ? [
-            { type: "lex", query: params.query },
             { type: "vec", query: params.query },
+            { type: "lex", query: params.query },
           ]
         : [{ type: searchTypeMap[params.tool] ?? "lex", query: params.query }];
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1269,8 +1269,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     minScore: number;
     collection?: string;
     timeoutMs: number;
+    skipDaemonStart?: boolean;
   }): Promise<QmdQueryResult[]> {
-    await this.ensureMcporterDaemonStarted(params.mcporter);
+    if (!params.skipDaemonStart) {
+      await this.ensureMcporterDaemonStarted(params.mcporter);
+    }
 
     // QMD's MCP server exposes a single `query` tool that accepts a `searches`
     // array with typed sub-queries.  Map the legacy tool names to the
@@ -2021,6 +2024,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     minScore: number;
     collectionNames: string[];
   }): Promise<QmdQueryResult[]> {
+    // Start the daemon once before iterating collections, not per-collection.
+    await this.ensureMcporterDaemonStarted(this.qmd.mcporter);
+
     const bestByDocId = new Map<string, QmdQueryResult>();
     for (const collectionName of params.collectionNames) {
       const parsed = await this.runQmdSearchViaMcporter({
@@ -2031,6 +2037,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         minScore: params.minScore,
         collection: collectionName,
         timeoutMs: this.qmd.limits.timeoutMs,
+        skipDaemonStart: true,
       });
       for (const entry of parsed) {
         if (typeof entry.docid !== "string" || !entry.docid.trim()) {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1300,7 +1300,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       minScore: params.minScore,
     };
     if (params.collection) {
-      callArgs.collection = params.collection;
+      callArgs.collections = [params.collection];
     }
 
     const result = await this.runMcporter(

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1272,9 +1272,27 @@ export class QmdMemoryManager implements MemorySearchManager {
   }): Promise<QmdQueryResult[]> {
     await this.ensureMcporterDaemonStarted(params.mcporter);
 
-    const selector = `${params.mcporter.serverName}.${params.tool}`;
+    // QMD's MCP server exposes a single `query` tool that accepts a `searches`
+    // array with typed sub-queries.  Map the legacy tool names to the
+    // appropriate search types so the call succeeds.
+    const searchTypeMap: Record<string, string> = {
+      search: "lex",
+      vector_search: "vec",
+      // deep_search → hybrid lex+vec for best recall
+      deep_search: "lex",
+    };
+
+    const selector = `${params.mcporter.serverName}.query`;
+    const searches: Array<{ type: string; query: string }> =
+      params.tool === "deep_search"
+        ? [
+            { type: "lex", query: params.query },
+            { type: "vec", query: params.query },
+          ]
+        : [{ type: searchTypeMap[params.tool] ?? "lex", query: params.query }];
+
     const callArgs: Record<string, unknown> = {
-      query: params.query,
+      searches,
       limit: params.limit,
       minScore: params.minScore,
     };


### PR DESCRIPTION
## Summary

- **Problem:** mcporter/qmd bridge always failed — every `memory_search` fell back to slow CLI mode
- **Why it matters:** mcporter keeps qmd warm for ~8x faster searches; the bridge existed but was broken since initial implementation
- **What changed:** Three bugs fixed in `src/memory/qmd-manager.ts`:
  1. Wrong MCP tool name: called `qmd.deep_search` / `qmd.search` / `qmd.vector_search` — qmd only exposes `query`
  2. Wrong args: passed `query: string` — `query` tool expects `searches: [{type, query}]` array; deep_search maps to lex+vec for hybrid recall
  3. Wrong collection param: passed `collection: string` — tool expects `collections: string[]`
- **Bonus:** `ensureMcporterDaemonStarted()` was called on every collection iteration in `runMcporterAcrossCollections`; now called once before the loop via `skipDaemonStart` param
- **What did NOT change:** CLI fallback path, search modes, FallbackMemoryManager, config schema

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- None

## User-visible / Behavior Changes

When `memory.qmd.mcporter.enabled: true`, `memory_search` now correctly routes through the mcporter daemon instead of always falling back to CLI.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps to reproduce (before fix)

1. Set `memory.qmd.mcporter.enabled: true`, restart gateway
2. Trigger `memory_search`
3. See: `mcporter call qmd.deep_search ... failed (code 128)`

### After fix

`memory_search` returns `"provider": "qmd"` with results, no fallback.

### Tests

`pnpm vitest run src/memory/qmd-manager.test.ts` — 57/57 pass