### PR TITLE
feat(config): add label for agents.defaults.timeoutSeconds

### DIFF
--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -450,6 +450,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
   "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
+  "agents.defaults.timeoutSeconds": "Timeout (Seconds)",
   "agents.defaults.cliBackends": "CLI Backends",
   "agents.defaults.compaction": "Compaction",
   "agents.defaults.compaction.mode": "Compaction Mode",


### PR DESCRIPTION
Add missing human-readable label for agents.defaults.timeoutSeconds config field