### PR TITLE
fix(cron): use agent-turn timeout for main systemEvent jobs with wakeMode=now

### DIFF
--- a/src/cron/service/timeout-policy.test.ts
+++ b/src/cron/service/timeout-policy.test.ts
@@ -40,6 +40,21 @@ describe("timeout-policy", () => {
     expect(timeout).toBeUndefined();
   });
 
+  it("uses agent-turn safety timeout for main systemEvent jobs with wakeMode=now", () => {
+    const job = makeJob({ kind: "systemEvent", text: "hello" });
+    const mainNowJob = { ...job, sessionTarget: "main" as const, wakeMode: "now" as const };
+    const timeout = resolveCronJobTimeoutMs(mainNowJob);
+    expect(timeout).toBe(AGENT_TURN_SAFETY_TIMEOUT_MS);
+  });
+
+  it("keeps default timeout for main systemEvent jobs without wakeMode=now", () => {
+    const job = makeJob({ kind: "systemEvent", text: "hello" });
+    // sessionTarget is already "main" from makeJob for systemEvent
+    expect(job.wakeMode).toBe("next-heartbeat");
+    const timeout = resolveCronJobTimeoutMs(job);
+    expect(timeout).toBe(DEFAULT_JOB_TIMEOUT_MS);
+  });
+
   it("applies explicit timeoutSeconds when positive", () => {
     const timeout = resolveCronJobTimeoutMs(
       makeJob({ kind: "agentTurn", message: "hi", timeoutSeconds: 1.9 }),

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -19,7 +19,16 @@ export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {
-    return job.payload.kind === "agentTurn" ? AGENT_TURN_SAFETY_TIMEOUT_MS : DEFAULT_JOB_TIMEOUT_MS;
+    if (job.payload.kind === "agentTurn") {
+      return AGENT_TURN_SAFETY_TIMEOUT_MS;
+    }
+    // systemEvent jobs targeting main with wakeMode=now block while the
+    // heartbeat (agent turn) completes.  Apply the agent-turn ceiling so
+    // long-running turns are not killed by the 10-min generic cap.
+    if (job.sessionTarget === "main" && job.wakeMode === "now") {
+      return AGENT_TURN_SAFETY_TIMEOUT_MS;
+    }
+    return DEFAULT_JOB_TIMEOUT_MS;
   }
   return configuredTimeoutMs <= 0 ? undefined : configuredTimeoutMs;
 }


### PR DESCRIPTION
## Problem

When a `systemEvent` cron job targets the main session with `wakeMode: "now"`, the scheduler calls `runHeartbeatOnce()` and **blocks** while the agent turn runs. The outer timeout applied by `resolveCronJobTimeoutMs()` is `DEFAULT_JOB_TIMEOUT_MS` (10 minutes) for all non-`agentTurn` payloads.

Long-running agent turns (transcriptions, web searches, multi-step tasks) get killed with `"cron: job execution timed out"` even though the agent is actively working. The reporter saw ~960s (16 min) runs getting cut.

The `wakeMode: "next-heartbeat"` path is not affected because it calls `requestHeartbeatNow()` and returns immediately.

## Root cause

`resolveCronJobTimeoutMs()` treats all `systemEvent` jobs the same regardless of whether the scheduler actually blocks on the agent turn.

## Fix

Apply `AGENT_TURN_SAFETY_TIMEOUT_MS` (60 min) when `job.sessionTarget === "main" && job.wakeMode === "now"`, matching the ceiling already used for `agentTurn` jobs. All other `systemEvent` paths keep the 10-min default.

2 files changed, 1 logic branch + 2 tests added.

Fixes #50621