### PR TITLE
[Bug] cron remove: fix silent failure when job does not exist

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -322,18 +322,18 @@ export async function remove(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove");
     await ensureLoaded(state);
-    const before = state.store?.jobs.length ?? 0;
     if (!state.store) {
-      return { ok: false, removed: false } as const;
+      return { ok: false, removed: false, reason: "store unavailable" } as const;
+    }
+    const job = state.store.jobs.find((j) => j.id === id);
+    if (!job) {
+      return { ok: false, removed: false, reason: "job not found" } as const;
     }
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
-    const removed = (state.store.jobs.length ?? 0) !== before;
     await persist(state);
     armTimer(state);
-    if (removed) {
-      emit(state, { jobId: id, action: "removed" });
-    }
-    return { ok: true, removed } as const;
+    emit(state, { jobId: id, action: "removed" });
+    return { ok: true, removed: true, jobName: job.name } as const;
   });
 }
 


### PR DESCRIPTION
## Summary

The `cron remove` command (and `openclaw cron rm` / `openclaw cron delete` aliases) sometimes reports success but the job keeps running. This happens because the underlying `remove()` operation always returned `ok: true`, even when the job did not exist.

## Root Cause

In `src/cron/service/ops.ts`, the `remove()` function:

1. Always returned `{ ok: true, removed }` regardless of whether a job was found
2. Called `armTimer()` even when nothing was removed
3. Emitted a removed event only when `removed === true` — masking the problem from observability

The CLI layer printed the success message based solely on `ok: true` without checking `removed`.

## Fix

Updated `remove()` to return a richer result:

- `{ ok: false, removed: false, reason: 'store unavailable' }` — store not loaded
- `{ ok: false, removed: false, reason: 'job not found' }` — job did not exist
- `{ ok: true, removed: true, jobName: '...' }` — successfully removed

Also removed the spurious `armTimer()` call when nothing was removed.

## Verification

The `cron rm <id>`, `cron remove <id>`, and `cron delete <id>` CLI aliases all route through the same `cron.remove` gateway RPC call, so fixing the service layer fixes all three.

Fixes #28715