### PR TITLE
fix: emit message:sent hook on Telegram streaming preview finalization

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -21,6 +21,7 @@ import type {
   TelegramAccountConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
@@ -30,7 +31,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
-import { deliverReplies } from "./bot/delivery.js";
+import { deliverReplies, emitMessageSentHooks } from "./bot/delivery.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -507,6 +508,22 @@ export const dispatchTelegramMessage = async ({
     log: logVerbose,
     markDelivered: () => {
       deliveryState.markDelivered();
+    },
+    // Emit message:sent hooks for preview-finalized/retained paths that bypass sendPayload.
+    onPreviewDelivered: (content) => {
+      const hookRunner = getGlobalHookRunner();
+      const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+      emitMessageSentHooks({
+        hookRunner,
+        enabled: hasMessageSentHooks,
+        sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
+        chatId: deliveryBaseOptions.chatId,
+        accountId: deliveryBaseOptions.accountId,
+        content,
+        success: true,
+        isGroup: deliveryBaseOptions.mirrorIsGroup,
+        groupId: deliveryBaseOptions.mirrorGroupId,
+      });
     },
   });
 

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -491,7 +491,7 @@ async function maybePinFirstDeliveredMessage(params: {
   }
 }
 
-function emitMessageSentHooks(params: {
+export function emitMessageSentHooks(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
   sessionKeyForInternalHooks?: string;

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,2 +1,2 @@
-export { deliverReplies } from "./delivery.replies.js";
+export { deliverReplies, emitMessageSentHooks } from "./delivery.replies.js";
 export { resolveMedia } from "./delivery.resolve-media.js";

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -83,6 +83,8 @@ type CreateLaneTextDelivererParams = {
   deletePreviewMessage: (messageId: number) => Promise<void>;
   log: (message: string) => void;
   markDelivered: () => void;
+  /** Called when a preview-finalized or preview-retained path delivers without sendPayload. */
+  onPreviewDelivered?: (content: string) => void;
 };
 
 type DeliverLaneTextParams = {
@@ -427,10 +429,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
       if (finalized === "edited") {
+        params.onPreviewDelivered?.(text);
         return "preview-finalized";
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
+        params.onPreviewDelivered?.(text);
         return "preview-retained";
       }
     }
@@ -506,6 +510,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           });
           if (materialized) {
             markActivePreviewComplete(laneName);
+            params.onPreviewDelivered?.(text);
             return "preview-finalized";
           }
         }
@@ -520,10 +525,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         });
         if (finalized === "edited") {
           markActivePreviewComplete(laneName);
+          params.onPreviewDelivered?.(text);
           return "preview-finalized";
         }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
+          params.onPreviewDelivered?.(text);
           return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -44,6 +44,7 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
+  const onPreviewDelivered = vi.fn();
   const activePreviewLifecycleByLane = { answer: "transient", reasoning: "transient" } as const;
   const retainPreviewOnCleanupByLane = { answer: false, reasoning: false } as const;
   const archivedAnswerPreviews: Array<{
@@ -66,6 +67,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onPreviewDelivered,
   });
 
   return {
@@ -82,6 +84,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onPreviewDelivered,
     archivedAnswerPreviews,
   };
 }
@@ -551,5 +554,66 @@ describe("createLaneTextDeliverer", () => {
       expect.objectContaining({ text: "Final with media", mediaUrl: "file:///tmp/example.png" }),
     );
     expect(harness.deletePreviewMessage).toHaveBeenCalledWith(4444);
+  });
+
+  // ── onPreviewDelivered hook emission tests ───────────────────────────────
+
+  it("calls onPreviewDelivered when preview is finalized via edit", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("calls onPreviewDelivered when preview is retained on ambiguous error", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-retained");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("calls onPreviewDelivered when DM draft preview is materialized", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft", messageId: 321 });
+    answerStream.materialize.mockResolvedValue(321);
+    answerStream.update.mockImplementation(() => {});
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Hello final",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final");
+  });
+
+  it("calls onPreviewDelivered when archived preview is finalized", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    seedArchivedAnswerPreview(harness);
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("does not call onPreviewDelivered when falling back to sendPayload", async () => {
+    const harness = createHarness();
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("sent");
+    expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `message:sent` internal hook events are never fired for Telegram DM replies when streaming preview mode is active (default). When the final answer fits within 4096 chars, the preview message is edited in-place via `tryMaterializeDraftPreviewForFinal` or `tryUpdatePreviewForLane`, returning `"preview-finalized"` or `"preview-retained"` without ever calling `sendPayload` -> `deliverReplies` -> `emitMessageSentHooks`.
- Why it matters: Any automation or integration depending on the `message:sent` hook silently breaks for the most common Telegram DM delivery path.
- What changed: Added an `onPreviewDelivered` callback to `createLaneTextDeliverer` that fires `emitMessageSentHooks` when a preview-finalized or preview-retained path delivers without going through `sendPayload`. Wired it up in `bot-message-dispatch.ts`.
- What did NOT change (scope boundary): The `sendPayload` / `deliverReplies` path is untouched. Non-final preview updates (`"preview-updated"`) do not fire the hook since they are partial streaming updates, not final deliveries.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #50878

## User-visible / Behavior Changes

`message:sent` hooks now fire for Telegram DM replies delivered via streaming preview finalization, matching the behavior of the standard `sendPayload` path.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Configure a `message:sent` hook
2. Send a DM to the Telegram bot with streaming preview mode active (default)
3. Observe that the bot replies with a short answer (< 4096 chars) via preview finalization

### Expected

- `message:sent` hook fires after the preview is finalized

### Actual

- `message:sent` hook never fires (before this fix)

## Evidence

- [x] Failing test/log before + passing after
  - Added 5 new test cases in `lane-delivery.test.ts` that verify `onPreviewDelivered` is called for preview-finalized, preview-retained, draft materialization, and archived preview paths, and is NOT called for the sendPayload fallback path
  - All 29 tests pass (24 existing + 5 new)

## Human Verification (required)

- Verified scenarios: All 29 lane-delivery tests pass including 5 new hook emission tests
- Edge cases checked: Draft materialization path, archived preview path, retained-on-error path, fallback-to-sendPayload path (should NOT call onPreviewDelivered)
- What you did **not** verify: Live Telegram DM end-to-end (requires bot token and active session)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the `onPreviewDelivered` callback is optional so removing it restores prior behavior
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Duplicate `message:sent` hook firings (should not happen since `onPreviewDelivered` only fires on paths that bypass `sendPayload`)

## Risks and Mitigations

- Risk: Hook fires twice if a preview path somehow also falls through to sendPayload
  - Mitigation: The code structure ensures mutual exclusion; preview-finalized/retained paths return early before reaching sendPayload. Tests confirm onPreviewDelivered is not called on the sendPayload path.