### PR TITLE
docs: format plugins tool reference table

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -65,14 +65,14 @@ marketplace source with `--marketplace`.
 
 These are published to npm and installed with `openclaw plugins install`:
 
-| Plugin          | Package                | Docs                               |
-| --------------- | ---------------------- | ---------------------------------- |
-| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)         |
+| Plugin          | Package                | Docs                                 |
+| --------------- | ---------------------- | ------------------------------------ |
+| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)           |
 | Microsoft Teams | `@openclaw/msteams`    | [Microsoft Teams](/channels/msteams) |
-| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)           |
-| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)  |
-| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)             |
-| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser) |
+| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)             |
+| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)    |
+| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)               |
+| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser)   |
 
 Microsoft Teams is plugin-only as of 2026.1.15.
 


### PR DESCRIPTION
## Summary
- format the official plugins table in `docs/tools/plugin.md`
- align the table spacing with `oxfmt`
- remove the docs-only formatting blocker from `check` / `check-docs`

## Change Type (select all)
- [x] Documentation

## Scope (select all touched areas)
- [x] Docs / examples

## Linked Issue/PR
- Related #50741

## User-visible / Behavior Changes
None. This is a docs formatting-only change.

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: Windows 11
- Runtime/container: local workspace
- Relevant config (redacted): None

### Steps
1. Run `pnpm exec oxfmt --check docs/tools/plugin.md` on `main`.
2. Observe the table alignment failure in `docs/tools/plugin.md`.
3. Apply `oxfmt` to the file and re-run the same check.

### Expected
- `docs/tools/plugin.md` is formatted and `oxfmt --check` passes.

### Actual
- Fixed by this PR.

## Evidence
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted local verification:
`pnpm exec oxfmt --check docs/tools/plugin.md`

Result:
- `All matched files use the correct format.`

## Human Verification (required)
What you personally verified (not just CI), and how:
- Verified the table in `docs/tools/plugin.md` is the only changed content.
- Verified `pnpm exec oxfmt --check docs/tools/plugin.md` passes locally.
- Did **not** run full `pnpm check:docs` on this Windows machine because the script shells through `xargs`, which is unavailable in the current local environment.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `docs/tools/plugin.md`
- Known bad symptoms reviewers should watch for: none beyond docs formatting drift

AI-assisted: yes. I verified the formatting change locally.