### PR TITLE
fix(cron): repair external reload schedule state and next-run recomputation

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,72 +1,50 @@
 ---
 name: coding-agent
-description: 'Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (for example spawn/run Codex or Claude Code in a Discord thread; use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode: pty:true required.'
+description: 'Delegate coding tasks to Codex, Claude Code, OpenCode, or Pi agents via immediate background processes. Use when: (1) building or creating features/apps, (2) reviewing PRs in a temp clone/worktree, (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-line fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). All coding-agent runs start with background:true immediately. Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode: pty:true required. Completion notification must use openclaw message send, not system event/heartbeat.'
 metadata:
   {
-    "openclaw":
-      {
-        "emoji": "🧩",
-        "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] },
-        "install":
-          [
-            {
-              "id": "node-claude",
-              "kind": "node",
-              "package": "@anthropic-ai/claude-code",
-              "bins": ["claude"],
-              "label": "Install Claude Code CLI (npm)",
-            },
-            {
-              "id": "node-codex",
-              "kind": "node",
-              "package": "@openai/codex",
-              "bins": ["codex"],
-              "label": "Install Codex CLI (npm)",
-            },
-          ],
-      },
+    "openclaw": { "emoji": "🧩", "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] } },
   }
 ---
 
-# Coding Agent (bash-first)
+# Coding Agent (always backgrounded)
 
-Use **bash** (with optional background mode) for all coding agent work. Simple and effective.
+Use **bash** with **background:true** for all coding-agent work.
+Do not use a foreground one-shot path here.
+Start the agent, get the `sessionId`, monitor with `process`, and require the worker to notify the user directly when it finishes.
 
 ## ⚠️ PTY Mode: Codex/Pi/OpenCode yes, Claude Code no
 
-For **Codex, Pi, and OpenCode**, PTY is still required (interactive terminal apps):
+For **Codex, Pi, and OpenCode**, PTY is required:
 
 ```bash
-# ✅ Correct for Codex/Pi/OpenCode
-bash pty:true command:"codex exec 'Your prompt'"
+# Correct for Codex/Pi/OpenCode
+bash pty:true background:true command:"codex exec 'Your prompt'"
 ```
 
 For **Claude Code** (`claude` CLI), use `--print --permission-mode bypassPermissions` instead.
-`--dangerously-skip-permissions` with PTY can exit after the confirmation dialog.
-`--print` mode keeps full tool access and avoids interactive confirmation:
+Do not use PTY for Claude Code here.
 
 ```bash
-# ✅ Correct for Claude Code (no PTY needed)
-cd /path/to/project && claude --permission-mode bypassPermissions --print 'Your task'
+# Correct for Claude Code
+bash background:true command:"claude --permission-mode bypassPermissions --print 'Your task'"
 
-# For background execution: use background:true on the exec tool
-
-# ❌ Wrong for Claude Code
+# Wrong for Claude Code
 bash pty:true command:"claude --dangerously-skip-permissions 'task'"
 ```
 
 ### Bash Tool Parameters
 
-| Parameter    | Type    | Description                                                                 |
-| ------------ | ------- | --------------------------------------------------------------------------- |
-| `command`    | string  | The shell command to run                                                    |
-| `pty`        | boolean | **Use for coding agents!** Allocates a pseudo-terminal for interactive CLIs |
-| `workdir`    | string  | Working directory (agent sees only this folder's context)                   |
-| `background` | boolean | Run in background, returns sessionId for monitoring                         |
-| `timeout`    | number  | Timeout in seconds (kills process on expiry)                                |
-| `elevated`   | boolean | Run on host instead of sandbox (if allowed)                                 |
+| Parameter    | Type    | Description                                                |
+| ------------ | ------- | ---------------------------------------------------------- |
+| `command`    | string  | The shell command to run                                   |
+| `pty`        | boolean | Use for Codex/Pi/OpenCode                                  |
+| `workdir`    | string  | Working directory                                          |
+| `background` | boolean | **Always true for this skill**                             |
+| `timeout`    | number  | Timeout in seconds                                         |
+| `elevated`   | boolean | Run on host instead of sandbox (if allowed)                |
 
-### Process Tool Actions (for background sessions)
+### Process Tool Actions
 
 | Action      | Description                                          |
 | ----------- | ---------------------------------------------------- |
@@ -81,48 +59,96 @@ bash pty:true command:"claude --dangerously-skip-permissions 'task'"
 
 ---
 
-## Quick Start: One-Shot Tasks
+## Mandatory Pattern
 
-For quick prompts/chats, create a temp git repo and run:
+Every coding-agent run follows this pattern:
 
-```bash
-# Quick chat (Codex needs a git repo!)
-SCRATCH=$(mktemp -d) && cd $SCRATCH && git init && codex exec "Your prompt here"
+1. Capture the notification route from the current conversation before spawning:
+   - `notifyChannel`
+   - `notifyTarget`
+   - `notifyAccount` (if applicable)
+   - `notifyReplyTo` (if replying to a specific message is desired)
+   - `notifyThreadId` (Telegram topic / Slack thread when applicable)
+2. Start the coding CLI with `background:true` immediately.
+3. Include the notification route in the worker prompt and require the worker to call `openclaw message send` on completion.
+4. Monitor with `process action:log` / `poll`.
+5. If the worker needs input or fails before notifying, handle that explicitly yourself. Do not rely on heartbeat.
 
-# Or in a real project - with PTY!
-bash pty:true workdir:~/Projects/myproject command:"codex exec 'Add error handling to the API calls'"
-```
-
-**Why git init?** Codex refuses to run outside a trusted git directory. Creating a temp repo solves this for scratch work.
+If you do not have a trustworthy notification route, say so and do not claim that completion will notify the user automatically.
 
 ---
 
-## The Pattern: workdir + background + pty
+## Notification Route
 
-For longer tasks, use background mode with PTY:
+Do not rely on:
+
+- `openclaw system event`
+- `tools.exec.notifyOnExit`
+- heartbeat delivery
+- `HEARTBEAT.md`
+
+Use a direct outbound completion message instead:
 
 ```bash
-# Start agent in target directory (with PTY!)
-bash pty:true workdir:~/project background:true command:"codex exec --full-auto 'Build a snake game'"
-# Returns sessionId for tracking
-
-# Monitor progress
-process action:log sessionId:XXX
-
-# Check if done
-process action:poll sessionId:XXX
-
-# Send input (if agent asks a question)
-process action:write sessionId:XXX data:"y"
-
-# Submit with Enter (like typing "yes" and pressing Enter)
-process action:submit sessionId:XXX data:"yes"
-
-# Kill if needed
-process action:kill sessionId:XXX
+openclaw message send --channel <channel> --target '<target>' --message '<text>'
 ```
 
-**Why workdir matters:** Agent wakes up in a focused directory, doesn't wander off reading unrelated files (like your soul.md 😅).
+Add optional routing flags only when they are real and applicable:
+
+- `--account <id>`
+- `--reply-to <messageId>`
+- `--thread-id <threadId>`
+
+`openclaw message send` is a direct outbound send. It does not depend on heartbeat being enabled.
+
+### Completion Prompt Snippet
+
+Append something like this to every worker prompt:
+
+```text
+Notification route for completion:
+- channel: <notifyChannel>
+- target: <notifyTarget>
+- account: <notifyAccount or omit>
+- reply_to: <notifyReplyTo or omit>
+- thread_id: <notifyThreadId or omit>
+
+When the task is completely finished, send exactly one completion message back to the user with openclaw message send using that route.
+If the task fails fatally, send exactly one failure message back to the user with openclaw message send using that route.
+Do not use openclaw system event. Do not rely on heartbeat. Do not skip the completion/failure message.
+```
+
+### Completion Command Template
+
+```bash
+openclaw message send \
+  --channel <notifyChannel> \
+  --target '<notifyTarget>' \
+  --message 'Done: <brief summary>'
+```
+
+Optional additions:
+
+```bash
+  --account <notifyAccount> \
+  --reply-to <notifyReplyTo> \
+  --thread-id <notifyThreadId>
+```
+
+---
+
+## Quick Start
+
+For scratch Codex work, create a temp git repo first, then start the worker in the background:
+
+```bash
+SCRATCH=$(mktemp -d)
+cd "$SCRATCH" && git init
+
+bash pty:true workdir:$SCRATCH background:true command:"codex exec 'Your prompt here'"
+```
+
+Codex refuses to run outside a trusted git directory.
 
 ---
 
@@ -134,53 +160,50 @@ process action:kill sessionId:XXX
 
 | Flag            | Effect                                             |
 | --------------- | -------------------------------------------------- |
-| `exec "prompt"` | One-shot execution, exits when done                |
+| `exec "prompt"` | One-shot execution inside the worker CLI           |
 | `--full-auto`   | Sandboxed but auto-approves in workspace           |
-| `--yolo`        | NO sandbox, NO approvals (fastest, most dangerous) |
+| `--yolo`        | No sandbox, no approvals                           |
 
 ### Building/Creating
 
 ```bash
-# Quick one-shot (auto-approves) - remember PTY!
-bash pty:true workdir:~/project command:"codex exec --full-auto 'Build a dark mode toggle'"
+# Always background immediately
+bash pty:true workdir:~/project background:true command:"codex exec --full-auto 'Build a dark mode toggle'"
 
-# Background for longer work
+# More autonomy
 bash pty:true workdir:~/project background:true command:"codex --yolo 'Refactor the auth module'"
 ```
 
 ### Reviewing PRs
 
-**⚠️ CRITICAL: Never review PRs in OpenClaw's own project folder!**
-Clone to temp folder or use git worktree.
+**Never review PRs in OpenClaw's own project folder.**
+Clone to a temp folder or use a worktree.
 
 ```bash
-# Clone to temp for safe review
 REVIEW_DIR=$(mktemp -d)
 git clone https://github.com/user/repo.git $REVIEW_DIR
 cd $REVIEW_DIR && gh pr checkout 130
-bash pty:true workdir:$REVIEW_DIR command:"codex review --base origin/main"
-# Clean up after: trash $REVIEW_DIR
 
-# Or use git worktree (keeps main intact)
-git worktree add /tmp/pr-130-review pr-130-branch
-bash pty:true workdir:/tmp/pr-130-review command:"codex review --base main"
+bash pty:true workdir:$REVIEW_DIR background:true command:"codex review --base origin/main"
 ```
 
-### Batch PR Reviews (parallel army!)
+Or:
 
 ```bash
-# Fetch all PR refs first
+git worktree add /tmp/pr-130-review pr-130-branch
+bash pty:true workdir:/tmp/pr-130-review background:true command:"codex review --base main"
+```
+
+### Batch PR Reviews
+
+```bash
 git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'
 
-# Deploy the army - one Codex per PR (all with PTY!)
 bash pty:true workdir:~/project background:true command:"codex exec 'Review PR #86. git diff origin/main...origin/pr/86'"
 bash pty:true workdir:~/project background:true command:"codex exec 'Review PR #87. git diff origin/main...origin/pr/87'"
 
-# Monitor all
 process action:list
-
-# Post results to GitHub
-gh pr comment <PR#> --body "<review content>"
+process action:log sessionId:XXX
 ```
 
 ---
@@ -188,10 +211,6 @@ gh pr comment <PR#> --body "<review content>"
 ## Claude Code
 
 ```bash
-# Foreground
-bash workdir:~/project command:"claude --permission-mode bypassPermissions --print 'Your task'"
-
-# Background
 bash workdir:~/project background:true command:"claude --permission-mode bypassPermissions --print 'Your task'"
 ```
 
@@ -200,7 +219,7 @@ bash workdir:~/project background:true command:"claude --permission-mode bypassP
 ## OpenCode
 
 ```bash
-bash pty:true workdir:~/project command:"opencode run 'Your task'"
+bash pty:true workdir:~/project background:true command:"opencode run 'Your task'"
 ```
 
 ---
@@ -209,108 +228,82 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 
 ```bash
 # Install: npm install -g @mariozechner/pi-coding-agent
-bash pty:true workdir:~/project command:"pi 'Your task'"
+bash pty:true workdir:~/project background:true command:"pi 'Your task'"
 
-# Non-interactive mode (PTY still recommended)
-bash pty:true command:"pi -p 'Summarize src/'"
+# Non-interactive mode
+bash pty:true workdir:~/project background:true command:"pi -p 'Summarize src/'"
 
 # Different provider/model
-bash pty:true command:"pi --provider openai --model gpt-4o-mini -p 'Your task'"
+bash pty:true workdir:~/project background:true command:"pi --provider openai --model gpt-4o-mini -p 'Your task'"
 ```
-
-**Note:** Pi now has Anthropic prompt caching enabled (PR #584, merged Jan 2026)!
 
 ---
 
 ## Parallel Issue Fixing with git worktrees
 
-For fixing multiple issues in parallel, use git worktrees:
-
 ```bash
-# 1. Create worktrees for each issue
 git worktree add -b fix/issue-78 /tmp/issue-78 main
 git worktree add -b fix/issue-99 /tmp/issue-99 main
 
-# 2. Launch Codex in each (background + PTY!)
-bash pty:true workdir:/tmp/issue-78 background:true command:"pnpm install && codex --yolo 'Fix issue #78: <description>. Commit and push.'"
-bash pty:true workdir:/tmp/issue-99 background:true command:"pnpm install && codex --yolo 'Fix issue #99 from the approved ticket summary. Implement only the in-scope edits and commit after review.'"
+bash pty:true workdir:/tmp/issue-78 background:true command:"pnpm install && codex --yolo 'Fix issue #78: <description>. Commit and push after review. Send the completion message with openclaw message send using the provided notify route.'"
+bash pty:true workdir:/tmp/issue-99 background:true command:"pnpm install && codex --yolo 'Fix issue #99 from the approved ticket summary. Implement only the in-scope edits. Send the completion message with openclaw message send using the provided notify route.'"
 
-# 3. Monitor progress
 process action:list
 process action:log sessionId:XXX
-
-# 4. Create PRs after fixes
-cd /tmp/issue-78 && git push -u origin fix/issue-78
-gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body "..."
-
-# 5. Cleanup
-git worktree remove /tmp/issue-78
-git worktree remove /tmp/issue-99
 ```
-
----
-
-## ⚠️ Rules
-
-1. **Use the right execution mode per agent**:
-   - Codex/Pi/OpenCode: `pty:true`
-   - Claude Code: `--print --permission-mode bypassPermissions` (no PTY required)
-2. **Respect tool choice** - if user asks for Codex, use Codex.
-   - Orchestrator mode: do NOT hand-code patches yourself.
-   - If an agent fails/hangs, respawn it or ask the user for direction, but don't silently take over.
-3. **Be patient** - don't kill sessions because they're "slow"
-4. **Monitor with process:log** - check progress without interfering
-5. **--full-auto for building** - auto-approves changes
-6. **vanilla for reviewing** - no special flags needed
-7. **Parallel is OK** - run many Codex processes at once for batch work
-8. **NEVER start Codex in ~/.openclaw/** - it'll read your soul docs and get weird ideas about the org chart!
-9. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
 
 ---
 
 ## Progress Updates (Critical)
 
-When you spawn coding agents in the background, keep the user in the loop.
+When you spawn a coding agent in the background, keep the user in the loop.
 
-- Send 1 short message when you start (what's running + where).
-- Then only update again when something changes:
-  - a milestone completes (build finished, tests passed)
-  - the agent asks a question / needs input
+- Send 1 short message when you start: what is running and where.
+- Update only when something changes:
+  - a milestone completes
+  - the worker asks a question
   - you hit an error or need user action
-  - the agent finishes (include what changed + where)
+  - the worker finishes
 - If you kill a session, immediately say you killed it and why.
+- If you are expecting the worker to self-notify with `openclaw message send`, say that clearly in your start update.
 
-This prevents the user from seeing only "Agent failed before reply" and having no idea what happened.
-
----
-
-## Auto-Notify on Completion
-
-For long-running background tasks, append a wake trigger to your prompt so OpenClaw gets notified immediately when the agent finishes (instead of waiting for the next heartbeat):
-
-```
-... your task here.
-
-When completely finished, run this command to notify me:
-openclaw system event --text "Done: [brief summary of what was built]" --mode now
-```
-
-**Example:**
-
-```bash
-bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
-
-When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
-```
-
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This prevents the user from seeing only a missing reply and having no idea what happened.
 
 ---
 
-## Learnings (Jan 2026)
+## Rules
 
-- **PTY is essential:** Coding agents are interactive terminal apps. Without `pty:true`, output breaks or agent hangs.
-- **Git repo required:** Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch work.
-- **exec is your friend:** `codex exec "prompt"` runs and exits cleanly - perfect for one-shots.
-- **submit vs write:** Use `submit` to send input + Enter, `write` for raw data without newline.
-- **Sass works:** Codex responds well to playful prompts. Asked it to write a haiku about being second fiddle to a space lobster, got: _"Second chair, I code / Space lobster sets the tempo / Keys glow, I follow"_ 🦞
+1. **Always background immediately.**
+   - Use `background:true` for every coding-agent launch.
+   - Do not use the foreground one-shot path in this skill.
+2. **Use the right execution mode per agent.**
+   - Codex/Pi/OpenCode: `pty:true`
+   - Claude Code: `--print --permission-mode bypassPermissions`
+3. **Respect tool choice.**
+   - If the user asked for Codex, use Codex.
+   - Orchestrator mode: do not hand-code the patch yourself instead of using the requested coding agent.
+4. **Capture notify routing before spawn.**
+   - Completion messaging must have a real route.
+5. **Use direct completion messaging.**
+   - Require `openclaw message send`.
+   - Do not rely on `openclaw system event` or heartbeat.
+6. **Do not silently take over.**
+   - If a worker fails or hangs, respawn it or ask for direction. Do not quietly switch to hand-editing.
+7. **Monitor with `process`.**
+   - `process action:log` is the default low-friction check.
+8. **Be patient.**
+   - Do not kill sessions just because they are slow.
+9. **Parallel is OK.**
+   - Many background Codex sessions can run at once.
+10. **Never start Codex in `~/.openclaw/`.**
+11. **Never checkout branches in `~/Projects/openclaw/`.**
+
+---
+
+## Learnings
+
+- **PTY is essential** for Codex/Pi/OpenCode.
+- **Git repo required**: Codex needs a trusted git directory.
+- **Use `exec` under background orchestration**: short and long tasks follow the same path now.
+- **`submit` vs `write`**: use `submit` to send input plus Enter.
+- **Direct message send beats heartbeat for completion notification** when the user must be told immediately and heartbeat may be disabled.

--- a/src/cron/service.external-reload-schedule-recompute.test.ts
+++ b/src/cron/service.external-reload-schedule-recompute.test.ts
@@ -878,6 +878,7 @@ describe("forceReload repairs externally changed schedules", () => {
 
     expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
     expect(state.store?.jobs[0]?.state.scheduleErrorCount).toBeUndefined();
+    expect(state.store?.jobs[0]?.state.lastError).toBeUndefined();
   });
 
   it("does not persist NaN updatedAtMs when manual-run reload sees an invalid timestamp", async () => {
@@ -1109,6 +1110,57 @@ describe("forceReload repairs externally changed schedules", () => {
     const reloaded = state.store?.jobs[0];
     expect(reloaded?.state.runningAtMs).toBe(runningAtMs);
     expect(reloaded?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:02:00.000Z"));
+  });
+
+  it("keeps runningAtMs when an external reload disables a still-running job", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-disable-running-job";
+    const runningAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+
+    const createJob = (enabled: boolean): CronJob => ({
+      id: jobId,
+      name: jobId,
+      enabled,
+      createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+      updatedAtMs: Date.parse("2026-03-19T12:01:00.000Z"),
+      schedule: { kind: "cron", expr: "* * * * *", tz: "UTC", staggerMs: 0 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {
+        nextRunAtMs: Date.parse("2026-03-19T12:11:00.000Z"),
+        runningAtMs,
+      },
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob(true)],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob(false)],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.enabled).toBe(false);
+    expect(state.store?.jobs[0]?.state.runningAtMs).toBe(runningAtMs);
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBeUndefined();
   });
 
   it("recomputes nextRunAtMs when an external every schedule changes", async () => {

--- a/src/cron/service.external-reload-schedule-recompute.test.ts
+++ b/src/cron/service.external-reload-schedule-recompute.test.ts
@@ -1,0 +1,1164 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { computeNextRunAtMs } from "./schedule.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+import {
+  hasSkipNextReloadRepairRecompute,
+  recomputeNextRuns,
+  recomputeNextRunsForMaintenance,
+} from "./service/jobs.js";
+import { run } from "./service/ops.js";
+import { createCronServiceState } from "./service/state.js";
+import { ensureLoaded } from "./service/store.js";
+import { onTimer } from "./service/timer.js";
+import type { CronJob } from "./types.js";
+
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-external-reload-",
+  baseTimeIso: "2026-03-19T01:44:00.000Z",
+});
+
+function createCronJob(params: {
+  id: string;
+  expr: string;
+  updatedAtMs?: number;
+  enabled?: boolean;
+  nextRunAtMs?: number;
+  scheduleErrorCount?: number;
+  lastError?: string;
+  lastStatus?: CronJob["state"]["lastStatus"];
+  runningAtMs?: number;
+}): CronJob {
+  return {
+    id: params.id,
+    name: params.id,
+    enabled: params.enabled ?? true,
+    createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+    updatedAtMs: params.updatedAtMs ?? Date.parse("2026-03-19T01:44:00.000Z"),
+    schedule: { kind: "cron", expr: params.expr, tz: "Asia/Shanghai", staggerMs: 0 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "tick" },
+    state: {
+      nextRunAtMs: params.nextRunAtMs,
+      scheduleErrorCount: params.scheduleErrorCount,
+      lastError: params.lastError,
+      lastStatus: params.lastStatus,
+      runningAtMs: params.runningAtMs,
+    },
+  };
+}
+
+describe("forceReload repairs externally changed schedules", () => {
+  it("recomputes nextRunAtMs when jobs.json changes a cron schedule outside cron.update", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "external-schedule-change";
+    const staleNextRunAtMs = Date.parse("2026-03-20T00:30:00.000Z");
+    const correctedNextRunAtMs = Date.parse("2026-03-19T12:30:00.000Z");
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createCronJob({ id: jobId, expr: "30 8 * * *", nextRunAtMs: staleNextRunAtMs })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createCronJob({ id: jobId, expr: "30 8,20 * * *", nextRunAtMs: staleNextRunAtMs })],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    const reloaded = state.store?.jobs.find((job) => job.id === jobId);
+    expect(reloaded?.state.nextRunAtMs).toBe(correctedNextRunAtMs);
+
+    const persisted = JSON.parse(await fsp.readFile(store.storePath, "utf8")) as {
+      jobs?: Array<{ id: string; state?: { nextRunAtMs?: number } }>;
+    };
+    expect(persisted.jobs?.find((job) => job.id === jobId)?.state?.nextRunAtMs).toBe(
+      correctedNextRunAtMs,
+    );
+  });
+
+  it("recomputes from updatedAtMs so delayed reload keeps newly earlier slots due", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-schedule-change-delayed-observe";
+    const staleNextRunAtMs = Date.parse("2026-03-20T00:30:00.000Z");
+
+    const createJob = (params: { expr: string; updatedAtMs: number }) =>
+      createCronJob({
+        id: jobId,
+        expr: params.expr,
+        updatedAtMs: params.updatedAtMs,
+        nextRunAtMs: staleNextRunAtMs,
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createJob({ expr: "30 23 * * *", updatedAtMs: Date.parse("2026-03-19T12:00:00.000Z") }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ expr: "* * * * *", updatedAtMs: Date.parse("2026-03-19T12:01:00.000Z") })],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:02:00.000Z"));
+  });
+
+  it("recomputes pure enable reloads from now instead of the older edit time", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-enable-delayed-observe";
+
+    const createJob = (params: { enabled: boolean; updatedAtMs: number }) =>
+      createCronJob({
+        id: jobId,
+        expr: "* * * * *",
+        enabled: params.enabled,
+        updatedAtMs: params.updatedAtMs,
+        nextRunAtMs: undefined,
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ enabled: false, updatedAtMs: Date.parse("2026-03-19T12:00:00.000Z") })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ enabled: true, updatedAtMs: Date.parse("2026-03-19T12:01:00.000Z") })],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:11:00.000Z"));
+  });
+
+  it("recomputes enable plus schedule reloads from now instead of the older edit time", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-enable-and-schedule-delayed-observe";
+
+    const createJob = (params: { enabled: boolean; expr: string; updatedAtMs: number }) =>
+      createCronJob({
+        id: jobId,
+        expr: params.expr,
+        enabled: params.enabled,
+        updatedAtMs: params.updatedAtMs,
+        nextRunAtMs: undefined,
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createJob({
+          enabled: false,
+          expr: "30 23 * * *",
+          updatedAtMs: Date.parse("2026-03-19T12:00:00.000Z"),
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createJob({
+          enabled: true,
+          expr: "* * * * *",
+          updatedAtMs: Date.parse("2026-03-19T12:01:00.000Z"),
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:11:00.000Z"));
+  });
+
+  it("does not repair when a cron rewrite only changes equivalent defaults", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T09:00:00.000Z");
+    const jobId = "external-equivalent-cron-rewrite";
+    const dueNextRunAtMs = Date.parse("2026-03-19T08:30:00.000Z");
+
+    const baseJob = (params: { updatedAtMs: number; tz?: string; staggerMs?: number }) =>
+      ({
+        id: jobId,
+        name: jobId,
+        enabled: true,
+        createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+        updatedAtMs: params.updatedAtMs,
+        schedule: {
+          kind: "cron" as const,
+          expr: "30 8 * * *",
+          ...(params.tz !== undefined ? { tz: params.tz } : {}),
+          ...(params.staggerMs !== undefined ? { staggerMs: params.staggerMs } : {}),
+        },
+        sessionTarget: "main" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "systemEvent" as const, text: "tick" },
+        state: {
+          nextRunAtMs: dueNextRunAtMs,
+        },
+      }) satisfies CronJob;
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [baseJob({ updatedAtMs: Date.parse("2026-03-19T08:00:00.000Z") })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        baseJob({
+          updatedAtMs: Date.parse("2026-03-19T08:45:00.000Z"),
+          tz: "   ",
+          staggerMs: 0,
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("does not repair when a cron rewrite only materializes the local timezone", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T09:00:00.000Z");
+    const jobId = "external-equivalent-local-timezone-rewrite";
+    const dueNextRunAtMs = computeNextRunAtMs(
+      { kind: "cron", expr: "*/10 * * * *" },
+      Date.parse("2026-03-19T08:40:00.000Z"),
+    );
+    const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    expect(dueNextRunAtMs).toBeDefined();
+    expect(localTimezone).toBeTruthy();
+
+    const baseJob = (params: { updatedAtMs: number; tz?: string }) =>
+      ({
+        id: jobId,
+        name: jobId,
+        enabled: true,
+        createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+        updatedAtMs: params.updatedAtMs,
+        schedule: {
+          kind: "cron" as const,
+          expr: "*/10 * * * *",
+          ...(params.tz !== undefined ? { tz: params.tz } : {}),
+        },
+        sessionTarget: "main" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "systemEvent" as const, text: "tick" },
+        state: {
+          nextRunAtMs: dueNextRunAtMs,
+        },
+      }) satisfies CronJob;
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [baseJob({ updatedAtMs: Date.parse("2026-03-19T08:40:00.000Z") })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        baseJob({
+          updatedAtMs: Date.parse("2026-03-19T08:55:00.000Z"),
+          tz: localTimezone,
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("does not repair when a cron rewrite only changes cron token casing", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T13:00:00.000Z");
+    const jobId = "external-equivalent-cron-case-rewrite";
+    const dueNextRunAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+
+    const baseJob = (params: { updatedAtMs: number; expr: string }) =>
+      ({
+        id: jobId,
+        name: jobId,
+        enabled: true,
+        createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+        updatedAtMs: params.updatedAtMs,
+        schedule: {
+          kind: "cron" as const,
+          expr: params.expr,
+          tz: "UTC",
+          staggerMs: 0,
+        },
+        sessionTarget: "main" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "systemEvent" as const, text: "tick" },
+        state: {
+          nextRunAtMs: dueNextRunAtMs,
+        },
+      }) satisfies CronJob;
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        baseJob({ updatedAtMs: Date.parse("2026-03-19T12:00:00.000Z"), expr: "0 12 * * MON" }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        baseJob({ updatedAtMs: Date.parse("2026-03-19T12:30:00.000Z"), expr: "0 12 * * mon" }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("does not repair when a cron rewrite only changes an equivalent timezone spelling", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T13:00:00.000Z");
+    const jobId = "external-equivalent-cron-timezone-rewrite";
+    const dueNextRunAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+
+    const baseJob = (params: { updatedAtMs: number; tz: string }) =>
+      ({
+        id: jobId,
+        name: jobId,
+        enabled: true,
+        createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+        updatedAtMs: params.updatedAtMs,
+        schedule: {
+          kind: "cron" as const,
+          expr: "0 12 * * *",
+          tz: params.tz,
+          staggerMs: 0,
+        },
+        sessionTarget: "main" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "systemEvent" as const, text: "tick" },
+        state: {
+          nextRunAtMs: dueNextRunAtMs,
+        },
+      }) satisfies CronJob;
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [baseJob({ updatedAtMs: Date.parse("2026-03-19T12:00:00.000Z"), tz: "utc" })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [baseJob({ updatedAtMs: Date.parse("2026-03-19T12:30:00.000Z"), tz: "UTC" })],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("falls back to file mtime when external edits keep updatedAtMs unchanged", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-schedule-change-unchanged-updatedAt";
+    const staleNextRunAtMs = Date.parse("2026-03-20T00:30:00.000Z");
+    const updatedAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+    const fileEditMtimeMs = Date.parse("2026-03-19T12:01:00.000Z");
+    const realStat = fs.promises.stat.bind(fs.promises);
+    const statSpy = vi.spyOn(fs.promises, "stat");
+    let statCallCount = 0;
+    statSpy.mockImplementation(async (...args) => {
+      const stats = await realStat(...args);
+      return Object.assign(stats, {
+        mtimeMs: statCallCount++ === 0 ? updatedAtMs : fileEditMtimeMs,
+      });
+    });
+
+    const createJob = (expr: string) =>
+      createCronJob({
+        id: jobId,
+        expr,
+        updatedAtMs,
+        nextRunAtMs: staleNextRunAtMs,
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob("30 23 * * *")],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob("* * * * *")],
+    });
+
+    try {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+      expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:02:00.000Z"));
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it("falls back to file mtime when external edits drop updatedAtMs", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-schedule-change-missing-updatedAt";
+    const staleNextRunAtMs = Date.parse("2026-03-20T00:30:00.000Z");
+    const initialUpdatedAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+    const fileEditMtimeMs = Date.parse("2026-03-19T12:01:00.000Z");
+    const realStat = fs.promises.stat.bind(fs.promises);
+    const statSpy = vi.spyOn(fs.promises, "stat");
+    let statCallCount = 0;
+    statSpy.mockImplementation(async (...args) => {
+      const stats = await realStat(...args);
+      return Object.assign(stats, {
+        mtimeMs: statCallCount++ === 0 ? initialUpdatedAtMs : fileEditMtimeMs,
+      });
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "30 23 * * *",
+          updatedAtMs: initialUpdatedAtMs,
+          nextRunAtMs: staleNextRunAtMs,
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await fsp.writeFile(
+      store.storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              ...createCronJob({
+                id: jobId,
+                expr: "* * * * *",
+                updatedAtMs: initialUpdatedAtMs,
+                nextRunAtMs: staleNextRunAtMs,
+              }),
+              updatedAtMs: "not-a-number",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    try {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+      expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:02:00.000Z"));
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it("records schedule errors instead of aborting reload when an external edit is invalid", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "external-invalid-schedule";
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "30 8 * * *",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "not a valid cron",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    await expect(
+      ensureLoaded(state, { forceReload: true, skipRecompute: true }),
+    ).resolves.toBeUndefined();
+
+    const reloaded = state.store?.jobs[0];
+    expect(reloaded?.state.nextRunAtMs).toBeUndefined();
+    expect(reloaded?.state.scheduleErrorCount).toBe(1);
+    expect(reloaded?.state.lastError).toMatch(/^schedule error:/);
+  });
+
+  it("records a cron-specific error when an external reload clears cron expr", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "external-blank-cron-expr";
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "30 8 * * *",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "   ",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    const reloaded = state.store?.jobs[0];
+    expect(reloaded?.state.scheduleErrorCount).toBe(1);
+    expect(reloaded?.state.lastError).toBe(
+      "schedule error: Error: invalid cron schedule: expr is required",
+    );
+  });
+
+  it("preserves schedule error count when an external reload only disables an invalid job", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T09:00:00.000Z");
+    const jobId = "external-disable-invalid-job";
+
+    const createJob = (params: { updatedAtMs: number; enabled: boolean }) =>
+      createCronJob({
+        id: jobId,
+        expr: "   ",
+        enabled: params.enabled,
+        updatedAtMs: params.updatedAtMs,
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 2,
+        lastError: "schedule error: invalid cron schedule: expr is required",
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ updatedAtMs: Date.parse("2026-03-19T08:40:00.000Z"), enabled: true })],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ updatedAtMs: Date.parse("2026-03-19T08:55:00.000Z"), enabled: false })],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    const reloaded = state.store?.jobs[0];
+    expect(reloaded?.enabled).toBe(false);
+    expect(reloaded?.state.scheduleErrorCount).toBe(2);
+    expect(reloaded?.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("does not double-count a reload schedule error during the immediate recompute", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "external-invalid-schedule-full-recompute";
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "30 8 * * *",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "not a valid cron",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    expect(state.store?.jobs[0]?.state.scheduleErrorCount).toBe(1);
+
+    recomputeNextRuns(state);
+    expect(state.store?.jobs[0]?.state.scheduleErrorCount).toBe(1);
+  });
+
+  it("keeps forceReload repairs when manual-run snapshot is merged back", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "manual-run-reload-merge";
+    const staleNextRunAtMs = Date.parse("2026-03-19T23:30:00.000Z");
+
+    const createJob = (params: { expr: string; enabled: boolean; nextRunAtMs?: number }) => ({
+      ...createCronJob({
+        id: jobId,
+        expr: params.expr,
+        enabled: params.enabled,
+        nextRunAtMs: params.nextRunAtMs,
+      }),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn", message: "tick" } as const,
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob({ expr: "30 23 * * *", enabled: true, nextRunAtMs: staleNextRunAtMs })],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [createJob({ expr: "30 8 * * *", enabled: false, nextRunAtMs: staleNextRunAtMs })],
+      });
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
+
+    const merged = state.store?.jobs[0];
+    expect(merged?.enabled).toBe(false);
+    expect(merged?.state.nextRunAtMs).toBeUndefined();
+    expect(merged?.state.lastStatus).toBe("ok");
+  });
+
+  it("keeps scheduleErrorCount cleared when external reload fixes schedule during force-run", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "manual-run-reload-clears-schedule-error-count";
+    const staleNextRunAtMs = Date.parse("2026-03-19T23:30:00.000Z");
+
+    const createJob = (expr: string) => ({
+      ...createCronJob({
+        id: jobId,
+        expr,
+        nextRunAtMs: staleNextRunAtMs,
+        scheduleErrorCount: 2,
+        lastError: "schedule error: invalid expression",
+      }),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn", message: "tick" } as const,
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob("30 23 * * *")],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [createJob("30 8 * * *")],
+      });
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
+    expect(state.store?.jobs[0]?.state.scheduleErrorCount).toBeUndefined();
+  });
+
+  it("does not persist NaN updatedAtMs when manual-run reload sees an invalid timestamp", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "manual-run-reload-invalid-updatedAt";
+
+    const createJob = () => ({
+      ...createCronJob({
+        id: jobId,
+        expr: "30 23 * * *",
+        updatedAtMs: Date.parse("2026-03-19T01:44:00.000Z"),
+        nextRunAtMs: Date.parse("2026-03-19T23:30:00.000Z"),
+      }),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn", message: "tick" } as const,
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob()],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await fsp.writeFile(
+        store.storePath,
+        JSON.stringify(
+          {
+            version: 1,
+            jobs: [
+              {
+                ...createJob(),
+                updatedAtMs: "not-a-number",
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
+    expect(Number.isFinite(state.store?.jobs[0]?.updatedAtMs)).toBe(true);
+    const persisted = JSON.parse(await fsp.readFile(store.storePath, "utf8")) as {
+      jobs?: Array<{ updatedAtMs?: unknown }>;
+    };
+    expect(typeof persisted.jobs?.[0]?.updatedAtMs).toBe("number");
+  });
+
+  it("preserves unrelated reload-skip markers through manual-run cleanup", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const manualJobId = "manual-run-preserves-other-skip-marker";
+    const invalidJobId = "manual-run-other-invalid-reload";
+
+    const createManualJob = (): CronJob => ({
+      ...createCronJob({
+        id: manualJobId,
+        expr: "30 23 * * *",
+        nextRunAtMs: Date.parse("2026-03-19T23:30:00.000Z"),
+      }),
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+
+    const createInvalidJob = (expr: string): CronJob =>
+      createCronJob({
+        id: invalidJobId,
+        expr,
+        nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createManualJob(), createInvalidJob("30 8 * * *")],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [createManualJob(), createInvalidJob("not a valid cron")],
+      });
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    expect(await run(state, manualJobId, "force")).toEqual({ ok: true, ran: true });
+
+    const invalidJob = state.store?.jobs.find((job) => job.id === invalidJobId);
+    expect(invalidJob?.state.scheduleErrorCount).toBe(1);
+    expect(hasSkipNextReloadRepairRecompute(state, invalidJobId)).toBe(true);
+
+    recomputeNextRunsForMaintenance(state);
+
+    expect(state.store?.jobs.find((job) => job.id === invalidJobId)?.state.scheduleErrorCount).toBe(
+      1,
+    );
+  });
+
+  it("preserves unrelated reload-skip markers through timer post-run cleanup", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const runningJobId = "timer-run-preserves-other-skip-marker";
+    const invalidJobId = "timer-run-other-invalid-reload";
+
+    const createRunningJob = (): CronJob => ({
+      ...createCronJob({
+        id: runningJobId,
+        expr: "30 23 * * *",
+        nextRunAtMs: nowMs,
+      }),
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+
+    const createInvalidJob = (expr: string): CronJob =>
+      createCronJob({
+        id: invalidJobId,
+        expr,
+        nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+      });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createRunningJob(), createInvalidJob("30 8 * * *")],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [createRunningJob(), createInvalidJob("not a valid cron")],
+      });
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    const invalidJob = state.store?.jobs.find((job) => job.id === invalidJobId);
+    expect(invalidJob?.state.scheduleErrorCount).toBe(1);
+    expect(hasSkipNextReloadRepairRecompute(state, invalidJobId)).toBe(true);
+
+    recomputeNextRunsForMaintenance(state);
+
+    expect(state.store?.jobs.find((job) => job.id === invalidJobId)?.state.scheduleErrorCount).toBe(
+      1,
+    );
+  });
+
+  it("preserves runningAtMs when an external reload comes from a stale file snapshot", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T12:10:00.000Z");
+    const jobId = "external-running-marker";
+    const runningAtMs = Date.parse("2026-03-19T12:00:00.000Z");
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "30 23 * * *",
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+          runningAtMs,
+        }),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        createCronJob({
+          id: jobId,
+          expr: "* * * * *",
+          updatedAtMs: Date.parse("2026-03-19T12:01:00.000Z"),
+          nextRunAtMs: Date.parse("2026-03-20T00:30:00.000Z"),
+          runningAtMs: runningAtMs - 60_000,
+        }),
+      ],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    const reloaded = state.store?.jobs[0];
+    expect(reloaded?.state.runningAtMs).toBe(runningAtMs);
+    expect(reloaded?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T12:02:00.000Z"));
+  });
+
+  it("recomputes nextRunAtMs when an external every schedule changes", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "external-every-schedule-change";
+
+    const createEveryJob = (everyMs: number): CronJob => ({
+      id: jobId,
+      name: jobId,
+      enabled: true,
+      createdAtMs: Date.parse("2026-03-18T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2026-03-19T01:44:00.000Z"),
+      schedule: {
+        kind: "every",
+        everyMs,
+        anchorMs: Date.parse("2026-03-19T00:00:00.000Z"),
+      },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {
+        nextRunAtMs: Date.parse("2026-03-20T00:00:00.000Z"),
+      },
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createEveryJob(6 * 60_000)],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createEveryJob(60_000)],
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(Date.parse("2026-03-19T01:44:00.000Z"));
+  });
+});

--- a/src/cron/service.external-reload-schedule-recompute.test.ts
+++ b/src/cron/service.external-reload-schedule-recompute.test.ts
@@ -834,6 +834,57 @@ describe("forceReload repairs externally changed schedules", () => {
     expect(merged?.state.lastStatus).toBe("ok");
   });
 
+  it("keeps one-shot terminal disable when external reload stays enabled during force-run", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "manual-run-reload-oneshot-terminal-disable";
+    const initialAt = Date.parse("2026-03-19T23:30:00.000Z");
+    const rewrittenAt = Date.parse("2026-03-20T00:30:00.000Z");
+
+    const createJob = (atMs: number) =>
+      ({
+        id: jobId,
+        name: jobId,
+        enabled: true,
+        createdAtMs: Date.parse("2026-03-18T00:30:00.000Z"),
+        updatedAtMs: Date.parse("2026-03-19T01:44:00.000Z"),
+        schedule: { kind: "at" as const, at: new Date(atMs).toISOString() },
+        sessionTarget: "isolated" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "agentTurn" as const, message: "tick" },
+        state: { nextRunAtMs: atMs },
+      }) satisfies CronJob;
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob(initialAt)],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        await writeCronStoreSnapshot({
+          storePath: store.storePath,
+          jobs: [createJob(rewrittenAt)],
+        });
+        nowMs += 500;
+        return { status: "error" as const, error: "invalid API key" };
+      }),
+    });
+
+    expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
+
+    const merged = state.store?.jobs[0];
+    expect(merged?.enabled).toBe(false);
+    expect(merged?.state.nextRunAtMs).toBeUndefined();
+    expect(merged?.state.lastStatus).toBe("error");
+  });
+
   it("keeps scheduleErrorCount cleared when external reload fixes schedule during force-run", async () => {
     const store = await makeStorePath();
     let nowMs = Date.parse("2026-03-19T01:44:00.000Z");

--- a/src/cron/service.external-reload-schedule-recompute.test.ts
+++ b/src/cron/service.external-reload-schedule-recompute.test.ts
@@ -881,6 +881,50 @@ describe("forceReload repairs externally changed schedules", () => {
     expect(state.store?.jobs[0]?.state.lastError).toBeUndefined();
   });
 
+  it("does not restore stale non-schedule lastError after manual-run reload merge", async () => {
+    const store = await makeStorePath();
+    let nowMs = Date.parse("2026-03-19T01:44:00.000Z");
+    const jobId = "manual-run-reload-keeps-non-schedule-error-cleared";
+
+    const createJob = (expr: string, lastError: string) => ({
+      ...createCronJob({
+        id: jobId,
+        expr,
+        nextRunAtMs: Date.parse("2026-03-19T23:30:00.000Z"),
+        lastError,
+      }),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn", message: "tick" } as const,
+    });
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createJob("30 23 * * *", "runtime failure before reload")],
+    });
+
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronStoreSnapshot({
+        storePath: store.storePath,
+        jobs: [createJob("30 8 * * *", "runtime failure from disk")],
+      });
+      nowMs += 500;
+      return { status: "ok" as const, summary: "done" };
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    expect(await run(state, jobId, "force")).toEqual({ ok: true, ran: true });
+    expect(state.store?.jobs[0]?.state.lastError).toBeUndefined();
+  });
+
   it("does not persist NaN updatedAtMs when manual-run reload sees an invalid timestamp", async () => {
     const store = await makeStorePath();
     let nowMs = Date.parse("2026-03-19T01:44:00.000Z");

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -903,6 +903,102 @@ describe("Cron issue regressions", () => {
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves successful external schedule repairs across timer-run completion", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "recurring-external-valid-repair";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "poll",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 10_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "poll" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronJobs(store.storePath, [
+        {
+          ...cronJob,
+          updatedAtMs: scheduledAt + 1,
+          schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+          state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+        },
+      ]);
+      now = scheduledAt + 10 * 60_000;
+      return { status: "ok" as const, summary: "ok" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(job).toBeDefined();
+    expect(job!.state.lastStatus).toBe("ok");
+    expect(job!.state.nextRunAtMs).toBe(scheduledAt + 60_000);
+    expect(job!.state.nextRunAtMs).toBeLessThan(now);
+  });
+
+  it("preserves force-run retry backoff when external schedule edits make the job earlier", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "force-run-external-edit-backoff";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "poll",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 10_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "poll" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        await writeCronJobs(store.storePath, [
+          {
+            ...cronJob,
+            updatedAtMs: scheduledAt + 1,
+            schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+            state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+          },
+        ]);
+        now = scheduledAt + 10 * 60_000;
+        return {
+          status: "error" as const,
+          error: "synthetic failure",
+        };
+      }),
+    });
+
+    await run(state, jobId, "force");
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(job).toBeDefined();
+    expect(job!.state.lastStatus).toBe("error");
+    expect(job!.state.nextRunAtMs).toBe(now + 30_000);
+    expect(job!.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
   it("#38822: one-shot job retries Bedrock too-many-tokens-per-day errors", async () => {
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-03-08T10:00:00.000Z");

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -950,6 +950,62 @@ describe("Cron issue regressions", () => {
     expect(job!.state.nextRunAtMs).toBeLessThan(now);
   });
 
+  it("consumes successful external schedule repair markers after the replayed run", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "recurring-external-valid-repair-marker";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "poll",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 10_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "poll" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      if (runIsolatedAgentJob.mock.calls.length === 1) {
+        await writeCronJobs(store.storePath, [
+          {
+            ...cronJob,
+            updatedAtMs: scheduledAt + 1,
+            schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+            state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+          },
+        ]);
+        now = scheduledAt + 10 * 60_000;
+      } else {
+        now += 500;
+      }
+      return { status: "ok" as const, summary: "ok" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+    expect(state.store?.jobs.find((entry) => entry.id === jobId)?.state.nextRunAtMs).toBe(
+      scheduledAt + 60_000,
+    );
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.nextRunAtMs).toBe(scheduledAt + 11 * 60_000);
+    expect(job?.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
   it("preserves force-run retry backoff when external schedule edits make the job earlier", async () => {
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -903,6 +903,61 @@ describe("Cron issue regressions", () => {
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
   });
 
+  it("applies one-shot retry backoff when a valid external reload edit lands mid-run", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "oneshot-external-valid-edit-retry-backoff";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "reminder",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "remind me" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const laterAt = scheduledAt + 5_000;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronJobs(store.storePath, [
+        {
+          ...cronJob,
+          updatedAtMs: scheduledAt + 1,
+          schedule: { kind: "at", at: new Date(laterAt).toISOString() },
+          state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+        },
+      ]);
+      now = scheduledAt + 10 * 60_000;
+      return {
+        status: "error" as const,
+        error: "429 rate limit exceeded",
+      };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      cronConfig: {
+        retry: { maxAttempts: 1, backoffMs: [1000], retryOn: ["rate_limit"] },
+      },
+    });
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(job).toBeDefined();
+    expect(job!.enabled).toBe(true);
+    expect(job!.state.lastStatus).toBe("error");
+    expect(job!.state.nextRunAtMs).toBe(now + 1000);
+    expect(job!.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
   it("preserves successful external schedule repairs across timer-run completion", async () => {
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
@@ -948,6 +1003,60 @@ describe("Cron issue regressions", () => {
     expect(job!.state.lastStatus).toBe("ok");
     expect(job!.state.nextRunAtMs).toBe(scheduledAt + 60_000);
     expect(job!.state.nextRunAtMs).toBeLessThan(now);
+  });
+
+  it("applies recurring error backoff when a valid external reload edit lands mid-run", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "recurring-external-valid-repair-backoff";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "poll",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 10_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "poll" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronJobs(store.storePath, [
+        {
+          ...cronJob,
+          updatedAtMs: scheduledAt + 1,
+          schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+          state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+        },
+      ]);
+      now = scheduledAt + 10 * 60_000;
+      return {
+        status: "error" as const,
+        error: "429 rate limit exceeded",
+      };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      cronConfig: {
+        retry: { maxAttempts: 1, backoffMs: [1000], retryOn: ["rate_limit"] },
+      },
+    });
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(job).toBeDefined();
+    expect(job!.enabled).toBe(true);
+    expect(job!.state.lastStatus).toBe("error");
+    expect(job!.state.nextRunAtMs).toBe(now + 30_000);
+    expect(job!.state.nextRunAtMs).toBeGreaterThan(now);
   });
 
   it("consumes successful external schedule repair markers after the replayed run", async () => {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -22,8 +22,12 @@ import {
   createNoopLogger,
   createRunningCronServiceState,
 } from "./service.test-harness.js";
-import { computeJobNextRunAtMs } from "./service/jobs.js";
-import { enqueueRun, run } from "./service/ops.js";
+import {
+  computeJobNextRunAtMs,
+  nextWakeAtMs,
+  recomputeNextRunsForMaintenance,
+} from "./service/jobs.js";
+import { enqueueRun, list, run, status } from "./service/ops.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
@@ -842,6 +846,61 @@ describe("Cron issue regressions", () => {
     expect(finishedJob).toBeDefined();
     expect(finishedJob!.state.lastStatus).toBe("ok");
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not schedule one-shot retry when external reload breaks the at schedule mid-run", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const jobId = "oneshot-external-invalid-at-no-retry";
+
+    const cronJob = createIsolatedRegressionJob({
+      id: jobId,
+      name: "reminder",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "remind me" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      await writeCronJobs(store.storePath, [
+        {
+          ...cronJob,
+          updatedAtMs: scheduledAt + 1,
+          schedule: { kind: "at", at: "not-a-valid-timestamp" },
+          state: { ...cronJob.state, nextRunAtMs: scheduledAt },
+        },
+      ]);
+      return {
+        status: "error" as const,
+        error: "429 rate limit exceeded",
+      };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+      cronConfig: {
+        retry: { maxAttempts: 1, backoffMs: [1000], retryOn: ["rate_limit"] },
+      },
+    });
+
+    await onTimer(state);
+
+    const job = state.store?.jobs.find((entry) => entry.id === jobId);
+    expect(job).toBeDefined();
+    expect(job!.enabled).toBe(true);
+    expect(job!.state.lastStatus).toBe("error");
+    expect(job!.state.scheduleErrorCount).toBe(1);
+    expect(job!.state.nextRunAtMs).toBeUndefined();
+    expect(nextWakeAtMs(state)).toBe(now + 2000);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
   });
 
   it("#38822: one-shot job retries Bedrock too-many-tokens-per-day errors", async () => {
@@ -1788,6 +1847,170 @@ describe("Cron issue regressions", () => {
     expect(job.state.lastError).toMatch(/^schedule error:/);
     expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
     expect(job.enabled).toBe(true);
+  });
+
+  it("does not double-count reload schedule errors in apply path before maintenance recompute", () => {
+    const startedAt = Date.parse("2026-03-02T12:10:00.000Z");
+    const endedAt = startedAt + 25;
+    const job = createIsolatedRegressionJob({
+      id: "apply-result-reload-dedupe-30905",
+      name: "apply-result-reload-dedupe-30905",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Invalid/Timezone" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: {
+        nextRunAtMs: undefined,
+        runningAtMs: startedAt - 500,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-30905-reload-dedupe.json",
+      log: noopLogger as never,
+      nowMs: () => endedAt,
+      jobs: [job],
+    });
+    state.skipNextReloadRepairRecomputeJobIds = new Set([job.id]);
+
+    applyJobResult(state, job, {
+      status: "ok",
+      delivered: true,
+      startedAt,
+      endedAt,
+    });
+
+    expect(job.state.scheduleErrorCount).toBe(1);
+    expect(state.skipNextReloadRepairRecomputeJobIds?.has(job.id)).toBe(true);
+    expect(nextWakeAtMs(state)).toBe(endedAt + 2_000);
+
+    recomputeNextRunsForMaintenance(state);
+    expect(job.state.scheduleErrorCount).toBe(1);
+    expect(state.skipNextReloadRepairRecomputeJobIds?.has(job.id)).toBe(false);
+    expect(nextWakeAtMs(state)).toBe(endedAt + 2_000);
+  });
+
+  it("keeps a future wake when apply skips immediate recompute after reload schedule error", () => {
+    const startedAt = Date.parse("2026-03-02T12:12:00.000Z");
+    const endedAt = startedAt + 25;
+    const job = createIsolatedRegressionJob({
+      id: "apply-result-reload-wake-30905",
+      name: "apply-result-reload-wake-30905",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Invalid/Timezone" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: {
+        nextRunAtMs: undefined,
+        runningAtMs: startedAt - 500,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-30905-reload-wake.json",
+      log: noopLogger as never,
+      nowMs: () => endedAt,
+      jobs: [job],
+    });
+    state.skipNextReloadRepairRecomputeJobIds = new Set([job.id]);
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "synthetic failure",
+      startedAt,
+      endedAt,
+    });
+
+    expect(job.state.scheduleErrorCount).toBe(1);
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(state.skipNextReloadRepairRecomputeJobIds?.has(job.id)).toBe(true);
+    expect(nextWakeAtMs(state)).toBe(endedAt + 2_000);
+
+    recomputeNextRunsForMaintenance(state);
+    expect(job.state.scheduleErrorCount).toBe(1);
+    expect(state.skipNextReloadRepairRecomputeJobIds?.has(job.id)).toBe(false);
+    expect(nextWakeAtMs(state)).toBe(endedAt + 2_000);
+  });
+
+  it("does not arm 2s wake for malformed every schedules with non-repairable missing nextRun", () => {
+    const nowMs = Date.parse("2026-03-02T12:20:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "missing-nextrun-malformed-every",
+      name: "missing-nextrun-malformed-every",
+      scheduledAt: nowMs,
+      schedule: { kind: "every", everyMs: Number.NaN, anchorMs: nowMs - 60_000 },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: {
+        nextRunAtMs: undefined,
+      },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-missing-nextrun-malformed-every.json",
+      log: noopLogger as never,
+      nowMs: () => nowMs,
+      jobs: [job],
+    });
+
+    expect(nextWakeAtMs(state)).toBeUndefined();
+  });
+
+  it("does not consume reload skip markers during read-only status/list maintenance", async () => {
+    const nowMs = Date.parse("2026-03-02T12:25:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "read-only-skip-marker",
+      name: "read-only-skip-marker",
+      scheduledAt: nowMs,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Invalid/Timezone" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-read-only-skip-marker.json",
+      log: noopLogger as never,
+      nowMs: () => nowMs,
+      jobs: [job],
+    });
+    state.skipNextReloadRepairRecomputeJobIds = new Set([job.id]);
+
+    const currentStatus = await status(state);
+    expect(currentStatus.nextWakeAtMs).toBe(nowMs + 2_000);
+    expect(state.skipNextReloadRepairRecomputeJobIds.has(job.id)).toBe(true);
+
+    const jobs = await list(state, { includeDisabled: true });
+    expect(jobs).toHaveLength(1);
+    expect(state.skipNextReloadRepairRecomputeJobIds.has(job.id)).toBe(true);
+
+    recomputeNextRunsForMaintenance(state);
+    expect(state.skipNextReloadRepairRecomputeJobIds.has(job.id)).toBe(false);
+  });
+
+  it("does not arm 2s wake for exhausted one-shot jobs with missing nextRun", () => {
+    const nowMs = Date.parse("2026-03-02T12:22:00.000Z");
+    const atMs = nowMs - 60_000;
+    const job = createIsolatedRegressionJob({
+      id: "missing-nextrun-exhausted-at",
+      name: "missing-nextrun-exhausted-at",
+      scheduledAt: nowMs,
+      schedule: { kind: "at", at: new Date(atMs).toISOString() },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: {
+        nextRunAtMs: undefined,
+        lastStatus: "ok",
+        lastRunAtMs: nowMs - 30_000,
+      },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-missing-nextrun-exhausted-at.json",
+      log: noopLogger as never,
+      nowMs: () => nowMs,
+      jobs: [job],
+    });
+
+    expect(nextWakeAtMs(state)).toBeUndefined();
   });
 
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -385,6 +385,7 @@ function createMockState(now: number, opts?: { defaultAgentId?: string }): CronS
       nowMs: () => now,
       defaultAgentId: opts?.defaultAgentId,
     },
+    skipNextReloadRepairRecomputeJobIds: new Set<string>(),
   } as unknown as CronServiceState;
 }
 

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -243,6 +243,7 @@ export function createMockCronStateForJobs(params: {
     timer: null,
     storeLoadedAtMs: nowMs,
     storeFileMtimeMs: null,
+    skipNextReloadRepairRecomputeJobIds: new Set<string>(),
     op: Promise.resolve(),
     warnedDisabled: false,
     deps: {

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -342,6 +342,23 @@ describe("cron schedule error isolation", () => {
     expect(nextWakeAtMs(state)).toBe(Date.now() + 60_000);
   });
 
+  it("fast-wakes malformed fixed schedules that still need one reload-repair follow-up", () => {
+    const badJob = createJob({
+      id: "bad-at-reload-follow-up",
+      name: "Bad At Reload Follow-up",
+      schedule: { kind: "at", at: "not-a-timestamp" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+    state.skipNextReloadRepairRecomputeJobIds.add(badJob.id);
+
+    expect(nextWakeAtMs(state)).toBe(Date.now() + 2_000);
+  });
+
   it("still fast-wakes malformed cron schedules that have schedule errors", () => {
     const badJob = createJob({
       id: "bad-cron-wake",

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CronJob, CronStoreFile } from "../types.js";
-import { recomputeNextRuns, recomputeNextRunsForMaintenance } from "./jobs.js";
+import { nextWakeAtMs, recomputeNextRuns, recomputeNextRunsForMaintenance } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
 function createMockState(jobs: CronJob[]): CronServiceState {
@@ -308,5 +308,37 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.nextRunAtMs).toBeUndefined();
     expect(badJob.state.scheduleErrorCount).toBe(2);
     expect(badJob.state.lastError).toBe("schedule error: previous");
+  });
+
+  it("does not fast-wake malformed every schedules that already have schedule errors", () => {
+    const badJob = createJob({
+      id: "bad-every-wake",
+      name: "Bad Every Wake",
+      schedule: { kind: "every", everyMs: Number.NaN },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    expect(nextWakeAtMs(state)).toBeUndefined();
+  });
+
+  it("still fast-wakes malformed cron schedules that have schedule errors", () => {
+    const badJob = createJob({
+      id: "bad-cron-wake",
+      name: "Bad Cron Wake",
+      schedule: { kind: "cron", expr: "bad cron" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    expect(nextWakeAtMs(state)).toBe(Date.now() + 2_000);
   });
 });

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -207,6 +207,21 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.scheduleErrorCount).toBe(1);
   });
 
+  it("treats impossible cron expressions as schedule errors", () => {
+    const badJob = createJob({
+      id: "impossible-cron",
+      name: "Impossible Cron",
+      schedule: { kind: "cron", expr: "0 0 31 2 *" },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.scheduleErrorCount).toBe(1);
+    expect(badJob.state.lastError).toMatch(/^schedule error:/);
+  });
+
   it("keeps malformed every schedules on the schedule-error path", () => {
     const badJob = createJob({
       id: "bad-every",

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CronJob, CronStoreFile } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import { recomputeNextRuns, recomputeNextRunsForMaintenance } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
 function createMockState(jobs: CronJob[]): CronServiceState {
@@ -28,6 +28,11 @@ function createMockState(jobs: CronJob[]): CronServiceState {
     store,
     timer: null,
     running: false,
+    op: Promise.resolve(),
+    warnedDisabled: false,
+    storeLoadedAtMs: null,
+    storeFileMtimeMs: null,
+    skipNextReloadRepairRecomputeJobIds: new Set<string>(),
   } as unknown as CronServiceState;
 }
 
@@ -200,5 +205,69 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.lastError).toContain("invalid cron schedule: expr is required");
     expect(badJob.state.lastError).not.toContain("Cannot read properties of undefined");
     expect(badJob.state.scheduleErrorCount).toBe(1);
+  });
+
+  it("keeps malformed every schedules on the schedule-error path", () => {
+    const badJob = createJob({
+      id: "bad-every",
+      name: "Bad Every",
+      schedule: { kind: "every", everyMs: Number.NaN },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.scheduleErrorCount).toBe(2);
+    expect(badJob.state.lastError).toContain("invalid every schedule");
+  });
+
+  it("keeps malformed at schedules on the schedule-error path", () => {
+    const badJob = createJob({
+      id: "bad-at",
+      name: "Bad At",
+      schedule: { kind: "at", at: "not-a-timestamp" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    recomputeNextRuns(state);
+
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.scheduleErrorCount).toBe(2);
+    expect(badJob.state.lastError).toContain("invalid at schedule");
+  });
+
+  it("does not increment schedule errors during read-only maintenance repair", () => {
+    const badJob = createJob({
+      id: "bad-every-read",
+      name: "Bad Every Read",
+      schedule: { kind: "every", everyMs: Number.NaN },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 2,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    const changed = recomputeNextRunsForMaintenance(state, {
+      treatUndefinedAsScheduleError: false,
+    });
+
+    expect(changed).toBe(false);
+    expect(badJob.enabled).toBe(true);
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.scheduleErrorCount).toBe(2);
+    expect(badJob.state.lastError).toBe("schedule error: previous");
   });
 });

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -310,7 +310,7 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.lastError).toBe("schedule error: previous");
   });
 
-  it("does not fast-wake malformed every schedules that already have schedule errors", () => {
+  it("keeps polling malformed every schedules with schedule errors on a slow cadence", () => {
     const badJob = createJob({
       id: "bad-every-wake",
       name: "Bad Every Wake",
@@ -323,7 +323,23 @@ describe("cron schedule error isolation", () => {
     });
     const state = createMockState([badJob]);
 
-    expect(nextWakeAtMs(state)).toBeUndefined();
+    expect(nextWakeAtMs(state)).toBe(Date.now() + 60_000);
+  });
+
+  it("keeps polling malformed at schedules with schedule errors on a slow cadence", () => {
+    const badJob = createJob({
+      id: "bad-at-wake",
+      name: "Bad At Wake",
+      schedule: { kind: "at", at: "not-a-timestamp" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    expect(nextWakeAtMs(state)).toBe(Date.now() + 60_000);
   });
 
   it("still fast-wakes malformed cron schedules that have schedule errors", () => {
@@ -338,6 +354,32 @@ describe("cron schedule error isolation", () => {
       },
     });
     const state = createMockState([badJob]);
+
+    expect(nextWakeAtMs(state)).toBe(Date.now() + 2_000);
+  });
+
+  it("keeps the earliest wake when cron and malformed fixed schedules both need polling", () => {
+    const badCronJob = createJob({
+      id: "bad-cron-wake",
+      name: "Bad Cron Wake",
+      schedule: { kind: "cron", expr: "bad cron" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const badAtJob = createJob({
+      id: "bad-at-wake",
+      name: "Bad At Wake",
+      schedule: { kind: "at", at: "not-a-timestamp" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 1,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badCronJob, badAtJob]);
 
     expect(nextWakeAtMs(state)).toBe(Date.now() + 2_000);
   });

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -285,4 +285,28 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.scheduleErrorCount).toBe(2);
     expect(badJob.state.lastError).toBe("schedule error: previous");
   });
+
+  it("does not increment thrown cron errors during read-only maintenance repair", () => {
+    const badJob = createJob({
+      id: "bad-timezone-read",
+      name: "Bad Timezone Read",
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "Invalid/Timezone" },
+      state: {
+        nextRunAtMs: undefined,
+        scheduleErrorCount: 2,
+        lastError: "schedule error: previous",
+      },
+    });
+    const state = createMockState([badJob]);
+
+    const changed = recomputeNextRunsForMaintenance(state, {
+      treatUndefinedAsScheduleError: false,
+    });
+
+    expect(changed).toBe(false);
+    expect(badJob.enabled).toBe(true);
+    expect(badJob.state.nextRunAtMs).toBeUndefined();
+    expect(badJob.state.scheduleErrorCount).toBe(2);
+    expect(badJob.state.lastError).toBe("schedule error: previous");
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -629,7 +629,7 @@ export function nextWakeAtMs(state: CronServiceState) {
     // Non-repairable malformed schedules (e.g. invalid every/at payloads)
     // should not keep the scheduler in a perpetual 2s poll loop.
     if ((job.state.scheduleErrorCount ?? 0) > 0) {
-      hasEnabledRepairableMissingNextRun = true;
+      hasEnabledRepairableMissingNextRun = job.schedule.kind === "cron";
       continue;
     }
     try {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -637,10 +637,11 @@ export function nextWakeAtMs(state: CronServiceState) {
     // eventually observed, but avoid re-arming malformed every/at schedules on
     // the same 2s fast-wake loop used for repairable cron recomputes.
     if ((job.state.scheduleErrorCount ?? 0) > 0) {
-      recordMissingWake(
-        nowMs +
-          (job.schedule.kind === "cron" ? MISSING_NEXT_RUN_WAKE_MS : SCHEDULE_ERROR_RELOAD_POLL_MS),
-      );
+      const wakeDelayMs =
+        job.schedule.kind === "cron" || hasSkipNextReloadRepairRecompute(state, job.id)
+          ? MISSING_NEXT_RUN_WAKE_MS
+          : SCHEDULE_ERROR_RELOAD_POLL_MS;
+      recordMissingWake(nowMs + wakeDelayMs);
       continue;
     }
     try {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -34,6 +34,7 @@ import type { CronServiceState } from "./state.js";
 
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 const MISSING_NEXT_RUN_WAKE_MS = 2_000;
+const SCHEDULE_ERROR_RELOAD_POLL_MS = 60_000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
 
@@ -610,7 +611,7 @@ export function recomputeNextRunsForMaintenance(
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
   let minEnabledNextRunAtMs: number | undefined;
-  let hasEnabledRepairableMissingNextRun = false;
+  let minMissingNextRunWakeAtMs: number | undefined;
   const nowMs = state.deps.nowMs();
 
   for (const job of jobs) {
@@ -625,30 +626,39 @@ export function nextWakeAtMs(state: CronServiceState) {
           : Math.min(minEnabledNextRunAtMs, nextRunAtMs);
       continue;
     }
-    // Only wake for missing nextRun values that can be repaired by recompute.
-    // Non-repairable malformed schedules (e.g. invalid every/at payloads)
-    // should not keep the scheduler in a perpetual 2s poll loop.
+    const recordMissingWake = (wakeAtMs: number) => {
+      minMissingNextRunWakeAtMs =
+        minMissingNextRunWakeAtMs === undefined
+          ? wakeAtMs
+          : Math.min(minMissingNextRunWakeAtMs, wakeAtMs);
+    };
+
+    // Keep polling missing nextRun values so later external schedule fixes are
+    // eventually observed, but avoid re-arming malformed every/at schedules on
+    // the same 2s fast-wake loop used for repairable cron recomputes.
     if ((job.state.scheduleErrorCount ?? 0) > 0) {
-      hasEnabledRepairableMissingNextRun = job.schedule.kind === "cron";
+      recordMissingWake(
+        nowMs +
+          (job.schedule.kind === "cron" ? MISSING_NEXT_RUN_WAKE_MS : SCHEDULE_ERROR_RELOAD_POLL_MS),
+      );
       continue;
     }
     try {
       if (computeJobNextRunAtMs(job, nowMs) !== undefined) {
-        hasEnabledRepairableMissingNextRun = true;
+        recordMissingWake(nowMs + MISSING_NEXT_RUN_WAKE_MS);
       }
     } catch {
-      hasEnabledRepairableMissingNextRun = true;
+      recordMissingWake(nowMs + MISSING_NEXT_RUN_WAKE_MS);
     }
   }
 
-  if (!hasEnabledRepairableMissingNextRun) {
+  if (minMissingNextRunWakeAtMs === undefined) {
     return minEnabledNextRunAtMs;
   }
 
-  const wakeForMissingNextRunAtMs = nowMs + MISSING_NEXT_RUN_WAKE_MS;
   return minEnabledNextRunAtMs === undefined
-    ? wakeForMissingNextRunAtMs
-    : Math.min(minEnabledNextRunAtMs, wakeForMissingNextRunAtMs);
+    ? minMissingNextRunWakeAtMs
+    : Math.min(minEnabledNextRunAtMs, minMissingNextRunWakeAtMs);
 }
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -515,7 +515,10 @@ function recomputeJobNextRunAtMs(params: {
       changed = true;
     }
   } catch (err) {
-    if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
+    if (
+      treatUndefinedAsScheduleError &&
+      recordScheduleComputeError({ state: params.state, job: params.job, err })
+    ) {
       changed = true;
     }
   }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -319,9 +319,21 @@ export function shouldTreatUndefinedNextRunAsScheduleError(job: CronJob): boolea
     return parseAbsoluteTimeMs(job.schedule.at) === null;
   }
   if (job.schedule.kind === "cron") {
-    return job.schedule.expr.trim().length === 0;
+    return true;
   }
   return false;
+}
+
+export function createUndefinedNextRunScheduleError(job: CronJob): Error {
+  if (job.schedule.kind === "every") {
+    return new Error("invalid every schedule: everyMs must be a finite number");
+  }
+  if (job.schedule.kind === "at") {
+    return new Error("invalid at schedule: at must be a valid absolute timestamp");
+  }
+  return job.schedule.expr.trim().length === 0
+    ? new Error("invalid cron schedule: expr is required")
+    : new Error("invalid cron schedule: no future run");
 }
 
 export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number | undefined {
@@ -484,12 +496,7 @@ function recomputeJobNextRunAtMs(params: {
       newNext === undefined &&
       shouldTreatUndefinedNextRunAsScheduleError(params.job)
     ) {
-      const err =
-        params.job.schedule.kind === "every"
-          ? new Error("invalid every schedule: everyMs must be a finite number")
-          : params.job.schedule.kind === "at"
-            ? new Error("invalid at schedule: at must be a valid absolute timestamp")
-            : new Error("invalid cron schedule: expr is required");
+      const err = createUndefinedNextRunScheduleError(params.job);
       if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
         changed = true;
       }
@@ -502,6 +509,9 @@ function recomputeJobNextRunAtMs(params: {
     // Clear schedule error count on successful computation.
     if (treatUndefinedAsSuccess && params.job.state.scheduleErrorCount) {
       params.job.state.scheduleErrorCount = undefined;
+      if (params.job.state.lastError?.startsWith("schedule error:")) {
+        params.job.state.lastError = undefined;
+      }
       changed = true;
     }
   } catch (err) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -33,6 +33,7 @@ import {
 import type { CronServiceState } from "./state.js";
 
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
+const MISSING_NEXT_RUN_WAKE_MS = 2_000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
 
@@ -238,6 +239,19 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
+export function removeJobById(state: CronServiceState, jobId: string): boolean {
+  if (!state.store) {
+    return false;
+  }
+  const before = state.store.jobs.length;
+  state.store.jobs = state.store.jobs.filter((job) => job.id !== jobId);
+  const removed = state.store.jobs.length !== before;
+  if (removed) {
+    state.skipNextReloadRepairRecomputeJobIds.delete(jobId);
+  }
+  return removed;
+}
+
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
   if (!job.enabled) {
     return undefined;
@@ -292,6 +306,22 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     return computeStaggeredCronNextRunAtMs(job, nextSecondMs);
   }
   return isFiniteTimestamp(next) ? next : undefined;
+}
+
+export function shouldTreatUndefinedNextRunAsScheduleError(job: CronJob): boolean {
+  if (!job.enabled) {
+    return false;
+  }
+  if (job.schedule.kind === "every") {
+    return coerceFiniteScheduleNumber(job.schedule.everyMs) === undefined;
+  }
+  if (job.schedule.kind === "at") {
+    return parseAbsoluteTimeMs(job.schedule.at) === null;
+  }
+  if (job.schedule.kind === "cron") {
+    return job.schedule.expr.trim().length === 0;
+  }
+  return false;
 }
 
 export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number | undefined {
@@ -413,16 +443,64 @@ function walkSchedulableJobs(
   return changed;
 }
 
-function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob; nowMs: number }) {
+export function hasSkipNextReloadRepairRecompute(state: CronServiceState, jobId: string): boolean {
+  return state.skipNextReloadRepairRecomputeJobIds.has(jobId);
+}
+
+export function consumeSkipNextReloadRepairRecompute(
+  state: CronServiceState,
+  jobId: string,
+): boolean {
+  if (!hasSkipNextReloadRepairRecompute(state, jobId)) {
+    return false;
+  }
+  state.skipNextReloadRepairRecomputeJobIds.delete(jobId);
+  return true;
+}
+
+function recomputeJobNextRunAtMs(params: {
+  state: CronServiceState;
+  job: CronJob;
+  nowMs: number;
+  consumeReloadRepairSkip?: boolean;
+  treatUndefinedAsScheduleError?: boolean;
+}) {
+  const consumeReloadRepairSkip = params.consumeReloadRepairSkip ?? true;
+  const treatUndefinedAsScheduleError = params.treatUndefinedAsScheduleError ?? true;
+  if (
+    consumeReloadRepairSkip
+      ? consumeSkipNextReloadRepairRecompute(params.state, params.job.id)
+      : hasSkipNextReloadRepairRecompute(params.state, params.job.id)
+  ) {
+    return false;
+  }
   let changed = false;
   try {
     const newNext = computeJobNextRunAtMs(params.job, params.nowMs);
+    const treatUndefinedAsSuccess =
+      newNext !== undefined || !shouldTreatUndefinedNextRunAsScheduleError(params.job);
+    if (
+      treatUndefinedAsScheduleError &&
+      newNext === undefined &&
+      shouldTreatUndefinedNextRunAsScheduleError(params.job)
+    ) {
+      const err =
+        params.job.schedule.kind === "every"
+          ? new Error("invalid every schedule: everyMs must be a finite number")
+          : params.job.schedule.kind === "at"
+            ? new Error("invalid at schedule: at must be a valid absolute timestamp")
+            : new Error("invalid cron schedule: expr is required");
+      if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
+        changed = true;
+      }
+      return changed;
+    }
     if (params.job.state.nextRunAtMs !== newNext) {
       params.job.state.nextRunAtMs = newNext;
       changed = true;
     }
     // Clear schedule error count on successful computation.
-    if (params.job.state.scheduleErrorCount) {
+    if (treatUndefinedAsSuccess && params.job.state.scheduleErrorCount) {
       params.job.state.scheduleErrorCount = undefined;
       changed = true;
     }
@@ -460,16 +538,31 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
-  opts?: { recomputeExpired?: boolean; nowMs?: number },
+  opts?: {
+    recomputeExpired?: boolean;
+    nowMs?: number;
+    consumeReloadRepairSkip?: boolean;
+    treatUndefinedAsScheduleError?: boolean;
+  },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
+  const consumeReloadRepairSkip = opts?.consumeReloadRepairSkip ?? true;
+  const treatUndefinedAsScheduleError = opts?.treatUndefinedAsScheduleError ?? true;
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
       let changed = false;
       if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
         // Missing or invalid nextRunAtMs is always repaired.
-        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+        if (
+          recomputeJobNextRunAtMs({
+            state,
+            job,
+            nowMs: now,
+            consumeReloadRepairSkip,
+            treatUndefinedAsScheduleError,
+          })
+        ) {
           changed = true;
         }
       } else if (
@@ -482,7 +575,15 @@ export function recomputeNextRunsForMaintenance(
         const lastRun = job.state.lastRunAtMs;
         const alreadyExecutedSlot = isFiniteTimestamp(lastRun) && lastRun >= job.state.nextRunAtMs;
         if (alreadyExecutedSlot) {
-          if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+          if (
+            recomputeJobNextRunAtMs({
+              state,
+              job,
+              nowMs: now,
+              consumeReloadRepairSkip,
+              treatUndefinedAsScheduleError,
+            })
+          ) {
             changed = true;
           }
         }
@@ -495,18 +596,46 @@ export function recomputeNextRunsForMaintenance(
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && isFiniteTimestamp(j.state.nextRunAtMs));
-  if (enabled.length === 0) {
-    return undefined;
+  let minEnabledNextRunAtMs: number | undefined;
+  let hasEnabledRepairableMissingNextRun = false;
+  const nowMs = state.deps.nowMs();
+
+  for (const job of jobs) {
+    if (!job.enabled) {
+      continue;
+    }
+    const nextRunAtMs = job.state.nextRunAtMs;
+    if (isFiniteTimestamp(nextRunAtMs)) {
+      minEnabledNextRunAtMs =
+        minEnabledNextRunAtMs === undefined
+          ? nextRunAtMs
+          : Math.min(minEnabledNextRunAtMs, nextRunAtMs);
+      continue;
+    }
+    // Only wake for missing nextRun values that can be repaired by recompute.
+    // Non-repairable malformed schedules (e.g. invalid every/at payloads)
+    // should not keep the scheduler in a perpetual 2s poll loop.
+    if ((job.state.scheduleErrorCount ?? 0) > 0) {
+      hasEnabledRepairableMissingNextRun = true;
+      continue;
+    }
+    try {
+      if (computeJobNextRunAtMs(job, nowMs) !== undefined) {
+        hasEnabledRepairableMissingNextRun = true;
+      }
+    } catch {
+      hasEnabledRepairableMissingNextRun = true;
+    }
   }
-  const first = enabled[0]?.state.nextRunAtMs;
-  if (!isFiniteTimestamp(first)) {
-    return undefined;
+
+  if (!hasEnabledRepairableMissingNextRun) {
+    return minEnabledNextRunAtMs;
   }
-  return enabled.reduce((min, j) => {
-    const next = j.state.nextRunAtMs;
-    return isFiniteTimestamp(next) ? Math.min(min, next) : min;
-  }, first);
+
+  const wakeForMissingNextRunAtMs = nowMs + MISSING_NEXT_RUN_WAKE_MS;
+  return minEnabledNextRunAtMs === undefined
+    ? wakeForMissingNextRunAtMs
+    : Math.min(minEnabledNextRunAtMs, wakeForMissingNextRunAtMs);
 }
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -64,6 +64,8 @@ function mergeManualRunSnapshotAfterReload(params: {
   } | null;
   removed: boolean;
 }) {
+  const isFiniteTimestamp = (value: unknown): value is number =>
+    typeof value === "number" && Number.isFinite(value);
   if (!params.state.store) {
     return;
   }
@@ -103,7 +105,12 @@ function mergeManualRunSnapshotAfterReload(params: {
   // Otherwise, keep the manual-run terminal state (e.g. one-shot disable on success).
   if (externalScheduleOrEnabledChanged) {
     reloaded.enabled = preservedEnabled;
-    reloaded.state.nextRunAtMs = preservedNextRunAtMs;
+    reloaded.state.nextRunAtMs =
+      params.snapshot.state.lastStatus === "error" &&
+      isFiniteTimestamp(params.snapshot.state.nextRunAtMs) &&
+      isFiniteTimestamp(preservedNextRunAtMs)
+        ? Math.max(preservedNextRunAtMs, params.snapshot.state.nextRunAtMs)
+        : preservedNextRunAtMs;
     reloaded.state.scheduleErrorCount = preservedScheduleErrorCount;
     reloaded.state.lastError = preservedScheduleErrorText?.startsWith("schedule error:")
       ? preservedScheduleErrorText

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -105,9 +105,7 @@ function mergeManualRunSnapshotAfterReload(params: {
     reloaded.enabled = preservedEnabled;
     reloaded.state.nextRunAtMs = preservedNextRunAtMs;
     reloaded.state.scheduleErrorCount = preservedScheduleErrorCount;
-    if (preservedScheduleErrorCount !== undefined) {
-      reloaded.state.lastError = preservedScheduleErrorText;
-    }
+    reloaded.state.lastError = preservedScheduleErrorText;
   } else {
     reloaded.enabled = params.snapshot.enabled;
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -88,6 +88,10 @@ function mergeManualRunSnapshotAfterReload(params: {
     params.baseline !== null &&
     (preservedEnabled !== params.baseline.enabled ||
       !schedulesEqual(reloaded.schedule, params.baseline.schedule));
+  const preserveOneShotTerminalState =
+    params.baseline?.schedule.kind === "at" &&
+    !params.snapshot.enabled &&
+    params.snapshot.state.nextRunAtMs === undefined;
 
   const mergedUpdatedAtMs = [reloaded.updatedAtMs, params.snapshot.updatedAtMs]
     .filter((value) => Number.isFinite(value))
@@ -104,11 +108,12 @@ function mergeManualRunSnapshotAfterReload(params: {
   // schedule or enabled flag was externally changed while the manual run was executing.
   // Otherwise, keep the manual-run terminal state (e.g. one-shot disable on success).
   if (externalScheduleOrEnabledChanged) {
-    reloaded.enabled = preservedEnabled;
-    reloaded.state.nextRunAtMs =
-      params.snapshot.state.lastStatus === "error" &&
-      isFiniteTimestamp(params.snapshot.state.nextRunAtMs) &&
-      isFiniteTimestamp(preservedNextRunAtMs)
+    reloaded.enabled = preserveOneShotTerminalState ? params.snapshot.enabled : preservedEnabled;
+    reloaded.state.nextRunAtMs = preserveOneShotTerminalState
+      ? params.snapshot.state.nextRunAtMs
+      : params.snapshot.state.lastStatus === "error" &&
+          isFiniteTimestamp(params.snapshot.state.nextRunAtMs) &&
+          isFiniteTimestamp(preservedNextRunAtMs)
         ? Math.max(preservedNextRunAtMs, params.snapshot.state.nextRunAtMs)
         : preservedNextRunAtMs;
     reloaded.state.scheduleErrorCount = preservedScheduleErrorCount;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -9,10 +9,12 @@ import {
   findJobOrThrow,
   isJobDue,
   nextWakeAtMs,
+  removeJobById,
   recomputeNextRuns,
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import { locked } from "./locked.js";
+import { schedulesEqual } from "./schedule-equality.js";
 import type { CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import {
@@ -47,6 +49,7 @@ export type CronListPageResult = {
   hasMore: boolean;
   nextOffset: number | null;
 };
+
 function mergeManualRunSnapshotAfterReload(params: {
   state: CronServiceState;
   jobId: string;
@@ -55,13 +58,17 @@ function mergeManualRunSnapshotAfterReload(params: {
     updatedAtMs: number;
     state: CronJob["state"];
   } | null;
+  baseline: {
+    enabled: boolean;
+    schedule: CronJob["schedule"];
+  } | null;
   removed: boolean;
 }) {
   if (!params.state.store) {
     return;
   }
   if (params.removed) {
-    params.state.store.jobs = params.state.store.jobs.filter((job) => job.id !== params.jobId);
+    removeJobById(params.state, params.jobId);
     return;
   }
   if (!params.snapshot) {
@@ -71,9 +78,39 @@ function mergeManualRunSnapshotAfterReload(params: {
   if (!reloaded) {
     return;
   }
-  reloaded.enabled = params.snapshot.enabled;
-  reloaded.updatedAtMs = params.snapshot.updatedAtMs;
-  reloaded.state = params.snapshot.state;
+  const preservedEnabled = reloaded.enabled;
+  const preservedNextRunAtMs = reloaded.state.nextRunAtMs;
+  const preservedScheduleErrorCount = reloaded.state.scheduleErrorCount;
+  const preservedScheduleErrorText = reloaded.state.lastError;
+  const externalScheduleOrEnabledChanged =
+    params.baseline !== null &&
+    (preservedEnabled !== params.baseline.enabled ||
+      !schedulesEqual(reloaded.schedule, params.baseline.schedule));
+
+  const mergedUpdatedAtMs = [reloaded.updatedAtMs, params.snapshot.updatedAtMs]
+    .filter((value) => Number.isFinite(value))
+    .map((value) => Math.max(0, Math.floor(value)));
+  if (mergedUpdatedAtMs.length > 0) {
+    reloaded.updatedAtMs = Math.max(...mergedUpdatedAtMs);
+  }
+  reloaded.state = {
+    ...reloaded.state,
+    ...params.snapshot.state,
+  };
+
+  // Only preserve reload-derived schedule/enable repairs when the underlying
+  // schedule or enabled flag was externally changed while the manual run was executing.
+  // Otherwise, keep the manual-run terminal state (e.g. one-shot disable on success).
+  if (externalScheduleOrEnabledChanged) {
+    reloaded.enabled = preservedEnabled;
+    reloaded.state.nextRunAtMs = preservedNextRunAtMs;
+    reloaded.state.scheduleErrorCount = preservedScheduleErrorCount;
+    if (preservedScheduleErrorCount !== undefined) {
+      reloaded.state.lastError = preservedScheduleErrorText;
+    }
+  } else {
+    reloaded.enabled = params.snapshot.enabled;
+  }
 }
 
 async function ensureLoadedForRead(state: CronServiceState) {
@@ -83,7 +120,10 @@ async function ensureLoadedForRead(state: CronServiceState) {
   }
   // Use the maintenance-only version so that read-only operations never
   // advance a past-due nextRunAtMs without executing the job (#16156).
-  const changed = recomputeNextRunsForMaintenance(state);
+  const changed = recomputeNextRunsForMaintenance(state, {
+    consumeReloadRepairSkip: false,
+    treatUndefinedAsScheduleError: false,
+  });
   if (changed) {
     await persist(state);
   }
@@ -309,6 +349,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
         job.state.nextRunAtMs = undefined;
         job.state.runningAtMs = undefined;
       }
+      state.skipNextReloadRepairRecomputeJobIds.delete(id);
     } else if (job.enabled) {
       // Non-schedule edits should not mutate other jobs, but still repair a
       // missing/corrupt nextRunAtMs for the updated job.
@@ -333,12 +374,10 @@ export async function remove(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove");
     await ensureLoaded(state);
-    const before = state.store?.jobs.length ?? 0;
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
-    state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
-    const removed = (state.store.jobs.length ?? 0) !== before;
+    const removed = removeJobById(state, id);
     await persist(state);
     armTimer(state);
     if (removed) {
@@ -390,7 +429,7 @@ async function inspectManualRunPreflight(
     // Normalize job tick state (clears stale runningAtMs markers) before
     // checking if already running, so a stale marker from a crashed Phase-1
     // persist does not block manual triggers for up to STUCK_RUN_MS (#17554).
-    recomputeNextRunsForMaintenance(state);
+    recomputeNextRunsForMaintenance(state, { consumeReloadRepairSkip: false });
     const job = findJobOrThrow(state, id);
     if (typeof job.state.runningAtMs === "number") {
       return { ok: true, ran: false, reason: "already-running" as const };
@@ -515,8 +554,7 @@ async function finishPreparedManualRun(
       usage: coreResult.usage,
     });
 
-    if (shouldDelete && state.store) {
-      state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
+    if (shouldDelete && removeJobById(state, job.id)) {
       emit(state, { jobId: job.id, action: "removed" });
     }
 
@@ -530,6 +568,12 @@ async function finishPreparedManualRun(
           updatedAtMs: job.updatedAtMs,
           state: structuredClone(job.state),
         };
+    const postRunBaseline = shouldDelete
+      ? null
+      : {
+          enabled: executionJob.enabled,
+          schedule: structuredClone(executionJob.schedule),
+        };
     const postRunRemoved = shouldDelete;
     // Isolated Telegram send can persist target writeback directly to disk.
     // Reload before final persist so manual `cron run` keeps those changes.
@@ -538,9 +582,13 @@ async function finishPreparedManualRun(
       state,
       jobId,
       snapshot: postRunSnapshot,
+      baseline: postRunBaseline,
       removed: postRunRemoved,
     });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    recomputeNextRunsForMaintenance(state, {
+      recomputeExpired: true,
+      consumeReloadRepairSkip: false,
+    });
     await persist(state);
     armTimer(state);
   });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -105,7 +105,9 @@ function mergeManualRunSnapshotAfterReload(params: {
     reloaded.enabled = preservedEnabled;
     reloaded.state.nextRunAtMs = preservedNextRunAtMs;
     reloaded.state.scheduleErrorCount = preservedScheduleErrorCount;
-    reloaded.state.lastError = preservedScheduleErrorText;
+    reloaded.state.lastError = preservedScheduleErrorText?.startsWith("schedule error:")
+      ? preservedScheduleErrorText
+      : params.snapshot.state.lastError;
   } else {
     reloaded.enabled = params.snapshot.enabled;
   }

--- a/src/cron/service/schedule-equality.test.ts
+++ b/src/cron/service/schedule-equality.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { schedulesEqual } from "./schedule-equality.js";
+
+describe("schedulesEqual", () => {
+  it("treats equivalent at timestamps as equal", () => {
+    expect(
+      schedulesEqual(
+        { kind: "at", at: "2026-03-19T12:00:00Z" },
+        { kind: "at", at: "2026-03-19T07:00:00-05:00" },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats normalized every schedules as equal", () => {
+    expect(
+      schedulesEqual(
+        { kind: "every", everyMs: 60_000.9, anchorMs: 1_234.8 } as CronJob["schedule"],
+        { kind: "every", everyMs: 60_000, anchorMs: 1_234 } as CronJob["schedule"],
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps materially different every schedules distinct", () => {
+    expect(
+      schedulesEqual(
+        { kind: "every", everyMs: 60_000, anchorMs: 1_234 },
+        { kind: "every", everyMs: 120_000, anchorMs: 1_234 },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/cron/service/schedule-equality.ts
+++ b/src/cron/service/schedule-equality.ts
@@ -1,0 +1,42 @@
+import { resolveCronStaggerMs } from "../stagger.js";
+import type { CronJob } from "../types.js";
+
+function normalizeCronExpr(expr: unknown): string | undefined {
+  const trimmed = typeof expr === "string" ? expr.trim() : "";
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function normalizeCronTimezone(tz: unknown): string | undefined {
+  const trimmed = typeof tz === "string" ? tz.trim() : "";
+  if (trimmed) {
+    try {
+      return new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).resolvedOptions().timeZone;
+    } catch {
+      return trimmed;
+    }
+  }
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return typeof localTimezone === "string" && localTimezone.trim()
+    ? localTimezone.trim()
+    : undefined;
+}
+
+export function schedulesEqual(a: CronJob["schedule"], b: CronJob["schedule"]): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "at" && b.kind === "at") {
+    return a.at === b.at;
+  }
+  if (a.kind === "every" && b.kind === "every") {
+    return a.everyMs === b.everyMs && a.anchorMs === b.anchorMs;
+  }
+  if (a.kind === "cron" && b.kind === "cron") {
+    return (
+      normalizeCronExpr(a.expr) === normalizeCronExpr(b.expr) &&
+      normalizeCronTimezone(a.tz) === normalizeCronTimezone(b.tz) &&
+      resolveCronStaggerMs(a) === resolveCronStaggerMs(b)
+    );
+  }
+  return false;
+}

--- a/src/cron/service/schedule-equality.ts
+++ b/src/cron/service/schedule-equality.ts
@@ -1,3 +1,5 @@
+import { parseAbsoluteTimeMs } from "../parse.js";
+import { coerceFiniteScheduleNumber } from "../schedule.js";
 import { resolveCronStaggerMs } from "../stagger.js";
 import type { CronJob } from "../types.js";
 
@@ -21,15 +23,36 @@ function normalizeCronTimezone(tz: unknown): string | undefined {
     : undefined;
 }
 
+function normalizeAtTimestamp(value: unknown): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = parseAbsoluteTimeMs(trimmed);
+  return parsed === null ? trimmed : new Date(parsed).toISOString();
+}
+
+function normalizeScheduleNumber(value: unknown, minimum: number): string | undefined {
+  const numeric = coerceFiniteScheduleNumber(value);
+  if (numeric !== undefined) {
+    return String(Math.max(minimum, Math.floor(numeric)));
+  }
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed || undefined;
+}
+
 export function schedulesEqual(a: CronJob["schedule"], b: CronJob["schedule"]): boolean {
   if (a.kind !== b.kind) {
     return false;
   }
   if (a.kind === "at" && b.kind === "at") {
-    return a.at === b.at;
+    return normalizeAtTimestamp(a.at) === normalizeAtTimestamp(b.at);
   }
   if (a.kind === "every" && b.kind === "every") {
-    return a.everyMs === b.everyMs && a.anchorMs === b.anchorMs;
+    return (
+      normalizeScheduleNumber(a.everyMs, 1) === normalizeScheduleNumber(b.everyMs, 1) &&
+      normalizeScheduleNumber(a.anchorMs, 0) === normalizeScheduleNumber(b.anchorMs, 0)
+    );
   }
   if (a.kind === "cron" && b.kind === "cron") {
     return (

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -127,6 +127,7 @@ export type CronServiceState = {
   warnedDisabled: boolean;
   storeLoadedAtMs: number | null;
   storeFileMtimeMs: number | null;
+  skipNextReloadRepairRecomputeJobIds: Set<string>;
 };
 
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
@@ -139,6 +140,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     warnedDisabled: false,
     storeLoadedAtMs: null,
     storeFileMtimeMs: null,
+    skipNextReloadRepairRecomputeJobIds: new Set(),
   };
 }
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -87,6 +87,7 @@ function repairNextRunsAfterExternalReload(params: {
     if (!previous) {
       continue;
     }
+    const wasRunningDuringReload = typeof previous.state.runningAtMs === "number";
     if (
       typeof previous.state.runningAtMs === "number" &&
       (typeof job.state.runningAtMs !== "number" ||
@@ -139,6 +140,9 @@ function repairNextRunsAfterExternalReload(params: {
     if (job.state.nextRunAtMs !== nextRunAtMs) {
       job.state.nextRunAtMs = nextRunAtMs;
       changed = true;
+    }
+    if (wasRunningDuringReload && job.enabled) {
+      skipRecomputeJobIds.add(job.id);
     }
     state.deps.log.debug(
       {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -3,6 +3,7 @@ import { normalizeStoredCronJobs } from "../store-migration.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import {
+  createUndefinedNextRunScheduleError,
   computeJobNextRunAtMs,
   recordScheduleComputeError,
   recomputeNextRuns,
@@ -114,12 +115,7 @@ function repairNextRunsAfterExternalReload(params: {
     try {
       nextRunAtMs = job.enabled ? computeJobNextRunAtMs(job, computeBaseMs) : undefined;
       if (nextRunAtMs === undefined && shouldTreatUndefinedNextRunAsScheduleError(job)) {
-        const err =
-          job.schedule.kind === "every"
-            ? new Error("invalid every schedule: everyMs must be a finite number")
-            : job.schedule.kind === "at"
-              ? new Error("invalid at schedule: at must be a valid absolute timestamp")
-              : new Error("invalid cron schedule: expr is required");
+        const err = createUndefinedNextRunScheduleError(job);
         if (recordScheduleComputeError({ state, job, err })) {
           changed = true;
         }
@@ -128,6 +124,9 @@ function repairNextRunsAfterExternalReload(params: {
       }
       if (job.enabled && job.state.scheduleErrorCount !== undefined) {
         job.state.scheduleErrorCount = undefined;
+        if (job.state.lastError?.startsWith("schedule error:")) {
+          job.state.lastError = undefined;
+        }
         changed = true;
       }
     } catch (err) {
@@ -141,11 +140,6 @@ function repairNextRunsAfterExternalReload(params: {
       job.state.nextRunAtMs = nextRunAtMs;
       changed = true;
     }
-    if (!job.enabled && job.state.runningAtMs !== undefined) {
-      job.state.runningAtMs = undefined;
-      changed = true;
-    }
-
     state.deps.log.debug(
       {
         jobId: job.id,

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import { normalizeStoredCronJobs } from "../store-migration.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import {
+  computeJobNextRunAtMs,
+  recordScheduleComputeError,
+  recomputeNextRuns,
+  shouldTreatUndefinedNextRunAsScheduleError,
+} from "./jobs.js";
+import { schedulesEqual } from "./schedule-equality.js";
 import type { CronServiceState } from "./state.js";
 
 async function getFileMtimeMs(path: string): Promise<number | null> {
@@ -12,6 +18,147 @@ async function getFileMtimeMs(path: string): Promise<number | null> {
   } catch {
     return null;
   }
+}
+
+function resolveExternalRepairComputeBaseMs(params: {
+  nowMs: number;
+  fileMtimeMs: number | null;
+  reloadedUpdatedAtMs: number;
+  previousUpdatedAtMs: number;
+  previousEnabled: boolean;
+  reloadedEnabled: boolean;
+}): number {
+  const {
+    nowMs,
+    fileMtimeMs,
+    reloadedUpdatedAtMs,
+    previousUpdatedAtMs,
+    previousEnabled,
+    reloadedEnabled,
+  } = params;
+  const normalizedFileMtimeMs =
+    typeof fileMtimeMs === "number" && Number.isFinite(fileMtimeMs)
+      ? Math.max(0, Math.floor(fileMtimeMs))
+      : Number.NEGATIVE_INFINITY;
+  if (reloadedEnabled && !previousEnabled) {
+    return nowMs;
+  }
+  if (!Number.isFinite(reloadedUpdatedAtMs)) {
+    return Number.isFinite(normalizedFileMtimeMs) ? Math.min(nowMs, normalizedFileMtimeMs) : nowMs;
+  }
+  const normalizedReloadedUpdatedAtMs = Math.max(0, Math.floor(reloadedUpdatedAtMs));
+  const normalizedPreviousUpdatedAtMs = Number.isFinite(previousUpdatedAtMs)
+    ? Math.max(0, Math.floor(previousUpdatedAtMs))
+    : Number.NEGATIVE_INFINITY;
+  if (normalizedReloadedUpdatedAtMs <= normalizedPreviousUpdatedAtMs) {
+    if (normalizedFileMtimeMs > normalizedPreviousUpdatedAtMs) {
+      return Math.min(nowMs, normalizedFileMtimeMs);
+    }
+    return nowMs;
+  }
+  return Math.min(nowMs, normalizedReloadedUpdatedAtMs);
+}
+
+function repairNextRunsAfterExternalReload(params: {
+  state: CronServiceState;
+  previousJobs: CronJob[] | undefined;
+}): boolean {
+  const { state, previousJobs } = params;
+  const skipRecomputeJobIds = state.skipNextReloadRepairRecomputeJobIds;
+  if (!state.store || previousJobs === undefined) {
+    return false;
+  }
+  if (skipRecomputeJobIds.size > 0) {
+    const currentJobIds = new Set(state.store.jobs.map((job) => job.id));
+    for (const jobId of skipRecomputeJobIds) {
+      if (!currentJobIds.has(jobId)) {
+        skipRecomputeJobIds.delete(jobId);
+      }
+    }
+  }
+
+  const previousById = new Map(previousJobs.map((job) => [job.id, job]));
+  const now = state.deps.nowMs();
+  let changed = false;
+
+  for (const job of state.store.jobs) {
+    const previous = previousById.get(job.id);
+    if (!previous) {
+      continue;
+    }
+    if (
+      typeof previous.state.runningAtMs === "number" &&
+      (typeof job.state.runningAtMs !== "number" ||
+        job.state.runningAtMs !== previous.state.runningAtMs)
+    ) {
+      job.state.runningAtMs = previous.state.runningAtMs;
+      changed = true;
+    }
+
+    const scheduleChanged = !schedulesEqual(previous.schedule, job.schedule);
+    const enabledChanged = previous.enabled !== job.enabled;
+    if (!scheduleChanged && !enabledChanged) {
+      continue;
+    }
+
+    skipRecomputeJobIds.delete(job.id);
+    const computeBaseMs = resolveExternalRepairComputeBaseMs({
+      nowMs: now,
+      fileMtimeMs: state.storeFileMtimeMs,
+      reloadedUpdatedAtMs: job.updatedAtMs,
+      previousUpdatedAtMs: previous.updatedAtMs,
+      previousEnabled: previous.enabled,
+      reloadedEnabled: job.enabled,
+    });
+    let nextRunAtMs: number | undefined;
+    try {
+      nextRunAtMs = job.enabled ? computeJobNextRunAtMs(job, computeBaseMs) : undefined;
+      if (nextRunAtMs === undefined && shouldTreatUndefinedNextRunAsScheduleError(job)) {
+        const err =
+          job.schedule.kind === "every"
+            ? new Error("invalid every schedule: everyMs must be a finite number")
+            : job.schedule.kind === "at"
+              ? new Error("invalid at schedule: at must be a valid absolute timestamp")
+              : new Error("invalid cron schedule: expr is required");
+        if (recordScheduleComputeError({ state, job, err })) {
+          changed = true;
+        }
+        skipRecomputeJobIds.add(job.id);
+        continue;
+      }
+      if (job.enabled && job.state.scheduleErrorCount !== undefined) {
+        job.state.scheduleErrorCount = undefined;
+        changed = true;
+      }
+    } catch (err) {
+      if (recordScheduleComputeError({ state, job, err })) {
+        changed = true;
+      }
+      skipRecomputeJobIds.add(job.id);
+      continue;
+    }
+    if (job.state.nextRunAtMs !== nextRunAtMs) {
+      job.state.nextRunAtMs = nextRunAtMs;
+      changed = true;
+    }
+    if (!job.enabled && job.state.runningAtMs !== undefined) {
+      job.state.runningAtMs = undefined;
+      changed = true;
+    }
+
+    state.deps.log.debug(
+      {
+        jobId: job.id,
+        scheduleChanged,
+        enabledChanged,
+        computeBaseMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+      },
+      "cron: repaired nextRunAtMs after external reload",
+    );
+  }
+
+  return changed;
 }
 
 export async function ensureLoaded(
@@ -31,6 +178,7 @@ export async function ensureLoaded(
   // Force reload always re-reads the file to avoid missing cross-service
   // edits on filesystems with coarse mtime resolution.
 
+  const previousJobs = state.store?.jobs;
   const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
   const loaded = await loadCronStore(state.deps.storePath);
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
@@ -38,12 +186,16 @@ export async function ensureLoaded(
   state.store = { version: 1, jobs: jobs as unknown as CronJob[] };
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
+  const repairedExternalReload = repairNextRunsAfterExternalReload({
+    state,
+    previousJobs,
+  });
 
   if (!opts?.skipRecompute) {
     recomputeNextRuns(state);
   }
 
-  if (mutated) {
+  if (mutated || repairedExternalReload) {
     await persist(state, { skipBackup: true });
   }
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -15,6 +15,7 @@ import type {
 import {
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
+  consumeSkipNextReloadRepairRecompute,
   hasSkipNextReloadRepairRecompute,
   nextWakeAtMs,
   removeJobById,
@@ -510,6 +511,13 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
+  if (
+    !shouldDelete &&
+    typeof job.state.nextRunAtMs === "number" &&
+    Number.isFinite(job.state.nextRunAtMs)
+  ) {
+    consumeSkipNextReloadRepairRecompute(state, job.id);
+  }
 
   emitJobFinished(state, job, result, result.startedAt);
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -15,7 +15,9 @@ import type {
 import {
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
+  hasSkipNextReloadRepairRecompute,
   nextWakeAtMs,
+  removeJobById,
   recomputeNextRunsForMaintenance,
   recordScheduleComputeError,
   resolveJobPayloadTextForMain,
@@ -368,6 +370,7 @@ export function applyJobResult(
 
   const shouldDelete =
     job.schedule.kind === "at" && job.deleteAfterRun === true && result.status === "ok";
+  const skipImmediateScheduleRecompute = hasSkipNextReloadRepairRecompute(state, job.id);
 
   if (!shouldDelete) {
     if (job.schedule.kind === "at") {
@@ -380,7 +383,15 @@ export function applyJobResult(
         const transient = isTransientCronError(result.error, retryConfig.retryOn);
         // consecutiveErrors is always set to ≥1 by the increment block above.
         const consecutive = job.state.consecutiveErrors;
-        if (transient && consecutive <= retryConfig.maxAttempts) {
+        if (skipImmediateScheduleRecompute) {
+          state.deps.log.info(
+            {
+              jobId: job.id,
+              jobName: job.name,
+            },
+            "cron: preserving external reload repair for one-shot job",
+          );
+        } else if (transient && consecutive <= retryConfig.maxAttempts) {
           // Schedule retry with backoff (#24355).
           const backoff = errorBackoffMs(consecutive, retryConfig.backoffMs);
           job.state.nextRunAtMs = result.endedAt + backoff;
@@ -416,54 +427,58 @@ export function applyJobResult(
     } else if (result.status === "error" && job.enabled) {
       // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
-      let normalNext: number | undefined;
-      try {
-        normalNext =
-          opts?.preserveSchedule && job.schedule.kind === "every"
-            ? computeNextWithPreservedLastRun(result.endedAt)
-            : computeJobNextRunAtMs(job, result.endedAt);
-      } catch (err) {
-        // If the schedule expression/timezone throws (croner edge cases),
-        // record the schedule error (auto-disables after repeated failures)
-        // and fall back to backoff-only schedule so the state update is not lost.
-        recordScheduleComputeError({ state, job, err });
-      }
-      const backoffNext = result.endedAt + backoff;
-      // Use whichever is later: the natural next run or the backoff delay.
-      job.state.nextRunAtMs =
-        normalNext !== undefined ? Math.max(normalNext, backoffNext) : backoffNext;
-      state.deps.log.info(
-        {
-          jobId: job.id,
-          consecutiveErrors: job.state.consecutiveErrors,
-          backoffMs: backoff,
-          nextRunAtMs: job.state.nextRunAtMs,
-        },
-        "cron: applying error backoff",
-      );
-    } else if (job.enabled) {
-      let naturalNext: number | undefined;
-      try {
-        naturalNext =
-          opts?.preserveSchedule && job.schedule.kind === "every"
-            ? computeNextWithPreservedLastRun(result.endedAt)
-            : computeJobNextRunAtMs(job, result.endedAt);
-      } catch (err) {
-        // If the schedule expression/timezone throws (croner edge cases),
-        // record the schedule error (auto-disables after repeated failures)
-        // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
-        recordScheduleComputeError({ state, job, err });
-      }
-      if (job.schedule.kind === "cron") {
-        // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
-        // after the current run ended.  Prevents spin-loops when the
-        // schedule computation lands in the same second due to
-        // timezone/croner edge cases (see #17821).
-        const minNext = result.endedAt + MIN_REFIRE_GAP_MS;
+      if (!skipImmediateScheduleRecompute) {
+        let normalNext: number | undefined;
+        try {
+          normalNext =
+            opts?.preserveSchedule && job.schedule.kind === "every"
+              ? computeNextWithPreservedLastRun(result.endedAt)
+              : computeJobNextRunAtMs(job, result.endedAt);
+        } catch (err) {
+          // If the schedule expression/timezone throws (croner edge cases),
+          // record the schedule error (auto-disables after repeated failures)
+          // and fall back to backoff-only schedule so the state update is not lost.
+          recordScheduleComputeError({ state, job, err });
+        }
+        const backoffNext = result.endedAt + backoff;
+        // Use whichever is later: the natural next run or the backoff delay.
         job.state.nextRunAtMs =
-          naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
-      } else {
-        job.state.nextRunAtMs = naturalNext;
+          normalNext !== undefined ? Math.max(normalNext, backoffNext) : backoffNext;
+        state.deps.log.info(
+          {
+            jobId: job.id,
+            consecutiveErrors: job.state.consecutiveErrors,
+            backoffMs: backoff,
+            nextRunAtMs: job.state.nextRunAtMs,
+          },
+          "cron: applying error backoff",
+        );
+      }
+    } else if (job.enabled) {
+      if (!skipImmediateScheduleRecompute) {
+        let naturalNext: number | undefined;
+        try {
+          naturalNext =
+            opts?.preserveSchedule && job.schedule.kind === "every"
+              ? computeNextWithPreservedLastRun(result.endedAt)
+              : computeJobNextRunAtMs(job, result.endedAt);
+        } catch (err) {
+          // If the schedule expression/timezone throws (croner edge cases),
+          // record the schedule error (auto-disables after repeated failures)
+          // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
+          recordScheduleComputeError({ state, job, err });
+        }
+        if (job.schedule.kind === "cron") {
+          // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
+          // after the current run ended.  Prevents spin-loops when the
+          // schedule computation lands in the same second due to
+          // timezone/croner edge cases (see #17821).
+          const minNext = result.endedAt + MIN_REFIRE_GAP_MS;
+          job.state.nextRunAtMs =
+            naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
+        } else {
+          job.state.nextRunAtMs = naturalNext;
+        }
       }
     } else {
       job.state.nextRunAtMs = undefined;
@@ -498,8 +513,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
 
   emitJobFinished(state, job, result, result.startedAt);
 
-  if (shouldDelete) {
-    store.jobs = jobs.filter((entry) => entry.id !== job.id);
+  if (shouldDelete && removeJobById(state, job.id)) {
     emit(state, { jobId: job.id, action: "removed" });
   }
 }
@@ -684,7 +698,9 @@ export async function onTimer(state: CronServiceState) {
         // locked block.  The full recomputeNextRuns would silently skip
         // those jobs (advancing nextRunAtMs without execution), causing
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
-        recomputeNextRunsForMaintenance(state);
+        recomputeNextRunsForMaintenance(state, {
+          consumeReloadRepairSkip: false,
+        });
         await persist(state);
       });
     }
@@ -1196,8 +1212,7 @@ export async function executeJob(
 
   emitJobFinished(state, job, coreResult, startedAt);
 
-  if (shouldDelete && state.store) {
-    state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
+  if (shouldDelete && removeJobById(state, job.id)) {
     emit(state, { jobId: job.id, action: "removed" });
   }
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -384,7 +384,7 @@ export function applyJobResult(
         const transient = isTransientCronError(result.error, retryConfig.retryOn);
         // consecutiveErrors is always set to ≥1 by the increment block above.
         const consecutive = job.state.consecutiveErrors;
-        if (skipImmediateScheduleRecompute) {
+        if (skipImmediateScheduleRecompute && job.state.scheduleErrorCount !== undefined) {
           state.deps.log.info(
             {
               jobId: job.id,
@@ -395,7 +395,13 @@ export function applyJobResult(
         } else if (transient && consecutive <= retryConfig.maxAttempts) {
           // Schedule retry with backoff (#24355).
           const backoff = errorBackoffMs(consecutive, retryConfig.backoffMs);
-          job.state.nextRunAtMs = result.endedAt + backoff;
+          const retryNextRunAtMs = result.endedAt + backoff;
+          job.state.nextRunAtMs =
+            skipImmediateScheduleRecompute &&
+            typeof job.state.nextRunAtMs === "number" &&
+            Number.isFinite(job.state.nextRunAtMs)
+              ? Math.max(job.state.nextRunAtMs, retryNextRunAtMs)
+              : retryNextRunAtMs;
           state.deps.log.info(
             {
               jobId: job.id,
@@ -428,7 +434,22 @@ export function applyJobResult(
     } else if (result.status === "error" && job.enabled) {
       // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
-      if (!skipImmediateScheduleRecompute) {
+      if (skipImmediateScheduleRecompute && job.state.scheduleErrorCount === undefined) {
+        const backoffNext = result.endedAt + backoff;
+        job.state.nextRunAtMs =
+          typeof job.state.nextRunAtMs === "number" && Number.isFinite(job.state.nextRunAtMs)
+            ? Math.max(job.state.nextRunAtMs, backoffNext)
+            : backoffNext;
+        state.deps.log.info(
+          {
+            jobId: job.id,
+            consecutiveErrors: job.state.consecutiveErrors,
+            backoffMs: backoff,
+            nextRunAtMs: job.state.nextRunAtMs,
+          },
+          "cron: preserving repaired schedule with error backoff",
+        );
+      } else if (!skipImmediateScheduleRecompute) {
         let normalNext: number | undefined;
         try {
           normalNext =


### PR DESCRIPTION
## Summary
- repair cron state after external jobs.json edits, including schedule, enabled, and related reload-derived fields
- recompute nextRunAtMs and preserve the correct skip/error semantics when reloads happen outside cron.update
- harden reload, cold-load, manual-run, and apply-path behavior with focused regression coverage

## Root Cause
Cron jobs edited outside cron.update could leave persisted runtime fields in a stale but still valid state. During reload, the loader intentionally preserved some existing values such as future nextRunAtMs, skip markers, and error state to avoid breaking overdue jobs or retry behavior. That preservation was too broad for true external edits, so changed schedules or re-enabled jobs could keep outdated derived state and miss newly eligible runs.

## Fix
- detect meaningful external changes by comparing the reloaded jobs.json entry with the last in-memory snapshot
- recompute derived scheduling state only when external edits actually changed schedule or enabled semantics
- preserve authoritative live-run state and unrelated skip or error markers where appropriate
- normalize equivalent schedule rewrites so no-op edits do not trigger synthetic repairs
- keep repaired state stable across force reloads, manual run/apply paths, delete flows, and cold-load recovery

## Tests
- add regression coverage for external schedule edits that bypass cron.update
- cover invalid/blank cron expressions, reload skip persistence, re-enable timing, cold-load repair, and error isolation
- validate behavior in:
  - src/cron/service.external-reload-schedule-recompute.test.ts
  - src/cron/service.issue-regressions.test.ts
  - src/cron/service.jobs.test.ts
  - src/cron/service/jobs.schedule-error-isolation.test.ts
