### PR TITLE
Fix anthropic auth header

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1533,6 +1533,44 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("respects explicit authHeader false overrides for implicit minimax providers", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://proxy.example.com",
+            api: "anthropic-messages",
+            authHeader: false,
+            models: [],
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "minimax", "MiniMax-M2.5");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "minimax",
+      id: "MiniMax-M2.5",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-minimax-test",
+      headers: { "anthropic-version": "2023-06-01", "x-api-key": "stale", "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.apiKey).toBe("sk-minimax-test");
+    expect(calls[0]?.headers).toEqual({
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "stale",
+      "X-Custom": "1",
+    });
+  });
+
   it("keeps apiKey auth mode for anthropic-compatible custom providers when authHeader is disabled", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1503,7 +1503,6 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.headers).toEqual({
       "anthropic-version": "2023-06-01",
       Authorization: "Bearer sk-proxy-test",
-      "x-api-key": null,
       "X-Custom": "1",
     });
   });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1470,7 +1470,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(headers).toEqual({ "X-Custom": "1" });
   });
 
-  it("uses Authorization header for anthropic-compatible custom providers when authHeader is enabled", () => {
+  it("uses bearer auth mode for anthropic-compatible custom providers when authHeader is enabled", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {
       models: {
@@ -1500,6 +1500,7 @@ describe("applyExtraParamsToAgent", () => {
     });
 
     expect(calls).toHaveLength(1);
+    expect(calls[0]?.apiKey).toBeUndefined();
     expect(calls[0]?.headers).toEqual({
       "anthropic-version": "2023-06-01",
       Authorization: "Bearer sk-proxy-test",
@@ -1507,7 +1508,7 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("does not add Authorization header for anthropic-compatible custom providers when authHeader is disabled", () => {
+  it("keeps apiKey auth mode for anthropic-compatible custom providers when authHeader is disabled", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {
       models: {
@@ -1536,6 +1537,7 @@ describe("applyExtraParamsToAgent", () => {
     });
 
     expect(calls).toHaveLength(1);
+    expect(calls[0]?.apiKey).toBe("sk-proxy-test");
     expect(calls[0]?.headers).toEqual({
       "anthropic-version": "2023-06-01",
       "x-api-key": "stale",

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1508,6 +1508,31 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("uses bearer auth mode for implicit minimax providers without explicit authHeader config", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    applyExtraParamsToAgent(agent, undefined, "minimax", "MiniMax-M2.5");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "minimax",
+      id: "MiniMax-M2.5",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-minimax-test",
+      headers: { "anthropic-version": "2023-06-01", "x-api-key": "stale", "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.apiKey).toBeUndefined();
+    expect(calls[0]?.headers).toEqual({
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer sk-minimax-test",
+      "X-Custom": "1",
+    });
+  });
+
   it("keeps apiKey auth mode for anthropic-compatible custom providers when authHeader is disabled", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1470,6 +1470,80 @@ describe("applyExtraParamsToAgent", () => {
     expect(headers).toEqual({ "X-Custom": "1" });
   });
 
+  it("uses Authorization header for anthropic-compatible custom providers when authHeader is enabled", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      models: {
+        providers: {
+          "ai-in-one": {
+            baseUrl: "https://ai.leessmin.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [],
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "ai-in-one", "claude-opus-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "ai-in-one",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-proxy-test",
+      headers: { "anthropic-version": "2023-06-01", "x-api-key": "stale", "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers).toEqual({
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer sk-proxy-test",
+      "x-api-key": null,
+      "X-Custom": "1",
+    });
+  });
+
+  it("does not add Authorization header for anthropic-compatible custom providers when authHeader is disabled", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      models: {
+        providers: {
+          "ai-in-one": {
+            baseUrl: "https://ai.leessmin.com",
+            api: "anthropic-messages",
+            models: [],
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "ai-in-one", "claude-opus-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "ai-in-one",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-proxy-test",
+      headers: { "anthropic-version": "2023-06-01", "x-api-key": "stale", "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers).toEqual({
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "stale",
+      "X-Custom": "1",
+    });
+  });
+
   it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
     const calls: Array<SimpleStreamOptions | undefined> = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1476,7 +1476,7 @@ describe("applyExtraParamsToAgent", () => {
       models: {
         providers: {
           "ai-in-one": {
-            baseUrl: "https://ai.leessmin.com",
+            baseUrl: "https://proxy.example.com",
             api: "anthropic-messages",
             authHeader: true,
             models: [],
@@ -1514,7 +1514,7 @@ describe("applyExtraParamsToAgent", () => {
       models: {
         providers: {
           "ai-in-one": {
-            baseUrl: "https://ai.leessmin.com",
+            baseUrl: "https://proxy.example.com",
             api: "anthropic-messages",
             models: [],
           },

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -327,6 +327,8 @@ function deleteHeaderCaseInsensitive(headers: Record<string, string>, headerName
   }
 }
 
+const IMPLICIT_ANTHROPIC_AUTH_HEADER_PROVIDERS = new Set(["minimax", "minimax-portal"]);
+
 function shouldUseAnthropicAuthorizationHeader(
   cfg: OpenClawConfig | undefined,
   provider: unknown,
@@ -334,7 +336,10 @@ function shouldUseAnthropicAuthorizationHeader(
   if (typeof provider !== "string" || !provider.trim()) {
     return false;
   }
-  return cfg?.models?.providers?.[provider]?.authHeader === true;
+  if (cfg?.models?.providers?.[provider]?.authHeader === true) {
+    return true;
+  }
+  return IMPLICIT_ANTHROPIC_AUTH_HEADER_PROVIDERS.has(provider);
 }
 
 export function createAnthropicAuthHeaderWrapper(

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -318,6 +318,15 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
   };
 }
 
+function deleteHeaderCaseInsensitive(headers: Record<string, string>, headerName: string): void {
+  const target = headerName.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === target) {
+      delete headers[key];
+    }
+  }
+}
+
 function shouldUseAnthropicAuthorizationHeader(
   cfg: OpenClawConfig | undefined,
   provider: unknown,
@@ -346,10 +355,13 @@ export function createAnthropicAuthHeaderWrapper(
       ...options.headers,
       Authorization: `Bearer ${options.apiKey}`,
     };
-    delete headers["x-api-key"];
+    deleteHeaderCaseInsensitive(headers, "authorization");
+    deleteHeaderCaseInsensitive(headers, "x-api-key");
+    headers.Authorization = `Bearer ${options.apiKey}`;
 
     return underlying(model, context, {
       ...options,
+      apiKey: undefined,
       headers,
     });
   };

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -336,8 +336,9 @@ function shouldUseAnthropicAuthorizationHeader(
   if (typeof provider !== "string" || !provider.trim()) {
     return false;
   }
-  if (cfg?.models?.providers?.[provider]?.authHeader === true) {
-    return true;
+  const explicitProvider = cfg?.models?.providers?.[provider];
+  if (explicitProvider && "authHeader" in explicitProvider) {
+    return explicitProvider.authHeader === true;
   }
   return IMPLICIT_ANTHROPIC_AUTH_HEADER_PROVIDERS.has(provider);
 }

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -342,13 +342,15 @@ export function createAnthropicAuthHeaderWrapper(
       return underlying(model, context, options);
     }
 
+    const headers = {
+      ...options.headers,
+      Authorization: `Bearer ${options.apiKey}`,
+    };
+    delete headers["x-api-key"];
+
     return underlying(model, context, {
       ...options,
-      headers: {
-        ...options.headers,
-        Authorization: `Bearer ${options.apiKey}`,
-        "x-api-key": null as unknown as string,
-      },
+      headers,
     });
   };
 }

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveFastModeParam } from "../fast-mode.js";
 import {
   requiresOpenAiCompatibleAnthropicToolPayload,
@@ -312,6 +313,41 @@ export function createAnthropicToolPayloadCompatibilityWrapper(
           }
         }
         return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
+function shouldUseAnthropicAuthorizationHeader(
+  cfg: OpenClawConfig | undefined,
+  provider: unknown,
+): boolean {
+  if (typeof provider !== "string" || !provider.trim()) {
+    return false;
+  }
+  return cfg?.models?.providers?.[provider]?.authHeader === true;
+}
+
+export function createAnthropicAuthHeaderWrapper(
+  baseStreamFn: StreamFn | undefined,
+  cfg: OpenClawConfig | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (
+      model.api !== "anthropic-messages" ||
+      !shouldUseAnthropicAuthorizationHeader(cfg, model.provider) ||
+      !options?.apiKey
+    ) {
+      return underlying(model, context, options);
+    }
+
+    return underlying(model, context, {
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${options.apiKey}`,
+        "x-api-key": null as unknown as string,
       },
     });
   };

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  createAnthropicAuthHeaderWrapper,
   createAnthropicBetaHeadersWrapper,
   createAnthropicFastModeWrapper,
   createAnthropicToolPayloadCompatibilityWrapper,
@@ -362,6 +363,8 @@ export function applyExtraParamsToAgent(
     log.debug(`applying extraParams to agent streamFn for ${provider}/${modelId}`);
     agent.streamFn = wrappedStreamFn;
   }
+
+  agent.streamFn = createAnthropicAuthHeaderWrapper(agent.streamFn, cfg);
 
   const anthropicBetas = resolveAnthropicBetas(merged, provider, modelId);
   if (anthropicBetas?.length) {

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -262,6 +262,48 @@ describe("promptCustomApiConfig", () => {
     expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
 
+  it("uses authHeader during unknown anthropic detection for an existing equivalent endpoint", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com/v1/", "test-key", "new-model", "custom", "alias"],
+      select: ["plaintext", "unknown"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: false, status: 404 }, { ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "existing-model",
+                name: "Existing",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondCall = fetchMock.mock.calls[1]?.[1] as
+      | { headers?: Record<string, string>; body?: string }
+      | undefined;
+    expect(secondCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer test-key",
+    });
+    expect(JSON.parse(secondCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+  });
+
   it("re-prompts base url when unknown detection fails", async () => {
     const prompter = createTestPrompter({
       text: [

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -403,7 +403,7 @@ describe("promptCustomApiConfig", () => {
 });
 
 describe("applyCustomApiConfig", () => {
-  it("preserves authHeader for anthropic custom providers when re-verifying", async () => {
+  it("preserves authHeader for the matching anthropic custom provider when re-verifying", async () => {
     const prompter = createTestPrompter({
       text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
       select: ["plaintext", "anthropic"],
@@ -429,6 +429,21 @@ describe("applyCustomApiConfig", () => {
               },
             ],
           },
+          "custom-other": {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            models: [
+              {
+                id: "other-model",
+                name: "Other",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
         },
       },
     });
@@ -440,6 +455,61 @@ describe("applyCustomApiConfig", () => {
       "Content-Type": "application/json",
       "anthropic-version": "2023-06-01",
       Authorization: "Bearer test-key",
+    });
+  });
+
+  it("does not inherit authHeader from a different provider that shares the same base url", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            models: [
+              {
+                id: "detected-model",
+                name: "Detected",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+          "custom-other": {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "other-model",
+                name: "Other",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "test-key",
     });
   });
 

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -262,6 +262,27 @@ describe("promptCustomApiConfig", () => {
     expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
 
+  it("uses authHeader during anthropic verification for implicit minimax endpoints", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://api.minimax.io/anthropic", "test-key", "MiniMax-M2.5", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string>; body?: string }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer test-key",
+    });
+    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+  });
+
   it("uses authHeader during unknown anthropic detection for an existing equivalent endpoint", async () => {
     const prompter = createTestPrompter({
       text: ["https://example.com/v1/", "test-key", "new-model", "custom", "alias"],

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -458,6 +458,46 @@ describe("applyCustomApiConfig", () => {
     });
   });
 
+  it("preserves authHeader when adding a new model to an existing equivalent anthropic endpoint", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com/v1/", "test-key", "new-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "existing-model",
+                name: "Existing",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer test-key",
+    });
+  });
+
   it("does not inherit authHeader from a different provider that shares the same base url", async () => {
     const prompter = createTestPrompter({
       text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
@@ -491,6 +531,62 @@ describe("applyCustomApiConfig", () => {
               {
                 id: "other-model",
                 name: "Other",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "test-key",
+    });
+  });
+
+  it("falls back to x-api-key when equivalent anthropic endpoints are ambiguous for a new model", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com/v1", "test-key", "new-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "existing-model-a",
+                name: "Existing A",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+          "custom-other": {
+            baseUrl: "https://example.com/v1/",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "existing-model-b",
+                name: "Existing B",
                 contextWindow: 131072,
                 maxTokens: 4096,
                 input: ["text"],

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -513,6 +513,46 @@ describe("applyCustomApiConfig", () => {
     });
   });
 
+  it("preserves authHeader when anthropic base urls differ only by /v1 or trailing slash", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com/v1/", "test-key", "detected-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "detected-model",
+                name: "Detected",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer test-key",
+    });
+  });
+
   it.each([
     {
       name: "uses hard-min context window for newly added custom models",

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -242,6 +242,26 @@ describe("promptCustomApiConfig", () => {
     expect(JSON.parse(secondCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
 
+  it("uses x-api-key for anthropic verification probes by default", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter);
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string>; body?: string }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "test-key",
+    });
+    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+  });
+
   it("re-prompts base url when unknown detection fails", async () => {
     const prompter = createTestPrompter({
       text: [
@@ -383,6 +403,46 @@ describe("promptCustomApiConfig", () => {
 });
 
 describe("applyCustomApiConfig", () => {
+  it("preserves authHeader for anthropic custom providers when re-verifying", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
+      select: ["plaintext", "anthropic"],
+    });
+    const fetchMock = stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(prompter, {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [
+              {
+                id: "detected-model",
+                name: "Detected",
+                contextWindow: 131072,
+                maxTokens: 4096,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(firstCall?.headers).toEqual({
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+      Authorization: "Bearer test-key",
+    });
+  });
+
   it.each([
     {
       name: "uses hard-min context window for newly added custom models",

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -762,6 +762,11 @@ export async function promptCustomApiConfig(params: {
           baseUrl,
           apiKey: resolvedApiKey,
           modelId,
+          authHeader: resolveAnthropicVerificationAuthHeader({
+            baseUrl,
+            modelId,
+            providers: config.models?.providers ?? {},
+          }),
         });
         if (anthropicProbe.ok) {
           probeSpinner.stop("Detected Anthropic-compatible endpoint.");

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -763,6 +763,7 @@ export async function promptCustomApiConfig(params: {
                 (provider) =>
                   provider?.api === "anthropic-messages" &&
                   provider?.baseUrl === baseUrl &&
+                  provider?.models?.some((existingModel) => existingModel.id === modelId) &&
                   provider?.authHeader === true,
               ) || false,
           })

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -65,6 +65,41 @@ function normalizeAnthropicProviderBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
 }
 
+function resolveAnthropicVerificationAuthHeader(params: {
+  baseUrl: string;
+  modelId: string;
+  providers: Record<string, ModelProviderConfig | undefined>;
+}): boolean {
+  const matchingProviders = Object.values(params.providers).filter(
+    (provider) =>
+      provider?.api === "anthropic-messages" &&
+      normalizeAnthropicProviderBaseUrl(provider.baseUrl ?? "") ===
+        normalizeAnthropicProviderBaseUrl(params.baseUrl),
+  );
+
+  if (matchingProviders.length === 0) {
+    return false;
+  }
+
+  const modelMatches = matchingProviders.filter((provider) =>
+    provider?.models?.some((existingModel) => existingModel.id === params.modelId),
+  );
+
+  if (modelMatches.length === 1) {
+    return modelMatches[0]?.authHeader === true;
+  }
+
+  if (modelMatches.length > 1) {
+    return false;
+  }
+
+  if (matchingProviders.length === 1) {
+    return matchingProviders[0]?.authHeader === true;
+  }
+
+  return false;
+}
+
 export type CustomApiCompatibility = "openai" | "anthropic";
 type CustomApiCompatibilityChoice = CustomApiCompatibility | "unknown";
 export type CustomApiResult = {
@@ -756,22 +791,17 @@ export async function promptCustomApiConfig(params: {
     }
 
     const verifySpinner = prompter.progress("Verifying...");
-    const normalizedAnthropicBaseUrl = normalizeAnthropicProviderBaseUrl(baseUrl);
     const result =
       compatibility === "anthropic"
         ? await requestAnthropicVerification({
             baseUrl,
             apiKey: resolvedApiKey,
             modelId,
-            authHeader:
-              Object.values(config.models?.providers ?? {}).some(
-                (provider) =>
-                  provider?.api === "anthropic-messages" &&
-                  normalizeAnthropicProviderBaseUrl(provider?.baseUrl ?? "") ===
-                    normalizedAnthropicBaseUrl &&
-                  provider?.models?.some((existingModel) => existingModel.id === modelId) &&
-                  provider?.authHeader === true,
-              ) || false,
+            authHeader: resolveAnthropicVerificationAuthHeader({
+              baseUrl,
+              modelId,
+              providers: config.models?.providers ?? {},
+            }),
           })
         : await requestOpenAiVerification({ baseUrl, apiKey: resolvedApiKey, modelId });
     if (result.ok) {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -1,6 +1,7 @@
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
+import { buildMinimaxProvider } from "../agents/models-config.providers.static.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-models.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
@@ -65,12 +66,24 @@ function normalizeAnthropicProviderBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
 }
 
+function buildAnthropicVerificationProviderSet(
+  providers: Record<string, ModelProviderConfig | undefined>,
+): Record<string, ModelProviderConfig | undefined> {
+  if (providers.minimax || providers["minimax-portal"]) {
+    return providers;
+  }
+  return {
+    minimax: buildMinimaxProvider(),
+    ...providers,
+  };
+}
+
 function resolveAnthropicVerificationAuthHeader(params: {
   baseUrl: string;
   modelId: string;
   providers: Record<string, ModelProviderConfig | undefined>;
 }): boolean {
-  const matchingProviders = Object.values(params.providers).filter(
+  const matchingProviders = Object.values(buildAnthropicVerificationProviderSet(params.providers)).filter(
     (provider) =>
       provider?.api === "anthropic-messages" &&
       normalizeAnthropicProviderBaseUrl(provider.baseUrl ?? "") ===

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -61,6 +61,10 @@ function transformAzureUrl(baseUrl: string, modelId: string): string {
   return `${normalizedUrl}/openai/deployments/${modelId}`;
 }
 
+function normalizeAnthropicProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
+}
+
 export type CustomApiCompatibility = "openai" | "anthropic";
 type CustomApiCompatibilityChoice = CustomApiCompatibility | "unknown";
 export type CustomApiResult = {
@@ -752,6 +756,7 @@ export async function promptCustomApiConfig(params: {
     }
 
     const verifySpinner = prompter.progress("Verifying...");
+    const normalizedAnthropicBaseUrl = normalizeAnthropicProviderBaseUrl(baseUrl);
     const result =
       compatibility === "anthropic"
         ? await requestAnthropicVerification({
@@ -762,7 +767,8 @@ export async function promptCustomApiConfig(params: {
               Object.values(config.models?.providers ?? {}).some(
                 (provider) =>
                   provider?.api === "anthropic-messages" &&
-                  provider?.baseUrl === baseUrl &&
+                  normalizeAnthropicProviderBaseUrl(provider?.baseUrl ?? "") ===
+                    normalizedAnthropicBaseUrl &&
                   provider?.models?.some((existingModel) => existingModel.id === modelId) &&
                   provider?.authHeader === true,
               ) || false,

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -233,12 +233,16 @@ function buildOpenAiHeaders(apiKey: string) {
   return headers;
 }
 
-function buildAnthropicHeaders(apiKey: string) {
+function buildAnthropicHeaders(apiKey: string, authHeader = false) {
   const headers: Record<string, string> = {
     "anthropic-version": "2023-06-01",
   };
   if (apiKey) {
-    headers["x-api-key"] = apiKey;
+    if (authHeader) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    } else {
+      headers["x-api-key"] = apiKey;
+    }
   }
   return headers;
 }
@@ -357,6 +361,7 @@ async function requestAnthropicVerification(params: {
   baseUrl: string;
   apiKey: string;
   modelId: string;
+  authHeader?: boolean;
 }): Promise<VerificationResult> {
   // Use a base URL with /v1 injected for this raw fetch only. The rest of the app uses the
   // Anthropic client, which appends /v1 itself; config should store the base URL
@@ -371,7 +376,7 @@ async function requestAnthropicVerification(params: {
   });
   return await requestVerification({
     endpoint,
-    headers: buildAnthropicHeaders(params.apiKey),
+    headers: buildAnthropicHeaders(params.apiKey, params.authHeader === true),
     body: {
       model: params.modelId,
       max_tokens: 1,
@@ -749,7 +754,18 @@ export async function promptCustomApiConfig(params: {
     const verifySpinner = prompter.progress("Verifying...");
     const result =
       compatibility === "anthropic"
-        ? await requestAnthropicVerification({ baseUrl, apiKey: resolvedApiKey, modelId })
+        ? await requestAnthropicVerification({
+            baseUrl,
+            apiKey: resolvedApiKey,
+            modelId,
+            authHeader:
+              Object.values(config.models?.providers ?? {}).some(
+                (provider) =>
+                  provider?.api === "anthropic-messages" &&
+                  provider?.baseUrl === baseUrl &&
+                  provider?.authHeader === true,
+              ) || false,
+          })
         : await requestOpenAiVerification({ baseUrl, apiKey: resolvedApiKey, modelId });
     if (result.ok) {
       verifySpinner.stop("Verification successful.");


### PR DESCRIPTION
## Summary

- Problem: custom providers using `api: "anthropic-messages"` did not honor `models.providers.*.authHeader` in the runtime request path, and Anthropic custom-endpoint verification also defaulted to Anthropic-style auth headers.
- Why it matters: Anthropic-compatible gateways/proxies that require `Authorization: Bearer <token>` could fail with authentication errors even when users explicitly configured `authHeader: true`.
- What changed: added a runtime wrapper that applies `Authorization: Bearer <apiKey>` for `anthropic-messages` providers when `authHeader === true`, clears `x-api-key` in that path, and made custom Anthropic endpoint verification respect the same setting.
- What did NOT change (scope boundary): default native Anthropic auth behavior did not change; custom Anthropic-compatible providers without `authHeader: true` are unchanged; no non-Anthropic adapters were modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Custom providers configured with `api: "anthropic-messages"` and `authHeader: true` now send `Authorization: Bearer <apiKey>` at runtime instead of relying on `x-api-key`.
- In the same configuration, custom Anthropic endpoint verification during onboarding now uses `Authorization: Bearer <apiKey>` instead of `x-api-key`.
- Default behavior for native Anthropic providers and custom Anthropic-compatible providers without `authHeader: true` is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - This PR changes how existing API credentials are serialized into outbound HTTP headers for a narrow, explicitly opted-in case (`api: "anthropic-messages"` + `authHeader: true`).
  - Risk: sending both `Authorization` and `x-api-key` could create ambiguous auth behavior on some proxies.
  - Mitigation: in the opted-in path, the runtime explicitly injects `Authorization: Bearer ...` and clears `x-api-key` to avoid conflicting auth styles. The default path is unchanged.

## Repro + Verification

### Environment

- OS: Windows 11 Pro 10.0.22631
- Runtime/container: local Node/pnpm dev environment
- Model/provider: custom provider with `api: "anthropic-messages"`
- Integration/channel (if any): None
- Relevant config (redacted):

```json
{
  "models": {
    "providers": {
      "custom-provider": {
        "baseUrl": "https://example.com",
        "api": "anthropic-messages",
        "authHeader": true,
        "models": [
          {
            "id": "claude-opus-4-6",
            "name": "Claude Opus 4.6",
            "reasoning": false,
            "input": ["text"],
            "cost": {
              "input": 0,
              "output": 0,
              "cacheRead": 0,
              "cacheWrite": 0
            },
            "contextWindow": 170000,
            "maxTokens": 64000
          }
        ]
      }
    }
  }
}
```

### Steps

1. Configure a custom provider with `api: "anthropic-messages"` and `authHeader: true`.
2. Trigger a runtime model call, or run custom endpoint verification during onboarding.
3. Observe the outbound auth header behavior.

### Expected

- Runtime and verification requests use `Authorization: Bearer <apiKey>`.
- `x-api-key` is not used in the opted-in path.

### Actual

- Before this patch, the Anthropic-compatible path did not honor `authHeader: true`.
- Runtime/verification behavior could still follow Anthropic-style auth semantics and fail against Bearer-only proxies/gateways.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts`
  - Ran `pnpm test -- src/commands/onboard-custom.test.ts`
  - Confirmed the runtime wrapper injects `Authorization: Bearer ...` and clears `x-api-key` when `authHeader: true` is configured for a custom `anthropic-messages` provider.
  - Confirmed Anthropic custom-endpoint verification still defaults to `x-api-key` unless the existing provider config explicitly enables `authHeader: true`.
- Edge cases checked:
  - `authHeader: true` path for custom Anthropic-compatible providers
  - default/no-`authHeader` path remains unchanged
  - non-Anthropic adapters not touched by this patch
- What you did **not** verify:
  - Did not manually verify against a live third-party Anthropic-compatible gateway in this PR.
  - Did not run the full repository test suite; only focused suites for the touched paths were run.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit, or stop setting `authHeader: true` for the affected custom Anthropic-compatible provider.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts`
  - `src/agents/pi-embedded-runner/extra-params.ts`
  - `src/commands/onboard-custom.ts`
  - remove the related tests if reverting the behavior entirely
- Known bad symptoms reviewers should watch for:
  - Native Anthropic requests unexpectedly switching to `Authorization`
  - Custom Anthropic-compatible providers receiving both `Authorization` and `x-api-key`
  - Onboarding verification using Bearer auth when `authHeader` is not enabled

## Risks and Mitigations

- Risk: a custom provider with `api: "anthropic-messages"` and `authHeader: true` might rely on the previous `x-api-key` behavior despite the config name implying Authorization-header auth.
  - Mitigation: the behavior change is gated strictly behind explicit opt-in (`authHeader: true`), and the default path remains unchanged.
- Risk: runtime and onboarding verification could diverge again in future changes.
  - Mitigation: added focused tests for both runtime wrapper behavior and onboarding verification behavior.
- Risk: clearing `x-api-key` could expose assumptions in downstream code/tests.
  - Mitigation: covered the opted-in path explicitly in tests and preserved all other existing headers (such as `anthropic-version`).
