### PR TITLE
fix: replace personal device names with generic placeholders in docs

### DIFF
--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -192,7 +192,7 @@ In group `120363403215116621@g.us` with agents `["alfred", "baerbel"]`:
 ```
 Session: agent:alfred:whatsapp:group:120363403215116621@g.us
 History: [user message, alfred's previous responses]
-Workspace: /Users/pascal/openclaw-alfred/
+Workspace: /Users/user/openclaw-alfred/
 Tools: read, write, exec
 ```
 
@@ -201,7 +201,7 @@ Tools: read, write, exec
 ```
 Session: agent:baerbel:whatsapp:group:120363403215116621@g.us
 History: [user message, baerbel's previous responses]
-Workspace: /Users/pascal/openclaw-baerbel/
+Workspace: /Users/user/openclaw-baerbel/
 Tools: read only
 ```
 

--- a/docs/zh-CN/channels/broadcast-groups.md
+++ b/docs/zh-CN/channels/broadcast-groups.md
@@ -199,7 +199,7 @@ Agents:
 ```
 Session: agent:alfred:whatsapp:group:120363403215116621@g.us
 History: [user message, alfred's previous responses]
-Workspace: /Users/pascal/openclaw-alfred/
+Workspace: /Users/user/openclaw-alfred/
 Tools: read, write, exec
 ```
 
@@ -208,7 +208,7 @@ Tools: read, write, exec
 ```
 Session: agent:baerbel:whatsapp:group:120363403215116621@g.us
 History: [user message, baerbel's previous responses]
-Workspace: /Users/pascal/openclaw-baerbel/
+Workspace: /Users/user/openclaw-baerbel/
 Tools: read only
 ```
 


### PR DESCRIPTION
## Summary

- Replace personal path `/Users/pascal/...` with generic `/Users/user/...` in broadcast-groups documentation examples (both English and zh-CN)

Fixes #50824

## Test plan

- [ ] Verify `docs/channels/broadcast-groups.md` lines 195 and 204 now use `/Users/user/` instead of `/Users/pascal/`
- [ ] Verify `docs/zh-CN/channels/broadcast-groups.md` lines 202 and 211 use the same generic placeholder
- [ ] Confirm no other personal paths remain in docs (`grep -r '/Users/pascal' docs/`)