### PR TITLE
feat(web_search): add DuckDuckGo as free web search provider

### DIFF
--- a/docs/tools/duckduckgo.md
+++ b/docs/tools/duckduckgo.md
@@ -1,0 +1,91 @@
+---
+summary: "DuckDuckGo web search — free, no API key required"
+read_when:
+  - You want free web search without an API key
+  - You want DuckDuckGo as a web_search provider
+  - You want privacy-focused web search
+title: "DuckDuckGo"
+---
+
+# DuckDuckGo
+
+OpenClaw can use **DuckDuckGo** as a `web_search` provider or via the dedicated
+`duckduckgo_search` plugin tool.
+
+DuckDuckGo is a privacy-focused search engine. Unlike other providers, **no API
+key is required** — making it a great default for quick setups and contributors
+who don't have paid search API access.
+
+## Configure DuckDuckGo search
+
+```json5
+{
+  plugins: {
+    entries: {
+      duckduckgo: {
+        enabled: true,
+        config: {
+          webSearch: {
+            region: "us-en", // optional: region code for localized results
+            safeSearch: "moderate", // optional: "strict", "moderate", or "off"
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "duckduckgo",
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- **No API key needed.** DuckDuckGo is free and open.
+- Choosing DuckDuckGo in onboarding or `openclaw configure --section web`
+  enables the bundled DuckDuckGo plugin automatically.
+- Store config under `plugins.entries.duckduckgo.config.webSearch.*`.
+- `web_search` with DuckDuckGo supports `query`, `count` (up to 25 results),
+  and `region`.
+
+## DuckDuckGo plugin tool
+
+### `duckduckgo_search`
+
+Use this for DuckDuckGo-specific options.
+
+| Parameter     | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `query`       | Search query string                                      |
+| `max_results` | Number of results, 1-25 (default: 5)                     |
+| `region`      | DuckDuckGo region code (e.g., `us-en`, `br-pt`, `de-de`) |
+
+### Region codes
+
+Common region codes:
+
+| Code    | Region         |
+| ------- | -------------- |
+| `us-en` | United States  |
+| `uk-en` | United Kingdom |
+| `br-pt` | Brazil         |
+| `de-de` | Germany        |
+| `fr-fr` | France         |
+| `es-es` | Spain          |
+| `jp-jp` | Japan          |
+| `au-en` | Australia      |
+
+Leave empty for international (unfiltered) results.
+
+## Choosing the right tool
+
+| Need                                    | Tool                |
+| --------------------------------------- | ------------------- |
+| Quick web search, no API key            | `web_search`        |
+| DuckDuckGo with region-specific results | `duckduckgo_search` |
+
+See [Web tools](/tools/web) for the full web tool setup and provider comparison.

--- a/extensions/duckduckgo/index.test.ts
+++ b/extensions/duckduckgo/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("duckduckgo plugin", () => {
+  it("exports a valid plugin entry with correct id and name", () => {
+    expect(plugin.id).toBe("duckduckgo");
+    expect(plugin.name).toBe("DuckDuckGo Plugin");
+    expect(typeof plugin.register).toBe("function");
+  });
+
+  it("registers web search provider and one tool", () => {
+    const registrations: {
+      webSearchProviders: unknown[];
+      tools: unknown[];
+    } = { webSearchProviders: [], tools: [] };
+
+    const mockApi = {
+      registerWebSearchProvider(provider: unknown) {
+        registrations.webSearchProviders.push(provider);
+      },
+      registerTool(tool: unknown) {
+        registrations.tools.push(tool);
+      },
+      config: {},
+    };
+
+    plugin.register(mockApi as never);
+
+    expect(registrations.webSearchProviders).toHaveLength(1);
+    expect(registrations.tools).toHaveLength(1);
+
+    const provider = registrations.webSearchProviders[0] as Record<
+      string,
+      unknown
+    >;
+    expect(provider.id).toBe("duckduckgo");
+    expect(provider.autoDetectOrder).toBe(100);
+    expect(provider.envVars).toEqual([]);
+
+    const toolNames = registrations.tools.map(
+      (t) => (t as Record<string, unknown>).name,
+    );
+    expect(toolNames).toContain("duckduckgo_search");
+  });
+
+  it("provider reports credential without API key", () => {
+    const registrations: { webSearchProviders: unknown[] } = {
+      webSearchProviders: [],
+    };
+
+    const mockApi = {
+      registerWebSearchProvider(provider: unknown) {
+        registrations.webSearchProviders.push(provider);
+      },
+      registerTool() {},
+      config: {},
+    };
+
+    plugin.register(mockApi as never);
+
+    const provider = registrations.webSearchProviders[0] as Record<
+      string,
+      unknown
+    >;
+    const getCredentialValue = provider.getCredentialValue as (
+      config?: Record<string, unknown>,
+    ) => unknown;
+    expect(getCredentialValue()).toBe("duckduckgo-no-key-needed");
+  });
+});

--- a/extensions/duckduckgo/index.ts
+++ b/extensions/duckduckgo/index.ts
@@ -1,0 +1,6 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import { createDdgSearchTool } from "./src/ddg-search-tool.js";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool(createDdgSearchTool(api) as unknown as AnyAgentTool);
+}

--- a/extensions/duckduckgo/openclaw.plugin.json
+++ b/extensions/duckduckgo/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "duckduckgo",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "region": {
+            "type": "string",
+            "description": "DuckDuckGo region code (e.g., 'us-en', 'br-pt', 'de-de'). Default: none (international)."
+          },
+          "safeSearch": {
+            "type": "string",
+            "enum": ["strict", "moderate", "off"],
+            "description": "SafeSearch level. Default: moderate."
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/duckduckgo",
+  "version": "2026.3.20",
+  "private": true,
+  "description": "OpenClaw DuckDuckGo web search plugin — free, no API key required",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/duckduckgo/skills/duckduckgo/SKILL.md
+++ b/extensions/duckduckgo/skills/duckduckgo/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: duckduckgo
+description: DuckDuckGo web search — free, no API key required.
+metadata: { "openclaw": { "emoji": "🦆" } }
+---
+
+# DuckDuckGo Search
+
+## When to use which tool
+
+| Need                           | Tool                | When                                     |
+| ------------------------------ | ------------------- | ---------------------------------------- |
+| Quick web search               | `web_search`        | Basic queries, no special options needed |
+| DuckDuckGo with region control | `duckduckgo_search` | Need region-specific localized results   |
+
+## web_search
+
+DuckDuckGo powers this automatically when selected as the search provider. Use
+for straightforward queries.
+
+| Parameter | Description              |
+| --------- | ------------------------ |
+| `query`   | Search query string      |
+| `count`   | Number of results (1-25) |
+
+## duckduckgo_search
+
+Use when you need region-specific results.
+
+| Parameter     | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `query`       | Search query string                                      |
+| `max_results` | Number of results, 1-25 (default: 5)                     |
+| `region`      | DuckDuckGo region code (e.g., `us-en`, `br-pt`, `de-de`) |
+
+### Region codes
+
+| Code    | Region         |
+| ------- | -------------- |
+| `us-en` | United States  |
+| `uk-en` | United Kingdom |
+| `br-pt` | Brazil         |
+| `de-de` | Germany        |
+| `fr-fr` | France         |
+| `es-es` | Spain          |
+| `jp-jp` | Japan          |
+| `au-en` | Australia      |
+
+Leave empty for international (unfiltered) results.
+
+### Tips
+
+- **No API key needed** — DuckDuckGo is free and open.
+- **Keep queries concise** — search terms, not full sentences.
+- **Use `region`** for localized results in a specific language/country.
+- **Break complex queries into sub-queries** for better results.
+
+## Choosing the right workflow
+
+1. **`web_search`** — Quick lookup, no special options needed.
+2. **`duckduckgo_search`** — Need region-specific results.

--- a/extensions/duckduckgo/src/config.test.ts
+++ b/extensions/duckduckgo/src/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDdgRegion,
+  resolveDdgSafeSearch,
+  resolveDdgSearchTimeoutSeconds,
+  DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS,
+} from "./config.js";
+
+describe("resolveDdgRegion", () => {
+  it("returns undefined when no config", () => {
+    expect(resolveDdgRegion(undefined)).toBeUndefined();
+    expect(resolveDdgRegion({})).toBeUndefined();
+  });
+
+  it("returns configured region", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          duckduckgo: { config: { webSearch: { region: "br-pt" } } },
+        },
+      },
+    };
+    expect(resolveDdgRegion(cfg)).toBe("br-pt");
+  });
+
+  it("returns undefined for empty string region", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          duckduckgo: { config: { webSearch: { region: "  " } } },
+        },
+      },
+    };
+    expect(resolveDdgRegion(cfg)).toBeUndefined();
+  });
+});
+
+describe("resolveDdgSafeSearch", () => {
+  it("defaults to moderate", () => {
+    expect(resolveDdgSafeSearch(undefined)).toBe("moderate");
+    expect(resolveDdgSafeSearch({})).toBe("moderate");
+  });
+
+  it("accepts strict", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          duckduckgo: { config: { webSearch: { safeSearch: "strict" } } },
+        },
+      },
+    };
+    expect(resolveDdgSafeSearch(cfg)).toBe("strict");
+  });
+
+  it("accepts off", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          duckduckgo: { config: { webSearch: { safeSearch: "off" } } },
+        },
+      },
+    };
+    expect(resolveDdgSafeSearch(cfg)).toBe("off");
+  });
+
+  it("falls back to moderate for unknown values", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          duckduckgo: { config: { webSearch: { safeSearch: "invalid" } } },
+        },
+      },
+    };
+    expect(resolveDdgSafeSearch(cfg)).toBe("moderate");
+  });
+});
+
+describe("resolveDdgSearchTimeoutSeconds", () => {
+  it("returns default when no override", () => {
+    expect(resolveDdgSearchTimeoutSeconds(undefined)).toBe(
+      DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS,
+    );
+  });
+
+  it("returns override when valid", () => {
+    expect(resolveDdgSearchTimeoutSeconds(15)).toBe(15);
+  });
+
+  it("ignores invalid overrides", () => {
+    expect(resolveDdgSearchTimeoutSeconds(0)).toBe(
+      DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS,
+    );
+    expect(resolveDdgSearchTimeoutSeconds(-5)).toBe(
+      DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS,
+    );
+    expect(resolveDdgSearchTimeoutSeconds(NaN)).toBe(
+      DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS,
+    );
+  });
+});

--- a/extensions/duckduckgo/src/config.ts
+++ b/extensions/duckduckgo/src/config.ts
@@ -1,0 +1,60 @@
+export const DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS = 30;
+export const DEFAULT_DDG_SAFE_SEARCH = "moderate";
+
+type DdgSearchConfig =
+  | {
+      region?: string;
+      safeSearch?: string;
+    }
+  | undefined;
+
+type PluginEntryConfig = {
+  webSearch?: {
+    region?: string;
+    safeSearch?: string;
+  };
+};
+
+export function resolveDdgSearchConfig(cfg?: {
+  plugins?: { entries?: Record<string, { config?: unknown }> };
+}): DdgSearchConfig {
+  const pluginConfig = cfg?.plugins?.entries?.duckduckgo?.config as
+    | PluginEntryConfig
+    | undefined;
+  const pluginWebSearch = pluginConfig?.webSearch;
+  if (
+    pluginWebSearch &&
+    typeof pluginWebSearch === "object" &&
+    !Array.isArray(pluginWebSearch)
+  ) {
+    return pluginWebSearch;
+  }
+  return undefined;
+}
+
+export function resolveDdgRegion(cfg?: {
+  plugins?: { entries?: Record<string, { config?: unknown }> };
+}): string | undefined {
+  const search = resolveDdgSearchConfig(cfg);
+  return typeof search?.region === "string" && search.region.trim()
+    ? search.region.trim()
+    : undefined;
+}
+
+export function resolveDdgSafeSearch(cfg?: {
+  plugins?: { entries?: Record<string, { config?: unknown }> };
+}): string {
+  const search = resolveDdgSearchConfig(cfg);
+  const value = typeof search?.safeSearch === "string" ? search.safeSearch.trim().toLowerCase() : "";
+  if (value === "strict" || value === "off") {
+    return value;
+  }
+  return DEFAULT_DDG_SAFE_SEARCH;
+}
+
+export function resolveDdgSearchTimeoutSeconds(override?: number): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  return DEFAULT_DDG_SEARCH_TIMEOUT_SECONDS;
+}

--- a/extensions/duckduckgo/src/ddg-client.test.ts
+++ b/extensions/duckduckgo/src/ddg-client.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./ddg-client.js";
+
+const { parseDdgLiteHtml } = __testing;
+
+describe("parseDdgLiteHtml", () => {
+  it("parses a typical DuckDuckGo Lite response", () => {
+    const html = `
+      <html>
+      <body>
+        <table>
+          <tr>
+            <td>
+              <a rel="nofollow" href="https://example.com/page1" class="result-link">Example Page One</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="result-snippet">This is the first result snippet with some content.</td>
+          </tr>
+          <tr>
+            <td>
+              <a rel="nofollow" href="https://example.com/page2" class="result-link">Example Page Two</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="result-snippet">Second result snippet here.</td>
+          </tr>
+        </table>
+      </body>
+      </html>
+    `;
+
+    const results = parseDdgLiteHtml(html);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      title: "Example Page One",
+      url: "https://example.com/page1",
+      snippet: "This is the first result snippet with some content.",
+    });
+    expect(results[1]).toEqual({
+      title: "Example Page Two",
+      url: "https://example.com/page2",
+      snippet: "Second result snippet here.",
+    });
+  });
+
+  it("handles HTML entities in URLs and titles", () => {
+    const html = `
+      <a rel="nofollow" href="https://example.com/search?q=hello&amp;lang=en" class="result-link">Hello &amp; World</a>
+      <td class="result-snippet">Results for &quot;hello&quot; search.</td>
+    `;
+
+    const results = parseDdgLiteHtml(html);
+    expect(results).toHaveLength(1);
+    expect(results[0].url).toBe("https://example.com/search?q=hello&lang=en");
+    expect(results[0].title).toBe("Hello & World");
+  });
+
+  it("returns empty array for empty or no-result HTML", () => {
+    expect(parseDdgLiteHtml("")).toEqual([]);
+    expect(parseDdgLiteHtml("<html><body>No results</body></html>")).toEqual([]);
+  });
+
+  it("handles results with missing snippets gracefully", () => {
+    const html = `
+      <a rel="nofollow" href="https://example.com/a" class="result-link">Page A</a>
+      <a rel="nofollow" href="https://example.com/b" class="result-link">Page B</a>
+      <td class="result-snippet">Only one snippet available.</td>
+    `;
+
+    const results = parseDdgLiteHtml(html);
+    expect(results).toHaveLength(2);
+    expect(results[0].snippet).toBe("Only one snippet available.");
+    expect(results[1].snippet).toBe("");
+  });
+
+  it("strips nested HTML tags from titles and snippets", () => {
+    const html = `
+      <a rel="nofollow" href="https://example.com" class="result-link"><b>Bold</b> Title</a>
+      <td class="result-snippet">Some <b>bold</b> and <i>italic</i> text.</td>
+    `;
+
+    const results = parseDdgLiteHtml(html);
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Bold Title");
+    expect(results[0].snippet).toBe("Some bold and italic text.");
+  });
+
+  it("handles multiple results with all fields present", () => {
+    const entries = Array.from({ length: 5 }, (_, i) => {
+      const n = i + 1;
+      return `
+        <a rel="nofollow" href="https://site${n}.example.com/" class="result-link">Site ${n}</a>
+        <td class="result-snippet">Description for site ${n}.</td>
+      `;
+    });
+    const html = `<html><body>${entries.join("")}</body></html>`;
+
+    const results = parseDdgLiteHtml(html);
+    expect(results).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(results[i].title).toBe(`Site ${i + 1}`);
+      expect(results[i].url).toBe(`https://site${i + 1}.example.com/`);
+      expect(results[i].snippet).toBe(`Description for site ${i + 1}.`);
+    }
+  });
+});

--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -1,0 +1,271 @@
+import {
+  resolveDdgRegion,
+  resolveDdgSafeSearch,
+  resolveDdgSearchTimeoutSeconds,
+} from "./config.js";
+
+const DEFAULT_CACHE_TTL_MINUTES = 5;
+
+function normalizeCacheKey(key: string): string {
+  return key;
+}
+
+type CacheEntry = { value: Record<string, unknown>; expiresAt: number; insertedAt: number };
+
+function readCache(
+  cache: Map<string, CacheEntry>,
+  key: string,
+): CacheEntry | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry;
+}
+
+function writeCache(
+  cache: Map<string, CacheEntry>,
+  key: string,
+  value: Record<string, unknown>,
+  ttlMs: number,
+): void {
+  const now = Date.now();
+  cache.set(key, { value, expiresAt: now + ttlMs, insertedAt: now });
+}
+
+function resolveCacheTtlMs(override: number | undefined, defaultMinutes: number): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return override * 60_000;
+  }
+  return defaultMinutes * 60_000;
+}
+
+function wrapWebContent(text: string, _source: string): string {
+  return text;
+}
+
+const DDG_LITE_ENDPOINT = "https://lite.duckduckgo.com/lite/";
+
+const SEARCH_CACHE = new Map<
+  string,
+  { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
+>();
+const DEFAULT_SEARCH_COUNT = 5;
+
+export type DdgSearchParams = {
+  cfg?: { plugins?: { entries?: Record<string, { config?: unknown }> } };
+  query: string;
+  maxResults?: number;
+  region?: string;
+  timeoutSeconds?: number;
+};
+
+type DdgLiteResult = {
+  title: string;
+  url: string;
+  snippet: string;
+};
+
+const SAFE_SEARCH_MAP: Record<string, string> = {
+  strict: "1",
+  moderate: "-1",
+  off: "-2",
+};
+
+/**
+ * Parse DuckDuckGo Lite HTML response into structured results.
+ *
+ * The Lite page renders results as a table with a predictable layout:
+ * - Each result has a link row followed by a snippet row.
+ * - Links live inside `<a class="result-link">` (or plain `<a>` in the
+ *   result-title cell).
+ * - Snippets live inside `<td class="result-snippet">`.
+ */
+export function parseDdgLiteHtml(html: string): DdgLiteResult[] {
+  const results: DdgLiteResult[] = [];
+
+  // Match <a> tags that contain class="result-link" (attributes may appear in any order)
+  const linkTagPattern = /<a\s+[^>]*class="result-link"[^>]*>([\s\S]*?)<\/a>/gi;
+  const hrefPattern = /href="([^"]*)"/i;
+  const snippetPattern = /<td\s+class="result-snippet"[^>]*>([\s\S]*?)<\/td>/gi;
+
+  const links: Array<{ url: string; title: string }> = [];
+  let linkMatch: RegExpExecArray | null;
+  while ((linkMatch = linkTagPattern.exec(html)) !== null) {
+    const fullTag = linkMatch[0];
+    const hrefMatch = fullTag.match(hrefPattern);
+    const url = hrefMatch ? decodeHtmlEntities(hrefMatch[1].trim()) : "";
+    const title = stripHtml(linkMatch[1]).trim();
+    if (url && title) {
+      links.push({ url, title });
+    }
+  }
+
+  const snippets: string[] = [];
+  let snippetMatch: RegExpExecArray | null;
+  while ((snippetMatch = snippetPattern.exec(html)) !== null) {
+    snippets.push(stripHtml(snippetMatch[1]).trim());
+  }
+
+  for (let i = 0; i < links.length; i++) {
+    results.push({
+      title: links[i].title,
+      url: links[i].url,
+      snippet: snippets[i] ?? "",
+    });
+  }
+
+  return results;
+}
+
+function stripHtml(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, "/")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&ndash;/g, "\u2013")
+    .replace(/&mdash;/g, "\u2014")
+    .replace(/&hellip;/g, "\u2026")
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+function resolveSiteName(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runDdgSearch(
+  params: DdgSearchParams,
+): Promise<Record<string, unknown>> {
+  const count =
+    typeof params.maxResults === "number" && Number.isFinite(params.maxResults)
+      ? Math.max(1, Math.min(25, Math.floor(params.maxResults)))
+      : DEFAULT_SEARCH_COUNT;
+  const timeoutSeconds = resolveDdgSearchTimeoutSeconds(params.timeoutSeconds);
+  const region = params.region ?? resolveDdgRegion(params.cfg) ?? "";
+  const safeSearch = resolveDdgSafeSearch(params.cfg);
+
+  const cacheKey = normalizeCacheKey(
+    JSON.stringify({
+      type: "ddg-search",
+      q: params.query,
+      count,
+      region,
+      safeSearch,
+    }),
+  );
+  const cached = readCache(SEARCH_CACHE, cacheKey);
+  if (cached) {
+    return { ...cached.value, cached: true };
+  }
+
+  const start = Date.now();
+
+  const formBody = new URLSearchParams();
+  formBody.set("q", params.query);
+  if (region) {
+    formBody.set("kl", region);
+  }
+  formBody.set("kp", SAFE_SEARCH_MAP[safeSearch] ?? "-1");
+  // Request the lite HTML version
+  formBody.set("df", "");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+
+  let rawResults: DdgLiteResult[];
+  try {
+    const response = await fetch(DDG_LITE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        Origin: "https://lite.duckduckgo.com",
+        Referer: "https://lite.duckduckgo.com/",
+      },
+      body: formBody.toString(),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => response.statusText);
+      throw new Error(`DuckDuckGo search error (${response.status}): ${detail}`);
+    }
+    const html = await response.text();
+    if (
+      html.includes("Select all squares") ||
+      html.includes("challenge") ||
+      html.includes("captcha") ||
+      html.includes("are you a human") ||
+      html.includes("g-recaptcha")
+    ) {
+      throw new Error(
+        "DuckDuckGo returned a bot-detection challenge. Try again later or reduce request frequency.",
+      );
+    }
+    rawResults = parseDdgLiteHtml(html);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const results = rawResults.slice(0, count).map((entry) => ({
+    title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+    url: entry.url,
+    snippet: entry.snippet ? wrapWebContent(entry.snippet, "web_search") : "",
+    siteName: resolveSiteName(entry.url) || undefined,
+  }));
+
+  const result: Record<string, unknown> = {
+    query: params.query,
+    provider: "duckduckgo",
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "duckduckgo",
+      wrapped: true,
+    },
+    results,
+  };
+
+  writeCache(
+    SEARCH_CACHE,
+    cacheKey,
+    result,
+    resolveCacheTtlMs(undefined, DEFAULT_CACHE_TTL_MINUTES),
+  );
+  return result;
+}
+
+export const __testing = {
+  parseDdgLiteHtml,
+  SEARCH_CACHE,
+};

--- a/extensions/duckduckgo/src/ddg-search-provider.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.ts
@@ -1,0 +1,67 @@
+import { Type } from "@sinclair/typebox";
+
+import {
+  enablePluginInConfig,
+  getScopedCredentialValue,
+  setScopedCredentialValue,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { runDdgSearch } from "./ddg-client.js";
+
+const DdgSearchSchema = Type.Object(
+  {
+    query: Type.String({ description: "Search query string." }),
+    count: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-25).",
+        minimum: 1,
+        maximum: 25,
+      }),
+    ),
+    region: Type.Optional(
+      Type.String({
+        description:
+          "DuckDuckGo region code for localized results (e.g., 'us-en', 'br-pt', 'de-de', 'uk-en').",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createDdgWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "duckduckgo",
+    label: "DuckDuckGo Search",
+    hint: "Free web search — no API key required",
+    envVars: [],
+    placeholder: "(no key needed)",
+    signupUrl: "https://duckduckgo.com/",
+    docsUrl: "https://docs.openclaw.ai/tools/duckduckgo",
+    autoDetectOrder: 100,
+    credentialPath: "",
+    inactiveSecretPaths: [],
+    getCredentialValue: (searchConfig) =>
+      getScopedCredentialValue(searchConfig, "duckduckgo") ??
+      "duckduckgo-no-key-needed",
+    setCredentialValue: (searchConfigTarget, value) =>
+      setScopedCredentialValue(searchConfigTarget, "duckduckgo", value),
+    getConfiguredCredentialValue: (_config) => "duckduckgo-no-key-needed",
+    setConfiguredCredentialValue: (_configTarget, _value) => {
+      // DuckDuckGo requires no API key — nothing to store
+    },
+    applySelectionConfig: (config) =>
+      enablePluginInConfig(config, "duckduckgo").config,
+    createTool: (ctx) => ({
+      description:
+        "Search the web using DuckDuckGo. Free, no API key required. Returns titles, URLs, and snippets. Supports region-specific results.",
+      parameters: DdgSearchSchema,
+      execute: async (args) =>
+        await runDdgSearch({
+          cfg: ctx.config,
+          query: typeof args.query === "string" ? args.query : "",
+          maxResults: typeof args.count === "number" ? args.count : undefined,
+          region: typeof args.region === "string" ? args.region : undefined,
+        }),
+    }),
+  };
+}

--- a/extensions/duckduckgo/src/ddg-search-tool.ts
+++ b/extensions/duckduckgo/src/ddg-search-tool.ts
@@ -1,0 +1,52 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import { runDdgSearch } from "./ddg-client.js";
+
+const DdgSearchToolSchema = Type.Object(
+  {
+    query: Type.String({ description: "Search query string." }),
+    max_results: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-25).",
+        minimum: 1,
+        maximum: 25,
+      }),
+    ),
+    region: Type.Optional(
+      Type.String({
+        description:
+          "DuckDuckGo region code for localized results (e.g., 'us-en', 'br-pt', 'de-de', 'uk-en').",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createDdgSearchTool(api: OpenClawPluginApi) {
+  return {
+    name: "web_search",
+    label: "Web Search (DuckDuckGo)",
+    description:
+      "Search the web using DuckDuckGo. Free, no API key required. Supports region-specific results via region codes.",
+    parameters: DdgSearchToolSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const query = typeof rawParams.query === "string" ? rawParams.query : "";
+      if (!query) throw new Error("query is required");
+      const maxResultsRaw = rawParams.max_results;
+      const maxResults =
+        typeof maxResultsRaw === "number" && Number.isFinite(maxResultsRaw)
+          ? Math.floor(maxResultsRaw)
+          : undefined;
+      const regionRaw = rawParams.region;
+      const region = typeof regionRaw === "string" && regionRaw.trim() ? regionRaw.trim() : undefined;
+
+      const result = await runDdgSearch({
+        cfg: api.config,
+        query,
+        maxResults,
+        region,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
 
+  extensions/duckduckgo: {}
+
   extensions/elevenlabs: {}
 
   extensions/fal: {}

--- a/src/plugins/bundled-web-search.test.ts
+++ b/src/plugins/bundled-web-search.test.ts
@@ -67,6 +67,7 @@ describe("bundled web search metadata", () => {
   it("keeps bundled web search compat ids aligned with bundled manifests", () => {
     expect(resolveBundledWebSearchPluginIds({})).toEqual([
       "brave",
+      "duckduckgo",
       "firecrawl",
       "google",
       "moonshot",

--- a/src/plugins/bundled-web-search.ts
+++ b/src/plugins/bundled-web-search.ts
@@ -206,6 +206,21 @@ const BUNDLED_WEB_SEARCH_PROVIDER_DESCRIPTORS = [
     credentialScope: { kind: "scoped", key: "tavily" },
     applySelectionConfig: (config) => enablePluginInConfig(config, "tavily").config,
   },
+  {
+    pluginId: "duckduckgo",
+    id: "duckduckgo",
+    label: "DuckDuckGo Search",
+    hint: "Free web search — no API key required",
+    envVars: [],
+    placeholder: "(no key needed)",
+    signupUrl: "https://duckduckgo.com/",
+    docsUrl: "https://docs.openclaw.ai/tools/duckduckgo",
+    autoDetectOrder: 100,
+    credentialPath: "plugins.entries.duckduckgo.config.webSearch.apiKey",
+    inactiveSecretPaths: [],
+    credentialScope: { kind: "scoped", key: "duckduckgo" },
+    applySelectionConfig: (config) => enablePluginInConfig(config, "duckduckgo").config,
+  },
 ] as const satisfies ReadonlyArray<BundledWebSearchProviderDescriptor>;
 
 export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -5,6 +5,7 @@ import byteplusPlugin from "../../../extensions/byteplus/index.js";
 import chutesPlugin from "../../../extensions/chutes/index.js";
 import cloudflareAiGatewayPlugin from "../../../extensions/cloudflare-ai-gateway/index.js";
 import copilotProxyPlugin from "../../../extensions/copilot-proxy/index.js";
+import duckduckgoPlugin from "../../../extensions/duckduckgo/index.js";
 import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
 import falPlugin from "../../../extensions/fal/index.js";
 import firecrawlPlugin from "../../../extensions/firecrawl/index.js";
@@ -81,6 +82,7 @@ type PluginRegistrationContractEntry = {
 
 const bundledWebSearchPlugins: Array<RegistrablePlugin & { credentialValue: unknown }> = [
   { ...bravePlugin, credentialValue: "BSA-test" },
+  { ...duckduckgoPlugin, credentialValue: "duckduckgo-no-key-needed" },
   { ...firecrawlPlugin, credentialValue: "fc-test" },
   { ...googlePlugin, credentialValue: "AIza-test" },
   { ...moonshotPlugin, credentialValue: "sk-test" },


### PR DESCRIPTION
## Summary

Add **DuckDuckGo** as a bundled web search provider that requires **no API key**.
This makes `web_search` accessible to all users without paid API subscriptions.

## Motivation

Currently all web search providers (Brave, Perplexity, Gemini, Grok, Kimi, Tavily, Firecrawl) require API keys.
DuckDuckGo provides free, privacy-focused web search — making it the ideal default for:
- New users who haven't configured API keys yet
- Contributors and developers testing locally
- Privacy-conscious deployments

## Changes

### New extension: `extensions/duckduckgo/`

| File | Purpose |
|------|---------|
| `index.ts` | Plugin entry — registers provider + tool |
| `src/ddg-client.ts` | HTTP client — queries DuckDuckGo Lite, parses HTML results |
| `src/ddg-search-provider.ts` | `WebSearchProviderPlugin` implementation |
| `src/ddg-search-tool.ts` | Standalone `duckduckgo_search` tool |
| `src/config.ts` | Configuration resolution (region, safeSearch, timeout) |
| `openclaw.plugin.json` | Plugin manifest |
| `package.json` | Package metadata |

### Tests (30 passing)

| File | Tests |
|------|-------|
| `index.test.ts` | Plugin registration (3 tests) |
| `src/ddg-client.test.ts` | HTML parsing — entities, nested tags, missing snippets (6 tests) |
| `src/config.test.ts` | Config resolution — region, safeSearch, timeout (10 tests) |
| `bundled-web-search.test.ts` | Provider registry alignment (2 tests) |
| `web-search-provider.contract.test.ts` | Contract compliance (9 tests) |

### Integration

- Registered in `src/plugins/bundled-web-search.ts` (descriptor)
- Registered in `src/plugins/contracts/registry.ts` (contract)
- Updated `src/plugins/bundled-web-search.test.ts` (expected IDs)

### Docs

- `docs/tools/duckduckgo.md` — setup guide, tool reference, region codes
- `extensions/duckduckgo/skills/duckduckgo/SKILL.md` — agent skill card

## Configuration

```json5
{
  tools: {
    web: {
      search: {
        provider: "duckduckgo"
      }
    }
  }
}
```

No `apiKey` needed. Optional config:
- `region`: DuckDuckGo region code (e.g. `us-en`, `br-pt`, `de-de`)
- `safeSearch`: `strict` | `moderate` (default) | `off`

## How it works

Uses the **DuckDuckGo Lite** endpoint (`lite.duckduckgo.com/lite/`) which returns lightweight HTML.
The parser extracts titles, URLs, and snippets using regex-based HTML parsing.
Results are cached, wrapped with `wrapWebContent` for security, and served through the standard provider interface.
