### PR TITLE
Infra: unify plugin split runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/probe: honor caller `--timeout` for active local loopback probes in `gateway status`, keep inactive remote-mode loopback probes fast, and clamp probe timers to JS-safe bounds so slow local/container gateways stop reporting false timeouts. (#47533) Thanks @MonkeyLeeT.
 - Config/startup: keep bundled web-search allowlist compatibility on a lightweight manifest path so config validation no longer pulls bundled web-search registry imports into startup, while still avoiding accidental auto-allow of config-loaded override plugins. (#51574) Thanks @RichardCao.
 - Gateway/chat.send: persist uploaded image references across reloads and compaction without delaying first-turn dispatch or double-submitting the same image to vision models. (#51324) Thanks @fuller-stack-dev.
+- Plugins/runtime state: share plugin-facing infra singleton state across duplicate module graphs and keep session-binding adapter ownership stable until the active owner unregisters. (#50725) thanks @huntharo.
 
 ### Breaking
 

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -5,6 +5,7 @@ import {
   resolveThreadBindingConversationIdFromBindingId,
   unregisterSessionBindingAdapter,
   type BindingTargetKind,
+  type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
@@ -556,6 +557,7 @@ export function createThreadBindingManager(
       unregisterSessionBindingAdapter({
         channel: "discord",
         accountId,
+        adapter: sessionBindingAdapter,
       });
       forgetThreadBindingToken(accountId);
     },
@@ -572,7 +574,7 @@ export function createThreadBindingManager(
     }
   }
 
-  registerSessionBindingAdapter({
+  const sessionBindingAdapter: SessionBindingAdapter = {
     channel: "discord",
     accountId,
     capabilities: {
@@ -682,7 +684,9 @@ export function createThreadBindingManager(
       });
       return removed ? [toSessionBindingRecord(removed, { idleTimeoutMs, maxAgeMs })] : [];
     },
-  });
+  };
+
+  registerSessionBindingAdapter(sessionBindingAdapter);
 
   registerManager(manager);
   return manager;

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -6,6 +6,7 @@ import {
   resolveThreadBindingConversationIdFromBindingId,
   unregisterSessionBindingAdapter,
   type BindingTargetKind,
+  type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
@@ -233,11 +234,15 @@ export function createFeishuThreadBindingManager(params: {
         }
       }
       getState().managersByAccountId.delete(accountId);
-      unregisterSessionBindingAdapter({ channel: "feishu", accountId });
+      unregisterSessionBindingAdapter({
+        channel: "feishu",
+        accountId,
+        adapter: sessionBindingAdapter,
+      });
     },
   };
 
-  registerSessionBindingAdapter({
+  const sessionBindingAdapter: SessionBindingAdapter = {
     channel: "feishu",
     accountId,
     capabilities: {
@@ -292,7 +297,9 @@ export function createFeishuThreadBindingManager(params: {
       const removed = manager.unbindConversation(conversationId);
       return removed ? [toSessionBindingRecord(removed, { idleTimeoutMs, maxAgeMs })] : [];
     },
-  });
+  };
+
+  registerSessionBindingAdapter(sessionBindingAdapter);
 
   getState().managersByAccountId.set(accountId, manager);
   return manager;

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { SessionBindingAdapter } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   readJsonFileWithFallback,
   registerSessionBindingAdapter,
@@ -367,6 +368,7 @@ export async function createMatrixThreadBindingManager(params: {
       unregisterSessionBindingAdapter({
         channel: "matrix",
         accountId: params.accountId,
+        adapter: sessionBindingAdapter,
       });
       if (getMatrixThreadBindingManagerEntry(params.accountId)?.manager === manager) {
         deleteMatrixThreadBindingManagerEntry(params.accountId);
@@ -413,7 +415,7 @@ export async function createMatrixThreadBindingManager(params: {
     return removed.map((record) => toSessionBindingRecord(record, defaults));
   };
 
-  registerSessionBindingAdapter({
+  const sessionBindingAdapter: SessionBindingAdapter = {
     channel: "matrix",
     accountId: params.accountId,
     capabilities: { placements: ["current", "child"], bindSupported: true, unbindSupported: true },
@@ -512,7 +514,9 @@ export async function createMatrixThreadBindingManager(params: {
       );
       return removed;
     },
-  });
+  };
+
+  registerSessionBindingAdapter(sessionBindingAdapter);
 
   if (params.enableSweeper !== false) {
     sweepTimer = setInterval(() => {

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -8,6 +8,7 @@ import {
   resolveThreadBindingEffectiveExpiresAt,
   unregisterSessionBindingAdapter,
   type BindingTargetKind,
+  type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { writeJsonAtomic } from "openclaw/plugin-sdk/infra-runtime";
@@ -542,7 +543,11 @@ export function createTelegramThreadBindingManager(
         clearInterval(sweepTimer);
         sweepTimer = null;
       }
-      unregisterSessionBindingAdapter({ channel: "telegram", accountId });
+      unregisterSessionBindingAdapter({
+        channel: "telegram",
+        accountId,
+        adapter: sessionBindingAdapter,
+      });
       const existingManager = getThreadBindingsState().managersByAccountId.get(accountId);
       if (existingManager === manager) {
         getThreadBindingsState().managersByAccountId.delete(accountId);
@@ -550,7 +555,7 @@ export function createTelegramThreadBindingManager(
     },
   };
 
-  registerSessionBindingAdapter({
+  const sessionBindingAdapter: SessionBindingAdapter = {
     channel: "telegram",
     accountId,
     capabilities: {
@@ -687,7 +692,9 @@ export function createTelegramThreadBindingManager(
           ]
         : [];
     },
-  });
+  };
+
+  registerSessionBindingAdapter(sessionBindingAdapter);
 
   const sweeperEnabled = params.enableSweeper !== false;
   if (sweeperEnabled) {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -8,6 +8,14 @@ import {
   resetAgentRunContextForTest,
 } from "./agent-events.js";
 
+type AgentEventsModule = typeof import("./agent-events.js");
+
+const agentEventsModuleUrl = new URL("./agent-events.ts", import.meta.url).href;
+
+async function importAgentEventsModule(cacheBust: string): Promise<AgentEventsModule> {
+  return (await import(`${agentEventsModuleUrl}?t=${cacheBust}`)) as AgentEventsModule;
+}
+
 describe("agent-events sequencing", () => {
   test("stores and clears run context", async () => {
     resetAgentRunContextForTest();
@@ -143,5 +151,43 @@ describe("agent-events sequencing", () => {
     stopBad();
 
     expect(seen).toEqual(["run-safe"]);
+  });
+
+  test("shares run context, listeners, and sequence state across duplicate module instances", async () => {
+    const first = await importAgentEventsModule(`first-${Date.now()}`);
+    const second = await importAgentEventsModule(`second-${Date.now()}`);
+
+    first.resetAgentEventsForTest();
+    first.registerAgentRunContext("run-dup", { sessionKey: "session-dup" });
+
+    const seen: Array<{ seq: number; sessionKey?: string }> = [];
+    const stop = first.onAgentEvent((evt) => {
+      if (evt.runId === "run-dup") {
+        seen.push({ seq: evt.seq, sessionKey: evt.sessionKey });
+      }
+    });
+
+    second.emitAgentEvent({
+      runId: "run-dup",
+      stream: "assistant",
+      data: { text: "from second" },
+      sessionKey: "   ",
+    });
+    first.emitAgentEvent({
+      runId: "run-dup",
+      stream: "assistant",
+      data: { text: "from first" },
+      sessionKey: "   ",
+    });
+
+    stop();
+
+    expect(second.getAgentRunContext("run-dup")).toEqual({ sessionKey: "session-dup" });
+    expect(seen).toEqual([
+      { seq: 1, sessionKey: "session-dup" },
+      { seq: 2, sessionKey: "session-dup" },
+    ]);
+
+    first.resetAgentEventsForTest();
   });
 });

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,4 +1,5 @@
 import type { VerboseLevel } from "../auto-reply/thinking.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
 
@@ -19,18 +20,27 @@ export type AgentRunContext = {
   isControlUiVisible?: boolean;
 };
 
-// Keep per-run counters so streams stay strictly monotonic per runId.
-const seqByRun = new Map<string, number>();
-const listeners = new Set<(evt: AgentEventPayload) => void>();
-const runContextById = new Map<string, AgentRunContext>();
+type AgentEventState = {
+  seqByRun: Map<string, number>;
+  listeners: Set<(evt: AgentEventPayload) => void>;
+  runContextById: Map<string, AgentRunContext>;
+};
+
+const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
+
+const state = resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
+  seqByRun: new Map<string, number>(),
+  listeners: new Set<(evt: AgentEventPayload) => void>(),
+  runContextById: new Map<string, AgentRunContext>(),
+}));
 
 export function registerAgentRunContext(runId: string, context: AgentRunContext) {
   if (!runId) {
     return;
   }
-  const existing = runContextById.get(runId);
+  const existing = state.runContextById.get(runId);
   if (!existing) {
-    runContextById.set(runId, { ...context });
+    state.runContextById.set(runId, { ...context });
     return;
   }
   if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
@@ -48,21 +58,21 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
 }
 
 export function getAgentRunContext(runId: string) {
-  return runContextById.get(runId);
+  return state.runContextById.get(runId);
 }
 
 export function clearAgentRunContext(runId: string) {
-  runContextById.delete(runId);
+  state.runContextById.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {
-  runContextById.clear();
+  state.runContextById.clear();
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
-  const nextSeq = (seqByRun.get(event.runId) ?? 0) + 1;
-  seqByRun.set(event.runId, nextSeq);
-  const context = runContextById.get(event.runId);
+  const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
+  state.seqByRun.set(event.runId, nextSeq);
+  const context = state.runContextById.get(event.runId);
   const isControlUiVisible = context?.isControlUiVisible ?? true;
   const eventSessionKey =
     typeof event.sessionKey === "string" && event.sessionKey.trim() ? event.sessionKey : undefined;
@@ -73,7 +83,7 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
     seq: nextSeq,
     ts: Date.now(),
   };
-  for (const listener of listeners) {
+  for (const listener of state.listeners) {
     try {
       listener(enriched);
     } catch {
@@ -83,6 +93,12 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
 }
 
 export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  state.listeners.add(listener);
+  return () => state.listeners.delete(listener);
+}
+
+export function resetAgentEventsForTest() {
+  state.seqByRun.clear();
+  state.listeners.clear();
+  state.runContextById.clear();
 }

--- a/src/infra/heartbeat-events.test.ts
+++ b/src/infra/heartbeat-events.test.ts
@@ -3,8 +3,17 @@ import {
   emitHeartbeatEvent,
   getLastHeartbeatEvent,
   onHeartbeatEvent,
+  resetHeartbeatEventsForTest,
   resolveIndicatorType,
 } from "./heartbeat-events.js";
+
+type HeartbeatEventsModule = typeof import("./heartbeat-events.js");
+
+const heartbeatEventsModuleUrl = new URL("./heartbeat-events.ts", import.meta.url).href;
+
+async function importHeartbeatEventsModule(cacheBust: string): Promise<HeartbeatEventsModule> {
+  return (await import(`${heartbeatEventsModuleUrl}?t=${cacheBust}`)) as HeartbeatEventsModule;
+}
 
 describe("resolveIndicatorType", () => {
   it("maps heartbeat statuses to indicator types", () => {
@@ -23,6 +32,7 @@ describe("heartbeat events", () => {
   });
 
   afterEach(() => {
+    resetHeartbeatEventsForTest();
     vi.useRealTimers();
   });
 
@@ -55,5 +65,29 @@ describe("heartbeat events", () => {
     emitHeartbeatEvent({ status: "failed" });
 
     expect(seen).toEqual(["first:ok-empty", "third:ok-empty"]);
+  });
+
+  it("shares heartbeat state across duplicate module instances", async () => {
+    const first = await importHeartbeatEventsModule(`first-${Date.now()}`);
+    const second = await importHeartbeatEventsModule(`second-${Date.now()}`);
+
+    first.resetHeartbeatEventsForTest();
+
+    const seen: string[] = [];
+    const stop = first.onHeartbeatEvent((evt) => {
+      seen.push(evt.status);
+    });
+
+    second.emitHeartbeatEvent({ status: "ok-token", preview: "pong" });
+
+    expect(first.getLastHeartbeatEvent()).toEqual({
+      ts: 1767960000000,
+      status: "ok-token",
+      preview: "pong",
+    });
+    expect(seen).toEqual(["ok-token"]);
+
+    stop();
+    first.resetHeartbeatEventsForTest();
   });
 });

--- a/src/infra/heartbeat-events.ts
+++ b/src/infra/heartbeat-events.ts
@@ -1,3 +1,5 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
 export type HeartbeatIndicatorType = "ok" | "alert" | "error";
 
 export type HeartbeatEventPayload = {
@@ -33,13 +35,22 @@ export function resolveIndicatorType(
   }
 }
 
-let lastHeartbeat: HeartbeatEventPayload | null = null;
-const listeners = new Set<(evt: HeartbeatEventPayload) => void>();
+type HeartbeatEventState = {
+  lastHeartbeat: HeartbeatEventPayload | null;
+  listeners: Set<(evt: HeartbeatEventPayload) => void>;
+};
+
+const HEARTBEAT_EVENT_STATE_KEY = Symbol.for("openclaw.heartbeatEvents.state");
+
+const state = resolveGlobalSingleton<HeartbeatEventState>(HEARTBEAT_EVENT_STATE_KEY, () => ({
+  lastHeartbeat: null,
+  listeners: new Set<(evt: HeartbeatEventPayload) => void>(),
+}));
 
 export function emitHeartbeatEvent(evt: Omit<HeartbeatEventPayload, "ts">) {
   const enriched: HeartbeatEventPayload = { ts: Date.now(), ...evt };
-  lastHeartbeat = enriched;
-  for (const listener of listeners) {
+  state.lastHeartbeat = enriched;
+  for (const listener of state.listeners) {
     try {
       listener(enriched);
     } catch {
@@ -49,10 +60,15 @@ export function emitHeartbeatEvent(evt: Omit<HeartbeatEventPayload, "ts">) {
 }
 
 export function onHeartbeatEvent(listener: (evt: HeartbeatEventPayload) => void): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  state.listeners.add(listener);
+  return () => state.listeners.delete(listener);
 }
 
 export function getLastHeartbeatEvent(): HeartbeatEventPayload | null {
-  return lastHeartbeat;
+  return state.lastHeartbeat;
+}
+
+export function resetHeartbeatEventsForTest(): void {
+  state.lastHeartbeat = null;
+  state.listeners.clear();
 }

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -4,9 +4,23 @@ import {
   getSessionBindingService,
   isSessionBindingError,
   registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
   type SessionBindingBindInput,
   type SessionBindingRecord,
 } from "./session-binding-service.js";
+
+type SessionBindingServiceModule = typeof import("./session-binding-service.js");
+
+const sessionBindingServiceModuleUrl = new URL("./session-binding-service.ts", import.meta.url)
+  .href;
+
+async function importSessionBindingServiceModule(
+  cacheBust: string,
+): Promise<SessionBindingServiceModule> {
+  return (await import(
+    `${sessionBindingServiceModuleUrl}?t=${cacheBust}`
+  )) as SessionBindingServiceModule;
+}
 
 function createRecord(input: SessionBindingBindInput): SessionBindingRecord {
   const conversationId =
@@ -199,23 +213,150 @@ describe("session binding service", () => {
     });
   });
 
-  it("rejects duplicate adapter registration for the same channel account", () => {
+  it("treats duplicate adapter registration for the same channel account as idempotent", async () => {
+    const firstBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
+    const secondBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
+
     registerSessionBindingAdapter({
       channel: "discord",
       accountId: "default",
-      bind: async (input) => createRecord(input),
+      bind: firstBind,
       listBySession: () => [],
       resolveByConversation: () => null,
     });
 
-    expect(() =>
-      registerSessionBindingAdapter({
-        channel: "Discord",
-        accountId: "DEFAULT",
-        bind: async (input) => createRecord(input),
-        listBySession: () => [],
-        resolveByConversation: () => null,
+    registerSessionBindingAdapter({
+      channel: "Discord",
+      accountId: "DEFAULT",
+      bind: secondBind,
+      listBySession: () => [],
+      resolveByConversation: () => null,
+    });
+
+    await expect(
+      getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-1",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-1",
+        },
       }),
-    ).toThrow("Session binding adapter already registered for discord:default");
+    ).resolves.toMatchObject({
+      conversation: expect.objectContaining({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-1",
+      }),
+    });
+    expect(firstBind).toHaveBeenCalledTimes(1);
+    expect(secondBind).not.toHaveBeenCalled();
+
+    unregisterSessionBindingAdapter({ channel: "discord", accountId: "default" });
+
+    await expect(
+      getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-2",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-2",
+        },
+      }),
+    ).resolves.toMatchObject({
+      conversation: expect.objectContaining({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-2",
+      }),
+    });
+
+    unregisterSessionBindingAdapter({ channel: "discord", accountId: "default" });
+
+    await expect(
+      getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-3",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-3",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "BINDING_ADAPTER_UNAVAILABLE",
+    });
+  });
+
+  it("shares registered adapters across duplicate module instances", async () => {
+    const first = await importSessionBindingServiceModule(`first-${Date.now()}`);
+    const second = await importSessionBindingServiceModule(`second-${Date.now()}`);
+    const firstBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
+    const secondBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
+
+    first.__testing.resetSessionBindingAdaptersForTests();
+    first.registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      bind: firstBind,
+      listBySession: () => [],
+      resolveByConversation: () => null,
+    });
+    second.registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      bind: secondBind,
+      listBySession: () => [],
+      resolveByConversation: () => null,
+    });
+
+    expect(second.__testing.getRegisteredAdapterKeys()).toEqual(["discord:default"]);
+
+    await expect(
+      second.getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-1",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-1",
+        },
+      }),
+    ).resolves.toMatchObject({
+      conversation: expect.objectContaining({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-1",
+      }),
+    });
+    expect(firstBind).toHaveBeenCalledTimes(1);
+    expect(secondBind).not.toHaveBeenCalled();
+
+    second.unregisterSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+    });
+
+    await expect(
+      first.getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-2",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-2",
+        },
+      }),
+    ).resolves.toMatchObject({
+      conversation: expect.objectContaining({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-2",
+      }),
+    });
+
+    first.__testing.resetSessionBindingAdaptersForTests();
   });
 });

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -214,21 +214,29 @@ describe("session binding service", () => {
     });
   });
 
-  it("promotes the remaining adapter when duplicate registrations unregister", async () => {
-    const firstBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
-    const secondBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
-
+  it("keeps the first live adapter authoritative until it unregisters", () => {
+    const firstBinding = {
+      bindingId: "first-binding",
+      targetSessionKey: "agent:main",
+      targetKind: "session" as const,
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-1",
+      },
+      status: "active" as const,
+      boundAt: 1,
+    };
     const firstAdapter: SessionBindingAdapter = {
       channel: "discord",
       accountId: "default",
-      bind: firstBind,
-      listBySession: () => [],
+      listBySession: (targetSessionKey) =>
+        targetSessionKey === "agent:main" ? [firstBinding] : [],
       resolveByConversation: () => null,
     };
     const secondAdapter: SessionBindingAdapter = {
       channel: "Discord",
       accountId: "DEFAULT",
-      bind: secondBind,
       listBySession: () => [],
       resolveByConversation: () => null,
     };
@@ -236,51 +244,7 @@ describe("session binding service", () => {
     registerSessionBindingAdapter(firstAdapter);
     registerSessionBindingAdapter(secondAdapter);
 
-    await expect(
-      getSessionBindingService().bind({
-        targetSessionKey: "agent:main:subagent:child-1",
-        targetKind: "subagent",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: "thread-1",
-        },
-      }),
-    ).resolves.toMatchObject({
-      conversation: expect.objectContaining({
-        channel: "discord",
-        accountId: "default",
-        conversationId: "thread-1",
-      }),
-    });
-    expect(firstBind).not.toHaveBeenCalled();
-    expect(secondBind).toHaveBeenCalledTimes(1);
-
-    unregisterSessionBindingAdapter({
-      channel: "discord",
-      accountId: "default",
-      adapter: firstAdapter,
-    });
-
-    await expect(
-      getSessionBindingService().bind({
-        targetSessionKey: "agent:main:subagent:child-2",
-        targetKind: "subagent",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: "thread-2",
-        },
-      }),
-    ).resolves.toMatchObject({
-      conversation: expect.objectContaining({
-        channel: "discord",
-        accountId: "default",
-        conversationId: "thread-2",
-      }),
-    });
-    expect(firstBind).not.toHaveBeenCalled();
-    expect(secondBind).toHaveBeenCalledTimes(2);
+    expect(getSessionBindingService().listBySession("agent:main")).toEqual([firstBinding]);
 
     unregisterSessionBindingAdapter({
       channel: "discord",
@@ -288,19 +252,15 @@ describe("session binding service", () => {
       adapter: secondAdapter,
     });
 
-    await expect(
-      getSessionBindingService().bind({
-        targetSessionKey: "agent:main:subagent:child-3",
-        targetKind: "subagent",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: "thread-3",
-        },
-      }),
-    ).rejects.toMatchObject({
-      code: "BINDING_ADAPTER_UNAVAILABLE",
+    expect(getSessionBindingService().listBySession("agent:main")).toEqual([firstBinding]);
+
+    unregisterSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      adapter: firstAdapter,
     });
+
+    expect(getSessionBindingService().listBySession("agent:main")).toEqual([]);
   });
 
   it("shares registered adapters across duplicate module instances", async () => {
@@ -346,17 +306,17 @@ describe("session binding service", () => {
         conversationId: "thread-1",
       }),
     });
-    expect(firstBind).not.toHaveBeenCalled();
-    expect(secondBind).toHaveBeenCalledTimes(1);
+    expect(firstBind).toHaveBeenCalledTimes(1);
+    expect(secondBind).not.toHaveBeenCalled();
 
-    second.unregisterSessionBindingAdapter({
+    first.unregisterSessionBindingAdapter({
       channel: "discord",
       accountId: "default",
-      adapter: secondAdapter,
+      adapter: firstAdapter,
     });
 
     await expect(
-      first.getSessionBindingService().bind({
+      second.getSessionBindingService().bind({
         targetSessionKey: "agent:main:subagent:child-2",
         targetKind: "subagent",
         conversation: {
@@ -375,10 +335,10 @@ describe("session binding service", () => {
     expect(firstBind).toHaveBeenCalledTimes(1);
     expect(secondBind).toHaveBeenCalledTimes(1);
 
-    first.unregisterSessionBindingAdapter({
+    second.unregisterSessionBindingAdapter({
       channel: "discord",
       accountId: "default",
-      adapter: firstAdapter,
+      adapter: secondAdapter,
     });
 
     await expect(

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -5,6 +5,7 @@ import {
   isSessionBindingError,
   registerSessionBindingAdapter,
   unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
   type SessionBindingBindInput,
   type SessionBindingRecord,
 } from "./session-binding-service.js";
@@ -213,25 +214,27 @@ describe("session binding service", () => {
     });
   });
 
-  it("treats duplicate adapter registration for the same channel account as idempotent", async () => {
+  it("promotes the remaining adapter when duplicate registrations unregister", async () => {
     const firstBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
     const secondBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
 
-    registerSessionBindingAdapter({
+    const firstAdapter: SessionBindingAdapter = {
       channel: "discord",
       accountId: "default",
       bind: firstBind,
       listBySession: () => [],
       resolveByConversation: () => null,
-    });
-
-    registerSessionBindingAdapter({
+    };
+    const secondAdapter: SessionBindingAdapter = {
       channel: "Discord",
       accountId: "DEFAULT",
       bind: secondBind,
       listBySession: () => [],
       resolveByConversation: () => null,
-    });
+    };
+
+    registerSessionBindingAdapter(firstAdapter);
+    registerSessionBindingAdapter(secondAdapter);
 
     await expect(
       getSessionBindingService().bind({
@@ -250,10 +253,14 @@ describe("session binding service", () => {
         conversationId: "thread-1",
       }),
     });
-    expect(firstBind).toHaveBeenCalledTimes(1);
-    expect(secondBind).not.toHaveBeenCalled();
+    expect(firstBind).not.toHaveBeenCalled();
+    expect(secondBind).toHaveBeenCalledTimes(1);
 
-    unregisterSessionBindingAdapter({ channel: "discord", accountId: "default" });
+    unregisterSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      adapter: firstAdapter,
+    });
 
     await expect(
       getSessionBindingService().bind({
@@ -272,8 +279,14 @@ describe("session binding service", () => {
         conversationId: "thread-2",
       }),
     });
+    expect(firstBind).not.toHaveBeenCalled();
+    expect(secondBind).toHaveBeenCalledTimes(2);
 
-    unregisterSessionBindingAdapter({ channel: "discord", accountId: "default" });
+    unregisterSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      adapter: secondAdapter,
+    });
 
     await expect(
       getSessionBindingService().bind({
@@ -295,22 +308,24 @@ describe("session binding service", () => {
     const second = await importSessionBindingServiceModule(`second-${Date.now()}`);
     const firstBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
     const secondBind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
-
-    first.__testing.resetSessionBindingAdaptersForTests();
-    first.registerSessionBindingAdapter({
+    const firstAdapter: SessionBindingAdapter = {
       channel: "discord",
       accountId: "default",
       bind: firstBind,
       listBySession: () => [],
       resolveByConversation: () => null,
-    });
-    second.registerSessionBindingAdapter({
+    };
+    const secondAdapter: SessionBindingAdapter = {
       channel: "discord",
       accountId: "default",
       bind: secondBind,
       listBySession: () => [],
       resolveByConversation: () => null,
-    });
+    };
+
+    first.__testing.resetSessionBindingAdaptersForTests();
+    first.registerSessionBindingAdapter(firstAdapter);
+    second.registerSessionBindingAdapter(secondAdapter);
 
     expect(second.__testing.getRegisteredAdapterKeys()).toEqual(["discord:default"]);
 
@@ -331,12 +346,13 @@ describe("session binding service", () => {
         conversationId: "thread-1",
       }),
     });
-    expect(firstBind).toHaveBeenCalledTimes(1);
-    expect(secondBind).not.toHaveBeenCalled();
+    expect(firstBind).not.toHaveBeenCalled();
+    expect(secondBind).toHaveBeenCalledTimes(1);
 
     second.unregisterSessionBindingAdapter({
       channel: "discord",
       accountId: "default",
+      adapter: secondAdapter,
     });
 
     await expect(
@@ -355,6 +371,28 @@ describe("session binding service", () => {
         accountId: "default",
         conversationId: "thread-2",
       }),
+    });
+    expect(firstBind).toHaveBeenCalledTimes(1);
+    expect(secondBind).toHaveBeenCalledTimes(1);
+
+    first.unregisterSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      adapter: firstAdapter,
+    });
+
+    await expect(
+      second.getSessionBindingService().bind({
+        targetSessionKey: "agent:main:subagent:child-3",
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-3",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "BINDING_ADAPTER_UNAVAILABLE",
     });
 
     first.__testing.resetSessionBindingAdaptersForTests();

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -147,16 +147,20 @@ function resolveAdapterCapabilities(
 }
 
 const SESSION_BINDING_ADAPTERS_KEY = Symbol.for("openclaw.sessionBinding.adapters");
-const SESSION_BINDING_ADAPTER_REF_COUNTS_KEY = Symbol.for(
-  "openclaw.sessionBinding.adapterRefCounts",
-);
 
-const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, SessionBindingAdapter>(
+type SessionBindingAdapterRegistration = {
+  adapter: SessionBindingAdapter;
+  normalizedAdapter: SessionBindingAdapter;
+};
+
+const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, SessionBindingAdapterRegistration[]>(
   SESSION_BINDING_ADAPTERS_KEY,
 );
-const ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, number>(
-  SESSION_BINDING_ADAPTER_REF_COUNTS_KEY,
-);
+
+function getActiveAdapterForKey(key: string): SessionBindingAdapter | null {
+  const registrations = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
+  return registrations?.at(-1)?.normalizedAdapter ?? null;
+}
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const normalizedAdapter = {
@@ -169,33 +173,42 @@ export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): v
     accountId: normalizedAdapter.accountId,
   });
   const existing = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
-  if (existing) {
-    // Duplicate module graphs can legitimately hit registration multiple times
-    // for the same logical adapter key in one process. Keep the first adapter
-    // stable and track registrations so later duplicate imports can unregister
-    // independently without deleting the live shared adapter too early.
-    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(
-      key,
-      Math.max(1, ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.get(key) ?? 1) + 1,
-    );
-    return;
-  }
-  ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, normalizedAdapter);
-  ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(key, 1);
+  const registrations = existing ? [...existing] : [];
+  registrations.push({
+    adapter,
+    normalizedAdapter,
+  });
+  ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, registrations);
 }
 
 export function unregisterSessionBindingAdapter(params: {
   channel: string;
   accountId: string;
+  adapter?: SessionBindingAdapter;
 }): void {
   const key = toAdapterKey(params);
-  const currentRefCount = ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.get(key) ?? 0;
-  if (currentRefCount > 1) {
-    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(key, currentRefCount - 1);
+  const registrations = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
+  if (!registrations || registrations.length === 0) {
     return;
   }
-  ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.delete(key);
-  ADAPTERS_BY_CHANNEL_ACCOUNT.delete(key);
+  const nextRegistrations = [...registrations];
+  if (params.adapter) {
+    // Remove the matching owner so a surviving duplicate graph can stay active.
+    const registrationIndex = nextRegistrations.findLastIndex(
+      (registration) => registration.adapter === params.adapter,
+    );
+    if (registrationIndex < 0) {
+      return;
+    }
+    nextRegistrations.splice(registrationIndex, 1);
+  } else {
+    nextRegistrations.pop();
+  }
+  if (nextRegistrations.length === 0) {
+    ADAPTERS_BY_CHANNEL_ACCOUNT.delete(key);
+    return;
+  }
+  ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, nextRegistrations);
 }
 
 function resolveAdapterForConversation(ref: ConversationRef): SessionBindingAdapter | null {
@@ -213,7 +226,13 @@ function resolveAdapterForChannelAccount(params: {
     channel: params.channel,
     accountId: params.accountId,
   });
-  return ADAPTERS_BY_CHANNEL_ACCOUNT.get(key) ?? null;
+  return getActiveAdapterForKey(key);
+}
+
+function getActiveRegisteredAdapters(): SessionBindingAdapter[] {
+  return [...ADAPTERS_BY_CHANNEL_ACCOUNT.values()]
+    .map((registrations) => registrations.at(-1)?.normalizedAdapter ?? null)
+    .filter((adapter): adapter is SessionBindingAdapter => Boolean(adapter));
 }
 
 function dedupeBindings(records: SessionBindingRecord[]): SessionBindingRecord[] {
@@ -297,7 +316,7 @@ function createDefaultSessionBindingService(): SessionBindingService {
         return [];
       }
       const results: SessionBindingRecord[] = [];
-      for (const adapter of ADAPTERS_BY_CHANNEL_ACCOUNT.values()) {
+      for (const adapter of getActiveRegisteredAdapters()) {
         const entries = adapter.listBySession(key);
         if (entries.length > 0) {
           results.push(...entries);
@@ -321,13 +340,13 @@ function createDefaultSessionBindingService(): SessionBindingService {
       if (!normalizedBindingId) {
         return;
       }
-      for (const adapter of ADAPTERS_BY_CHANNEL_ACCOUNT.values()) {
+      for (const adapter of getActiveRegisteredAdapters()) {
         adapter.touch?.(normalizedBindingId, at);
       }
     },
     unbind: async (input) => {
       const removed: SessionBindingRecord[] = [];
-      for (const adapter of ADAPTERS_BY_CHANNEL_ACCOUNT.values()) {
+      for (const adapter of getActiveRegisteredAdapters()) {
         if (!adapter.unbind) {
           continue;
         }
@@ -350,7 +369,6 @@ export function getSessionBindingService(): SessionBindingService {
 export const __testing = {
   resetSessionBindingAdaptersForTests() {
     ADAPTERS_BY_CHANNEL_ACCOUNT.clear();
-    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.clear();
   },
   getRegisteredAdapterKeys() {
     return [...ADAPTERS_BY_CHANNEL_ACCOUNT.keys()];

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -159,7 +159,7 @@ const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, SessionBindingAdapt
 
 function getActiveAdapterForKey(key: string): SessionBindingAdapter | null {
   const registrations = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
-  return registrations?.at(-1)?.normalizedAdapter ?? null;
+  return registrations?.[0]?.normalizedAdapter ?? null;
 }
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
@@ -231,7 +231,7 @@ function resolveAdapterForChannelAccount(params: {
 
 function getActiveRegisteredAdapters(): SessionBindingAdapter[] {
   return [...ADAPTERS_BY_CHANNEL_ACCOUNT.values()]
-    .map((registrations) => registrations.at(-1)?.normalizedAdapter ?? null)
+    .map((registrations) => registrations[0]?.normalizedAdapter ?? null)
     .filter((adapter): adapter is SessionBindingAdapter => Boolean(adapter));
 }
 

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -1,4 +1,5 @@
 import { normalizeAccountId } from "../../routing/session-key.js";
+import { resolveGlobalMap } from "../../shared/global-singleton.js";
 
 export type BindingTargetKind = "subagent" | "session";
 export type BindingStatus = "active" | "ending" | "ended";
@@ -145,7 +146,17 @@ function resolveAdapterCapabilities(
   };
 }
 
-const ADAPTERS_BY_CHANNEL_ACCOUNT = new Map<string, SessionBindingAdapter>();
+const SESSION_BINDING_ADAPTERS_KEY = Symbol.for("openclaw.sessionBinding.adapters");
+const SESSION_BINDING_ADAPTER_REF_COUNTS_KEY = Symbol.for(
+  "openclaw.sessionBinding.adapterRefCounts",
+);
+
+const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, SessionBindingAdapter>(
+  SESSION_BINDING_ADAPTERS_KEY,
+);
+const ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, number>(
+  SESSION_BINDING_ADAPTER_REF_COUNTS_KEY,
+);
 
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const normalizedAdapter = {
@@ -158,19 +169,33 @@ export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): v
     accountId: normalizedAdapter.accountId,
   });
   const existing = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
-  if (existing && existing !== adapter) {
-    throw new Error(
-      `Session binding adapter already registered for ${normalizedAdapter.channel}:${normalizedAdapter.accountId}`,
+  if (existing) {
+    // Duplicate module graphs can legitimately hit registration multiple times
+    // for the same logical adapter key in one process. Keep the first adapter
+    // stable and track registrations so later duplicate imports can unregister
+    // independently without deleting the live shared adapter too early.
+    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(
+      key,
+      Math.max(1, ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.get(key) ?? 1) + 1,
     );
+    return;
   }
   ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, normalizedAdapter);
+  ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(key, 1);
 }
 
 export function unregisterSessionBindingAdapter(params: {
   channel: string;
   accountId: string;
 }): void {
-  ADAPTERS_BY_CHANNEL_ACCOUNT.delete(toAdapterKey(params));
+  const key = toAdapterKey(params);
+  const currentRefCount = ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.get(key) ?? 0;
+  if (currentRefCount > 1) {
+    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.set(key, currentRefCount - 1);
+    return;
+  }
+  ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.delete(key);
+  ADAPTERS_BY_CHANNEL_ACCOUNT.delete(key);
 }
 
 function resolveAdapterForConversation(ref: ConversationRef): SessionBindingAdapter | null {
@@ -325,6 +350,7 @@ export function getSessionBindingService(): SessionBindingService {
 export const __testing = {
   resetSessionBindingAdaptersForTests() {
     ADAPTERS_BY_CHANNEL_ACCOUNT.clear();
+    ADAPTER_REF_COUNTS_BY_CHANNEL_ACCOUNT.clear();
   },
   getRegisteredAdapterKeys() {
     return [...ADAPTERS_BY_CHANNEL_ACCOUNT.keys()];

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -13,6 +13,14 @@ import {
   resetSystemEventsForTest,
 } from "./system-events.js";
 
+type SystemEventsModule = typeof import("./system-events.js");
+
+const systemEventsModuleUrl = new URL("./system-events.ts", import.meta.url).href;
+
+async function importSystemEventsModule(cacheBust: string): Promise<SystemEventsModule> {
+  return (await import(`${systemEventsModuleUrl}?t=${cacheBust}`)) as SystemEventsModule;
+}
+
 const cfg = {} as unknown as OpenClawConfig;
 const mainKey = resolveMainSessionKey(cfg);
 
@@ -106,6 +114,26 @@ describe("system events (session routing)", () => {
     expect(peekSystemEvents(key)).toEqual(
       Array.from({ length: 20 }, (_, index) => `event ${index + 3}`),
     );
+  });
+
+  it("shares queued events across duplicate module instances", async () => {
+    const first = await importSystemEventsModule(`first-${Date.now()}`);
+    const second = await importSystemEventsModule(`second-${Date.now()}`);
+    const key = "agent:main:test-duplicate-module";
+
+    first.resetSystemEventsForTest();
+    second.enqueueSystemEvent("Node connected", { sessionKey: key, contextKey: "build:123" });
+
+    expect(first.peekSystemEventEntries(key)).toEqual([
+      expect.objectContaining({
+        text: "Node connected",
+        contextKey: "build:123",
+      }),
+    ]);
+    expect(first.isSystemEventContextChanged(key, "build:123")).toBe(false);
+    expect(first.drainSystemEvents(key)).toEqual(["Node connected"]);
+
+    first.resetSystemEventsForTest();
   });
 
   it("filters heartbeat/noise lines, returning undefined", async () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -2,6 +2,8 @@
 // prefixed to the next prompt. We intentionally avoid persistence to keep
 // events ephemeral. Events are session-scoped and require an explicit key.
 
+import { resolveGlobalMap } from "../shared/global-singleton.js";
+
 export type SystemEvent = { text: string; ts: number; contextKey?: string | null };
 
 const MAX_EVENTS = 20;
@@ -12,7 +14,9 @@ type SessionQueue = {
   lastContextKey: string | null;
 };
 
-const queues = new Map<string, SessionQueue>();
+const SYSTEM_EVENT_QUEUES_KEY = Symbol.for("openclaw.systemEvents.queues");
+
+const queues = resolveGlobalMap<string, SessionQueue>(SYSTEM_EVENT_QUEUES_KEY);
 
 type SystemEventOptions = {
   sessionKey: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: I found several plugin-facing infra/runtime modules still storing mutable state in module-local variables, so duplicate import graphs could split listeners, queues, and session-binding adapters.
- Why it matters: In practice this lets one graph register state that another graph cannot see, which breaks heartbeat/system event delivery, agent event sequencing/listeners, and session-binding adapter resolution.
- What changed: I moved the mutable state in `heartbeat-events`, `agent-events`, `system-events`, and `session-binding-service` onto process-global singletons, updated the Discord/Feishu/Telegram/Matrix thread-binding managers to unregister the exact adapter they registered, and added duplicate-module regression tests for each surface.
- What did NOT change (scope boundary): I did not change approval policy or unrelated plugin runtime behavior beyond making existing shared state visible across duplicate module instances and making session-binding adapter ownership lifecycle-safe.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Plugin-facing infra/runtime state now survives duplicate module graphs, so:
- heartbeat listeners and last-event reads stay in sync
- agent event listeners, per-run sequence counters, and run context stay in sync
- system events enqueue/drain from the same queue
- session-binding adapters resolve consistently across plugin/core boundaries
- duplicate adapter registrations no longer throw or unregister the live adapter too early
- the active session-binding adapter remains authoritative until it unregisters, then a surviving duplicate is promoted

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin runtime / shared infra
- Relevant config (redacted): default local test config

### Steps

1. Import one of the affected modules twice with cache-busting query strings so it initializes two module graphs in one process.
2. Register or mutate runtime state through the first import, then read or consume that state through the second import.
3. Observe the old module-local implementation lose visibility across the two graphs.

### Expected

- Both imports should share the same runtime state because they are running in the same process.

### Actual

- Before this patch, each import held its own mutable state, so the second graph could miss listeners, queued events, or adapters created by the first graph.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I added and ran duplicate-module regression tests for all four affected infra surfaces, then ran focused infra and channel-manager test suites on the rebased branch.
- Edge cases checked: I verified duplicate session-binding registrations preserve the first live adapter until it unregisters, that unregister is owner-specific, and that a surviving duplicate adapter is promoted after the active owner unregisters.
- What you did **not** verify: I did not manually repro every external channel in a live environment because the bug is at the shared runtime state layer and the new tests plus duplicate-import repros exercise that failure mode directly.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/infra/heartbeat-events.ts`, `src/infra/agent-events.ts`, `src/infra/system-events.ts`, `src/infra/outbound/session-binding-service.ts`, `extensions/discord/src/monitor/thread-bindings.manager.ts`, `extensions/feishu/src/thread-bindings.ts`, `extensions/telegram/src/thread-bindings.ts`, `extensions/matrix/src/matrix/thread-bindings.ts`
- Known bad symptoms reviewers should watch for: Duplicate-module tests failing again, adapters/events disappearing when registered from a plugin graph, or duplicate session-binding registrations taking over before the active owner unregisters.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A shared singleton key could accidentally collide or preserve state across tests if reset hooks are incomplete.
- Mitigation: I used namespaced `Symbol.for(...)` keys and added/reset dedicated test helpers around the new duplicate-module regressions.
