### PR TITLE
auth: relax token validation for new Anthropic token format

### DIFF
--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -1,7 +1,8 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 
 export const ANTHROPIC_SETUP_TOKEN_PREFIX = "sk-ant-oat01-";
-export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 80;
+/** Anthropic changed token format ~2026; new tokens lack the sk-ant-oat01- prefix. */
+export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 40;
 export const DEFAULT_TOKEN_PROFILE_NAME = "default";
 
 export function normalizeTokenProfileName(raw: string): string {
@@ -28,11 +29,12 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
-  }
-  if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
-    return "Token looks too short; paste the full setup-token";
+  // Accept both legacy sk-ant-oat01- tokens and new-format tokens (Anthropic changed format ~2026).
+  if (
+    !trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX) &&
+    trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH
+  ) {
+    return `Token looks too short; paste the full setup-token`;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Lowers minimum token length from 80 to 40 to accommodate new Anthropic token format (~2026)
- Accepts tokens that don't start with `sk-ant-oat01-` prefix, as long as they meet the minimum length
- Preserves validation for tokens that are too short and lack the expected prefix

## Test plan
- [ ] Verify new-format tokens (without `sk-ant-oat01-` prefix, ≥40 chars) are accepted
- [ ] Verify legacy tokens with `sk-ant-oat01-` prefix still work
- [ ] Verify short tokens without the prefix are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)