### PR TITLE
fix: default to secure TLS in Synology Chat transport

### DIFF
--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -49,7 +49,7 @@ export async function sendMessage(
   incomingUrl: string,
   text: string,
   userId?: string | number,
-  allowInsecureSsl = true,
+  allowInsecureSsl = false,
 ): Promise<boolean> {
   // Synology Chat API requires user_ids (numeric) to specify the recipient
   // The @mention is optional but user_ids is mandatory
@@ -90,7 +90,7 @@ export async function sendFileUrl(
   incomingUrl: string,
   fileUrl: string,
   userId?: string | number,
-  allowInsecureSsl = true,
+  allowInsecureSsl = false,
 ): Promise<boolean> {
   const body = buildWebhookBody({ file_url: fileUrl }, userId);
 
@@ -112,7 +112,7 @@ export async function sendFileUrl(
  */
 export async function fetchChatUsers(
   incomingUrl: string,
-  allowInsecureSsl = true,
+  allowInsecureSsl = false,
   log?: { warn: (...args: unknown[]) => void },
 ): Promise<ChatUser[]> {
   const now = Date.now();
@@ -187,7 +187,7 @@ export async function fetchChatUsers(
 export async function resolveChatUserId(
   incomingUrl: string,
   webhookUsername: string,
-  allowInsecureSsl = true,
+  allowInsecureSsl = false,
   log?: { warn: (...args: unknown[]) => void },
 ): Promise<number | undefined> {
   const users = await fetchChatUsers(incomingUrl, allowInsecureSsl, log);
@@ -220,7 +220,7 @@ function parseNumericUserId(userId?: string | number): number | undefined {
   return Number.isNaN(numericId) ? undefined : numericId;
 }
 
-function doPost(url: string, body: string, allowInsecureSsl = true): Promise<boolean> {
+function doPost(url: string, body: string, allowInsecureSsl = false): Promise<boolean> {
   return new Promise((resolve, reject) => {
     let parsedUrl: URL;
     try {


### PR DESCRIPTION
## Summary

- Change the default value of `allowInsecureSsl` from `true` to `false` in all five transport-level functions in `extensions/synology-chat/src/client.ts` (`sendMessage`, `sendFileUrl`, `fetchChatUsers`, `resolveChatUserId`, `doPost`).
- This ensures TLS certificate verification is enabled by default, fixing the security risk of silently skipping certificate validation on HTTPS connections.
- Users who need to connect to a Synology NAS with a self-signed certificate can still explicitly pass `allowInsecureSsl = true`.

Fixes #50803