### PR TITLE
fix(agents): propagate sessions_send timeout to target runs and session lock waits

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -24,6 +24,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
       tools: {
         // Keep sessions tools permissive in this suite; dedicated visibility tests cover defaults.
         sessions: { visibility: "all" },
+        agentToAgent: { enabled: true, allow: ["*"] },
       },
     }),
     resolveGatewayPort: () => 18789,
@@ -32,6 +33,18 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
+
+const permissiveSessionsConfig = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender" as const,
+    agentToAgent: { maxPingPongTurns: 2 },
+  },
+  tools: {
+    sessions: { visibility: "all" as const },
+    agentToAgent: { enabled: true, allow: ["*"] },
+  },
+};
 
 const waitForCalls = async (getCount: () => number, count: number, timeoutMs = 2000) => {
   await vi.waitFor(
@@ -228,7 +241,9 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    const tool = createOpenClawTools({
+      config: permissiveSessionsConfig,
+    }).find((candidate) => candidate.name === "sessions_history");
     expect(tool).toBeDefined();
     if (!tool) {
       throw new Error("missing sessions_history tool");
@@ -277,7 +292,9 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    const tool = createOpenClawTools({
+      config: permissiveSessionsConfig,
+    }).find((candidate) => candidate.name === "sessions_history");
     expect(tool).toBeDefined();
     if (!tool) {
       throw new Error("missing sessions_history tool");
@@ -469,7 +486,9 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    const tool = createOpenClawTools({
+      config: permissiveSessionsConfig,
+    }).find((candidate) => candidate.name === "sessions_history");
     expect(tool).toBeDefined();
     if (!tool) {
       throw new Error("missing sessions_history tool");
@@ -573,6 +592,7 @@ describe("sessions tools", () => {
     const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
+      config: permissiveSessionsConfig,
     }).find((candidate) => candidate.name === "sessions_send");
     expect(tool).toBeDefined();
     if (!tool) {
@@ -596,7 +616,7 @@ describe("sessions tools", () => {
     const waitPromise = tool.execute("call6", {
       sessionKey: "main",
       message: "wait",
-      timeoutSeconds: 1,
+      timeoutSeconds: 60,
     });
     const waited = await waitPromise;
     expect(waited.details).toMatchObject({
@@ -613,6 +633,14 @@ describe("sessions tools", () => {
     const waitCalls = calls.filter((call) => call.method === "agent.wait");
     const historyOnlyCalls = calls.filter((call) => call.method === "chat.history");
     expect(agentCalls).toHaveLength(8);
+    expect(
+      agentCalls
+        .slice(0, 4)
+        .every((call) => (call.params as { timeout?: string }).timeout === "30"),
+    ).toBe(true);
+    expect(
+      agentCalls.slice(4).every((call) => (call.params as { timeout?: string }).timeout === "60"),
+    ).toBe(true);
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
@@ -678,6 +706,7 @@ describe("sessions tools", () => {
     const tool = createOpenClawTools({
       agentSessionKey: "main",
       agentChannel: "discord",
+      config: permissiveSessionsConfig,
     }).find((candidate) => candidate.name === "sessions_send");
     expect(tool).toBeDefined();
     if (!tool) {
@@ -696,7 +725,7 @@ describe("sessions tools", () => {
     );
     expect(agentCall?.[0]).toMatchObject({
       method: "agent",
-      params: { sessionKey: targetKey },
+      params: { sessionKey: targetKey, timeout: "30" },
     });
   });
 
@@ -769,6 +798,7 @@ describe("sessions tools", () => {
     const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
+      config: permissiveSessionsConfig,
     }).find((candidate) => candidate.name === "sessions_send");
     expect(tool).toBeDefined();
     if (!tool) {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -729,6 +729,62 @@ describe("sessions tools", () => {
     });
   });
 
+  it("sessions_send defaults target timeout to 30 seconds when timeoutSeconds is omitted", async () => {
+    const targetKey = "agent:main:discord:channel:default-timeout";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: Record<string, unknown>;
+        timeoutMs?: number;
+      };
+      if (request.method === "sessions.resolve") {
+        return { key: targetKey };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-default", acceptedAt: 321 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-default", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "default-ok" }] }],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+      config: permissiveSessionsConfig,
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call7b", {
+      sessionKey: "sess-default-timeout",
+      message: "ping",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      reply: "default-ok",
+    });
+    expect(callGatewayMock.mock.calls[1]?.[0]).toMatchObject({
+      method: "agent",
+      params: { sessionKey: targetKey, timeout: "30" },
+      timeoutMs: 10_000,
+    });
+    expect(callGatewayMock.mock.calls[2]?.[0]).toMatchObject({
+      method: "agent.wait",
+      params: { runId: "run-default", timeoutMs: 30_000 },
+      timeoutMs: 32_000,
+    });
+  });
+
   it("sessions_send runs ping-pong then announces", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;
@@ -823,6 +879,9 @@ describe("sessions tools", () => {
 
     const agentCalls = calls.filter((call) => call.method === "agent");
     expect(agentCalls).toHaveLength(4);
+    expect(agentCalls.every((call) => (call.params as { timeout?: string }).timeout === "1")).toBe(
+      true,
+    );
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -455,6 +455,44 @@ describe("runEmbeddedAttempt sessions_spawn workspace inheritance", () => {
       }),
     );
   });
+
+  it("propagates non-default timeoutMs into session lock acquisition", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeout-workspace-"));
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeout-agent-dir-"));
+    tempPaths.push(workspaceDir, agentDir);
+
+    hoisted.createAgentSessionMock.mockImplementation(async () => ({
+      session: createDefaultEmbeddedSession(),
+    }));
+
+    const result = await runEmbeddedAttempt({
+      sessionId: "embedded-session",
+      sessionKey: "agent:main:main",
+      sessionFile: path.join(workspaceDir, "session.jsonl"),
+      workspaceDir,
+      agentDir,
+      config: {},
+      prompt: "no-op prompt",
+      timeoutMs: 45_000,
+      runId: "run-timeout-propagation",
+      provider: "openai",
+      modelId: "gpt-test",
+      model: testModel,
+      authStorage: {} as AuthStorage,
+      modelRegistry: {} as ModelRegistry,
+      thinkLevel: "off",
+      senderIsOwner: true,
+      disableMessageTool: true,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(hoisted.acquireSessionWriteLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: path.join(workspaceDir, "session.jsonl"),
+        timeoutMs: 45_000,
+      }),
+    );
+  });
 });
 
 describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -160,6 +160,7 @@ vi.mock("../wait-for-idle-before-flush.js", () => ({
 
 vi.mock("../runs.js", () => ({
   setActiveEmbeddedRun: () => {},
+  updateActiveEmbeddedRunSnapshot: () => {},
   clearActiveEmbeddedRun: () => {},
 }));
 
@@ -432,6 +433,12 @@ describe("runEmbeddedAttempt sessions_spawn workspace inheritance", () => {
     });
 
     expect(result.promptError).toBeNull();
+    expect(hoisted.acquireSessionWriteLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: path.join(realWorkspace, "session.jsonl"),
+        timeoutMs: 10_000,
+      }),
+    );
     expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
     expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1705,6 +1705,7 @@ export async function runEmbeddedAttempt(
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
+      timeoutMs: params.timeoutMs,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
         timeoutMs: params.timeoutMs,
       }),

--- a/src/agents/tools/agent-step.test.ts
+++ b/src/agents/tools/agent-step.test.ts
@@ -103,4 +103,59 @@ describe("runAgentStep", () => {
       timeoutMs: 47_000,
     });
   });
+
+  it.each([
+    { timeoutMs: 1, expectedTimeout: "1" },
+    { timeoutMs: 1001, expectedTimeout: "2" },
+  ])(
+    "clamps and rounds target timeout for timeoutMs=$timeoutMs",
+    async ({ timeoutMs, expectedTimeout }) => {
+      callGatewayMock.mockImplementation(async (opts: unknown) => {
+        const request = opts as { method?: string };
+        if (request.method === "agent") {
+          return { runId: "run-boundary" };
+        }
+        if (request.method === "agent.wait") {
+          return { status: "ok" };
+        }
+        if (request.method === "chat.history") {
+          return {
+            messages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "ready" }],
+              },
+            ],
+          };
+        }
+        return {};
+      });
+
+      const result = await runAgentStep({
+        sessionKey: "agent:main:child",
+        message: "hello",
+        extraSystemPrompt: "context",
+        timeoutMs,
+        sourceSessionKey: "agent:main:parent",
+        sourceChannel: "discord",
+      });
+
+      expect(result).toBe("ready");
+      expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({
+        method: "agent",
+        params: {
+          sessionKey: "agent:main:child",
+          timeout: expectedTimeout,
+        },
+      });
+      expect(callGatewayMock.mock.calls[1]?.[0]).toMatchObject({
+        method: "agent.wait",
+        params: {
+          runId: "run-boundary",
+          timeoutMs,
+        },
+        timeoutMs: timeoutMs + 2000,
+      });
+    },
+  );
 });

--- a/src/agents/tools/agent-step.test.ts
+++ b/src/agents/tools/agent-step.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
-import { readLatestAssistantReply } from "./agent-step.js";
+import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 
 describe("readLatestAssistantReply", () => {
   beforeEach(() => {
@@ -45,5 +45,62 @@ describe("readLatestAssistantReply", () => {
     const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
 
     expect(result).toBe("older output");
+  });
+});
+
+describe("runAgentStep", () => {
+  beforeEach(() => {
+    callGatewayMock.mockClear();
+  });
+
+  it("propagates timeout to target agent runs while preserving wait timing", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-1" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "ready" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await runAgentStep({
+      sessionKey: "agent:main:child",
+      message: "hello",
+      extraSystemPrompt: "context",
+      timeoutMs: 45_000,
+      sourceSessionKey: "agent:main:parent",
+      sourceChannel: "discord",
+    });
+
+    expect(result).toBe("ready");
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({
+      method: "agent",
+      params: {
+        sessionKey: "agent:main:child",
+        message: "hello",
+        timeout: "45",
+      },
+      timeoutMs: 10_000,
+    });
+    expect(callGatewayMock.mock.calls[1]?.[0]).toMatchObject({
+      method: "agent.wait",
+      params: {
+        runId: "run-1",
+        timeoutMs: 45_000,
+      },
+      timeoutMs: 47_000,
+    });
   });
 });

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -42,6 +42,7 @@ export async function runAgentStep(params: {
   sourceTool?: string;
 }): Promise<string | undefined> {
   const stepIdem = crypto.randomUUID();
+  const targetTimeoutSeconds = Math.max(1, Math.ceil(params.timeoutMs / 1000));
   const response = await callGateway<{ runId?: string }>({
     method: "agent",
     params: {
@@ -51,6 +52,7 @@ export async function runAgentStep(params: {
       deliver: false,
       channel: params.channel ?? INTERNAL_MESSAGE_CHANNEL,
       lane: params.lane ?? AGENT_LANE_NESTED,
+      timeout: String(targetTimeoutSeconds),
       extraSystemPrompt: params.extraSystemPrompt,
       inputProvenance: {
         kind: "inter_session",

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -220,6 +220,7 @@ export function createSessionsSendTool(opts?: {
           : 30;
       const timeoutMs = timeoutSeconds * 1000;
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
+      const targetTimeoutSeconds = timeoutSeconds === 0 ? 30 : Math.max(1, timeoutSeconds);
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
       const visibilityGuard = await createSessionVisibilityGuard({
@@ -250,6 +251,7 @@ export function createSessionsSendTool(opts?: {
         deliver: false,
         channel: INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_NESTED,
+        timeout: String(targetTimeoutSeconds),
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {
           kind: "inter_session",


### PR DESCRIPTION
# Draft PR: propagate sessions_send timeout into target run and session lock wait

Date: 2026-03-20
Status: draft only
Scope: upstream `openclaw/` PR, not applied in local checkout

## Suggested Title

`fix(agents): propagate sessions_send timeout to target runs and session lock waits`

## Problem

`sessions_send(timeoutSeconds=...)` currently controls caller-side reply wait, but it does not fully control the target run's runtime budget.

In busy target sessions this creates a misleading failure mode:

- caller sends with `timeoutSeconds=60`
- runtime still fails with `session file locked (timeout 10000ms)`
- the user reasonably thinks the 60-second budget was ignored

This happens because two separate timeout gaps remain:

1. `sessions-send-tool.ts` does not pass caller timeout into the target `method: "agent"` run params
2. `attempt.ts` does not pass `params.timeoutMs` into `acquireSessionWriteLock`, so lock wait falls back to the lock helper default (`10_000ms`)

The A2A helper path in `agent-step.ts` has the same timeout propagation gap.

## Proposed Change

### 1. Propagate target run timeout in `sessions_send`

File:

- `/Users/k/coding/openclaw/src/agents/tools/sessions-send-tool.ts`

Change:

- include `timeout` in `sendParams`
- use caller `timeoutSeconds` when it is positive
- keep a bounded baseline for fire-and-forget (`timeoutSeconds === 0`) rather than making the target run effectively unbounded

Suggested shape:

```ts
const targetTimeoutSeconds =
  timeoutSeconds === 0 ? 30 : Math.max(1, timeoutSeconds);

const sendParams = {
  ...existingParams,
  timeout: String(targetTimeoutSeconds),
};
```

### 2. Propagate run timeout into session write lock acquisition

File:

- `/Users/k/coding/openclaw/src/agents/pi-embedded-runner/run/attempt.ts`

Change:

```ts
const sessionLock = await acquireSessionWriteLock({
  sessionFile: params.sessionFile,
  timeoutMs: params.timeoutMs,
  maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
    timeoutMs: params.timeoutMs,
  }),
});
```

This is the direct fix for the observed `session file locked (timeout 10000ms)` mismatch.

### 3. Align A2A helper timeout semantics

File:

- `/Users/k/coding/openclaw/src/agents/tools/agent-step.ts`

Change:

- pass `timeout` into the helper's `method: "agent"` call
- derive it from `params.timeoutMs`

Suggested shape:

```ts
const targetTimeoutSeconds = Math.max(1, Math.ceil(params.timeoutMs / 1000));

const response = await callGateway({
  method: "agent",
  params: {
    ...existingParams,
    timeout: String(targetTimeoutSeconds),
  },
  timeoutMs: 10_000,
});
```

## Why This Is Safe

- no protocol surface change is required
- no new config keys are required for the first round
- caller-facing `timeoutSeconds` meaning becomes more truthful instead of changing shape
- regression coverage can be added by extending existing tests instead of introducing a new integration harness

## Tests

### sessions_send tool coverage

Extend:

- `/Users/k/coding/openclaw/src/agents/openclaw-tools.sessions.test.ts#L512`
- `/Users/k/coding/openclaw/src/agents/openclaw-tools.sessions.test.ts#L655`

Add assertions:

- `timeoutSeconds: 60` causes `method: "agent"` params to include `timeout: "60"`
- `timeoutSeconds: 0` still uses bounded target timeout behavior

### helper coverage

Extend:

- `/Users/k/coding/openclaw/src/agents/tools/agent-step.test.ts`

Add assertions:

- `runAgentStep({ timeoutMs: 45000 })` sends `params.timeout === "45"`

### embedded runner coverage

Extend:

- `/Users/k/coding/openclaw/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts#L268`

Add assertion:

- `acquireSessionWriteLock` receives `timeoutMs: params.timeoutMs`

## Behavior Before / After

Before:

- `timeoutSeconds=60` only extends the caller-side wait
- target run can still fail early on a hard-coded or default 10-second lock wait

After:

- caller timeout is propagated into target run creation
- target session lock wait uses the effective run timeout
- A2A helper path and main `sessions_send` path follow the same timeout semantics

## References

- runtime evidence:
  - `/Users/k/coding/.openclaw/workspace-heartbeat/memory/2026-03-20-sessions-send-runtime-findings.md`
- implementation plan:
  - `/Users/k/coding/.openclaw/workspace-heartbeat/memory/2026-03-20-sessions-send-upstream-fix-plan.md`

## Non-Goals

- introducing a separate dispatch timeout config in the first patch
- changing heartbeat-monitor protocol or `watch_policy`
- modifying other unrelated A2A delivery semantics
