### PR TITLE
fix: recognize snake_case tool call types in session history repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/session history: preserve snake_case `tool_call`, `tool_use`, and `function_call` blocks through transcript repair and result-pairing rebuilds, including `sessions_spawn` redaction paths. Fixes #48915. (#50802) Thanks @lishuaigit.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -145,6 +145,46 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(JSON.stringify(result.added)).not.toContain("missing tool result");
   });
 
+  it("repairs result pairing for snake_case tool call blocks", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_call", id: "call_1", name: "read", arguments: { path: "README.md" } },
+          { type: "tool_use", id: "call_2", name: "exec", input: { command: "true" } },
+          { type: "function_call", id: "call_3", name: "write", arguments: { path: "out" } },
+        ],
+      },
+      { role: "user", content: "late user message" },
+      {
+        role: "toolResult",
+        toolCallId: "call_2",
+        toolName: "exec",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultText: "aborted",
+    });
+
+    expect(result.added.map((message) => message.toolCallId)).toEqual(["call_1", "call_3"]);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "toolResult",
+      "toolResult",
+      "user",
+    ]);
+    expect(getAssistantToolCallBlocks(result.messages).map((block) => block.type)).toEqual([
+      "tool_call",
+      "tool_use",
+      "function_call",
+    ]);
+    expect((result.messages[2] as { toolCallId?: string }).toolCallId).toBe("call_2");
+  });
+
   it("repairs blank tool result names from matching tool calls", () => {
     const input = castAgentMessages([
       {
@@ -363,7 +403,11 @@ describe("sanitizeToolCallInputs", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
-        content: [{ type: "tool_use", id: "call_1", name: "read", input: {} }],
+        content: [
+          { type: "tool_use", id: "call_1", name: "read", input: {} },
+          { type: "tool_call", id: "call_2", name: "write", arguments: {} },
+          { type: "function_call", id: "call_3", name: "exec", arguments: {} },
+        ],
       },
       {
         role: "toolResult",
@@ -375,11 +419,33 @@ describe("sanitizeToolCallInputs", () => {
     ]);
 
     const out = sanitizeToolCallInputs(input);
-    // Both messages should be preserved (tool_use is recognized)
     expect(out).toHaveLength(2);
     expect(out[0]?.role).toBe("assistant");
     const blocks = getAssistantToolCallBlocks(out);
-    expect(blocks).toHaveLength(1);
+    expect(blocks.map((block) => block.type)).toEqual(["tool_use", "tool_call", "function_call"]);
+  });
+
+  it("preserves valid snake_case tool calls when malformed siblings are dropped", () => {
+    const out = sanitizeToolCallInputs(
+      castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "checking" },
+            { type: "tool_call", id: "call_read", name: "read", arguments: { path: "a" } },
+            { type: "tool_use", id: "call_bad", name: "read" },
+            { type: "function_call", id: "call_exec", name: "exec", arguments: { cmd: "true" } },
+          ],
+        },
+      ]),
+    );
+
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(Array.isArray(assistant.content) ? assistant.content : []).toEqual([
+      { type: "text", text: "checking" },
+      { type: "tool_call", id: "call_read", name: "read", arguments: { path: "a" } },
+      { type: "function_call", id: "call_exec", name: "exec", arguments: { cmd: "true" } },
+    ]);
   });
 
   it("drops snake_case tool_use blocks missing input", () => {
@@ -632,6 +698,40 @@ describe("sanitizeToolCallInputs", () => {
     });
 
     expect(out).toEqual(input);
+  });
+
+  it("reserves snake_case tool ids when preserving signed-thinking assistant turns", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "First signed replay turn.",
+            thinkingSignature: "sig_first_snake",
+          },
+          { type: "tool_use", id: "call_shared", name: "read", input: { path: "a" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Second signed replay turn.",
+            thinkingSignature: "sig_second_snake",
+          },
+          { type: "tool_call", id: "call_shared", name: "read", arguments: { path: "b" } },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["read"],
+      allowProviderOwnedThinkingReplay: true,
+    });
+
+    expect(out).toEqual([input[0]]);
   });
 
   it("keeps generic thinking turns mutable when immutable preservation is disabled", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -761,6 +761,34 @@ describe("sanitizeToolCallInputs", () => {
     const attachments = (inputObj.attachments ?? []) as Array<Record<string, unknown>>;
     expect(attachments[0]?.content).toBe("__OPENCLAW_REDACTED__");
   });
+
+  it("redacts sessions_spawn attachments in snake_case tool_use blocks", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_snake",
+            name: "sessions_spawn",
+            input: {
+              task: "do stuff",
+              attachments: [{ name: "secret.txt", content: "TOP_SECRET" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out) as Array<Record<string, unknown>>;
+
+    expect(toolCalls).toHaveLength(1);
+    const inputObj = (toolCalls[0]?.input ?? {}) as Record<string, unknown>;
+    expect(inputObj.task).toBe("do stuff");
+    const attachments = (inputObj.attachments ?? []) as Array<Record<string, unknown>>;
+    expect(attachments[0]?.content).toBe("__OPENCLAW_REDACTED__");
+  });
   it("preserves other block properties when trimming tool names", () => {
     const toolCalls = sanitizeAssistantToolCalls([
       { type: "toolCall", id: "call_1", name: " read ", arguments: { path: "/tmp/test" } },

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -8,7 +8,14 @@ import {
 } from "./session-transcript-repair.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 
-const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
 
 function getAssistantToolCallBlocks(messages: AgentMessage[]) {
   const assistant = messages[0] as Extract<AgentMessage, { role: "assistant" }> | undefined;
@@ -349,6 +356,43 @@ describe("sanitizeToolCallInputs", () => {
     ]);
 
     const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
+  it("recognizes snake_case tool call block types (tool_use, tool_call, function_call)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "read", input: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    // Both messages should be preserved (tool_use is recognized)
+    expect(out).toHaveLength(2);
+    expect(out[0]?.role).toBe("assistant");
+    const blocks = getAssistantToolCallBlocks(out);
+    expect(blocks).toHaveLength(1);
+  });
+
+  it("drops snake_case tool_use blocks missing input", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "read" }],
+      },
+      { role: "user", content: "hello" },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    // The broken tool_use block should be dropped
     expect(out.map((m) => m.role)).toEqual(["user"]);
   });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -360,7 +360,10 @@ export function repairToolCallInputs(
         if (
           (block as { type?: unknown }).type === "toolCall" ||
           (block as { type?: unknown }).type === "toolUse" ||
-          (block as { type?: unknown }).type === "functionCall"
+          (block as { type?: unknown }).type === "functionCall" ||
+          (block as { type?: unknown }).type === "tool_call" ||
+          (block as { type?: unknown }).type === "tool_use" ||
+          (block as { type?: unknown }).type === "function_call"
         ) {
           // Only sanitize (redact) sessions_spawn blocks; all others are passed through
           // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -38,7 +38,12 @@ function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   const type = (block as { type?: unknown }).type;
   return (
     typeof type === "string" &&
-    (type === "toolCall" || type === "toolUse" || type === "functionCall")
+    (type === "toolCall" ||
+      type === "toolUse" ||
+      type === "functionCall" ||
+      type === "tool_call" ||
+      type === "tool_use" ||
+      type === "function_call")
   );
 }
 

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -218,6 +218,40 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expectSingleToolCallRewrite(out, "callitem123", "strict");
     });
 
+    it("rewrites snake_case assistant tool-call IDs with their matching tool results", () => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", id: "call_1", name: "read", arguments: {} },
+            { type: "tool_use", id: "use_2", name: "read", input: {} },
+            { type: "function_call", id: "fn_3", name: "read", arguments: {} },
+          ],
+        },
+        buildToolResult({ toolCallId: "call_1", text: "call" }),
+        buildToolResult({ toolCallId: "use_2", text: "use" }),
+        buildToolResult({ toolCallId: "fn_3", text: "function" }),
+      ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input);
+
+      expect(out).not.toBe(input);
+      const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const toolCall = assistant.content?.[0] as { id?: string };
+      const toolUse = assistant.content?.[1] as { id?: string };
+      const functionCall = assistant.content?.[2] as { id?: string };
+      expect(toolCall.id).toBe("call1");
+      expect(toolUse.id).toBe("use2");
+      expect(functionCall.id).toBe("fn3");
+      expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        toolCall.id,
+      );
+      expect((out[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(toolUse.id);
+      expect((out[3] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        functionCall.id,
+      );
+    });
+
     it("avoids collisions when sanitization would produce duplicate IDs", () => {
       const input = buildDuplicateIdCollisionInput();
 

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -11,7 +11,14 @@ const NATIVE_ANTHROPIC_TOOL_USE_ID_RE = /^toolu_[A-Za-z0-9_]+$/;
 const NATIVE_KIMI_TOOL_CALL_ID_RE = /^functions\.[A-Za-z0-9_-]+:\d+$/;
 
 const STRICT9_LEN = 9;
-const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
 
 export type ToolCallLike = {
   id: string;

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -374,11 +374,7 @@ function rewriteAssistantToolCallIds(params: {
     const rec = block as { type?: unknown; id?: unknown };
     const type = rec.type;
     const id = rec.id;
-    if (
-      (type !== "functionCall" && type !== "toolUse" && type !== "toolCall") ||
-      typeof id !== "string" ||
-      !id
-    ) {
+    if (typeof type !== "string" || !TOOL_CALL_TYPES.has(type) || typeof id !== "string" || !id) {
       return block;
     }
     const nextId = params.resolveId(id);


### PR DESCRIPTION
## Summary

- **Problem:** After an interrupted Anthropic tool call, users get persistent "Session history looks corrupted (tool call input missing)" errors that `/new` cannot reliably resolve.
- **Root cause:** `isRawToolCallBlock()` in `session-transcript-repair.ts` only recognizes camelCase block types (`toolCall`, `toolUse`, `functionCall`) but Anthropic persists `tool_use` (snake_case). The broken block survives `repairToolCallInputs()` sanitization, and Anthropic rejects the request with `"tool_use.input: field required"`.
- **Fix:** Add `tool_call`, `tool_use`, and `function_call` to the type check so the repair logic can detect and fix (or drop) broken snake_case blocks.

## Change Type

- [x] Bug fix

## Scope

- [x] Session history / transcript repair

## Linked Issue

- Closes #48915

## User-visible / Behavior Changes

**Before:** Interrupted Anthropic tool call → persistent "session history corrupted" error → `/new` doesn't fix it

**After:** Broken `tool_use` blocks are detected and dropped by the sanitizer → session recovers automatically

## Security Impact

None.

## Evidence

- [x] 25 tests passing (23 existing + 2 new snake_case tests)

```
✓ recognizes snake_case tool call block types (tool_use, tool_call, function_call)
✓ drops snake_case tool_use blocks missing input
```

## Compatibility

- Backward compatible. Only adds more type strings to an existing check.

## Risks

None — the added types follow the exact same repair logic as the existing camelCase types.

[AI-assisted development by OpenClaw agent 虾干 🦐]