### PR TITLE
UI: Show current context used tokens in WebChat

### DIFF
--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -37,7 +37,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
           key: "main",
           kind: "direct",
           updatedAt: null,
-          inputTokens: 3_800,
+          totalTokens: 3_800,
           contextTokens: 4_000,
         },
       ],

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,8 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  // Use the same notion as `session_status`: the fresh totalTokens
+  const used = session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary

- Fix the WebChat context usage banner to use the same definition of **used tokens** as the `session_status` command.
- The banner now uses the **fresh per-session total tokens** (`session.totalTokens`) instead of the historical input token counter (`session.inputTokens`), so the UI `used / limit` matches the CLI's current context usage numbers.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48787

## Problem

In the WebChat header, the context usage notice displayed values like:

`219.7k / 128k tokens`

However, `session_status` for the same session reported something closer to the **current** context usage, e.g.:

`64k / 128k (50%)`

The UI discrepancy came from using `session.inputTokens` as the "used" value. `session_status` (and the underlying context accounting) uses the *fresh* total tokens after pruning, so the banner could appear to be far above the context limit even when the current context window was only partially full.

## What Changed

- In `ui/src/ui/views/chat.ts`, `renderContextNotice` now computes `used` from:
  - **Before**: `const used = session?.inputTokens ?? 0`
  - **After**: `const used = session?.totalTokens ?? 0`
- `limit` remains unchanged:
  - `session?.contextTokens ?? defaultContextTokens ?? 0`

This aligns the WebChat banner with the CLI's `session_status` semantics and removes the "used far exceeds limit" confusion.

## User-visible / Behavior Changes

When the context usage warning becomes visible, the banner's percentage and `used / limit` values now reflect the **current context window usage**, consistent with `session_status`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Open the WebChat UI.
2. Trigger the context usage notice (85%+).
3. Run/compare with `session_status` for the same session.

### Expected

- WebChat banner's `used / limit` aligns with the current context usage shown by `session_status`.

### Actual

- WebChat banner's `used / limit` matches `session_status` after this fix.

## Evidence
- [ ] Screenshot/recording
  - Before: 
<img width="1543" height="120" alt="image" src="https://github.com/user-attachments/assets/2cd37ed1-9b45-4470-94c8-c42f9e7af8a6" />
<img width="1547" height="84" alt="image" src="https://github.com/user-attachments/assets/e27322bc-d841-4e28-bd1d-de65686a9d5c" />
  - After:  (Less than 85% will not be displayed)
<img width="1484" height="102" alt="image" src="https://github.com/user-attachments/assets/500f5426-915f-46db-a428-4fa2f6e70971" />

## Testing
pnpm test -- ui/src/ui/views/chat.browser.test.ts --run
success

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the `renderContextNotice` `used` calculation in `ui/src/ui/views/chat.ts`
- Files/config to restore:
  - `ui/src/ui/views/chat.ts`
- Known bad symptoms reviewers should watch for:
  - (fill in)

## Risks and Mitigations

- Risk:
  - If some sessions don’t provide `totalTokens` but still provide `inputTokens`, the banner might be hidden or show different values than before.
- Mitigation:
  - This PR keeps the existing visibility guard (notice only renders when usable `used` and `limit` are present) and aligns the semantics with `session_status`.

