### PR TITLE
fix: respect enabled: true as force-enable in shouldIncludeSkill

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -200,7 +200,8 @@ function buildSkillStatus(
       isEnvSatisfied,
       isConfigSatisfied,
     });
-  const eligible = !disabled && !blockedByAllowlist && requirementsSatisfied;
+  const forceEnabled = skillConfig?.enabled === true;
+  const eligible = !disabled && !blockedByAllowlist && (forceEnabled || requirementsSatisfied);
 
   return {
     name: entry.skill.name,

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { shouldIncludeSkill } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+vi.mock("../../shared/config-eval.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../shared/config-eval.js")>()),
+  hasBinary: vi.fn().mockReturnValue(false),
+}));
+
+function makeEntry(overrides?: Partial<SkillEntry>): SkillEntry {
+  return {
+    skill: {
+      name: "test-skill",
+      description: "A test skill",
+      filePath: "/skills/test-skill/SKILL.md",
+      baseDir: "/skills/test-skill",
+      source: "openclaw-bundled",
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+    metadata: {
+      requires: { bins: ["nonexistent-bin"] },
+    },
+    ...overrides,
+  };
+}
+
+describe("shouldIncludeSkill", () => {
+  it("force-disables when enabled is false", () => {
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config: { skills: { entries: { "test-skill": { enabled: false } } } },
+    });
+    expect(result).toBe(false);
+  });
+
+  it("force-enables when enabled is true, bypassing requires.bins", () => {
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config: { skills: { entries: { "test-skill": { enabled: true } } } },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("falls through to runtime eligibility when enabled is undefined", () => {
+    // hasBinary is mocked to return false, so requires.bins rejects
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("respects allowBundled even when enabled is true", () => {
+    const config: OpenClawConfig = {
+      skills: {
+        allowBundled: ["other-skill"],
+        entries: { "test-skill": { enabled: true } },
+      },
+    };
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config,
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -84,6 +84,9 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  if (skillConfig?.enabled === true) {
+    return true;
+  }
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -84,6 +84,9 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  // enabled: true force-enables, bypassing runtime eligibility (bins, OS, etc.).
+  // Placed after isBundledSkillAllowed so allowBundled still gates bundled skills.
+  // enabled: false short-circuits before that check since the result is the same.
   if (skillConfig?.enabled === true) {
     return true;
   }


### PR DESCRIPTION
## Summary

- `enabled: false` force-disables a skill, but `enabled: true` does not force-enable — it still checks `requires.bins`, OS restrictions, etc.
- This creates an asymmetry: users cannot override runtime eligibility checks to force-include a skill they know works in their environment.
- Fix: when `enabled: true`, skip `evaluateRuntimeEligibility` and return `true`. The `isBundledSkillAllowed` check still runs first, so allowBundled restrictions are respected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32752

## User-visible / Behavior Changes

Setting `skills.entries.<key>.enabled: true` in config now guarantees the skill is included, regardless of whether required binaries are installed or OS restrictions would normally exclude it.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (skill was already available, just gated by runtime check)
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure a skill that requires a binary not present on the system (e.g., `requires: { bins: ["nonexistent"] }`)
2. Set `skills.entries.<skill-name>.enabled: true` in config
3. Check if the skill is included

### Expected

- Skill is included (force-enabled).

### Actual

- Before: Skill is excluded because `evaluateRuntimeEligibility` fails on the missing binary.
- After: Skill is included because `enabled: true` bypasses runtime eligibility.

## Evidence

- [x] Failing test/log before + passing after

New test file `src/agents/skills/config.test.ts` with 4 test cases covering force-disable, force-enable, fallthrough, and allowBundled interaction.

## Human Verification (required)

- Verified scenarios: Tested on a fork with a skill requiring a missing binary. `enabled: true` correctly force-enables, `enabled: false` correctly force-disables.
- Edge cases checked: `allowBundled` restrictions are still respected even when `enabled: true`.
- What you did **not** verify: Not every skill entry combination, but the logic is straightforward (3-line change with early return).

## Compatibility / Migration

- Backward compatible? Yes — `enabled: undefined` (default) behavior is unchanged.
- Config/env changes? No new config keys.
- Migration needed? No.

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 3-line change in `config.ts`.
- Known bad symptoms: A skill that should be excluded by runtime checks appearing in the agent's skill list.

## Risks and Mitigations

- Risk: User force-enables a skill whose required binary is truly missing, leading to runtime errors.
  - Mitigation: This is an explicit opt-in (`enabled: true`). The user is taking responsibility for ensuring the skill works.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)