### PR TITLE
fix: resolve duplicate property definition in Matrix plugin

### DIFF
--- a/extensions/matrix/src/runtime-api.ts
+++ b/extensions/matrix/src/runtime-api.ts
@@ -1,3 +1,39 @@
+// Re-export helper-api symbols from their local source to break the circular
+// re-export path: openclaw/plugin-sdk/matrix re-exports from
+// extensions/matrix/helper-api.js, so importing plugin-sdk/matrix here would
+// cause Jiti to define these properties twice (once via the local module graph
+// and once via the alias round-trip), triggering "Cannot redefine property".
+export {
+  findMatrixAccountEntry,
+  requiresExplicitMatrixDefaultAccount,
+  resolveConfiguredMatrixAccountIds,
+  resolveMatrixChannelConfig,
+  resolveMatrixDefaultOrOnlyAccountId,
+} from "./account-selection.js";
+export {
+  getMatrixScopedEnvVarNames,
+  listMatrixEnvAccountIds,
+  resolveMatrixEnvAccountToken,
+} from "./env-vars.js";
+export {
+  hashMatrixAccessToken,
+  resolveMatrixAccountStorageRoot,
+  resolveMatrixCredentialsDir,
+  resolveMatrixCredentialsFilename,
+  resolveMatrixCredentialsPath,
+  resolveMatrixHomeserverKey,
+  resolveMatrixLegacyFlatStoragePaths,
+  resolveMatrixLegacyFlatStoreRoot,
+  sanitizeMatrixPathSegment,
+} from "./storage-paths.js";
+// Thread-binding helpers that plugin-sdk/matrix re-exports from extensions/matrix.
+export {
+  setMatrixThreadBindingIdleTimeoutBySessionKey,
+  setMatrixThreadBindingMaxAgeBySessionKey,
+} from "./matrix/thread-bindings-shared.js";
+// Star re-export for the remaining (non-extension) symbols in plugin-sdk/matrix.
+// Properties already defined above are skipped by the CJS interop guard, so the
+// circular helper-api path is never reached for those symbols.
 export * from "openclaw/plugin-sdk/matrix";
 export {
   assertHttpUrlTargetsPrivateNetwork,
@@ -8,6 +44,4 @@ export {
   type LookupFn,
   type SsrFPolicy,
 } from "openclaw/plugin-sdk/infra-runtime";
-// Keep auth-precedence available internally without re-exporting helper-api
-// twice through both plugin-sdk/matrix and ../runtime-api.js.
 export * from "./auth-precedence.js";


### PR DESCRIPTION
## Summary

- Problem: Matrix plugin fails to load with `TypeError: Cannot redefine property: requiresExplicitMatrixDefaultAccount` because `extensions/matrix/src/runtime-api.ts` does `export * from "openclaw/plugin-sdk/matrix"`, and `src/plugin-sdk/matrix.ts` re-exports several symbols from `extensions/matrix/helper-api.js` which barrel-exports from local source files. Jiti's CJS interop tries to define these properties twice on the same module exports object (once via the local module graph and once via the alias round-trip through plugin-sdk/matrix), triggering the error.
- Why it matters: The Matrix plugin is completely broken and cannot load, blocking all Matrix users.
- What changed: Pre-export all helper-api and thread-bindings-runtime symbols from their local source files in `extensions/matrix/src/runtime-api.ts` **before** the `export * from "openclaw/plugin-sdk/matrix"` star re-export. Properties already defined are skipped by the CJS interop guard, so the circular helper-api path is never reached for those symbols.
- What did NOT change: No behavioral changes to any exported function. The public API surface remains identical.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50868

## User-visible / Behavior Changes

Matrix plugin loads successfully again instead of crashing with a TypeError.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Docker)
- Runtime/container: Node 22+ / Docker
- Integration/channel: Matrix

### Steps

1. Build Docker image from main
2. Start gateway with Matrix plugin enabled
3. Observe plugin load failure

### Expected

- Matrix plugin loads without error

### Actual

- `TypeError: Cannot redefine property: requiresExplicitMatrixDefaultAccount`

## Evidence

- [x] Failing test/log before + passing after
- `extensions/matrix/index.test.ts` ("loads the matrix runtime api through Jiti") passes with the fix

## Human Verification (required)

- Verified scenarios: Jiti runtime API loading test passes, all lint and format checks pass
- Edge cases checked: All helper-api symbols (account-selection, env-vars, storage-paths) and thread-bindings-runtime symbols are pre-exported to cover the full circular path
- What you did **not** verify: Live Docker deployment

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single file change in `extensions/matrix/src/runtime-api.ts`
- Files/config to restore: `extensions/matrix/src/runtime-api.ts`
- Known bad symptoms reviewers should watch for: Any missing exports from the runtime-api barrel

## Risks and Mitigations

- Risk: A future refactor adds new symbols to helper-api.js that are also re-exported via plugin-sdk/matrix, which would need to be added to the pre-export list.
  - Mitigation: The comment in the file explains the pattern; the existing test validates Jiti loading.