### PR TITLE
feat: per-agent session maintenance config overrides

### DIFF
--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -162,7 +162,7 @@ async function previewStoreCleanup(params: {
   activeKey?: string;
   fixMissing?: boolean;
 }) {
-  const maintenance = resolveMaintenanceConfig();
+  const maintenance = resolveMaintenanceConfig(params.target.agentId);
   const beforeStore = loadSessionStore(params.target.storePath, { skipCache: true });
   const previewStore = structuredClone(beforeStore);
   const staleKeys = new Set<string>();
@@ -371,6 +371,7 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
         });
       },
       {
+        agentId: target.agentId,
         activeSessionKey: opts.activeKey,
         maintenanceOverride: {
           mode,

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -293,7 +293,6 @@ function renderStoreDryRunPlan(params: {
 export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runtime: RuntimeEnv) {
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
-  const mode = opts.enforce ? "enforce" : resolveMaintenanceConfig().mode;
   const targets = resolveSessionStoreTargetsOrExit({
     cfg,
     opts: {
@@ -312,9 +311,10 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
     actionRows: SessionCleanupActionRow[];
   }> = [];
   for (const target of targets) {
+    const targetMode = opts.enforce ? "enforce" : resolveMaintenanceConfig(target.agentId).mode;
     const result = await previewStoreCleanup({
       target,
-      mode,
+      mode: targetMode,
       dryRun: Boolean(opts.dryRun),
       activeKey: opts.activeKey,
       fixMissing: Boolean(opts.fixMissing),
@@ -330,7 +330,6 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
       }
       writeRuntimeJson(runtime, {
         allAgents: true,
-        mode,
         dryRun: true,
         stores: previewResults.map((result) => result.summary),
       });
@@ -356,6 +355,7 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
 
   const appliedSummaries: SessionCleanupSummary[] = [];
   for (const target of targets) {
+    const targetMode = opts.enforce ? "enforce" : resolveMaintenanceConfig(target.agentId).mode;
     const appliedReportRef: { current: SessionMaintenanceApplyReport | null } = {
       current: null,
     };
@@ -374,7 +374,7 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
         agentId: target.agentId,
         activeSessionKey: opts.activeKey,
         maintenanceOverride: {
-          mode,
+          mode: targetMode,
         },
         onMaintenanceApplied: (report) => {
           appliedReportRef.current = report;
@@ -390,7 +390,7 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
             ...(preview?.summary ?? {
               agentId: target.agentId,
               storePath: target.storePath,
-              mode,
+              mode: targetMode,
               dryRun: false,
               beforeCount: 0,
               afterCount: 0,
@@ -436,7 +436,6 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
     }
     writeRuntimeJson(runtime, {
       allAgents: true,
-      mode,
       dryRun: false,
       stores: appliedSummaries,
     });

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4031,6 +4031,80 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                   },
                   additionalProperties: false,
                 },
+                maintenance: {
+                  type: "object",
+                  properties: {
+                    mode: {
+                      type: "string",
+                      enum: ["enforce", "warn"],
+                    },
+                    pruneAfter: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                    pruneDays: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxEntries: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    rotateBytes: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                    resetArchiveRetention: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                        {
+                          type: "boolean",
+                          const: false,
+                        },
+                      ],
+                    },
+                    maxDiskBytes: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                    highWaterBytes: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                  },
+                  additionalProperties: false,
+                },
                 sandbox: {
                   type: "object",
                   properties: {

--- a/src/config/sessions/store-maintenance.per-agent.test.ts
+++ b/src/config/sessions/store-maintenance.per-agent.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock config loading to control test inputs.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+import { loadConfig } from "../config.js";
+import { resolveMaintenanceConfig } from "./store-maintenance.js";
+
+const mockLoadConfig = vi.mocked(loadConfig);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Per-agent session maintenance config resolution.
+// ---------------------------------------------------------------------------
+
+describe("resolveMaintenanceConfig with agentId", () => {
+  it("returns global config when no agentId is provided", () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "7d",
+          maxEntries: 200,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "worker",
+            maintenance: { mode: "warn", maxEntries: 50 },
+          },
+        ],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig();
+
+    expect(result.mode).toBe("enforce");
+    expect(result.maxEntries).toBe(200);
+    expect(result.pruneAfterMs).toBe(7 * DAY_MS);
+  });
+
+  it("merges per-agent overrides over global config", () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "30d",
+          maxEntries: 500,
+          rotateBytes: "10mb",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "approval",
+            maintenance: {
+              mode: "warn",
+              maxEntries: 50,
+              pruneAfter: "1d",
+            },
+          },
+        ],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("approval");
+
+    expect(result.mode).toBe("warn");
+    expect(result.maxEntries).toBe(50);
+    expect(result.pruneAfterMs).toBe(1 * DAY_MS);
+    // rotateBytes falls through from global.
+    expect(result.rotateBytes).toBe(10_485_760);
+  });
+
+  it("falls through to global when agent has no maintenance config", () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          maxEntries: 300,
+        },
+      },
+      agents: {
+        list: [{ id: "worker" }],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("worker");
+
+    expect(result.mode).toBe("enforce");
+    expect(result.maxEntries).toBe(300);
+  });
+
+  it("falls through to global when agent is not found in list", () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          maxEntries: 100,
+        },
+      },
+      agents: {
+        list: [{ id: "other" }],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("nonexistent");
+
+    expect(result.mode).toBe("enforce");
+    expect(result.maxEntries).toBe(100);
+  });
+
+  it("uses built-in defaults when no global or per-agent config exists", () => {
+    mockLoadConfig.mockReturnValue({} as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("any-agent");
+
+    expect(result.mode).toBe("warn");
+    expect(result.maxEntries).toBe(500);
+    expect(result.pruneAfterMs).toBe(30 * DAY_MS);
+    expect(result.rotateBytes).toBe(10_485_760);
+  });
+
+  it("per-agent maxDiskBytes/highWaterBytes override global", () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          maxDiskBytes: "200mb",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "heavy",
+            maintenance: {
+              maxDiskBytes: "500mb",
+              highWaterBytes: "400mb",
+            },
+          },
+        ],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("heavy");
+
+    expect(result.maxDiskBytes).toBe(500 * 1024 * 1024);
+    expect(result.highWaterBytes).toBe(400 * 1024 * 1024);
+  });
+
+  it("per-agent config without global maintenance still works", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: {
+        list: [
+          {
+            id: "standalone",
+            maintenance: {
+              mode: "enforce",
+              pruneAfter: "2d",
+              maxEntries: 10,
+            },
+          },
+        ],
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = resolveMaintenanceConfig("standalone");
+
+    expect(result.mode).toBe("enforce");
+    expect(result.maxEntries).toBe(10);
+    expect(result.pruneAfterMs).toBe(2 * DAY_MS);
+  });
+});

--- a/src/config/sessions/store-maintenance.per-agent.test.ts
+++ b/src/config/sessions/store-maintenance.per-agent.test.ts
@@ -1,14 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock config loading to control test inputs.
 vi.mock("../config.js", () => ({
   loadConfig: vi.fn().mockReturnValue({}),
 }));
 
-import { loadConfig } from "../config.js";
-import { resolveMaintenanceConfig } from "./store-maintenance.js";
-
-const mockLoadConfig = vi.mocked(loadConfig);
+let loadConfig: typeof import("../config.js").loadConfig;
+let resolveMaintenanceConfig: typeof import("./store-maintenance.js").resolveMaintenanceConfig;
+let mockLoadConfig: ReturnType<typeof vi.fn>;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -17,6 +16,16 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // ---------------------------------------------------------------------------
 
 describe("resolveMaintenanceConfig with agentId", () => {
+  beforeAll(async () => {
+    ({ loadConfig } = await import("../config.js"));
+    ({ resolveMaintenanceConfig } = await import("./store-maintenance.js"));
+    mockLoadConfig = vi.mocked(loadConfig) as ReturnType<typeof vi.fn>;
+  });
+
+  beforeEach(() => {
+    mockLoadConfig.mockClear();
+  });
+
   it("returns global config when no agentId is provided", () => {
     mockLoadConfig.mockReturnValue({
       session: {
@@ -34,7 +43,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
           },
         ],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig();
 
@@ -65,7 +74,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
           },
         ],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig("approval");
 
@@ -87,7 +96,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
       agents: {
         list: [{ id: "worker" }],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig("worker");
 
@@ -106,7 +115,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
       agents: {
         list: [{ id: "other" }],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig("nonexistent");
 
@@ -115,7 +124,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
   });
 
   it("uses built-in defaults when no global or per-agent config exists", () => {
-    mockLoadConfig.mockReturnValue({} as ReturnType<typeof loadConfig>);
+    mockLoadConfig.mockReturnValue({});
 
     const result = resolveMaintenanceConfig("any-agent");
 
@@ -143,7 +152,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
           },
         ],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig("heavy");
 
@@ -165,7 +174,7 @@ describe("resolveMaintenanceConfig with agentId", () => {
           },
         ],
       },
-    } as ReturnType<typeof loadConfig>);
+    });
 
     const result = resolveMaintenanceConfig("standalone");
 

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -124,16 +124,58 @@ function resolveHighWaterBytes(
 }
 
 /**
- * Resolve maintenance settings from openclaw.json (`session.maintenance`).
+ * Look up per-agent maintenance overrides from `agents.list[].maintenance`.
+ * Returns `undefined` when the agent has no overrides or is not found.
+ */
+function resolveAgentMaintenanceOverride(
+  agentId: string | undefined,
+): SessionMaintenanceConfig | undefined {
+  if (!agentId) {
+    return undefined;
+  }
+  try {
+    const agents = loadConfig().agents?.list;
+    if (!agents) {
+      return undefined;
+    }
+    const agent = agents.find((a) => a.id === agentId);
+    return agent?.maintenance ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Merge global session.maintenance with per-agent overrides.
+ * Per-agent values take precedence; unset fields fall through to global.
+ */
+function mergeMaintenanceConfig(
+  global: SessionMaintenanceConfig | undefined,
+  perAgent: SessionMaintenanceConfig | undefined,
+): SessionMaintenanceConfig | undefined {
+  if (!perAgent) {
+    return global;
+  }
+  if (!global) {
+    return perAgent;
+  }
+  return { ...global, ...perAgent };
+}
+
+/**
+ * Resolve maintenance settings from openclaw.json (`session.maintenance`),
+ * optionally merging per-agent overrides from `agents.list[].maintenance`.
  * Falls back to built-in defaults when config is missing or unset.
  */
-export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
-  let maintenance: SessionMaintenanceConfig | undefined;
+export function resolveMaintenanceConfig(agentId?: string): ResolvedSessionMaintenanceConfig {
+  let globalMaintenance: SessionMaintenanceConfig | undefined;
   try {
-    maintenance = loadConfig().session?.maintenance;
+    globalMaintenance = loadConfig().session?.maintenance;
   } catch {
     // Config may not be available (e.g. in tests). Use defaults.
   }
+  const agentOverride = resolveAgentMaintenanceOverride(agentId);
+  const maintenance = mergeMaintenanceConfig(globalMaintenance, agentOverride);
   const pruneAfterMs = resolvePruneAfterMs(maintenance);
   const maxDiskBytes = resolveMaxDiskBytes(maintenance);
   return {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -290,6 +290,8 @@ export type { ResolvedSessionMaintenanceConfig, SessionMaintenanceWarning };
 type SaveSessionStoreOptions = {
   /** Skip pruning, capping, and rotation (e.g. during one-time migrations). */
   skipMaintenance?: boolean;
+  /** Agent id for per-agent maintenance config resolution. */
+  agentId?: string;
   /** Active session key for warn-only maintenance. */
   activeSessionKey?: string;
   /**
@@ -393,7 +395,10 @@ async function saveSessionStoreUnlocked(
 
   if (!opts?.skipMaintenance) {
     // Resolve maintenance config once (avoids repeated loadConfig() calls).
-    const maintenance = { ...resolveMaintenanceConfig(), ...opts?.maintenanceOverride };
+    const maintenance = {
+      ...resolveMaintenanceConfig(opts?.agentId),
+      ...opts?.maintenanceOverride,
+    };
     const shouldWarnOnly = maintenance.mode === "warn";
     const beforeCount = Object.keys(store).length;
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,7 +1,7 @@
 import type { ChatType } from "../channels/chat-type.js";
 import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
-import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
+import type { HumanDelayConfig, IdentityConfig, SessionMaintenanceConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
@@ -86,6 +86,8 @@ export type AgentConfig = {
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
   };
+  /** Optional per-agent session maintenance overrides. */
+  maintenance?: SessionMaintenanceConfig;
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -10,6 +10,7 @@ import {
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
+import { SessionMaintenanceSchema } from "./zod-schema.maintenance.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 export const HeartbeatSchema = z
@@ -797,6 +798,7 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    maintenance: SessionMaintenanceSchema,
     sandbox: AgentSandboxSchema,
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,

--- a/src/config/zod-schema.maintenance.ts
+++ b/src/config/zod-schema.maintenance.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { parseByteSize } from "../cli/parse-bytes.js";
+import { parseDurationMs } from "../cli/parse-duration.js";
+
+export const SessionMaintenanceSchema = z
+  .object({
+    mode: z.enum(["enforce", "warn"]).optional(),
+    pruneAfter: z.union([z.string(), z.number()]).optional(),
+    /** @deprecated Use pruneAfter instead. */
+    pruneDays: z.number().int().positive().optional(),
+    maxEntries: z.number().int().positive().optional(),
+    rotateBytes: z.union([z.string(), z.number()]).optional(),
+    resetArchiveRetention: z.union([z.string(), z.number(), z.literal(false)]).optional(),
+    maxDiskBytes: z.union([z.string(), z.number()]).optional(),
+    highWaterBytes: z.union([z.string(), z.number()]).optional(),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    if (val.pruneAfter !== undefined) {
+      try {
+        parseDurationMs(String(val.pruneAfter).trim(), { defaultUnit: "d" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["pruneAfter"],
+          message: "invalid duration (use ms, s, m, h, d)",
+        });
+      }
+    }
+    if (val.rotateBytes !== undefined) {
+      try {
+        parseByteSize(String(val.rotateBytes).trim(), { defaultUnit: "b" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["rotateBytes"],
+          message: "invalid size (use b, kb, mb, gb, tb)",
+        });
+      }
+    }
+    if (val.resetArchiveRetention !== undefined && val.resetArchiveRetention !== false) {
+      try {
+        parseDurationMs(String(val.resetArchiveRetention).trim(), { defaultUnit: "d" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["resetArchiveRetention"],
+          message: "invalid duration (use ms, s, m, h, d)",
+        });
+      }
+    }
+    if (val.maxDiskBytes !== undefined) {
+      try {
+        parseByteSize(String(val.maxDiskBytes).trim(), { defaultUnit: "b" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["maxDiskBytes"],
+          message: "invalid size (use b, kb, mb, gb, tb)",
+        });
+      }
+    }
+    if (val.highWaterBytes !== undefined) {
+      try {
+        parseByteSize(String(val.highWaterBytes).trim(), { defaultUnit: "b" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["highWaterBytes"],
+          message: "invalid size (use b, kb, mb, gb, tb)",
+        });
+      }
+    }
+  })
+  .optional();

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,6 +1,4 @@
 import { z } from "zod";
-import { parseByteSize } from "../cli/parse-bytes.js";
-import { parseDurationMs } from "../cli/parse-duration.js";
 import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import {
@@ -11,7 +9,10 @@ import {
   TypingModeSchema,
   TtsConfigSchema,
 } from "./zod-schema.core.js";
+import { SessionMaintenanceSchema } from "./zod-schema.maintenance.js";
 import { sensitive } from "./zod-schema.sensitive.js";
+
+export { SessionMaintenanceSchema };
 
 const SessionResetConfigSchema = z
   .object({
@@ -69,77 +70,7 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
-    maintenance: z
-      .object({
-        mode: z.enum(["enforce", "warn"]).optional(),
-        pruneAfter: z.union([z.string(), z.number()]).optional(),
-        /** @deprecated Use pruneAfter instead. */
-        pruneDays: z.number().int().positive().optional(),
-        maxEntries: z.number().int().positive().optional(),
-        rotateBytes: z.union([z.string(), z.number()]).optional(),
-        resetArchiveRetention: z.union([z.string(), z.number(), z.literal(false)]).optional(),
-        maxDiskBytes: z.union([z.string(), z.number()]).optional(),
-        highWaterBytes: z.union([z.string(), z.number()]).optional(),
-      })
-      .strict()
-      .superRefine((val, ctx) => {
-        if (val.pruneAfter !== undefined) {
-          try {
-            parseDurationMs(String(val.pruneAfter).trim(), { defaultUnit: "d" });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["pruneAfter"],
-              message: "invalid duration (use ms, s, m, h, d)",
-            });
-          }
-        }
-        if (val.rotateBytes !== undefined) {
-          try {
-            parseByteSize(String(val.rotateBytes).trim(), { defaultUnit: "b" });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["rotateBytes"],
-              message: "invalid size (use b, kb, mb, gb, tb)",
-            });
-          }
-        }
-        if (val.resetArchiveRetention !== undefined && val.resetArchiveRetention !== false) {
-          try {
-            parseDurationMs(String(val.resetArchiveRetention).trim(), { defaultUnit: "d" });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["resetArchiveRetention"],
-              message: "invalid duration (use ms, s, m, h, d)",
-            });
-          }
-        }
-        if (val.maxDiskBytes !== undefined) {
-          try {
-            parseByteSize(String(val.maxDiskBytes).trim(), { defaultUnit: "b" });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["maxDiskBytes"],
-              message: "invalid size (use b, kb, mb, gb, tb)",
-            });
-          }
-        }
-        if (val.highWaterBytes !== undefined) {
-          try {
-            parseByteSize(String(val.highWaterBytes).trim(), { defaultUnit: "b" });
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["highWaterBytes"],
-              message: "invalid size (use b, kb, mb, gb, tb)",
-            });
-          }
-        }
-      })
-      .optional(),
+    maintenance: SessionMaintenanceSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
Closes #52775

## Summary

- Allow each agent to define its own `maintenance` config (mode, pruneAfter, maxEntries, rotateBytes, maxDiskBytes, highWaterBytes) that overrides the global `session.maintenance` settings
- Extract `SessionMaintenanceSchema` into a shared `zod-schema.maintenance.ts` module, reused by both `SessionSchema` and `AgentEntrySchema`
- Merge per-agent overrides over global config in `resolveMaintenanceConfig()`, with unset fields falling through to global defaults
- Thread `agentId` through `sessions-cleanup` and `saveSessionStore` paths

## Motivation

Different agents may have very different session lifecycle needs. A lightweight approval bot might only need 50 sessions retained for 1 day, while a heavy research agent might need 500 sessions for 30 days. This change lets operators tune maintenance per-agent without affecting the global baseline.

## Example config

```json
{
  "session": {
    "maintenance": { "mode": "enforce", "pruneAfter": "30d", "maxEntries": 500 }
  },
  "agents": {
    "list": [
      {
        "id": "approval",
        "maintenance": { "mode": "warn", "maxEntries": 50, "pruneAfter": "1d" }
      }
    ]
  }
}
```

## Test plan

- [x] Added `store-maintenance.per-agent.test.ts` with 7 test cases covering:
  - Global-only config (no agentId)
  - Per-agent overrides merged over global
  - Agent with no maintenance config (falls through)
  - Unknown agentId (falls through)
  - Built-in defaults when no config exists
  - Per-agent maxDiskBytes/highWaterBytes override
  - Per-agent config without global maintenance
- [x] Fixed bug: cleanup command now resolves mode per-target instead of using global mode
- [ ] Run `pnpm test` to verify all tests pass
- [ ] Run `pnpm check` to verify lint/format