### PR TITLE
fix(ui): prevent copy button showing CopyCopied! by using hidden attr

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -30,6 +30,16 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
+  it("copy button hides 'Copied!' text by default (#50756)", () => {
+    const html = toSanitizedMarkdownHtml(["```ts", "const x = 1", "```"].join("\n"));
+    // The done span must carry the hidden attribute so it is invisible
+    // even before CSS loads, preventing the "CopyCopied!" regression.
+    expect(html).toContain('class="code-block-copy__done" hidden');
+    expect(html).toContain('class="code-block-copy__idle"');
+    // Idle span must NOT be hidden
+    expect(html).not.toMatch(/code-block-copy__idle[^>]*hidden/);
+  });
+
   it("flattens remote markdown images into alt text", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
     expect(html).not.toContain("<img");

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -38,6 +38,7 @@ const allowedTags = [
 
 const allowedAttrs = [
   "class",
+  "hidden",
   "href",
   "rel",
   "target",
@@ -193,7 +194,7 @@ htmlEscapeRenderer.code = ({
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-  const copyBtn = `<button type="button" class="code-block-copy" data-code="${attrSafe}" aria-label="Copy code"><span class="code-block-copy__idle">Copy</span><span class="code-block-copy__done">Copied!</span></button>`;
+  const copyBtn = `<button type="button" class="code-block-copy" data-code="${attrSafe}" aria-label="Copy code"><span class="code-block-copy__idle">Copy</span><span class="code-block-copy__done" hidden>Copied!</span></button>`;
   const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
 
   const trimmed = text.trim();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -843,7 +843,15 @@ export function renderChat(props: ChatProps) {
     navigator.clipboard.writeText(code).then(
       () => {
         btn.classList.add("copied");
-        setTimeout(() => btn.classList.remove("copied"), 1500);
+        const idle = btn.querySelector(".code-block-copy__idle") as HTMLElement | null;
+        const done = btn.querySelector(".code-block-copy__done") as HTMLElement | null;
+        if (idle) idle.hidden = true;
+        if (done) done.hidden = false;
+        setTimeout(() => {
+          btn.classList.remove("copied");
+          if (idle) idle.hidden = false;
+          if (done) done.hidden = true;
+        }, 1500);
       },
       () => {},
     );


### PR DESCRIPTION
## Summary

Fixes #50756 — The copy button in code blocks displayed `CopyCopied!` instead of just `Copy`.

- **Problem:** The "Copied!" span inside the copy button was hidden purely via CSS (`display: none`). When CSS fails to load or loads late, both spans render simultaneously as "CopyCopied!".
- **Why it matters:** Users see broken UI text on code block copy buttons, especially on slower connections or certain browser caching behaviors.
- **What changed:** Added HTML `hidden` attribute to the `__done` span so it is invisible even before CSS loads. Updated the click handler to toggle `hidden` alongside the existing CSS class. Added `"hidden"` to the DOMPurify allowlist so the attribute survives sanitization.
- **What did NOT change:** CSS rules remain intact as a secondary styling layer; no markup structure changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #50756

## User-visible / Behavior Changes

- Code block copy button now correctly shows only "Copy" on initial render, regardless of CSS load timing.
- Click behavior unchanged: shows "Copied!" for 1.5s then reverts to "Copy".

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Added `"hidden"` to DOMPurify `allowedAttrs` — this is a safe, standard HTML boolean attribute with no XSS surface.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime: OpenClaw 3.13+
- Browser: MS Edge (Chromium)

### Steps

1. Start OpenClaw and open Control UI
2. Send a message that triggers a code block response
3. Observe the copy button text

### Expected

- Button shows "Copy"

### Actual (before fix)

- Button shows "CopyCopied!"

## Evidence

- [x] Failing test/log before + passing after
- `cd ui && npx vitest run src/ui/markdown.test.ts` — all 16 tests pass including new regression test
- New test `copy button hides 'Copied!' text by default (#50756)` verifies the `hidden` attribute is present on `__done` and absent on `__idle`

## Human Verification (required)

- Verified scenarios: Code block rendering with copy button in test environment
- Edge cases checked: DOMPurify sanitization preserves `hidden` attr; click toggle works correctly with both `hidden` and CSS class
- What I did **not** verify: Other browsers (Safari, Firefox) — but `hidden` is universally supported

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; the CSS fallback still exists
- Files/config to restore: `ui/src/ui/markdown.ts`, `ui/src/ui/views/chat.ts`
- Known bad symptoms: Copy button text not toggling on click

## Risks and Mitigations

None — minimal change to a UI-only code path with regression test coverage.