### PR TITLE
fix(azure): include azure-openai-responses in reasoning block downgrade

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -564,7 +564,9 @@ export async function sanitizeSessionHistory(params: {
   );
 
   const isOpenAIResponsesApi =
-    params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses" ||
+    params.modelApi === "azure-openai-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
   const priorSnapshot = hasSnapshot ? readLastModelSnapshot(params.sessionManager) : null;
   const modelChanged = priorSnapshot


### PR DESCRIPTION
lobster-biscuit

Closes #49167

## Problem

Azure OpenAI users hit `400 Bad Request` ("required following item") on every multi-turn conversation. Orphan reasoning blocks from prior turns survive in history because `downgradeOpenAIReasoningBlocks()` is not applied for the Azure provider.

## Root cause

`src/agents/pi-embedded-runner/google.ts:566-567` — `isOpenAIResponsesApi` checks `openai-responses` and `openai-codex-responses` but misses `azure-openai-responses`.

`openai-stream-wrappers.ts:12` already includes `azure-openai-responses` in `OPENAI_RESPONSES_PROVIDERS` — this PR aligns the guard.

## User impact

All Azure OpenAI Responses API users cannot have multi-turn conversations. Every second turn fails with 400.

## Fix

Add `azure-openai-responses` to the `isOpenAIResponsesApi` check. 1 file, +3/-1.

## How to verify

1. Configure Azure OpenAI with a reasoning model
2. Have a multi-turn conversation (2+ turns)
3. Before: 400 error. After: works.

## Tests

No dedicated test for this check — existing integration tests cover the downgrade path for openai-responses. Azure variant follows identical code path once the guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)