### PR TITLE
fix: emit message:sent hook on Telegram streaming preview finalization

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -11,6 +11,7 @@ import {
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
 const deliverReplies = vi.hoisted(() => vi.fn());
+const emitInternalMessageSentHook = vi.hoisted(() => vi.fn());
 const createForumTopicTelegram = vi.hoisted(() => vi.fn());
 const deleteMessageTelegram = vi.hoisted(() => vi.fn());
 const editForumTopicTelegram = vi.hoisted(() => vi.fn());
@@ -46,6 +47,7 @@ vi.mock("./draft-stream.js", () => ({
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+  emitInternalMessageSentHook,
 }));
 
 vi.mock("./send.js", () => ({
@@ -103,6 +105,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     deliverReplies.mockClear();
+    emitInternalMessageSentHook.mockClear();
     createForumTopicTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editForumTopicTelegram.mockClear();
@@ -519,6 +522,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.stop).toHaveBeenCalled();
+  });
+
+  it("emits only the internal message:sent hook when a final answer stays in preview", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Primary result" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Primary result",
+      expect.any(Object),
+    );
+    expect(emitInternalMessageSentHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeyForInternalHooks: "s1",
+        chatId: "123",
+        content: "Primary result",
+        success: true,
+        messageId: 999,
+      }),
+    );
   });
 
   it("keeps streamed preview visible when final text regresses after a tool warning", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -510,7 +510,7 @@ export const dispatchTelegramMessage = async ({
       deliveryState.markDelivered();
     },
     // Emit message:sent hooks for preview-finalized/retained paths that bypass sendPayload.
-    onPreviewDelivered: (content) => {
+    onPreviewDelivered: (content, messageId) => {
       const hookRunner = getGlobalHookRunner();
       const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
       emitMessageSentHooks({
@@ -521,6 +521,7 @@ export const dispatchTelegramMessage = async ({
         accountId: deliveryBaseOptions.accountId,
         content,
         success: true,
+        messageId,
         isGroup: deliveryBaseOptions.mirrorIsGroup,
         groupId: deliveryBaseOptions.mirrorGroupId,
       });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -21,6 +21,7 @@ import type {
   TelegramAccountConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
@@ -30,7 +31,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
-import { deliverReplies } from "./bot/delivery.js";
+import { deliverReplies, emitMessageSentHooks } from "./bot/delivery.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -507,6 +508,22 @@ export const dispatchTelegramMessage = async ({
     log: logVerbose,
     markDelivered: () => {
       deliveryState.markDelivered();
+    },
+    // Emit message:sent hooks for preview-finalized/retained paths that bypass sendPayload.
+    onPreviewDelivered: (content) => {
+      const hookRunner = getGlobalHookRunner();
+      const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+      emitMessageSentHooks({
+        hookRunner,
+        enabled: hasMessageSentHooks,
+        sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
+        chatId: deliveryBaseOptions.chatId,
+        accountId: deliveryBaseOptions.accountId,
+        content,
+        success: true,
+        isGroup: deliveryBaseOptions.mirrorIsGroup,
+        groupId: deliveryBaseOptions.mirrorGroupId,
+      });
     },
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -21,7 +21,6 @@ import type {
   TelegramAccountConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
-import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
@@ -31,7 +30,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
-import { deliverReplies, emitMessageSentHooks } from "./bot/delivery.js";
+import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -42,6 +41,7 @@ import {
   createLaneDeliveryStateTracker,
   createLaneTextDeliverer,
   type DraftLaneState,
+  type LaneDeliveryResult,
   type LaneName,
   type LanePreviewLifecycle,
 } from "./lane-delivery.js";
@@ -481,6 +481,21 @@ export const dispatchTelegramMessage = async ({
     }
     return result.delivered;
   };
+  const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
+    if (result.kind !== "preview-finalized") {
+      return;
+    }
+    emitInternalMessageSentHook({
+      sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
+      chatId: deliveryBaseOptions.chatId,
+      accountId: deliveryBaseOptions.accountId,
+      content: result.delivery.content,
+      success: true,
+      messageId: result.delivery.messageId,
+      isGroup: deliveryBaseOptions.mirrorIsGroup,
+      groupId: deliveryBaseOptions.mirrorGroupId,
+    });
+  };
   const deliverLaneText = createLaneTextDeliverer({
     lanes,
     archivedAnswerPreviews,
@@ -508,23 +523,6 @@ export const dispatchTelegramMessage = async ({
     log: logVerbose,
     markDelivered: () => {
       deliveryState.markDelivered();
-    },
-    // Emit message:sent hooks for preview-finalized/retained paths that bypass sendPayload.
-    onPreviewDelivered: (content, messageId) => {
-      const hookRunner = getGlobalHookRunner();
-      const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
-      emitMessageSentHooks({
-        hookRunner,
-        enabled: hasMessageSentHooks,
-        sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
-        chatId: deliveryBaseOptions.chatId,
-        accountId: deliveryBaseOptions.accountId,
-        content,
-        success: true,
-        messageId,
-        isGroup: deliveryBaseOptions.mirrorIsGroup,
-        groupId: deliveryBaseOptions.mirrorGroupId,
-      });
     },
   });
 
@@ -630,8 +628,11 @@ export const dispatchTelegramMessage = async ({
               previewButtons,
               allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
             });
+            if (info.kind === "final") {
+              emitPreviewFinalizedHook(result);
+            }
             if (segment.lane === "reasoning") {
-              if (result !== "skipped") {
+              if (result.kind !== "skipped") {
                 reasoningStepState.noteReasoningDelivered();
                 await flushBufferedFinalAnswer();
               }

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -491,7 +491,7 @@ async function maybePinFirstDeliveredMessage(params: {
   }
 }
 
-function emitMessageSentHooks(params: {
+export function emitMessageSentHooks(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
   sessionKeyForInternalHooks?: string;

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -491,9 +491,7 @@ async function maybePinFirstDeliveredMessage(params: {
   }
 }
 
-export function emitMessageSentHooks(params: {
-  hookRunner: ReturnType<typeof getGlobalHookRunner>;
-  enabled: boolean;
+type EmitMessageSentHookParams = {
   sessionKeyForInternalHooks?: string;
   chatId: string;
   accountId?: string;
@@ -503,11 +501,10 @@ export function emitMessageSentHooks(params: {
   messageId?: number;
   isGroup?: boolean;
   groupId?: string;
-}): void {
-  if (!params.enabled && !params.sessionKeyForInternalHooks) {
-    return;
-  }
-  const canonical = buildCanonicalSentMessageHookContext({
+};
+
+function buildTelegramSentHookContext(params: EmitMessageSentHookParams) {
+  return buildCanonicalSentMessageHookContext({
     to: params.chatId,
     content: params.content,
     success: params.success,
@@ -519,20 +516,13 @@ export function emitMessageSentHooks(params: {
     isGroup: params.isGroup,
     groupId: params.groupId,
   });
-  if (params.enabled) {
-    fireAndForgetHook(
-      Promise.resolve(
-        params.hookRunner!.runMessageSent(
-          toPluginMessageSentEvent(canonical),
-          toPluginMessageContext(canonical),
-        ),
-      ),
-      "telegram: message_sent plugin hook failed",
-    );
-  }
+}
+
+export function emitInternalMessageSentHook(params: EmitMessageSentHookParams): void {
   if (!params.sessionKeyForInternalHooks) {
     return;
   }
+  const canonical = buildTelegramSentHookContext(params);
   fireAndForgetHook(
     triggerInternalHook(
       createInternalHookEvent(
@@ -544,6 +534,30 @@ export function emitMessageSentHooks(params: {
     ),
     "telegram: message:sent internal hook failed",
   );
+}
+
+function emitMessageSentHooks(
+  params: EmitMessageSentHookParams & {
+    hookRunner: ReturnType<typeof getGlobalHookRunner>;
+    enabled: boolean;
+  },
+): void {
+  if (!params.enabled && !params.sessionKeyForInternalHooks) {
+    return;
+  }
+  const canonical = buildTelegramSentHookContext(params);
+  if (params.enabled) {
+    fireAndForgetHook(
+      Promise.resolve(
+        params.hookRunner!.runMessageSent(
+          toPluginMessageSentEvent(canonical),
+          toPluginMessageContext(canonical),
+        ),
+      ),
+      "telegram: message_sent plugin hook failed",
+    );
+  }
+  emitInternalMessageSentHook(params);
 }
 
 export async function deliverReplies(params: {

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,2 +1,2 @@
-export { deliverReplies } from "./delivery.replies.js";
+export { deliverReplies, emitMessageSentHooks } from "./delivery.replies.js";
 export { resolveMedia } from "./delivery.resolve-media.js";

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,2 +1,2 @@
-export { deliverReplies, emitMessageSentHooks } from "./delivery.replies.js";
+export { deliverReplies, emitInternalMessageSentHook } from "./delivery.replies.js";
 export { resolveMedia } from "./delivery.resolve-media.js";

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -84,7 +84,7 @@ type CreateLaneTextDelivererParams = {
   log: (message: string) => void;
   markDelivered: () => void;
   /** Called when a preview-finalized or preview-retained path delivers without sendPayload. */
-  onPreviewDelivered?: (content: string) => void;
+  onPreviewDelivered?: (content: string, messageId?: number) => void;
 };
 
 type DeliverLaneTextParams = {
@@ -191,10 +191,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     lane: DraftLaneState;
     laneName: LaneName;
     text: string;
-  }): Promise<boolean> => {
+  }): Promise<number | undefined> => {
     const stream = args.lane.stream;
     if (!stream || !isDraftPreviewLane(args.lane)) {
-      return false;
+      return undefined;
     }
     // Draft previews have no message_id to edit; materialize the final text
     // into a real message and treat that as the finalized delivery.
@@ -204,11 +204,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       params.log(
         `telegram: ${args.laneName} draft preview materialize produced no message id; falling back to standard send`,
       );
-      return false;
+      return undefined;
     }
     args.lane.lastPartialText = args.text;
     params.markDelivered();
-    return true;
+    return materializedMessageId;
   };
 
   const tryEditPreviewMessage = async (args: {
@@ -429,12 +429,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
       if (finalized === "edited") {
-        params.onPreviewDelivered?.(text);
+        params.onPreviewDelivered?.(text, archivedPreview.messageId);
         return "preview-finalized";
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
-        params.onPreviewDelivered?.(text);
+        params.onPreviewDelivered?.(text, archivedPreview.messageId);
         return "preview-retained";
       }
     }
@@ -503,17 +503,18 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
         if (canMaterializeDraftFinal(lane, previewButtons)) {
-          const materialized = await tryMaterializeDraftPreviewForFinal({
+          const materializedMessageId = await tryMaterializeDraftPreviewForFinal({
             lane,
             laneName,
             text,
           });
-          if (materialized) {
+          if (typeof materializedMessageId === "number") {
             markActivePreviewComplete(laneName);
-            params.onPreviewDelivered?.(text);
+            params.onPreviewDelivered?.(text, materializedMessageId);
             return "preview-finalized";
           }
         }
+        const previewMessageId = lane.stream?.messageId();
         const finalized = await tryUpdatePreviewForLane({
           lane,
           laneName,
@@ -525,12 +526,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         });
         if (finalized === "edited") {
           markActivePreviewComplete(laneName);
-          params.onPreviewDelivered?.(text);
+          params.onPreviewDelivered?.(text, previewMessageId ?? lane.stream?.messageId());
           return "preview-finalized";
         }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
-          params.onPreviewDelivered?.(text);
+          params.onPreviewDelivered?.(text, previewMessageId ?? lane.stream?.messageId());
           return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -109,7 +109,7 @@ type TryUpdatePreviewParams = {
   previewTextSnapshot?: string;
 };
 
-type PreviewEditResult = "edited" | "retained" | "fallback";
+type PreviewEditResult = "edited" | "retained" | "regressive-skipped" | "fallback";
 
 type ConsumeArchivedAnswerPreviewParams = {
   lane: DraftLaneState;
@@ -340,7 +340,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (shouldSkipRegressive) {
         params.markDelivered();
-        return "edited";
+        return "regressive-skipped";
       }
       return editPreview(
         previewMessageId,
@@ -430,6 +430,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (finalized === "edited") {
         params.onPreviewDelivered?.(text, archivedPreview.messageId);
+        return "preview-finalized";
+      }
+      if (finalized === "regressive-skipped") {
+        // Kept the longer preview; emit hook with actual visible content.
+        const visibleText = archivedPreview.textSnapshot ?? text;
+        params.onPreviewDelivered?.(visibleText, archivedPreview.messageId);
         return "preview-finalized";
       }
       if (finalized === "retained") {
@@ -530,6 +536,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           params.onPreviewDelivered?.(text, previewMessageId ?? lane.stream?.messageId());
           return "preview-finalized";
         }
+        if (finalized === "regressive-skipped") {
+          markActivePreviewComplete(laneName);
+          // The final text was shorter than the visible preview, so we kept the
+          // preview. Emit the hook with the actual visible content (lastPartialText).
+          const visibleText = lane.lastPartialText ?? text;
+          params.onPreviewDelivered?.(visibleText, previewMessageId ?? lane.stream?.messageId());
+          return "preview-finalized";
+        }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
           // Do not emit onPreviewDelivered for retained paths — the edit
@@ -575,7 +589,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         skipRegressive: "always",
         context: "update",
       });
-      if (updated === "edited") {
+      if (updated === "edited" || updated === "regressive-skipped") {
         return "preview-updated";
       }
     }

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -83,7 +83,7 @@ type CreateLaneTextDelivererParams = {
   deletePreviewMessage: (messageId: number) => Promise<void>;
   log: (message: string) => void;
   markDelivered: () => void;
-  /** Called when a preview-finalized or preview-retained path delivers without sendPayload. */
+  /** Called when a preview is successfully finalized without going through sendPayload. */
   onPreviewDelivered?: (content: string, messageId?: number) => void;
 };
 

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -431,11 +431,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       if (finalized === "edited") {
         params.onPreviewDelivered?.(text, archivedPreview.messageId);
         return "preview-finalized";
-      }
-      if (finalized === "regressive-skipped") {
-        // Kept the longer preview; emit hook with actual visible content.
-        params.onPreviewDelivered?.(archivedPreview.textSnapshot, archivedPreview.messageId);
-        return "preview-finalized";
+        const visibleText = archivedPreview.textSnapshot;
+        params.onPreviewDelivered?.(visibleText, archivedPreview.messageId);
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -434,7 +434,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
-        params.onPreviewDelivered?.(text, archivedPreview.messageId);
+        // Do not emit onPreviewDelivered for retained paths — the edit
+        // failed/was ambiguous, so the visible message may still be stale.
         return "preview-retained";
       }
     }
@@ -531,7 +532,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
-          params.onPreviewDelivered?.(text, previewMessageId ?? lane.stream?.messageId());
+          // Do not emit onPreviewDelivered for retained paths — the edit
+          // failed/was ambiguous, so the visible message may still be stale.
           return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -83,6 +83,8 @@ type CreateLaneTextDelivererParams = {
   deletePreviewMessage: (messageId: number) => Promise<void>;
   log: (message: string) => void;
   markDelivered: () => void;
+  /** Called when a preview-finalized or preview-retained path delivers without sendPayload. */
+  onPreviewDelivered?: (content: string) => void;
 };
 
 type DeliverLaneTextParams = {
@@ -427,10 +429,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
       if (finalized === "edited") {
+        params.onPreviewDelivered?.(text);
         return "preview-finalized";
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
+        params.onPreviewDelivered?.(text);
         return "preview-retained";
       }
     }
@@ -506,6 +510,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           });
           if (materialized) {
             markActivePreviewComplete(laneName);
+            params.onPreviewDelivered?.(text);
             return "preview-finalized";
           }
         }
@@ -520,10 +525,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         });
         if (finalized === "edited") {
           markActivePreviewComplete(laneName);
+          params.onPreviewDelivered?.(text);
           return "preview-finalized";
         }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
+          params.onPreviewDelivered?.(text);
           return "preview-retained";
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -434,8 +434,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       if (finalized === "regressive-skipped") {
         // Kept the longer preview; emit hook with actual visible content.
-        const visibleText = archivedPreview.textSnapshot ?? text;
-        params.onPreviewDelivered?.(visibleText, archivedPreview.messageId);
+        params.onPreviewDelivered?.(archivedPreview.textSnapshot, archivedPreview.messageId);
         return "preview-finalized";
       }
       if (finalized === "retained") {
@@ -540,8 +539,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           markActivePreviewComplete(laneName);
           // The final text was shorter than the visible preview, so we kept the
           // preview. Emit the hook with the actual visible content (lastPartialText).
-          const visibleText = lane.lastPartialText ?? text;
-          params.onPreviewDelivered?.(visibleText, previewMessageId ?? lane.stream?.messageId());
+          params.onPreviewDelivered?.(
+            lane.lastPartialText,
+            previewMessageId ?? lane.stream?.messageId(),
+          );
           return "preview-finalized";
         }
         if (finalized === "retained") {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -57,11 +57,14 @@ export type ArchivedPreview = {
 export type LanePreviewLifecycle = "transient" | "complete";
 
 export type LaneDeliveryResult =
-  | "preview-finalized"
-  | "preview-retained"
-  | "preview-updated"
-  | "sent"
-  | "skipped";
+  | {
+      kind: "preview-finalized";
+      delivery: {
+        content: string;
+        messageId?: number;
+      };
+    }
+  | { kind: "preview-retained" | "preview-updated" | "sent" | "skipped" };
 
 type CreateLaneTextDelivererParams = {
   lanes: Record<LaneName, DraftLaneState>;
@@ -83,8 +86,6 @@ type CreateLaneTextDelivererParams = {
   deletePreviewMessage: (messageId: number) => Promise<void>;
   log: (message: string) => void;
   markDelivered: () => void;
-  /** Called when a preview is successfully finalized without going through sendPayload. */
-  onPreviewDelivered?: (content: string, messageId?: number) => void;
 };
 
 type DeliverLaneTextParams = {
@@ -134,6 +135,16 @@ type PreviewTargetResolution = {
   previewMessageId: number | undefined;
   stopCreatesFirstPreview: boolean;
 };
+
+function result(
+  kind: LaneDeliveryResult["kind"],
+  delivery?: Extract<LaneDeliveryResult, { kind: "preview-finalized" }>["delivery"],
+): LaneDeliveryResult {
+  if (kind === "preview-finalized") {
+    return { kind, delivery: delivery! };
+  }
+  return { kind };
+}
 
 function shouldSkipRegressivePreviewUpdate(args: {
   currentPreviewText: string | undefined;
@@ -429,16 +440,20 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
       if (finalized === "edited") {
-        params.onPreviewDelivered?.(text, archivedPreview.messageId);
-        return "preview-finalized";
-        const visibleText = archivedPreview.textSnapshot;
-        params.onPreviewDelivered?.(visibleText, archivedPreview.messageId);
+        return result("preview-finalized", {
+          content: text,
+          messageId: archivedPreview.messageId,
+        });
+      }
+      if (finalized === "regressive-skipped") {
+        return result("preview-finalized", {
+          content: archivedPreview.textSnapshot,
+          messageId: archivedPreview.messageId,
+        });
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
-        // Do not emit onPreviewDelivered for retained paths — the edit
-        // failed/was ambiguous, so the visible message may still be stale.
-        return "preview-retained";
+        return result("preview-retained");
       }
     }
     // Send the replacement message first, then clean up the old preview.
@@ -455,7 +470,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         );
       }
     }
-    return delivered ? "sent" : "skipped";
+    return delivered ? result("sent") : result("skipped");
   };
 
   return async ({
@@ -513,8 +528,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           });
           if (typeof materializedMessageId === "number") {
             markActivePreviewComplete(laneName);
-            params.onPreviewDelivered?.(text, materializedMessageId);
-            return "preview-finalized";
+            return result("preview-finalized", {
+              content: text,
+              messageId: materializedMessageId,
+            });
           }
         }
         const previewMessageId = lane.stream?.messageId();
@@ -529,24 +546,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         });
         if (finalized === "edited") {
           markActivePreviewComplete(laneName);
-          params.onPreviewDelivered?.(text, previewMessageId ?? lane.stream?.messageId());
-          return "preview-finalized";
+          return result("preview-finalized", {
+            content: text,
+            messageId: previewMessageId ?? lane.stream?.messageId(),
+          });
         }
         if (finalized === "regressive-skipped") {
           markActivePreviewComplete(laneName);
-          // The final text was shorter than the visible preview, so we kept the
-          // preview. Emit the hook with the actual visible content (lastPartialText).
-          params.onPreviewDelivered?.(
-            lane.lastPartialText,
-            previewMessageId ?? lane.stream?.messageId(),
-          );
-          return "preview-finalized";
+          return result("preview-finalized", {
+            content: lane.lastPartialText,
+            messageId: previewMessageId ?? lane.stream?.messageId(),
+          });
         }
         if (finalized === "retained") {
           markActivePreviewComplete(laneName);
-          // Do not emit onPreviewDelivered for retained paths — the edit
-          // failed/was ambiguous, so the visible message may still be stale.
-          return "preview-retained";
+          return result("preview-retained");
         }
       } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {
         params.log(
@@ -555,7 +569,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       await params.stopDraftLane(lane);
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-      return delivered ? "sent" : "skipped";
+      return delivered ? result("sent") : result("skipped");
     }
 
     if (allowPreviewUpdateForNonFinal && canEditViaPreview) {
@@ -571,11 +585,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             `telegram: ${laneName} draft preview update not emitted; falling back to standard send`,
           );
           const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-          return delivered ? "sent" : "skipped";
+          return delivered ? result("sent") : result("skipped");
         }
         lane.lastPartialText = text;
         params.markDelivered();
-        return "preview-updated";
+        return result("preview-updated");
       }
       const updated = await tryUpdatePreviewForLane({
         lane,
@@ -588,11 +602,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         context: "update",
       });
       if (updated === "edited" || updated === "regressive-skipped") {
-        return "preview-updated";
+        return result("preview-updated");
       }
     }
 
     const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-    return delivered ? "sent" : "skipped";
+    return delivered ? result("sent") : result("skipped");
   };
 }

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -617,6 +617,20 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
   });
 
+  it("calls onPreviewDelivered when stop creates first preview", async () => {
+    const harness = createHarness({ answerMessageIdAfterStop: 777 });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final", 777);
+  });
+
   it("calls onPreviewDelivered with visible preview text on regressive-skip", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.lanes.answer.lastPartialText = "Recovered final answer.";

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -567,14 +567,14 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 999);
   });
 
-  it("calls onPreviewDelivered when preview is retained on ambiguous error", async () => {
+  it("does not call onPreviewDelivered when preview is retained on ambiguous error", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
     expect(result).toBe("preview-retained");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 999);
+    expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
   });
 
   it("calls onPreviewDelivered when DM draft preview is materialized", async () => {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -564,7 +564,7 @@ describe("createLaneTextDeliverer", () => {
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
     expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 999);
   });
 
   it("calls onPreviewDelivered when preview is retained on ambiguous error", async () => {
@@ -574,7 +574,7 @@ describe("createLaneTextDeliverer", () => {
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
     expect(result).toBe("preview-retained");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 999);
   });
 
   it("calls onPreviewDelivered when DM draft preview is materialized", async () => {
@@ -595,7 +595,7 @@ describe("createLaneTextDeliverer", () => {
     });
 
     expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final", 321);
   });
 
   it("calls onPreviewDelivered when archived preview is finalized", async () => {
@@ -605,7 +605,7 @@ describe("createLaneTextDeliverer", () => {
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
     expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 5555);
   });
 
   it("does not call onPreviewDelivered when falling back to sendPayload", async () => {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -44,6 +44,7 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
+  const onPreviewDelivered = vi.fn();
   const activePreviewLifecycleByLane = { answer: "transient", reasoning: "transient" } as const;
   const retainPreviewOnCleanupByLane = { answer: false, reasoning: false } as const;
   const archivedAnswerPreviews: Array<{
@@ -66,6 +67,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onPreviewDelivered,
   });
 
   return {
@@ -82,6 +84,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onPreviewDelivered,
     archivedAnswerPreviews,
   };
 }
@@ -551,5 +554,66 @@ describe("createLaneTextDeliverer", () => {
       expect.objectContaining({ text: "Final with media", mediaUrl: "file:///tmp/example.png" }),
     );
     expect(harness.deletePreviewMessage).toHaveBeenCalledWith(4444);
+  });
+
+  // ── onPreviewDelivered hook emission tests ───────────────────────────────
+
+  it("calls onPreviewDelivered when preview is finalized via edit", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("calls onPreviewDelivered when preview is retained on ambiguous error", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-retained");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("calls onPreviewDelivered when DM draft preview is materialized", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft", messageId: 321 });
+    answerStream.materialize.mockResolvedValue(321);
+    answerStream.update.mockImplementation(() => {});
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Hello final",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final");
+  });
+
+  it("calls onPreviewDelivered when archived preview is finalized", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    seedArchivedAnswerPreview(harness);
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL);
+  });
+
+  it("does not call onPreviewDelivered when falling back to sendPayload", async () => {
+    const harness = createHarness();
+
+    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
+
+    expect(result).toBe("sent");
+    expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -616,4 +616,20 @@ describe("createLaneTextDeliverer", () => {
     expect(result).toBe("sent");
     expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
   });
+
+  it("calls onPreviewDelivered with visible preview text on regressive-skip", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.lastPartialText = "Recovered final answer.";
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Recovered final answer",
+      payload: { text: "Recovered final answer" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    // Hook receives the longer visible preview text, not the shorter final text.
+    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Recovered final answer.", 999);
+  });
 });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../../src/auto-reply/types.js";
 import { createTestDraftStream } from "./draft-stream.test-helpers.js";
-import { createLaneTextDeliverer, type DraftLaneState, type LaneName } from "./lane-delivery.js";
+import {
+  createLaneTextDeliverer,
+  type DraftLaneState,
+  type LaneDeliveryResult,
+  type LaneName,
+} from "./lane-delivery.js";
 
 const HELLO_FINAL = "Hello final";
 
@@ -44,7 +49,6 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
-  const onPreviewDelivered = vi.fn();
   const activePreviewLifecycleByLane = { answer: "transient", reasoning: "transient" } as const;
   const retainPreviewOnCleanupByLane = { answer: false, reasoning: false } as const;
   const archivedAnswerPreviews: Array<{
@@ -67,7 +71,6 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
-    onPreviewDelivered,
   });
 
   return {
@@ -84,7 +87,6 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
-    onPreviewDelivered,
     archivedAnswerPreviews,
   };
 }
@@ -104,7 +106,7 @@ async function expectFinalPreviewRetained(params: {
   expectedLogSnippet?: string;
 }) {
   const result = await deliverFinalAnswer(params.harness, params.text ?? HELLO_FINAL);
-  expect(result).toBe("preview-retained");
+  expect(result.kind).toBe("preview-retained");
   expect(params.harness.sendPayload).not.toHaveBeenCalled();
   if (params.expectedLogSnippet) {
     expect(params.harness.log).toHaveBeenCalledWith(
@@ -127,7 +129,7 @@ async function expectFinalEditFallbackToSend(params: {
   expectedLogSnippet: string;
 }) {
   const result = await deliverFinalAnswer(params.harness, params.text);
-  expect(result).toBe("sent");
+  expect(result.kind).toBe("sent");
   expect(params.harness.editPreview).toHaveBeenCalledTimes(1);
   expect(params.harness.sendPayload).toHaveBeenCalledWith(
     expect.objectContaining({ text: params.text }),
@@ -137,13 +139,23 @@ async function expectFinalEditFallbackToSend(params: {
   );
 }
 
+function expectPreviewFinalized(
+  result: LaneDeliveryResult,
+): Extract<LaneDeliveryResult, { kind: "preview-finalized" }>["delivery"] {
+  expect(result.kind).toBe("preview-finalized");
+  if (result.kind !== "preview-finalized") {
+    throw new Error(`expected preview-finalized, got ${result.kind}`);
+  }
+  return result.delivery;
+}
+
 describe("createLaneTextDeliverer", () => {
   it("finalizes text-only replies by editing an existing preview message", async () => {
     const harness = createHarness({ answerMessageId: 999 });
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({ content: HELLO_FINAL, messageId: 999 });
     expect(harness.editPreview).toHaveBeenCalledWith(
       expect.objectContaining({
         laneName: "answer",
@@ -167,7 +179,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({ content: "no problem", messageId: 777 });
     expect(harness.answer.stream?.update).toHaveBeenCalledWith("no problem");
     expect(harness.editPreview).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -190,7 +202,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-retained");
+    expect(result.kind).toBe("preview-retained");
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
@@ -208,7 +220,7 @@ describe("createLaneTextDeliverer", () => {
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({ content: HELLO_FINAL, messageId: 999 });
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
@@ -247,7 +259,7 @@ describe("createLaneTextDeliverer", () => {
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: HELLO_FINAL }),
     );
@@ -276,7 +288,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.editPreview).not.toHaveBeenCalled();
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Short final" }),
@@ -294,7 +306,10 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({
+      content: "Recovered final answer.",
+      messageId: 999,
+    });
     expect(harness.editPreview).not.toHaveBeenCalled();
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
@@ -311,7 +326,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.editPreview).not.toHaveBeenCalled();
     expect(harness.sendPayload).toHaveBeenCalledWith(expect.objectContaining({ text: longText }));
     expect(harness.log).toHaveBeenCalledWith(expect.stringContaining("preview final too long"));
@@ -334,7 +349,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({ content: "Hello final", messageId: 321 });
     expect(harness.flushDraftLane).toHaveBeenCalled();
     expect(answerStream.materialize).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
@@ -363,7 +378,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("preview-finalized");
+    expect(expectPreviewFinalized(result)).toEqual({ content: "Final answer", messageId: 654 });
     expect(answerStream.materialize).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
@@ -380,7 +395,7 @@ describe("createLaneTextDeliverer", () => {
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(answerStream.materialize).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: HELLO_FINAL }),
@@ -405,7 +420,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Image incoming", mediaUrl: "file:///tmp/example.png" }),
     );
@@ -428,7 +443,7 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Choose one" }),
     );
@@ -459,7 +474,7 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Complete final answer" }),
     );
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.deletePreviewMessage).toHaveBeenCalledWith(5555);
   });
 
@@ -472,10 +487,28 @@ describe("createLaneTextDeliverer", () => {
 
     expect(harness.editPreview).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).not.toHaveBeenCalled();
-    expect(result).toBe("preview-retained");
+    expect(result.kind).toBe("preview-retained");
     expect(harness.log).toHaveBeenCalledWith(
       expect.stringContaining("edit target missing; keeping alternate preview without fallback"),
     );
+  });
+
+  it("keeps the archived preview when the final text regresses", async () => {
+    const harness = createHarness();
+    harness.archivedAnswerPreviews.push({
+      messageId: 5555,
+      textSnapshot: "Recovered final answer.",
+      deleteIfUnused: true,
+    });
+
+    const result = await deliverFinalAnswer(harness, "Recovered final answer");
+
+    expect(expectPreviewFinalized(result)).toEqual({
+      content: "Recovered final answer.",
+      messageId: 5555,
+    });
+    expect(harness.editPreview).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
   it("falls back on 4xx client rejection with error_code during final", async () => {
@@ -508,7 +541,7 @@ describe("createLaneTextDeliverer", () => {
 
     const result = await deliverFinalAnswer(harness, HELLO_FINAL);
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: HELLO_FINAL }),
     );
@@ -549,101 +582,10 @@ describe("createLaneTextDeliverer", () => {
       infoKind: "final",
     });
 
-    expect(result).toBe("sent");
+    expect(result.kind).toBe("sent");
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Final with media", mediaUrl: "file:///tmp/example.png" }),
     );
     expect(harness.deletePreviewMessage).toHaveBeenCalledWith(4444);
-  });
-
-  // ── onPreviewDelivered hook emission tests ───────────────────────────────
-
-  it("calls onPreviewDelivered when preview is finalized via edit", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-
-    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
-
-    expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 999);
-  });
-
-  it("does not call onPreviewDelivered when preview is retained on ambiguous error", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-    harness.editPreview.mockRejectedValue(new Error("500: Internal Server Error"));
-
-    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
-
-    expect(result).toBe("preview-retained");
-    expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
-  });
-
-  it("calls onPreviewDelivered when DM draft preview is materialized", async () => {
-    const answerStream = createTestDraftStream({ previewMode: "draft", messageId: 321 });
-    answerStream.materialize.mockResolvedValue(321);
-    answerStream.update.mockImplementation(() => {});
-    const harness = createHarness({
-      answerStream: answerStream as DraftLaneState["stream"],
-      answerHasStreamedMessage: true,
-      answerLastPartialText: "Hello final",
-    });
-
-    const result = await harness.deliverLaneText({
-      laneName: "answer",
-      text: "Hello final",
-      payload: { text: "Hello final" },
-      infoKind: "final",
-    });
-
-    expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final", 321);
-  });
-
-  it("calls onPreviewDelivered when archived preview is finalized", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-    seedArchivedAnswerPreview(harness);
-
-    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
-
-    expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith(HELLO_FINAL, 5555);
-  });
-
-  it("does not call onPreviewDelivered when falling back to sendPayload", async () => {
-    const harness = createHarness();
-
-    const result = await deliverFinalAnswer(harness, HELLO_FINAL);
-
-    expect(result).toBe("sent");
-    expect(harness.onPreviewDelivered).not.toHaveBeenCalled();
-  });
-
-  it("calls onPreviewDelivered when stop creates first preview", async () => {
-    const harness = createHarness({ answerMessageIdAfterStop: 777 });
-
-    const result = await harness.deliverLaneText({
-      laneName: "answer",
-      text: "Hello final",
-      payload: { text: "Hello final" },
-      infoKind: "final",
-    });
-
-    expect(result).toBe("preview-finalized");
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Hello final", 777);
-  });
-
-  it("calls onPreviewDelivered with visible preview text on regressive-skip", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-    harness.lanes.answer.lastPartialText = "Recovered final answer.";
-
-    const result = await harness.deliverLaneText({
-      laneName: "answer",
-      text: "Recovered final answer",
-      payload: { text: "Recovered final answer" },
-      infoKind: "final",
-    });
-
-    expect(result).toBe("preview-finalized");
-    // Hook receives the longer visible preview text, not the shorter final text.
-    expect(harness.onPreviewDelivered).toHaveBeenCalledWith("Recovered final answer.", 999);
   });
 });


### PR DESCRIPTION
## Summary
- Emit `message:sent` hook when Telegram streaming preview is finalized, not just on `sendPayload` path
- Add `messageId` to the preview-delivered callback for parity with normal delivery
- Skip hook emission for `preview-retained` paths where delivery is uncertain

Closes #50878