### PR TITLE
docs(azure): replace ARM template deployment with pure az CLI commands

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -801,10 +801,6 @@
       "destination": "/install/azure"
     },
     {
-      "source": "/install/azure/azure",
-      "destination": "/install/azure"
-    },
-    {
       "source": "/platforms/fly",
       "destination": "/install/fly"
     },

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -280,7 +280,7 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
 
 ## Cost considerations
 
-Azure Bastion Standard SKU runs approximately **$140/month** and the VM (Standard_B2as_v2) runs approximately **$55/month**. This is significantly more than some other hosting options in this repo.
+Azure Bastion Standard SKU runs approximately **\$140/month** and the VM (Standard\_B2as\_v2) runs approximately **\$55/month**.
 
 To reduce costs:
 
@@ -290,7 +290,7 @@ To reduce costs:
   az vm start -g rg-openclaw -n vm-openclaw   # restart later
   ```
 - **Delete Bastion when not needed** and recreate it when you need SSH access. Bastion is the largest cost component and takes only a few minutes to provision.
-- **Use the Basic Bastion SKU** (~$38/month) if you only need Portal-based SSH and don't require CLI tunneling (`az network bastion ssh`).
+- **Use the Basic Bastion SKU** (~\$38/month) if you only need Portal-based SSH and don't require CLI tunneling (`az network bastion ssh`).
 
 ## Cleanup
 

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -279,7 +279,7 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
 
 ## Cost considerations
 
-Azure Bastion Standard SKU runs approximately **\$140/month** and the VM (Standard\_B2as\_v2) runs approximately **\$55/month**.
+Azure Bastion Standard SKU runs approximately **\$140/month** and the VM (Standard_B2as_v2) runs approximately **\$55/month**.
 
 To reduce costs:
 

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -19,14 +19,6 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
 - Install OpenClaw with the installer script
 - Verify the Gateway
 
-## Quick path (experienced operators)
-
-1. Sign in to Azure CLI and register `Microsoft.Compute` + `Microsoft.Network` providers
-2. Create resource group, NSG (Bastion-only SSH rules), VNet (VM + Bastion subnets)
-3. Create VM (Ubuntu 24.04, no public IP, SSH key auth)
-4. Create Azure Bastion (Standard SKU, tunneling enabled)
-5. SSH through Bastion, run the OpenClaw installer, verify the Gateway
-
 ## What you need
 
 - An Azure subscription with permission to create compute and network resources

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -284,7 +284,7 @@ Azure Bastion Standard SKU runs approximately **\$140/month** and the VM (Standa
 
 To reduce costs:
 
-- **Deallocate the VM** when not in use (stops compute billing; disk charges remain):
+- **Deallocate the VM** when not in use (stops compute billing; disk charges remain). The OpenClaw Gateway will not be reachable while the VM is deallocated — restart it when you need it live again:
   ```bash
   az vm deallocate -g rg-openclaw -n vm-openclaw
   az vm start -g rg-openclaw -n vm-openclaw   # restart later

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -231,7 +231,7 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
       --sku Standard --enable-tunneling true
     ```
 
-    Bastion provisioning takes a few minutes.
+    Bastion provisioning typically takes 5-10 minutes but can take up to 15-30 minutes in some regions.
 
   </Step>
 </Steps>

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -285,8 +285,8 @@ To reduce costs:
 
 - **Deallocate the VM** when not in use (stops compute billing; disk charges remain). The OpenClaw Gateway will not be reachable while the VM is deallocated — restart it when you need it live again:
   ```bash
-  az vm deallocate -g rg-openclaw -n vm-openclaw
-  az vm start -g rg-openclaw -n vm-openclaw   # restart later
+  az vm deallocate -g "${RG}" -n "${VM_NAME}"
+  az vm start -g "${RG}" -n "${VM_NAME}"   # restart later
   ```
 - **Delete Bastion when not needed** and recreate it when you need SSH access. Bastion is the largest cost component and takes only a few minutes to provision.
 - **Use the Basic Bastion SKU** (~\$38/month) if you only need Portal-based SSH and don't require CLI tunneling (`az network bastion ssh`).
@@ -296,7 +296,7 @@ To reduce costs:
 To delete all resources created by this guide:
 
 ```bash
-az group delete -n rg-openclaw --yes --no-wait
+az group delete -n "${RG}" --yes --no-wait
 ```
 
 This removes the resource group and everything inside it (VM, VNet, NSG, Bastion, public IP).

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -256,13 +256,12 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
 
   <Step title="Install OpenClaw (in the VM shell)">
     ```bash
-    curl -fsSL https://openclaw.ai/install.sh -o /tmp/openclaw-install.sh
-    bash /tmp/openclaw-install.sh
-    rm -f /tmp/openclaw-install.sh
-    openclaw --version
+    curl -fsSL https://openclaw.ai/install.sh -o /tmp/install.sh
+    bash /tmp/install.sh
+    rm -f /tmp/install.sh
     ```
 
-    The installer script handles Node detection/installation and runs onboarding by default.
+    The installer installs Node LTS and dependencies if not already present, installs OpenClaw, and launches the onboarding wizard. See [Install](/install) for details.
 
   </Step>
 

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -19,12 +19,22 @@ This guide sets up an Azure Linux VM with the Azure CLI, applies Network Securit
 - Install OpenClaw with the installer script
 - Verify the Gateway
 
-## Before you start
+## Quick path (experienced operators)
 
-You'll need:
+1. Sign in to Azure CLI and register `Microsoft.Compute` + `Microsoft.Network` providers
+2. Create resource group, NSG (Bastion-only SSH rules), VNet (VM + Bastion subnets)
+3. Create VM (Ubuntu 24.04, no public IP, SSH key auth)
+4. Create Azure Bastion (Standard SKU, tunneling enabled)
+5. SSH through Bastion, run the OpenClaw installer, verify the Gateway
+
+## What you need
 
 - An Azure subscription with permission to create compute and network resources
 - Azure CLI installed (see [Azure CLI install steps](https://learn.microsoft.com/cli/azure/install-azure-cli) if needed)
+- An SSH key pair (the guide covers generating one if needed)
+- ~20-30 minutes
+
+## Configure deployment
 
 <Steps>
   <Step title="Sign in to Azure CLI">
@@ -113,7 +123,11 @@ You'll need:
     ```
 
   </Step>
+</Steps>
 
+## Deploy Azure resources
+
+<Steps>
   <Step title="Create the resource group">
     ```bash
     az group create -n "${RG}" -l "${LOCATION}"
@@ -228,7 +242,11 @@ You'll need:
     Bastion provisioning takes a few minutes.
 
   </Step>
+</Steps>
 
+## Install OpenClaw
+
+<Steps>
   <Step title="SSH into the VM through Azure Bastion">
     ```bash
     VM_ID="$(az vm show -g "${RG}" -n "${VM_NAME}" --query id -o tsv)"

--- a/docs/install/azure.md
+++ b/docs/install/azure.md
@@ -4,25 +4,24 @@ read_when:
   - You want OpenClaw running 24/7 on Azure with Network Security Group hardening
   - You want a production-grade, always-on OpenClaw Gateway on your own Azure Linux VM
   - You want secure administration with Azure Bastion SSH
-  - You want repeatable deployments with Azure Resource Manager templates
 title: "Azure"
 ---
 
 # OpenClaw on Azure Linux VM
 
-This guide sets up an Azure Linux VM, applies Network Security Group (NSG) hardening, configures Azure Bastion (managed Azure SSH entry point), and installs OpenClaw.
+This guide sets up an Azure Linux VM with the Azure CLI, applies Network Security Group (NSG) hardening, configures Azure Bastion for SSH access, and installs OpenClaw.
 
-## What you’ll do
+## What you'll do
 
-- Deploy Azure compute and network resources with Azure Resource Manager (ARM) templates
-- Apply Azure Network Security Group (NSG) rules so VM SSH is allowed only from Azure Bastion
-- Use Azure Bastion for SSH access
+- Create Azure networking (VNet, subnets, NSG) and compute resources with the Azure CLI
+- Apply Network Security Group rules so VM SSH is allowed only from Azure Bastion
+- Use Azure Bastion for SSH access (no public IP on the VM)
 - Install OpenClaw with the installer script
 - Verify the Gateway
 
 ## Before you start
 
-You’ll need:
+You'll need:
 
 - An Azure subscription with permission to create compute and network resources
 - Azure CLI installed (see [Azure CLI install steps](https://learn.microsoft.com/cli/azure/install-azure-cli) if needed)
@@ -30,9 +29,12 @@ You’ll need:
 <Steps>
   <Step title="Sign in to Azure CLI">
     ```bash
-    az login # Sign in and select your Azure subscription
-    az extension add -n ssh # Extension required for Azure Bastion SSH management
+    az login
+    az extension add -n ssh
     ```
+
+    The `ssh` extension is required for Azure Bastion native SSH tunneling.
+
   </Step>
 
   <Step title="Register required resource providers (one-time)">
@@ -41,7 +43,7 @@ You’ll need:
     az provider register --namespace Microsoft.Network
     ```
 
-    Verify Azure resource provider registration. Wait until both show `Registered`.
+    Verify registration. Wait until both show `Registered`.
 
     ```bash
     az provider show --namespace Microsoft.Compute --query registrationState -o tsv
@@ -54,9 +56,20 @@ You’ll need:
     ```bash
     RG="rg-openclaw"
     LOCATION="westus2"
-    TEMPLATE_URI="https://raw.githubusercontent.com/openclaw/openclaw/main/infra/azure/templates/azuredeploy.json"
-    PARAMS_URI="https://raw.githubusercontent.com/openclaw/openclaw/main/infra/azure/templates/azuredeploy.parameters.json"
+    VNET_NAME="vnet-openclaw"
+    VNET_PREFIX="10.40.0.0/16"
+    VM_SUBNET_NAME="snet-openclaw-vm"
+    VM_SUBNET_PREFIX="10.40.2.0/24"
+    BASTION_SUBNET_PREFIX="10.40.1.0/26"
+    NSG_NAME="nsg-openclaw-vm"
+    VM_NAME="vm-openclaw"
+    ADMIN_USERNAME="openclaw"
+    BASTION_NAME="bas-openclaw"
+    BASTION_PIP_NAME="pip-openclaw-bastion"
     ```
+
+    Adjust names and CIDR ranges to fit your environment. The Bastion subnet must be at least `/26`.
+
   </Step>
 
   <Step title="Select SSH key">
@@ -66,7 +79,7 @@ You’ll need:
     SSH_PUB_KEY="$(cat ~/.ssh/id_ed25519.pub)"
     ```
 
-    If you don’t have an SSH key yet, run the following:
+    If you don't have an SSH key yet, generate one:
 
     ```bash
     ssh-keygen -t ed25519 -a 100 -f ~/.ssh/id_ed25519 -C "you@example.com"
@@ -76,17 +89,15 @@ You’ll need:
   </Step>
 
   <Step title="Select VM size and OS disk size">
-    Set VM and disk sizing variables:
-
     ```bash
     VM_SIZE="Standard_B2as_v2"
     OS_DISK_SIZE_GB=64
     ```
 
-    Choose a VM size and OS disk size that are available in your Azure subscription/region and matches your workload:
+    Choose a VM size and OS disk size available in your subscription and region:
 
     - Start smaller for light usage and scale up later
-    - Use more vCPU/RAM/OS disk size for heavier automation, more channels, or larger model/tool workloads
+    - Use more vCPU/RAM/disk for heavier automation, more channels, or larger model/tool workloads
     - If a VM size is unavailable in your region or subscription quota, pick the closest available SKU
 
     List VM sizes available in your target region:
@@ -95,7 +106,7 @@ You’ll need:
     az vm list-skus --location "${LOCATION}" --resource-type virtualMachines -o table
     ```
 
-    Check your current VM vCPU and OS disk size usage/quota:
+    Check your current vCPU and disk usage/quota:
 
     ```bash
     az vm list-usage --location "${LOCATION}" -o table
@@ -109,28 +120,117 @@ You’ll need:
     ```
   </Step>
 
-  <Step title="Deploy resources">
-    This command applies your selected SSH key, VM size, and OS disk size.
+  <Step title="Create the network security group">
+    Create the NSG and add rules so only the Bastion subnet can SSH into the VM.
 
     ```bash
-    az deployment group create \
-      -g "${RG}" \
-      --template-uri "${TEMPLATE_URI}" \
-      --parameters "${PARAMS_URI}" \
-      --parameters location="${LOCATION}" \
-      --parameters vmSize="${VM_SIZE}" \
-      --parameters osDiskSizeGb="${OS_DISK_SIZE_GB}" \
-      --parameters sshPublicKey="${SSH_PUB_KEY}"
+    az network nsg create \
+      -g "${RG}" -n "${NSG_NAME}" -l "${LOCATION}"
+
+    # Allow SSH from the Bastion subnet only
+    az network nsg rule create \
+      -g "${RG}" --nsg-name "${NSG_NAME}" \
+      -n AllowSshFromBastionSubnet --priority 100 \
+      --access Allow --direction Inbound --protocol Tcp \
+      --source-address-prefixes "${BASTION_SUBNET_PREFIX}" \
+      --destination-port-ranges 22
+
+    # Deny SSH from the public internet
+    az network nsg rule create \
+      -g "${RG}" --nsg-name "${NSG_NAME}" \
+      -n DenyInternetSsh --priority 110 \
+      --access Deny --direction Inbound --protocol Tcp \
+      --source-address-prefixes Internet \
+      --destination-port-ranges 22
+
+    # Deny SSH from other VNet sources
+    az network nsg rule create \
+      -g "${RG}" --nsg-name "${NSG_NAME}" \
+      -n DenyVnetSsh --priority 120 \
+      --access Deny --direction Inbound --protocol Tcp \
+      --source-address-prefixes VirtualNetwork \
+      --destination-port-ranges 22
     ```
+
+    The rules are evaluated by priority (lowest number first): Bastion traffic is allowed at 100, then all other SSH is blocked at 110 and 120.
+
+  </Step>
+
+  <Step title="Create the virtual network and subnets">
+    Create the VNet with the VM subnet (NSG attached), then add the Bastion subnet.
+
+    ```bash
+    az network vnet create \
+      -g "${RG}" -n "${VNET_NAME}" -l "${LOCATION}" \
+      --address-prefixes "${VNET_PREFIX}" \
+      --subnet-name "${VM_SUBNET_NAME}" \
+      --subnet-prefixes "${VM_SUBNET_PREFIX}"
+
+    # Attach the NSG to the VM subnet
+    az network vnet subnet update \
+      -g "${RG}" --vnet-name "${VNET_NAME}" \
+      -n "${VM_SUBNET_NAME}" --nsg "${NSG_NAME}"
+
+    # AzureBastionSubnet — name is required by Azure
+    az network vnet subnet create \
+      -g "${RG}" --vnet-name "${VNET_NAME}" \
+      -n AzureBastionSubnet \
+      --address-prefixes "${BASTION_SUBNET_PREFIX}"
+    ```
+
+  </Step>
+
+  <Step title="Create the VM">
+    The VM has no public IP. SSH access is exclusively through Azure Bastion.
+
+    ```bash
+    az vm create \
+      -g "${RG}" -n "${VM_NAME}" -l "${LOCATION}" \
+      --image "Canonical:ubuntu-24_04-lts:server:latest" \
+      --size "${VM_SIZE}" \
+      --os-disk-size-gb "${OS_DISK_SIZE_GB}" \
+      --storage-sku StandardSSD_LRS \
+      --admin-username "${ADMIN_USERNAME}" \
+      --ssh-key-values "${SSH_PUB_KEY}" \
+      --vnet-name "${VNET_NAME}" \
+      --subnet "${VM_SUBNET_NAME}" \
+      --public-ip-address "" \
+      --nsg ""
+    ```
+
+    `--public-ip-address ""` prevents a public IP from being assigned. `--nsg ""` skips creating a per-NIC NSG (the subnet-level NSG handles security).
+
+    **Reproducibility:** The command above uses `latest` for the Ubuntu image. To pin a specific version, list available versions and replace `latest`:
+
+    ```bash
+    az vm image list \
+      --publisher Canonical --offer ubuntu-24_04-lts \
+      --sku server --all -o table
+    ```
+
+  </Step>
+
+  <Step title="Create Azure Bastion">
+    Azure Bastion provides managed SSH access to the VM without exposing a public IP. Standard SKU with tunneling is required for CLI-based `az network bastion ssh`.
+
+    ```bash
+    az network public-ip create \
+      -g "${RG}" -n "${BASTION_PIP_NAME}" -l "${LOCATION}" \
+      --sku Standard --allocation-method Static
+
+    az network bastion create \
+      -g "${RG}" -n "${BASTION_NAME}" -l "${LOCATION}" \
+      --vnet-name "${VNET_NAME}" \
+      --public-ip-address "${BASTION_PIP_NAME}" \
+      --sku Standard --enable-tunneling true
+    ```
+
+    Bastion provisioning takes a few minutes.
 
   </Step>
 
   <Step title="SSH into the VM through Azure Bastion">
     ```bash
-    RG="rg-openclaw"
-    VM_NAME="vm-openclaw"
-    BASTION_NAME="bas-openclaw"
-    ADMIN_USERNAME="openclaw"
     VM_ID="$(az vm show -g "${RG}" -n "${VM_NAME}" --query id -o tsv)"
 
     az network bastion ssh \
@@ -165,10 +265,32 @@ You’ll need:
 
     Most enterprise Azure teams already have GitHub Copilot licenses. If that is your case, we recommend choosing the GitHub Copilot provider in the OpenClaw onboarding wizard. See [GitHub Copilot provider](/providers/github-copilot).
 
-    The included ARM template uses Ubuntu image `version: "latest"` for convenience. If you need reproducible builds, pin a specific image version in `infra/azure/templates/azuredeploy.json` (you can list versions with `az vm image list --publisher Canonical --offer ubuntu-24_04-lts --sku server --all -o table`).
-
   </Step>
 </Steps>
+
+## Cost considerations
+
+Azure Bastion Standard SKU runs approximately **$140/month** and the VM (Standard_B2as_v2) runs approximately **$55/month**. This is significantly more than some other hosting options in this repo.
+
+To reduce costs:
+
+- **Deallocate the VM** when not in use (stops compute billing; disk charges remain):
+  ```bash
+  az vm deallocate -g rg-openclaw -n vm-openclaw
+  az vm start -g rg-openclaw -n vm-openclaw   # restart later
+  ```
+- **Delete Bastion when not needed** and recreate it when you need SSH access. Bastion is the largest cost component and takes only a few minutes to provision.
+- **Use the Basic Bastion SKU** (~$38/month) if you only need Portal-based SSH and don't require CLI tunneling (`az network bastion ssh`).
+
+## Cleanup
+
+To delete all resources created by this guide:
+
+```bash
+az group delete -n rg-openclaw --yes --no-wait
+```
+
+This removes the resource group and everything inside it (VM, VNet, NSG, Bastion, public IP).
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- Problem: The Azure install guide referenced ARM templates in `infra/azure/templates/` which have been removed upstream. The guide was broken (404 template URIs).
- Why it matters: Users following the Azure install guide could not complete the deployment.
- What changed: Rewrote `docs/install/azure.md` to use pure `az` CLI commands instead of ARM templates. Added cost considerations and cleanup sections. Removed stale redirect from `docs.json`.
- What did NOT change (scope boundary): No Gateway/runtime code, auth logic, provider behavior, or installer execution behavior changed. Security posture (Bastion-only SSH, no public IP, NSG hardening) is identical.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Follow-up to #47898 (addresses review feedback from @BradGroux)

## User-visible / Behavior Changes

- Azure install guide now uses 13 explicit `az` CLI steps instead of a single ARM template deployment
- New "Cost considerations" section documents Bastion (~$140/mo) and VM (~$55/mo) pricing with cost-saving tips
- New "Cleanup" section with `az group delete` for easy teardown
- Removed stale `/install/azure/azure` redirect from `docs.json`
- Removed all references to `infra/azure/templates/` (directory no longer exists)

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (docs-only)

### Steps

1. Review the diff for `docs/install/azure.md` — all ARM template references replaced with `az` CLI commands
2. Verify `docs.json` is valid JSON with stale redirect removed
3. Confirm no remaining references to `infra/azure/templates/` in the docs directory
4. Verify the `az` CLI commands match the resources previously created by the ARM template (NSG with 3 rules, VNet with 2 subnets, VM with no public IP, Bastion Standard with tunneling)

### Expected

- Azure guide is self-contained with pure `az` CLI commands
- No broken references to removed ARM templates
- Cost and cleanup sections present
- Security posture unchanged (Bastion-only SSH, NSG rules, no public IP)

### Actual

- All above checks passed

## Evidence

- [x] Prior PR screenshots from #47898 show the same infrastructure deployed end-to-end
- [x] CLI commands verified against Azure CLI documentation

## Human Verification (required)

- Verified scenarios:
  - Reviewed full diff (`docs/install/azure.md`, `docs/docs.json`)
  - Confirmed `az` CLI commands create identical resources to the removed ARM template
  - Validated `docs.json` remains valid JSON
  - Grep confirmed zero remaining references to `infra/azure/templates/` in docs
- Edge cases checked:
  - NSG rule priority ordering preserved (100 Allow Bastion → 110 Deny Internet → 120 Deny VNet)
  - `--public-ip-address ""` and `--nsg ""` flags verified for VM creation
  - Bastion Standard SKU with `--enable-tunneling true` for CLI SSH support
- What you did **not** verify:
  - Full end-to-end Azure deployment with these exact commands (ARM template version was verified in #47898)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR/commit
- Files/config to restore: `docs/install/azure.md`, `docs/docs.json`
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations

`None` — docs-only change with no runtime impact.
