### PR TITLE
fix(compaction): only zero usage for pre-compaction messages (#50795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Docs: https://docs.openclaw.ai
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
 - Discord/commands: trim overlong slash-command descriptions to Discord's 100-character limit and map rejected deploy indexes from Discord validation payloads back to command names/descriptions, so deploys stop failing on long descriptions and startup logs identify the rejected commands. (#54118) thanks @huntharo
 - Agents/cooldowns: scope rate-limit cooldowns per model so one 429 no longer blocks every model on the same auth profile, replace the exponential 1 min → 1 h escalation with a stepped 30 s / 1 min / 5 min ladder, and surface a user-facing countdown message when all models are rate-limited. (#49834) Thanks @kiranvk-2011.
+- Agents/compaction: preserve post-compaction assistant usage snapshots while keeping the compaction end event payload stable, so the TUI context counter no longer sticks at zero after compaction. (#50845) Thanks @Hollychou924.
 
 ## 2026.3.23
 

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -131,19 +131,74 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   return nextEntry?.compactionCount;
 }
 
+function parseMessageTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
 function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedPiSubscribeContext): void {
   const messages = ctx.params.session.messages;
   if (!Array.isArray(messages)) {
     return;
   }
-  for (const message of messages) {
+
+  // Find the latest compactionSummary message to determine the cutoff point.
+  // Only assistant messages older than (or at the same position as) the latest
+  // compaction should have their usage zeroed out.  Messages produced after the
+  // compaction contain fresh, accurate usage data and must be left untouched so
+  // the TUI "📚 Context" counter reflects the real post-compaction token count.
+  let latestCompactionSummaryIndex = -1;
+  let latestCompactionTimestamp: number | null = null;
+  for (let i = 0; i < messages.length; i += 1) {
+    const entry = messages[i] as { role?: unknown; timestamp?: unknown } | undefined;
+    if (entry?.role !== "compactionSummary") {
+      continue;
+    }
+    latestCompactionSummaryIndex = i;
+    latestCompactionTimestamp = parseMessageTimestamp(entry.timestamp ?? null);
+  }
+
+  if (latestCompactionSummaryIndex === -1) {
+    // No compaction summary found — nothing to clear.
+    return;
+  }
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
     if (!message || typeof message !== "object") {
       continue;
     }
-    const candidate = message as { role?: unknown; usage?: unknown };
+    const candidate = message as { role?: unknown; usage?: unknown; timestamp?: unknown };
     if (candidate.role !== "assistant") {
       continue;
     }
+    if (!candidate.usage || typeof candidate.usage !== "object") {
+      continue;
+    }
+
+    // A message is considered stale (pre-compaction) if:
+    //   1. Its timestamp is <= the latest compaction summary timestamp, OR
+    //   2. Its array index is before the compaction summary (legacy fallback for
+    //      messages without timestamps).
+    const messageTimestamp = parseMessageTimestamp(candidate.timestamp);
+    const staleByTimestamp =
+      latestCompactionTimestamp !== null &&
+      messageTimestamp !== null &&
+      messageTimestamp <= latestCompactionTimestamp;
+    const staleByLegacyOrdering = i < latestCompactionSummaryIndex;
+
+    if (!staleByTimestamp && !staleByLegacyOrdering) {
+      // Post-compaction message — preserve its accurate usage data.
+      continue;
+    }
+
     // pi-coding-agent expects assistant usage to exist when computing context usage.
     // Reset stale snapshots to zeros instead of deleting the field.
     candidate.usage = makeZeroUsageSnapshot();

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -74,11 +74,11 @@ export function handleAutoCompactionEnd(
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry },
   });
 
   // Run after_compaction plugin hook (fire-and-forget)

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -165,11 +165,6 @@ function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedPiSubscribeConte
     latestCompactionTimestamp = parseMessageTimestamp(entry.timestamp ?? null);
   }
 
-  if (latestCompactionSummaryIndex === -1) {
-    // No compaction summary found — nothing to clear.
-    return;
-  }
-
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i];
     if (!message || typeof message !== "object") {
@@ -183,20 +178,24 @@ function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedPiSubscribeConte
       continue;
     }
 
-    // A message is considered stale (pre-compaction) if:
-    //   1. Its timestamp is <= the latest compaction summary timestamp, OR
-    //   2. Its array index is before the compaction summary (legacy fallback for
-    //      messages without timestamps).
-    const messageTimestamp = parseMessageTimestamp(candidate.timestamp);
-    const staleByTimestamp =
-      latestCompactionTimestamp !== null &&
-      messageTimestamp !== null &&
-      messageTimestamp <= latestCompactionTimestamp;
-    const staleByLegacyOrdering = i < latestCompactionSummaryIndex;
+    // When a compactionSummary exists, only zero out messages that pre-date it.
+    // Messages produced after the compaction contain fresh, accurate usage data
+    // and must be left untouched so the TUI "📚 Context" counter stays correct.
+    // When no compactionSummary exists (e.g. legacy sessions or in-progress
+    // compaction without a recorded summary), fall back to zeroing all assistant
+    // usage to preserve the original behaviour (#50795).
+    if (latestCompactionSummaryIndex !== -1) {
+      const messageTimestamp = parseMessageTimestamp(candidate.timestamp);
+      const staleByTimestamp =
+        latestCompactionTimestamp !== null &&
+        messageTimestamp !== null &&
+        messageTimestamp <= latestCompactionTimestamp;
+      const staleByLegacyOrdering = i < latestCompactionSummaryIndex;
 
-    if (!staleByTimestamp && !staleByLegacyOrdering) {
-      // Post-compaction message — preserve its accurate usage data.
-      continue;
+      if (!staleByTimestamp && !staleByLegacyOrdering) {
+        // Post-compaction message — preserve its accurate usage data.
+        continue;
+      }
     }
 
     // pi-coding-agent expects assistant usage to exist when computing context usage.

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -63,6 +63,15 @@ let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
 let originalForceStderr: boolean;
 
+function canReflectProcessTitleWrites(): boolean {
+  const original = process.title;
+  const probe = `${original}-probe`;
+  process.title = probe;
+  const didReflect = process.title === probe;
+  process.title = original;
+  return didReflect;
+}
+
 beforeAll(async () => {
   ({ registerPreActionHooks } = await import("./preaction.js"));
 });
@@ -202,7 +211,6 @@ describe("registerPreActionHooks", () => {
   }
 
   it("handles debug mode and plugin-required command preaction", async () => {
-    const processTitleSetSpy = vi.spyOn(process, "title", "set");
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "openclaw", "status", "--debug"],
@@ -215,7 +223,9 @@ describe("registerPreActionHooks", () => {
       commandPath: ["status"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
-    expect(processTitleSetSpy).toHaveBeenCalledWith("openclaw-status");
+    expect(process.title).toBe(
+      canReflectProcessTitleWrites() ? "openclaw-status" : originalProcessTitle,
+    );
 
     vi.clearAllMocks();
     await runPreAction({
@@ -230,7 +240,6 @@ describe("registerPreActionHooks", () => {
       commandPath: ["message", "send"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
-    processTitleSetSpy.mockRestore();
   });
 
   it("keeps setup alias and channels add manifest-first", async () => {

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -148,7 +148,7 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r2",
       stream: "compaction",
-      data: { phase: "end", willRetry: false, completed: true },
+      data: { phase: "end", willRetry: false },
     });
   });
 
@@ -179,7 +179,7 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r3",
       stream: "compaction",
-      data: { phase: "end", willRetry: true, completed: true },
+      data: { phase: "end", willRetry: true },
     });
   });
 
@@ -298,5 +298,53 @@ describe("compaction hook wiring", () => {
 
     const assistant = messages[0] as { usage?: unknown };
     expect(assistant.usage).toEqual({ totalTokens: 184_297, input: 130_000, output: 2_000 });
+  });
+
+  it("preserves post-compaction assistant usage after the latest compaction summary", () => {
+    const preCompactionUsage = { totalTokens: 180_000, input: 100, output: 50 };
+    const postCompactionUsage = { totalTokens: 12_345, input: 75, output: 30 };
+    const messages = [
+      {
+        role: "assistant",
+        content: "response before compaction",
+        timestamp: "2026-03-20T10:00:00.000Z",
+        usage: preCompactionUsage,
+      },
+      {
+        role: "compactionSummary",
+        summary: "compressed",
+        tokensBefore: 190_000,
+        timestamp: "2026-03-20T10:01:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "response after compaction",
+        timestamp: "2026-03-20T10:02:00.000Z",
+        usage: postCompactionUsage,
+      },
+    ];
+
+    const ctx = {
+      params: { runId: "r6", session: { messages } },
+      state: { compactionInFlight: true },
+      log: { debug: vi.fn(), warn: vi.fn() },
+      maybeResolveCompactionWait: vi.fn(),
+      getCompactionCount: () => 1,
+      incrementCompactionCount: vi.fn(),
+    };
+
+    handleAutoCompactionEnd(
+      ctx as never,
+      {
+        type: "auto_compaction_end",
+        willRetry: false,
+        result: { summary: "compacted" },
+      } as never,
+    );
+
+    const assistantBefore = messages[0] as { usage?: unknown };
+    const assistantAfter = messages[2] as { usage?: unknown };
+    expect(assistantBefore.usage).toEqual(makeZeroUsageSnapshot());
+    expect(assistantAfter.usage).toEqual(postCompactionUsage);
   });
 });

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -47,10 +47,10 @@ describe("runCommandWithTimeout", () => {
 
   it("kills command when no output timeout elapses", async () => {
     const result = await runCommandWithTimeout(
-      [process.execPath, "-e", "setTimeout(() => {}, 10)"],
+      [process.execPath, "-e", "setTimeout(() => {}, 250)"],
       {
-        timeoutMs: 30,
-        noOutputTimeoutMs: 4,
+        timeoutMs: 500,
+        noOutputTimeoutMs: 80,
       },
     );
 

--- a/ui/src/ui/controllers/scope-errors.test.ts
+++ b/ui/src/ui/controllers/scope-errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { GatewayRequestError } from "../gateway.ts";
+import {
+  formatMissingOperatorReadScopeMessage,
+  isMissingOperatorReadScopeError,
+} from "./scope-errors.ts";
+
+describe("isMissingOperatorReadScopeError", () => {
+  it("detects structured AUTH_UNAUTHORIZED scope failures", () => {
+    const err = new GatewayRequestError({
+      code: "PERMISSION_DENIED",
+      message: "not allowed",
+      details: { code: "AUTH_UNAUTHORIZED" },
+    });
+
+    expect(isMissingOperatorReadScopeError(err)).toBe(true);
+  });
+
+  it("falls back to the gateway message when no detail code is present", () => {
+    const err = new GatewayRequestError({
+      code: "PERMISSION_DENIED",
+      message: "missing scope: operator.read",
+    });
+
+    expect(isMissingOperatorReadScopeError(err)).toBe(true);
+  });
+
+  it("ignores unrelated gateway errors", () => {
+    const err = new GatewayRequestError({
+      code: "PERMISSION_DENIED",
+      message: "not allowed",
+      details: { code: "PAIRING_REQUIRED" },
+    });
+
+    expect(isMissingOperatorReadScopeError(err)).toBe(false);
+  });
+});
+
+describe("formatMissingOperatorReadScopeMessage", () => {
+  it("formats a targeted operator scope error", () => {
+    expect(formatMissingOperatorReadScopeMessage("usage")).toBe(
+      "This connection is missing operator.read, so usage cannot be loaded yet.",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The `📚 Context` counter in the TUI always shows `0/1.0m (0%)` after any compaction because `clearStaleAssistantUsageOnSessionMessages()` unconditionally zeros out **all** assistant message usage — including messages created **after** the compaction that contain accurate, fresh usage data from the LLM API.

## Root Cause

```typescript
// BEFORE (broken): clears ALL assistant usage
for (const message of messages) {
  if (candidate.role !== "assistant") continue;
  candidate.usage = makeZeroUsageSnapshot(); // ← nukes post-compaction messages too
}
```

The function is called after every non-retried compaction (line 62). It correctly identifies that pre-compaction usage is stale (reflects the old larger context), but it over-eagerly zeros post-compaction messages which have the correct new context usage.

## Fix

Locate the latest `compactionSummary` message in the session, then only zero usage for assistant messages that are **older than** (or at the same index as) the compaction summary. Post-compaction messages are left untouched.

```typescript
// AFTER (fixed): only clears pre-compaction stale usage
// Find latest compactionSummary → only zero messages before it
const staleByTimestamp = latestCompactionTimestamp !== null &&
  messageTimestamp !== null &&
  messageTimestamp <= latestCompactionTimestamp;
const staleByLegacyOrdering = i < latestCompactionSummaryIndex;
if (!staleByTimestamp && !staleByLegacyOrdering) continue; // keep post-compaction
candidate.usage = makeZeroUsageSnapshot();
```

Added `parseMessageTimestamp()` helper (same logic as in `google.ts`) for timestamp-based detection with index-based fallback for messages without timestamps.

## Reference

The `src/agents/pi-embedded-runner/google.ts` runner already uses the correct pattern: `stripStaleAssistantUsageBeforeLatestCompaction()`. This PR aligns the compaction event handler with that approach.

Fixes #50795