### PR TITLE
fix: correct broken internal links across documentation

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -937,6 +937,8 @@ Default slash command settings:
 
   </Accordion>
 
+### Exec approvals
+
   <Accordion title="Exec approvals in Discord">
     Discord supports button-based exec approvals in DMs and can optionally post approval prompts in the originating channel.
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -800,6 +800,8 @@ openclaw message poll --channel telegram --target -1001234567890:topic:42 \
 
   </Accordion>
 
+### Exec approvals
+
   <Accordion title="Exec approvals in Telegram">
     Telegram supports exec approvals in approver DMs and can optionally post approval prompts in the originating chat or topic.
 

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -115,4 +115,4 @@ Full troubleshooting: [/channels/signal#troubleshooting](/channels/signal#troubl
 | DMs do not process                  | `openclaw pairing list matrix`               | Approve sender or adjust DM policy.             |
 | Encrypted rooms fail                | Verify crypto module and encryption settings | Enable encryption support and rejoin/sync room. |
 
-Full troubleshooting: [/channels/matrix#troubleshooting](/channels/matrix#troubleshooting)
+Full troubleshooting: [/channels/matrix](/channels/matrix)

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -115,4 +115,4 @@ Full troubleshooting: [/channels/signal#troubleshooting](/channels/signal#troubl
 | DMs do not process                  | `openclaw pairing list matrix`               | Approve sender or adjust DM policy.             |
 | Encrypted rooms fail                | Verify crypto module and encryption settings | Enable encryption support and rejoin/sync room. |
 
-Full troubleshooting: [/channels/matrix](/channels/matrix)
+Full setup and config: [Matrix](/channels/matrix)

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -402,7 +402,7 @@ Docker installs and the containerized gateway live here:
 For Docker gateway deployments, `scripts/docker/setup.sh` can bootstrap sandbox config.
 Set `OPENCLAW_SANDBOX=1` (or `true`/`yes`/`on`) to enable that path. You can
 override socket location with `OPENCLAW_DOCKER_SOCKET`. Full setup and env
-reference: [Docker](/install/docker#enable-agent-sandbox-for-docker-gateway-opt-in).
+reference: [Docker](/install/docker#agent-sandbox).
 
 ## setupCommand (one-time container setup)
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -56,7 +56,7 @@ Related:
 
 - [/providers/anthropic](/providers/anthropic)
 - [/reference/token-use](/reference/token-use)
-- [FAQ: Why am I seeing HTTP 429 (rate_limit_error) from Anthropic?](/help/faq#why-am-i-seeing-http-429-rate_limit_error-from-anthropic)
+- [FAQ: Why am I seeing HTTP 429 (rate_limit_error) from Anthropic?](/help/faq#anthropic-429-errors)
 
 ## No replies
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -56,7 +56,7 @@ Related:
 
 - [/providers/anthropic](/providers/anthropic)
 - [/reference/token-use](/reference/token-use)
-- [/help/faq#why-am-i-seeing-http-429-ratelimiterror-from-anthropic](/help/faq#why-am-i-seeing-http-429-ratelimiterror-from-anthropic)
+- [/help/faq#quick-start-and-first-run-setup](/help/faq#quick-start-and-first-run-setup)
 
 ## No replies
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -56,7 +56,7 @@ Related:
 
 - [/providers/anthropic](/providers/anthropic)
 - [/reference/token-use](/reference/token-use)
-- [FAQ: Why am I seeing HTTP 429 (rate_limit_error) from Anthropic?](/help/faq#quick-start-and-first-run-setup)
+- [FAQ: Why am I seeing HTTP 429 (rate_limit_error) from Anthropic?](/help/faq#why-am-i-seeing-http-429-rate_limit_error-from-anthropic)
 
 ## No replies
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -56,7 +56,7 @@ Related:
 
 - [/providers/anthropic](/providers/anthropic)
 - [/reference/token-use](/reference/token-use)
-- [/help/faq#quick-start-and-first-run-setup](/help/faq#quick-start-and-first-run-setup)
+- [FAQ: Why am I seeing HTTP 429 (rate_limit_error) from Anthropic?](/help/faq#quick-start-and-first-run-setup)
 
 ## No replies
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -266,8 +266,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
   <Accordion title="Cannot access docs.openclaw.ai (SSL error)">
     Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-    Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-    detail: [Troubleshooting](/help/faq#quick-start-and-first-run-setup).
+    Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
     Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
     If you still can't reach the site, the docs are mirrored on GitHub:

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -267,7 +267,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title="Cannot access docs.openclaw.ai (SSL error)">
     Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
     Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-    detail: [Troubleshooting](/help/faq#docsopenclawai-shows-an-ssl-error-comcast-xfinity).
+    detail: [Troubleshooting](/help/faq#quick-start-and-first-run-setup).
     Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
     If you still can't reach the site, the docs are mirrored on GitHub:

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -580,6 +580,8 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
   </Accordion>
 
+### Anthropic 429 errors
+
   <Accordion title="Why am I seeing HTTP 429 rate_limit_error from Anthropic?">
     That means your **Anthropic quota/rate limit** is exhausted for the current window. If you
     use a **Claude subscription** (setup-token), wait for the window to

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -91,7 +91,7 @@ Custom profiles use `~/.openclaw-<profile>/` or a path set via `OPENCLAW_STATE_D
 
   <Accordion title="Remote mode">
     If your UI points at a **remote** gateway, the remote host owns sessions and workspace.
-    Migrate the gateway host itself, not your local laptop. See [FAQ](/help/faq#where-does-openclaw-store-its-data).
+    Migrate the gateway host itself, not your local laptop. See [FAQ](/help/faq#where-things-live-on-disk).
   </Accordion>
 
   <Accordion title="Secrets in backups">

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -121,7 +121,7 @@ Example:
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration-reference) for the full `plugins.*` schema.
 
 ## Notes
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -35,7 +35,28 @@ See the full plugin system guide: [Plugins](/tools/plugin).
 For the native capability model and current external-compatibility guidance:
 [Capability model](/plugins/architecture#public-capability-model).
 
-## Required fields
+## What this file does
+
+`openclaw.plugin.json` is the metadata OpenClaw reads before it loads your
+plugin code.
+
+Use it for:
+
+- plugin identity
+- config validation
+- auth and onboarding metadata that should be available without booting plugin
+  runtime
+- config UI hints
+
+Do not use it for:
+
+- registering runtime behavior
+- declaring code entrypoints
+- npm install metadata
+
+Those belong in your plugin code and `package.json`.
+
+## Minimal example
 
 ```json
 {
@@ -48,45 +69,18 @@ For the native capability model and current external-compatibility guidance:
 }
 ```
 
-Required keys:
-
-- `id` (string): canonical plugin id.
-- `configSchema` (object): JSON Schema for plugin config (inline).
-
-Optional keys:
-
-- `kind` (string): plugin kind (examples: `"memory"`, `"context-engine"`).
-- `channels` (array): channel ids registered by this plugin (channel capability; example: `["matrix"]`).
-- `providers` (array): provider ids registered by this plugin (text inference capability).
-- `providerAuthEnvVars` (object): auth env vars keyed by provider id. Use this
-  when OpenClaw should resolve provider credentials from env without loading
-  plugin runtime first.
-- `providerAuthChoices` (array): cheap onboarding/auth-choice metadata keyed by
-  provider + auth method. Use this when OpenClaw should show a provider in
-  auth-choice pickers, preferred-provider resolution, and CLI help without
-  loading plugin runtime first.
-- `skills` (array): skill directories to load (relative to the plugin root).
-- `name` (string): display name for the plugin.
-- `description` (string): short plugin summary.
-- `uiHints` (object): config field labels/placeholders/sensitive flags for UI rendering.
-- `version` (string): plugin version (informational).
-
-### `providerAuthChoices` shape
-
-Each entry can declare:
-
-- `provider`: provider id
-- `method`: auth method id
-- `choiceId`: stable onboarding/auth-choice id
-- `choiceLabel` / `choiceHint`: picker label + short hint
-- `groupId` / `groupLabel` / `groupHint`: grouped onboarding bucket metadata
-- `optionKey` / `cliFlag` / `cliOption` / `cliDescription`: optional one-flag
-  CLI wiring for simple auth flows such as API keys
-
-Example:
+## Rich example
 
 ```json
 {
+  "id": "openrouter",
+  "name": "OpenRouter",
+  "description": "OpenRouter provider plugin",
+  "version": "1.0.0",
+  "providers": ["openrouter"],
+  "providerAuthEnvVars": {
+    "openrouter": ["OPENROUTER_API_KEY"]
+  },
   "providerAuthChoices": [
     {
       "provider": "openrouter",
@@ -98,11 +92,109 @@ Example:
       "optionKey": "openrouterApiKey",
       "cliFlag": "--openrouter-api-key",
       "cliOption": "--openrouter-api-key <key>",
-      "cliDescription": "OpenRouter API key"
+      "cliDescription": "OpenRouter API key",
+      "onboardingScopes": ["text-inference"]
     }
-  ]
+  ],
+  "uiHints": {
+    "apiKey": {
+      "label": "API key",
+      "placeholder": "sk-or-v1-...",
+      "sensitive": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": {
+        "type": "string"
+      }
+    }
+  }
 }
 ```
+
+## Top-level field reference
+
+| Field                 | Required | Type                             | What it means                                                                                                                |
+| --------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | Yes      | `string`                         | Canonical plugin id. This is the id used in `plugins.entries.<id>`.                                                          |
+| `configSchema`        | Yes      | `object`                         | Inline JSON Schema for this plugin's config.                                                                                 |
+| `enabledByDefault`    | No       | `true`                           | Marks a bundled plugin as enabled by default. Omit it, or set any non-`true` value, to leave the plugin disabled by default. |
+| `kind`                | No       | `"memory"` \| `"context-engine"` | Declares an exclusive plugin kind used by `plugins.slots.*`.                                                                 |
+| `channels`            | No       | `string[]`                       | Channel ids owned by this plugin. Used for discovery and config validation.                                                  |
+| `providers`           | No       | `string[]`                       | Provider ids owned by this plugin.                                                                                           |
+| `providerAuthEnvVars` | No       | `Record<string, string[]>`       | Cheap provider-auth env metadata that OpenClaw can inspect without loading plugin code.                                      |
+| `providerAuthChoices` | No       | `object[]`                       | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                |
+| `skills`              | No       | `string[]`                       | Skill directories to load, relative to the plugin root.                                                                      |
+| `name`                | No       | `string`                         | Human-readable plugin name.                                                                                                  |
+| `description`         | No       | `string`                         | Short summary shown in plugin surfaces.                                                                                      |
+| `version`             | No       | `string`                         | Informational plugin version.                                                                                                |
+| `uiHints`             | No       | `Record<string, object>`         | UI labels, placeholders, and sensitivity hints for config fields.                                                            |
+
+## providerAuthChoices reference
+
+Each `providerAuthChoices` entry describes one onboarding or auth choice.
+OpenClaw reads this before provider runtime loads.
+
+| Field              | Required | Type                                            | What it means                                                                                            |
+| ------------------ | -------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `provider`         | Yes      | `string`                                        | Provider id this choice belongs to.                                                                      |
+| `method`           | Yes      | `string`                                        | Auth method id to dispatch to.                                                                           |
+| `choiceId`         | Yes      | `string`                                        | Stable auth-choice id used by onboarding and CLI flows.                                                  |
+| `choiceLabel`      | No       | `string`                                        | User-facing label. If omitted, OpenClaw falls back to `choiceId`.                                        |
+| `choiceHint`       | No       | `string`                                        | Short helper text for the picker.                                                                        |
+| `groupId`          | No       | `string`                                        | Optional group id for grouping related choices.                                                          |
+| `groupLabel`       | No       | `string`                                        | User-facing label for that group.                                                                        |
+| `groupHint`        | No       | `string`                                        | Short helper text for the group.                                                                         |
+| `optionKey`        | No       | `string`                                        | Internal option key for simple one-flag auth flows.                                                      |
+| `cliFlag`          | No       | `string`                                        | CLI flag name, such as `--openrouter-api-key`.                                                           |
+| `cliOption`        | No       | `string`                                        | Full CLI option shape, such as `--openrouter-api-key <key>`.                                             |
+| `cliDescription`   | No       | `string`                                        | Description used in CLI help.                                                                            |
+| `onboardingScopes` | No       | `Array<"text-inference" \| "image-generation">` | Which onboarding surfaces this choice should appear in. If omitted, it defaults to `["text-inference"]`. |
+
+## uiHints reference
+
+`uiHints` is a map from config field names to small rendering hints.
+
+```json
+{
+  "uiHints": {
+    "apiKey": {
+      "label": "API key",
+      "help": "Used for OpenRouter requests",
+      "placeholder": "sk-or-v1-...",
+      "sensitive": true
+    }
+  }
+}
+```
+
+Each field hint can include:
+
+| Field         | Type       | What it means                           |
+| ------------- | ---------- | --------------------------------------- |
+| `label`       | `string`   | User-facing field label.                |
+| `help`        | `string`   | Short helper text.                      |
+| `tags`        | `string[]` | Optional UI tags.                       |
+| `advanced`    | `boolean`  | Marks the field as advanced.            |
+| `sensitive`   | `boolean`  | Marks the field as secret or sensitive. |
+| `placeholder` | `string`   | Placeholder text for form inputs.       |
+
+## Manifest versus package.json
+
+The two files serve different jobs:
+
+| File                   | Use it for                                                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `openclaw.plugin.json` | Discovery, config validation, auth-choice metadata, and UI hints that must exist before plugin code runs           |
+| `package.json`         | npm metadata, dependency installation, and the `openclaw` block used for entrypoints and setup or catalog metadata |
+
+If you are unsure where a piece of metadata belongs, use this rule:
+
+- if OpenClaw must know it before loading plugin code, put it in `openclaw.plugin.json`
+- if it is about packaging, entry files, or npm install behavior, put it in `package.json`
 
 ## JSON Schema requirements
 
@@ -121,13 +213,15 @@ Example:
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/gateway/configuration-reference) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration) for the full `plugins.*` schema.
 
 ## Notes
 
 - The manifest is **required for native OpenClaw plugins**, including local filesystem loads.
 - Runtime still loads the plugin module separately; the manifest is only for
   discovery + validation.
+- Only documented manifest fields are read by the manifest loader. Avoid adding
+  custom top-level keys here.
 - `providerAuthEnvVars` is the cheap metadata path for auth probes, env-marker
   validation, and similar provider-auth surfaces that should not boot plugin
   runtime just to inspect env names.
@@ -140,6 +234,8 @@ See [Configuration reference](/gateway/configuration-reference) for the full `pl
   - `kind: "memory"` is selected by `plugins.slots.memory`.
   - `kind: "context-engine"` is selected by `plugins.slots.contextEngine`
     (default: built-in `legacy`).
+- `channels`, `providers`, and `skills` can be omitted when a plugin does not
+  need them.
 - If your plugin depends on native modules, document the build steps and any
   package-manager allowlist requirements (for example, pnpm `allow-build-scripts`
   - `pnpm rebuild <package>`).

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -354,8 +354,8 @@ topics, OpenClaw preserves the topic for the approval prompt and the post-approv
 
 See:
 
-- [Discord](/channels/discord#feature-details)
-- [Telegram](/channels/telegram#feature-reference)
+- [Discord](/channels/discord#exec-approvals)
+- [Telegram](/channels/telegram#exec-approvals)
 
 ### macOS IPC flow
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -354,8 +354,8 @@ topics, OpenClaw preserves the topic for the approval prompt and the post-approv
 
 See:
 
-- [Discord](/channels/discord#exec-approvals-in-discord)
-- [Telegram](/channels/telegram#exec-approvals-in-telegram)
+- [Discord](/channels/discord#feature-details)
+- [Telegram](/channels/telegram#feature-reference)
 
 ### macOS IPC flow
 

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -91,7 +91,7 @@ That field also accepts SecretRef objects.
 
 **Via environment:** set `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
 in the Gateway process environment. For a gateway install, put it in
-`~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#how-does-openclaw-load-environment-variables).
+`~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#env-vars-and-env-loading).
 
 If `provider: "perplexity"` is configured and the Perplexity key SecretRef is unresolved with no env fallback, startup/reload fails fast.
 

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -170,5 +170,9 @@ await web_search({
 - OpenRouter or explicit `plugins.entries.perplexity.config.webSearch.baseUrl` / `model` switches Perplexity back to Sonar chat completions for compatibility
 - Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`)
 
-See [Web tools](/tools/web) for the full web_search configuration.
-See [Perplexity Search API docs](https://docs.perplexity.ai/docs/search/quickstart) for more details.
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [Perplexity Search API docs](https://docs.perplexity.ai/docs/search/quickstart) -- official Perplexity documentation
+- [Brave Search](/tools/brave-search) -- structured results with country/language filters
+- [Exa Search](/tools/exa-search) -- neural search with content extraction

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -1,124 +1,116 @@
 ---
-summary: "OpenClaw plugins/extensions: discovery, config, and safety"
+summary: "Install, configure, and manage OpenClaw plugins"
 read_when:
-  - Adding or modifying plugins/extensions
-  - Documenting plugin install or load rules
+  - Installing or configuring plugins
+  - Understanding plugin discovery and load rules
   - Working with Codex/Claude-compatible plugin bundles
 title: "Plugins"
+sidebarTitle: "Install and Configure"
 ---
 
-# Plugins (Extensions)
+# Plugins
+
+Plugins extend OpenClaw with new capabilities: channels, model providers, tools,
+skills, speech, image generation, and more. Some plugins are **core** (shipped
+with OpenClaw), others are **external** (published on npm by the community).
 
 ## Quick start
 
-A plugin is either:
+<Steps>
+  <Step title="See what is loaded">
+    ```bash
+    openclaw plugins list
+    ```
+  </Step>
 
-- a native **OpenClaw plugin** (`openclaw.plugin.json` + runtime module), or
-- a compatible **bundle** (`.codex-plugin/plugin.json` or `.claude-plugin/plugin.json`)
+  <Step title="Install a plugin">
+    ```bash
+    # From npm
+    openclaw plugins install @openclaw/voice-call
 
-Both show up under `openclaw plugins`, but only native OpenClaw plugins execute
-runtime code in-process.
+    # From a local directory or archive
+    openclaw plugins install ./my-plugin
+    openclaw plugins install ./my-plugin.tgz
+    ```
 
-1. See what is already loaded:
+  </Step>
 
-```bash
-openclaw plugins list
+  <Step title="Restart the Gateway">
+    ```bash
+    openclaw gateway restart
+    ```
+
+    Then configure under `plugins.entries.\<id\>.config` in your config file.
+
+  </Step>
+</Steps>
+
+If you prefer chat-native control, enable `commands.plugins: true` and use:
+
+```text
+/plugin install clawhub:@openclaw/voice-call
+/plugin show voice-call
+/plugin enable voice-call
 ```
 
-2. Install an official plugin (example: Voice Call):
+The install path uses the same resolver as the CLI: local path/archive, explicit
+`clawhub:<pkg>`, or bare package spec (ClawHub first, then npm fallback).
 
-```bash
-openclaw plugins install @openclaw/voice-call
-```
+## Plugin types
 
-Npm specs are registry-only. See [install rules](/cli/plugins#install) for
-details on pinning, prerelease gating, and supported spec formats.
+OpenClaw recognizes two plugin formats:
 
-3. Restart the Gateway, then configure under `plugins.entries.<id>.config`.
+| Format     | How it works                                                       | Examples                                               |
+| ---------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
+| **Native** | `openclaw.plugin.json` + runtime module; executes in-process       | Official plugins, community npm packages               |
+| **Bundle** | Codex/Claude/Cursor-compatible layout; mapped to OpenClaw features | `.codex-plugin/`, `.claude-plugin/`, `.cursor-plugin/` |
 
-See [Voice Call](/plugins/voice-call) for a concrete example plugin.
-Looking for third-party listings? See [Community plugins](/plugins/community).
-Need the bundle compatibility details? See [Plugin bundles](/plugins/bundles).
+Both show up under `openclaw plugins list`. See [Plugin Bundles](/plugins/bundles) for bundle details.
 
-For compatible bundles, install from a local directory or archive:
+If you are writing a native plugin, start with [Building Plugins](/plugins/building-plugins)
+and the [Plugin SDK Overview](/plugins/sdk-overview).
 
-```bash
-openclaw plugins install ./my-bundle
-openclaw plugins install ./my-bundle.tgz
-```
+## Official plugins
 
-For Claude marketplace installs, list the marketplace first, then install by
-marketplace entry name:
+### Installable (npm)
 
-```bash
-openclaw plugins marketplace list <marketplace-name>
-openclaw plugins install <plugin-name>@<marketplace-name>
-```
+| Plugin          | Package                | Docs                                 |
+| --------------- | ---------------------- | ------------------------------------ |
+| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)           |
+| Microsoft Teams | `@openclaw/msteams`    | [Microsoft Teams](/channels/msteams) |
+| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)             |
+| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)    |
+| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)               |
+| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser)   |
 
-OpenClaw resolves known Claude marketplace names from
-`~/.claude/plugins/known_marketplaces.json`. You can also pass an explicit
-marketplace source with `--marketplace`.
+### Core (shipped with OpenClaw)
 
-## Available plugins (official)
+<AccordionGroup>
+  <Accordion title="Model providers (enabled by default)">
+    `anthropic`, `byteplus`, `cloudflare-ai-gateway`, `github-copilot`, `google`,
+    `huggingface`, `kilocode`, `kimi-coding`, `minimax`, `mistral`, `modelstudio`,
+    `moonshot`, `nvidia`, `openai`, `opencode`, `opencode-go`, `openrouter`,
+    `qianfan`, `qwen-portal-auth`, `synthetic`, `together`, `venice`,
+    `vercel-ai-gateway`, `volcengine`, `xiaomi`, `zai`
+  </Accordion>
 
-### Installable plugins
+  <Accordion title="Memory plugins">
+    - `memory-core` — bundled memory search (default via `plugins.slots.memory`)
+    - `memory-lancedb` — install-on-demand long-term memory with auto-recall/capture (set `plugins.slots.memory = "memory-lancedb"`)
+  </Accordion>
 
-These are published to npm and installed with `openclaw plugins install`:
+  <Accordion title="Speech providers (enabled by default)">
+    `elevenlabs`, `microsoft`
+  </Accordion>
 
-| Plugin          | Package                | Docs                               |
-| --------------- | ---------------------- | ---------------------------------- |
-| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)         |
-| Microsoft Teams | `@openclaw/msteams`    | [MS Teams](/channels/msteams)      |
-| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)           |
-| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)  |
-| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)             |
-| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser) |
+  <Accordion title="Other">
+    - `copilot-proxy` — VS Code Copilot Proxy bridge (disabled by default)
+  </Accordion>
+</AccordionGroup>
 
-Microsoft Teams is plugin-only as of 2026.1.15.
+Looking for third-party plugins? See [Community Plugins](/plugins/community).
 
-Packaged installs also ship install-on-demand metadata for heavyweight official
-plugins. Today that includes WhatsApp and `memory-lancedb`: onboarding,
-`openclaw channels add`, `openclaw channels login --channel whatsapp`, and
-other channel setup flows prompt to install them when first used instead of
-shipping their full runtime trees inside the main npm tarball.
-
-### Bundled plugins
-
-These ship with OpenClaw and are enabled by default unless noted.
-
-**Memory:**
-
-- `memory-core` -- bundled memory search (default via `plugins.slots.memory`)
-- `memory-lancedb` -- install-on-demand long-term memory with auto-recall/capture (set `plugins.slots.memory = "memory-lancedb"`)
-
-**Model providers** (all enabled by default):
-
-`anthropic`, `byteplus`, `cloudflare-ai-gateway`, `github-copilot`, `google`, `huggingface`, `kilocode`, `kimi-coding`, `minimax`, `mistral`, `modelstudio`, `moonshot`, `nvidia`, `openai`, `opencode`, `opencode-go`, `openrouter`, `qianfan`, `qwen-portal-auth`, `synthetic`, `together`, `venice`, `vercel-ai-gateway`, `volcengine`, `xiaomi`, `zai`
-
-**Speech providers** (enabled by default):
-
-`elevenlabs`, `microsoft`
-
-**Other bundled:**
-
-- `copilot-proxy` -- VS Code Copilot Proxy bridge (disabled by default)
-
-## Compatible bundles
-
-OpenClaw also recognizes compatible external bundle layouts:
-
-- Codex-style bundles: `.codex-plugin/plugin.json`
-- Claude-style bundles: `.claude-plugin/plugin.json` or the default Claude
-  component layout without a manifest
-- Cursor-style bundles: `.cursor-plugin/plugin.json`
-
-They are shown in the plugin list as `format=bundle`, with a subtype of
-`codex`, `claude`, or `cursor` in verbose/inspect output.
-
-See [Plugin bundles](/plugins/bundles) for the exact detection rules, mapping
-behavior, and current support matrix.
-
-## Config
+## Configuration
 
 ```json5
 {
@@ -134,204 +126,152 @@ behavior, and current support matrix.
 }
 ```
 
-Fields:
+| Field            | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| `enabled`        | Master toggle (default: `true`)                           |
+| `allow`          | Plugin allowlist (optional)                               |
+| `deny`           | Plugin denylist (optional; deny wins)                     |
+| `load.paths`     | Extra plugin files/directories                            |
+| `slots`          | Exclusive slot selectors (e.g. `memory`, `contextEngine`) |
+| `entries.\<id\>` | Per-plugin toggles + config                               |
 
-- `enabled`: master toggle (default: true)
-- `allow`: allowlist (optional)
-- `deny`: denylist (optional; deny wins)
-- `load.paths`: extra plugin files/dirs
-- `slots`: exclusive slot selectors such as `memory` and `contextEngine`
-- `entries.<id>`: per-plugin toggles + config
+Config changes **require a gateway restart**. If the Gateway is running with config
+watch + in-process restart enabled (the default `openclaw gateway` path), that
+restart is usually performed automatically a moment after the config write lands.
 
-Config changes **require a gateway restart**. See
-[Configuration reference](/gateway/configuration-reference) for the full config schema.
-
-Validation rules (strict):
-
-- Unknown plugin ids in `entries`, `allow`, `deny`, or `slots` are **errors**.
-- Unknown `channels.<id>` keys are **errors** unless a plugin manifest declares
-  the channel id.
-- Native plugin config is validated using the JSON Schema embedded in
-  `openclaw.plugin.json` (`configSchema`).
-- Compatible bundles currently do not expose native OpenClaw config schemas.
-- If a plugin is disabled, its config is preserved and a **warning** is emitted.
-
-### Disabled vs missing vs invalid
-
-These states are intentionally different:
-
-- **disabled**: plugin exists, but enablement rules turned it off
-- **missing**: config references a plugin id that discovery did not find
-- **invalid**: plugin exists, but its config does not match the declared schema
-
-OpenClaw preserves config for disabled plugins so toggling them back on is not
-destructive.
+<Accordion title="Plugin states: disabled vs missing vs invalid">
+  - **Disabled**: plugin exists but enablement rules turned it off. Config is preserved.
+  - **Missing**: config references a plugin id that discovery did not find.
+  - **Invalid**: plugin exists but its config does not match the declared schema.
+</Accordion>
 
 ## Discovery and precedence
 
-OpenClaw scans, in order:
+OpenClaw scans for plugins in this order (first match wins):
 
-1. Config paths
+<Steps>
+  <Step title="Config paths">
+    `plugins.load.paths` — explicit file or directory paths.
+  </Step>
 
-- `plugins.load.paths` (file or directory)
+  <Step title="Workspace extensions">
+    `\<workspace\>/.openclaw/extensions/*.ts` and `\<workspace\>/.openclaw/extensions/*/index.ts`.
+  </Step>
 
-2. Workspace extensions
+  <Step title="Global extensions">
+    `~/.openclaw/extensions/*.ts` and `~/.openclaw/extensions/*/index.ts`.
+  </Step>
 
-- `<workspace>/.openclaw/extensions/*.ts`
-- `<workspace>/.openclaw/extensions/*/index.ts`
-
-3. Global extensions
-
-- `~/.openclaw/extensions/*.ts`
-- `~/.openclaw/extensions/*/index.ts`
-
-4. Bundled extensions (shipped with OpenClaw; mixed default-on/default-off)
-
-- `<openclaw>/dist/extensions/*` in packaged installs
-- `<workspace>/dist-runtime/extensions/*` in local built checkouts
-- `<workspace>/extensions/*` in source/Vitest workflows
-
-Many bundled provider plugins are enabled by default so model catalogs/runtime
-hooks stay available without extra setup. Others still require explicit
-enablement via `plugins.entries.<id>.enabled` or
-`openclaw plugins enable <id>`.
-
-Bundled plugin runtime dependencies are owned by each plugin package. Packaged
-builds stage opted-in bundled dependencies under
-`dist/extensions/<id>/node_modules` instead of requiring mirrored copies in the
-root package. Very large official plugins can ship as metadata-only bundled
-entries and install their runtime package on demand. npm artifacts ship the
-built `dist/extensions/*` tree; source `extensions/*` directories stay in source
-checkouts only.
-
-Installed plugins are enabled by default, but can be disabled the same way.
-
-Workspace plugins are **disabled by default** unless you explicitly enable them
-or allowlist them. This is intentional: a checked-out repo should not silently
-become production gateway code.
-
-If multiple plugins resolve to the same id, the first match in the order above
-wins and lower-precedence copies are ignored.
+  <Step title="Bundled plugins">
+    Shipped with OpenClaw. Many are enabled by default (model providers, speech).
+    Others require explicit enablement.
+  </Step>
+</Steps>
 
 ### Enablement rules
 
-Enablement is resolved after discovery:
-
 - `plugins.enabled: false` disables all plugins
-- `plugins.deny` always wins
-- `plugins.entries.<id>.enabled: false` disables that plugin
-- workspace-origin plugins are disabled by default
-- allowlists restrict the active set when `plugins.allow` is non-empty
-- allowlists are **id-based**, not source-based
-- bundled plugins are disabled by default unless:
-  - the bundled id is in the built-in default-on set, or
-  - you explicitly enable it, or
-  - channel config implicitly enables the bundled channel plugin
-- exclusive slots can force-enable the selected plugin for that slot
+- `plugins.deny` always wins over allow
+- `plugins.entries.\<id\>.enabled: false` disables that plugin
+- Workspace-origin plugins are **disabled by default** (must be explicitly enabled)
+- Bundled plugins follow the built-in default-on set unless overridden
+- Exclusive slots can force-enable the selected plugin for that slot
 
 ## Plugin slots (exclusive categories)
 
-Some plugin categories are **exclusive** (only one active at a time). Use
-`plugins.slots` to select which plugin owns the slot:
+Some categories are exclusive (only one active at a time):
 
 ```json5
 {
   plugins: {
     slots: {
-      memory: "memory-core", // or "none" to disable memory plugins
-      contextEngine: "legacy", // or a plugin id such as "lossless-claw"
+      memory: "memory-core", // or "none" to disable
+      contextEngine: "legacy", // or a plugin id
     },
   },
 }
 ```
 
-Supported exclusive slots:
+| Slot            | What it controls      | Default             |
+| --------------- | --------------------- | ------------------- |
+| `memory`        | Active memory plugin  | `memory-core`       |
+| `contextEngine` | Active context engine | `legacy` (built-in) |
 
-- `memory`: active memory plugin (`"none"` disables memory plugins)
-- `contextEngine`: active context engine plugin (`"legacy"` is the built-in default)
-
-If multiple plugins declare `kind: "memory"` or `kind: "context-engine"`, only
-the selected plugin loads for that slot. Others are disabled with diagnostics.
-Declare `kind` in your [plugin manifest](/plugins/manifest).
-
-## Plugin IDs
-
-Default plugin ids:
-
-- Package packs: `package.json` `name`
-- Standalone file: file base name (`~/.../voice-call.ts` -> `voice-call`)
-
-If a plugin exports `id`, OpenClaw uses it but warns when it does not match the
-configured id.
-
-## Inspection
+## CLI reference
 
 ```bash
-openclaw plugins inspect openai        # deep detail on one plugin
-openclaw plugins inspect openai --json # machine-readable
-openclaw plugins list                  # compact inventory
-openclaw plugins status                # operational summary
-openclaw plugins doctor                # issue-focused diagnostics
-```
+openclaw plugins list                    # compact inventory
+openclaw plugins inspect <id>            # deep detail
+openclaw plugins inspect <id> --json     # machine-readable
+openclaw plugins status                  # operational summary
+openclaw plugins doctor                  # diagnostics
 
-## CLI
+openclaw plugins install <package>        # install (ClawHub first, then npm)
+openclaw plugins install clawhub:<pkg>   # install from ClawHub only
+openclaw plugins install <path>          # install from local path
+openclaw plugins install -l <path>       # link (no copy) for dev
+openclaw plugins update <id>             # update one plugin
+openclaw plugins update --all            # update all
 
-```bash
-openclaw plugins list
-openclaw plugins inspect <id>
-openclaw plugins install <path>                 # copy a local file/dir into ~/.openclaw/extensions/<id>
-openclaw plugins install ./extensions/voice-call # relative path ok
-openclaw plugins install ./plugin.tgz           # install from a local tarball
-openclaw plugins install ./plugin.zip           # install from a local zip
-openclaw plugins install -l ./extensions/voice-call # link (no copy) for dev
-openclaw plugins install @openclaw/voice-call   # install from npm
-openclaw plugins install @openclaw/voice-call --pin # store exact resolved name@version
-openclaw plugins update <id-or-npm-spec>
-openclaw plugins update --all
 openclaw plugins enable <id>
 openclaw plugins disable <id>
-openclaw plugins doctor
 ```
 
-See [`openclaw plugins` CLI reference](/cli/plugins) for full details on each
-command (install rules, inspect output, marketplace installs, uninstall).
+See [`openclaw plugins` CLI reference](/cli/plugins) for full details.
 
-Plugins may also register their own top-level commands (example:
-`openclaw voicecall`).
+## Plugin API overview
 
-## Plugin API (overview)
+Plugins export either a function or an object with `register(api)`:
 
-Plugins export either:
+```typescript
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  register(api) {
+    api.registerProvider({
+      /* ... */
+    });
+    api.registerTool({
+      /* ... */
+    });
+    api.registerChannel({
+      /* ... */
+    });
+  },
+});
+```
 
-- A function: `(api) => { ... }`
-- An object: `{ id, name, configSchema, register(api) { ... } }`
+Common registration methods:
 
-`register(api)` is where plugins attach behavior. Common registrations include:
+| Method                               | What it registers    |
+| ------------------------------------ | -------------------- |
+| `registerProvider`                   | Model provider (LLM) |
+| `registerChannel`                    | Chat channel         |
+| `registerTool`                       | Agent tool           |
+| `registerHook` / `on(...)`           | Lifecycle hooks      |
+| `registerSpeechProvider`             | Text-to-speech / STT |
+| `registerMediaUnderstandingProvider` | Image/audio analysis |
+| `registerImageGenerationProvider`    | Image generation     |
+| `registerWebSearchProvider`          | Web search           |
+| `registerHttpRoute`                  | HTTP endpoint        |
+| `registerCommand` / `registerCli`    | CLI commands         |
+| `registerContextEngine`              | Context engine       |
+| `registerService`                    | Background service   |
 
-- `registerTool`
-- `registerHook`
-- `on(...)` for typed lifecycle hooks
-- `registerChannel`
-- `registerProvider`
-- `registerSpeechProvider`
-- `registerMediaUnderstandingProvider`
-- `registerWebSearchProvider`
-- `registerHttpRoute`
-- `registerCommand`
-- `registerCli`
-- `registerContextEngine`
-- `registerService`
+Hook guard behavior for typed lifecycle hooks:
 
-See [Plugin manifest](/plugins/manifest) for the manifest file format.
+- `before_tool_call`: `{ block: true }` is terminal; lower-priority handlers are skipped.
+- `before_tool_call`: `{ block: false }` is a no-op and does not clear an earlier block.
+- `message_sending`: `{ cancel: true }` is terminal; lower-priority handlers are skipped.
+- `message_sending`: `{ cancel: false }` is a no-op and does not clear an earlier cancel.
 
-## Further reading
+For full typed hook behavior, see [SDK Overview](/plugins/sdk-overview#hook-decision-semantics).
 
-- [Plugin architecture and internals](/plugins/architecture) -- capability model,
-  ownership model, contracts, load pipeline, runtime helpers, and developer API
-  reference
-- [Building extensions](/plugins/building-extensions)
-- [Plugin bundles](/plugins/bundles)
-- [Plugin manifest](/plugins/manifest)
-- [Plugin agent tools](/plugins/agent-tools)
-- [Capability Cookbook](/tools/capability-cookbook)
-- [Community plugins](/plugins/community)
+## Related
+
+- [Building Plugins](/plugins/building-plugins) — create your own plugin
+- [Plugin Bundles](/plugins/bundles) — Codex/Claude/Cursor bundle compatibility
+- [Plugin Manifest](/plugins/manifest) — manifest schema
+- [Registering Tools](/plugins/building-plugins#registering-agent-tools) — add agent tools in a plugin
+- [Plugin Internals](/plugins/architecture) — capability model and load pipeline
+- [Community Plugins](/plugins/community) — third-party listings

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -144,7 +144,7 @@ Fields:
 - `entries.<id>`: per-plugin toggles + config
 
 Config changes **require a gateway restart**. See
-[Configuration reference](/configuration) for the full config schema.
+[Configuration reference](/gateway/configuration-reference) for the full config schema.
 
 Validation rules (strict):
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,378 +1,128 @@
 ---
-summary: "Web search + fetch tools (Brave, Firecrawl, Gemini, Grok, Kimi, Perplexity, and Tavily providers)"
+summary: "web_search tool -- search the web with Brave, Firecrawl, Gemini, Grok, Kimi, Perplexity, or Tavily"
 read_when:
-  - You want to enable web_search or web_fetch
-  - You need provider API key setup
-  - You want to use Gemini with Google Search grounding
-title: "Web Tools"
+  - You want to enable or configure web_search
+  - You need to choose a search provider
+  - You want to understand auto-detection and provider fallback
+title: "Web Search"
+sidebarTitle: "Web Search"
 ---
 
-# Web tools
+# Web Search
 
-OpenClaw ships two lightweight web tools:
+The `web_search` tool searches the web using your configured provider and
+returns results. Results are cached by query for 15 minutes (configurable).
 
-- `web_search` — Search the web using Brave Search API, Firecrawl Search, Gemini with Google Search grounding, Grok, Kimi, Perplexity Search API, or Tavily Search API.
-- `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
+<Info>
+  `web_search` is a lightweight HTTP tool, not browser automation. For
+  JS-heavy sites or logins, use the [Web Browser](/tools/browser). For
+  fetching a specific URL, use [Web Fetch](/tools/web-fetch).
+</Info>
 
-These are **not** browser automation. For JS-heavy sites or logins, use the
-[Browser tool](/tools/browser).
+## Quick start
 
-## How it works
+<Steps>
+  <Step title="Get an API key">
+    Pick a provider and get an API key. See the provider pages below for
+    sign-up links.
+  </Step>
+  <Step title="Configure">
+    ```bash
+    openclaw configure --section web
+    ```
+    This stores the key and sets the provider. You can also set an env var
+    (e.g. `BRAVE_API_KEY`) and skip this step.
+  </Step>
+  <Step title="Use it">
+    The agent can now call `web_search`:
 
-- `web_search` calls your configured provider and returns results.
-- Results are cached by query for 15 minutes (configurable).
-- `web_fetch` does a plain HTTP GET and extracts readable content
-  (HTML → markdown/text). It does **not** execute JavaScript.
-- `web_fetch` is enabled by default (unless explicitly disabled).
-- The bundled Firecrawl plugin also adds `firecrawl_search` and `firecrawl_scrape` when enabled.
-- The bundled Tavily plugin also adds `tavily_search` and `tavily_extract` when enabled.
+    ```javascript
+    await web_search({ query: "OpenClaw plugin SDK" });
+    ```
 
-See [Brave Search setup](/tools/brave-search), [Perplexity Search setup](/tools/perplexity-search), and [Tavily Search setup](/tools/tavily) for provider-specific details.
+  </Step>
+</Steps>
 
-## Choosing a search provider
+## Choosing a provider
 
-| Provider                  | Result shape                       | Provider-specific filters                                    | Notes                                                                          | API key                                     |
-| ------------------------- | ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------- |
-| **Brave Search API**      | Structured results with snippets   | `country`, `language`, `ui_lang`, time                       | Supports Brave `llm-context` mode                                              | `BRAVE_API_KEY`                             |
-| **Firecrawl Search**      | Structured results with snippets   | Use `firecrawl_search` for Firecrawl-specific search options | Best for pairing search with Firecrawl scraping/extraction                     | `FIRECRAWL_API_KEY`                         |
-| **Gemini**                | AI-synthesized answers + citations | —                                                            | Uses Google Search grounding                                                   | `GEMINI_API_KEY`                            |
-| **Grok**                  | AI-synthesized answers + citations | —                                                            | Uses xAI web-grounded responses                                                | `XAI_API_KEY`                               |
-| **Kimi**                  | AI-synthesized answers + citations | —                                                            | Uses Moonshot web search                                                       | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter`                 | Supports content extraction controls; OpenRouter uses Sonar compatibility path | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
-| **Tavily Search API**     | Structured results with snippets   | Use `tavily_search` for Tavily-specific search options       | Search depth, topic filtering, AI answers, URL extraction via `tavily_extract` | `TAVILY_API_KEY`                            |
+<CardGroup cols={2}>
+  <Card title="Brave Search" icon="shield" href="/tools/brave-search">
+    Structured results with snippets. Supports `llm-context` mode, country/language filters. Free tier available.
+  </Card>
+  <Card title="DuckDuckGo" icon="bird" href="/tools/duckduckgo-search">
+    Key-free fallback. No API key needed. Unofficial HTML-based integration.
+  </Card>
+  <Card title="Exa" icon="brain" href="/tools/exa-search">
+    Neural + keyword search with content extraction (highlights, text, summaries).
+  </Card>
+  <Card title="Firecrawl" icon="flame" href="/tools/firecrawl">
+    Structured results. Best paired with `firecrawl_search` and `firecrawl_scrape` for deep extraction.
+  </Card>
+  <Card title="Gemini" icon="sparkles" href="/tools/gemini-search">
+    AI-synthesized answers with citations via Google Search grounding.
+  </Card>
+  <Card title="Grok" icon="zap" href="/tools/grok-search">
+    AI-synthesized answers with citations via xAI web grounding.
+  </Card>
+  <Card title="Kimi" icon="moon" href="/tools/kimi-search">
+    AI-synthesized answers with citations via Moonshot web search.
+  </Card>
+  <Card title="Perplexity" icon="search" href="/tools/perplexity-search">
+    Structured results with content extraction controls and domain filtering.
+  </Card>
+  <Card title="Tavily" icon="globe" href="/tools/tavily">
+    Structured results with search depth, topic filtering, and `tavily_extract` for URL extraction.
+  </Card>
+</CardGroup>
 
-### Auto-detection
+### Provider comparison
 
-The table above is alphabetical. If no `provider` is explicitly set, runtime auto-detection checks providers in this order:
+| Provider                               | Result style               | Filters                                          | API key                                     |
+| -------------------------------------- | -------------------------- | ------------------------------------------------ | ------------------------------------------- |
+| [Brave](/tools/brave-search)           | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
+| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets        | --                                               | None (key-free)                             |
+| [Exa](/tools/exa-search)               | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
+| [Firecrawl](/tools/firecrawl)          | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
+| [Gemini](/tools/gemini-search)         | AI-synthesized + citations | --                                               | `GEMINI_API_KEY`                            |
+| [Grok](/tools/grok-search)             | AI-synthesized + citations | --                                               | `XAI_API_KEY`                               |
+| [Kimi](/tools/kimi-search)             | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
+| [Perplexity](/tools/perplexity-search) | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| [Tavily](/tools/tavily)                | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
 
-1. **Brave** — `BRAVE_API_KEY` env var or `plugins.entries.brave.config.webSearch.apiKey`
-2. **Gemini** — `GEMINI_API_KEY` env var or `plugins.entries.google.config.webSearch.apiKey`
-3. **Grok** — `XAI_API_KEY` env var or `plugins.entries.xai.config.webSearch.apiKey`
-4. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `plugins.entries.moonshot.config.webSearch.apiKey`
-5. **Perplexity** — `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `plugins.entries.perplexity.config.webSearch.apiKey`
-6. **Firecrawl** — `FIRECRAWL_API_KEY` env var or `plugins.entries.firecrawl.config.webSearch.apiKey`
-7. **Tavily** — `TAVILY_API_KEY` env var or `plugins.entries.tavily.config.webSearch.apiKey`
+## Auto-detection
 
-If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
+Provider lists in docs and setup flows are alphabetical. Auto-detection keeps a
+separate precedence order:
 
-Runtime SecretRef behavior:
+If no `provider` is set, OpenClaw checks for API keys in this order and uses
+the first one found:
 
-- Web tool SecretRefs are resolved atomically at gateway startup/reload.
-- In auto-detect mode, OpenClaw resolves only the selected provider key. Non-selected provider SecretRefs stay inactive until selected.
-- If the selected provider SecretRef is unresolved and no provider env fallback exists, startup/reload fails fast.
+1. **Brave** -- `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
+2. **Gemini** -- `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
+3. **Grok** -- `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`
+4. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey`
+5. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey`
+6. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
+7. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
 
-## Setting up web search
+If no keys are found, it falls back to Brave (you will get a missing-key error
+prompting you to configure one).
 
-Use `openclaw configure --section web` to set up your API key and choose a provider.
+<Note>
+  All provider key fields support SecretRef objects. In auto-detect mode,
+  OpenClaw resolves only the selected provider key -- non-selected SecretRefs
+  stay inactive.
+</Note>
 
-### Brave Search
-
-1. Create a Brave Search API account at [brave.com/search/api](https://brave.com/search/api/)
-2. In the dashboard, choose the **Search** plan and generate an API key.
-3. Run `openclaw configure --section web` to store the key in config, or set `BRAVE_API_KEY` in your environment.
-
-Each Brave plan includes **\$5/month in free credit** (renewing). The Search
-plan costs \$5 per 1,000 requests, so the credit covers 1,000 queries/month. Set
-your usage limit in the Brave dashboard to avoid unexpected charges. See the
-[Brave API portal](https://brave.com/search/api/) for current plans and
-pricing.
-
-### Perplexity Search
-
-1. Create a Perplexity account at [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api)
-2. Generate an API key in the dashboard
-3. Run `openclaw configure --section web` to store the key in config, or set `PERPLEXITY_API_KEY` in your environment.
-
-For legacy Sonar/OpenRouter compatibility, set `OPENROUTER_API_KEY` instead, or configure `plugins.entries.perplexity.config.webSearch.apiKey` with an `sk-or-...` key. Setting `plugins.entries.perplexity.config.webSearch.baseUrl` or `model` also opts Perplexity back into the chat-completions compatibility path.
-
-Provider-specific web search config now lives under `plugins.entries.<plugin>.config.webSearch.*`.
-Legacy `tools.web.search.*` provider paths still load through a compatibility shim for one release, but they should not be used in new configs.
-
-See [Perplexity Search API Docs](https://docs.perplexity.ai/guides/search-quickstart) for more details.
-
-### Where to store the key
-
-**Via config:** run `openclaw configure --section web`. It stores the key under the provider-specific config path:
-
-- Brave: `plugins.entries.brave.config.webSearch.apiKey`
-- Firecrawl: `plugins.entries.firecrawl.config.webSearch.apiKey`
-- Gemini: `plugins.entries.google.config.webSearch.apiKey`
-- Grok: `plugins.entries.xai.config.webSearch.apiKey`
-- Kimi: `plugins.entries.moonshot.config.webSearch.apiKey`
-- Perplexity: `plugins.entries.perplexity.config.webSearch.apiKey`
-- Tavily: `plugins.entries.tavily.config.webSearch.apiKey`
-
-All of these fields also support SecretRef objects.
-
-**Via environment:** set provider env vars in the Gateway process environment:
-
-- Brave: `BRAVE_API_KEY`
-- Firecrawl: `FIRECRAWL_API_KEY`
-- Gemini: `GEMINI_API_KEY`
-- Grok: `XAI_API_KEY`
-- Kimi: `KIMI_API_KEY` or `MOONSHOT_API_KEY`
-- Perplexity: `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
-- Tavily: `TAVILY_API_KEY`
-
-For a gateway install, put these in `~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#env-vars-and-env-loading).
-
-### Config examples
-
-**Brave Search:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      brave: {
-        config: {
-          webSearch: {
-            apiKey: "YOUR_BRAVE_API_KEY", // optional if BRAVE_API_KEY is set // pragma: allowlist secret
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "brave",
-      },
-    },
-  },
-}
-```
-
-**Firecrawl Search:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      firecrawl: {
-        enabled: true,
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "firecrawl",
-      },
-    },
-  },
-  plugins: {
-    entries: {
-      firecrawl: {
-        enabled: true,
-        config: {
-          webSearch: {
-            apiKey: "fc-...", // optional if FIRECRAWL_API_KEY is set
-            baseUrl: "https://api.firecrawl.dev",
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-When you choose Firecrawl in onboarding or `openclaw configure --section web`, OpenClaw enables the bundled Firecrawl plugin automatically so `web_search`, `firecrawl_search`, and `firecrawl_scrape` are all available.
-
-**Tavily Search:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      tavily: {
-        enabled: true,
-        config: {
-          webSearch: {
-            apiKey: "tvly-...", // optional if TAVILY_API_KEY is set
-            baseUrl: "https://api.tavily.com",
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "tavily",
-      },
-    },
-  },
-}
-```
-
-When you choose Tavily in onboarding or `openclaw configure --section web`, OpenClaw enables the bundled Tavily plugin automatically so `web_search`, `tavily_search`, and `tavily_extract` are all available.
-
-**Brave LLM Context mode:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      brave: {
-        config: {
-          webSearch: {
-            apiKey: "YOUR_BRAVE_API_KEY", // optional if BRAVE_API_KEY is set // pragma: allowlist secret
-            mode: "llm-context",
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "brave",
-      },
-    },
-  },
-}
-```
-
-`llm-context` returns extracted page chunks for grounding instead of standard Brave snippets.
-In this mode, `country` and `language` / `search_lang` still work, but `ui_lang`,
-`freshness`, `date_after`, and `date_before` are rejected.
-
-**Perplexity Search:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      perplexity: {
-        config: {
-          webSearch: {
-            apiKey: "pplx-...", // optional if PERPLEXITY_API_KEY is set
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "perplexity",
-      },
-    },
-  },
-}
-```
-
-**Perplexity via OpenRouter / Sonar compatibility:**
-
-```json5
-{
-  plugins: {
-    entries: {
-      perplexity: {
-        config: {
-          webSearch: {
-            apiKey: "<openrouter-api-key>", // optional if OPENROUTER_API_KEY is set
-            baseUrl: "https://openrouter.ai/api/v1",
-            model: "perplexity/sonar-pro",
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        enabled: true,
-        provider: "perplexity",
-      },
-    },
-  },
-}
-```
-
-## Using Gemini (Google Search grounding)
-
-Gemini models support built-in [Google Search grounding](https://ai.google.dev/gemini-api/docs/grounding),
-which returns AI-synthesized answers backed by live Google Search results with citations.
-
-### Getting a Gemini API key
-
-1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
-2. Create an API key
-3. Set `GEMINI_API_KEY` in the Gateway environment, or configure `plugins.entries.google.config.webSearch.apiKey`
-
-### Setting up Gemini search
-
-```json5
-{
-  plugins: {
-    entries: {
-      google: {
-        config: {
-          webSearch: {
-            // API key (optional if GEMINI_API_KEY is set)
-            apiKey: "AIza...",
-            // Model (defaults to "gemini-2.5-flash")
-            model: "gemini-2.5-flash",
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        provider: "gemini",
-      },
-    },
-  },
-}
-```
-
-**Environment alternative:** set `GEMINI_API_KEY` in the Gateway environment.
-For a gateway install, put it in `~/.openclaw/.env`.
-
-### Notes
-
-- Citation URLs from Gemini grounding are automatically resolved from Google's
-  redirect URLs to direct URLs.
-- Redirect resolution uses the SSRF guard path (HEAD + redirect checks + http/https validation) before returning the final citation URL.
-- Redirect resolution uses strict SSRF defaults, so redirects to private/internal targets are blocked.
-- The default model (`gemini-2.5-flash`) is fast and cost-effective.
-  Any Gemini model that supports grounding can be used.
-
-## web_search
-
-Search the web using your configured provider.
-
-### Requirements
-
-- `tools.web.search.enabled` must not be `false` (default: enabled)
-- API key for your chosen provider:
-  - **Brave**: `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
-  - **Firecrawl**: `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
-  - **Gemini**: `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
-  - **Grok**: `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`
-  - **Kimi**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `plugins.entries.moonshot.config.webSearch.apiKey`
-  - **Perplexity**: `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `plugins.entries.perplexity.config.webSearch.apiKey`
-  - **Tavily**: `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
-- All provider key fields above support SecretRef objects.
-
-### Config
+## Config
 
 ```json5
 {
   tools: {
     web: {
       search: {
-        enabled: true,
-        apiKey: "BRAVE_API_KEY_HERE", // optional if BRAVE_API_KEY is set
+        enabled: true, // default: true
+        provider: "brave", // or omit for auto-detection
         maxResults: 5,
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,
@@ -382,19 +132,54 @@ Search the web using your configured provider.
 }
 ```
 
-### Tool parameters
+Provider-specific config (API keys, base URLs, modes) lives under
+`plugins.entries.<plugin>.config.webSearch.*`. See the provider pages for
+examples.
 
-Parameters depend on the selected provider.
+### Storing API keys
 
-Perplexity's OpenRouter / Sonar compatibility path supports only `query` and `freshness`.
-If you set `plugins.entries.perplexity.config.webSearch.baseUrl` / `model`, use `OPENROUTER_API_KEY`, or configure an `sk-or-...` key under `plugins.entries.perplexity.config.webSearch.apiKey`, Search API-only filters return explicit errors.
+<Tabs>
+  <Tab title="Config file">
+    Run `openclaw configure --section web` or set the key directly:
+
+    ```json5
+    {
+      plugins: {
+        entries: {
+          brave: {
+            config: {
+              webSearch: {
+                apiKey: "YOUR_KEY", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      },
+    }
+    ```
+
+  </Tab>
+  <Tab title="Environment variable">
+    Set the provider env var in the Gateway process environment:
+
+    ```bash
+    export BRAVE_API_KEY="YOUR_KEY"
+    ```
+
+    For a gateway install, put it in `~/.openclaw/.env`.
+    See [Env vars](/help/faq#env-vars-and-env-loading).
+
+  </Tab>
+</Tabs>
+
+## Tool parameters
 
 | Parameter             | Description                                           |
 | --------------------- | ----------------------------------------------------- |
 | `query`               | Search query (required)                               |
 | `count`               | Results to return (1-10, default: 5)                  |
-| `country`             | 2-letter ISO country code (e.g., "US", "DE")          |
-| `language`            | ISO 639-1 language code (e.g., "en", "de")            |
+| `country`             | 2-letter ISO country code (e.g. "US", "DE")           |
+| `language`            | ISO 639-1 language code (e.g. "en", "de")             |
 | `freshness`           | Time filter: `day`, `week`, `month`, or `year`        |
 | `date_after`          | Results after this date (YYYY-MM-DD)                  |
 | `date_before`         | Results before this date (YYYY-MM-DD)                 |
@@ -403,114 +188,53 @@ If you set `plugins.entries.perplexity.config.webSearch.baseUrl` / `model`, use 
 | `max_tokens`          | Total content budget, default 25000 (Perplexity only) |
 | `max_tokens_per_page` | Per-page token limit, default 2048 (Perplexity only)  |
 
-Firecrawl `web_search` supports `query` and `count`. For Firecrawl-specific controls like `sources`, `categories`, result scraping, or scrape timeout, use `firecrawl_search` from the bundled Firecrawl plugin.
+<Warning>
+  Not all parameters work with all providers. Brave `llm-context` mode
+  rejects `ui_lang`, `freshness`, `date_after`, and `date_before`.
+  Firecrawl and Tavily only support `query` and `count` through `web_search`
+  -- use their dedicated tools for advanced options.
+</Warning>
 
-Tavily `web_search` supports `query` and `count` (up to 20 results). For Tavily-specific controls like `search_depth`, `topic`, `include_answer`, or domain filters, use `tavily_search` from the bundled Tavily plugin. For URL content extraction, use `tavily_extract`. See [Tavily](/tools/tavily) for details.
-
-**Examples:**
+## Examples
 
 ```javascript
+// Basic search
+await web_search({ query: "OpenClaw plugin SDK" });
+
 // German-specific search
-await web_search({
-  query: "TV online schauen",
-  country: "DE",
-  language: "de",
-});
+await web_search({ query: "TV online schauen", country: "DE", language: "de" });
 
 // Recent results (past week)
-await web_search({
-  query: "TMBG interview",
-  freshness: "week",
-});
+await web_search({ query: "AI developments", freshness: "week" });
 
-// Date range search
+// Date range
 await web_search({
-  query: "AI developments",
+  query: "climate research",
   date_after: "2024-01-01",
   date_before: "2024-06-30",
 });
 
 // Domain filtering (Perplexity only)
 await web_search({
-  query: "climate research",
-  domain_filter: ["nature.com", "science.org", ".edu"],
-});
-
-// Exclude domains (Perplexity only)
-await web_search({
   query: "product reviews",
   domain_filter: ["-reddit.com", "-pinterest.com"],
 });
-
-// More content extraction (Perplexity only)
-await web_search({
-  query: "detailed AI research",
-  max_tokens: 50000,
-  max_tokens_per_page: 4096,
-});
 ```
 
-When Brave `llm-context` mode is enabled, `ui_lang`, `freshness`, `date_after`, and
-`date_before` are not supported. Use Brave `web` mode for those filters.
+## Tool profiles
 
-## web_fetch
-
-Fetch a URL and extract readable content.
-
-### web_fetch requirements
-
-- `tools.web.fetch.enabled` must not be `false` (default: enabled)
-- Optional Firecrawl fallback: set `tools.web.fetch.firecrawl.apiKey` or `FIRECRAWL_API_KEY`.
-- `tools.web.fetch.firecrawl.apiKey` supports SecretRef objects.
-
-### web_fetch config
+If you use tool profiles or allowlists, add `web_search` or `group:web`:
 
 ```json5
 {
   tools: {
-    web: {
-      fetch: {
-        enabled: true,
-        maxChars: 50000,
-        maxCharsCap: 50000,
-        maxResponseBytes: 2000000,
-        timeoutSeconds: 30,
-        cacheTtlMinutes: 15,
-        maxRedirects: 3,
-        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-        readability: true,
-        firecrawl: {
-          enabled: true,
-          apiKey: "FIRECRAWL_API_KEY_HERE", // optional if FIRECRAWL_API_KEY is set
-          baseUrl: "https://api.firecrawl.dev",
-          onlyMainContent: true,
-          maxAgeMs: 86400000, // ms (1 day)
-          timeoutSeconds: 60,
-        },
-      },
-    },
+    allow: ["web_search"],
+    // or: allow: ["group:web"]  (includes both web_search and web_fetch)
   },
 }
 ```
 
-### web_fetch tool parameters
+## Related
 
-- `url` (required, http/https only)
-- `extractMode` (`markdown` | `text`)
-- `maxChars` (truncate long pages)
-
-Notes:
-
-- `web_fetch` uses Readability (main-content extraction) first, then Firecrawl (if configured). If both fail, the tool returns an error.
-- Firecrawl requests use bot-circumvention mode and cache results by default.
-- Firecrawl SecretRefs are resolved only when Firecrawl is active (`tools.web.fetch.enabled !== false` and `tools.web.fetch.firecrawl.enabled !== false`).
-- If Firecrawl is active and its SecretRef is unresolved with no `FIRECRAWL_API_KEY` fallback, startup/reload fails fast.
-- `web_fetch` sends a Chrome-like User-Agent and `Accept-Language` by default; override `userAgent` if needed.
-- `web_fetch` blocks private/internal hostnames and re-checks redirects (limit with `maxRedirects`).
-- `maxChars` is clamped to `tools.web.fetch.maxCharsCap`.
-- `web_fetch` caps the downloaded response body size to `tools.web.fetch.maxResponseBytes` before parsing; oversized responses are truncated and include a warning.
-- `web_fetch` is best-effort extraction; some sites will need the browser tool.
-- See [Firecrawl](/tools/firecrawl) for key setup and service details.
-- Responses are cached (default 15 minutes) to reduce repeated fetches.
-- If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
-- If the API key is missing, `web_search` returns a short setup hint with a docs link.
+- [Web Fetch](/tools/web-fetch) -- fetch a URL and extract readable content
+- [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -114,7 +114,7 @@ All of these fields also support SecretRef objects.
 - Perplexity: `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
 - Tavily: `TAVILY_API_KEY`
 
-For a gateway install, put these in `~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#how-does-openclaw-load-environment-variables).
+For a gateway install, put these in `~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#env-vars-and-env-loading).
 
 ### Config examples
 


### PR DESCRIPTION
## Summary

Fixes #50828

- Fix `/configuration` links in plugin docs to point to `/gateway/configuration-reference`
- Fix broken FAQ anchors after FAQ restructuring (`#where-does-openclaw-store-its-data` -> `#where-things-live-on-disk`, `#how-does-openclaw-load-environment-variables` -> `#env-vars-and-env-loading`, and broken accordion self-references)
- Fix broken channel anchors (`/channels/matrix#troubleshooting`, Discord/Telegram exec approval accordion anchors)
- Fix broken Docker sandbox anchor (`#enable-agent-sandbox-for-docker-gateway-opt-in` -> `#agent-sandbox`)

## Test plan

- [ ] Verify all updated links resolve correctly on docs.openclaw.ai after deploy
- [ ] Spot-check that anchor targets land on the correct section headings