### PR TITLE
Sessions: add kind filter

### DIFF
--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -127,6 +127,10 @@ describe("registerStatusHealthSessionsCommands", () => {
       "/tmp/sessions.json",
       "--active",
       "120",
+      "--kind",
+      "group",
+      "--kind",
+      "global",
     ]);
 
     expect(setVerbose).toHaveBeenCalledWith(true);
@@ -135,6 +139,7 @@ describe("registerStatusHealthSessionsCommands", () => {
         json: true,
         store: "/tmp/sessions.json",
         active: "120",
+        kind: ["group", "global"],
       }),
       runtime,
     );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -9,7 +9,7 @@ import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
-import { parsePositiveIntOrUndefined } from "./helpers.js";
+import { collectOption, parsePositiveIntOrUndefined } from "./helpers.js";
 
 function resolveVerbose(opts: { verbose?: boolean; debug?: boolean }): boolean {
   return Boolean(opts.verbose || opts.debug);
@@ -121,6 +121,11 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--agent <id>", "Agent id to inspect (default: configured default agent)")
     .option("--all-agents", "Aggregate sessions across all configured agents", false)
     .option("--active <minutes>", "Only show sessions updated within the past N minutes")
+    .option(
+      "--kind <type>",
+      "Filter by session kind (repeatable: direct, group, global, unknown)",
+      collectOption,
+    )
     .addHelpText(
       "after",
       () =>
@@ -129,6 +134,8 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           ["openclaw sessions --agent work", "List sessions for one agent."],
           ["openclaw sessions --all-agents", "Aggregate sessions across agents."],
           ["openclaw sessions --active 120", "Only last 2 hours."],
+          ["openclaw sessions --kind group", "Only group and channel sessions."],
+          ["openclaw sessions --kind direct --kind global", "Combine multiple session kinds."],
           ["openclaw sessions --json", "Machine-readable output."],
           ["openclaw sessions --store ./tmp/sessions.json", "Use a specific session store."],
         ])}\n\n${theme.muted(
@@ -149,6 +156,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           agent: opts.agent as string | undefined,
           allAgents: Boolean(opts.allAgents),
           active: opts.active as string | undefined,
+          kind: opts.kind as string[] | undefined,
         },
         defaultRuntime,
       );

--- a/src/commands/sessions-kind.test.ts
+++ b/src/commands/sessions-kind.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSessionKinds } from "./sessions-kind.js";
+
+function createRuntime() {
+  const errors: string[] = [];
+  return {
+    runtime: {
+      log: vi.fn(),
+      error: (msg: unknown) => errors.push(String(msg)),
+      exit: (code: number) => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+    errors,
+  };
+}
+
+describe("resolveSessionKinds", () => {
+  it("returns null when no filter is provided", () => {
+    const { runtime } = createRuntime();
+    expect(resolveSessionKinds(undefined, runtime)).toBeNull();
+  });
+
+  it("accepts repeated and comma-separated values", () => {
+    const { runtime } = createRuntime();
+    expect(Array.from(resolveSessionKinds(["group, global", "direct"], runtime) ?? [])).toEqual([
+      "group",
+      "global",
+      "direct",
+    ]);
+  });
+
+  it("rejects invalid kinds", () => {
+    const { runtime, errors } = createRuntime();
+    expect(() => resolveSessionKinds(["weird"], runtime)).toThrow("exit 1");
+    expect(errors[0]).toContain("--kind must be one of: direct, group, global, unknown");
+  });
+
+  it("rejects empty filter entries", () => {
+    const { runtime, errors } = createRuntime();
+    expect(() => resolveSessionKinds([",  ,"], runtime)).toThrow("exit 1");
+    expect(errors[0]).toContain(
+      "--kind must include at least one value: direct, group, global, unknown",
+    );
+  });
+});

--- a/src/commands/sessions-kind.ts
+++ b/src/commands/sessions-kind.ts
@@ -1,0 +1,35 @@
+import type { RuntimeEnv } from "../runtime.js";
+
+export const SESSION_KINDS = ["direct", "group", "global", "unknown"] as const;
+
+export type SessionKind = (typeof SESSION_KINDS)[number];
+
+export function resolveSessionKinds(
+  rawKinds: string[] | undefined,
+  runtime: RuntimeEnv,
+): Set<SessionKind> | null {
+  if (!rawKinds || rawKinds.length === 0) {
+    return null;
+  }
+  const kinds = new Set<SessionKind>();
+  for (const rawEntry of rawKinds) {
+    for (const piece of rawEntry.split(",")) {
+      const kind = piece.trim().toLowerCase();
+      if (!kind) {
+        continue;
+      }
+      if (!SESSION_KINDS.includes(kind as SessionKind)) {
+        runtime.error(`--kind must be one of: ${SESSION_KINDS.join(", ")}`);
+        runtime.exit(1);
+        return null;
+      }
+      kinds.add(kind as SessionKind);
+    }
+  }
+  if (kinds.size === 0) {
+    runtime.error(`--kind must include at least one value: ${SESSION_KINDS.join(", ")}`);
+    runtime.exit(1);
+    return null;
+  }
+  return kinds;
+}

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -8,6 +8,7 @@ import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
+import { resolveSessionKinds } from "./sessions-kind.js";
 import {
   formatSessionAgeCell,
   formatSessionFlagsCell,
@@ -85,7 +86,14 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
 };
 
 export async function sessionsCommand(
-  opts: { json?: boolean; store?: string; active?: string; agent?: string; allAgents?: boolean },
+  opts: {
+    json?: boolean;
+    store?: string;
+    active?: string;
+    agent?: string;
+    allAgents?: boolean;
+    kind?: string[];
+  },
   runtime: RuntimeEnv,
 ) {
   const aggregateAgents = opts.allAgents === true;
@@ -119,6 +127,11 @@ export async function sessionsCommand(
     activeMinutes = parsed;
   }
 
+  const allowedKinds = resolveSessionKinds(opts.kind, runtime);
+  if (opts.kind && allowedKinds === null) {
+    return;
+  }
+
   const rows = targets
     .flatMap((target) => {
       const store = loadSessionStore(target.storePath);
@@ -130,12 +143,15 @@ export async function sessionsCommand(
     })
     .filter((row) => {
       if (activeMinutes === undefined) {
-        return true;
+        return allowedKinds ? allowedKinds.has(row.kind) : true;
       }
       if (!row.updatedAt) {
         return false;
       }
-      return Date.now() - row.updatedAt <= activeMinutes * 60_000;
+      if (Date.now() - row.updatedAt > activeMinutes * 60_000) {
+        return false;
+      }
+      return allowedKinds ? allowedKinds.has(row.kind) : true;
     })
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 
@@ -155,6 +171,7 @@ export async function sessionsCommand(
           allAgents: aggregateAgents ? true : undefined,
           count: rows.length,
           activeMinutes: activeMinutes ?? null,
+          kinds: allowedKinds ? Array.from(allowedKinds) : null,
           sessions: rows.map((r) => {
             const model = resolveSessionDisplayModel(cfg, r, displayDefaults);
             return {
@@ -185,6 +202,9 @@ export async function sessionsCommand(
   runtime.log(info(`Sessions listed: ${rows.length}`));
   if (activeMinutes) {
     runtime.log(info(`Filtered to last ${activeMinutes} minute(s)`));
+  }
+  if (allowedKinds) {
+    runtime.log(info(`Kinds: ${Array.from(allowedKinds).join(", ")}`));
   }
   if (rows.length === 0) {
     runtime.log("No sessions found.");


### PR DESCRIPTION
## Summary
- add a repeatable `openclaw sessions --kind <type>` filter for direct, group, global, and unknown sessions
- share kind parsing in a small helper so the CLI can accept repeated or comma-separated values consistently
- cover the new option wiring and parser behavior with focused tests

## Testing
- `pnpm test -- src/commands/sessions-kind.test.ts`
- `pnpm test -- src/cli/program/register.status-health-sessions.test.ts`
- `pnpm build`
- `node --import tsx` smoke: `sessionsCommand({ store, kind: ['group', 'global'] })`
- `node --import tsx` smoke: `sessionsCommand({ store, json: true, kind: ['group,global'] })`
- `node --import tsx` smoke: invalid `--kind` exits with an error
