### PR TITLE
fix: preserve plugin HTTP routes across registry swaps

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
 import { createTestRegistry } from "./__tests__/test-utils.js";
 import { createGatewayPluginRequestHandler } from "./plugins-http.js";
@@ -67,6 +69,39 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
     expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the global active registry when closure registry has no routes", async () => {
+    const closureRegistry = createTestRegistry(); // empty
+    const routeHandler = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 200;
+    });
+
+    // Set up a global active registry with a route
+    const activeReg = createEmptyPluginRegistry();
+    activeReg.httpRoutes.push({
+      pluginId: "gchat",
+      path: "/googlechat",
+      handler: routeHandler,
+    });
+    setActivePluginRegistry(activeReg);
+
+    const handler = createGatewayPluginRequestHandler({
+      registry: closureRegistry,
+      log: { warn: vi.fn() } as unknown as Parameters<
+        typeof createGatewayPluginRequestHandler
+      >[0]["log"],
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/googlechat" } as IncomingMessage, res);
+    expect(handled).toBe(true);
+    expect(routeHandler).toHaveBeenCalledTimes(1);
+
+    // Clean up global state — clear routes before swapping so the
+    // route-preservation logic does not carry them forward.
+    activeReg.httpRoutes = [];
+    setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
   it("logs and responds with 500 when a handler throws", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -15,8 +16,20 @@ export function createGatewayPluginRequestHandler(params: {
 }): PluginHttpRequestHandler {
   const { registry, log } = params;
   return async (req, res) => {
-    const routes = registry.httpRoutes ?? [];
-    const handlers = registry.httpHandlers ?? [];
+    // The registry captured in the closure may become stale when
+    // setActivePluginRegistry() is called after startup (e.g. during
+    // config validation, health-monitor cycles, or memory updates).
+    // Fall back to the current global active registry when the closure
+    // registry has no routes.
+    const activeRegistry = getActivePluginRegistry();
+    const effectiveRegistry =
+      activeRegistry &&
+      (activeRegistry.httpRoutes?.length ?? 0) > 0 &&
+      (registry.httpRoutes?.length ?? 0) === 0
+        ? activeRegistry
+        : registry;
+    const routes = effectiveRegistry.httpRoutes ?? [];
+    const handlers = effectiveRegistry.httpHandlers ?? [];
     if (routes.length === 0 && handlers.length === 0) {
       return false;
     }

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { createEmptyPluginRegistry } from "./registry.js";
+import {
+  setActivePluginRegistry,
+  getActivePluginRegistry,
+  requireActivePluginRegistry,
+} from "./runtime.js";
+
+describe("setActivePluginRegistry", () => {
+  beforeEach(() => {
+    // Clear routes on the current active registry before swapping so the
+    // route-preservation logic in setActivePluginRegistry does not carry
+    // leftover routes from a previous test into the new clean registry.
+    const current = getActivePluginRegistry();
+    if (current) {
+      current.httpRoutes = [];
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("activates the provided registry", () => {
+    const reg = createEmptyPluginRegistry();
+    setActivePluginRegistry(reg);
+    expect(getActivePluginRegistry()).toBe(reg);
+  });
+
+  it("copies httpRoutes from the previous registry to the new one", () => {
+    const prev = createEmptyPluginRegistry();
+    const route = { path: "/webhook", handler: async () => {}, pluginId: "test" };
+    prev.httpRoutes.push(route);
+    setActivePluginRegistry(prev);
+
+    const next = createEmptyPluginRegistry();
+    setActivePluginRegistry(next);
+
+    expect(next.httpRoutes).toHaveLength(1);
+    expect(next.httpRoutes[0].path).toBe("/webhook");
+  });
+
+  it("does not duplicate routes that already exist in the new registry", () => {
+    const prev = createEmptyPluginRegistry();
+    const route = { path: "/hook", handler: async () => {}, pluginId: "a" };
+    prev.httpRoutes.push(route);
+    setActivePluginRegistry(prev);
+
+    const next = createEmptyPluginRegistry();
+    next.httpRoutes.push({ path: "/hook", handler: async () => {}, pluginId: "b" });
+    setActivePluginRegistry(next);
+
+    expect(next.httpRoutes).toHaveLength(1);
+    expect(next.httpRoutes[0].pluginId).toBe("b");
+  });
+
+  it("does not share array references between old and new registries", () => {
+    const prev = createEmptyPluginRegistry();
+    prev.httpRoutes.push({ path: "/x", handler: async () => {}, pluginId: "p" });
+    setActivePluginRegistry(prev);
+
+    const next = createEmptyPluginRegistry();
+    setActivePluginRegistry(next);
+
+    // Mutating prev's array should not affect next
+    prev.httpRoutes.splice(0, prev.httpRoutes.length);
+    expect(next.httpRoutes).toHaveLength(1);
+  });
+});
+
+describe("requireActivePluginRegistry", () => {
+  it("returns the active registry", () => {
+    const reg = createEmptyPluginRegistry();
+    setActivePluginRegistry(reg);
+    expect(requireActivePluginRegistry()).toBe(reg);
+  });
+});

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -21,6 +21,22 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+  const prev = state.registry;
+  // Carry forward any HTTP routes registered on the outgoing registry so
+  // they are not silently lost when a new registry is activated (e.g. by
+  // config validation or periodic plugin reloads).  Routes are copied
+  // individually rather than sharing the array reference so that a later
+  // unregister call (which splices from the old array) does not remove the
+  // route from the new registry.
+  if (prev && prev !== registry && prev.httpRoutes) {
+    const target = registry.httpRoutes ?? [];
+    for (const route of prev.httpRoutes) {
+      if (!target.some((r) => r.path === route.path)) {
+        target.push(route);
+      }
+    }
+    registry.httpRoutes = target;
+  }
   state.registry = registry;
   state.key = cacheKey ?? null;
 }


### PR DESCRIPTION
## Summary

Fixes #50810 — plugin HTTP routes (e.g. Google Chat's `/googlechat` webhook) silently return 404 after ~5 minutes when periodic registry swaps replace the active plugin registry.

- **`createGatewayPluginRequestHandler`**: Falls back to the current global active registry when the closure registry has no routes, so routes registered after the handler was created are still reachable
- **`setActivePluginRegistry`**: Copies `httpRoutes` from the outgoing registry into the incoming one (by value, not by reference) so routes survive swaps. Copying by value is important — sharing the array reference would let a channel-restart's unregister call splice the route from both registries

## Test plan

- [x] New unit tests for `setActivePluginRegistry` route preservation (4 cases: basic copy, dedup, no array sharing, basic activation)
- [x] New unit test for `createGatewayPluginRequestHandler` global registry fallback
- [x] All existing `plugins-http.test.ts` tests pass
- [x] Verified on live gateway: `/googlechat` route persists past 15+ minutes (previously died at ~5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)