### PR TITLE
feat: handle location.update node event in gateway

### DIFF
--- a/apps/ios/Sources/Location/SignificantLocationMonitor.swift
+++ b/apps/ios/Sources/Location/SignificantLocationMonitor.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 import Foundation
+import OSLog
 import OpenClawKit
 
 /// Monitors significant location changes and pushes `location.update`
@@ -7,6 +8,8 @@ import OpenClawKit
 /// the user is at their configured work location.
 @MainActor
 enum SignificantLocationMonitor {
+    nonisolated private static let logger = Logger(subsystem: "ai.openclaw.ios", category: "SignificantLocation")
+
     static func startIfNeeded(
         locationService: any LocationServicing,
         locationMode: OpenClawLocationMode,
@@ -17,6 +20,10 @@ enum SignificantLocationMonitor {
         let status = locationService.authorizationStatus()
         guard status == .authorizedAlways else { return }
         locationService.startMonitoringSignificantLocationChanges { location in
+            let lat = location.coordinate.latitude
+            let lon = location.coordinate.longitude
+            let accuracy = location.horizontalAccuracy
+            logger.info("Significant location change detected lat=\(lat) lon=\(lon) accuracyMeters=\(accuracy)")
             struct Payload: Codable {
                 var lat: Double
                 var lon: Double
@@ -24,18 +31,22 @@ enum SignificantLocationMonitor {
                 var source: String?
             }
             let payload = Payload(
-                lat: location.coordinate.latitude,
-                lon: location.coordinate.longitude,
-                accuracyMeters: location.horizontalAccuracy,
+                lat: lat,
+                lon: lon,
+                accuracyMeters: accuracy,
                 source: "ios-significant-location")
             guard let data = try? JSONEncoder().encode(payload),
                   let json = String(data: data, encoding: .utf8)
-            else { return }
+            else {
+                logger.error("Failed to encode location payload")
+                return
+            }
             Task { @MainActor in
                 if let beforeSend {
                     await beforeSend()
                 }
                 await gateway.sendEvent(event: "location.update", payloadJSON: json)
+                logger.info("location.update sent to gateway")
             }
         }
     }

--- a/apps/ios/Sources/Location/SignificantLocationMonitor.swift
+++ b/apps/ios/Sources/Location/SignificantLocationMonitor.swift
@@ -23,8 +23,8 @@ enum SignificantLocationMonitor {
             let lat = location.coordinate.latitude
             let lon = location.coordinate.longitude
             let accuracy = location.horizontalAccuracy
-            logger.info("Significant location change detected accuracyMeters=\(accuracy)")
-            logger.debug("Location detail lat=\(lat) lon=\(lon)")
+            logger.info("Significant location change detected")
+            logger.debug("Location detail lat=\(lat) lon=\(lon) accuracyMeters=\(accuracy)")
             struct Payload: Codable {
                 var lat: Double
                 var lon: Double

--- a/apps/ios/Sources/Location/SignificantLocationMonitor.swift
+++ b/apps/ios/Sources/Location/SignificantLocationMonitor.swift
@@ -23,7 +23,8 @@ enum SignificantLocationMonitor {
             let lat = location.coordinate.latitude
             let lon = location.coordinate.longitude
             let accuracy = location.horizontalAccuracy
-            logger.info("Significant location change detected lat=\(lat) lon=\(lon) accuracyMeters=\(accuracy)")
+            logger.info("Significant location change detected accuracyMeters=\(accuracy)")
+            logger.debug("Location detail lat=\(lat) lon=\(lon)")
             struct Payload: Codable {
                 var lat: Double
                 var lon: Double

--- a/docs/gateway/bridge-protocol.md
+++ b/docs/gateway/bridge-protocol.md
@@ -53,7 +53,7 @@ authoritative pin without explicit user intent or other out-of-band verification
 Client → Gateway:
 
 - `req` / `res`: scoped gateway RPC (chat, sessions, config, health, voicewake, skills.bins)
-- `event`: node signals (voice transcript, agent request, chat subscribe, exec lifecycle)
+- `event`: node signals (voice transcript, agent request, chat subscribe, exec lifecycle, location update)
 
 Gateway → Client:
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -265,6 +265,7 @@ Notes:
 - Location is **off by default**.
 - “Always” requires system permission; background fetch is best-effort.
 - The response includes lat/lon, accuracy (meters), and timestamp.
+- Nodes can also push `location.update` events via `node.event` for passive location monitoring (e.g. iOS significant location changes). See [Location Command](/nodes/location-command#event-locationupdate) for details.
 
 ## SMS (Android nodes)
 

--- a/docs/nodes/location-command.md
+++ b/docs/nodes/location-command.md
@@ -1,5 +1,5 @@
 ---
-summary: "Location command for nodes (location.get), permission modes, and Android foreground behavior"
+summary: "Location command (location.get) and event (location.update) for nodes, permission modes, and background behavior"
 read_when:
   - Adding location node support or permissions UI
   - Designing Android location permissions or foreground behavior
@@ -78,6 +78,57 @@ Errors (stable codes):
 - `LOCATION_BACKGROUND_UNAVAILABLE`: app is backgrounded but only While Using allowed.
 - `LOCATION_TIMEOUT`: no fix in time.
 - `LOCATION_UNAVAILABLE`: system failure / no providers.
+
+## Event: `location.update`
+
+Nodes can push location updates to the gateway via `node.event` with
+`event: "location.update"`. The gateway enqueues the update as a system event
+so hooks (e.g. severance) can react to location changes.
+
+Payload:
+
+```json
+{
+  "lat": 48.20849,
+  "lon": 16.37208,
+  "accuracyMeters": 12.5,
+  "source": "ios-significant-location"
+}
+```
+
+- `lat` and `lon` are required (finite numbers).
+- `accuracyMeters` and `source` are optional.
+- `sessionKey` is optional; defaults to `node-<nodeId>`.
+
+The gateway deduplicates events per node via `contextKey: location:<nodeId>` and
+triggers a heartbeat wake so the agent session can process the location change.
+
+### Heartbeat delivery
+
+`location.update` is **event-driven, not polling-based**. The gateway:
+
+1. Enqueues the location summary as a system event (`enqueueSystemEvent`).
+2. Immediately triggers `requestHeartbeatNow` with reason `"location-update"`.
+3. The heartbeat runner wakes within 250ms (coalesce window).
+
+The reason `"location-update"` is classified as `"wake"`, which means:
+
+- **File gate bypass**: the heartbeat runs even if `HEARTBEAT.md` is empty.
+- **Pending events inspection**: system events tagged with `location:*` context
+  keys are included in the heartbeat prompt, so the agent sees the location
+  data (lat, lon, accuracy, source) in the same run.
+
+This follows the same tagged-event pattern as cron events (`cron:*` context
+keys). The agent receives the location data as part of its heartbeat prompt
+and can act on it immediately (e.g. record to memory, trigger severance logic).
+
+### iOS significant location monitoring
+
+On iOS, the app uses `SignificantLocationMonitor` to push `location.update`
+events automatically when the "Always" location mode is enabled and
+`authorizedAlways` permission is granted. When the app is backgrounded, the
+monitor wakes the gateway connection before sending (see
+`handleSignificantLocationWakeIfNeeded`).
 
 ## Background behavior
 

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1149,7 +1149,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         getHealthCache: context.getHealthCache,
         refreshHealthSnapshot: context.refreshHealthSnapshot,
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-        logGateway: { warn: context.logGateway.warn },
+        logGateway: { info: context.logGateway.info, warn: context.logGateway.warn },
       };
       await handleNodeEvent(nodeContext, nodeId, {
         event: p.event,

--- a/src/gateway/server-node-events-types.ts
+++ b/src/gateway/server-node-events-types.ts
@@ -27,7 +27,7 @@ export type NodeEventContext = {
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
-  logGateway: { warn: (msg: string) => void };
+  logGateway: { info: (msg: string) => void; warn: (msg: string) => void };
 };
 
 export type NodeEvent = {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -112,7 +112,7 @@ function buildCtx(): NodeEventContext {
     getHealthCache: () => null,
     refreshHealthSnapshot: async () => ({}) as HealthSummary,
     loadGatewayModelCatalog: async () => [],
-    logGateway: { warn: () => {} },
+    logGateway: { info: () => {}, warn: () => {} },
   };
 }
 
@@ -437,7 +437,7 @@ describe("voice transcript events", () => {
   it("does not block agent dispatch when session-store touch fails", async () => {
     const warn = vi.fn();
     const ctx = buildCtx();
-    ctx.logGateway = { warn };
+    ctx.logGateway = { info: () => {}, warn };
     updateSessionStoreMock.mockRejectedValueOnce(new Error("disk down"));
 
     await handleNodeEvent(ctx, "node-v3", {
@@ -620,7 +620,7 @@ describe("agent request events", () => {
   it("disables delivery when route is unresolved instead of falling back globally", async () => {
     const warn = vi.fn();
     const ctx = buildCtx();
-    ctx.logGateway = { warn };
+    ctx.logGateway = { info: () => {}, warn };
 
     await handleNodeEvent(ctx, "node-route-miss", {
       event: "agent.request",

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -592,7 +592,8 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         typeof obj.accuracyMeters === "number" && Number.isFinite(obj.accuracyMeters)
           ? obj.accuracyMeters
           : undefined;
-      const source = normalizeNonEmptyString(obj.source);
+      const rawSource = normalizeNonEmptyString(obj.source);
+      const source = rawSource ? compactNotificationEventText(rawSource) : null;
       const sessionKeyRaw = normalizeNonEmptyString(obj.sessionKey) ?? `node-${nodeId}`;
       const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -578,6 +578,45 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
       return;
     }
+    case "location.update": {
+      const obj = parsePayloadObject(evt.payloadJSON);
+      if (!obj) {
+        return;
+      }
+      const lat = typeof obj.lat === "number" && Number.isFinite(obj.lat) ? obj.lat : null;
+      const lon = typeof obj.lon === "number" && Number.isFinite(obj.lon) ? obj.lon : null;
+      if (lat === null || lon === null) {
+        return;
+      }
+      const accuracyMeters =
+        typeof obj.accuracyMeters === "number" && Number.isFinite(obj.accuracyMeters)
+          ? obj.accuracyMeters
+          : undefined;
+      const source = normalizeNonEmptyString(obj.source);
+      const sessionKeyRaw = normalizeNonEmptyString(obj.sessionKey) ?? `node-${nodeId}`;
+      const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
+
+      let summary = `Location update (node=${nodeId}): lat=${lat} lon=${lon}`;
+      if (accuracyMeters !== undefined) {
+        summary += ` accuracy=${accuracyMeters}m`;
+      }
+      if (source) {
+        summary += ` source=${source}`;
+      }
+
+      ctx.logGateway.info(
+        `location.update received node=${nodeId}` + (source ? ` source=${source}` : ""),
+      );
+
+      const queued = enqueueSystemEvent(summary, {
+        sessionKey,
+        contextKey: `location:${nodeId}`,
+      });
+      if (queued) {
+        requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "location-update" }));
+      }
+      return;
+    }
     case "push.apns.register": {
       const obj = parsePayloadObject(evt.payloadJSON);
       if (!obj) {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -52,6 +52,29 @@ export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string
   );
 }
 
+export function buildLocationEventPrompt(
+  locationEvents: string[],
+  opts?: { deliverToUser?: boolean },
+): string {
+  const deliverToUser = opts?.deliverToUser ?? true;
+  const eventText = locationEvents.join("\n").trim();
+  if (!deliverToUser) {
+    return (
+      "A location update was received from a connected node. " +
+      "The location data is shown below. " +
+      "Handle this internally according to your HEARTBEAT.md instructions. " +
+      "Reply HEARTBEAT_OK when nothing needs user-facing follow-up.\n\n" +
+      eventText
+    );
+  }
+  return (
+    "A location update was received from a connected node. " +
+    "The location data is shown below. " +
+    "Process it according to your HEARTBEAT.md instructions.\n\n" +
+    eventText
+  );
+}
+
 const HEARTBEAT_OK_PREFIX = HEARTBEAT_TOKEN.toLowerCase();
 
 // Detect heartbeat-specific noise so cron reminders don't trigger on non-reminder events.

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -34,6 +34,9 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "wake") {
     return "wake";
   }
+  if (trimmed === "location-update") {
+    return "wake";
+  }
   if (trimmed.startsWith("acp:spawn:")) {
     return "wake";
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -399,6 +399,7 @@ type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   hasTaggedCronEvents: boolean;
+  hasTaggedLocationEvents: boolean;
   shouldInspectPendingEvents: boolean;
   skipReason?: HeartbeatSkipReason;
 };
@@ -430,18 +431,26 @@ async function resolveHeartbeatPreflight(params: {
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
   );
+  const hasTaggedLocationEvents = pendingEventEntries.some((event) =>
+    event.contextKey?.startsWith("location:"),
+  );
   const shouldInspectPendingEvents =
-    reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || hasTaggedCronEvents;
+    reasonFlags.isExecEventReason ||
+    reasonFlags.isCronEventReason ||
+    hasTaggedCronEvents ||
+    hasTaggedLocationEvents;
   const shouldBypassFileGates =
     reasonFlags.isExecEventReason ||
     reasonFlags.isCronEventReason ||
     reasonFlags.isWakeReason ||
-    hasTaggedCronEvents;
+    hasTaggedCronEvents ||
+    hasTaggedLocationEvents;
   const basePreflight = {
     ...reasonFlags,
     session,
     pendingEventEntries,
     hasTaggedCronEvents,
+    hasTaggedLocationEvents,
     shouldInspectPendingEvents,
   } satisfies Omit<HeartbeatPreflight, "skipReason">;
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -53,6 +53,7 @@ import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import {
   buildExecEventPrompt,
   buildCronEventPrompt,
+  buildLocationEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
@@ -485,6 +486,7 @@ type HeartbeatPromptResolution = {
   prompt: string;
   hasExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasLocationEvents: boolean;
 };
 
 function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
@@ -517,16 +519,22 @@ function resolveHeartbeatRunPrompt(params: {
         isCronSystemEvent(event.text),
     )
     .map((event) => event.text);
+  const locationEvents = pendingEventEntries
+    .filter((event) => event.contextKey?.startsWith("location:"))
+    .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
+  const hasLocationEvents = locationEvents.length > 0;
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
-      : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
+      : hasLocationEvents
+        ? buildLocationEventPrompt(locationEvents, { deliverToUser: params.canRelayToUser })
+        : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
 
-  return { prompt, hasExecCompletion, hasCronEvents };
+  return { prompt, hasExecCompletion, hasCronEvents, hasLocationEvents };
 }
 
 export async function runHeartbeatOnce(opts: {
@@ -639,13 +647,15 @@ export async function runHeartbeatOnce(opts: {
     delivery.channel !== "none" && delivery.to && visibility.showAlerts,
   );
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const { prompt, hasExecCompletion, hasCronEvents } = resolveHeartbeatRunPrompt({
-    cfg,
-    heartbeat,
-    preflight,
-    canRelayToUser,
-    workspaceDir,
-  });
+  const { prompt, hasExecCompletion, hasCronEvents, hasLocationEvents } = resolveHeartbeatRunPrompt(
+    {
+      cfg,
+      heartbeat,
+      preflight,
+      canRelayToUser,
+      workspaceDir,
+    },
+  );
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
@@ -654,7 +664,13 @@ export async function runHeartbeatOnce(opts: {
     OriginatingTo: delivery.to,
     AccountId: delivery.accountId,
     MessageThreadId: delivery.threadId,
-    Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
+    Provider: hasExecCompletion
+      ? "exec-event"
+      : hasCronEvents
+        ? "cron-event"
+        : hasLocationEvents
+          ? "location-event"
+          : "heartbeat",
     SessionKey: runSessionKey,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {


### PR DESCRIPTION
## Summary

- **Problem:** `location.update` events sent from iOS nodes via `node.event` were silently dropped by the gateway (`default` case in `handleNodeEvent`)
- **Why it matters:** The agent could not react to location changes (e.g. severance hooks, memory logging) because the event never reached the heartbeat prompt
- **What changed:** Added `location.update` handler in gateway that enqueues a system event and wakes the heartbeat; classified `location-update` as `wake` reason; added tagged-event detection (`location:*`) so pending location events are included in the heartbeat prompt; added logging on both iOS and gateway sides
- **What did NOT change (scope boundary):** No changes to `location.get` command flow, node command policy, iOS location permissions model, or heartbeat prompt templates

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

- `location.update` events from iOS nodes now trigger a heartbeat wake and appear in the agent heartbeat prompt as a system event
- Gateway logs `location.update received node=<id> source=<source>` at info level when an event arrives

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (gateway), iOS simulator
- Runtime/container: Node 25, `pnpm gateway:watch`
- Model/provider: Claude Opus 4.6
- Integration/channel (if any): iOS node
- Relevant config (redacted): `locationMode: .always`, `authorizedAlways`

### Steps

1. Start the gateway with `pnpm gateway:watch`
2. Add the following to the gateway's `HEARTBEAT.md`:
   ```
   ## Location Tracking

   - On `location.update` event, append to the Location Log table in `memory/YYYY-MM-DD.md`
   - Format: `| HH:MM | lat, lng | notes |`
   - Create the Location Log table if it does not exist
   ```
3. Open the iOS app on a real device with Always location permission granted
4. Move between locations to trigger iOS Significant Location Change events (or use Xcode > Debug > Simulate Location)

### Expected

- Xcode log shows `location.update sent to gateway`
- Gateway log shows `[gateway] location.update received node=... source=ios-significant-location`
- `memory/YYYY-MM-DD.md` is updated with a Location Log table:
  ```
  ## Location Log

  | Time (JST) | Lat, Lng | Notes |
  |---|---|---|
  | 13:41 | 37.4451, -122.2707 | Near Palo Alto, ±5m |
  | 14:03 | 37.7501, -122.4033 | San Francisco, ±5m |
  | 14:04 | 37.7575, -122.4039 | San Francisco, ±5m |
  ```

### Actual

Same as expected.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: iOS simulator sends `location.update`, `sendEvent` completes without error, gateway `dist/` contains handler code after build
- Edge cases checked: missing `lat`/`lon` (early return), missing `accuracyMeters`/`source` (optional), consecutive duplicate events (deduplicated by `enqueueSystemEvent`)
- What you did **not** verify: end-to-end on real device (pending), heartbeat prompt content with location data

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the 3 commits on `feature/location-update`; the `default` case resumes silently dropping the event
- Files/config to restore: `src/gateway/server-node-events.ts`, `src/infra/heartbeat-reason.ts`, `src/infra/heartbeat-runner.ts`
- Known bad symptoms reviewers should watch for: unexpected heartbeat wakes when no location events are expected; excessive system events if a node sends rapid location updates (mitigated by `enqueueSystemEvent` dedup)

## Risks and Mitigations

- Risk: Rapid location updates from a node could flood the system event queue and trigger frequent heartbeat wakes
  - Mitigation: `enqueueSystemEvent` deduplicates consecutive identical events per `contextKey` (`location:<nodeId>`), and the heartbeat coalesce window (250ms) batches rapid wakes

