### PR TITLE
fix(web): stop silently rewriting /tasks route

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -386,7 +386,10 @@ export function syncTabWithLocation(host: SettingsHost, replace: boolean) {
   if (typeof window === "undefined") {
     return;
   }
-  const resolved = tabFromPath(window.location.pathname, host.basePath) ?? "chat";
+  const resolved = tabFromPath(window.location.pathname, host.basePath);
+  if (!resolved) {
+    return;
+  }
   setTabFromRoute(host, resolved);
   syncUrlWithTab(host, resolved, replace);
 }

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -23,6 +23,14 @@ describe("control UI routing", () => {
     expect(window.location.pathname).toBe("/sessions");
   });
 
+  it("does not silently rewrite unknown routes", async () => {
+    const app = mountApp("/tasks");
+    await app.updateComplete;
+
+    expect(app.tab).toBe("chat");
+    expect(window.location.pathname).toBe("/tasks");
+  });
+
   it("respects /ui base paths", async () => {
     const app = mountApp("/ui/cron");
     await app.updateComplete;


### PR DESCRIPTION
## Summary
- stop silently rewriting the unknown `/tasks` route to another tab
- keep route behavior explicit for stale/unknown routes
- add a regression test covering `/tasks`

## Testing
- existing branch commit: `651b793 docs: remove legacy tasks redirect`

Closes #40312