### PR TITLE
fix: resolve duplicate property definition in Matrix plugin

### DIFF
--- a/extensions/matrix/src/runtime-api.ts
+++ b/extensions/matrix/src/runtime-api.ts
@@ -1,3 +1,39 @@
+// Re-export helper-api symbols from their local source to break the circular
+// re-export path: openclaw/plugin-sdk/matrix re-exports from
+// extensions/matrix/helper-api.js, so importing plugin-sdk/matrix here would
+// cause Jiti to define these properties twice (once via the local module graph
+// and once via the alias round-trip), triggering "Cannot redefine property".
+export {
+  findMatrixAccountEntry,
+  requiresExplicitMatrixDefaultAccount,
+  resolveConfiguredMatrixAccountIds,
+  resolveMatrixChannelConfig,
+  resolveMatrixDefaultOrOnlyAccountId,
+} from "./account-selection.js";
+export {
+  getMatrixScopedEnvVarNames,
+  listMatrixEnvAccountIds,
+  resolveMatrixEnvAccountToken,
+} from "./env-vars.js";
+export {
+  hashMatrixAccessToken,
+  resolveMatrixAccountStorageRoot,
+  resolveMatrixCredentialsDir,
+  resolveMatrixCredentialsFilename,
+  resolveMatrixCredentialsPath,
+  resolveMatrixHomeserverKey,
+  resolveMatrixLegacyFlatStoragePaths,
+  resolveMatrixLegacyFlatStoreRoot,
+  sanitizeMatrixPathSegment,
+} from "./storage-paths.js";
+// Thread-binding helpers that plugin-sdk/matrix re-exports from extensions/matrix.
+export {
+  setMatrixThreadBindingIdleTimeoutBySessionKey,
+  setMatrixThreadBindingMaxAgeBySessionKey,
+} from "./matrix/thread-bindings-shared.js";
+// Star re-export for the remaining (non-extension) symbols in plugin-sdk/matrix.
+// Properties already defined above are skipped by the CJS interop guard, so the
+// circular helper-api path is never reached for those symbols.
 export * from "openclaw/plugin-sdk/matrix";
 export {
   assertHttpUrlTargetsPrivateNetwork,
@@ -8,6 +44,4 @@ export {
   type LookupFn,
   type SsrFPolicy,
 } from "openclaw/plugin-sdk/infra-runtime";
-// Keep auth-precedence available internally without re-exporting helper-api
-// twice through both plugin-sdk/matrix and ../runtime-api.js.
 export * from "./auth-precedence.js";


### PR DESCRIPTION
## Summary

- Fixes the `TypeError: Cannot redefine property: requiresExplicitMatrixDefaultAccount` error that occurs when loading the Matrix plugin via Jiti
- The root cause is that `extensions/matrix/src/runtime-api.ts` uses `export * from "openclaw/plugin-sdk/matrix"`, and `src/plugin-sdk/matrix.ts` re-exports symbols from `extensions/matrix/helper-api.js` -- creating a circular re-export path that causes Jiti's CJS interop to define the same property twice on the module exports object
- The fix explicitly re-exports the extension-local symbols (`requiresExplicitMatrixDefaultAccount`, storage helpers, env helpers, thread-binding helpers) from their local source files *before* the star re-export, so the CJS interop `hasOwnProperty` guard skips the duplicate definitions from the alias round-trip

Fixes #50868

## Test plan

- [x] `pnpm test -- extensions/matrix/index.test.ts` passes (verifies plugin loads and Jiti runtime-api boundary)
- [x] `pnpm test -- extensions/matrix/src/actions.test.ts` passes (consumer of `requiresExplicitMatrixDefaultAccount`)
- [x] `pnpm test -- src/infra/matrix-account-selection.test.ts` passes
- [x] `pnpm test -- extensions/matrix/src/config-schema.test.ts` passes
- [x] `pnpm test -- extensions/matrix/src/channel.account-paths.test.ts` passes
- [x] `pnpm format` clean