### PR TITLE
fix: mid-turn 429 rate limit silent no-reply and context engine registration failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/SDK: thread `moduleUrl` through plugin-sdk alias resolution so user-installed plugins outside the openclaw directory (e.g. `~/.openclaw/extensions/`) correctly resolve `openclaw/plugin-sdk/*` subpath imports, and gate `plugin-sdk:check-exports` in `release:check`. (#54283) Thanks @xieyongliang.
 - Telegram/pairing: ignore self-authored DM `message` updates so bot-pinned status cards and similar service updates do not trigger bogus pairing requests or re-enter inbound dispatch. (#54530) thanks @huntharo
 - iMessage: stop leaking inline `[[reply_to:...]]` tags into delivered text by sending `reply_to` as RPC metadata and stripping stray directive tags from outbound messages. (#39512) Thanks @mvanhorn.
+- Agents/embedded replies: surface mid-turn 429 and overload failures when embedded runs end without a user-visible reply, while preserving successful media-only replies that still use legacy `mediaUrl`. (#50930) Thanks @infichen.
 
 ## 2026.3.24
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1603,6 +1603,13 @@ export async function runEmbeddedPiAgent(
           // loop (see #8643). The captured lastAssistant has a non-terminal
           // stopReason (e.g. "toolUse") with no text content, producing empty
           // payloads. Surface an error instead of silently dropping the reply.
+          //
+          // Exclusions:
+          //  - didSendDeterministicApprovalPrompt: approval-prompt turns
+          //    intentionally produce empty payloads with stopReason=toolUse
+          //  - lastToolError: suppressed/recoverable tool failures also produce
+          //    empty payloads with stopReason=toolUse; those are handled by
+          //    buildEmbeddedRunPayloads' own warning policy
           if (
             payloads.length === 0 &&
             !aborted &&
@@ -1610,7 +1617,8 @@ export async function runEmbeddedPiAgent(
             !attempt.didSendViaMessagingTool &&
             !attempt.clientToolCall &&
             !attempt.yieldDetected &&
-            !attempt.didSendDeterministicApprovalPrompt
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !attempt.lastToolError
           ) {
             const incompleteStopReason = lastAssistant?.stopReason;
             // Only trigger for non-terminal stop reasons (toolUse, etc.) to
@@ -1625,11 +1633,7 @@ export async function runEmbeddedPiAgent(
               return {
                 payloads: [
                   {
-                    text:
-                      incompleteStopReason === "toolUse"
-                        ? "⚠️ API rate limit reached mid-turn — the model couldn't generate a response " +
-                          "after tool calls completed. Please try again in a moment."
-                        : "⚠️ Agent couldn't generate a response after tool calls completed. Please try again.",
+                    text: "⚠️ Agent couldn't generate a response. Please try again.",
                     isError: true,
                   },
                 ],

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1615,7 +1615,6 @@ export async function runEmbeddedPiAgent(
             payloads.length === 0 &&
             !aborted &&
             !timedOut &&
-            !attempt.didSendViaMessagingTool &&
             !attempt.clientToolCall &&
             !attempt.yieldDetected &&
             !attempt.didSendDeterministicApprovalPrompt &&

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1634,9 +1634,7 @@ export async function runEmbeddedPiAgent(
               // Mark the failing profile for cooldown so multi-profile setups
               // rotate away from the exhausted credential on the next turn.
               if (lastProfileId) {
-                const failoverReason = classifyFailoverReason(
-                  lastAssistant?.errorMessage ?? "",
-                );
+                const failoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
                 await maybeMarkAuthProfileFailure({
                   profileId: lastProfileId,
                   reason: resolveAuthProfileFailureReason(failoverReason),

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -64,6 +64,7 @@ import {
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
+import { isLikelyMutatingToolName } from "../tool-mutation.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
@@ -1630,10 +1631,32 @@ export async function runEmbeddedPiAgent(
                 `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                   `stopReason=${incompleteStopReason} payloads=0 — surfacing error to user`,
               );
+
+              // Mark the failing profile for cooldown so multi-profile setups
+              // rotate away from the exhausted credential on the next turn.
+              if (lastProfileId) {
+                const failoverReason = classifyFailoverReason(
+                  lastAssistant?.errorMessage ?? "",
+                );
+                await maybeMarkAuthProfileFailure({
+                  profileId: lastProfileId,
+                  reason: resolveAuthProfileFailureReason(failoverReason),
+                });
+              }
+
+              // Warn about potential side-effects when mutating tools executed
+              // before the turn was interrupted, so users don't blindly retry.
+              const hadMutatingTools = attempt.toolMetas.some((t) =>
+                isLikelyMutatingToolName(t.toolName),
+              );
+              const errorText = hadMutatingTools
+                ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
+                : "⚠️ Agent couldn't generate a response. Please try again.";
+
               return {
                 payloads: [
                   {
-                    text: "⚠️ Agent couldn't generate a response. Please try again.",
+                    text: errorText,
                     isError: true,
                   },
                 ],

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1596,6 +1596,56 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          // Detect incomplete turns where prompt() resolved prematurely due to
+          // pi-agent-core's auto-retry timing issue: when a mid-turn 429/overload
+          // triggers an internal retry, waitForRetry() resolves on the next
+          // assistant message *before* tool execution completes in the retried
+          // loop (see #8643). The captured lastAssistant has a non-terminal
+          // stopReason (e.g. "toolUse") with no text content, producing empty
+          // payloads. Surface an error instead of silently dropping the reply.
+          if (
+            payloads.length === 0 &&
+            !aborted &&
+            !timedOut &&
+            !attempt.didSendViaMessagingTool &&
+            !attempt.clientToolCall &&
+            !attempt.yieldDetected
+          ) {
+            const incompleteStopReason = lastAssistant?.stopReason;
+            // Only trigger for non-terminal stop reasons (toolUse, etc.) to
+            // avoid false positives when the model legitimately produces no text.
+            // StopReason union: "aborted" | "error" | "length" | "toolUse"
+            // "toolUse" is the key signal that prompt() resolved mid-turn.
+            if (incompleteStopReason === "toolUse" || incompleteStopReason === "error") {
+              log.warn(
+                `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `stopReason=${incompleteStopReason} payloads=0 — surfacing error to user`,
+              );
+              return {
+                payloads: [
+                  {
+                    text:
+                      "⚠️ API rate limit reached mid-turn — the model couldn't generate a response " +
+                      "after tool calls completed. Please try again in a moment.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta,
+                  aborted,
+                  systemPromptReport: attempt.systemPromptReport,
+                },
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                messagingToolSentTexts: attempt.messagingToolSentTexts,
+                messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                messagingToolSentTargets: attempt.messagingToolSentTargets,
+                successfulCronAdds: attempt.successfulCronAdds,
+              };
+            }
+          }
+
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1609,7 +1609,8 @@ export async function runEmbeddedPiAgent(
             !timedOut &&
             !attempt.didSendViaMessagingTool &&
             !attempt.clientToolCall &&
-            !attempt.yieldDetected
+            !attempt.yieldDetected &&
+            !attempt.didSendDeterministicApprovalPrompt
           ) {
             const incompleteStopReason = lastAssistant?.stopReason;
             // Only trigger for non-terminal stop reasons (toolUse, etc.) to
@@ -1625,8 +1626,10 @@ export async function runEmbeddedPiAgent(
                 payloads: [
                   {
                     text:
-                      "⚠️ API rate limit reached mid-turn — the model couldn't generate a response " +
-                      "after tool calls completed. Please try again in a moment.",
+                      incompleteStopReason === "toolUse"
+                        ? "⚠️ API rate limit reached mid-turn — the model couldn't generate a response " +
+                          "after tool calls completed. Please try again in a moment."
+                        : "⚠️ Agent couldn't generate a response after tool calls completed. Please try again.",
                     isError: true,
                   },
                 ],

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -61,6 +61,7 @@ export type EmbeddedPiRunResult = {
     mediaUrls?: string[];
     replyToId?: string;
     isError?: boolean;
+    isReasoning?: boolean;
   }>;
   meta: EmbeddedPiRunMeta;
   // True if a messaging tool (telegram, whatsapp, discord, slack, sessions_send)

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -708,9 +708,12 @@ export async function runAgentTurnWithFallback(params: {
   // error payload into runResult so it flows through the normal
   // kind:"success" path — preserving streaming dedup, message_send
   // suppression, and usage/model metadata updates.
-  if (runResult && !runResult.didSendViaMessagingTool) {
+  if (runResult) {
     const hasNonErrorContent = runResult.payloads?.some(
-      (p) => !p.isError && (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
+      (p) =>
+        !p.isError &&
+        !p.isReasoning &&
+        (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
     );
     if (!hasNonErrorContent) {
       const metaErrorMsg = finalEmbeddedError?.message ?? "";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -719,7 +719,7 @@ export async function runAgentTurnWithFallback(params: {
         return {
           kind: "final",
           payload: {
-            text: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+            text: "⚠️ API rate limit reached — the model couldn't generate a response. Please try again in a moment.",
           },
         };
       }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
@@ -710,10 +713,7 @@ export async function runAgentTurnWithFallback(params: {
   // suppression, and usage/model metadata updates.
   if (runResult) {
     const hasNonErrorContent = runResult.payloads?.some(
-      (p) =>
-        !p.isError &&
-        !p.isReasoning &&
-        (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
+      (p) => !p.isError && !p.isReasoning && hasOutboundReplyContent(p, { trimText: true }),
     );
     if (!hasNonErrorContent) {
       const metaErrorMsg = finalEmbeddedError?.message ?? "";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -702,26 +702,32 @@ export async function runAgentTurnWithFallback(params: {
   // avoid self-matching on pre-formatted "⚠️" messages from run.ts, and
   // skip already-formatted payloads so tool-specific 429 errors (e.g.
   // browser/search tool failures) are preserved rather than overwritten.
-  {
-    const hasNonErrorContent = runResult?.payloads?.some(
+  //
+  // Instead of early-returning kind:"final" (which would bypass
+  // buildReplyPayloads() filtering and session bookkeeping), inject the
+  // error payload into runResult so it flows through the normal
+  // kind:"success" path — preserving streaming dedup, message_send
+  // suppression, and usage/model metadata updates.
+  if (runResult && !runResult.didSendViaMessagingTool) {
+    const hasNonErrorContent = runResult.payloads?.some(
       (p) => !p.isError && (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
     );
     if (!hasNonErrorContent) {
       const metaErrorMsg = finalEmbeddedError?.message ?? "";
       const rawErrorPayloadText =
-        runResult?.payloads?.find((p) => p.isError && p.text?.trim() && !p.text.startsWith("⚠️"))
+        runResult.payloads?.find((p) => p.isError && p.text?.trim() && !p.text.startsWith("⚠️"))
           ?.text ?? "";
       const errorCandidate = metaErrorMsg || rawErrorPayloadText;
       if (
         errorCandidate &&
         (isRateLimitErrorMessage(errorCandidate) || isOverloadedErrorMessage(errorCandidate))
       ) {
-        return {
-          kind: "final",
-          payload: {
+        runResult.payloads = [
+          {
             text: "⚠️ API rate limit reached — the model couldn't generate a response. Please try again in a moment.",
+            isError: true,
           },
-        };
+        ];
       }
     }
   }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,8 @@ import {
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
+  isOverloadedErrorMessage,
+  isRateLimitErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -680,13 +682,43 @@ export async function runAgentTurnWithFallback(params: {
   // overflow errors were returned as embedded error payloads.
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
-    return {
-      kind: "final",
-      payload: {
-        text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
-      },
-    };
+  if (finalEmbeddedError && !hasPayloadText) {
+    const errorMsg = finalEmbeddedError.message ?? "";
+    if (isContextOverflowError(errorMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+        },
+      };
+    }
+  }
+
+  // Surface rate limit and overload errors that occur mid-turn (after tool
+  // calls) instead of silently returning an empty response. See #36142.
+  // Only applies when the assistant produced no valid (non-error) reply text,
+  // so tool-level rate-limit messages don't override a successful turn.
+  {
+    const hasNonErrorContent = runResult?.payloads?.some(
+      (p) => !p.isError && (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
+    );
+    if (!hasNonErrorContent) {
+      const errorPayloadText =
+        runResult?.payloads?.find((p) => p.isError && p.text?.trim())?.text ?? "";
+      const metaErrorMsg = finalEmbeddedError?.message ?? "";
+      const errorCandidate = errorPayloadText || metaErrorMsg;
+      if (
+        errorCandidate &&
+        (isRateLimitErrorMessage(errorCandidate) || isOverloadedErrorMessage(errorCandidate))
+      ) {
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+          },
+        };
+      }
+    }
   }
 
   return {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -698,15 +698,20 @@ export async function runAgentTurnWithFallback(params: {
   // calls) instead of silently returning an empty response. See #36142.
   // Only applies when the assistant produced no valid (non-error) reply text,
   // so tool-level rate-limit messages don't override a successful turn.
+  // Prioritize metaErrorMsg (raw upstream error) over errorPayloadText to
+  // avoid self-matching on pre-formatted "⚠️" messages from run.ts, and
+  // skip already-formatted payloads so tool-specific 429 errors (e.g.
+  // browser/search tool failures) are preserved rather than overwritten.
   {
     const hasNonErrorContent = runResult?.payloads?.some(
       (p) => !p.isError && (p.text?.trim() || (p.mediaUrls?.length ?? 0) > 0),
     );
     if (!hasNonErrorContent) {
-      const errorPayloadText =
-        runResult?.payloads?.find((p) => p.isError && p.text?.trim())?.text ?? "";
       const metaErrorMsg = finalEmbeddedError?.message ?? "";
-      const errorCandidate = errorPayloadText || metaErrorMsg;
+      const rawErrorPayloadText =
+        runResult?.payloads?.find((p) => p.isError && p.text?.trim() && !p.text.startsWith("⚠️"))
+          ?.text ?? "";
+      const errorCandidate = metaErrorMsg || rawErrorPayloadText;
       if (
         errorCandidate &&
         (isRateLimitErrorMessage(errorCandidate) || isOverloadedErrorMessage(errorCandidate))

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1946,3 +1946,97 @@ describe("runReplyAgent billing error classification", () => {
     expect(payload?.text).not.toContain("Context overflow");
   });
 });
+
+describe("runReplyAgent mid-turn rate-limit fallback", () => {
+  function createRun() {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
+  it("surfaces a final error when only reasoning preceded a mid-turn rate limit", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "reasoning", isReasoning: true }],
+      meta: {
+        error: {
+          kind: "retry_limit",
+          message: "429 Too Many Requests: rate limit exceeded",
+        },
+      },
+    });
+
+    const result = await createRun();
+    const payload = Array.isArray(result) ? result[0] : result;
+
+    expect(payload?.text).toContain("API rate limit reached");
+  });
+
+  it("preserves successful media-only replies that use legacy mediaUrl", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ mediaUrl: "https://example.test/image.png" }],
+      meta: {
+        error: {
+          kind: "retry_limit",
+          message: "429 Too Many Requests: rate limit exceeded",
+        },
+      },
+    });
+
+    const result = await createRun();
+    const payload = Array.isArray(result) ? result[0] : result;
+
+    expect(payload).toMatchObject({
+      mediaUrl: "https://example.test/image.png",
+    });
+    expect(payload?.text).toBeUndefined();
+  });
+});

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -202,6 +202,8 @@ describe("registerPreActionHooks", () => {
   }
 
   it("handles debug mode and plugin-required command preaction", async () => {
+    const processTitleSetSpy = vi.spyOn(process, "title", "set");
+
     await runPreAction({
       parseArgv: ["status"],
       processArgv: ["node", "openclaw", "status", "--debug"],
@@ -214,7 +216,7 @@ describe("registerPreActionHooks", () => {
       commandPath: ["status"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
-    expect(process.title).toBe("openclaw-status");
+    expect(processTitleSetSpy).toHaveBeenCalledWith("openclaw-status");
 
     vi.clearAllMocks();
     await runPreAction({
@@ -229,6 +231,7 @@ describe("registerPreActionHooks", () => {
       commandPath: ["message", "send"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
+    processTitleSetSpy.mockRestore();
   });
 
   it("keeps setup alias and channels add manifest-first", async () => {

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -98,7 +98,6 @@ describe("resolveProviderAuths key normalization", () => {
     suiteCase = 0;
   });
 
-<<<<<<< HEAD
   beforeEach(async () => {
     vi.resetModules();
     ({ resolveProviderAuths } = await import("./provider-usage.auth.js"));

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -7,9 +7,59 @@ import { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 
+vi.mock("../agents/auth-profiles.js", async () => {
+  const profiles = await vi.importActual<typeof import("../agents/auth-profiles/profiles.js")>(
+    "../agents/auth-profiles/profiles.js",
+  );
+  const order = await vi.importActual<typeof import("../agents/auth-profiles/order.js")>(
+    "../agents/auth-profiles/order.js",
+  );
+  const oauth = await vi.importActual<typeof import("../agents/auth-profiles/oauth.js")>(
+    "../agents/auth-profiles/oauth.js",
+  );
+
+  const readStore = (agentDir?: string) => {
+    if (!agentDir) {
+      return { version: 1, profiles: {} };
+    }
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    try {
+      const parsed = JSON.parse(nodeFs.readFileSync(authPath, "utf8")) as {
+        version?: number;
+        profiles?: Record<string, unknown>;
+        order?: Record<string, string[]>;
+        lastGood?: Record<string, string>;
+        usageStats?: Record<string, unknown>;
+      };
+      return {
+        version: parsed.version ?? 1,
+        profiles: parsed.profiles ?? {},
+        ...(parsed.order ? { order: parsed.order } : {}),
+        ...(parsed.lastGood ? { lastGood: parsed.lastGood } : {}),
+        ...(parsed.usageStats ? { usageStats: parsed.usageStats } : {}),
+      };
+    } catch {
+      return { version: 1, profiles: {} };
+    }
+  };
+
+  return {
+    clearRuntimeAuthProfileStoreSnapshots: () => {},
+    ensureAuthProfileStore: (agentDir?: string) => readStore(agentDir),
+    dedupeProfileIds: profiles.dedupeProfileIds,
+    listProfilesForProvider: profiles.listProfilesForProvider,
+    resolveApiKeyForProfile: oauth.resolveApiKeyForProfile,
+    resolveAuthProfileOrder: order.resolveAuthProfileOrder,
+  };
+});
+
 const resolveProviderUsageAuthWithPluginMock = vi.fn(async (..._args: unknown[]) => null);
 
 vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderUsageAuthWithPlugin: resolveProviderUsageAuthWithPluginMock,
+}));
+
+vi.mock("../plugins/provider-runtime.ts", () => ({
   resolveProviderUsageAuthWithPlugin: resolveProviderUsageAuthWithPluginMock,
 }));
 
@@ -17,6 +67,10 @@ vi.mock("../agents/cli-credentials.js", () => ({
   readCodexCliCredentialsCached: () => null,
   readMiniMaxCliCredentialsCached: () => null,
   readQwenCliCredentialsCached: () => null,
+}));
+
+vi.mock("../agents/auth-profiles/external-cli-sync.js", () => ({
+  syncExternalCliCredentials: () => false,
 }));
 
 let resolveProviderAuths: typeof import("./provider-usage.auth.js").resolveProviderAuths;
@@ -44,6 +98,7 @@ describe("resolveProviderAuths key normalization", () => {
     suiteCase = 0;
   });
 
+<<<<<<< HEAD
   beforeEach(async () => {
     vi.resetModules();
     ({ resolveProviderAuths } = await import("./provider-usage.auth.js"));
@@ -64,9 +119,15 @@ describe("resolveProviderAuths key normalization", () => {
   async function withSuiteHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
     const base = path.join(suiteRoot, `case-${++suiteCase}`);
     nodeFs.mkdirSync(base, { recursive: true });
-    nodeFs.mkdirSync(path.join(base, ".openclaw", "agents", "main", "sessions"), {
-      recursive: true,
-    });
+    const stateDir = path.join(base, ".openclaw");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    nodeFs.mkdirSync(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+    nodeFs.mkdirSync(agentDir, { recursive: true });
+    nodeFs.writeFileSync(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify({ version: 1, profiles: {} }, null, 2)}\n`,
+      "utf8",
+    );
     return await fn(base);
   }
 


### PR DESCRIPTION
- Fix legacy.ts: use registerContextEngineForOwner with core owner to bypass public-sdk protection on default slot
- Add incomplete turn detection in run.ts: surface error when prompt() resolves prematurely during mid-turn 429 retry producing empty payloads
- Fix TS2367: use correct StopReason union members (toolUse|error) instead of non-existent end_turn|max_tokens

Fixes issues introduced by PR #47046 (5e293da)

## Summary

- **Problem:** PR #47046 introduced owner-based context engine registration but did not update `legacy.ts`, causing the legacy engine to silently fail registration (public-sdk owner blocked from claiming the protected "legacy" slot). Additionally, mid-turn 429 rate limit detection code never triggers because `prompt()` resolves prematurely with `stopReason: "toolUse"` before the 429 error occurs, leaving `runResult.payloads` as `undefined` — the detection code checks for error payloads that were never built. Finally, `StopReason` type comparisons used non-existent union members (`end_turn`, `max_tokens`), causing TS2367 compile errors.
- **Why it matters:** Users receive no response at all when mid-turn 429 occurs (silent failure), and with the registration bug, the entire agent system is non-functional.
- **What changed:** (1) `legacy.ts` now uses `registerContextEngineForOwner` with `"core"` owner. (2) `run.ts` adds incomplete turn detection: when `buildEmbeddedRunPayloads` produces empty payloads and `lastAssistant.stopReason` is `"toolUse"` or `"error"`, surfaces a user-facing error message. (3) `StopReason` comparisons use correct union members.
- **What did NOT change (scope boundary):** No changes to the agent loop, tool execution pipeline, model fallback mechanism, or session state machine. The upper-layer detection code in `agent-runner-execution.ts` from PR #47046 is preserved as-is (defense-in-depth).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #47046

## User-visible / Behavior Changes

- When a 429 rate limit error occurs mid-turn (after tool calls have executed but before the model generates a final reply), users now receive: `"⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment."` instead of silent no-reply.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js (pnpm)
- Model/provider: Third-party API provider with strict rate limits
- Integration/channel: WeChat (meishi channel)
- Relevant config: Model configured without fallback candidates

### Steps

1. Deploy openclaw with PR #47046 changes applied
2. Send a message that triggers multi-step tool use (e.g., "access PDF files under /opt/cxz/book, summarize the first 3")
3. Agent executes tools (ls, pdftotext) successfully, then hits 429 rate limit on the subsequent model call

### Expected

- User receives an error message indicating rate limit was hit

### Actual (before fix)

- User receives no reply at all (silent failure)
- With the registration bug: user receives `"Context engine "legacy" is not registered. Available engines: (none)"`

## Evidence

- [x] Trace/log snippets
  - Debug log shows: `embedded run prompt end` (stopReason: toolUse) → tool execution → 429 error → `embedded run done` → no delivery. After fix: incomplete turn detected, error payload surfaced to user.
- [x] Human verification on live channel: confirmed error message is now delivered to user after mid-turn 429.

## Human Verification (required)

- Verified scenarios:
  - Context engine registration: agent starts successfully without "not registered" error
  - Mid-turn 429: user receives the rate limit error message on meishi channel
  - `pnpm tsgo`: type-checks pass with no errors on modified files
- Edge cases checked:
  - Normal turns (no 429) are unaffected — `stopReason` is not `"toolUse"` when payloads are built successfully
  - Aborted runs excluded via `!aborted` guard
  - Messaging-tool sends excluded via `!attempt.didSendViaMessagingTool` guard
- What you did **not** verify:
  - FailoverError path (when fallback models are configured)
  - Overload (529) errors (same code path as 429, should work identically)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/agents/pi-embedded-runner/run.ts`, `src/context-engine/legacy.ts`
- Known bad symptoms reviewers should watch for: False-positive "rate limit" errors on normal turns where the model legitimately produces no text content (mitigated by `stopReason` check — only `"toolUse"` and `"error"` trigger the detection)

## Risks and Mitigations

- Risk: False-positive incomplete turn detection on legitimate empty-payload turns with `stopReason: "toolUse"` (e.g., client tool calls)
  - Mitigation: Guarded by `!attempt.clientToolCall`, `!attempt.didSendViaMessagingTool`, `!attempt.yieldDetected`, and `!aborted` checks
- Risk: The upstream sessionKey compatibility code in `registry.ts` was preserved during conflict resolution but not tested in this environment
  - Mitigation: `wrapContextEngineWithSessionKeyCompat` is a transparent proxy that only activates when engines reject `sessionKey` params — no behavioral change for the legacy engine which already accepts `sessionKey`
