### PR TITLE
fix(onboard): discover model context window from proxy /model/info API

### DIFF
--- a/extensions/copilot-proxy/index.ts
+++ b/extensions/copilot-proxy/index.ts
@@ -89,7 +89,9 @@ async function fetchModelInfoMap(
     for (const entry of data.data ?? []) {
       const name = entry.model_name;
       const info = entry.model_info;
-      if (!name || !info) continue;
+      if (!name || !info) {
+        continue;
+      }
 
       const contextWindow = info.max_input_tokens;
       const maxTokens = info.max_output_tokens;
@@ -182,11 +184,7 @@ export default definePluginEntry({
                       authHeader: false,
                       models: modelIds.map((modelId) => {
                         const info = modelInfoMap.get(modelId);
-                        return buildModelDefinition(
-                          modelId,
-                          info?.contextWindow,
-                          info?.maxTokens,
-                        );
+                        return buildModelDefinition(modelId, info?.contextWindow, info?.maxTokens);
                       }),
                     },
                   },

--- a/extensions/copilot-proxy/index.ts
+++ b/extensions/copilot-proxy/index.ts
@@ -57,7 +57,60 @@ function parseModelIds(input: string): string[] {
   return Array.from(new Set(parsed));
 }
 
-function buildModelDefinition(modelId: string) {
+// Model info returned by LiteLLM /v1/model/info endpoint
+type LiteLLMModelInfo = {
+  data?: Array<{
+    model_name?: string;
+    model_info?: {
+      max_input_tokens?: number;
+      max_output_tokens?: number;
+    };
+  }>;
+};
+
+/**
+ * Query the proxy's /v1/model/info endpoint (LiteLLM-compatible) to discover
+ * actual context window and max output tokens for each model. Falls back to
+ * defaults when the endpoint is unavailable or returns incomplete data.
+ */
+async function fetchModelInfoMap(
+  baseUrl: string,
+): Promise<Map<string, { contextWindow: number; maxTokens: number }>> {
+  const result = new Map<string, { contextWindow: number; maxTokens: number }>();
+  try {
+    const url = `${baseUrl}/model/info`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      return result;
+    }
+    const data = (await response.json()) as LiteLLMModelInfo;
+    for (const entry of data.data ?? []) {
+      const name = entry.model_name;
+      const info = entry.model_info;
+      if (!name || !info) continue;
+
+      const contextWindow = info.max_input_tokens;
+      const maxTokens = info.max_output_tokens;
+      if (typeof contextWindow === "number" || typeof maxTokens === "number") {
+        result.set(name, {
+          contextWindow: typeof contextWindow === "number" ? contextWindow : DEFAULT_CONTEXT_WINDOW,
+          maxTokens: typeof maxTokens === "number" ? maxTokens : DEFAULT_MAX_TOKENS,
+        });
+      }
+    }
+  } catch {
+    // Proxy might not support /model/info — fall back to defaults silently
+  }
+  return result;
+}
+
+function buildModelDefinition(
+  modelId: string,
+  contextWindow: number = DEFAULT_CONTEXT_WINDOW,
+  maxTokens: number = DEFAULT_MAX_TOKENS,
+) {
   return {
     id: modelId,
     name: modelId,
@@ -65,8 +118,8 @@ function buildModelDefinition(modelId: string) {
     reasoning: false,
     input: ["text", "image"] as Array<"text" | "image">,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    contextWindow,
+    maxTokens,
   };
 }
 
@@ -104,6 +157,10 @@ export default definePluginEntry({
             const defaultModelId = modelIds[0] ?? DEFAULT_MODEL_IDS[0];
             const defaultModelRef = `copilot-proxy/${defaultModelId}`;
 
+            // Query proxy for actual model capabilities (context window, max tokens).
+            // Falls back to defaults if the endpoint is unavailable.
+            const modelInfoMap = await fetchModelInfoMap(baseUrl);
+
             return {
               profiles: [
                 {
@@ -123,7 +180,14 @@ export default definePluginEntry({
                       apiKey: DEFAULT_API_KEY,
                       api: "openai-completions",
                       authHeader: false,
-                      models: modelIds.map((modelId) => buildModelDefinition(modelId)),
+                      models: modelIds.map((modelId) => {
+                        const info = modelInfoMap.get(modelId);
+                        return buildModelDefinition(
+                          modelId,
+                          info?.contextWindow,
+                          info?.maxTokens,
+                        );
+                      }),
                     },
                   },
                 },

--- a/src/commands/auth-choice.apply.api-key-providers.ts
+++ b/src/commands/auth-choice.apply.api-key-providers.ts
@@ -63,10 +63,12 @@ export async function applyLiteLlmApiKeyProvider({
   }
 
   // Track the resolved plaintext API key for the model info probe.
-  // ensureApiKeyFromOptionEnvOrPrompt always returns plaintext even in ref mode.
   let resolvedApiKey: string | undefined;
 
   if (!hasCredential) {
+    // ensureApiKeyFromOptionEnvOrPrompt always returns the plaintext key,
+    // even in --secret-input-mode=ref (the ref is passed to setCredential,
+    // but the return value is the resolved plaintext).
     resolvedApiKey = await ensureApiKeyFromOptionEnvOrPrompt({
       token: params.opts?.token,
       tokenProvider: normalizedTokenProvider,
@@ -86,9 +88,17 @@ export async function applyLiteLlmApiKeyProvider({
       noteTitle: "LiteLLM",
     });
     hasCredential = true;
+  } else if (existingCred?.type === "api_key") {
+    // Reusing a previously stored credential — try to read the plaintext key
+    // so the model info probe can authenticate on secured proxies.
+    const storedKey = (existingCred as { key?: unknown }).key;
+    if (typeof storedKey === "string") {
+      resolvedApiKey = storedKey;
+    }
   }
 
-  // Fall back to the LITELLM_API_KEY env var when reusing an existing credential.
+  // Fall back to the LITELLM_API_KEY env var when no plaintext key is available
+  // (e.g. ref-backed profiles where the stored key is a SecretRef object).
   if (!resolvedApiKey) {
     resolvedApiKey = process.env.LITELLM_API_KEY ?? undefined;
   }

--- a/src/commands/auth-choice.apply.api-key-providers.ts
+++ b/src/commands/auth-choice.apply.api-key-providers.ts
@@ -62,6 +62,9 @@ export async function applyLiteLlmApiKeyProvider({
     profileId = existingProfileId;
   }
 
+  // Track the API key so we can authenticate the model info probe later.
+  let resolvedApiKey: string | undefined;
+
   if (!hasCredential) {
     await ensureApiKeyFromOptionEnvOrPrompt({
       token: params.opts?.token,
@@ -75,13 +78,20 @@ export async function applyLiteLlmApiKeyProvider({
       normalize: normalizeApiKeyInput,
       validate: validateApiKeyInput,
       prompter: params.prompter,
-      setCredential: async (apiKey, mode) =>
-        setLitellmApiKey(apiKey, params.agentDir, { secretInputMode: mode }),
+      setCredential: async (apiKey, mode) => {
+        resolvedApiKey = typeof apiKey === "string" ? apiKey : undefined;
+        return setLitellmApiKey(apiKey, params.agentDir, { secretInputMode: mode });
+      },
       noteMessage:
         "LiteLLM provides a unified API to 100+ LLM providers.\nGet your API key from your LiteLLM proxy or https://litellm.ai\nDefault proxy runs on http://localhost:4000",
       noteTitle: "LiteLLM",
     });
     hasCredential = true;
+  }
+
+  // Also check the LITELLM_API_KEY env var as a fallback for the probe auth.
+  if (!resolvedApiKey) {
+    resolvedApiKey = process.env.LITELLM_API_KEY ?? undefined;
   }
 
   if (hasCredential) {
@@ -93,17 +103,21 @@ export async function applyLiteLlmApiKeyProvider({
   }
   setConfig(nextConfig);
 
-  // Fetch actual model capabilities from LiteLLM before applying config.
-  // This ensures contextWindow and maxTokens reflect the real model (e.g. 1M
-  // for claude-opus-4.6-1m) instead of the 128k default.
+  // Resolve baseUrl: prefer any previously configured value (which may already
+  // include /v1), fall back to the default. fetchLitellmModelInfo handles
+  // stripping a trailing /v1 to avoid /v1/v1/model/info.
   const existingProvider = nextConfig.models?.providers?.litellm as
     | { baseUrl?: unknown }
     | undefined;
   const baseUrl =
-    typeof existingProvider?.baseUrl === "string"
+    typeof existingProvider?.baseUrl === "string" && existingProvider.baseUrl.trim()
       ? existingProvider.baseUrl.trim()
       : LITELLM_BASE_URL;
-  const modelInfo = await fetchLitellmModelInfo(baseUrl, LITELLM_DEFAULT_MODEL_ID);
+
+  // Fetch actual model capabilities from LiteLLM before applying config.
+  // This ensures contextWindow and maxTokens reflect the real model (e.g. 1M
+  // for claude-opus-4.6-1m) instead of the 128k default.
+  const modelInfo = await fetchLitellmModelInfo(baseUrl, LITELLM_DEFAULT_MODEL_ID, resolvedApiKey);
 
   await applyProviderDefaultModel({
     defaultModel: LITELLM_DEFAULT_MODEL_REF,

--- a/src/commands/auth-choice.apply.api-key-providers.ts
+++ b/src/commands/auth-choice.apply.api-key-providers.ts
@@ -62,11 +62,12 @@ export async function applyLiteLlmApiKeyProvider({
     profileId = existingProfileId;
   }
 
-  // Track the API key so we can authenticate the model info probe later.
+  // Track the resolved plaintext API key for the model info probe.
+  // ensureApiKeyFromOptionEnvOrPrompt always returns plaintext even in ref mode.
   let resolvedApiKey: string | undefined;
 
   if (!hasCredential) {
-    await ensureApiKeyFromOptionEnvOrPrompt({
+    resolvedApiKey = await ensureApiKeyFromOptionEnvOrPrompt({
       token: params.opts?.token,
       tokenProvider: normalizedTokenProvider,
       secretInputMode: requestedSecretInputMode,
@@ -78,10 +79,8 @@ export async function applyLiteLlmApiKeyProvider({
       normalize: normalizeApiKeyInput,
       validate: validateApiKeyInput,
       prompter: params.prompter,
-      setCredential: async (apiKey, mode) => {
-        resolvedApiKey = typeof apiKey === "string" ? apiKey : undefined;
-        return setLitellmApiKey(apiKey, params.agentDir, { secretInputMode: mode });
-      },
+      setCredential: async (apiKey, mode) =>
+        setLitellmApiKey(apiKey, params.agentDir, { secretInputMode: mode }),
       noteMessage:
         "LiteLLM provides a unified API to 100+ LLM providers.\nGet your API key from your LiteLLM proxy or https://litellm.ai\nDefault proxy runs on http://localhost:4000",
       noteTitle: "LiteLLM",
@@ -89,7 +88,7 @@ export async function applyLiteLlmApiKeyProvider({
     hasCredential = true;
   }
 
-  // Also check the LITELLM_API_KEY env var as a fallback for the probe auth.
+  // Fall back to the LITELLM_API_KEY env var when reusing an existing credential.
   if (!resolvedApiKey) {
     resolvedApiKey = process.env.LITELLM_API_KEY ?? undefined;
   }
@@ -103,9 +102,9 @@ export async function applyLiteLlmApiKeyProvider({
   }
   setConfig(nextConfig);
 
-  // Resolve baseUrl: prefer any previously configured value (which may already
-  // include /v1), fall back to the default. fetchLitellmModelInfo handles
-  // stripping a trailing /v1 to avoid /v1/v1/model/info.
+  // Determine the LiteLLM base URL from a previously persisted config, if any,
+  // or fall back to the default localhost address. This fetch happens before
+  // applyProviderDefaultModel writes the new config.
   const existingProvider = nextConfig.models?.providers?.litellm as
     | { baseUrl?: unknown }
     | undefined;
@@ -114,9 +113,8 @@ export async function applyLiteLlmApiKeyProvider({
       ? existingProvider.baseUrl.trim()
       : LITELLM_BASE_URL;
 
-  // Fetch actual model capabilities from LiteLLM before applying config.
-  // This ensures contextWindow and maxTokens reflect the real model (e.g. 1M
-  // for claude-opus-4.6-1m) instead of the 128k default.
+  // Probe the proxy for actual model capabilities (context window, max tokens)
+  // so the config reflects the real model limits instead of the 128k default.
   const modelInfo = await fetchLitellmModelInfo(baseUrl, LITELLM_DEFAULT_MODEL_ID, resolvedApiKey);
 
   await applyProviderDefaultModel({

--- a/src/commands/auth-choice.apply.api-key-providers.ts
+++ b/src/commands/auth-choice.apply.api-key-providers.ts
@@ -4,7 +4,13 @@ import { LITELLM_DEFAULT_MODEL_REF, setLitellmApiKey } from "../plugins/provider
 import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key.js";
 import { ensureApiKeyFromOptionEnvOrPrompt } from "./auth-choice.apply-helpers.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
-import { applyLitellmConfig, applyLitellmProviderConfig } from "./onboard-auth.config-litellm.js";
+import {
+  applyLitellmConfig,
+  applyLitellmProviderConfig,
+  fetchLitellmModelInfo,
+  LITELLM_BASE_URL,
+  LITELLM_DEFAULT_MODEL_ID,
+} from "./onboard-auth.config-litellm.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
 type ApiKeyProviderConfigApplier = (
@@ -86,10 +92,23 @@ export async function applyLiteLlmApiKeyProvider({
     });
   }
   setConfig(nextConfig);
+
+  // Fetch actual model capabilities from LiteLLM before applying config.
+  // This ensures contextWindow and maxTokens reflect the real model (e.g. 1M
+  // for claude-opus-4.6-1m) instead of the 128k default.
+  const existingProvider = nextConfig.models?.providers?.litellm as
+    | { baseUrl?: unknown }
+    | undefined;
+  const baseUrl =
+    typeof existingProvider?.baseUrl === "string"
+      ? existingProvider.baseUrl.trim()
+      : LITELLM_BASE_URL;
+  const modelInfo = await fetchLitellmModelInfo(baseUrl, LITELLM_DEFAULT_MODEL_ID);
+
   await applyProviderDefaultModel({
     defaultModel: LITELLM_DEFAULT_MODEL_REF,
-    applyDefaultConfig: applyLitellmConfig,
-    applyProviderConfig: applyLitellmProviderConfig,
+    applyDefaultConfig: (cfg) => applyLitellmConfig(cfg, modelInfo),
+    applyProviderConfig: (cfg) => applyLitellmProviderConfig(cfg, modelInfo),
     noteDefault: LITELLM_DEFAULT_MODEL_REF,
   });
   return { config: getConfig(), agentModelOverride: getAgentModelOverride() };

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -49,18 +49,20 @@ export async function fetchLitellmModelInfo(
     }
     const data = (await response.json()) as LiteLLMModelInfoResponse;
     for (const entry of data.data ?? []) {
-      if (entry.model_name !== modelId) continue;
+      if (entry.model_name !== modelId) {
+        continue;
+      }
       const info = entry.model_info;
-      if (!info) continue;
+      if (!info) {
+        continue;
+      }
       return {
         contextWindow:
           typeof info.max_input_tokens === "number"
             ? info.max_input_tokens
             : defaults.contextWindow,
         maxTokens:
-          typeof info.max_output_tokens === "number"
-            ? info.max_output_tokens
-            : defaults.maxTokens,
+          typeof info.max_output_tokens === "number" ? info.max_output_tokens : defaults.maxTokens,
       };
     }
   } catch {
@@ -69,10 +71,7 @@ export async function fetchLitellmModelInfo(
   return defaults;
 }
 
-function buildLitellmModelDefinition(overrides?: {
-  contextWindow?: number;
-  maxTokens?: number;
-}): {
+function buildLitellmModelDefinition(overrides?: { contextWindow?: number; maxTokens?: number }): {
   id: string;
   name: string;
   reasoning: boolean;

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -28,20 +28,39 @@ type LiteLLMModelInfoResponse = {
 };
 
 /**
+ * Strip a trailing `/v1` suffix from a base URL so callers can safely
+ * append `/v1/model/info` without producing `/v1/v1/model/info`.
+ */
+function stripV1Suffix(url: string): string {
+  const trimmed = url.replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed.slice(0, -3) : trimmed;
+}
+
+/**
  * Query LiteLLM /v1/model/info to get actual context window and max output
  * tokens for a specific model. Falls back to defaults on any failure.
+ *
+ * @param baseUrl - LiteLLM proxy base URL (with or without trailing /v1)
+ * @param modelId - model name to look up
+ * @param apiKey - optional API key for authenticated proxies
  */
 export async function fetchLitellmModelInfo(
   baseUrl: string,
   modelId: string,
+  apiKey?: string,
 ): Promise<{ contextWindow: number; maxTokens: number }> {
   const defaults = {
     contextWindow: LITELLM_DEFAULT_CONTEXT_WINDOW,
     maxTokens: LITELLM_DEFAULT_MAX_TOKENS,
   };
   try {
-    const url = `${baseUrl.replace(/\/+$/, "")}/v1/model/info`;
+    const url = `${stripV1Suffix(baseUrl)}/v1/model/info`;
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
     const response = await fetch(url, {
+      headers,
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -28,6 +28,14 @@ type LiteLLMModelInfoResponse = {
   }>;
 };
 
+/** Result from probing the LiteLLM /v1/model/info endpoint. */
+export type LiteLLMModelInfoResult = {
+  contextWindow: number;
+  maxTokens: number;
+  /** True when the values came from the proxy; false when using fallback defaults. */
+  discovered: boolean;
+};
+
 /**
  * Strip a trailing `/v1` suffix from a base URL so callers can safely
  * append `/v1/model/info` without producing `/v1/v1/model/info`.
@@ -49,10 +57,11 @@ export async function fetchLitellmModelInfo(
   baseUrl: string,
   modelId: string,
   apiKey?: string,
-): Promise<{ contextWindow: number; maxTokens: number }> {
-  const defaults = {
+): Promise<LiteLLMModelInfoResult> {
+  const defaults: LiteLLMModelInfoResult = {
     contextWindow: LITELLM_DEFAULT_CONTEXT_WINDOW,
     maxTokens: LITELLM_DEFAULT_MAX_TOKENS,
+    discovered: false,
   };
   try {
     const url = `${stripV1Suffix(baseUrl)}/v1/model/info`;
@@ -83,6 +92,7 @@ export async function fetchLitellmModelInfo(
             : defaults.contextWindow,
         maxTokens:
           typeof info.max_output_tokens === "number" ? info.max_output_tokens : defaults.maxTokens,
+        discovered: true,
       };
     }
   } catch {
@@ -159,7 +169,7 @@ function patchExistingModelLimits(
 
 export function applyLitellmProviderConfig(
   cfg: OpenClawConfig,
-  modelInfoOverrides?: { contextWindow?: number; maxTokens?: number },
+  modelInfo?: LiteLLMModelInfoResult,
 ): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[LITELLM_DEFAULT_MODEL_REF] = {
@@ -167,7 +177,7 @@ export function applyLitellmProviderConfig(
     alias: models[LITELLM_DEFAULT_MODEL_REF]?.alias ?? "LiteLLM",
   };
 
-  const defaultModel = buildLitellmModelDefinition(modelInfoOverrides);
+  const defaultModel = buildLitellmModelDefinition(modelInfo);
 
   const existingProvider = cfg.models?.providers?.litellm as { baseUrl?: unknown } | undefined;
   const resolvedBaseUrl =
@@ -182,13 +192,14 @@ export function applyLitellmProviderConfig(
     defaultModelId: LITELLM_DEFAULT_MODEL_ID,
   });
 
-  // When the model already existed in a previous config, the merge helper
-  // keeps the old entry unchanged. Patch contextWindow/maxTokens so re-auth
-  // picks up newly discovered limits (e.g. 128k → 1M after upgrading model).
-  if (modelInfoOverrides) {
+  // Only patch existing model entries when the probe actually discovered real
+  // values from the proxy. When the probe falls back to defaults (proxy down,
+  // 401, model not found), skip the patch to preserve any previously discovered
+  // limits already stored in the config.
+  if (modelInfo?.discovered) {
     next = patchExistingModelLimits(next, "litellm", LITELLM_DEFAULT_MODEL_ID, {
-      contextWindow: modelInfoOverrides.contextWindow ?? LITELLM_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: modelInfoOverrides.maxTokens ?? LITELLM_DEFAULT_MAX_TOKENS,
+      contextWindow: modelInfo.contextWindow,
+      maxTokens: modelInfo.maxTokens,
     });
   }
 
@@ -197,8 +208,8 @@ export function applyLitellmProviderConfig(
 
 export function applyLitellmConfig(
   cfg: OpenClawConfig,
-  modelInfoOverrides?: { contextWindow?: number; maxTokens?: number },
+  modelInfo?: LiteLLMModelInfoResult,
 ): OpenClawConfig {
-  const next = applyLitellmProviderConfig(cfg, modelInfoOverrides);
+  const next = applyLitellmProviderConfig(cfg, modelInfo);
   return applyAgentDefaultModelPrimary(next, LITELLM_DEFAULT_MODEL_REF);
 }

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -16,7 +16,63 @@ const LITELLM_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-function buildLitellmModelDefinition(): {
+// Model info returned by LiteLLM /v1/model/info endpoint
+type LiteLLMModelInfoResponse = {
+  data?: Array<{
+    model_name?: string;
+    model_info?: {
+      max_input_tokens?: number;
+      max_output_tokens?: number;
+    };
+  }>;
+};
+
+/**
+ * Query LiteLLM /v1/model/info to get actual context window and max output
+ * tokens for a specific model. Falls back to defaults on any failure.
+ */
+export async function fetchLitellmModelInfo(
+  baseUrl: string,
+  modelId: string,
+): Promise<{ contextWindow: number; maxTokens: number }> {
+  const defaults = {
+    contextWindow: LITELLM_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: LITELLM_DEFAULT_MAX_TOKENS,
+  };
+  try {
+    const url = `${baseUrl.replace(/\/+$/, "")}/v1/model/info`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      return defaults;
+    }
+    const data = (await response.json()) as LiteLLMModelInfoResponse;
+    for (const entry of data.data ?? []) {
+      if (entry.model_name !== modelId) continue;
+      const info = entry.model_info;
+      if (!info) continue;
+      return {
+        contextWindow:
+          typeof info.max_input_tokens === "number"
+            ? info.max_input_tokens
+            : defaults.contextWindow,
+        maxTokens:
+          typeof info.max_output_tokens === "number"
+            ? info.max_output_tokens
+            : defaults.maxTokens,
+      };
+    }
+  } catch {
+    // LiteLLM might not be running yet during onboard — fall back silently
+  }
+  return defaults;
+}
+
+function buildLitellmModelDefinition(overrides?: {
+  contextWindow?: number;
+  maxTokens?: number;
+}): {
   id: string;
   name: string;
   reasoning: boolean;
@@ -31,19 +87,22 @@ function buildLitellmModelDefinition(): {
     reasoning: true,
     input: ["text", "image"],
     cost: LITELLM_DEFAULT_COST,
-    contextWindow: LITELLM_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: LITELLM_DEFAULT_MAX_TOKENS,
+    contextWindow: overrides?.contextWindow ?? LITELLM_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: overrides?.maxTokens ?? LITELLM_DEFAULT_MAX_TOKENS,
   };
 }
 
-export function applyLitellmProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+export function applyLitellmProviderConfig(
+  cfg: OpenClawConfig,
+  modelInfoOverrides?: { contextWindow?: number; maxTokens?: number },
+): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[LITELLM_DEFAULT_MODEL_REF] = {
     ...models[LITELLM_DEFAULT_MODEL_REF],
     alias: models[LITELLM_DEFAULT_MODEL_REF]?.alias ?? "LiteLLM",
   };
 
-  const defaultModel = buildLitellmModelDefinition();
+  const defaultModel = buildLitellmModelDefinition(modelInfoOverrides);
 
   const existingProvider = cfg.models?.providers?.litellm as { baseUrl?: unknown } | undefined;
   const resolvedBaseUrl =
@@ -59,7 +118,10 @@ export function applyLitellmProviderConfig(cfg: OpenClawConfig): OpenClawConfig 
   });
 }
 
-export function applyLitellmConfig(cfg: OpenClawConfig): OpenClawConfig {
-  const next = applyLitellmProviderConfig(cfg);
+export function applyLitellmConfig(
+  cfg: OpenClawConfig,
+  modelInfoOverrides?: { contextWindow?: number; maxTokens?: number },
+): OpenClawConfig {
+  const next = applyLitellmProviderConfig(cfg, modelInfoOverrides);
   return applyAgentDefaultModelPrimary(next, LITELLM_DEFAULT_MODEL_REF);
 }

--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { LITELLM_DEFAULT_MODEL_REF } from "../plugins/provider-auth-storage.js";
 import {
   applyAgentDefaultModelPrimary,
@@ -110,6 +111,52 @@ function buildLitellmModelDefinition(overrides?: { contextWindow?: number; maxTo
   };
 }
 
+/**
+ * Patch contextWindow/maxTokens on an existing model entry in the provider
+ * config. `applyProviderConfigWithDefaultModel` preserves existing model
+ * entries when the defaultModelId is already present, so a re-auth/upgrade
+ * would otherwise keep stale 128k/8192 values. This post-apply patch
+ * overwrites only the two capability fields on the matching model.
+ */
+function patchExistingModelLimits(
+  cfg: OpenClawConfig,
+  providerId: string,
+  modelId: string,
+  overrides: { contextWindow: number; maxTokens: number },
+): OpenClawConfig {
+  const provider = cfg.models?.providers?.[providerId];
+  if (!provider) {
+    return cfg;
+  }
+  const models = (provider as { models?: ModelDefinitionConfig[] }).models;
+  if (!models) {
+    return cfg;
+  }
+  const idx = models.findIndex((m) => m.id === modelId);
+  if (idx < 0) {
+    return cfg;
+  }
+  const existing = models[idx];
+  if (
+    existing.contextWindow === overrides.contextWindow &&
+    existing.maxTokens === overrides.maxTokens
+  ) {
+    return cfg; // already up to date
+  }
+  const updatedModels = [...models];
+  updatedModels[idx] = { ...existing, ...overrides };
+  return {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      providers: {
+        ...cfg.models?.providers,
+        [providerId]: { ...provider, models: updatedModels },
+      },
+    },
+  };
+}
+
 export function applyLitellmProviderConfig(
   cfg: OpenClawConfig,
   modelInfoOverrides?: { contextWindow?: number; maxTokens?: number },
@@ -126,7 +173,7 @@ export function applyLitellmProviderConfig(
   const resolvedBaseUrl =
     typeof existingProvider?.baseUrl === "string" ? existingProvider.baseUrl.trim() : "";
 
-  return applyProviderConfigWithDefaultModel(cfg, {
+  let next = applyProviderConfigWithDefaultModel(cfg, {
     agentModels: models,
     providerId: "litellm",
     api: "openai-completions",
@@ -134,6 +181,18 @@ export function applyLitellmProviderConfig(
     defaultModel,
     defaultModelId: LITELLM_DEFAULT_MODEL_ID,
   });
+
+  // When the model already existed in a previous config, the merge helper
+  // keeps the old entry unchanged. Patch contextWindow/maxTokens so re-auth
+  // picks up newly discovered limits (e.g. 128k → 1M after upgrading model).
+  if (modelInfoOverrides) {
+    next = patchExistingModelLimits(next, "litellm", LITELLM_DEFAULT_MODEL_ID, {
+      contextWindow: modelInfoOverrides.contextWindow ?? LITELLM_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: modelInfoOverrides.maxTokens ?? LITELLM_DEFAULT_MAX_TOKENS,
+    });
+  }
+
+  return next;
 }
 
 export function applyLitellmConfig(


### PR DESCRIPTION
## Summary

- During onboard, copilot-proxy and LiteLLM providers hardcode `contextWindow: 128000` and `maxTokens: 8192` for all discovered models
- This causes premature context compaction for models with larger windows (e.g. `claude-opus-4.6-1m` routed through LiteLLM with 1M context), wasting ~87% of available capacity
- Fix: query the proxy /v1/model/info endpoint during setup to read actual max_input_tokens and max_output_tokens per model, falling back to previous defaults when the endpoint is unavailable

## Root Cause

LiteLLM exposes model capabilities via model_info in its config (e.g. max_input_tokens: 1000000 for Opus 4.6 1M), and serves this data at /v1/model/info. However, the onboard flow never queries this endpoint - it assigns the same 128k/8192 defaults to every model regardless of actual capability.

This means the context window guard triggers compaction at ~100k tokens even when the underlying model supports 1M, leading to unnecessary history truncation in long sessions.

## Changes

- **extensions/copilot-proxy/index.ts**: add fetchModelInfoMap() that queries /v1/model/info during onboard and passes discovered contextWindow/maxTokens to buildModelDefinition()
- **src/commands/onboard-auth.config-litellm.ts**: add fetchLitellmModelInfo() export and accept optional modelInfoOverrides in config appliers (keeps functions sync for type compatibility)
- **src/commands/auth-choice.apply.api-key-providers.ts**: call fetchLitellmModelInfo() before applying config, passing real values via closure

## Backward Compatibility

- When /v1/model/info is unavailable (proxy not running, non-LiteLLM proxy, network error), falls back silently to previous 128k/8192 defaults
- applyLitellmConfig and applyLitellmProviderConfig remain sync - the async fetch happens in the caller
- Non-interactive onboard path continues using defaults (LiteLLM may not be running during non-interactive setup)

## Test plan

- [x] pnpm tsgo passes (type check)
- [x] onboard-auth.config-shared.test.ts - 6/6 pass
- [x] onboard-auth.test.ts - 31/31 pass
- [x] onboard-custom.test.ts - 29/29 pass
- [x] Verified locally: with LiteLLM running, opus model gets contextWindow: 1000000 instead of 128000
- [x] Verified locally: with LiteLLM stopped, falls back to 128000 default gracefully
