### PR TITLE
fix(discord): proactive hello-connected poll to catch missed WS open event

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -526,6 +526,48 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("pushes connected status via proactive poll when WS open event was missed", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const { emitter, gateway } = createGatewayHarness();
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      const statusUpdates: Array<Record<string, unknown>> = [];
+      const statusSink = (patch: Record<string, unknown>) => {
+        statusUpdates.push({ ...patch });
+      };
+
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      (lifecycleParams as Record<string, unknown>).statusSink = statusSink;
+
+      // READY arrives at 200ms (sets isConnected without any "open" debug event
+      // reaching onGatewayDebug — the event was consumed by the early listener).
+      setTimeout(() => {
+        gateway.isConnected = true;
+      }, 200);
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+      // Advance past the READY poll tick so both the proactive poll and
+      // waitForDiscordGatewayReady detect isConnected.
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      // With the proactive poll, connected: true is pushed TWICE — once by
+      // the proactive poll interval and once by the startup guard at line 390.
+      // Without the proactive poll, only the startup guard push would exist.
+      const connectedTruePushes = statusUpdates.filter((s) => s.connected === true);
+      expect(connectedTruePushes.length).toBeGreaterThanOrEqual(2);
+      expect(connectedTruePushes[0]).toMatchObject({
+        connected: true,
+        lastDisconnect: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not push connected: true when abortSignal is already aborted", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const emitter = new EventEmitter();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -323,6 +323,39 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
 
+    // Proactive hello-connected poll: Carbon starts the gateway during client
+    // construction and the "WebSocket connection opened" debug event may fire
+    // before the lifecycle listener is attached (consumed by the early startup
+    // listener in provider.ts). Without the open event, onGatewayDebug never
+    // starts its own hello-connected poll, leaving the READY→isConnected
+    // transition undetected for status updates. Kickstart polling here so the
+    // first READY is caught even when the WS open event was missed.
+    if (gateway && !gateway.isConnected && !lifecycleStopping) {
+      helloConnectedPollId = setInterval(() => {
+        if (lifecycleStopping) {
+          if (helloConnectedPollId) {
+            clearInterval(helloConnectedPollId);
+            helloConnectedPollId = undefined;
+          }
+          return;
+        }
+        if (!gateway.isConnected) {
+          return;
+        }
+        resetHelloStallCounter();
+        const connectedAt = Date.now();
+        reconnectStallWatchdog.disarm();
+        pushStatus({
+          ...createConnectedChannelStatusPatch(connectedAt),
+          lastDisconnect: null,
+        });
+        if (helloConnectedPollId) {
+          clearInterval(helloConnectedPollId);
+          helloConnectedPollId = undefined;
+        }
+      }, HELLO_CONNECTED_POLL_MS);
+    }
+
     // Carbon starts the gateway during client construction, before OpenClaw can
     // attach lifecycle listeners. Require a READY/RESUMED-connected gateway
     // before continuing so the monitor does not look healthy while silently


### PR DESCRIPTION
## Summary

- **Problem:** After a health-monitor restart, the `connected` channel status stays `false` in ~95% of reconnection attempts because the "WebSocket connection opened" debug event is consumed by the early startup listener (`onEarlyGatewayDebug` in `provider.ts`) before the lifecycle listener (`onGatewayDebug` in `provider.lifecycle.ts`) is attached.
- **Why it matters:** The health monitor sees the stale `connected: false` status and triggers repeated restarts, creating a reconnection loop that degrades reliability and delays message delivery.
- **What changed:** Added a proactive hello-connected poll immediately after attaching `onGatewayDebug`. When the gateway exists but is not yet connected, the poll checks `gateway.isConnected` every 250ms and pushes `connected: true` when READY arrives — even if the WS open debug event was missed. The poll reuses the existing `helloConnectedPollId` variable and is cleaned up by `clearHelloWatch()` on any subsequent debug event or in the finally block.
- **What did NOT change (scope boundary):** The `waitForDiscordGatewayReady` startup guard, the reconnect stall watchdog, the hello timeout/stall counter logic, and `onGatewayDebug`'s existing reconnect handling are all untouched. The proactive poll is purely additive.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #50836

## User-visible / Behavior Changes

Discord channel `connected` status now reliably transitions to `true` after health-monitor restarts instead of staying `false` indefinitely.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (race is timing-dependent, most reproducible under fast startup)
- Runtime/container: Node 22+
- Integration/channel: Discord

### Steps

1. Configure Discord channel with health-monitor enabled
2. Wait for health-monitor to detect a stale connection and trigger restart
3. Observe `channels status` output for Discord

### Expected

- `connected: true` within seconds of gateway READY

### Actual (before fix)

- `connected: false` persists in ~95% of health-monitor restarts
- Only recovers when startup is slow enough for READY to arrive before `onEarlyGatewayDebug` is removed

## Evidence

- [x] Failing test/log before + passing after

New test: "pushes connected status via proactive poll when WS open event was missed" — simulates READY arriving via `isConnected = true` without any "WebSocket connection opened" debug event, verifies `connected: true` is pushed.

All 15 tests in `provider.lifecycle.test.ts` pass (including the new regression test).

## Human Verification (required)

- Verified scenarios: All 15 lifecycle tests pass; new test covers the specific race condition.
- Edge cases checked: Abort signal already aborted (existing test), proactive poll cleanup via `clearHelloWatch`, no conflict with `waitForDiscordGatewayReady` (they coexist — poll pushes status, wait gates startup).
- What I did **not** verify: Live Discord health-monitor restart (no Discord bot credentials available).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the proactive poll is isolated to one code block.
- Files/config to restore: `extensions/discord/src/monitor/provider.lifecycle.ts`
- Known bad symptoms reviewers should watch for: Duplicate `connected: true` status pushes (harmless but noisy in logs).

## Risks and Mitigations

- Risk: Proactive poll and `onGatewayDebug`'s own poll could overlap briefly if a "WebSocket connection opened" event arrives right after the proactive poll starts.
  - Mitigation: `onGatewayDebug` calls `clearHelloWatch()` before starting its own poll, so the proactive poll is always cleared first. At worst, `connected: true` is pushed once by the proactive poll and once by the reconnect poll — both are idempotent status updates.
