### PR TITLE
fix(telegram): prevent silent wrong-bot routing when accountId not in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Docs: https://docs.openclaw.ai
 - Tests/CLI: reduce command-secret gateway test import pressure while keeping the real protocol payload validator in place, so the isolated lane no longer carries the heavier runtime-web and message-channel graphs. (#50663) Thanks @huntharo.
 - Gateway/plugins: share plugin interactive callback routing and plugin bind approval state across duplicate module graphs so Telegram Codex picker buttons and plugin bind approvals no longer fall through to normal inbound message routing. (#50722) Thanks @huntharo.
 - Agents/compaction: add an opt-in post-compaction session JSONL truncation step that drops summarized transcript entries while preserving the retained branch tail and live session metadata. (#41021) thanks @thirumaleshp.
+- Telegram/routing: fail loud when `message send` targets an unknown non-default Telegram `accountId`, instead of silently falling back to the channel-level bot token and sending through the wrong bot. (#50853) Thanks @hclsys.
 
 ### Breaking
 

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -188,6 +188,24 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("none");
   });
 
+  it("does not fall through to channel-level token when non-default accountId is not in config", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "wrong-bot-token",
+          accounts: {
+            knownBot: { botToken: "known-bot-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg, { accountId: "unknownBot" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+  });
+
   it("throws when botToken is an unresolved SecretRef object", () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -44,6 +44,17 @@ export function resolveTelegramToken(
   const accountCfg = resolveAccountCfg(
     accountId !== DEFAULT_ACCOUNT_ID ? accountId : DEFAULT_ACCOUNT_ID,
   );
+
+  // When a non-default accountId is explicitly specified but not found in config,
+  // return empty immediately — do NOT fall through to channel-level defaults,
+  // which would silently route the message via the wrong bot's token.
+  if (accountId !== DEFAULT_ACCOUNT_ID && !accountCfg) {
+    opts.logMissingFile?.(
+      `channels.telegram.accounts: unknown accountId "${accountId}" — not found in config, refusing channel-level fallback`,
+    );
+    return { token: "", source: "none" };
+  }
+
   const accountTokenFile = accountCfg?.tokenFile?.trim();
   if (accountTokenFile) {
     const token = tryReadSecretFileSync(


### PR DESCRIPTION
lobster-biscuit

Closes #49383

## Problem

When message tool passes an `accountId` that doesn't match any configured account, `resolveTelegramToken()` silently falls through to the channel-level `botToken` — routing the message via the **wrong Telegram bot**. No error, no warning.

## Root cause

`extensions/telegram/src/token.ts:44-46` — `resolveAccountCfg()` returns `undefined` for unknown accountIds, but the code continues to channel-level fallbacks instead of stopping. Introduced in `e5bca0832f` when Telegram was moved to `extensions/`.

## User impact

Silent cross-bot message leak. Messages intended for Bot A get sent via Bot B's token. No error, no warning. User discovers only when the wrong bot responds.

## Fix

Return `{ token: "", source: "none" }` with a diagnostic log when a non-default accountId is not found. Existing behavior for known accounts (with or without per-account tokens) preserved — they still fall through to channel-level defaults as designed.

## How to verify

1. Configure 2 Telegram bots with different accountIds
2. Call message tool with an accountId not in config
3. Before: message sent via wrong bot. After: empty token, surfaces as error.

## Tests

Added: "does not fall through when non-default accountId not in config" (1/1 new, 10/10 existing unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)