### PR TITLE
fix(daemon): suppress stale exit details when systemd service is running

### DIFF
--- a/src/daemon/runtime-format.ts
+++ b/src/daemon/runtime-format.ts
@@ -20,10 +20,14 @@ export function formatRuntimeStatus(runtime: ServiceRuntimeLike | undefined): st
   if (runtime.subState) {
     details.push(`sub ${runtime.subState}`);
   }
-  if (runtime.lastExitStatus !== undefined) {
+  // Suppress stale exit details when the service is currently running —
+  // systemd retains the previous exit info even after a successful restart,
+  // which misleads users into thinking the active service has a problem.
+  const isRunning = runtime.status === "running";
+  if (runtime.lastExitStatus !== undefined && !isRunning) {
     details.push(`last exit ${runtime.lastExitStatus}`);
   }
-  if (runtime.lastExitReason) {
+  if (runtime.lastExitReason && !isRunning) {
     details.push(`reason ${runtime.lastExitReason}`);
   }
   if (runtime.lastRunResult) {


### PR DESCRIPTION
## Summary
- After restarting a gateway via systemd, `openclaw status` showed stale exit details (e.g. "last exit 1, reason exit-code") from the previous failed run
- systemd preserves `ExecMainStatus` and `ExecMainCode` across restarts until the new process exits
- Now suppresses these stale details when the service is currently active/running
- Only shows exit details when the service is actually stopped/failed

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway
- [x] CLI

## Linked Issue/PR
Closes #50560

## User-visible Changes
- `openclaw status` no longer shows confusing stale exit details after a successful service restart

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
- **Environment:** Linux with systemd
- **Reproduction:** Gateway crashes (exit code 1), restart via systemd, run `openclaw status` — shows "state failed" details despite service running
- **Expected:** Status shows running without stale exit details
- **Actual (before fix):** Shows "running (state active, sub running, last exit 1, reason exit-code)"

## Evidence
- 43/43 systemd tests pass
- Type-check clean

## Human Verification
- Verified the fix only suppresses exit details when `status === "running"` (ActiveState=active)
- Verified failed/stopped services still show exit details (unchanged behavior)
- Did NOT verify on a live Linux systemd environment

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert this single commit

## Risks and Mitigations
- None — exit details are only hidden when the service is confirmed running; stopped/failed services still show full diagnostics