### PR TITLE
Docs: remove stale unreleased qualifier from version references

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2149,11 +2149,11 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title='Why do I see "Unknown model: minimax/MiniMax-M2.5"?'>
     This means the **provider isn't configured** (no MiniMax provider config or auth
     profile was found), so the model can't be resolved. A fix for this detection is
-    in **2026.1.12** (unreleased at the time of writing).
+    in **2026.1.12**.
 
     Fix checklist:
 
-    1. Upgrade to **2026.1.12** (or run from source `main`), then restart the gateway.
+    1. Upgrade to **2026.1.12** or later, then restart the gateway.
     2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
        exists in env/auth profiles so the provider can be injected.
     3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.5` or

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -198,9 +198,9 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 This usually means the **MiniMax provider isn’t configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
-**2026.1.12** (unreleased at the time of writing). Fix by:
+**2026.1.12**. Fix by:
 
-- Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
+- Upgrading to **2026.1.12** or later, then restarting the gateway.
 - Running `openclaw configure` and selecting **MiniMax M2.5**, or
 - Adding the `models.providers.minimax` block manually, or
 - Setting `MINIMAX_API_KEY` (or a MiniMax auth profile) so the provider can be injected.


### PR DESCRIPTION
## Summary
- Remove '(unreleased at the time of writing)' from 2026.1.12 references in minimax.md and faq.md
- Update upgrade instructions to say 'or later' instead of 'or run from source main'

## Test plan
- [ ] Visual review of affected sections