### PR TITLE
fix(models): add gpt-5.4 mini and nano fallbacks

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -125,6 +125,22 @@ describe("loadModelCatalog", () => {
         input: ["text", "image"],
       },
       {
+        id: "gpt-5-mini",
+        provider: "openai",
+        name: "GPT-5 Mini",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
+      },
+      {
+        id: "gpt-5-nano",
+        provider: "openai",
+        name: "GPT-5 Nano",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
+      },
+      {
         id: "gpt-5.2-pro",
         provider: "openai",
         name: "GPT-5.2 Pro",
@@ -154,6 +170,26 @@ describe("loadModelCatalog", () => {
     expect(result).toContainEqual(
       expect.objectContaining({
         provider: "openai",
+        id: "gpt-5.4-mini",
+        name: "gpt-5.4-mini",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.4-nano",
+        name: "gpt-5.4-nano",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai",
         id: "gpt-5.4-pro",
         name: "gpt-5.4-pro",
       }),
@@ -163,6 +199,56 @@ describe("loadModelCatalog", () => {
         provider: "openai-codex",
         id: "gpt-5.4",
         name: "gpt-5.4",
+      }),
+    );
+  });
+
+  it("patches gpt-5.4 mini/nano catalog metadata when falling back to gpt-4.1 templates", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gpt-5.2",
+        provider: "openai",
+        name: "GPT-5.2",
+        reasoning: true,
+        contextWindow: 1_050_000,
+        input: ["text", "image"],
+      },
+      {
+        id: "gpt-4.1-mini",
+        provider: "openai",
+        name: "GPT-4.1 Mini",
+        reasoning: false,
+        contextWindow: 1_023_000,
+        input: ["text"],
+      },
+      {
+        id: "gpt-4.1-nano",
+        provider: "openai",
+        name: "GPT-4.1 Nano",
+        reasoning: false,
+        contextWindow: 1_023_000,
+        input: ["text"],
+      },
+    ]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.4-mini",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
+      }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.4-nano",
+        reasoning: true,
+        contextWindow: 391000,
+        input: ["text", "image"],
       }),
     );
   });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -35,7 +35,11 @@ let importPiSdk = defaultImportPiSdk;
 const CODEX_PROVIDER = "openai-codex";
 const OPENAI_PROVIDER = "openai";
 const OPENAI_GPT54_MODEL_ID = "gpt-5.4";
+const OPENAI_GPT54_MINI_MODEL_ID = "gpt-5.4-mini";
+const OPENAI_GPT54_NANO_MODEL_ID = "gpt-5.4-nano";
 const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
+const OPENAI_GPT54_MINI_CONTEXT_TOKENS = 391_000;
+const OPENAI_GPT54_NANO_CONTEXT_TOKENS = 391_000;
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
@@ -45,6 +49,7 @@ type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  patch?: Partial<Pick<ModelCatalogEntry, "contextWindow" | "reasoning" | "input">>;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -52,6 +57,26 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_MODEL_ID,
     templateIds: ["gpt-5.2"],
+  },
+  {
+    provider: OPENAI_PROVIDER,
+    id: OPENAI_GPT54_MINI_MODEL_ID,
+    templateIds: ["gpt-5-mini", "gpt-4.1-mini"],
+    patch: {
+      contextWindow: OPENAI_GPT54_MINI_CONTEXT_TOKENS,
+      reasoning: true,
+      input: ["text", "image"],
+    },
+  },
+  {
+    provider: OPENAI_PROVIDER,
+    id: OPENAI_GPT54_NANO_MODEL_ID,
+    templateIds: ["gpt-5-nano", "gpt-4.1-nano"],
+    patch: {
+      contextWindow: OPENAI_GPT54_NANO_CONTEXT_TOKENS,
+      reasoning: true,
+      input: ["text", "image"],
+    },
   },
   {
     provider: OPENAI_PROVIDER,
@@ -90,6 +115,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
     }
     models.push({
       ...template,
+      ...fallback.patch,
       id: fallback.id,
       name: fallback.id,
     });

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -5,10 +5,16 @@ import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 const OPENAI_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
+const OPENAI_GPT_54_NANO_MODEL_ID = "gpt-5.4-nano";
 const OPENAI_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_GPT_54_MINI_CONTEXT_TOKENS = 391_000;
+const OPENAI_GPT_54_NANO_CONTEXT_TOKENS = 391_000;
 const OPENAI_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
+const OPENAI_GPT_54_MINI_TEMPLATE_MODEL_IDS = ["gpt-5-mini", "gpt-4.1-mini"] as const;
+const OPENAI_GPT_54_NANO_TEMPLATE_MODEL_IDS = ["gpt-5-nano", "gpt-4.1-nano"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
@@ -49,10 +55,19 @@ function resolveOpenAIGpt54ForwardCompatModel(
   const trimmedModelId = modelId.trim();
   const lower = trimmedModelId.toLowerCase();
   let templateIds: readonly string[];
+  let contextWindow: number;
   if (lower === OPENAI_GPT_54_MODEL_ID) {
     templateIds = OPENAI_GPT_54_TEMPLATE_MODEL_IDS;
+    contextWindow = OPENAI_GPT_54_CONTEXT_TOKENS;
+  } else if (lower === OPENAI_GPT_54_MINI_MODEL_ID) {
+    templateIds = OPENAI_GPT_54_MINI_TEMPLATE_MODEL_IDS;
+    contextWindow = OPENAI_GPT_54_MINI_CONTEXT_TOKENS;
+  } else if (lower === OPENAI_GPT_54_NANO_MODEL_ID) {
+    templateIds = OPENAI_GPT_54_NANO_TEMPLATE_MODEL_IDS;
+    contextWindow = OPENAI_GPT_54_NANO_CONTEXT_TOKENS;
   } else if (lower === OPENAI_GPT_54_PRO_MODEL_ID) {
     templateIds = OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS;
+    contextWindow = OPENAI_GPT_54_CONTEXT_TOKENS;
   } else {
     return undefined;
   }
@@ -69,7 +84,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
         baseUrl: "https://api.openai.com/v1",
         reasoning: true,
         input: ["text", "image"],
-        contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS,
+        contextWindow,
         maxTokens: OPENAI_GPT_54_MAX_TOKENS,
       },
     }) ??
@@ -82,7 +97,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
       reasoning: true,
       input: ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS,
+      contextWindow,
       maxTokens: OPENAI_GPT_54_MAX_TOKENS,
     } as Model<Api>)
   );

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -58,6 +58,44 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("builds an openai forward-compat fallback for gpt-5.4-mini", () => {
+    mockDiscoveredModel({
+      provider: "openai",
+      modelId: "gpt-5-mini",
+      templateModel: makeModel("gpt-5-mini"),
+    });
+
+    const result = resolveModel("openai", "gpt-5.4-mini", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4-mini",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+    });
+  });
+
+  it("builds an openai forward-compat fallback for gpt-5.4-nano", () => {
+    mockDiscoveredModel({
+      provider: "openai",
+      modelId: "gpt-5-nano",
+      templateModel: makeModel("gpt-5-nano"),
+    });
+
+    const result = resolveModel("openai", "gpt-5.4-nano", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4-nano",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+    });
+  });
+
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -518,6 +518,58 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds an openai fallback for gpt-5.4-mini", () => {
+    mockDiscoveredModel({
+      provider: "openai",
+      modelId: "gpt-5-mini",
+      templateModel: buildForwardCompatTemplate({
+        id: "gpt-5-mini",
+        name: "GPT-5 Mini",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        contextWindow: 391_000,
+      }),
+    });
+
+    const result = resolveModel("openai", "gpt-5.4-mini", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4-mini",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      contextWindow: 391_000,
+    });
+  });
+
+  it("builds an openai fallback for gpt-5.4-nano", () => {
+    mockDiscoveredModel({
+      provider: "openai",
+      modelId: "gpt-5-nano",
+      templateModel: buildForwardCompatTemplate({
+        id: "gpt-5-nano",
+        name: "GPT-5 Nano",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        contextWindow: 391_000,
+      }),
+    });
+
+    const result = resolveModel("openai", "gpt-5.4-nano", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4-nano",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      contextWindow: 391_000,
+    });
+  });
+
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     mockDiscoveredModel({
       provider: "anthropic",


### PR DESCRIPTION
## Summary
- add synthetic model-catalog fallback entries for `openai/gpt-5.4-mini` and `openai/gpt-5.4-nano`
- extend the existing forward-compat catalog test coverage for the new models

## Root cause
`openclaw models list --all` already had synthetic forward-compat entries for `openai/gpt-5.4` and `openai/gpt-5.4-pro`, but it did not yet synthesize the newly announced `gpt-5.4-mini` and `gpt-5.4-nano` entries from existing OpenAI template models.

## Validation
- `npx --yes pnpm exec vitest run --config vitest.config.ts src/agents/model-catalog.test.ts`
- PASS (1 file, 7 tests)

## AI assistance
- AI-assisted
- Testing: lightly tested (targeted catalog test file)

Fixes #50265
