### PR TITLE
fix(ui): preserve openrouter model prefix in chat picker

### DIFF
--- a/test/chat-model-ref.test.ts
+++ b/test/chat-model-ref.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildQualifiedChatModelValue,
+  createChatModelOverride,
+  normalizeChatModelOverrideValue,
+} from "../ui/src/ui/chat-model-ref.ts";
+import type { ModelCatalogEntry } from "../ui/src/ui/types.ts";
+
+describe("chat-model-ref canonical OpenRouter ids", () => {
+  const openRouterCatalog: ModelCatalogEntry[] = [
+    {
+      id: "openrouter/hunter-alpha",
+      name: "Hunter Alpha",
+      provider: "openrouter",
+    },
+  ];
+
+  it("does not duplicate the provider prefix when already provider-native", () => {
+    expect(buildQualifiedChatModelValue("openrouter/hunter-alpha", "openrouter")).toBe(
+      "openrouter/hunter-alpha",
+    );
+  });
+
+  it("preserves canonical OpenRouter-native ids during override normalization", () => {
+    expect(
+      normalizeChatModelOverrideValue(
+        createChatModelOverride("openrouter/hunter-alpha"),
+        openRouterCatalog,
+      ),
+    ).toBe("openrouter/hunter-alpha");
+  });
+});

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -38,6 +38,22 @@ describe("chat-model-ref helpers", () => {
     ).toBe("gpt-5-mini");
   });
 
+  it("normalizes misclassified slash model ids to the matching qualified value", () => {
+    const openRouterCatalog: ModelCatalogEntry[] = [
+      {
+        id: "moonshotai/kimi-k2.5",
+        name: "Kimi K2.5",
+        provider: "openrouter",
+      },
+    ];
+    expect(
+      normalizeChatModelOverrideValue(
+        createChatModelOverride("moonshotai/kimi-k2.5"),
+        openRouterCatalog,
+      ),
+    ).toBe("openrouter/moonshotai/kimi-k2.5");
+  });
+
   it("formats qualified model refs consistently for default labels", () => {
     expect(formatChatModelDisplay("openai/gpt-5-mini")).toBe("gpt-5-mini · openai");
     expect(formatChatModelDisplay("alias-only")).toBe("alias-only");

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -54,6 +54,23 @@ describe("chat-model-ref helpers", () => {
     ).toBe("openrouter/moonshotai/kimi-k2.5");
   });
 
+  it("preserves canonical OpenRouter-native ids without duplicating the provider", () => {
+    const openRouterCatalog: ModelCatalogEntry[] = [
+      {
+        id: "openrouter/hunter-alpha",
+        name: "Hunter Alpha",
+        provider: "openrouter",
+      },
+    ];
+
+    expect(
+      normalizeChatModelOverrideValue(
+        createChatModelOverride("openrouter/hunter-alpha"),
+        openRouterCatalog,
+      ),
+    ).toBe("openrouter/hunter-alpha");
+  });
+
   it("formats qualified model refs consistently for default labels", () => {
     expect(formatChatModelDisplay("openai/gpt-5-mini")).toBe("gpt-5-mini · openai");
     expect(formatChatModelDisplay("alias-only")).toBe("alias-only");

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -42,7 +42,13 @@ export function normalizeChatModelOverrideValue(
     return "";
   }
   if (override.kind === "qualified") {
-    return trimmed;
+    const qualifiedMatch = catalog.some((entry) => {
+      const candidate = buildQualifiedChatModelValue(entry.id, entry.provider);
+      return candidate.toLowerCase() === trimmed.toLowerCase();
+    });
+    if (qualifiedMatch) {
+      return trimmed;
+    }
   }
 
   let matchedValue = "";

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -16,7 +16,18 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
     return "";
   }
   const trimmedProvider = provider?.trim();
-  return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
+  if (!trimmedProvider) {
+    return trimmedModel;
+  }
+
+  // Preserve canonical provider-native ids (for example OpenRouter ids like `openrouter/hunter-alpha`)
+  // so we don't accidentally build `openrouter/openrouter/hunter-alpha`.
+  const providerPrefix = `${trimmedProvider}/`;
+  if (trimmedModel.toLowerCase().startsWith(providerPrefix.toLowerCase())) {
+    return trimmedModel;
+  }
+
+  return `${trimmedProvider}/${trimmedModel}`;
 }
 
 export function createChatModelOverride(value: string): ChatModelOverride | null {


### PR DESCRIPTION
## Summary

- **Problem:** Control UI chat model picker could send OpenRouter-style model IDs (e.g. `moonshotai/kimi-k2.5`) without the `openrouter/` provider prefix, causing `model not allowed` when `agents.defaults.models` keys are fully qualified (`openrouter/moonshotai/...`).
- **Why it matters:** Users cannot switch models from the picker for OpenRouter allowlisted models.
- **What changed:** `normalizeChatModelOverrideValue()` only treats a value as already-qualified if it matches a catalog `provider/id` entry; otherwise it falls through to id-based resolution so `openrouter/` is restored from the catalog.
- **What did NOT change:** Gateway `sessions.patch` / allowlist logic; only client-side normalization.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #50711

## User-visible / Behavior Changes

Chat model selection for OpenRouter models configured with full `openrouter/...` paths now sends the full qualified ref to the gateway.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Steps

1. Configure `agents.defaults.models` with `openrouter/moonshotai/kimi-k2.5` (or similar).
2. Open Control UI → Chat → model dropdown → pick that model.

### Expected

Session model is set to `openrouter/moonshotai/kimi-k2.5` without `model not allowed`.

## Evidence

- [x] Unit test: `ui/src/ui/chat-model-ref.test.ts` (misclassified slash id normalizes to `openrouter/...`)

## Tests

- `pnpm test -- ui/src/ui/chat-model-ref.test.ts ui/src/ui/views/chat.test.ts -t model`
- `pnpm check` (via `scripts/committer` at commit time)