### PR TITLE
fix(ollama): deserialize string tool call arguments to object

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -54,6 +54,19 @@ describe("convertToOllamaMessages", () => {
     ]);
   });
 
+  it("deserializes string tool call arguments to object for Ollama", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_2", name: "exec", arguments: '{"command":"pwd"}' }],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "exec", arguments: { command: "pwd" } } },
+    ]);
+  });
+
   it("converts tool result messages with 'tool' role", () => {
     const messages = [{ role: "tool", content: "file1.txt\nfile2.txt" }];
     const result = convertToOllamaMessages(messages);

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -67,6 +67,30 @@ describe("convertToOllamaMessages", () => {
     ]);
   });
 
+  it("deserializes string tool_use input to object for Ollama", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_3", name: "exec", input: '{"command":"ls"}' }],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "exec", arguments: { command: "ls" } } },
+    ]);
+  });
+
+  it("returns empty object for invalid JSON string arguments", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_4", name: "exec", arguments: "not-json" }],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([{ function: { name: "exec", arguments: {} } }]);
+  });
+
   it("converts tool result messages with 'tool' role", () => {
     const messages = [{ role: "tool", content: "file1.txt\nfile2.txt" }];
     const result = convertToOllamaMessages(messages);

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -246,6 +246,21 @@ function extractOllamaImages(content: unknown): string[] {
     .map((part) => part.data);
 }
 
+function ensureArgsObject(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {}
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
 function extractToolCalls(content: unknown): OllamaToolCall[] {
   if (!Array.isArray(content)) {
     return [];
@@ -254,9 +269,9 @@ function extractToolCalls(content: unknown): OllamaToolCall[] {
   const result: OllamaToolCall[] = [];
   for (const part of parts) {
     if (part.type === "toolCall") {
-      result.push({ function: { name: part.name, arguments: part.arguments } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.arguments) } });
     } else if (part.type === "tool_use") {
-      result.push({ function: { name: part.name, arguments: part.input } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.input) } });
     }
   }
   return result;

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -249,7 +249,7 @@ function extractOllamaImages(content: unknown): string[] {
 function ensureArgsObject(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
     try {
-      const parsed = JSON.parse(value);
+      const parsed = parseJsonPreservingUnsafeIntegers(value);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>;
       }


### PR DESCRIPTION
## Summary
- Ollama expects tool call `arguments` as an object, but OpenClaw stores them as a JSON string (OpenAI format)
- When assistant messages with tool calls are sent back to Ollama as conversation context, the string arguments cause Ollama to fail with `"Value looks like object, but can't find closing '}' symbol"`
- Added `ensureArgsObject()` that deserializes string arguments to objects before passing to Ollama
- Handles both `toolCall` and `tool_use` content part types

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway

## Linked Issue/PR
Closes #50689

## User-visible Changes
- Ollama models with native tool calling now correctly receive tool call arguments as objects, fixing empty responses after tool execution

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
- **Environment:** macOS, Node 25.5.0, vitest
- **Reproduction:** Configure agent with Ollama model supporting tools, send message that triggers tool call, tool executes successfully, model returns empty response
- **Expected:** Model receives arguments as object, responds normally after tool execution
- **Actual (before fix):** Model receives arguments as JSON string, fails to parse, returns empty content

## Evidence
- 32/32 ollama-stream tests pass (31 existing + 1 new)
- New test: verifies string arguments `'{"command":"pwd"}'` are deserialized to `{ command: "pwd" }`
- Type-check clean

## Human Verification
- Verified `ensureArgsObject` handles: string→object, object passthrough, invalid string→empty object, null/undefined→empty object
- Verified existing tests still pass with object arguments (no regression)
- Did NOT verify against a live Ollama instance

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert this single commit to restore previous behavior

## Risks and Mitigations
- None — the function safely handles all input types with try/catch for JSON.parse