### PR TITLE
fix(src/auto-reply/reply/acp-reset-target.ts): eager import causing startup latency

### DIFF
--- a/src/auto-reply/reply/acp-reset-target.ts
+++ b/src/auto-reply/reply/acp-reset-target.ts
@@ -3,7 +3,6 @@ import {
   normalizeBindingConfig,
   type ConfiguredAcpBindingChannel,
 } from "../../acp/persistent-bindings.types.js";
-import { resolveConfiguredBindingRecord } from "../../channels/plugins/binding-registry.js";
 import { listAcpBindings } from "../../config/bindings.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
@@ -59,7 +58,7 @@ function resolveRawConfiguredAcpSessionKey(params: {
   return undefined;
 }
 
-export function resolveEffectiveResetTargetSessionKey(params: {
+export async function resolveEffectiveResetTargetSessionKey(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   accountId?: string | null;
@@ -69,7 +68,7 @@ export function resolveEffectiveResetTargetSessionKey(params: {
   allowNonAcpBindingSessionKey?: boolean;
   skipConfiguredFallbackWhenActiveSessionNonAcp?: boolean;
   fallbackToActiveAcpWhenUnbound?: boolean;
-}): string | undefined {
+}): Promise<string | undefined> {
   const activeSessionKey = normalizeText(params.activeSessionKey);
   const activeAcpSessionKey =
     activeSessionKey && isAcpSessionKey(activeSessionKey) ? activeSessionKey : undefined;
@@ -81,6 +80,11 @@ export function resolveEffectiveResetTargetSessionKey(params: {
     return activeAcpSessionKey;
   }
   const accountId = normalizeText(params.accountId) || DEFAULT_ACCOUNT_ID;
+
+  // Lazy load the binding registry only when necessary (inside the function)
+  // to avoid startup latency. This must be awaited.
+  const { resolveConfiguredBindingRecord } =
+    await import("../../channels/plugins/binding-registry.js");
   const parentConversationId = normalizeText(params.parentConversationId) || undefined;
   const allowNonAcpBindingSessionKey = Boolean(params.allowNonAcpBindingSessionKey);
 


### PR DESCRIPTION
The \`resolveEffectiveResetTargetSessionKey\` function had a top-level import of \`binding-registry.js\` that was only needed in a specific code path, causing unnecessary startup latency.

Changes:

- Removed top-level \`import { resolveConfiguredBindingRecord }\` statement
- Changed function signature to \`async\`
- Added dynamic \`import()\` inside the function, only loading the module when needed
- Return type changed from \`string | undefined\` to \`Promise<string | undefined>\`
- Pattern from PR #50212
- No semantic changes—only lazy-loads heavy dependency