### PR TITLE
feat: add Eternal AI provider extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -201,6 +201,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/diagnostics-otel/**"
+"extensions: eternal-ai":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/eternal-ai/**"s
 "extensions: llm-task":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/eternal-ai/index.ts
+++ b/extensions/eternal-ai/index.ts
@@ -1,0 +1,51 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog";
+import { applyEternalAiConfig, ETERNAL_AI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildEternalAiProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "eternal-ai";
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Eternal AI Provider",
+  description: "Bundled Eternal AI provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Eternal AI",
+      envVars: ["ETERNAL_AI_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Eternal AI API key",
+          hint: "Uncensored and Private AI",
+          optionKey: "eternalAiApiKey",
+          flagName: "--eternal-ai-api-key",
+          envVar: "ETERNAL_AI_API_KEY",
+          promptMessage: "Enter Eternal AI API key",
+          defaultModel: ETERNAL_AI_DEFAULT_MODEL_REF,
+          expectedProviders: ["eternal-ai"],
+          applyConfig: (cfg) => applyEternalAiConfig(cfg),
+          wizard: {
+            choiceId: "eternal-ai-api-key",
+            choiceLabel: "Eternal AI API key",
+            groupId: "eternal-ai",
+            groupLabel: "Eternal AI",
+            groupHint: "Uncensored and Private AI",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: (ctx) =>
+          buildSingleProviderApiKeyCatalog({
+            ctx,
+            providerId: PROVIDER_ID,
+            buildProvider: buildEternalAiProvider,
+          }),
+      },
+    });
+  },
+});

--- a/extensions/eternal-ai/onboard.ts
+++ b/extensions/eternal-ai/onboard.ts
@@ -1,0 +1,31 @@
+import {
+  applyProviderConfigWithModelCatalogPreset,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildEternalAiProvider,
+  ETERNAL_AI_BASE_URL,
+  ETERNAL_AI_DEFAULT_MODEL_ID,
+} from "./provider-catalog.js";
+
+export const ETERNAL_AI_DEFAULT_MODEL_REF = `eternal-ai/${ETERNAL_AI_DEFAULT_MODEL_ID}`;
+
+function applyEternalAiPreset(cfg: OpenClawConfig, primaryModelRef?: string): OpenClawConfig {
+  const provider = buildEternalAiProvider();
+  return applyProviderConfigWithModelCatalogPreset(cfg, {
+    providerId: "eternal-ai",
+    api: "openai-completions",
+    baseUrl: ETERNAL_AI_BASE_URL,
+    catalogModels: provider.models,
+    aliases: [{ modelRef: ETERNAL_AI_DEFAULT_MODEL_REF, alias: "Eternal AI" }],
+    primaryModelRef,
+  });
+}
+
+export function applyEternalAiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyEternalAiPreset(cfg);
+}
+
+export function applyEternalAiConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyEternalAiPreset(cfg, ETERNAL_AI_DEFAULT_MODEL_REF);
+}

--- a/extensions/eternal-ai/openclaw.plugin.json
+++ b/extensions/eternal-ai/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "eternal-ai",
+  "providers": ["eternal-ai"],
+  "providerAuthEnvVars": {
+    "eternal-ai": ["ETERNAL_AI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "eternal-ai",
+      "method": "api-key",
+      "choiceId": "eternal-ai-api-key",
+      "choiceLabel": "Eternal AI API key",
+      "groupId": "eternal-ai",
+      "groupLabel": "Eternal AI",
+      "groupHint": "Uncensored and Private AI",
+      "optionKey": "eternalAiApiKey",
+      "cliFlag": "--eternal-ai-api-key",
+      "cliOption": "--eternal-ai-api-key <key>",
+      "cliDescription": "Eternal AI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/eternal-ai/package.json
+++ b/extensions/eternal-ai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/eternal-ai-provider",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Eternal AI provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/eternal-ai/provider-catalog.ts
+++ b/extensions/eternal-ai/provider-catalog.ts
@@ -3,8 +3,8 @@ import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
 export const ETERNAL_AI_BASE_URL = "https://open.eternalai.org/v1";
 export const ETERNAL_AI_DEFAULT_MODEL_ID = "uncensored-eternal-ai-1.0";
 
-const ETERNAL_AI_DEFAULT_CONTEXT_WINDOW = 128000;
-const ETERNAL_AI_DEFAULT_MAX_TOKENS = 12288;
+const ETERNAL_AI_DEFAULT_CONTEXT_WINDOW = 200000;
+const ETERNAL_AI_DEFAULT_MAX_TOKENS = 200000;
 
 export function buildEternalAiProvider(): ModelProviderConfig {
   return {

--- a/extensions/eternal-ai/provider-catalog.ts
+++ b/extensions/eternal-ai/provider-catalog.ts
@@ -1,0 +1,33 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
+
+export const ETERNAL_AI_BASE_URL = "https://open.eternalai.org/v1";
+export const ETERNAL_AI_DEFAULT_MODEL_ID = "uncensored-eternal-ai-1.0";
+
+const ETERNAL_AI_DEFAULT_CONTEXT_WINDOW = 128000;
+const ETERNAL_AI_DEFAULT_MAX_TOKENS = 12288;
+
+export function buildEternalAiProvider(): ModelProviderConfig {
+  return {
+    baseUrl: ETERNAL_AI_BASE_URL,
+    api: "openai-completions",
+    headers: {
+      "x-api-key": "${ETERNAL_AI_API_KEY}",
+    },
+    models: [
+      {
+        id: ETERNAL_AI_DEFAULT_MODEL_ID,
+        name: "Uncensored Eternal AI 1.0",
+        reasoning: false,
+        input: ["text"],
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: ETERNAL_AI_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: ETERNAL_AI_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,8 @@ importers:
 
   extensions/elevenlabs: {}
 
+  extensions/eternal-ai: {}
+
   extensions/fal: {}
 
   extensions/feishu:

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -6,6 +6,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   byteplus: ["BYTEPLUS_API_KEY"],
   chutes: ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"],
   "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
+  "eternal-ai": ["ETERNAL_AI_API_KEY"],
   fal: ["FAL_KEY"],
   firecrawl: ["FIRECRAWL_API_KEY"],
   "github-copilot": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],


### PR DESCRIPTION
## Summary

- Adds a new bundled provider extension for [Eternal AI](https://eternalai.org), an uncensored and private AI platform
- OpenAI-compatible API integration via `https://open.eternalai.org/v1`
- Default model: `uncensored-eternal-ai-1.0` (200k context window, 200k max output tokens)

## Why Eternal AI?

Eternal AI is ideal for users who want:

- **Uncensored models** — No content restrictions or filters, ask anything without limitations
- **Private inference** — Prompts and responses are not stored or used for training
- **Large context** — 200k context window and 200k max output tokens for handling complex, long-form tasks

This expands OpenClaw's provider ecosystem with an option for users who prioritize freedom, privacy, and censorship resistance.

## Change Type

- [x] Feature

## Scope

- [x] Integrations (new provider)
- [x] UI/DX (onboard wizard)

## User-visible Changes

- New "Eternal AI" option in `openclaw onboard` model/auth provider picker
- Auth via `ETERNAL_AI_API_KEY` env var or `--eternal-ai-api-key` CLI flag
- Hint displayed: "Uncensored and Private AI"

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — uses existing provider API key mechanism
- New/changed network calls? Yes — calls `https://open.eternalai.org/v1` (OpenAI-compatible endpoint)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 22+
- Model/provider: Eternal AI

### Steps

1. `pnpm install && pnpm build`
2. `pnpm openclaw onboard`
3. Select "Eternal AI (Uncensored and Private AI)"
4. Enter API key

### Expected

- Provider appears in picker, model configured successfully

### Actual

- Works as expected

## Evidence

- [x] Tested locally via `pnpm openclaw onboard` — provider appears in picker, API key prompt works, model configured successfully
- [x] `pnpm check` passes (only pre-existing TS error in `extensions/discord/src/monitor/provider.ts`, unrelated)

## Human Verification

- Verified scenarios: onboard flow, provider selection, API key entry, model configuration
- Edge cases checked: none (purely additive, no existing behavior changed)
- What I did **not** verify: live model inference end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: remove `extensions/eternal-ai/` directory
- Files/config to restore: revert `.github/labeler.yml` and `src/plugins/bundled-provider-auth-env-vars.generated.ts`
- Known bad symptoms: none expected (purely additive)

## Risks and Mitigations

- Low risk: follows same pattern as other bundled provider extensions (Venice AI, Together AI, etc.)

## AI Disclosure

- [x] This PR was AI-assisted (Claude Code)
- [x] Fully tested locally
- [x] I understand what the code does
