### PR TITLE
Heartbeat: skip when cron lane or other lanes are busy

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1053,6 +1053,7 @@ Periodic heartbeat runs.
         includeReasoning: false,
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
+        skipWhenBusy: false, // default: false; true skips heartbeat when subagent/nested lanes are active
         session: "main",
         to: "+15555550123",
         directPolicy: "allow", // allow (default) | block
@@ -1071,6 +1072,7 @@ Periodic heartbeat runs.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.
 - `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
 - `isolatedSession`: when true, each heartbeat runs in a fresh session with no prior conversation history. Same isolation pattern as cron `sessionTarget: "isolated"`. Reduces per-heartbeat token cost from ~100K to ~2-5K tokens.
+- `skipWhenBusy`: when true, skips the heartbeat turn when subagent or nested lanes have active tasks. Prevents heartbeat/subagent collisions. The cron wake-now path retries on this state instead of skipping permanently.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -275,6 +275,8 @@ export type AgentDefaultsConfig = {
      * Default: false (only the final heartbeat payload is delivered).
      */
     includeReasoning?: boolean;
+    /** Skip heartbeat when other lanes (subagent, nested) have active tasks. Default: false. */
+    skipWhenBusy?: boolean;
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -35,6 +35,7 @@ export const HeartbeatSchema = z
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),
     isolatedSession: z.boolean().optional(),
+    skipWhenBusy: z.boolean().optional(),
   })
   .strict()
   .superRefine((val, ctx) => {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -71,6 +71,8 @@ export type CronServiceDeps = {
     sessionKey?: string;
     /** Optional heartbeat config override (e.g. target: "last" for cron-triggered heartbeats). */
     heartbeat?: { target?: string };
+    /** When true, skip the cron-in-progress check (caller is already inside a cron lane). */
+    fromCronLane?: boolean;
   }) => Promise<HeartbeatRunResult>;
   /**
    * WakeMode=now: max time to wait for runHeartbeatOnce to stop returning

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1204,7 +1204,41 @@ async function executeMainSessionCronJob(
           reason,
           agentId: job.agentId,
           sessionKey: targetMainSessionKey,
+          // Cron-triggered heartbeats should deliver to the last active channel.
+          // Without this override, heartbeat target defaults to "none" (since
+          // e2362d35) and cron main-session responses are silently swallowed.
+          // See: https://github.com/openclaw/openclaw/issues/28508
+          heartbeat: { target: "last" },
+          // We are already inside the cron lane — skip the cron-in-progress
+          // check to avoid self-blocking.
+          fromCronLane: true,
         });
+        const isTransientBusy =
+          heartbeatResult.status === "skipped" &&
+          (heartbeatResult.reason === "requests-in-flight" ||
+            heartbeatResult.reason === "cron-in-progress" ||
+            heartbeatResult.reason === "lanes-busy");
+        if (!isTransientBusy) {
+          break;
+        }
+        if (abortSignal?.aborted) {
+          return resolveAbortError();
+        }
+        if (state.deps.nowMs() - waitStartedAt > maxWaitMs) {
+          if (abortSignal?.aborted) {
+            return resolveAbortError();
+          }
+          state.deps.requestHeartbeatNow({
+            reason,
+            agentId: job.agentId,
+            sessionKey: targetMainSessionKey,
+          });
+          return { status: "ok", summary: text };
+        }
+        await waitWithAbort(retryDelayMs);
+      }
+
+      if (heartbeatResult.status === "ran") {
         return { status: "ok", summary: text };
       }
       if (abortSignal?.aborted) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -279,6 +279,7 @@ export function buildGatewayCronService(params: {
         agentId,
         sessionKey,
         heartbeat: heartbeatOverride,
+        fromCronLane: opts?.fromCronLane,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/infra/heartbeat-runner.cron-collision.test.ts
+++ b/src/infra/heartbeat-runner.cron-collision.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { CommandLane } from "../process/lanes.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+describe("heartbeat cron-collision avoidance", () => {
+  function makeGetQueueSize(busy: Partial<Record<string, number>>) {
+    return (lane?: string) => busy[lane ?? CommandLane.Main] ?? 0;
+  }
+
+  const baseDeps = {
+    nowMs: () => Date.now(),
+    sendOutbound: vi.fn(),
+    resolveModel: vi.fn(),
+  };
+
+  it("skips with cron-in-progress when cron lane is busy", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m" },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({ [CommandLane.Cron]: 1 }),
+      },
+    });
+    expect(res).toEqual({ status: "skipped", reason: "cron-in-progress" });
+  });
+
+  it("does not skip when cron lane is idle", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m" },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({}),
+      },
+    });
+    // Should proceed past the cron check (may skip for another reason like
+    // no delivery target, but not "cron-in-progress").
+    expect(res.status === "skipped" && res.reason === "cron-in-progress").toBe(false);
+  });
+
+  it("skips with lanes-busy when skipWhenBusy is set and subagent lane is busy", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m", skipWhenBusy: true },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({ [CommandLane.Subagent]: 1 }),
+      },
+    });
+    expect(res).toEqual({ status: "skipped", reason: "lanes-busy" });
+  });
+
+  it("skips with lanes-busy when skipWhenBusy is set and nested lane is busy", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m", skipWhenBusy: true },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({ [CommandLane.Nested]: 2 }),
+      },
+    });
+    expect(res).toEqual({ status: "skipped", reason: "lanes-busy" });
+  });
+
+  it("does not skip for subagent/nested when skipWhenBusy is not set", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m" },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({ [CommandLane.Subagent]: 1 }),
+      },
+    });
+    expect(res.status === "skipped" && res.reason === "lanes-busy").toBe(false);
+  });
+
+  it("checks main before cron (main takes priority)", async () => {
+    const res = await runHeartbeatOnce({
+      heartbeat: { every: "30m" },
+      deps: {
+        ...baseDeps,
+        getQueueSize: makeGetQueueSize({
+          [CommandLane.Main]: 1,
+          [CommandLane.Cron]: 1,
+        }),
+      },
+    });
+    expect(res).toEqual({ status: "skipped", reason: "requests-in-flight" });
+  });
+});

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -199,6 +199,69 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("reschedules timer when runOnce returns cron-in-progress", async () => {
+    useFakeHeartbeatTime();
+
+    let callCount = 0;
+    const runSpy = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 1) {
+        return { status: "skipped", reason: "cron-in-progress" } as const;
+      }
+      return { status: "ran", durationMs: 1 } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce: runSpy,
+    });
+
+    // First heartbeat returns cron-in-progress
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // The wake layer retries after DEFAULT_RETRY_MS (1 s).
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    runner.stop();
+  });
+
+  it("lanes-busy does not short-circuit other agents in the scheduler", async () => {
+    useFakeHeartbeatTime();
+
+    // Two agents: first returns lanes-busy, second should still run.
+    let callIdx = 0;
+    const runSpy = vi.fn().mockImplementation(async () => {
+      callIdx++;
+      // The scheduler iterates agents in list order.  The first call is
+      // for agent "a" (busy), the second is for agent "b" (runs fine).
+      if (callIdx === 1) {
+        return { status: "skipped", reason: "lanes-busy" } as const;
+      }
+      return { status: "ran", durationMs: 1 } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([
+        { id: "a", heartbeat: { every: "30m", skipWhenBusy: true } },
+        { id: "b", heartbeat: { every: "30m" } },
+      ]),
+      runOnce: runSpy,
+    });
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    // Both agents should have been visited — lanes-busy must not return early.
+    // runSpy is called at least twice (once per agent); the wake layer may also
+    // fire a retry for the lanes-busy agent, so allow ≥2.
+    expect(runSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Verify agent "b" actually ran (not just retries of "a").
+    const results = await Promise.all(runSpy.mock.results.map((r: { value: unknown }) => r.value));
+    expect(results.some((r) => (r as { status: string }).status === "ran")).toBe(true);
+
+    runner.stop();
+  });
+
   it("does not push nextDueMs forward on repeated requests-in-flight skips", async () => {
     useFakeHeartbeatTime();
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -535,6 +535,8 @@ export async function runHeartbeatOnce(opts: {
   heartbeat?: HeartbeatConfig;
   reason?: string;
   deps?: HeartbeatDeps;
+  /** When true, skip the cron-in-progress check (caller is already inside a cron lane). */
+  fromCronLane?: boolean;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? loadConfig();
   const explicitAgentId = typeof opts.agentId === "string" ? opts.agentId.trim() : "";
@@ -559,9 +561,33 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "quiet-hours" };
   }
 
-  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main);
-  if (queueSize > 0) {
+  const resolvedGetQueueSize = opts.deps?.getQueueSize ?? getQueueSize;
+  const mainQueueSize = resolvedGetQueueSize(CommandLane.Main);
+  if (mainQueueSize > 0) {
     return { status: "skipped", reason: "requests-in-flight" };
+  }
+
+  // Skip when a cron job is running to avoid competing for inference resources.
+  // NOTE: this catches manually-triggered / enqueued cron runs.  Timer-driven
+  // cron jobs execute outside the command queue (via onTimer), so they are not
+  // reflected in CommandLane.Cron.  A follow-up should route timer-driven cron
+  // execution through the lane or expose CronService.isRunning().
+  // When fromCronLane is true, the caller is already inside a cron lane
+  // (e.g. wakeMode: "now") — skip this check to avoid self-blocking.
+  if (!opts.fromCronLane) {
+    const cronQueueSize = resolvedGetQueueSize(CommandLane.Cron);
+    if (cronQueueSize > 0) {
+      return { status: "skipped", reason: "cron-in-progress" };
+    }
+  }
+
+  // Opt-in: skip when any lane (subagent, nested) has active tasks.
+  if (heartbeat?.skipWhenBusy) {
+    const subagentSize = resolvedGetQueueSize(CommandLane.Subagent);
+    const nestedSize = resolvedGetQueueSize(CommandLane.Nested);
+    if (subagentSize + nestedSize > 0) {
+      return { status: "skipped", reason: "lanes-busy" };
+    }
   }
 
   // Preflight centralizes trigger classification, event inspection, and HEARTBEAT.md gating.
@@ -1179,6 +1205,69 @@ export function startHeartbeatRunner(opts: {
         scheduleNext();
       }
     }
+
+    let hadLanesBusy = false;
+    for (const agent of state.agents.values()) {
+      if (isInterval && now < agent.nextDueMs) {
+        continue;
+      }
+
+      let res: HeartbeatRunResult;
+      try {
+        res = await runOnce({
+          cfg: state.cfg,
+          agentId: agent.agentId,
+          heartbeat: agent.heartbeat,
+          reason,
+          deps: { runtime: state.runtime },
+        });
+      } catch (err) {
+        // If runOnce throws (e.g. during session compaction), we must still
+        // advance the timer and call scheduleNext so heartbeats keep firing.
+        const errMsg = formatErrorMessage(err);
+        log.error(`heartbeat runner: runOnce threw unexpectedly: ${errMsg}`, { error: errMsg });
+        advanceAgentSchedule(agent, now);
+        continue;
+      }
+      if (
+        res.status === "skipped" &&
+        (res.reason === "requests-in-flight" || res.reason === "cron-in-progress")
+      ) {
+        // Do not advance the schedule — a global lane is busy and the wake
+        // layer will retry shortly (DEFAULT_RETRY_MS = 1 s).  Calling
+        // scheduleNext() here would register a 0 ms timer that races with
+        // the wake layer's 1 s retry and wins, bypassing the cooldown.
+        return res;
+      }
+      if (res.status === "skipped" && res.reason === "lanes-busy") {
+        // lanes-busy is per-agent (opt-in via skipWhenBusy), so do not
+        // short-circuit the entire scheduler — other agents may still
+        // need to run.  Skip this agent without advancing its schedule,
+        // and defer to the wake layer's 1 s retry (no scheduleNext).
+        hadLanesBusy = true;
+        continue;
+      }
+      if (res.status !== "skipped" || res.reason !== "disabled") {
+        advanceAgentSchedule(agent, now);
+      }
+      if (res.status === "ran") {
+        ran = true;
+      }
+    }
+
+    if (hadLanesBusy && !ran) {
+      // At least one agent was skipped due to lanes-busy and no agent
+      // ran successfully.  Return without calling scheduleNext() so the
+      // wake layer retries after DEFAULT_RETRY_MS (1 s) instead of a
+      // tight 0 ms re-arm caused by the un-advanced nextDueMs.
+      return { status: "skipped", reason: "lanes-busy" };
+    }
+
+    scheduleNext();
+    if (ran) {
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
+    return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
   };
 
   const wakeHandler: HeartbeatWakeHandler = async (params) =>

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -81,6 +81,32 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it("retries cron-in-progress after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "cron-in-progress" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDefaultDelay({
+      handler,
+      initialReason: "interval",
+      expectedRetryReason: "interval",
+    });
+  });
+
+  it("retries lanes-busy after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "lanes-busy" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDefaultDelay({
+      handler,
+      initialReason: "interval",
+      expectedRetryReason: "interval",
+    });
+  });
+
   it("keeps retry cooldown even when a sooner request arrives", async () => {
     vi.useFakeTimers();
     const handler = setRetryOnceHeartbeatHandler();

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -163,8 +163,13 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
           ...(pendingWake.sessionKey ? { sessionKey: pendingWake.sessionKey } : {}),
         };
         const res = await active(wakeOpts);
-        if (res.status === "skipped" && res.reason === "requests-in-flight") {
-          // The main lane is busy; retry this wake target soon.
+        if (
+          res.status === "skipped" &&
+          (res.reason === "requests-in-flight" ||
+            res.reason === "cron-in-progress" ||
+            res.reason === "lanes-busy")
+        ) {
+          // A lane is busy; retry this wake target soon.
           queuePendingWakeReason({
             reason: pendingWake.reason ?? "retry",
             agentId: pendingWake.agentId,


### PR DESCRIPTION
## Summary

- Always skip heartbeats when a cron job is actively executing (`cron-in-progress`), preventing inference resource contention with local LLMs
- Add opt-in `heartbeat.skipWhenBusy` config to also skip when subagent/nested lanes have active tasks (`lanes-busy`)
- Both new skip reasons use the same proven retry mechanism as `requests-in-flight` (1s wake retry, no schedule advancement)

Closes #50773

## Test plan

- [x] `pnpm test -- src/infra/heartbeat-runner.cron-collision.test.ts` — 6 new tests pass (cron skip, idle no-skip, subagent/nested skipWhenBusy, priority ordering)
- [x] `pnpm test -- src/infra/heartbeat-wake.test.ts` — 2 new retry tests for `cron-in-progress` and `lanes-busy`
- [x] `pnpm test -- src/infra/heartbeat-runner.scheduler.test.ts` — 1 new scheduler no-advance test for `cron-in-progress`
- [x] `pnpm check` — lint/format/type checks pass
- [x] `pnpm build` — no build regressions