### PR TITLE
Add Task Board phase 1 control-ui slice

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -124,6 +124,7 @@ function createLazy<T>(loader: () => Promise<T>): () => T | null {
 const lazyAgents = createLazy(() => import("./views/agents.ts"));
 const lazyChannels = createLazy(() => import("./views/channels.ts"));
 const lazyCron = createLazy(() => import("./views/cron.ts"));
+const lazyTasks = createLazy(() => import("./views/task-board.ts"));
 const lazyDebug = createLazy(() => import("./views/debug.ts"));
 const lazyInstances = createLazy(() => import("./views/instances.ts"));
 const lazyLogs = createLazy(() => import("./views/logs.ts"));
@@ -662,6 +663,20 @@ export function renderApp(state: AppViewState) {
                 onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
                 onRefreshLogs: () => state.loadOverview(),
               })
+            : nothing
+        }
+
+        ${
+          state.tab === "tasks"
+            ? lazyRender(lazyTasks, (m) =>
+                m.renderTaskBoard({
+                  loading: state.taskBoardLoading,
+                  error: state.taskBoardError,
+                  cards: state.taskBoardCards,
+                  lastLoadedAt: state.taskBoardLastLoadedAt,
+                  onRefresh: () => state.loadTaskBoard(),
+                }),
+              )
             : nothing
         }
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -32,6 +32,7 @@ import {
   type Tab,
 } from "./navigation.ts";
 import { saveSettings, type UiSettings } from "./storage.ts";
+import { loadTaskBoard } from "./task-board/service.ts";
 import { startThemeTransition, type ThemeTransitionContext } from "./theme-transition.ts";
 import { resolveTheme, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type { AgentsListResult, AttentionItem } from "./types.ts";
@@ -228,6 +229,9 @@ export async function refreshActiveTab(host: SettingsHost) {
   }
   if (host.tab === "sessions") {
     await loadSessions(host as unknown as OpenClawApp);
+  }
+  if (host.tab === "tasks") {
+    await loadTaskBoard(host as unknown as Parameters<typeof loadTaskBoard>[0]);
   }
   if (host.tab === "cron") {
     await loadCron(host);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -8,6 +8,7 @@ import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import type { UiSettings } from "./storage.ts";
+import type { TaskBoardCardVM } from "./task-board/types.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ResolvedTheme, ThemeMode, ThemeName } from "./theme.ts";
 import type {
@@ -192,6 +193,10 @@ export type AppViewState = {
   sessionsPage: number;
   sessionsPageSize: number;
   sessionsActionsOpenKey: string | null;
+  taskBoardLoading: boolean;
+  taskBoardError: string | null;
+  taskBoardCards: TaskBoardCardVM[];
+  taskBoardLastLoadedAt: number | null;
   usageLoading: boolean;
   usageResult: SessionsUsageResult | null;
   usageCostSummary: CostUsageSummary | null;
@@ -314,6 +319,7 @@ export type AppViewState = {
     setBorderRadius: (value: number) => void;
     applySettings: (next: UiSettings) => void;
     loadOverview: () => Promise<void>;
+    loadTaskBoard: () => Promise<void>;
     loadAssistantIdentity: () => Promise<void>;
     loadCron: () => Promise<void>;
     handleWhatsAppStart: (force: boolean) => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -62,6 +62,8 @@ import type { SkillMessage } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
+import { loadTaskBoard as loadTaskBoardInternal } from "./task-board/service.ts";
+import type { TaskBoardCardVM } from "./task-board/types.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type {
   AgentsListResult,
@@ -290,6 +292,11 @@ export class OpenClawApp extends LitElement {
   @state() sessionsPage = 0;
   @state() sessionsPageSize = 10;
   @state() sessionsActionsOpenKey: string | null = null;
+
+  @state() taskBoardLoading = false;
+  @state() taskBoardError: string | null = null;
+  @state() taskBoardCards: TaskBoardCardVM[] = [];
+  @state() taskBoardLastLoadedAt: number | null = null;
 
   @state() usageLoading = false;
   @state() usageResult: import("./types.js").SessionsUsageResult | null = null;
@@ -578,6 +585,10 @@ export class OpenClawApp extends LitElement {
 
   async loadOverview() {
     await loadOverviewInternal(this as unknown as Parameters<typeof loadOverviewInternal>[0]);
+  }
+
+  async loadTaskBoard() {
+    await loadTaskBoardInternal(this as unknown as Parameters<typeof loadTaskBoardInternal>[0]);
   }
 
   async loadCron() {

--- a/ui/src/ui/components/task-board/card.ts
+++ b/ui/src/ui/components/task-board/card.ts
@@ -1,0 +1,96 @@
+import { html, nothing } from "lit";
+import { formatDurationHuman, formatRelativeTimestamp, formatTokens } from "../../format.ts";
+import type { TaskBoardCardVM } from "../../task-board/types.ts";
+
+function statusLabel(status: TaskBoardCardVM["status"]) {
+  switch (status) {
+    case "queued":
+      return "queued";
+    case "in_progress":
+      return "in progress";
+    case "waiting":
+      return "waiting";
+    case "blocked":
+      return "blocked";
+    case "paused":
+      return "paused";
+    case "done":
+      return "done";
+    case "disabled":
+      return "disabled";
+    case "error":
+      return "error";
+    default:
+      return status;
+  }
+}
+
+function badgeClass(kind: "status" | "health", value: string) {
+  if (value === "error" || value === "blocked") {
+    return "pill danger";
+  }
+  if (value === "warning" || value === "waiting") {
+    return "pill warning";
+  }
+  if (value === "stale" || value === "paused" || value === "disabled") {
+    return "pill muted";
+  }
+  return kind === "health" ? "pill success" : "pill";
+}
+
+function renderTime(label: string, value: string | null) {
+  if (!value) {
+    return nothing;
+  }
+  return html`<div class="muted" style="font-size: 12px;">${label}：${formatRelativeTimestamp(Date.parse(value))}</div>`;
+}
+
+function renderDuration(label: string, seconds: number | null) {
+  if (seconds == null) {
+    return nothing;
+  }
+  return html`<div class="muted" style="font-size: 12px;">${label}：${formatDurationHuman(seconds * 1000)}</div>`;
+}
+
+export function renderTaskCard(card: TaskBoardCardVM) {
+  return html`
+    <article class="card" style="display: flex; flex-direction: column; gap: 12px;">
+      <div class="row" style="justify-content: space-between; align-items: flex-start; gap: 12px;">
+        <div>
+          <div class="card-title">${card.title}</div>
+          <div class="card-sub">${card.owner}</div>
+        </div>
+        <div class="row" style="gap: 6px; flex-wrap: wrap; justify-content: flex-end;">
+          <span class=${badgeClass("status", card.status)}>${statusLabel(card.status)}</span>
+          <span class=${badgeClass("health", card.health)}>${card.health}</span>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 16px;">
+        <div>
+          <div class="muted" style="font-size: 12px;">进度</div>
+          <div>${card.progressPercent != null ? `${card.progressPercent}%` : "—"}</div>
+        </div>
+        <div>
+          <div class="muted" style="font-size: 12px;">token</div>
+          <div>${card.tokenUsage.value != null ? formatTokens(card.tokenUsage.value) : "—"}</div>
+        </div>
+      </div>
+
+      <div style="display: flex; flex-direction: column; gap: 4px;">
+        ${renderTime("started", card.startedAt)}
+        ${renderTime("last run", card.lastRunAt)}
+        ${renderTime("next run", card.nextRunAt)}
+        ${renderDuration("running for", card.runningForSec)}
+        ${renderDuration("waiting for", card.waitingForSec)}
+      </div>
+
+      ${card.summary ? html`<div>${card.summary}</div>` : nothing}
+      ${card.blocker ? html`<div class="pill danger" style="width: fit-content;">${card.blocker}</div>` : nothing}
+
+      <div class="muted" style="font-size: 12px;">
+        source: ${card.sourceOfTruth.join(" + ")}${card.tokenUsage.source ? ` · token=${card.tokenUsage.source}` : ""}
+      </div>
+    </article>
+  `;
+}

--- a/ui/src/ui/components/task-board/lane.ts
+++ b/ui/src/ui/components/task-board/lane.ts
@@ -1,0 +1,28 @@
+import { html } from "lit";
+import type { TaskBoardCardVM } from "../../task-board/types.ts";
+import { renderTaskCard } from "./card.ts";
+
+export type TaskBoardLaneProps = {
+  title: string;
+  subtitle: string;
+  cards: TaskBoardCardVM[];
+  emptyText: string;
+};
+
+export function renderTaskBoardLane(props: TaskBoardLaneProps) {
+  return html`
+    <section class="card" style="display: flex; flex-direction: column; gap: 16px; min-height: 320px;">
+      <div>
+        <div class="card-title">${props.title}</div>
+        <div class="card-sub">${props.subtitle}</div>
+      </div>
+      <div style="display: grid; gap: 12px;">
+        ${
+          props.cards.length > 0
+            ? props.cards.map((card) => renderTaskCard(card))
+            : html`<div class="muted">${props.emptyText}</div>`
+        }
+      </div>
+    </section>
+  `;
+}

--- a/ui/src/ui/components/task-board/page.test.ts
+++ b/ui/src/ui/components/task-board/page.test.ts
@@ -1,0 +1,45 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderTaskBoardPage } from "./page.ts";
+
+function renderToText(template: unknown) {
+  const root = document.createElement("div");
+  render(template, root);
+  return root.textContent ?? "";
+}
+
+describe("renderTaskBoardPage", () => {
+  it("shows no-data banner and lane empty states", () => {
+    const text = renderToText(
+      renderTaskBoardPage({
+        loading: false,
+        error: null,
+        cards: [],
+        lastLoadedAt: null,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(text).toContain("当前没有可展示的数据");
+    expect(text).toContain("当前没有可显示的主动任务");
+    expect(text).toContain("当前没有可显示的定时任务");
+  });
+
+  it("shows error banner without falling back to no-data banner", () => {
+    const text = renderToText(
+      renderTaskBoardPage({
+        loading: false,
+        error: "boom",
+        cards: [],
+        lastLoadedAt: null,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(text).toContain("读取失败");
+    expect(text).toContain("boom");
+    expect(text).not.toContain("当前没有可展示的数据");
+  });
+});

--- a/ui/src/ui/components/task-board/page.ts
+++ b/ui/src/ui/components/task-board/page.ts
@@ -1,0 +1,86 @@
+import { html, nothing } from "lit";
+import { splitTaskBoardCardsByLane, type TaskBoardCardVM } from "../../task-board/types.ts";
+import { renderTaskBoardLane } from "./lane.ts";
+import { renderTaskBoardToolbar } from "./toolbar.ts";
+
+export type TaskBoardPageProps = {
+  loading: boolean;
+  error: string | null;
+  cards: TaskBoardCardVM[];
+  lastLoadedAt: number | null;
+  onRefresh: () => void;
+};
+
+function renderStateBanner(params: { title: string; body: string; tone?: "neutral" | "danger" }) {
+  const tone = params.tone ?? "neutral";
+  const border =
+    tone === "danger"
+      ? "var(--color-danger, #dc2626)"
+      : "var(--border-color, rgba(255,255,255,0.12))";
+  const bg = tone === "danger" ? "rgba(220,38,38,0.08)" : "var(--panel-2, rgba(255,255,255,0.03))";
+  return html`
+    <section
+      class="card"
+      style="margin-bottom: 16px; border-left: 4px solid ${border}; background: ${bg};"
+    >
+      <div class="card-title">${params.title}</div>
+      <div class="card-sub" style="margin-top: 6px; line-height: 1.6;">${params.body}</div>
+    </section>
+  `;
+}
+
+export function renderTaskBoardPage(props: TaskBoardPageProps) {
+  const lanes = splitTaskBoardCardsByLane(props.cards);
+  const noData = props.cards.length === 0;
+
+  return html`
+    ${renderTaskBoardToolbar({
+      loading: props.loading,
+      lastLoadedAt: props.lastLoadedAt,
+      onRefresh: props.onRefresh,
+    })}
+
+    ${
+      props.error
+        ? renderStateBanner({
+            title: "读取失败",
+            body: `Task Board 这轮没有拿到完整数据。可先点刷新重试；若持续失败，再回看 sessions.list / cron.list / cron.runs 的响应。错误：${props.error}`,
+            tone: "danger",
+          })
+        : nothing
+    }
+
+    ${
+      !props.error && props.loading && noData
+        ? renderStateBanner({
+            title: "正在加载",
+            body: "Task Board 正在拉取 sessions 与 cron 数据。首次加载可能需要几秒。",
+          })
+        : nothing
+    }
+
+    ${
+      !props.error && !props.loading && noData
+        ? renderStateBanner({
+            title: "当前没有可展示的数据",
+            body: "这不是页面崩溃；只是这轮没有拿到 active session 或 scheduled job。可先点刷新，再判断是否真为空。",
+          })
+        : nothing
+    }
+
+    <section class="grid grid--2" style="align-items: start;">
+      ${renderTaskBoardLane({
+        title: "当前主动任务",
+        subtitle: "只看仍在推进的 active sessions。",
+        cards: lanes.active,
+        emptyText: props.loading ? "主动任务加载中…" : "当前没有可显示的主动任务。",
+      })}
+      ${renderTaskBoardLane({
+        title: "定时任务",
+        subtitle: "只看 cron / scheduled jobs 的运行健康。",
+        cards: lanes.scheduled,
+        emptyText: props.loading ? "定时任务加载中…" : "当前没有可显示的定时任务。",
+      })}
+    </section>
+  `;
+}

--- a/ui/src/ui/components/task-board/toolbar.ts
+++ b/ui/src/ui/components/task-board/toolbar.ts
@@ -1,0 +1,30 @@
+import { html } from "lit";
+
+export type TaskBoardToolbarProps = {
+  loading: boolean;
+  lastLoadedAt: number | null;
+  onRefresh: () => void;
+};
+
+export function renderTaskBoardToolbar(props: TaskBoardToolbarProps) {
+  return html`
+    <section class="card" style="margin-bottom: 16px;">
+      <div class="row" style="justify-content: space-between; align-items: center; gap: 12px;">
+        <div>
+          <div class="card-title">Phase 1 · Task Board</div>
+          <div class="card-sub">
+            只读切片：先看 active / scheduled 两栏，不读 transcript。
+          </div>
+        </div>
+        <div class="row" style="gap: 10px; align-items: center;">
+          <span class="muted" style="font-size: 12px;">
+            ${props.lastLoadedAt ? `上次刷新：${new Date(props.lastLoadedAt).toLocaleTimeString()}` : "尚未加载"}
+          </span>
+          <button class="btn primary" ?disabled=${props.loading} @click=${props.onRefresh}>
+            ${props.loading ? "加载中…" : "刷新"}
+          </button>
+        </div>
+      </div>
+    </section>
+  `;
+}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -5,7 +5,7 @@ export const TAB_GROUPS = [
   { label: "chat", tabs: ["chat"] },
   {
     label: "control",
-    tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
+    tabs: ["overview", "tasks", "channels", "instances", "sessions", "usage", "cron"],
   },
   { label: "agent", tabs: ["agents", "skills", "nodes"] },
   {
@@ -26,6 +26,7 @@ export const TAB_GROUPS = [
 export type Tab =
   | "agents"
   | "overview"
+  | "tasks"
   | "channels"
   | "instances"
   | "sessions"
@@ -46,6 +47,7 @@ export type Tab =
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
   overview: "/overview",
+  tasks: "/tasks",
   channels: "/channels",
   instances: "/instances",
   sessions: "/sessions",
@@ -153,6 +155,8 @@ export function iconForTab(tab: Tab): IconName {
       return "messageSquare";
     case "overview":
       return "barChart";
+    case "tasks":
+      return "fileText";
     case "channels":
       return "link";
     case "instances":
@@ -189,9 +193,15 @@ export function iconForTab(tab: Tab): IconName {
 }
 
 export function titleForTab(tab: Tab) {
+  if (tab === "tasks") {
+    return "Task Board";
+  }
   return t(`tabs.${tab}`);
 }
 
 export function subtitleForTab(tab: Tab) {
+  if (tab === "tasks") {
+    return "Active work and scheduled jobs in one glance.";
+  }
   return t(`subtitles.${tab}`);
 }

--- a/ui/src/ui/task-board/adapters/cron-adapter.ts
+++ b/ui/src/ui/task-board/adapters/cron-adapter.ts
@@ -1,0 +1,186 @@
+import { parseAgentSessionKey } from "../../../../../src/routing/session-key.js";
+import type { CronJob, CronRunLogEntry } from "../../types.ts";
+import type { TaskBoardCardVM, TaskBoardHealth, TaskBoardStatus } from "../types.ts";
+
+const CRON_WARNING_MS = 60 * 60 * 1000;
+const CRON_STALE_MS = 6 * 60 * 60 * 1000;
+
+function deriveProgress(status: TaskBoardStatus): number {
+  switch (status) {
+    case "queued":
+      return 10;
+    case "in_progress":
+      return 40;
+    case "waiting":
+      return 70;
+    case "blocked":
+      return 50;
+    case "done":
+      return 100;
+    case "paused":
+      return 0;
+    case "disabled":
+      return 0;
+    case "error":
+      return 50;
+    default:
+      return 0;
+  }
+}
+
+function buildLatestRunMap(entries: CronRunLogEntry[]): Map<string, CronRunLogEntry> {
+  const map = new Map<string, CronRunLogEntry>();
+  for (const entry of entries) {
+    if (!entry?.jobId || map.has(entry.jobId)) {
+      continue;
+    }
+    map.set(entry.jobId, entry);
+  }
+  return map;
+}
+
+function resolveOwner(job: CronJob): string {
+  if (job.agentId?.trim()) {
+    return job.agentId.trim();
+  }
+  const parsed = parseAgentSessionKey(job.sessionKey);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  return "system";
+}
+
+function deriveScheduledStatus(
+  job: CronJob,
+  latestRun: CronRunLogEntry | null | undefined,
+): TaskBoardStatus {
+  if (!job.enabled) {
+    return "disabled";
+  }
+  if (job.state?.runningAtMs) {
+    return "in_progress";
+  }
+  if (
+    latestRun?.status === "error" ||
+    job.state?.lastRunStatus === "error" ||
+    job.state?.lastStatus === "error"
+  ) {
+    return "error";
+  }
+  return "waiting";
+}
+
+function deriveScheduledHealth(
+  job: CronJob,
+  latestRun: CronRunLogEntry | null | undefined,
+  nowMs: number,
+): TaskBoardHealth {
+  if (!job.enabled) {
+    return "warning";
+  }
+  if (job.state?.runningAtMs) {
+    return "healthy";
+  }
+  if (
+    latestRun?.status === "error" ||
+    job.state?.lastRunStatus === "error" ||
+    job.state?.lastStatus === "error"
+  ) {
+    return "error";
+  }
+  const reference = latestRun?.ts ?? job.state?.lastRunAtMs ?? job.updatedAtMs ?? null;
+  if (!reference) {
+    return "warning";
+  }
+  const age = Math.max(0, nowMs - reference);
+  if (age >= CRON_STALE_MS) {
+    return "stale";
+  }
+  if (age >= CRON_WARNING_MS) {
+    return "warning";
+  }
+  return "healthy";
+}
+
+function resolveRecentResult(
+  job: CronJob,
+  latestRun: CronRunLogEntry | null | undefined,
+): string | null {
+  if (!job.enabled) {
+    return "已禁用";
+  }
+  if (job.state?.runningAtMs) {
+    return "运行中";
+  }
+  if (latestRun?.summary?.trim()) {
+    return latestRun.summary.trim();
+  }
+  if (latestRun?.status === "ok") {
+    return "最近一次运行正常";
+  }
+  if (latestRun?.status === "error") {
+    return latestRun.error?.trim() || "最近一次运行失败";
+  }
+  if (job.state?.lastRunStatus === "ok") {
+    return "最近一次运行正常";
+  }
+  if (job.state?.lastError?.trim()) {
+    return job.state.lastError.trim();
+  }
+  return null;
+}
+
+export function buildCronTaskCards(
+  jobs: CronJob[] | null | undefined,
+  entries: CronRunLogEntry[] | null | undefined,
+  nowMs = Date.now(),
+): TaskBoardCardVM[] {
+  const latestRuns = buildLatestRunMap(entries ?? []);
+  return (jobs ?? [])
+    .map((job) => {
+      const latestRun = latestRuns.get(job.id);
+      const status = deriveScheduledStatus(job, latestRun);
+      const lastRunAtMs = latestRun?.ts ?? job.state?.lastRunAtMs ?? null;
+      const nextRunAtMs = job.state?.nextRunAtMs ?? latestRun?.nextRunAtMs ?? null;
+      const runningAtMs = job.state?.runningAtMs ?? null;
+      return {
+        id: job.id,
+        lane: "scheduled",
+        title: job.name,
+        owner: resolveOwner(job),
+        status,
+        health: deriveScheduledHealth(job, latestRun, nowMs),
+        progressPercent: deriveProgress(status),
+        progressSource: "estimated",
+        startedAt: runningAtMs ? new Date(runningAtMs).toISOString() : null,
+        lastRunAt: lastRunAtMs ? new Date(lastRunAtMs).toISOString() : null,
+        nextRunAt: nextRunAtMs ? new Date(nextRunAtMs).toISOString() : null,
+        runningForSec: runningAtMs ? Math.max(0, Math.floor((nowMs - runningAtMs) / 1000)) : null,
+        waitingForSec:
+          !runningAtMs && lastRunAtMs
+            ? Math.max(0, Math.floor((nowMs - lastRunAtMs) / 1000))
+            : null,
+        tokenUsage: {
+          value: latestRun?.usage?.total_tokens ?? null,
+          window: latestRun ? "last run" : null,
+          source: latestRun ? "cron.runs" : null,
+        },
+        summary: job.description?.trim() || resolveRecentResult(job, latestRun),
+        blocker: status === "error" ? resolveRecentResult(job, latestRun) : null,
+        decisionNeeded: false,
+        recentResult: resolveRecentResult(job, latestRun),
+        enabled: job.enabled,
+        sourceOfTruth: ["cron.list", "cron.runs"],
+      } satisfies TaskBoardCardVM;
+    })
+    .toSorted((a, b) => {
+      const aRank = a.health === "error" ? 0 : a.status === "disabled" ? 1 : 2;
+      const bRank = b.health === "error" ? 0 : b.status === "disabled" ? 1 : 2;
+      if (aRank !== bRank) {
+        return aRank - bRank;
+      }
+      const aNext = a.nextRunAt ? Date.parse(a.nextRunAt) : Number.MAX_SAFE_INTEGER;
+      const bNext = b.nextRunAt ? Date.parse(b.nextRunAt) : Number.MAX_SAFE_INTEGER;
+      return aNext - bNext;
+    });
+}

--- a/ui/src/ui/task-board/adapters/session-adapter.test.ts
+++ b/ui/src/ui/task-board/adapters/session-adapter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionTaskCards } from "./session-adapter.ts";
+
+describe("buildSessionTaskCards", () => {
+  it("excludes cron sessions and maps active session fields", () => {
+    const now = Date.UTC(2026, 2, 20, 1, 0, 0);
+    const startedAt = now - 5 * 60 * 1000;
+    const updatedAt = now - 60 * 1000;
+
+    const cards = buildSessionTaskCards(
+      {
+        ts: now,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:ops-engineer:telegram:direct:5323237514",
+            kind: "direct",
+            label: "ops direct",
+            updatedAt,
+            startedAt,
+            status: "running",
+            totalTokens: 1234,
+          },
+          {
+            key: "agent:ops-engineer:cron:gateway-watchdog",
+            kind: "direct",
+            updatedAt,
+            status: "done",
+            totalTokens: 999,
+          },
+        ],
+      },
+      now,
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      id: "agent:ops-engineer:telegram:direct:5323237514",
+      lane: "active",
+      title: "ops direct",
+      owner: "ops-engineer",
+      status: "in_progress",
+      health: "healthy",
+      progressPercent: 40,
+      progressSource: "estimated",
+      runningForSec: 300,
+      waitingForSec: null,
+      tokenUsage: {
+        value: 1234,
+        window: "session total",
+        source: "sessions.list",
+      },
+      sourceOfTruth: ["sessions.list"],
+    });
+  });
+
+  it("surfaces failed sessions as error cards and marks stale waiting sessions", () => {
+    const now = Date.UTC(2026, 2, 20, 1, 0, 0);
+    const failedAt = now - 30 * 1000;
+    const staleAt = now - 3 * 60 * 60 * 1000;
+
+    const cards = buildSessionTaskCards(
+      {
+        ts: now,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:ops-engineer:main",
+            kind: "direct",
+            updatedAt: failedAt,
+            status: "failed",
+            displayName: "ops main",
+          },
+          {
+            key: "agent:writer-ops:main",
+            kind: "direct",
+            updatedAt: staleAt,
+            status: "done",
+            displayName: "writer main",
+          },
+        ],
+      },
+      now,
+    );
+
+    expect(cards[0]).toMatchObject({
+      owner: "ops-engineer",
+      status: "error",
+      health: "error",
+      blocker: "最近一轮失败",
+    });
+    expect(cards[1]).toMatchObject({
+      owner: "writer-ops",
+      status: "waiting",
+      health: "stale",
+      waitingForSec: 3 * 60 * 60,
+    });
+  });
+});

--- a/ui/src/ui/task-board/adapters/session-adapter.ts
+++ b/ui/src/ui/task-board/adapters/session-adapter.ts
@@ -1,0 +1,178 @@
+import { isCronSessionKey, parseAgentSessionKey } from "../../../../../src/routing/session-key.js";
+import type { GatewaySessionRow, SessionsListResult, SessionRunStatus } from "../../types.ts";
+import type { TaskBoardCardVM, TaskBoardHealth, TaskBoardStatus } from "../types.ts";
+
+const ACTIVE_WARNING_MS = 30 * 60 * 1000;
+const ACTIVE_STALE_MS = 2 * 60 * 60 * 1000;
+
+function deriveActiveStatus(row: GatewaySessionRow): TaskBoardStatus {
+  if (
+    row.abortedLastRun ||
+    row.status === "failed" ||
+    row.status === "killed" ||
+    row.status === "timeout"
+  ) {
+    return "error";
+  }
+  if (row.status === "running") {
+    return "in_progress";
+  }
+  if (row.status === "done") {
+    return "waiting";
+  }
+  if (!row.updatedAt) {
+    return "queued";
+  }
+  return "waiting";
+}
+
+function deriveProgress(status: TaskBoardStatus): number {
+  switch (status) {
+    case "queued":
+      return 10;
+    case "in_progress":
+      return 40;
+    case "waiting":
+      return 70;
+    case "blocked":
+      return 50;
+    case "done":
+      return 100;
+    case "paused":
+      return 0;
+    case "disabled":
+      return 0;
+    case "error":
+      return 50;
+    default:
+      return 0;
+  }
+}
+
+function deriveHealth(
+  status: TaskBoardStatus,
+  updatedAt: number | null | undefined,
+  nowMs: number,
+) {
+  if (status === "error") {
+    return "error" satisfies TaskBoardHealth;
+  }
+  if (!updatedAt) {
+    return "warning" satisfies TaskBoardHealth;
+  }
+  const age = Math.max(0, nowMs - updatedAt);
+  if (age >= ACTIVE_STALE_MS) {
+    return "stale" satisfies TaskBoardHealth;
+  }
+  if (age >= ACTIVE_WARNING_MS) {
+    return "warning" satisfies TaskBoardHealth;
+  }
+  return "healthy" satisfies TaskBoardHealth;
+}
+
+function resolveOwner(row: GatewaySessionRow): string {
+  const parsed = parseAgentSessionKey(row.key);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  const display = row.displayName?.trim();
+  if (display) {
+    return display;
+  }
+  return row.key;
+}
+
+function resolveTitle(row: GatewaySessionRow): string {
+  const label = row.label?.trim();
+  if (label) {
+    return label;
+  }
+  const display = row.displayName?.trim();
+  if (display) {
+    return display;
+  }
+  const parsed = parseAgentSessionKey(row.key);
+  if (parsed?.agentId) {
+    return parsed.rest ? `${parsed.agentId} · ${parsed.rest}` : parsed.agentId;
+  }
+  return row.key;
+}
+
+function normalizeStatusText(status?: SessionRunStatus): string | null {
+  if (!status) {
+    return null;
+  }
+  if (status === "running") {
+    return "正在运行";
+  }
+  if (status === "done") {
+    return "最近一轮已结束";
+  }
+  if (status === "failed") {
+    return "最近一轮失败";
+  }
+  if (status === "killed") {
+    return "最近一轮被终止";
+  }
+  if (status === "timeout") {
+    return "最近一轮超时";
+  }
+  return status;
+}
+
+export function buildSessionTaskCards(
+  result: SessionsListResult | null | undefined,
+  nowMs = Date.now(),
+): TaskBoardCardVM[] {
+  const rows = result?.sessions ?? [];
+  return rows
+    .filter((row) => row?.key && !isCronSessionKey(row.key))
+    .map((row) => {
+      const status = deriveActiveStatus(row);
+      const startedAt = row.startedAt ?? row.updatedAt ?? null;
+      const updatedAt = row.updatedAt ?? null;
+      const runningForSec =
+        startedAt && status === "in_progress"
+          ? Math.max(0, Math.floor((nowMs - startedAt) / 1000))
+          : null;
+      const waitingForSec =
+        updatedAt && status !== "in_progress"
+          ? Math.max(0, Math.floor((nowMs - updatedAt) / 1000))
+          : null;
+      const totalTokens = row.totalTokens ?? row.inputTokens ?? row.outputTokens ?? null;
+      return {
+        id: row.key,
+        lane: "active",
+        title: resolveTitle(row),
+        owner: resolveOwner(row),
+        status,
+        health: deriveHealth(status, updatedAt, nowMs),
+        progressPercent: deriveProgress(status),
+        progressSource: "estimated",
+        startedAt: startedAt ? new Date(startedAt).toISOString() : null,
+        lastRunAt: updatedAt ? new Date(updatedAt).toISOString() : null,
+        nextRunAt: null,
+        runningForSec,
+        waitingForSec,
+        tokenUsage: {
+          value: totalTokens,
+          window: "session total",
+          source: "sessions.list",
+        },
+        summary: row.displayName?.trim() || normalizeStatusText(row.status),
+        blocker: status === "error" ? normalizeStatusText(row.status) : null,
+        decisionNeeded: false,
+        recentResult: normalizeStatusText(row.status),
+        enabled: true,
+        sourceOfTruth: ["sessions.list"],
+      } satisfies TaskBoardCardVM;
+    })
+    .toSorted((a, b) => {
+      const aRank = a.status === "error" ? 0 : a.status === "in_progress" ? 1 : 2;
+      const bRank = b.status === "error" ? 0 : b.status === "in_progress" ? 1 : 2;
+      if (aRank !== bRank) {
+        return aRank - bRank;
+      }
+      return (b.runningForSec ?? b.waitingForSec ?? 0) - (a.runningForSec ?? a.waitingForSec ?? 0);
+    });
+}

--- a/ui/src/ui/task-board/service.ts
+++ b/ui/src/ui/task-board/service.ts
@@ -1,0 +1,57 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { CronJobsListResult, CronRunsResult, SessionsListResult } from "../types.ts";
+import { buildCronTaskCards } from "./adapters/cron-adapter.ts";
+import { buildSessionTaskCards } from "./adapters/session-adapter.ts";
+import type { TaskBoardCardVM } from "./types.ts";
+
+export type TaskBoardState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  taskBoardLoading: boolean;
+  taskBoardError: string | null;
+  taskBoardCards: TaskBoardCardVM[];
+  taskBoardLastLoadedAt: number | null;
+};
+
+export async function loadTaskBoard(state: TaskBoardState) {
+  if (!state.client || !state.connected || state.taskBoardLoading) {
+    return;
+  }
+  state.taskBoardLoading = true;
+  state.taskBoardError = null;
+  try {
+    const [sessionsResult, cronJobsResult, cronRunsResult] = await Promise.all([
+      state.client.request<SessionsListResult>("sessions.list", {
+        activeMinutes: 24 * 60,
+        limit: 200,
+        includeGlobal: true,
+        includeUnknown: false,
+      }),
+      state.client.request<CronJobsListResult>("cron.list", {
+        includeDisabled: true,
+        enabled: "all",
+        limit: 200,
+        offset: 0,
+        sortBy: "nextRunAtMs",
+        sortDir: "asc",
+      }),
+      state.client.request<CronRunsResult>("cron.runs", {
+        scope: "all",
+        limit: 200,
+        offset: 0,
+        sortDir: "desc",
+        status: "all",
+      }),
+    ]);
+    const nowMs = Date.now();
+    state.taskBoardCards = [
+      ...buildSessionTaskCards(sessionsResult, nowMs),
+      ...buildCronTaskCards(cronJobsResult?.jobs ?? [], cronRunsResult?.entries ?? [], nowMs),
+    ];
+    state.taskBoardLastLoadedAt = nowMs;
+  } catch (err) {
+    state.taskBoardError = String(err);
+  } finally {
+    state.taskBoardLoading = false;
+  }
+}

--- a/ui/src/ui/task-board/types.ts
+++ b/ui/src/ui/task-board/types.ts
@@ -1,0 +1,51 @@
+export type TaskBoardLane = "active" | "scheduled";
+export type TaskBoardStatus =
+  | "queued"
+  | "in_progress"
+  | "waiting"
+  | "blocked"
+  | "paused"
+  | "done"
+  | "disabled"
+  | "error";
+export type TaskBoardHealth = "healthy" | "warning" | "stale" | "error";
+export type TaskBoardProgressSource = "explicit" | "derived" | "estimated" | null;
+
+export type TaskBoardCardVM = {
+  id: string;
+  lane: TaskBoardLane;
+  title: string;
+  owner: string;
+  status: TaskBoardStatus;
+  health: TaskBoardHealth;
+  progressPercent: number | null;
+  progressSource: TaskBoardProgressSource;
+  startedAt: string | null;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  runningForSec: number | null;
+  waitingForSec: number | null;
+  tokenUsage: {
+    value: number | null;
+    window: string | null;
+    source: string | null;
+  };
+  summary: string | null;
+  blocker: string | null;
+  decisionNeeded: boolean;
+  recentResult: string | null;
+  enabled: boolean | null;
+  sourceOfTruth: string[];
+};
+
+export type TaskBoardCardsByLane = {
+  active: TaskBoardCardVM[];
+  scheduled: TaskBoardCardVM[];
+};
+
+export function splitTaskBoardCardsByLane(cards: TaskBoardCardVM[]): TaskBoardCardsByLane {
+  return {
+    active: cards.filter((card) => card.lane === "active"),
+    scheduled: cards.filter((card) => card.lane === "scheduled"),
+  };
+}

--- a/ui/src/ui/views/task-board.ts
+++ b/ui/src/ui/views/task-board.ts
@@ -1,0 +1,7 @@
+import { renderTaskBoardPage, type TaskBoardPageProps } from "../components/task-board/page.ts";
+
+export type TaskBoardProps = TaskBoardPageProps;
+
+export function renderTaskBoard(props: TaskBoardProps) {
+  return renderTaskBoardPage(props);
+}


### PR DESCRIPTION
## Summary
- add a Phase 1 Task Board page to Control UI
- wire a new `tasks` tab into navigation, app state, routing, and rendering
- add task-board adapters/service/components for active sessions + scheduled cron jobs
- add targeted tests for session adapter mapping and page empty/error states

## Validation
- `pnpm --dir ui test src/ui/task-board/adapters/session-adapter.test.ts src/ui/components/task-board/page.test.ts`
- `pnpm run ui:build`
- local preview + browser check of `/tasks`

## Scope / non-goals
- read-only Phase 1 slice only
- no transcript reads
- no semantic SESSION-STATE/handoff layer yet
