### PR TITLE
fix(ci): auto-isolate memory-heavy unit tests

### DIFF
--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -483,6 +483,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.tavily.config.webSearch.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.tavily.config.webSearch.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.xai.config.webSearch.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.xai.config.webSearch.apiKey",
@@ -549,13 +556,6 @@
       "id": "tools.web.search.perplexity.apiKey",
       "configFile": "openclaw.json",
       "path": "tools.web.search.perplexity.apiKey",
-      "secretShape": "secret_input",
-      "optIn": true
-    },
-    {
-      "id": "plugins.entries.tavily.config.webSearch.apiKey",
-      "configFile": "openclaw.json",
-      "path": "plugins.entries.tavily.config.webSearch.apiKey",
       "secretShape": "secret_input",
       "optIn": true
     }

--- a/extensions/feishu/src/monitor.acp-init-failure.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.acp-init-failure.lifecycle.test.ts
@@ -166,13 +166,6 @@ function createTopicEvent(messageId: string) {
   };
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 async function setupLifecycleMonitor() {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -201,6 +194,7 @@ async function setupLifecycleMonitor() {
 
 describe("Feishu ACP-init failure lifecycle", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     handlers = {};
     lastRuntime = null;
@@ -334,6 +328,7 @@ describe("Feishu ACP-init failure lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
       return;
@@ -346,9 +341,13 @@ describe("Feishu ACP-init failure lifecycle", () => {
     const event = createTopicEvent("om_topic_msg_1");
 
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    });
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).not.toHaveBeenCalled();
     expect(resolveConfiguredBindingRouteMock).toHaveBeenCalledTimes(1);
@@ -371,9 +370,13 @@ describe("Feishu ACP-init failure lifecycle", () => {
     const event = createTopicEvent("om_topic_msg_2");
 
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    });
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
     expect(lastRuntime?.error).not.toHaveBeenCalled();

--- a/extensions/feishu/src/monitor.bot-menu.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.lifecycle.test.ts
@@ -155,13 +155,6 @@ function createBotMenuEvent(params: { eventKey: string; timestamp: string }) {
   };
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 async function setupLifecycleMonitor() {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -190,6 +183,7 @@ async function setupLifecycleMonitor() {
 
 describe("Feishu bot-menu lifecycle", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     handlers = {};
     lastRuntime = null;
@@ -292,6 +286,7 @@ describe("Feishu bot-menu lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
       return;
@@ -307,9 +302,13 @@ describe("Feishu bot-menu lifecycle", () => {
     });
 
     await onBotMenu(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    });
     await onBotMenu(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).not.toHaveBeenCalled();
     expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
@@ -332,9 +331,16 @@ describe("Feishu bot-menu lifecycle", () => {
     sendCardFeishuMock.mockRejectedValueOnce(new Error("boom"));
 
     await onBotMenu(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    });
     await onBotMenu(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(createFeishuReplyDispatcherMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).not.toHaveBeenCalled();
     expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);

--- a/extensions/feishu/src/monitor.broadcast.reply-once.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.broadcast.reply-once.lifecycle.test.ts
@@ -184,13 +184,6 @@ function createBroadcastEvent(messageId: string) {
   };
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 async function setupLifecycleMonitor(accountId: "account-A" | "account-B") {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlersByAccount.set(accountId, registered);
@@ -220,6 +213,7 @@ async function setupLifecycleMonitor(accountId: "account-A" | "account-B") {
 
 describe("Feishu broadcast reply-once lifecycle", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     handlersByAccount = new Map();
     runtimesByAccount = new Map();
@@ -327,6 +321,7 @@ describe("Feishu broadcast reply-once lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
       return;
@@ -340,9 +335,14 @@ describe("Feishu broadcast reply-once lifecycle", () => {
     const event = createBroadcastEvent("om_broadcast_once");
 
     await onMessageA(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock.mock.calls.length).toBeGreaterThan(0);
+    });
     await onMessageB(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(2);
+      expect(createFeishuReplyDispatcherMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(runtimesByAccount.get("account-A")?.error).not.toHaveBeenCalled();
     expect(runtimesByAccount.get("account-B")?.error).not.toHaveBeenCalled();
@@ -383,9 +383,13 @@ describe("Feishu broadcast reply-once lifecycle", () => {
     });
 
     await onMessageA(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock.mock.calls.length).toBeGreaterThan(0);
+    });
     await onMessageB(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(2);
+    });
 
     expect(runtimesByAccount.get("account-A")?.error).not.toHaveBeenCalled();
     expect(runtimesByAccount.get("account-B")?.error).not.toHaveBeenCalled();

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginRuntimeMock } from "../../../test/helpers/extensions/plugin-runtime-mock.js";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { resetProcessedFeishuCardActionTokensForTests } from "./card-action.js";
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { monitorSingleAccount } from "./monitor.account.js";
 import { setFeishuRuntime } from "./runtime.js";
@@ -181,13 +182,6 @@ function createCardActionEvent(params: {
   };
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 async function setupLifecycleMonitor() {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -216,9 +210,11 @@ async function setupLifecycleMonitor() {
 
 describe("Feishu card-action lifecycle", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     handlers = {};
     lastRuntime = null;
+    resetProcessedFeishuCardActionTokensForTests();
     process.env.OPENCLAW_STATE_DIR = `/tmp/openclaw-feishu-card-action-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
     const dispatcher = {
@@ -318,6 +314,8 @@ describe("Feishu card-action lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    resetProcessedFeishuCardActionTokensForTests();
     if (originalStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
       return;
@@ -334,9 +332,14 @@ describe("Feishu card-action lifecycle", () => {
     });
 
     await onCardAction(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    });
     await onCardAction(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(createFeishuReplyDispatcherMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).not.toHaveBeenCalled();
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
@@ -379,9 +382,15 @@ describe("Feishu card-action lifecycle", () => {
     });
 
     await onCardAction(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
+    });
     await onCardAction(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);

--- a/extensions/feishu/src/monitor.reply-once.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.reply-once.lifecycle.test.ts
@@ -167,13 +167,6 @@ function createTextEvent(messageId: string) {
   };
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 async function setupLifecycleMonitor() {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -202,6 +195,7 @@ async function setupLifecycleMonitor() {
 
 describe("Feishu reply-once lifecycle", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     handlers = {};
     lastRuntime = null;
@@ -304,6 +298,7 @@ describe("Feishu reply-once lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
       return;
@@ -316,9 +311,14 @@ describe("Feishu reply-once lifecycle", () => {
     const event = createTextEvent("om_lifecycle_once");
 
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    });
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(createFeishuReplyDispatcherMock).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).not.toHaveBeenCalled();
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
@@ -358,9 +358,15 @@ describe("Feishu reply-once lifecycle", () => {
     });
 
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
+    });
     await onMessage(event);
-    await settleAsyncWork();
+    await vi.waitFor(() => {
+      expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
+    });
 
     expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);

--- a/extensions/zalouser/src/accounts.test-mocks.ts
+++ b/extensions/zalouser/src/accounts.test-mocks.ts
@@ -1,10 +1,14 @@
 import { vi } from "vitest";
 import { createDefaultResolvedZalouserAccount } from "./test-helpers.js";
 
-vi.mock("./accounts.js", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
+vi.mock("./accounts.js", () => {
   return {
-    ...actual,
+    listZalouserAccountIds: () => ["default"],
+    resolveDefaultZalouserAccountId: () => "default",
     resolveZalouserAccountSync: () => createDefaultResolvedZalouserAccount(),
+    resolveZalouserAccount: async () => createDefaultResolvedZalouserAccount(),
+    listEnabledZalouserAccounts: async () => [createDefaultResolvedZalouserAccount()],
+    getZcaUserInfo: async () => null,
+    checkZcaAuthenticated: async () => false,
   };
 });

--- a/extensions/zalouser/src/channel.directory.test.ts
+++ b/extensions/zalouser/src/channel.directory.test.ts
@@ -1,18 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import "./accounts.test-mocks.js";
-import { createZalouserRuntimeEnv } from "./test-helpers.js";
-
-const listZaloGroupMembersMock = vi.hoisted(() => vi.fn(async () => []));
-
-vi.mock("./zalo-js.js", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    listZaloGroupMembers: listZaloGroupMembersMock,
-  };
-});
-
+import "./zalo-js.test-mocks.js";
 import { zalouserPlugin } from "./channel.js";
+import { createZalouserRuntimeEnv } from "./test-helpers.js";
+import { listZaloGroupMembersMock } from "./zalo-js.test-mocks.js";
 
 const runtimeStub = createZalouserRuntimeEnv();
 

--- a/extensions/zalouser/src/channel.sendpayload.test.ts
+++ b/extensions/zalouser/src/channel.sendpayload.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { primeChannelOutboundSendMock } from "../../../src/channels/plugins/contracts/suites.js";
 import "./accounts.test-mocks.js";
+import "./zalo-js.test-mocks.js";
 import type { ReplyPayload } from "../runtime-api.js";
 import { zalouserPlugin } from "./channel.js";
 import { setZalouserRuntime } from "./runtime.js";

--- a/extensions/zalouser/src/channel.setup.test.ts
+++ b/extensions/zalouser/src/channel.setup.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../../src/channels/plugins/setup-wizard.js";
 import { withEnvAsync } from "../../../test/helpers/extensions/env.js";
+import "./zalo-js.test-mocks.js";
 import { zalouserSetupPlugin } from "./channel.setup.js";
 
 const zalouserSetupAdapter = buildChannelSetupWizardAdapterFromSetupWizard({

--- a/extensions/zalouser/src/channel.test.ts
+++ b/extensions/zalouser/src/channel.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "./zalo-js.test-mocks.js";
 import { zalouserPlugin } from "./channel.js";
 import { setZalouserRuntime } from "./runtime.js";
 import { sendMessageZalouser, sendReactionZalouser } from "./send.js";

--- a/extensions/zalouser/src/monitor.account-scope.test.ts
+++ b/extensions/zalouser/src/monitor.account-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import "./monitor.send-mocks.js";
+import "./zalo-js.test-mocks.js";
 import { __testing } from "./monitor.js";
 import { sendMessageZalouserMock } from "./monitor.send-mocks.js";
 import { setZalouserRuntime } from "./runtime.js";

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import "./monitor.send-mocks.js";
+import "./zalo-js.test-mocks.js";
 import { resolveZalouserAccountSync } from "./accounts.js";
 import { __testing } from "./monitor.js";
 import {

--- a/extensions/zalouser/src/reaction.ts
+++ b/extensions/zalouser/src/reaction.ts
@@ -1,4 +1,4 @@
-import { Reactions } from "./zca-client.js";
+import { Reactions } from "./zca-constants.js";
 
 const REACTION_ALIAS_MAP = new Map<string, string>([
   ["like", Reactions.LIKE],

--- a/extensions/zalouser/src/send.test.ts
+++ b/extensions/zalouser/src/send.test.ts
@@ -17,7 +17,7 @@ import {
   sendZaloTextMessage,
   sendZaloTypingEvent,
 } from "./zalo-js.js";
-import { TextStyle } from "./zca-client.js";
+import { TextStyle } from "./zca-constants.js";
 
 vi.mock("./zalo-js.js", () => ({
   sendZaloTextMessage: vi.fn(),

--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -8,7 +8,7 @@ import {
   sendZaloTextMessage,
   sendZaloTypingEvent,
 } from "./zalo-js.js";
-import { TextStyle } from "./zca-client.js";
+import { TextStyle } from "./zca-constants.js";
 
 export type ZalouserSendOptions = ZaloSendOptions;
 export type ZalouserSendResult = ZaloSendResult;

--- a/extensions/zalouser/src/setup-surface.test.ts
+++ b/extensions/zalouser/src/setup-surface.test.ts
@@ -3,30 +3,7 @@ import { buildChannelSetupWizardAdapterFromSetupWizard } from "../../../src/chan
 import { createRuntimeEnv } from "../../../test/helpers/extensions/runtime-env.js";
 import { createTestWizardPrompter } from "../../../test/helpers/extensions/setup-wizard.js";
 import type { OpenClawConfig } from "../runtime-api.js";
-
-vi.mock("./zalo-js.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./zalo-js.js")>();
-  return {
-    ...actual,
-    checkZaloAuthenticated: vi.fn(async () => false),
-    logoutZaloProfile: vi.fn(async () => {}),
-    startZaloQrLogin: vi.fn(async () => ({
-      message: "qr pending",
-      qrDataUrl: undefined,
-    })),
-    waitForZaloQrLogin: vi.fn(async () => ({
-      connected: false,
-      message: "login pending",
-    })),
-    resolveZaloAllowFromEntries: vi.fn(async ({ entries }: { entries: string[] }) =>
-      entries.map((entry) => ({ input: entry, resolved: true, id: entry, note: undefined })),
-    ),
-    resolveZaloGroupsByEntries: vi.fn(async ({ entries }: { entries: string[] }) =>
-      entries.map((entry) => ({ input: entry, resolved: true, id: entry, note: undefined })),
-    ),
-  };
-});
-
+import "./zalo-js.test-mocks.js";
 import { zalouserPlugin } from "./channel.js";
 
 const zalouserConfigureAdapter = buildChannelSetupWizardAdapterFromSetupWizard({

--- a/extensions/zalouser/src/text-styles.test.ts
+++ b/extensions/zalouser/src/text-styles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseZalouserTextStyles } from "./text-styles.js";
-import { TextStyle } from "./zca-client.js";
+import { TextStyle } from "./zca-constants.js";
 
 describe("parseZalouserTextStyles", () => {
   it("renders inline markdown emphasis as Zalo style ranges", () => {

--- a/extensions/zalouser/src/text-styles.ts
+++ b/extensions/zalouser/src/text-styles.ts
@@ -1,4 +1,4 @@
-import { TextStyle, type Style } from "./zca-client.js";
+import { TextStyle, type Style } from "./zca-constants.js";
 
 type InlineStyle = (typeof TextStyle)[keyof typeof TextStyle];
 

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -1,4 +1,4 @@
-import type { Style } from "./zca-client.js";
+import type { Style } from "./zca-constants.js";
 
 export type ZcaFriend = {
   userId: string;

--- a/extensions/zalouser/src/zalo-js.test-mocks.ts
+++ b/extensions/zalouser/src/zalo-js.test-mocks.ts
@@ -1,0 +1,60 @@
+import { vi } from "vitest";
+
+const zaloJsMocks = vi.hoisted(() => ({
+  checkZaloAuthenticatedMock: vi.fn(async () => false),
+  getZaloUserInfoMock: vi.fn(async () => null),
+  listZaloFriendsMock: vi.fn(async () => []),
+  listZaloFriendsMatchingMock: vi.fn(async () => []),
+  listZaloGroupMembersMock: vi.fn(async () => []),
+  listZaloGroupsMock: vi.fn(async () => []),
+  listZaloGroupsMatchingMock: vi.fn(async () => []),
+  logoutZaloProfileMock: vi.fn(async () => {}),
+  resolveZaloAllowFromEntriesMock: vi.fn(async ({ entries }: { entries: string[] }) =>
+    entries.map((entry) => ({ input: entry, resolved: true, id: entry, note: undefined })),
+  ),
+  resolveZaloGroupContextMock: vi.fn(async () => null),
+  resolveZaloGroupsByEntriesMock: vi.fn(async ({ entries }: { entries: string[] }) =>
+    entries.map((entry) => ({ input: entry, resolved: true, id: entry, note: undefined })),
+  ),
+  startZaloListenerMock: vi.fn(async () => ({ stop: vi.fn() })),
+  startZaloQrLoginMock: vi.fn(async () => ({
+    message: "qr pending",
+    qrDataUrl: undefined,
+  })),
+  waitForZaloQrLoginMock: vi.fn(async () => ({
+    connected: false,
+    message: "login pending",
+  })),
+}));
+
+export const checkZaloAuthenticatedMock = zaloJsMocks.checkZaloAuthenticatedMock;
+export const getZaloUserInfoMock = zaloJsMocks.getZaloUserInfoMock;
+export const listZaloFriendsMock = zaloJsMocks.listZaloFriendsMock;
+export const listZaloFriendsMatchingMock = zaloJsMocks.listZaloFriendsMatchingMock;
+export const listZaloGroupMembersMock = zaloJsMocks.listZaloGroupMembersMock;
+export const listZaloGroupsMock = zaloJsMocks.listZaloGroupsMock;
+export const listZaloGroupsMatchingMock = zaloJsMocks.listZaloGroupsMatchingMock;
+export const logoutZaloProfileMock = zaloJsMocks.logoutZaloProfileMock;
+export const resolveZaloAllowFromEntriesMock = zaloJsMocks.resolveZaloAllowFromEntriesMock;
+export const resolveZaloGroupContextMock = zaloJsMocks.resolveZaloGroupContextMock;
+export const resolveZaloGroupsByEntriesMock = zaloJsMocks.resolveZaloGroupsByEntriesMock;
+export const startZaloListenerMock = zaloJsMocks.startZaloListenerMock;
+export const startZaloQrLoginMock = zaloJsMocks.startZaloQrLoginMock;
+export const waitForZaloQrLoginMock = zaloJsMocks.waitForZaloQrLoginMock;
+
+vi.mock("./zalo-js.js", () => ({
+  checkZaloAuthenticated: checkZaloAuthenticatedMock,
+  getZaloUserInfo: getZaloUserInfoMock,
+  listZaloFriends: listZaloFriendsMock,
+  listZaloFriendsMatching: listZaloFriendsMatchingMock,
+  listZaloGroupMembers: listZaloGroupMembersMock,
+  listZaloGroups: listZaloGroupsMock,
+  listZaloGroupsMatching: listZaloGroupsMatchingMock,
+  logoutZaloProfile: logoutZaloProfileMock,
+  resolveZaloAllowFromEntries: resolveZaloAllowFromEntriesMock,
+  resolveZaloGroupContext: resolveZaloGroupContextMock,
+  resolveZaloGroupsByEntries: resolveZaloGroupsByEntriesMock,
+  startZaloListener: startZaloListenerMock,
+  startZaloQrLogin: startZaloQrLoginMock,
+  waitForZaloQrLogin: waitForZaloQrLoginMock,
+}));

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -19,17 +19,16 @@ import type {
   ZcaUserInfo,
 } from "./types.js";
 import {
-  LoginQRCallbackEventType,
   TextStyle,
-  ThreadType,
-  Zalo,
   type API,
   type Credentials,
   type GroupInfo,
   type LoginQRCallbackEvent,
   type Message,
   type User,
+  Zalo,
 } from "./zca-client.js";
+import { LoginQRCallbackEventType, ThreadType } from "./zca-constants.js";
 
 const API_LOGIN_TIMEOUT_MS = 20_000;
 const QR_LOGIN_TTL_MS = 3 * 60_000;

--- a/extensions/zalouser/src/zca-client.ts
+++ b/extensions/zalouser/src/zca-client.ts
@@ -1,67 +1,17 @@
 import * as zcaJsRuntime from "zca-js";
+import {
+  LoginQRCallbackEventType,
+  Reactions,
+  TextStyle,
+  ThreadType,
+  type Style,
+} from "./zca-constants.js";
 
 const zcaJs = zcaJsRuntime as unknown as {
-  ThreadType: unknown;
-  LoginQRCallbackEventType: unknown;
-  Reactions: unknown;
   Zalo: unknown;
 };
-
-export const ThreadType = zcaJs.ThreadType as {
-  User: 0;
-  Group: 1;
-};
-
-export const LoginQRCallbackEventType = zcaJs.LoginQRCallbackEventType as {
-  QRCodeGenerated: 0;
-  QRCodeExpired: 1;
-  QRCodeScanned: 2;
-  QRCodeDeclined: 3;
-  GotLoginInfo: 4;
-};
-
-export const Reactions = zcaJs.Reactions as Record<string, string> & {
-  HEART: string;
-  LIKE: string;
-  HAHA: string;
-  WOW: string;
-  CRY: string;
-  ANGRY: string;
-  NONE: string;
-};
-
-// Mirror zca-js sendMessage style constants locally because the package root
-// typing surface does not consistently expose TextStyle/Style to tsgo.
-export const TextStyle = {
-  Bold: "b",
-  Italic: "i",
-  Underline: "u",
-  StrikeThrough: "s",
-  Red: "c_db342e",
-  Orange: "c_f27806",
-  Yellow: "c_f7b503",
-  Green: "c_15a85f",
-  Small: "f_13",
-  Big: "f_18",
-  UnorderedList: "lst_1",
-  OrderedList: "lst_2",
-  Indent: "ind_$",
-} as const;
-
-type TextStyleValue = (typeof TextStyle)[keyof typeof TextStyle];
-
-export type Style =
-  | {
-      start: number;
-      len: number;
-      st: Exclude<TextStyleValue, typeof TextStyle.Indent>;
-    }
-  | {
-      start: number;
-      len: number;
-      st: typeof TextStyle.Indent;
-      indentSize?: number;
-    };
+export { LoginQRCallbackEventType, Reactions, TextStyle, ThreadType };
+export type { Style };
 
 export type Credentials = {
   imei: string;

--- a/extensions/zalouser/src/zca-constants.ts
+++ b/extensions/zalouser/src/zca-constants.ts
@@ -1,0 +1,55 @@
+export const ThreadType = {
+  User: 0,
+  Group: 1,
+} as const;
+
+export const LoginQRCallbackEventType = {
+  QRCodeGenerated: 0,
+  QRCodeExpired: 1,
+  QRCodeScanned: 2,
+  QRCodeDeclined: 3,
+  GotLoginInfo: 4,
+} as const;
+
+export const Reactions = {
+  HEART: "/-heart",
+  LIKE: "/-strong",
+  HAHA: ":>",
+  WOW: ":o",
+  CRY: ":-((",
+  ANGRY: ":-h",
+  NONE: "",
+} as const;
+
+// Mirror zca-js sendMessage style constants locally because the package root
+// typing surface does not consistently expose TextStyle/Style to tsgo.
+export const TextStyle = {
+  Bold: "b",
+  Italic: "i",
+  Underline: "u",
+  StrikeThrough: "s",
+  Red: "c_db342e",
+  Orange: "c_f27806",
+  Yellow: "c_f7b503",
+  Green: "c_15a85f",
+  Small: "f_13",
+  Big: "f_18",
+  UnorderedList: "lst_1",
+  OrderedList: "lst_2",
+  Indent: "ind_$",
+} as const;
+
+type TextStyleValue = (typeof TextStyle)[keyof typeof TextStyle];
+
+export type Style =
+  | {
+      start: number;
+      len: number;
+      st: Exclude<TextStyleValue, typeof TextStyle.Indent>;
+    }
+  | {
+      start: number;
+      len: number;
+      st: typeof TextStyle.Indent;
+      indentSize?: number;
+    };

--- a/package.json
+++ b/package.json
@@ -669,6 +669,7 @@
     "test:parallels:windows": "bash scripts/e2e/parallels-windows-smoke.sh",
     "test:perf:budget": "node scripts/test-perf-budget.mjs",
     "test:perf:hotspots": "node scripts/test-hotspots.mjs",
+    "test:perf:update-memory-hotspots": "node scripts/test-update-memory-hotspots.mjs",
     "test:perf:update-timings": "node scripts/test-update-timings.mjs",
     "test:sectriage": "pnpm exec vitest run --config vitest.gateway.config.ts && vitest run --config vitest.unit.config.ts --exclude src/daemon/launchd.integration.test.ts --exclude src/process/exec.test.ts",
     "test:startup:memory": "node scripts/check-cli-startup-memory.mjs",

--- a/scripts/test-parallel-memory.mjs
+++ b/scripts/test-parallel-memory.mjs
@@ -10,6 +10,10 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
 
 const COMPLETED_TEST_FILE_LINE_PATTERN =
   /(?<file>(?:src|extensions|test|ui)\/\S+?\.(?:live\.test|e2e\.test|test)\.ts)\s+\(.*\)\s+(?<duration>\d+(?:\.\d+)?)(?<unit>ms|s)\s*$/;
+const MEMORY_TRACE_SUMMARY_PATTERN =
+  /^\[test-parallel\]\[mem\] summary (?<lane>\S+) files=(?<files>\d+) peak=(?<peak>[0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) totalDelta=(?<totalDelta>[+-][0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) peakAt=(?<peakAt>\S+) top=(?<top>.*)$/u;
+const MEMORY_TRACE_TOP_ENTRY_PATTERN =
+  /^(?<file>(?:src|extensions|test|ui)\/\S+?\.(?:live\.test|e2e\.test|test)\.ts):(?<delta>[+-][0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB))$/u;
 
 const PS_COLUMNS = ["pid=", "ppid=", "rss=", "comm="];
 
@@ -19,6 +23,21 @@ function parseDurationMs(rawValue, unit) {
     return null;
   }
   return unit === "s" ? Math.round(parsed * 1000) : Math.round(parsed);
+}
+
+export function parseMemoryValueKb(rawValue) {
+  const match = rawValue.match(/^(?<sign>[+-]?)(?<value>\d+(?:\.\d+)?)(?<unit>GiB|MiB|KiB)$/u);
+  if (!match?.groups) {
+    return null;
+  }
+  const value = Number.parseFloat(match.groups.value);
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const multiplier =
+    match.groups.unit === "GiB" ? 1024 ** 2 : match.groups.unit === "MiB" ? 1024 : 1;
+  const signed = Math.round(value * multiplier);
+  return match.groups.sign === "-" ? -signed : signed;
 }
 
 function stripAnsi(text) {
@@ -36,6 +55,52 @@ export function parseCompletedTestFileLines(text) {
       return {
         file: match.groups.file,
         durationMs: parseDurationMs(match.groups.duration, match.groups.unit),
+      };
+    })
+    .filter((entry) => entry !== null);
+}
+
+export function parseMemoryTraceSummaryLines(text) {
+  return stripAnsi(text)
+    .split(/\r?\n/u)
+    .map((line) => {
+      const match = line.match(MEMORY_TRACE_SUMMARY_PATTERN);
+      if (!match?.groups) {
+        return null;
+      }
+      const peakRssKb = parseMemoryValueKb(match.groups.peak);
+      const totalDeltaKb = parseMemoryValueKb(match.groups.totalDelta);
+      const fileCount = Number.parseInt(match.groups.files, 10);
+      if (!Number.isInteger(fileCount) || peakRssKb === null || totalDeltaKb === null) {
+        return null;
+      }
+      const top =
+        match.groups.top === "none"
+          ? []
+          : match.groups.top
+              .split(/,\s+/u)
+              .map((entry) => {
+                const topMatch = entry.match(MEMORY_TRACE_TOP_ENTRY_PATTERN);
+                if (!topMatch?.groups) {
+                  return null;
+                }
+                const deltaKb = parseMemoryValueKb(topMatch.groups.delta);
+                if (deltaKb === null) {
+                  return null;
+                }
+                return {
+                  file: topMatch.groups.file,
+                  deltaKb,
+                };
+              })
+              .filter((entry) => entry !== null);
+      return {
+        lane: match.groups.lane,
+        files: fileCount,
+        peakRssKb,
+        totalDeltaKb,
+        peakAt: match.groups.peakAt,
+        top,
       };
     })
     .filter((entry) => entry !== null);

--- a/scripts/test-parallel-memory.mjs
+++ b/scripts/test-parallel-memory.mjs
@@ -7,13 +7,14 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
   `${ESCAPE}(?:\\][^${BELL}]*(?:${BELL}|${ESCAPE}\\\\)|\\[[0-?]*[ -/]*[@-~]|[@-Z\\\\-_])`,
   "g",
 );
+const GITHUB_ACTIONS_LOG_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+/u;
 
 const COMPLETED_TEST_FILE_LINE_PATTERN =
   /(?<file>(?:src|extensions|test|ui)\/\S+?\.(?:live\.test|e2e\.test|test)\.ts)\s+\(.*\)\s+(?<duration>\d+(?:\.\d+)?)(?<unit>ms|s)\s*$/;
 const MEMORY_TRACE_SUMMARY_PATTERN =
-  /^\[test-parallel\]\[mem\] summary (?<lane>\S+) files=(?<files>\d+) peak=(?<peak>[0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) totalDelta=(?<totalDelta>[+-][0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) peakAt=(?<peakAt>\S+) top=(?<top>.*)$/u;
+  /^\[test-parallel\]\[mem\] summary (?<lane>\S+) files=(?<files>\d+) peak=(?<peak>[0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) totalDelta=(?<totalDelta>[+-]?[0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB)) peakAt=(?<peakAt>\S+) top=(?<top>.*)$/u;
 const MEMORY_TRACE_TOP_ENTRY_PATTERN =
-  /^(?<file>(?:src|extensions|test|ui)\/\S+?\.(?:live\.test|e2e\.test|test)\.ts):(?<delta>[+-][0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB))$/u;
+  /^(?<file>(?:src|extensions|test|ui)\/\S+?\.(?:live\.test|e2e\.test|test)\.ts):(?<delta>[+-]?[0-9]+(?:\.[0-9]+)?(?:GiB|MiB|KiB))$/u;
 
 const PS_COLUMNS = ["pid=", "ppid=", "rss=", "comm="];
 
@@ -44,9 +45,14 @@ function stripAnsi(text) {
   return text.replaceAll(ANSI_ESCAPE_PATTERN, "");
 }
 
+function normalizeLogLine(line) {
+  return line.replace(GITHUB_ACTIONS_LOG_PREFIX_PATTERN, "");
+}
+
 export function parseCompletedTestFileLines(text) {
   return stripAnsi(text)
     .split(/\r?\n/u)
+    .map((line) => normalizeLogLine(line))
     .map((line) => {
       const match = line.match(COMPLETED_TEST_FILE_LINE_PATTERN);
       if (!match?.groups) {
@@ -63,6 +69,7 @@ export function parseCompletedTestFileLines(text) {
 export function parseMemoryTraceSummaryLines(text) {
   return stripAnsi(text)
     .split(/\r?\n/u)
+    .map((line) => normalizeLogLine(line))
     .map((line) => {
       const match = line.match(MEMORY_TRACE_SUMMARY_PATTERN);
       if (!match?.groups) {

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -15,8 +15,10 @@ import {
   resolveTestRunExitCode,
 } from "./test-parallel-utils.mjs";
 import {
+  loadUnitMemoryHotspotManifest,
   loadTestRunnerBehavior,
   loadUnitTimingManifest,
+  selectMemoryHeavyFiles,
   packFilesByDuration,
   selectTimedHeavyFiles,
 } from "./test-runner-manifest.mjs";
@@ -262,6 +264,7 @@ const inferTarget = (fileFilter) => {
   return { owner: "base", isolated };
 };
 const unitTimingManifest = loadUnitTimingManifest();
+const unitMemoryHotspotManifest = loadUnitMemoryHotspotManifest();
 const parseEnvNumber = (name, fallback) => {
   const parsed = Number.parseInt(process.env[name] ?? "", 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
@@ -298,6 +301,16 @@ const heavyUnitLaneCount = parseEnvNumber(
   defaultHeavyUnitLaneCount,
 );
 const heavyUnitMinDurationMs = parseEnvNumber("OPENCLAW_TEST_HEAVY_UNIT_MIN_MS", 1200);
+const defaultMemoryHeavyUnitFileLimit =
+  testProfile === "serial" ? 0 : isCI ? 32 : testProfile === "low" ? 8 : 16;
+const memoryHeavyUnitFileLimit = parseEnvNumber(
+  "OPENCLAW_TEST_MEMORY_HEAVY_UNIT_FILE_LIMIT",
+  defaultMemoryHeavyUnitFileLimit,
+);
+const memoryHeavyUnitMinDeltaKb = parseEnvNumber(
+  "OPENCLAW_TEST_MEMORY_HEAVY_UNIT_MIN_KB",
+  unitMemoryHotspotManifest.defaultMinDeltaKb,
+);
 const timedHeavyUnitFiles =
   shouldSplitUnitRuns && heavyUnitFileLimit > 0
     ? selectTimedHeavyFiles({
@@ -308,8 +321,26 @@ const timedHeavyUnitFiles =
         timings: unitTimingManifest,
       })
     : [];
+const memoryHeavyUnitFiles =
+  shouldSplitUnitRuns && memoryHeavyUnitFileLimit > 0
+    ? selectMemoryHeavyFiles({
+        candidates: allKnownUnitFiles,
+        limit: memoryHeavyUnitFileLimit,
+        minDeltaKb: memoryHeavyUnitMinDeltaKb,
+        exclude: unitBehaviorOverrideSet,
+        hotspots: unitMemoryHotspotManifest,
+      })
+    : [];
 const unitFastExcludedFiles = [
-  ...new Set([...unitBehaviorOverrideSet, ...timedHeavyUnitFiles, ...channelSingletonFiles]),
+  ...new Set([
+    ...unitBehaviorOverrideSet,
+    ...timedHeavyUnitFiles,
+    ...memoryHeavyUnitFiles,
+    ...channelSingletonFiles,
+  ]),
+];
+const unitAutoSingletonFiles = [
+  ...new Set([...unitSingletonIsolatedFiles, ...memoryHeavyUnitFiles]),
 ];
 const estimateUnitDurationMs = (file) =>
   unitTimingManifest.files[file]?.durationMs ?? unitTimingManifest.defaultDurationMs;
@@ -353,7 +384,7 @@ const baseRuns = [
             ]
           : []),
         ...unitHeavyEntries,
-        ...unitSingletonIsolatedFiles.map((file) => ({
+        ...unitAutoSingletonFiles.map((file) => ({
           name: `${path.basename(file, ".test.ts")}-isolated`,
           args: [
             "vitest",

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -320,7 +320,7 @@ const heavyUnitLaneCount = parseEnvNumber(
 );
 const heavyUnitMinDurationMs = parseEnvNumber("OPENCLAW_TEST_HEAVY_UNIT_MIN_MS", 1200);
 const defaultMemoryHeavyUnitFileLimit =
-  testProfile === "serial" ? 0 : isCI ? 32 : testProfile === "low" ? 8 : 16;
+  testProfile === "serial" ? 0 : isCI ? 64 : testProfile === "low" ? 8 : 16;
 const memoryHeavyUnitFileLimit = parseEnvNumber(
   "OPENCLAW_TEST_MEMORY_HEAVY_UNIT_FILE_LIMIT",
   defaultMemoryHeavyUnitFileLimit,

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -352,12 +352,40 @@ const unitFastExcludedFiles = [
 const unitAutoSingletonFiles = [
   ...new Set([...unitSingletonIsolatedFiles, ...memoryHeavyUnitFiles]),
 ];
-const unitFastExtraExcludeFile =
-  unitFastExcludedFiles.length > 0
-    ? writeTempJsonArtifact("vitest-unit-fast-excludes", unitFastExcludedFiles)
-    : null;
 const estimateUnitDurationMs = (file) =>
   unitTimingManifest.files[file]?.durationMs ?? unitTimingManifest.defaultDurationMs;
+const unitFastExcludedFileSet = new Set(unitFastExcludedFiles);
+const unitFastCandidateFiles = allKnownUnitFiles.filter(
+  (file) => !unitFastExcludedFileSet.has(file),
+);
+const defaultUnitFastLaneCount = isCI && !isWindows ? 2 : 1;
+const unitFastLaneCount = Math.max(
+  1,
+  parseEnvNumber("OPENCLAW_TEST_UNIT_FAST_LANES", defaultUnitFastLaneCount),
+);
+const unitFastBuckets =
+  unitFastLaneCount > 1
+    ? packFilesByDuration(unitFastCandidateFiles, unitFastLaneCount, estimateUnitDurationMs)
+    : [unitFastCandidateFiles];
+const unitFastEntries = unitFastBuckets
+  .filter((files) => files.length > 0)
+  .map((files, index) => ({
+    name: unitFastBuckets.length === 1 ? "unit-fast" : `unit-fast-${String(index + 1)}`,
+    env: {
+      OPENCLAW_VITEST_INCLUDE_FILE: writeTempJsonArtifact(
+        `vitest-unit-fast-include-${String(index + 1)}`,
+        files,
+      ),
+    },
+    args: [
+      "vitest",
+      "run",
+      "--config",
+      "vitest.unit.config.ts",
+      `--pool=${useVmForks ? "vmForks" : "forks"}`,
+      ...(disableIsolation ? ["--isolate=false"] : []),
+    ],
+  }));
 const heavyUnitBuckets = packFilesByDuration(
   timedHeavyUnitFiles,
   heavyUnitLaneCount,
@@ -370,23 +398,7 @@ const unitHeavyEntries = heavyUnitBuckets.map((files, index) => ({
 const baseRuns = [
   ...(shouldSplitUnitRuns
     ? [
-        {
-          name: "unit-fast",
-          env:
-            unitFastExtraExcludeFile === null
-              ? undefined
-              : {
-                  OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE: unitFastExtraExcludeFile,
-                },
-          args: [
-            "vitest",
-            "run",
-            "--config",
-            "vitest.unit.config.ts",
-            `--pool=${useVmForks ? "vmForks" : "forks"}`,
-            ...(disableIsolation ? ["--isolate=false"] : []),
-          ],
-        },
+        ...unitFastEntries,
         ...(unitBehaviorIsolatedFiles.length > 0
           ? [
               {
@@ -1223,14 +1235,17 @@ if (passthroughRequiresSingleRun && passthroughOptionArgs.length > 0) {
 }
 
 if (isMacMiniProfile && targetedEntries.length === 0) {
-  const unitFastEntry = parallelRuns.find((entry) => entry.name === "unit-fast");
-  if (unitFastEntry) {
-    const unitFastCode = await run(unitFastEntry, passthroughOptionArgs);
+  const unitFastEntriesForMacMini = parallelRuns.filter((entry) =>
+    entry.name.startsWith("unit-fast"),
+  );
+  for (const entry of unitFastEntriesForMacMini) {
+    // eslint-disable-next-line no-await-in-loop
+    const unitFastCode = await run(entry, passthroughOptionArgs);
     if (unitFastCode !== 0) {
       process.exit(unitFastCode);
     }
   }
-  const deferredEntries = parallelRuns.filter((entry) => entry.name !== "unit-fast");
+  const deferredEntries = parallelRuns.filter((entry) => !entry.name.startsWith("unit-fast"));
   const failedMacMiniParallel = await runEntriesWithLimit(
     deferredEntries,
     passthroughOptionArgs,

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -28,6 +28,25 @@ const pnpm = "pnpm";
 const behaviorManifest = loadTestRunnerBehavior();
 const existingFiles = (entries) =>
   entries.map((entry) => entry.file).filter((file) => fs.existsSync(file));
+let tempArtifactDir = null;
+const ensureTempArtifactDir = () => {
+  if (tempArtifactDir === null) {
+    tempArtifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-parallel-"));
+  }
+  return tempArtifactDir;
+};
+const writeTempJsonArtifact = (name, value) => {
+  const filePath = path.join(ensureTempArtifactDir(), `${name}.json`);
+  fs.writeFileSync(filePath, `${JSON.stringify(value)}\n`, "utf8");
+  return filePath;
+};
+const cleanupTempArtifacts = () => {
+  if (tempArtifactDir === null) {
+    return;
+  }
+  fs.rmSync(tempArtifactDir, { recursive: true, force: true });
+  tempArtifactDir = null;
+};
 const existingUnitConfigFiles = (entries) => existingFiles(entries).filter(isUnitConfigTestFile);
 const unitBehaviorIsolatedFiles = existingUnitConfigFiles(behaviorManifest.unit.isolated);
 const unitSingletonIsolatedFiles = existingUnitConfigFiles(behaviorManifest.unit.singletonIsolated);
@@ -333,6 +352,10 @@ const unitFastExcludedFiles = [
 const unitAutoSingletonFiles = [
   ...new Set([...unitSingletonIsolatedFiles, ...memoryHeavyUnitFiles]),
 ];
+const unitFastExtraExcludeFile =
+  unitFastExcludedFiles.length > 0
+    ? writeTempJsonArtifact("vitest-unit-fast-excludes", unitFastExcludedFiles)
+    : null;
 const estimateUnitDurationMs = (file) =>
   unitTimingManifest.files[file]?.durationMs ?? unitTimingManifest.defaultDurationMs;
 const heavyUnitBuckets = packFilesByDuration(
@@ -349,6 +372,12 @@ const baseRuns = [
     ? [
         {
           name: "unit-fast",
+          env:
+            unitFastExtraExcludeFile === null
+              ? undefined
+              : {
+                  OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE: unitFastExtraExcludeFile,
+                },
           args: [
             "vitest",
             "run",
@@ -356,7 +385,6 @@ const baseRuns = [
             "vitest.unit.config.ts",
             `--pool=${useVmForks ? "vmForks" : "forks"}`,
             ...(disableIsolation ? ["--isolate=false"] : []),
-            ...unitFastExcludedFiles.flatMap((file) => ["--exclude", file]),
           ],
         },
         ...(unitBehaviorIsolatedFiles.length > 0
@@ -982,7 +1010,12 @@ const runOnce = (entry, extraArgs = []) =>
     try {
       child = spawn(pnpm, args, {
         stdio: ["inherit", "pipe", "pipe"],
-        env: { ...process.env, VITEST_GROUP: entry.name, NODE_OPTIONS: resolvedNodeOptions },
+        env: {
+          ...process.env,
+          ...entry.env,
+          VITEST_GROUP: entry.name,
+          NODE_OPTIONS: resolvedNodeOptions,
+        },
         shell: isWindows,
       });
       captureTreeSample("spawn");
@@ -1134,6 +1167,7 @@ const shutdown = (signal) => {
 
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("exit", cleanupTempArtifacts);
 
 if (process.env.OPENCLAW_TEST_LIST_LANES === "1") {
   const entriesToPrint = targetedEntries.length > 0 ? targetedEntries : runs;

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -18,9 +18,8 @@ import {
   loadUnitMemoryHotspotManifest,
   loadTestRunnerBehavior,
   loadUnitTimingManifest,
-  selectMemoryHeavyFiles,
+  selectUnitHeavyFileGroups,
   packFilesByDuration,
-  selectTimedHeavyFiles,
 } from "./test-runner-manifest.mjs";
 
 // On Windows, `.cmd` launchers can fail with `spawn EINVAL` when invoked without a shell
@@ -311,33 +310,25 @@ const memoryHeavyUnitMinDeltaKb = parseEnvNumber(
   "OPENCLAW_TEST_MEMORY_HEAVY_UNIT_MIN_KB",
   unitMemoryHotspotManifest.defaultMinDeltaKb,
 );
-const timedHeavyUnitFiles =
-  shouldSplitUnitRuns && heavyUnitFileLimit > 0
-    ? selectTimedHeavyFiles({
+const { memoryHeavyFiles: memoryHeavyUnitFiles, timedHeavyFiles: timedHeavyUnitFiles } =
+  shouldSplitUnitRuns
+    ? selectUnitHeavyFileGroups({
         candidates: allKnownUnitFiles,
-        limit: heavyUnitFileLimit,
-        minDurationMs: heavyUnitMinDurationMs,
-        exclude: unitBehaviorOverrideSet,
+        behaviorOverrides: unitBehaviorOverrideSet,
+        timedLimit: heavyUnitFileLimit,
+        timedMinDurationMs: heavyUnitMinDurationMs,
+        memoryLimit: memoryHeavyUnitFileLimit,
+        memoryMinDeltaKb: memoryHeavyUnitMinDeltaKb,
         timings: unitTimingManifest,
-      })
-    : [];
-const memoryHeavyUnitFiles =
-  shouldSplitUnitRuns && memoryHeavyUnitFileLimit > 0
-    ? selectMemoryHeavyFiles({
-        candidates: allKnownUnitFiles,
-        limit: memoryHeavyUnitFileLimit,
-        minDeltaKb: memoryHeavyUnitMinDeltaKb,
-        exclude: unitBehaviorOverrideSet,
         hotspots: unitMemoryHotspotManifest,
       })
-    : [];
+    : {
+        memoryHeavyFiles: [],
+        timedHeavyFiles: [],
+      };
+const unitSchedulingOverrideSet = new Set([...unitBehaviorOverrideSet, ...memoryHeavyUnitFiles]);
 const unitFastExcludedFiles = [
-  ...new Set([
-    ...unitBehaviorOverrideSet,
-    ...timedHeavyUnitFiles,
-    ...memoryHeavyUnitFiles,
-    ...channelSingletonFiles,
-  ]),
+  ...new Set([...unitSchedulingOverrideSet, ...timedHeavyUnitFiles, ...channelSingletonFiles]),
 ];
 const unitAutoSingletonFiles = [
   ...new Set([...unitSingletonIsolatedFiles, ...memoryHeavyUnitFiles]),

--- a/scripts/test-runner-manifest.mjs
+++ b/scripts/test-runner-manifest.mjs
@@ -168,6 +168,44 @@ export function selectMemoryHeavyFiles({
     .map((entry) => entry.file);
 }
 
+export function selectUnitHeavyFileGroups({
+  candidates,
+  behaviorOverrides = new Set(),
+  timedLimit,
+  timedMinDurationMs,
+  memoryLimit,
+  memoryMinDeltaKb,
+  timings,
+  hotspots,
+}) {
+  const memoryHeavyFiles =
+    memoryLimit > 0
+      ? selectMemoryHeavyFiles({
+          candidates,
+          limit: memoryLimit,
+          minDeltaKb: memoryMinDeltaKb,
+          exclude: behaviorOverrides,
+          hotspots,
+        })
+      : [];
+  const schedulingOverrides = new Set([...behaviorOverrides, ...memoryHeavyFiles]);
+  const timedHeavyFiles =
+    timedLimit > 0
+      ? selectTimedHeavyFiles({
+          candidates,
+          limit: timedLimit,
+          minDurationMs: timedMinDurationMs,
+          exclude: schedulingOverrides,
+          timings,
+        })
+      : [];
+
+  return {
+    memoryHeavyFiles,
+    timedHeavyFiles,
+  };
+}
+
 export function packFilesByDuration(files, bucketCount, estimateDurationMs) {
   const normalizedBucketCount = Math.max(0, Math.floor(bucketCount));
   if (normalizedBucketCount <= 0 || files.length === 0) {

--- a/scripts/test-runner-manifest.mjs
+++ b/scripts/test-runner-manifest.mjs
@@ -3,10 +3,16 @@ import path from "node:path";
 
 export const behaviorManifestPath = "test/fixtures/test-parallel.behavior.json";
 export const unitTimingManifestPath = "test/fixtures/test-timings.unit.json";
+export const unitMemoryHotspotManifestPath = "test/fixtures/test-memory-hotspots.unit.json";
 
 const defaultTimingManifest = {
   config: "vitest.unit.config.ts",
   defaultDurationMs: 250,
+  files: {},
+};
+const defaultMemoryHotspotManifest = {
+  config: "vitest.unit.config.ts",
+  defaultMinDeltaKb: 256 * 1024,
   files: {},
 };
 
@@ -82,6 +88,46 @@ export function loadUnitTimingManifest() {
   };
 }
 
+export function loadUnitMemoryHotspotManifest() {
+  const raw = readJson(unitMemoryHotspotManifestPath, defaultMemoryHotspotManifest);
+  const defaultMinDeltaKb =
+    Number.isFinite(raw.defaultMinDeltaKb) && raw.defaultMinDeltaKb > 0
+      ? raw.defaultMinDeltaKb
+      : defaultMemoryHotspotManifest.defaultMinDeltaKb;
+  const files = Object.fromEntries(
+    Object.entries(raw.files ?? {})
+      .map(([file, value]) => {
+        const normalizedFile = normalizeRepoPath(file);
+        const deltaKb =
+          Number.isFinite(value?.deltaKb) && value.deltaKb > 0 ? Math.round(value.deltaKb) : null;
+        const sources = Array.isArray(value?.sources)
+          ? value.sources.filter((source) => typeof source === "string" && source.length > 0)
+          : [];
+        if (deltaKb === null) {
+          return [normalizedFile, null];
+        }
+        return [
+          normalizedFile,
+          {
+            deltaKb,
+            ...(sources.length > 0 ? { sources } : {}),
+          },
+        ];
+      })
+      .filter(([, value]) => value !== null),
+  );
+
+  return {
+    config:
+      typeof raw.config === "string" && raw.config
+        ? raw.config
+        : defaultMemoryHotspotManifest.config,
+    generatedAt: typeof raw.generatedAt === "string" ? raw.generatedAt : "",
+    defaultMinDeltaKb,
+    files,
+  };
+}
+
 export function selectTimedHeavyFiles({
   candidates,
   limit,
@@ -98,6 +144,26 @@ export function selectTimedHeavyFiles({
     }))
     .filter((entry) => entry.known && entry.durationMs >= minDurationMs)
     .toSorted((a, b) => b.durationMs - a.durationMs)
+    .slice(0, limit)
+    .map((entry) => entry.file);
+}
+
+export function selectMemoryHeavyFiles({
+  candidates,
+  limit,
+  minDeltaKb,
+  exclude = new Set(),
+  hotspots,
+}) {
+  return candidates
+    .filter((file) => !exclude.has(file))
+    .map((file) => ({
+      file,
+      deltaKb: hotspots.files[file]?.deltaKb ?? 0,
+      known: Boolean(hotspots.files[file]),
+    }))
+    .filter((entry) => entry.known && entry.deltaKb >= minDeltaKb)
+    .toSorted((a, b) => b.deltaKb - a.deltaKb)
     .slice(0, limit)
     .map((entry) => entry.file);
 }

--- a/scripts/test-update-memory-hotspots.mjs
+++ b/scripts/test-update-memory-hotspots.mjs
@@ -57,6 +57,40 @@ function parseArgs(argv) {
   return args;
 }
 
+function mergeHotspotEntry(aggregated, file, value) {
+  if (!(Number.isFinite(value?.deltaKb) && value.deltaKb > 0)) {
+    return;
+  }
+  const normalizeSourceLabel = (source) => {
+    const separator = source.lastIndexOf(":");
+    if (separator === -1) {
+      return source.endsWith(".log") ? source.slice(0, -4) : source;
+    }
+    const name = source.slice(0, separator);
+    const lane = source.slice(separator + 1);
+    return `${name.endsWith(".log") ? name.slice(0, -4) : name}:${lane}`;
+  };
+  const nextSources = Array.isArray(value?.sources)
+    ? value.sources
+        .filter((source) => typeof source === "string" && source.length > 0)
+        .map(normalizeSourceLabel)
+    : [];
+  const previous = aggregated.get(file);
+  if (!previous) {
+    aggregated.set(file, {
+      deltaKb: Math.round(value.deltaKb),
+      sources: [...new Set(nextSources)],
+    });
+    return;
+  }
+  previous.deltaKb = Math.max(previous.deltaKb, Math.round(value.deltaKb));
+  for (const source of nextSources) {
+    if (!previous.sources.includes(source)) {
+      previous.sources.push(source);
+    }
+  }
+}
+
 const opts = parseArgs(process.argv.slice(2));
 
 if (opts.logs.length === 0) {
@@ -65,6 +99,14 @@ if (opts.logs.length === 0) {
 }
 
 const aggregated = new Map();
+try {
+  const existing = JSON.parse(fs.readFileSync(opts.out, "utf8"));
+  for (const [file, value] of Object.entries(existing.files ?? {})) {
+    mergeHotspotEntry(aggregated, file, value);
+  }
+} catch {
+  // Start from scratch when the output file does not exist yet.
+}
 for (const logPath of opts.logs) {
   const text = fs.readFileSync(logPath, "utf8");
   const summaries = parseMemoryTraceSummaryLines(text).filter(
@@ -75,19 +117,10 @@ for (const logPath of opts.logs) {
       if (record.deltaKb < opts.minDeltaKb) {
         continue;
       }
-      const nextSource = `${path.basename(logPath)}:${summary.lane}`;
-      const previous = aggregated.get(record.file);
-      if (!previous) {
-        aggregated.set(record.file, {
-          deltaKb: record.deltaKb,
-          sources: [nextSource],
-        });
-        continue;
-      }
-      previous.deltaKb = Math.max(previous.deltaKb, record.deltaKb);
-      if (!previous.sources.includes(nextSource)) {
-        previous.sources.push(nextSource);
-      }
+      mergeHotspotEntry(aggregated, record.file, {
+        deltaKb: record.deltaKb,
+        sources: [`${path.basename(logPath, path.extname(logPath))}:${summary.lane}`],
+      });
     }
   }
 }

--- a/scripts/test-update-memory-hotspots.mjs
+++ b/scripts/test-update-memory-hotspots.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parseMemoryTraceSummaryLines } from "./test-parallel-memory.mjs";
+import { unitMemoryHotspotManifestPath } from "./test-runner-manifest.mjs";
+
+function parseArgs(argv) {
+  const args = {
+    config: "vitest.unit.config.ts",
+    out: unitMemoryHotspotManifestPath,
+    lane: "unit-fast",
+    logs: [],
+    minDeltaKb: 256 * 1024,
+    limit: 64,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--config") {
+      args.config = argv[i + 1] ?? args.config;
+      i += 1;
+      continue;
+    }
+    if (arg === "--out") {
+      args.out = argv[i + 1] ?? args.out;
+      i += 1;
+      continue;
+    }
+    if (arg === "--lane") {
+      args.lane = argv[i + 1] ?? args.lane;
+      i += 1;
+      continue;
+    }
+    if (arg === "--log") {
+      const logPath = argv[i + 1];
+      if (typeof logPath === "string" && logPath.length > 0) {
+        args.logs.push(logPath);
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--min-delta-kb") {
+      const parsed = Number.parseInt(argv[i + 1] ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        args.minDeltaKb = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--limit") {
+      const parsed = Number.parseInt(argv[i + 1] ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        args.limit = parsed;
+      }
+      i += 1;
+      continue;
+    }
+  }
+  return args;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+
+if (opts.logs.length === 0) {
+  console.error("[test-update-memory-hotspots] pass at least one --log <path>.");
+  process.exit(2);
+}
+
+const aggregated = new Map();
+for (const logPath of opts.logs) {
+  const text = fs.readFileSync(logPath, "utf8");
+  const summaries = parseMemoryTraceSummaryLines(text).filter(
+    (summary) => summary.lane === opts.lane,
+  );
+  for (const summary of summaries) {
+    for (const record of summary.top) {
+      if (record.deltaKb < opts.minDeltaKb) {
+        continue;
+      }
+      const nextSource = `${path.basename(logPath)}:${summary.lane}`;
+      const previous = aggregated.get(record.file);
+      if (!previous) {
+        aggregated.set(record.file, {
+          deltaKb: record.deltaKb,
+          sources: [nextSource],
+        });
+        continue;
+      }
+      previous.deltaKb = Math.max(previous.deltaKb, record.deltaKb);
+      if (!previous.sources.includes(nextSource)) {
+        previous.sources.push(nextSource);
+      }
+    }
+  }
+}
+
+const files = Object.fromEntries(
+  [...aggregated.entries()]
+    .toSorted((left, right) => right[1].deltaKb - left[1].deltaKb)
+    .slice(0, opts.limit)
+    .map(([file, value]) => [
+      file,
+      {
+        deltaKb: value.deltaKb,
+        sources: value.sources.toSorted(),
+      },
+    ]),
+);
+
+const output = {
+  config: opts.config,
+  generatedAt: new Date().toISOString(),
+  defaultMinDeltaKb: opts.minDeltaKb,
+  lane: opts.lane,
+  files,
+};
+
+fs.writeFileSync(opts.out, `${JSON.stringify(output, null, 2)}\n`);
+console.log(
+  `[test-update-memory-hotspots] wrote ${String(Object.keys(files).length)} hotspots to ${opts.out}`,
+);

--- a/src/secrets/runtime.coverage.test.ts
+++ b/src/secrets/runtime.coverage.test.ts
@@ -20,7 +20,7 @@ vi.mock("../plugins/web-search-providers.js", () => ({
 }));
 
 function createTestProvider(params: {
-  id: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "firecrawl";
+  id: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "firecrawl" | "tavily";
   pluginId: string;
   order: number;
 }): PluginWebSearchProviderEntry {
@@ -80,6 +80,7 @@ function buildTestWebSearchProviders(): PluginWebSearchProviderEntry[] {
     createTestProvider({ id: "kimi", pluginId: "moonshot", order: 40 }),
     createTestProvider({ id: "perplexity", pluginId: "perplexity", order: 50 }),
     createTestProvider({ id: "firecrawl", pluginId: "firecrawl", order: 60 }),
+    createTestProvider({ id: "tavily", pluginId: "tavily", order: 70 }),
   ];
 }
 
@@ -193,6 +194,9 @@ function buildConfigForOpenClawTarget(entry: SecretRegistryEntry, envId: string)
   }
   if (entry.id === "plugins.entries.firecrawl.config.webSearch.apiKey") {
     setPathCreateStrict(config, ["tools", "web", "search", "provider"], "firecrawl");
+  }
+  if (entry.id === "plugins.entries.tavily.config.webSearch.apiKey") {
+    setPathCreateStrict(config, ["tools", "web", "search", "provider"], "tavily");
   }
   return config;
 }

--- a/test/fixtures/test-memory-hotspots.unit.json
+++ b/test/fixtures/test-memory-hotspots.unit.json
@@ -1,6 +1,6 @@
 {
   "config": "vitest.unit.config.ts",
-  "generatedAt": "2026-03-20T00:00:00.000Z",
+  "generatedAt": "2026-03-20T04:39:09.078Z",
   "defaultMinDeltaKb": 262144,
   "lane": "unit-fast",
   "files": {
@@ -11,6 +11,18 @@
         "gha-23328306205-node-test-2-2:unit-fast"
       ]
     },
+    "src/plugins/conversation-binding.test.ts": {
+      "deltaKb": 787149,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
+    "src/plugins/contracts/wizard.contract.test.ts": {
+      "deltaKb": 783770,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
+    },
+    "ui/src/ui/views/chat.test.ts": {
+      "deltaKb": 740864,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
     "src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts": {
       "deltaKb": 652288,
       "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
@@ -18,6 +30,14 @@
     "src/plugins/install.test.ts": {
       "deltaKb": 545485,
       "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/tui/tui.submit-handler.test.ts": {
+      "deltaKb": 528486,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
+    },
+    "src/infra/provider-usage.auth.normalizes-keys.test.ts": {
+      "deltaKb": 510362,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
     },
     "src/infra/update-runner.test.ts": {
       "deltaKb": 474726,
@@ -35,13 +55,25 @@
       "deltaKb": 446054,
       "sources": ["gha-23328306205-compat-node22:unit-fast"]
     },
+    "src/plugins/interactive.test.ts": {
+      "deltaKb": 441242,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
+    },
     "src/infra/run-node.test.ts": {
       "deltaKb": 427213,
       "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
     },
+    "src/infra/provider-usage.test.ts": {
+      "deltaKb": 389837,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
     "src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts": {
       "deltaKb": 377446,
       "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts": {
+      "deltaKb": 355840,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
     },
     "src/infra/state-migrations.test.ts": {
       "deltaKb": 345805,
@@ -50,6 +82,22 @@
     "src/config/sessions/store.pruning.integration.test.ts": {
       "deltaKb": 342221,
       "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/channels/plugins/contracts/outbound-payload.contract.test.ts": {
+      "deltaKb": 335565,
+      "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
+    },
+    "src/infra/outbound/outbound-policy.test.ts": {
+      "deltaKb": 334950,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
+    "src/media-understanding/providers/moonshot/video.test.ts": {
+      "deltaKb": 333005,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
+    "src/config/sessions.test.ts": {
+      "deltaKb": 324813,
+      "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
     },
     "src/acp/translator.cancel-scoping.test.ts": {
       "deltaKb": 324403,

--- a/test/fixtures/test-memory-hotspots.unit.json
+++ b/test/fixtures/test-memory-hotspots.unit.json
@@ -1,0 +1,79 @@
+{
+  "config": "vitest.unit.config.ts",
+  "generatedAt": "2026-03-20T00:00:00.000Z",
+  "defaultMinDeltaKb": 262144,
+  "lane": "unit-fast",
+  "files": {
+    "src/config/schema.help.quality.test.ts": {
+      "deltaKb": 1111491,
+      "sources": [
+        "gha-23328306205-compat-node22:unit-fast",
+        "gha-23328306205-node-test-2-2:unit-fast"
+      ]
+    },
+    "src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts": {
+      "deltaKb": 652288,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/plugins/install.test.ts": {
+      "deltaKb": 545485,
+      "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/infra/update-runner.test.ts": {
+      "deltaKb": 474726,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/cron/isolated-agent/run.cron-model-override.test.ts": {
+      "deltaKb": 469914,
+      "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    },
+    "src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts": {
+      "deltaKb": 457421,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/cron/isolated-agent/run.skill-filter.test.ts": {
+      "deltaKb": 446054,
+      "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/infra/run-node.test.ts": {
+      "deltaKb": 427213,
+      "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    },
+    "src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts": {
+      "deltaKb": 377446,
+      "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/infra/state-migrations.test.ts": {
+      "deltaKb": 345805,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/config/sessions/store.pruning.integration.test.ts": {
+      "deltaKb": 342221,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/acp/translator.cancel-scoping.test.ts": {
+      "deltaKb": 324403,
+      "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/tui/tui-session-actions.test.ts": {
+      "deltaKb": 319898,
+      "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/infra/outbound/message-action-runner.context.test.ts": {
+      "deltaKb": 318157,
+      "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/cron/service.store-load-invalid-main-job.test.ts": {
+      "deltaKb": 308019,
+      "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    },
+    "src/cron/service.store-migration.test.ts": {
+      "deltaKb": 282931,
+      "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    },
+    "src/media-understanding/providers/google/video.test.ts": {
+      "deltaKb": 274022,
+      "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    }
+  }
+}

--- a/test/fixtures/test-memory-hotspots.unit.json
+++ b/test/fixtures/test-memory-hotspots.unit.json
@@ -1,6 +1,6 @@
 {
   "config": "vitest.unit.config.ts",
-  "generatedAt": "2026-03-20T04:39:09.078Z",
+  "generatedAt": "2026-03-20T04:59:15.285Z",
   "defaultMinDeltaKb": 262144,
   "lane": "unit-fast",
   "files": {
@@ -14,6 +14,10 @@
     "src/plugins/conversation-binding.test.ts": {
       "deltaKb": 787149,
       "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
+    "src/infra/outbound/targets.test.ts": {
+      "deltaKb": 784179,
+      "sources": ["job2:unit-fast"]
     },
     "src/plugins/contracts/wizard.contract.test.ts": {
       "deltaKb": 783770,
@@ -35,13 +39,25 @@
       "deltaKb": 528486,
       "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
     },
+    "src/media-understanding/resolve.test.ts": {
+      "deltaKb": 516506,
+      "sources": ["job1:unit-fast"]
+    },
     "src/infra/provider-usage.auth.normalizes-keys.test.ts": {
       "deltaKb": 510362,
       "sources": ["gha-23329089711-node-test-1-2:unit-fast"]
     },
+    "src/acp/client.test.ts": {
+      "deltaKb": 491213,
+      "sources": ["job2:unit-fast"]
+    },
     "src/infra/update-runner.test.ts": {
       "deltaKb": 474726,
       "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/secrets/runtime-web-tools.test.ts": {
+      "deltaKb": 473190,
+      "sources": ["job1:unit-fast"]
     },
     "src/cron/isolated-agent/run.cron-model-override.test.ts": {
       "deltaKb": 469914,
@@ -63,6 +79,10 @@
       "deltaKb": 427213,
       "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
     },
+    "src/media-understanding/runner.video.test.ts": {
+      "deltaKb": 402739,
+      "sources": ["job1:unit-fast"]
+    },
     "src/infra/provider-usage.test.ts": {
       "deltaKb": 389837,
       "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
@@ -70,6 +90,10 @@
     "src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts": {
       "deltaKb": 377446,
       "sources": ["gha-23328306205-compat-node22:unit-fast"]
+    },
+    "src/infra/outbound/agent-delivery.test.ts": {
+      "deltaKb": 373043,
+      "sources": ["job1:unit-fast"]
     },
     "src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts": {
       "deltaKb": 355840,
@@ -91,9 +115,17 @@
       "deltaKb": 334950,
       "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
     },
+    "src/config/sessions/store.pruning.test.ts": {
+      "deltaKb": 333312,
+      "sources": ["job2:unit-fast"]
+    },
     "src/media-understanding/providers/moonshot/video.test.ts": {
       "deltaKb": 333005,
       "sources": ["gha-23329089711-node-test-2-2:unit-fast"]
+    },
+    "src/infra/heartbeat-runner.model-override.test.ts": {
+      "deltaKb": 325632,
+      "sources": ["job1:unit-fast"]
     },
     "src/config/sessions.test.ts": {
       "deltaKb": 324813,
@@ -102,6 +134,10 @@
     "src/acp/translator.cancel-scoping.test.ts": {
       "deltaKb": 324403,
       "sources": ["gha-23328306205-node-test-1-2:unit-fast"]
+    },
+    "src/infra/heartbeat-runner.ghost-reminder.test.ts": {
+      "deltaKb": 321536,
+      "sources": ["job1:unit-fast"]
     },
     "src/tui/tui-session-actions.test.ts": {
       "deltaKb": 319898,
@@ -115,6 +151,10 @@
       "deltaKb": 308019,
       "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
     },
+    "src/channels/plugins/outbound/signal.test.ts": {
+      "deltaKb": 301056,
+      "sources": ["job2:unit-fast"]
+    },
     "src/cron/service.store-migration.test.ts": {
       "deltaKb": 282931,
       "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
@@ -122,6 +162,10 @@
     "src/media-understanding/providers/google/video.test.ts": {
       "deltaKb": 274022,
       "sources": ["gha-23328306205-node-test-2-2:unit-fast"]
+    },
+    "src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts": {
+      "deltaKb": 267366,
+      "sources": ["job2:unit-fast"]
     }
   }
 }

--- a/test/scripts/test-parallel.test.ts
+++ b/test/scripts/test-parallel.test.ts
@@ -84,7 +84,7 @@ describe("scripts/test-parallel memory trace parsing", () => {
   it("parses memory trace summary lines and hotspot deltas", () => {
     const summaries = parseMemoryTraceSummaryLines(
       [
-        "[test-parallel][mem] summary unit-fast files=360 peak=13.22GiB totalDelta=+6.69GiB peakAt=poll top=src/config/schema.help.quality.test.ts:+1.06GiB, src/infra/update-runner.test.ts:+463.6MiB",
+        "2026-03-20T04:32:18.7721466Z [test-parallel][mem] summary unit-fast files=360 peak=13.22GiB totalDelta=6.69GiB peakAt=poll top=src/config/schema.help.quality.test.ts:1.06GiB, src/infra/update-runner.test.ts:+463.6MiB",
       ].join("\n"),
     );
 
@@ -93,12 +93,12 @@ describe("scripts/test-parallel memory trace parsing", () => {
       lane: "unit-fast",
       files: 360,
       peakRssKb: parseMemoryValueKb("13.22GiB"),
-      totalDeltaKb: parseMemoryValueKb("+6.69GiB"),
+      totalDeltaKb: parseMemoryValueKb("6.69GiB"),
       peakAt: "poll",
       top: [
         {
           file: "src/config/schema.help.quality.test.ts",
-          deltaKb: parseMemoryValueKb("+1.06GiB"),
+          deltaKb: parseMemoryValueKb("1.06GiB"),
         },
         {
           file: "src/infra/update-runner.test.ts",

--- a/test/scripts/test-parallel.test.ts
+++ b/test/scripts/test-parallel.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseCompletedTestFileLines } from "../../scripts/test-parallel-memory.mjs";
+import {
+  parseCompletedTestFileLines,
+  parseMemoryTraceSummaryLines,
+  parseMemoryValueKb,
+} from "../../scripts/test-parallel-memory.mjs";
 import {
   appendCapturedOutput,
   hasFatalTestRunOutput,
@@ -75,5 +79,32 @@ describe("scripts/test-parallel memory trace parsing", () => {
         ].join("\n"),
       ),
     ).toEqual([]);
+  });
+
+  it("parses memory trace summary lines and hotspot deltas", () => {
+    const summaries = parseMemoryTraceSummaryLines(
+      [
+        "[test-parallel][mem] summary unit-fast files=360 peak=13.22GiB totalDelta=+6.69GiB peakAt=poll top=src/config/schema.help.quality.test.ts:+1.06GiB, src/infra/update-runner.test.ts:+463.6MiB",
+      ].join("\n"),
+    );
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toEqual({
+      lane: "unit-fast",
+      files: 360,
+      peakRssKb: parseMemoryValueKb("13.22GiB"),
+      totalDeltaKb: parseMemoryValueKb("+6.69GiB"),
+      peakAt: "poll",
+      top: [
+        {
+          file: "src/config/schema.help.quality.test.ts",
+          deltaKb: parseMemoryValueKb("+1.06GiB"),
+        },
+        {
+          file: "src/infra/update-runner.test.ts",
+          deltaKb: parseMemoryValueKb("+463.6MiB"),
+        },
+      ],
+    });
   });
 });

--- a/test/scripts/test-runner-manifest.test.ts
+++ b/test/scripts/test-runner-manifest.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectMemoryHeavyFiles,
+  selectTimedHeavyFiles,
+} from "../../scripts/test-runner-manifest.mjs";
+
+describe("scripts/test-runner-manifest timed selection", () => {
+  it("only selects known timed heavy files above the minimum", () => {
+    expect(
+      selectTimedHeavyFiles({
+        candidates: ["a.test.ts", "b.test.ts", "c.test.ts"],
+        limit: 3,
+        minDurationMs: 1000,
+        exclude: new Set(["c.test.ts"]),
+        timings: {
+          defaultDurationMs: 250,
+          files: {
+            "a.test.ts": { durationMs: 2500 },
+            "b.test.ts": { durationMs: 900 },
+            "c.test.ts": { durationMs: 5000 },
+          },
+        },
+      }),
+    ).toEqual(["a.test.ts"]);
+  });
+});
+
+describe("scripts/test-runner-manifest memory selection", () => {
+  it("selects known memory hotspots above the minimum", () => {
+    expect(
+      selectMemoryHeavyFiles({
+        candidates: ["a.test.ts", "b.test.ts", "c.test.ts", "d.test.ts"],
+        limit: 3,
+        minDeltaKb: 256 * 1024,
+        exclude: new Set(["c.test.ts"]),
+        hotspots: {
+          files: {
+            "a.test.ts": { deltaKb: 600 * 1024 },
+            "b.test.ts": { deltaKb: 120 * 1024 },
+            "c.test.ts": { deltaKb: 900 * 1024 },
+          },
+        },
+      }),
+    ).toEqual(["a.test.ts"]);
+  });
+
+  it("orders selected memory hotspots by descending retained heap", () => {
+    expect(
+      selectMemoryHeavyFiles({
+        candidates: ["a.test.ts", "b.test.ts", "c.test.ts"],
+        limit: 2,
+        minDeltaKb: 1,
+        hotspots: {
+          files: {
+            "a.test.ts": { deltaKb: 300 },
+            "b.test.ts": { deltaKb: 700 },
+            "c.test.ts": { deltaKb: 500 },
+          },
+        },
+      }),
+    ).toEqual(["b.test.ts", "c.test.ts"]);
+  });
+});

--- a/test/scripts/test-runner-manifest.test.ts
+++ b/test/scripts/test-runner-manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   selectMemoryHeavyFiles,
   selectTimedHeavyFiles,
+  selectUnitHeavyFileGroups,
 } from "../../scripts/test-runner-manifest.mjs";
 
 describe("scripts/test-runner-manifest timed selection", () => {
@@ -59,5 +60,34 @@ describe("scripts/test-runner-manifest memory selection", () => {
         },
       }),
     ).toEqual(["b.test.ts", "c.test.ts"]);
+  });
+
+  it("gives memory-heavy isolation precedence over timed-heavy buckets", () => {
+    expect(
+      selectUnitHeavyFileGroups({
+        candidates: ["overlap.test.ts", "memory-only.test.ts", "timed-only.test.ts"],
+        behaviorOverrides: new Set(),
+        timedLimit: 3,
+        timedMinDurationMs: 1000,
+        memoryLimit: 3,
+        memoryMinDeltaKb: 256 * 1024,
+        timings: {
+          defaultDurationMs: 250,
+          files: {
+            "overlap.test.ts": { durationMs: 5000 },
+            "timed-only.test.ts": { durationMs: 4200 },
+          },
+        },
+        hotspots: {
+          files: {
+            "overlap.test.ts": { deltaKb: 900 * 1024 },
+            "memory-only.test.ts": { deltaKb: 700 * 1024 },
+          },
+        },
+      }),
+    ).toEqual({
+      memoryHeavyFiles: ["overlap.test.ts", "memory-only.test.ts"],
+      timedHeavyFiles: ["timed-only.test.ts"],
+    });
   });
 });

--- a/test/vitest-unit-config.test.ts
+++ b/test/vitest-unit-config.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadExtraExcludePatternsFromEnv } from "../vitest.unit.config.ts";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+const writeExcludeFile = (value: unknown) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-vitest-unit-config-"));
+  tempDirs.add(dir);
+  const filePath = path.join(dir, "extra-exclude.json");
+  fs.writeFileSync(filePath, `${JSON.stringify(value)}\n`, "utf8");
+  return filePath;
+};
+
+describe("loadExtraExcludePatternsFromEnv", () => {
+  it("returns an empty list when no extra exclude file is configured", () => {
+    expect(loadExtraExcludePatternsFromEnv({})).toEqual([]);
+  });
+
+  it("loads extra exclude patterns from a JSON file", () => {
+    const filePath = writeExcludeFile([
+      "src/infra/update-runner.test.ts",
+      42,
+      "",
+      "ui/src/ui/views/chat.test.ts",
+    ]);
+
+    expect(
+      loadExtraExcludePatternsFromEnv({
+        OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE: filePath,
+      }),
+    ).toEqual(["src/infra/update-runner.test.ts", "ui/src/ui/views/chat.test.ts"]);
+  });
+
+  it("throws when the configured file is not a JSON array", () => {
+    const filePath = writeExcludeFile({ exclude: ["src/infra/update-runner.test.ts"] });
+
+    expect(() =>
+      loadExtraExcludePatternsFromEnv({
+        OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE: filePath,
+      }),
+    ).toThrow(/JSON array/u);
+  });
+});

--- a/test/vitest-unit-config.test.ts
+++ b/test/vitest-unit-config.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadExtraExcludePatternsFromEnv } from "../vitest.unit.config.ts";
+import {
+  loadExtraExcludePatternsFromEnv,
+  loadIncludePatternsFromEnv,
+} from "../vitest.unit.config.ts";
 
 const tempDirs = new Set<string>();
 
@@ -13,13 +16,34 @@ afterEach(() => {
   tempDirs.clear();
 });
 
-const writeExcludeFile = (value: unknown) => {
+const writePatternFile = (basename: string, value: unknown) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-vitest-unit-config-"));
   tempDirs.add(dir);
-  const filePath = path.join(dir, "extra-exclude.json");
+  const filePath = path.join(dir, basename);
   fs.writeFileSync(filePath, `${JSON.stringify(value)}\n`, "utf8");
   return filePath;
 };
+
+describe("loadIncludePatternsFromEnv", () => {
+  it("returns null when no include file is configured", () => {
+    expect(loadIncludePatternsFromEnv({})).toBeNull();
+  });
+
+  it("loads include patterns from a JSON file", () => {
+    const filePath = writePatternFile("include.json", [
+      "src/infra/update-runner.test.ts",
+      42,
+      "",
+      "ui/src/ui/views/chat.test.ts",
+    ]);
+
+    expect(
+      loadIncludePatternsFromEnv({
+        OPENCLAW_VITEST_INCLUDE_FILE: filePath,
+      }),
+    ).toEqual(["src/infra/update-runner.test.ts", "ui/src/ui/views/chat.test.ts"]);
+  });
+});
 
 describe("loadExtraExcludePatternsFromEnv", () => {
   it("returns an empty list when no extra exclude file is configured", () => {
@@ -27,7 +51,7 @@ describe("loadExtraExcludePatternsFromEnv", () => {
   });
 
   it("loads extra exclude patterns from a JSON file", () => {
-    const filePath = writeExcludeFile([
+    const filePath = writePatternFile("extra-exclude.json", [
       "src/infra/update-runner.test.ts",
       42,
       "",
@@ -42,7 +66,9 @@ describe("loadExtraExcludePatternsFromEnv", () => {
   });
 
   it("throws when the configured file is not a JSON array", () => {
-    const filePath = writeExcludeFile({ exclude: ["src/infra/update-runner.test.ts"] });
+    const filePath = writePatternFile("extra-exclude.json", {
+      exclude: ["src/infra/update-runner.test.ts"],
+    });
 
     expect(() =>
       loadExtraExcludePatternsFromEnv({

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { defineConfig } from "vitest/config";
 import baseConfig from "./vitest.config.ts";
 import {
@@ -8,12 +9,33 @@ import {
 const base = baseConfig as unknown as Record<string, unknown>;
 const baseTest = (baseConfig as { test?: { include?: string[]; exclude?: string[] } }).test ?? {};
 const exclude = baseTest.exclude ?? [];
+export function loadExtraExcludePatternsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string[] {
+  const extraExcludeFile = env.OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE?.trim();
+  if (!extraExcludeFile) {
+    return [];
+  }
+  const parsed = JSON.parse(fs.readFileSync(extraExcludeFile, "utf8")) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(
+      `OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE must point to a JSON array: ${extraExcludeFile}`,
+    );
+  }
+  return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
 
 export default defineConfig({
   ...base,
   test: {
     ...baseTest,
     include: unitTestIncludePatterns,
-    exclude: [...exclude, ...unitTestAdditionalExcludePatterns],
+    exclude: [
+      ...new Set([
+        ...exclude,
+        ...unitTestAdditionalExcludePatterns,
+        ...loadExtraExcludePatternsFromEnv(),
+      ]),
+    ],
   },
 });

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -9,6 +9,24 @@ import {
 const base = baseConfig as unknown as Record<string, unknown>;
 const baseTest = (baseConfig as { test?: { include?: string[]; exclude?: string[] } }).test ?? {};
 const exclude = baseTest.exclude ?? [];
+function loadPatternListFile(filePath: string, label: string): string[] {
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(`${label} must point to a JSON array: ${filePath}`);
+  }
+  return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+export function loadIncludePatternsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string[] | null {
+  const includeFile = env.OPENCLAW_VITEST_INCLUDE_FILE?.trim();
+  if (!includeFile) {
+    return null;
+  }
+  return loadPatternListFile(includeFile, "OPENCLAW_VITEST_INCLUDE_FILE");
+}
+
 export function loadExtraExcludePatternsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): string[] {
@@ -16,20 +34,14 @@ export function loadExtraExcludePatternsFromEnv(
   if (!extraExcludeFile) {
     return [];
   }
-  const parsed = JSON.parse(fs.readFileSync(extraExcludeFile, "utf8")) as unknown;
-  if (!Array.isArray(parsed)) {
-    throw new TypeError(
-      `OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE must point to a JSON array: ${extraExcludeFile}`,
-    );
-  }
-  return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+  return loadPatternListFile(extraExcludeFile, "OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE");
 }
 
 export default defineConfig({
   ...base,
   test: {
     ...baseTest,
-    include: unitTestIncludePatterns,
+    include: loadIncludePatternsFromEnv() ?? unitTestIncludePatterns,
     exclude: [
       ...new Set([
         ...exclude,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Linux CI `unit-fast` OOMs kept resurfacing because the test scheduler only knew about file duration, not retained heap growth.
- Why it matters: short but memory-heavy files could stay in the shared `unit-fast` lane, so CI kept rediscovering the same class of failures as new hotspot sets.
- What changed: added a separate unit memory-hotspot manifest plus scheduler support to auto-isolate those files, and seeded the manifest from the March 20, 2026 CI hotspot set.
- What did NOT change (scope boundary): this does not change production code paths or test semantics; it only changes how unit tests are scheduled.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 local workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test wrapper plus seeded unit memory-hotspot manifest

### Steps

1. Inspect the failing March 20, 2026 Linux CI runs and collect `[test-parallel][mem] summary unit-fast ...` hotspot lines.
2. Seed `test/fixtures/test-memory-hotspots.unit.json` from those hotspot files.
3. Run `pnpm test` and verify `unit-fast` stays green while the seeded hotspot files run in isolated lanes.

### Expected

- `unit-fast` excludes memory-heavy files automatically.
- Seeded hotspot files run as isolated singleton lanes.
- Full local test suite remains green.

### Actual

- Observed exactly that locally after the scheduler change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- test/scripts/test-parallel.test.ts test/scripts/test-runner-manifest.test.ts`
  - `pnpm check`
  - `pnpm test`
  - smoke-generated the memory-hotspot manifest from a synthetic CI-style summary log with `node scripts/test-update-memory-hotspots.mjs --log ...`
- Edge cases checked:
  - summary parsing for `GiB`/`MiB` deltas
  - scheduler behavior when a file is missing from the timing manifest but present in the memory manifest
  - dormant behavior when no memory hotspot manifest entries match
- What you did **not** verify:
  - a full GitHub Actions run on this branch yet

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the seeded entries from `test/fixtures/test-memory-hotspots.unit.json`
- Files/config to restore: `scripts/test-parallel.mjs`, `scripts/test-runner-manifest.mjs`, `scripts/test-parallel-memory.mjs`, `test/fixtures/test-memory-hotspots.unit.json`
- Known bad symptoms reviewers should watch for: hotspot files no longer peel out of `unit-fast`, or isolated lane fan-out becomes unexpectedly large

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the seeded memory-hotspot manifest can go stale as the suite evolves.
  - Mitigation: the new updater script lets us regenerate from CI memory summaries instead of hand-editing the behavior manifest.
- Risk: extra isolated lanes can increase wall-clock time slightly.
  - Mitigation: only hotspot files above the configured retained-heap threshold are auto-isolated.
