### PR TITLE
fix(ollama): deserialize tool call args for Ollama API #50713

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -54,6 +54,77 @@ describe("convertToOllamaMessages", () => {
     ]);
   });
 
+  it("parses OpenAI-style toolCall arguments JSON strings for Ollama", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "get_weather",
+            arguments: '{"location": "Beijing"}',
+          },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "get_weather", arguments: { location: "Beijing" } } },
+    ]);
+  });
+
+  it("preserves unsafe integer literals in OpenAI-style toolCall argument JSON strings", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "send",
+            arguments: '{"target":12345678901234567890}',
+          },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls?.[0].function.arguments).toEqual({
+      target: "12345678901234567890",
+    });
+  });
+
+  it("parses tool_use input JSON strings for Ollama", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_1",
+            name: "get_weather",
+            input: '{"location":"Paris"}',
+          },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { function: { name: "get_weather", arguments: { location: "Paris" } } },
+    ]);
+  });
+
+  it("treats invalid toolCall arguments JSON as empty object", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "broken", arguments: "{not json" }],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([{ function: { name: "broken", arguments: {} } }]);
+  });
+
   it("converts tool result messages with 'tool' role", () => {
     const messages = [{ role: "tool", content: "file1.txt\nfile2.txt" }];
     const result = convertToOllamaMessages(messages);
@@ -166,6 +237,29 @@ describe("buildAssistantMessage", () => {
     expect(toolCall.id).toMatch(/^ollama_call_[0-9a-f-]{36}$/);
   });
 
+  it("normalizes string tool call arguments from Ollama wire format", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [{ function: { name: "get_weather", arguments: '{"location": "Beijing"}' } }],
+      },
+      done: true,
+      prompt_eval_count: 20,
+      eval_count: 10,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    const toolCall = result.content[0] as {
+      type: "toolCall";
+      name: string;
+      arguments: Record<string, unknown>;
+    };
+    expect(toolCall.name).toBe("get_weather");
+    expect(toolCall.arguments).toEqual({ location: "Beijing" });
+  });
+
   it("sets all costs to zero for local models", () => {
     const response = {
       model: "qwen3:32b",
@@ -261,7 +355,7 @@ describe("parseNdjsonStream", () => {
 
     // Simulate the accumulation logic from createOllamaStreamFn
     const accumulatedToolCalls: Array<{
-      function: { name: string; arguments: Record<string, unknown> };
+      function: { name: string; arguments: Record<string, unknown> | string };
     }> = [];
     const chunks = [];
     for await (const chunk of parseNdjsonStream(reader)) {

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -66,7 +66,8 @@ interface OllamaTool {
 interface OllamaToolCall {
   function: {
     name: string;
-    arguments: Record<string, unknown>;
+    /** Wire format may be a JSON string; normalize before re-sending to Ollama. */
+    arguments: Record<string, unknown> | string;
   };
 }
 
@@ -221,8 +222,39 @@ interface OllamaChatResponse {
 type InputContentPart =
   | { type: "text"; text: string }
   | { type: "image"; data: string }
-  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
-  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+  | {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown> | string;
+    }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> | string };
+
+/**
+ * Normalize tool `arguments` / `input` for Ollama: OpenAI-style messages use a JSON string;
+ * Ollama expects an object. Uses the same unsafe-integer quoting as NDJSON parsing.
+ */
+function normalizeOllamaToolArguments(raw: unknown): Record<string, unknown> {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return {};
+    }
+    try {
+      const parsed = parseJsonPreservingUnsafeIntegers(trimmed);
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
 
 function extractTextContent(content: unknown): string {
   if (typeof content === "string") {
@@ -254,9 +286,13 @@ function extractToolCalls(content: unknown): OllamaToolCall[] {
   const result: OllamaToolCall[] = [];
   for (const part of parts) {
     if (part.type === "toolCall") {
-      result.push({ function: { name: part.name, arguments: part.arguments } });
+      result.push({
+        function: { name: part.name, arguments: normalizeOllamaToolArguments(part.arguments) },
+      });
     } else if (part.type === "tool_use") {
-      result.push({ function: { name: part.name, arguments: part.input } });
+      result.push({
+        function: { name: part.name, arguments: normalizeOllamaToolArguments(part.input) },
+      });
     }
   }
   return result;
@@ -355,7 +391,7 @@ export function buildAssistantMessage(
         type: "toolCall",
         id: `ollama_call_${randomUUID()}`,
         name: tc.function.name,
-        arguments: tc.function.arguments,
+        arguments: normalizeOllamaToolArguments(tc.function.arguments),
       });
     }
   }


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/50713

## Summary

Assistant messages store tool calls with OpenAI-style `arguments` as a JSON **string**. When that history is sent back through `convertToOllamaMessages()`, Ollama expects `function.arguments` to be a JSON **object**; passing a string breaks Ollama parsing and can yield empty model output after tool runs. This change normalizes string (and object) tool args via a shared helper that parses with the same unsafe-integer preservation used for NDJSON streaming, and applies it both when building Ollama chat requests and when building assistant messages from Ollama responses.

## Existing Functionality Check

- [x] Searched the codebase for Ollama message / tool-call conversion.
  - `src/agents/ollama-stream.ts` — `extractToolCalls`, `convertToOllamaMessages`, `buildAssistantMessage`, NDJSON parsing helpers.

## What Changed

- **`src/agents/ollama-stream.ts`**
  - Added `normalizeOllamaToolArguments()` and use it in `extractToolCalls()` (`toolCall` + `tool_use`) and `buildAssistantMessage()` so wire-format string arguments become objects before JSON serialization to `/api/chat` and before storing `ToolCall` content.
  - String parsing uses `parseJsonPreservingUnsafeIntegers` so behavior matches `parseNdjsonStream` and avoids silent rounding past `MAX_SAFE_INTEGER`.
- **`src/agents/ollama-stream.test.ts`**
  - OpenAI-style JSON string arguments for `toolCall`, invalid JSON → `{}`, unsafe integer literals in argument strings, `tool_use` + string `input`, existing `buildAssistantMessage` string-arguments coverage retained/aligned.

## Tests

- `pnpm test -- src/agents/ollama-stream.test.ts`
- `pnpm check`

## Checklist

- [x] Describes what & why (see Summary)
- [x] Scoped to Ollama stream / tool argument normalization
- [x] Tests updated for string args + edge cases