### PR TITLE
fix(cli): resolve gateway host from bind mode and surface auth hint on silent disconnect

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -8,6 +8,7 @@ import {
 } from "../config/config.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { resolveSecretInputString } from "../secrets/resolve-secret-input-string.js";
 import {
@@ -147,6 +148,23 @@ export function ensureExplicitGatewayAuth(params: {
   throw new Error(message);
 }
 
+/**
+ * Resolve the host the CLI should connect to based on the gateway bind mode.
+ * tailnet/custom bind to a specific interface; loopback and lan accept on 127.0.0.1.
+ */
+function resolveLocalHostForBind(bindMode: string, customBindHost?: string): string {
+  if (bindMode === "tailnet") {
+    return pickPrimaryTailnetIPv4() ?? "127.0.0.1";
+  }
+  if (bindMode === "custom") {
+    const host = customBindHost?.trim();
+    if (host) {
+      return host;
+    }
+  }
+  return "127.0.0.1";
+}
+
 export function buildGatewayConnectionDetails(
   options: {
     config?: OpenClawConfig;
@@ -164,8 +182,11 @@ export function buildGatewayConnectionDetails(
   const localPort = resolveGatewayPort(config);
   const bindMode = config.gateway?.bind ?? "loopback";
   const scheme = tlsEnabled ? "wss" : "ws";
-  // Self-connections should always target loopback; bind mode only controls listener exposure.
-  const localUrl = `${scheme}://127.0.0.1:${localPort}`;
+  // Derive local connection host from bind mode: tailnet/custom bind to a specific interface
+  // that may not include loopback, so the CLI must target the same address the server listens on.
+  // lan (0.0.0.0) and loopback always accept connections on 127.0.0.1.
+  const localHost = resolveLocalHostForBind(bindMode, config.gateway?.customBindHost);
+  const localUrl = `${scheme}://${localHost}:${localPort}`;
   const cliUrlOverride =
     typeof options.url === "string" && options.url.trim().length > 0
       ? options.url.trim()
@@ -742,12 +763,17 @@ function formatGatewayCloseError(
   code: number,
   reason: string,
   connectionDetails: GatewayConnectionDetails,
+  authHint?: string,
 ): string {
   const reasonText = reason?.trim() || "no close reason";
   const hint =
     code === 1006 ? "abnormal closure (no close frame)" : code === 1000 ? "normal closure" : "";
   const suffix = hint ? ` ${hint}` : "";
-  return `gateway closed (${code}${suffix}): ${reasonText}\n${connectionDetails.message}`;
+  // Surface auth hint when the gateway closes without an explicit reason — a common
+  // symptom of missing or rejected credentials.
+  const authLine =
+    authHint && (code === 1000 || code === 1008) && !reason?.trim() ? `\n${authHint}` : "";
+  return `gateway closed (${code}${suffix}): ${reasonText}${authLine}\n${connectionDetails.message}`;
 }
 
 function formatGatewayTimeoutError(
@@ -796,6 +822,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   timeoutMs: number;
   safeTimerTimeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
+  authHint?: string;
 }): Promise<T> {
   const { opts, scopes, url, token, password, tlsFingerprint, timeoutMs, safeTimerTimeoutMs } =
     params;
@@ -859,7 +886,11 @@ async function executeGatewayRequestWithScopes<T>(params: {
         }
         ignoreClose = true;
         client.stop();
-        stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
+        stop(
+          new Error(
+            formatGatewayCloseError(code, reason, params.connectionDetails, params.authHint),
+          ),
+        );
       },
     });
 
@@ -898,6 +929,13 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;
+  // Build auth hint for better error messages when the gateway rejects unauthenticated connections.
+  const authMode = context.config.gateway?.auth?.mode;
+  const hasResolvedAuth = Boolean(token || password);
+  const authHint =
+    authMode && authMode !== "none" && !hasResolvedAuth
+      ? `Authentication required — pass --token or configure gateway.auth.token in ${context.configPath}`
+      : undefined;
   return await executeGatewayRequestWithScopes<T>({
     opts,
     scopes,
@@ -908,6 +946,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     timeoutMs,
     safeTimerTimeoutMs,
     connectionDetails,
+    authHint,
   });
 }
 


### PR DESCRIPTION
## Problem

Two related bugs that make the gateway unusable with CLI tools when non-default bind or auth settings are configured:

### Bug 1: CLI fails silently when `gateway.auth.mode = "token"` is set

When a user configures token auth in `openclaw.json`, all CLI tools (`openclaw cron list`, `openclaw sessions list`, etc.) fail with:
```
gateway closed (1000 normal closure): no close reason
```
There is no indication that authentication is required. The user has no idea what went wrong.

### Bug 2: CLI hardcodes `127.0.0.1` regardless of `gateway.bind` mode

When `gateway.bind = "tailnet"`, the gateway listens on the Tailscale IP (e.g. `100.88.110.43`) — not loopback. But CLI tools always try `ws://127.0.0.1:18789` and fail to connect entirely.

Same issue applies to `gateway.bind = "custom"` with a `customBindHost`.

## Fix

**`src/gateway/call.ts`**

1. Added `resolveLocalHostForBind()` — derives the correct connection host from `gateway.bind` config:
   - `tailnet` → `pickPrimaryTailnetIPv4()` (already used elsewhere in the codebase)
   - `custom` → `gateway.customBindHost`
   - `loopback` / `lan` / anything else → `127.0.0.1` (existing behaviour preserved)

2. Added auth hint to `formatGatewayCloseError()` — when the gateway closes with code 1000 or 1008 and no reason, and the config has auth enabled but no token was resolved, appends:
   ```
   Authentication required — pass --token or configure gateway.auth.token in ~/.openclaw/openclaw.json
   ```

## Reproducer

```json
// ~/.openclaw/openclaw.json
{
  "gateway": {
    "bind": "tailnet",
    "auth": { "mode": "token", "token": "your-token" }
  }
}
```

Then run `openclaw cron list` — previously failed silently, now works correctly (or gives a clear auth error if the token is missing).

## Notes

- No new dependencies
- `pickPrimaryTailnetIPv4` is already imported elsewhere in the codebase
- Behaviour is fully backwards-compatible — loopback bind still targets `127.0.0.1`