### PR TITLE
feat(sessions): support private delivery for sessions_send

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -103,6 +103,8 @@ Parameters:
 - `sessionKey` (required; accepts session key or `sessionId` from `sessions_list`)
 - `message` (required)
 - `timeoutSeconds?: number` (default >0; 0 = fire-and-forget)
+- `deliveryMode?: "private" | "announce"` (optional; choose private session-only delivery or external announce delivery)
+- `announce?: boolean` (legacy compatibility; `false` suppresses the final external announce delivery)
 
 Behavior:
 
@@ -111,6 +113,9 @@ Behavior:
 - If wait times out: `{ runId, status: "timeout", error }`. Run continues; call `sessions_history` later.
 - If the run fails: `{ runId, status: "error", error }`.
 - Announce delivery runs after the primary run completes and is best-effort; `status: "ok"` does not guarantee the announce was delivered.
+- `deliveryMode: "private"` keeps the exchange private to the requester/target sessions by skipping the final send to the target chat/channel.
+- `deliveryMode: "announce"` enables the final send to the target chat/channel.
+- Legacy compatibility: `announce: false` behaves like `deliveryMode: "private"`. If both are passed, `deliveryMode` wins.
 - Waits via gateway `agent.wait` (server-side) so reconnects don't drop the wait.
 - Agent-to-agent message context is injected for the primary run.
 - Inter-session messages are persisted with `message.provenance.kind = "inter_session"` so transcript readers can distinguish routed agent instructions from external user input.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -518,7 +518,7 @@ Core parameters:
 
 - `sessions_list`: `kinds?`, `limit?`, `activeMinutes?`, `messageLimit?` (0 = none)
 - `sessions_history`: `sessionKey` (or `sessionId`), `limit?`, `includeTools?`
-- `sessions_send`: `sessionKey` (or `sessionId`), `message`, `timeoutSeconds?` (0 = fire-and-forget)
+- `sessions_send`: `sessionKey` (or `sessionId`), `message`, `timeoutSeconds?` (0 = fire-and-forget), `deliveryMode?` (`private|announce`), `announce?` (legacy compatibility)
 - `sessions_spawn`: `task`, `label?`, `runtime?`, `agentId?`, `model?`, `thinking?`, `cwd?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`, `sandbox?`, `streamTo?`, `attachments?`, `attachAs?`
 - `session_status`: `sessionKey?` (default current; accepts `sessionId`), `model?` (`default` clears override)
 
@@ -528,6 +528,9 @@ Notes:
 - `messageLimit > 0` fetches last N messages per session (tool messages filtered).
 - Session targeting is controlled by `tools.sessions.visibility` (default `tree`: current session + spawned subagent sessions). If you run a shared agent for multiple users, consider setting `tools.sessions.visibility: "self"` to prevent cross-session browsing.
 - `sessions_send` waits for final completion when `timeoutSeconds > 0`.
+- Set `deliveryMode: "private"` to keep the exchange inside the participating sessions and skip the final external announce delivery to the target chat/channel.
+- Set `deliveryMode: "announce"` to post the final announce back to the target chat/channel.
+- Legacy compatibility: `announce: false` behaves like `deliveryMode: "private"`. If both are passed, `deliveryMode` wins.
 - Delivery/announce happens after completion and is best-effort; `status: "ok"` confirms the agent run finished, not that the announce was delivered.
 - `sessions_spawn` supports `runtime: "subagent" | "acp"` (`subagent` default). For ACP runtime behavior, see [ACP Agents](/tools/acp-agents).
 - For ACP runtime, `streamTo: "parent"` routes initial-run progress summaries back to the requester session as system events instead of direct child delivery.

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -5,11 +5,22 @@ import {
 } from "./sessions-send-helpers.js";
 
 describe("sessions_send helper prompts", () => {
+  it("does not include private-delivery guidance by default", () => {
+    const prompt = buildAgentToAgentMessageContext({
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "main",
+      targetSessionKey: "agent:target:discord:group:123",
+    });
+
+    expect(prompt).not.toContain('deliveryMode: "private"');
+  });
+
   it("includes explicit private-delivery flags in sender reply guidance", () => {
     const prompt = buildAgentToAgentMessageContext({
       requesterSessionKey: "agent:main:main",
       requesterChannel: "main",
       targetSessionKey: "agent:target:discord:group:123",
+      includePrivateReplyGuidance: true,
     });
 
     expect(prompt).toContain(
@@ -27,6 +38,7 @@ describe("sessions_send helper prompts", () => {
       currentRole: "requester",
       turn: 1,
       maxTurns: 5,
+      includePrivateReplyGuidance: true,
     });
     expect(requesterTurnPrompt).not.toContain('deliveryMode: "private"');
 
@@ -38,6 +50,7 @@ describe("sessions_send helper prompts", () => {
       currentRole: "target",
       turn: 2,
       maxTurns: 5,
+      includePrivateReplyGuidance: true,
     });
     expect(targetTurnPrompt).toContain(
       'use sessions_send targeting agent:main:main with deliveryMode: "private"',

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -1,100 +1,46 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentToAgentMessageContext,
+  buildAgentToAgentReplyContext,
+} from "./sessions-send-helpers.js";
 
-describe("resolveAnnounceTargetFromKey", () => {
-  beforeEach(() => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "discord",
-          source: "test",
-          plugin: {
-            id: "discord",
-            meta: {
-              id: "discord",
-              label: "Discord",
-              selectionLabel: "Discord",
-              docsPath: "/channels/discord",
-              blurb: "Discord test stub.",
-            },
-            capabilities: { chatTypes: ["direct", "channel", "thread"] },
-            messaging: {
-              resolveSessionTarget: ({ id }: { id: string }) => `channel:${id}`,
-            },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-            },
-          },
-        },
-        {
-          pluginId: "slack",
-          source: "test",
-          plugin: {
-            id: "slack",
-            meta: {
-              id: "slack",
-              label: "Slack",
-              selectionLabel: "Slack",
-              docsPath: "/channels/slack",
-              blurb: "Slack test stub.",
-            },
-            capabilities: { chatTypes: ["direct", "channel", "thread"] },
-            messaging: {
-              resolveSessionTarget: ({ id }: { id: string }) => `channel:${id}`,
-            },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-            },
-          },
-        },
-        {
-          pluginId: "telegram",
-          source: "test",
-          plugin: {
-            id: "telegram",
-            meta: {
-              id: "telegram",
-              label: "Telegram",
-              selectionLabel: "Telegram",
-              docsPath: "/channels/telegram",
-              blurb: "Telegram test stub.",
-            },
-            capabilities: { chatTypes: ["direct", "group", "thread"] },
-            messaging: {
-              normalizeTarget: (raw: string) => raw.replace(/^group:/, ""),
-            },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-            },
-          },
-        },
-      ]),
+describe("sessions_send helper prompts", () => {
+  it("includes explicit private-delivery flags in sender reply guidance", () => {
+    const prompt = buildAgentToAgentMessageContext({
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "main",
+      targetSessionKey: "agent:target:discord:group:123",
+    });
+
+    expect(prompt).toContain(
+      'use sessions_send targeting agent:main:main with deliveryMode: "private"',
     );
+    expect(prompt).toContain("announce: false for legacy clients");
   });
 
-  it("lets plugins own session-derived target shapes", () => {
-    expect(resolveAnnounceTargetFromKey("agent:main:discord:group:dev")).toEqual({
-      channel: "discord",
-      to: "channel:dev",
-      threadId: undefined,
+  it("shows sender-session continuation guidance only on target ping-pong turns", () => {
+    const requesterTurnPrompt = buildAgentToAgentReplyContext({
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "main",
+      targetSessionKey: "agent:target:discord:group:123",
+      targetChannel: "discord",
+      currentRole: "requester",
+      turn: 1,
+      maxTurns: 5,
     });
-    expect(resolveAnnounceTargetFromKey("agent:main:slack:group:C123")).toEqual({
-      channel: "slack",
-      to: "channel:C123",
-      threadId: undefined,
-    });
-  });
+    expect(requesterTurnPrompt).not.toContain('deliveryMode: "private"');
 
-  it("keeps generic topic extraction and plugin normalization for other channels", () => {
-    expect(resolveAnnounceTargetFromKey("agent:main:telegram:group:-100123:topic:99")).toEqual({
-      channel: "telegram",
-      to: "-100123",
-      threadId: "99",
+    const targetTurnPrompt = buildAgentToAgentReplyContext({
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "main",
+      targetSessionKey: "agent:target:discord:group:123",
+      targetChannel: "discord",
+      currentRole: "target",
+      turn: 2,
+      maxTurns: 5,
     });
+    expect(targetTurnPrompt).toContain(
+      'use sessions_send targeting agent:main:main with deliveryMode: "private"',
+    );
   });
 });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -84,6 +84,13 @@ function buildAgentSessionLines(params: {
   ].filter((line): line is string => Boolean(line));
 }
 
+function buildPrivateReplyHint(sessionKey: string, params?: { lowercaseLead?: boolean }) {
+  const lead = params?.lowercaseLead
+    ? "for a private reply back to the sender"
+    : "For a private reply back to the sender";
+  return `${lead}, use sessions_send targeting ${sessionKey} with deliveryMode: "private" (or announce: false for legacy clients), if your sessions visibility allows that target.`;
+}
+
 export function buildAgentToAgentMessageContext(params: {
   requesterSessionKey?: string;
   requesterChannel?: string;
@@ -94,9 +101,7 @@ export function buildAgentToAgentMessageContext(params: {
   );
   lines.push("This message was delivered via sessions_send.");
   if (params.requesterSessionKey) {
-    lines.push(
-      `For a private reply back to the sender, use sessions_send targeting ${params.requesterSessionKey} (if your sessions visibility allows that target).`,
-    );
+    lines.push(buildPrivateReplyHint(params.requesterSessionKey));
   }
   lines.push(
     "Do not use channel messaging tools for private agent-to-agent replies unless you intentionally want to post to an external chat/channel.",
@@ -121,8 +126,8 @@ export function buildAgentToAgentReplyContext(params: {
     `Turn ${params.turn} of ${params.maxTurns}.`,
     ...buildAgentSessionLines(params),
     "This conversation is happening through sessions_send.",
-    params.requesterSessionKey
-      ? `If you need to continue privately with the sender outside this ping-pong step, use sessions_send targeting ${params.requesterSessionKey} (if your sessions visibility allows that target).`
+    params.currentRole === "target" && params.requesterSessionKey
+      ? `If you need to continue privately with the sender outside this ping-pong step, ${buildPrivateReplyHint(params.requesterSessionKey, { lowercaseLead: true })}`
       : undefined,
     "Avoid channel messaging tools for private replies unless you explicitly intend to post externally.",
     `If you want to stop the ping-pong, reply exactly "${REPLY_SKIP_TOKEN}".`,

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -92,6 +92,15 @@ export function buildAgentToAgentMessageContext(params: {
   const lines = ["Agent-to-agent message context:", ...buildAgentSessionLines(params)].filter(
     Boolean,
   );
+  lines.push("This message was delivered via sessions_send.");
+  if (params.requesterSessionKey) {
+    lines.push(
+      `For a private reply back to the sender, use sessions_send targeting ${params.requesterSessionKey}.`,
+    );
+  }
+  lines.push(
+    "Do not use channel messaging tools for private agent-to-agent replies unless you intentionally want to post to an external chat/channel.",
+  );
   return lines.join("\n");
 }
 
@@ -111,6 +120,11 @@ export function buildAgentToAgentReplyContext(params: {
     `Current agent: ${currentLabel}.`,
     `Turn ${params.turn} of ${params.maxTurns}.`,
     ...buildAgentSessionLines(params),
+    "This conversation is happening through sessions_send.",
+    params.requesterSessionKey
+      ? `If you need to continue privately with the sender outside this ping-pong step, use sessions_send targeting ${params.requesterSessionKey}.`
+      : undefined,
+    "Avoid channel messaging tools for private replies unless you explicitly intend to post externally.",
     `If you want to stop the ping-pong, reply exactly "${REPLY_SKIP_TOKEN}".`,
   ].filter(Boolean);
   return lines.join("\n");

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -95,7 +95,7 @@ export function buildAgentToAgentMessageContext(params: {
   lines.push("This message was delivered via sessions_send.");
   if (params.requesterSessionKey) {
     lines.push(
-      `For a private reply back to the sender, use sessions_send targeting ${params.requesterSessionKey}.`,
+      `For a private reply back to the sender, use sessions_send targeting ${params.requesterSessionKey} (if your sessions visibility allows that target).`,
     );
   }
   lines.push(
@@ -122,7 +122,7 @@ export function buildAgentToAgentReplyContext(params: {
     ...buildAgentSessionLines(params),
     "This conversation is happening through sessions_send.",
     params.requesterSessionKey
-      ? `If you need to continue privately with the sender outside this ping-pong step, use sessions_send targeting ${params.requesterSessionKey}.`
+      ? `If you need to continue privately with the sender outside this ping-pong step, use sessions_send targeting ${params.requesterSessionKey} (if your sessions visibility allows that target).`
       : undefined,
     "Avoid channel messaging tools for private replies unless you explicitly intend to post externally.",
     `If you want to stop the ping-pong, reply exactly "${REPLY_SKIP_TOKEN}".`,

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -95,17 +95,18 @@ export function buildAgentToAgentMessageContext(params: {
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
+  includePrivateReplyGuidance?: boolean;
 }) {
   const lines = ["Agent-to-agent message context:", ...buildAgentSessionLines(params)].filter(
     Boolean,
   );
   lines.push("This message was delivered via sessions_send.");
-  if (params.requesterSessionKey) {
+  if (params.includePrivateReplyGuidance && params.requesterSessionKey) {
     lines.push(buildPrivateReplyHint(params.requesterSessionKey));
+    lines.push(
+      "Do not use channel messaging tools for private agent-to-agent replies unless you intentionally want to post to an external chat/channel.",
+    );
   }
-  lines.push(
-    "Do not use channel messaging tools for private agent-to-agent replies unless you intentionally want to post to an external chat/channel.",
-  );
   return lines.join("\n");
 }
 
@@ -117,6 +118,7 @@ export function buildAgentToAgentReplyContext(params: {
   currentRole: "requester" | "target";
   turn: number;
   maxTurns: number;
+  includePrivateReplyGuidance?: boolean;
 }) {
   const currentLabel =
     params.currentRole === "requester" ? "Agent 1 (requester)" : "Agent 2 (target)";
@@ -126,10 +128,14 @@ export function buildAgentToAgentReplyContext(params: {
     `Turn ${params.turn} of ${params.maxTurns}.`,
     ...buildAgentSessionLines(params),
     "This conversation is happening through sessions_send.",
-    params.currentRole === "target" && params.requesterSessionKey
+    params.includePrivateReplyGuidance &&
+    params.currentRole === "target" &&
+    params.requesterSessionKey
       ? `If you need to continue privately with the sender outside this ping-pong step, ${buildPrivateReplyHint(params.requesterSessionKey, { lowercaseLead: true })}`
       : undefined,
-    "Avoid channel messaging tools for private replies unless you explicitly intend to post externally.",
+    params.includePrivateReplyGuidance
+      ? "Avoid channel messaging tools for private replies unless you explicitly intend to post externally."
+      : undefined,
     `If you want to stop the ping-pong, reply exactly "${REPLY_SKIP_TOKEN}".`,
   ].filter(Boolean);
   return lines.join("\n");

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -20,6 +20,7 @@ export async function runSessionsSendA2AFlow(params: {
   displayKey: string;
   message: string;
   announceTimeoutMs: number;
+  announceEnabled?: boolean;
   maxPingPongTurns: number;
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
@@ -97,6 +98,10 @@ export async function runSessionsSendA2AFlow(params: {
         currentSessionKey = nextSessionKey;
         nextSessionKey = swap;
       }
+    }
+
+    if (params.announceEnabled === false) {
+      return;
     }
 
     const announcePrompt = buildAgentToAgentAnnounceContext({

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -21,6 +21,7 @@ export async function runSessionsSendA2AFlow(params: {
   message: string;
   announceTimeoutMs: number;
   announceEnabled?: boolean;
+  privateDelivery?: boolean;
   maxPingPongTurns: number;
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
@@ -77,6 +78,7 @@ export async function runSessionsSendA2AFlow(params: {
           currentRole,
           turn,
           maxTurns: params.maxPingPongTurns,
+          includePrivateReplyGuidance: params.privateDelivery === true,
         });
         const replyText = await runAgentStep({
           sessionKey: currentSessionKey,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -9,6 +9,7 @@ import {
   INTERNAL_MESSAGE_CHANNEL,
 } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
+import { optionalStringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
@@ -24,12 +25,16 @@ import {
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
+const SESSIONS_SEND_DELIVERY_MODES = ["private", "announce"] as const;
+
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
   agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  announce: Type.Optional(Type.Boolean()),
+  deliveryMode: optionalStringEnum(SESSIONS_SEND_DELIVERY_MODES),
 });
 
 async function startAgentRun(params: {
@@ -218,6 +223,15 @@ export function createSessionsSendTool(opts?: {
         typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
           ? Math.max(0, Math.floor(params.timeoutSeconds))
           : 30;
+      const deliveryMode = readStringParam(params, "deliveryMode")?.toLowerCase();
+      const announceEnabled =
+        deliveryMode === "private"
+          ? false
+          : deliveryMode === "announce"
+            ? true
+            : typeof params.announce === "boolean"
+              ? params.announce
+              : true;
       const timeoutMs = timeoutSeconds * 1000;
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
@@ -261,13 +275,16 @@ export function createSessionsSendTool(opts?: {
       const requesterSessionKey = opts?.agentSessionKey;
       const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
-      const delivery = { status: "pending", mode: "announce" as const };
+      const delivery = announceEnabled
+        ? { status: "pending", mode: "announce" as const }
+        : { status: "disabled", mode: "none" as const };
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
         void runSessionsSendA2AFlow({
           targetSessionKey: resolvedKey,
           displayKey,
           message,
           announceTimeoutMs,
+          announceEnabled,
           maxPingPongTurns,
           requesterSessionKey,
           requesterChannel,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -256,6 +256,7 @@ export function createSessionsSendTool(opts?: {
         requesterSessionKey: opts?.agentSessionKey,
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
+        includePrivateReplyGuidance: !announceEnabled,
       });
       const sendParams = {
         message,
@@ -285,6 +286,7 @@ export function createSessionsSendTool(opts?: {
           message,
           announceTimeoutMs,
           announceEnabled,
+          privateDelivery: !announceEnabled,
           maxPingPongTurns,
           requesterSessionKey,
           requesterChannel,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -701,8 +701,53 @@ describe("sessions_send gating", () => {
     expect(extraSystemPrompt).toContain(
       "For a private reply back to the sender, use sessions_send targeting agent:main:main",
     );
+    expect(extraSystemPrompt).toContain('deliveryMode: "private"');
     expect(extraSystemPrompt).toContain(
       "Do not use channel messaging tools for private agent-to-agent replies",
     );
+  });
+
+  it("does not inject private-reply guidance when announce delivery is used", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-initial" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "initial" }] }],
+        };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    await tool.execute("call-prompt-guidance-announce", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "hi",
+      timeoutSeconds: 1,
+      deliveryMode: "announce",
+    });
+
+    const initialAgentCall = calls.find((call) => call.method === "agent");
+    const extraSystemPrompt =
+      typeof initialAgentCall?.params?.extraSystemPrompt === "string"
+        ? initialAgentCall.params.extraSystemPrompt
+        : "";
+    expect(extraSystemPrompt).toContain("This message was delivered via sessions_send.");
+    expect(extraSystemPrompt).not.toContain('deliveryMode: "private"');
+    expect(extraSystemPrompt).not.toContain("announce: false for legacy clients");
   });
 });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -601,7 +601,7 @@ describe("sessions_send gating", () => {
         sessions: { visibility: "all" },
       },
     });
-    const calls = [];
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: Record<string, unknown> };
       calls.push(request);
@@ -642,6 +642,19 @@ describe("sessions_send gating", () => {
       status: "ok",
       delivery: { status: "disabled", mode: "none" },
     });
+    await vi.waitFor(
+      () => {
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(2);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+    expect(
+      calls.some(
+        (call) =>
+          typeof call.params?.extraSystemPrompt === "string" &&
+          call.params.extraSystemPrompt.includes("Agent-to-agent announce step"),
+      ),
+    ).toBe(false);
     expect(calls.some((call) => call.method === "send")).toBe(false);
   });
 
@@ -686,7 +699,7 @@ describe("sessions_send gating", () => {
         : "";
     expect(extraSystemPrompt).toContain("This message was delivered via sessions_send.");
     expect(extraSystemPrompt).toContain(
-      "For a private reply back to the sender, use sessions_send targeting agent:main:main.",
+      "For a private reply back to the sender, use sessions_send targeting agent:main:main",
     );
     expect(extraSystemPrompt).toContain(
       "Do not use channel messaging tools for private agent-to-agent replies",

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -401,6 +401,16 @@ describe("sessions_send gating", () => {
     callGatewayMock.mockClear();
   });
 
+  it("exposes announce as an optional boolean parameter", () => {
+    const tool = createMainSessionsSendTool();
+    const schema = tool.parameters as {
+      properties?: Record<string, { type?: unknown; enum?: unknown }>;
+    };
+    expect(schema.properties?.announce?.type).toBe("boolean");
+    expect(schema.properties?.deliveryMode?.type).toBe("string");
+    expect(schema.properties?.deliveryMode?.enum).toEqual(["private", "announce"]);
+  });
+
   it("returns an error when neither sessionKey nor label is provided", async () => {
     const tool = createMainSessionsSendTool();
 
@@ -448,5 +458,238 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.list" });
     expect(result.details).toMatchObject({ status: "forbidden" });
+  });
+
+  it("announces to the target chat by default", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        const extraSystemPrompt =
+          typeof request.params?.extraSystemPrompt === "string"
+            ? request.params.extraSystemPrompt
+            : "";
+        if (extraSystemPrompt.includes("Agent-to-agent reply step")) {
+          return { runId: "run-reply" };
+        }
+        if (extraSystemPrompt.includes("Agent-to-agent announce step")) {
+          return { runId: "run-announce" };
+        }
+        return { runId: "run-initial" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "initial" }] }],
+        };
+      }
+      if (request.method === "send") {
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-announce-default", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "hi",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      reply: "initial",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    await vi.waitFor(
+      () => {
+        expect(calls.filter((call) => call.method === "send")).toHaveLength(1);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+    const sendCall = calls.find((call) => call.method === "send");
+    expect(sendCall?.params).toMatchObject({
+      channel: "discord",
+      to: "group:target",
+      message: "initial",
+    });
+  });
+
+  it("skips external announce delivery when announce=false", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        const extraSystemPrompt =
+          typeof request.params?.extraSystemPrompt === "string"
+            ? request.params.extraSystemPrompt
+            : "";
+        if (extraSystemPrompt.includes("Agent-to-agent reply step")) {
+          return { runId: "run-reply" };
+        }
+        if (extraSystemPrompt.includes("Agent-to-agent announce step")) {
+          throw new Error("announce step should not run when announce=false");
+        }
+        return { runId: "run-initial" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "initial" }] }],
+        };
+      }
+      if (request.method === "send") {
+        throw new Error("send should not be called when announce=false");
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-announce-suppressed", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "hi",
+      timeoutSeconds: 1,
+      announce: false,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      reply: "initial",
+      delivery: { status: "disabled", mode: "none" },
+    });
+    await vi.waitFor(
+      () => {
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(2);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+    expect(
+      calls.some(
+        (call) =>
+          typeof call.params?.extraSystemPrompt === "string" &&
+          call.params.extraSystemPrompt.includes("Agent-to-agent announce step"),
+      ),
+    ).toBe(false);
+    expect(calls.some((call) => call.method === "send")).toBe(false);
+  });
+
+  it("prefers deliveryMode=private over announce=true", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const calls = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        const extraSystemPrompt =
+          typeof request.params?.extraSystemPrompt === "string"
+            ? request.params.extraSystemPrompt
+            : "";
+        if (extraSystemPrompt.includes("Agent-to-agent announce step")) {
+          throw new Error("announce step should not run when deliveryMode=private");
+        }
+        return { runId: "run-initial" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "initial" }] }],
+        };
+      }
+      if (request.method === "send") {
+        throw new Error("send should not be called when deliveryMode=private");
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-deliverymode-private", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "hi",
+      timeoutSeconds: 1,
+      deliveryMode: "private",
+      announce: true,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      delivery: { status: "disabled", mode: "none" },
+    });
+    expect(calls.some((call) => call.method === "send")).toBe(false);
+  });
+
+  it("injects sender session key and sessions_send private-reply guidance", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-initial" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "initial" }] }],
+        };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    await tool.execute("call-prompt-guidance", {
+      sessionKey: "agent:main:discord:group:target",
+      message: "hi",
+      timeoutSeconds: 1,
+      deliveryMode: "private",
+    });
+
+    const initialAgentCall = calls.find((call) => call.method === "agent");
+    const extraSystemPrompt =
+      typeof initialAgentCall?.params?.extraSystemPrompt === "string"
+        ? initialAgentCall.params.extraSystemPrompt
+        : "";
+    expect(extraSystemPrompt).toContain("This message was delivered via sessions_send.");
+    expect(extraSystemPrompt).toContain(
+      "For a private reply back to the sender, use sessions_send targeting agent:main:main.",
+    );
+    expect(extraSystemPrompt).toContain(
+      "Do not use channel messaging tools for private agent-to-agent replies",
+    );
   });
 });

--- a/src/secrets/runtime.integration.test.ts
+++ b/src/secrets/runtime.integration.test.ts
@@ -263,6 +263,10 @@ describe("secrets runtime snapshot integration", () => {
     await withTempHome("openclaw-secrets-runtime-web-reload-lkg-", async (home) => {
       const prepared = await prepareSecretsRuntimeSnapshot({
         config: asConfig({
+          plugins: {
+            enabled: true,
+            allow: ["google"],
+          },
           tools: {
             web: {
               search: {
@@ -276,6 +280,8 @@ describe("secrets runtime snapshot integration", () => {
         }),
         env: {
           WEB_SEARCH_GEMINI_API_KEY: "web-search-gemini-runtime-key",
+          GEMINI_API_KEY: "",
+          GOOGLE_API_KEY: "",
         },
         agentDirs: ["/tmp/openclaw-agent-main"],
         loadAuthStore: () => ({ version: 1, profiles: {} }),
@@ -287,6 +293,7 @@ describe("secrets runtime snapshot integration", () => {
         writeConfigFile({
           ...loadConfig(),
           plugins: {
+            ...loadConfig().plugins,
             entries: {
               google: {
                 config: {
@@ -342,7 +349,7 @@ describe("secrets runtime snapshot integration", () => {
         id: "MISSING_WEB_SEARCH_GEMINI_API_KEY",
       });
     });
-  }, 180_000);
+  }, 300_000);
 
   it("recomputes config-derived agent dirs when refreshing active secrets runtime snapshots", async () => {
     await withTempHome("openclaw-secrets-runtime-agent-dirs-", async (home) => {


### PR DESCRIPTION
## Summary
- add `deliveryMode` (`private|announce`) and legacy `announce` support to `sessions_send`
- skip final external announce/send when private mode is selected
- inject clearer `sessions_send` private-reply guidance into A2A prompts
- document new parameters and behavior in sessions docs
- add tests for default announce behavior, private suppression, precedence rules, and prompt guidance

## Validation
- `corepack pnpm vitest run src/agents/tools/sessions.test.ts -t "exposes announce as an optional boolean parameter|announces to the target chat by default|skips external announce delivery when announce=false|prefers deliveryMode=private over announce=true|injects sender session key and sessions_send private-reply guidance"`
- `corepack pnpm vitest run src/gateway/server.sessions-send.test.ts`
- `corepack pnpm exec oxfmt --check docs/concepts/session-tool.md docs/tools/index.md src/agents/tools/sessions-send-helpers.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.ts src/agents/tools/sessions.test.ts`