### PR TITLE
fix(ios): restore contacts/calendar permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS: restore contacts and calendar permission prompts with first-use consent flow, least-privilege calendar write scope, and cancellation-safe permission waits. Thanks @eulicesl.
 - Gateway/shutdown: cancel delayed post-ready maintenance during close and suppress maintenance/cron startup after quick restarts, preventing orphaned background timers. Thanks @vincentkoc.
 - Agents/generated media: treat attachment-style message tool actions as completed chat sends, preventing duplicate fallback media posts when generated files were already uploaded.
 - Control UI/sessions: show each session's agent runtime in the Sessions table and allow filtering by runtime labels, matching the Agents panel runtime wording. Thanks @vincentkoc.

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -10,6 +10,11 @@ final class CalendarService: CalendarServicing {
 
         func install(_ continuation: CheckedContinuation<Bool, Never>) {
             self.lock.lock()
+            if self.hasResumed {
+                self.lock.unlock()
+                continuation.resume(returning: false)
+                return
+            }
             self.continuation = continuation
             self.lock.unlock()
         }
@@ -174,6 +179,25 @@ final class CalendarService: CalendarServicing {
         }
     }
 
+#if DEBUG
+extension CalendarService {
+    final class _TestPermissionRequestBox: @unchecked Sendable {
+        private let box = PermissionRequestBox()
+
+        func resume(_ value: Bool) {
+            self.box.resume(value)
+        }
+
+        func installAndAwait() async -> Bool {
+            await withCheckedContinuation { continuation in
+                self.box.install(continuation)
+            }
+        }
+    }
+}
+#endif
+
+extension CalendarService {
     private static func resolveCalendar(
         store: EKEventStore,
         calendarId: String?,

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -3,11 +3,36 @@ import Foundation
 import OpenClawKit
 
 final class CalendarService: CalendarServicing {
+    private final class PermissionRequestBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Bool, Never>?
+        private var hasResumed = false
+
+        func install(_ continuation: CheckedContinuation<Bool, Never>) {
+            self.lock.lock()
+            self.continuation = continuation
+            self.lock.unlock()
+        }
+
+        func resume(_ value: Bool) {
+            self.lock.lock()
+            guard !self.hasResumed else {
+                self.lock.unlock()
+                return
+            }
+            self.hasResumed = true
+            let continuation = self.continuation
+            self.continuation = nil
+            self.lock.unlock()
+            continuation?.resume(returning: value)
+        }
+    }
+
     func events(params: OpenClawCalendarEventsParams) async throws -> OpenClawCalendarEventsPayload {
         let store = EKEventStore()
         let status = EKEventStore.authorizationStatus(for: .event)
         let authorized: Bool
-        if status == .notDetermined {
+        if status == .notDetermined || status == .writeOnly {
             authorized = await Self.requestEventAccess(store: store)
         } else {
             authorized = EventKitAuthorization.allowsRead(status: status)
@@ -106,34 +131,46 @@ final class CalendarService: CalendarServicing {
     }
 
     private static func requestEventAccess(store: EKEventStore) async -> Bool {
-        if #available(iOS 17.0, *) {
-            return await withCheckedContinuation { continuation in
+        await self.awaitPermissionRequest { completion in
+            if #available(iOS 17.0, *) {
                 store.requestFullAccessToEvents { granted, _ in
-                    continuation.resume(returning: granted)
+                    completion(granted)
                 }
-            }
-        }
-
-        return await withCheckedContinuation { continuation in
-            store.requestAccess(to: .event) { granted, _ in
-                continuation.resume(returning: granted)
+            } else {
+                store.requestAccess(to: .event) { granted, _ in
+                    completion(granted)
+                }
             }
         }
     }
 
     private static func requestWriteOnlyEventAccess(store: EKEventStore) async -> Bool {
-        if #available(iOS 17.0, *) {
-            return await withCheckedContinuation { continuation in
+        await self.awaitPermissionRequest { completion in
+            if #available(iOS 17.0, *) {
                 store.requestWriteOnlyAccessToEvents { granted, _ in
-                    continuation.resume(returning: granted)
+                    completion(granted)
+                }
+            } else {
+                store.requestAccess(to: .event) { granted, _ in
+                    completion(granted)
                 }
             }
         }
+    }
 
-        return await withCheckedContinuation { continuation in
-            store.requestAccess(to: .event) { granted, _ in
-                continuation.resume(returning: granted)
+    private static func awaitPermissionRequest(
+        _ start: @escaping (@Sendable @escaping (Bool) -> Void) -> Void) async -> Bool
+    {
+        let box = PermissionRequestBox()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                box.install(continuation)
+                start { granted in
+                    box.resume(granted)
+                }
             }
+        } onCancel: {
+            box.resume(false)
         }
     }
 

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -8,6 +8,13 @@ final class CalendarService: CalendarServicing {
         private var continuation: CheckedContinuation<Bool, Never>?
         private var hasResumed = false
 
+        /// Whether the continuation has already been resumed (by a result or cancellation).
+        var isResolved: Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.hasResumed
+        }
+
         func install(_ continuation: CheckedContinuation<Bool, Never>) {
             self.lock.lock()
             if self.hasResumed {
@@ -170,6 +177,10 @@ final class CalendarService: CalendarServicing {
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 box.install(continuation)
+                /// If the task was already cancelled (onCancel raced ahead and
+                /// resumed the continuation with false), skip starting the OS
+                /// permission prompt entirely.
+                guard !box.isResolved else { return }
                 start { granted in
                     box.resume(granted)
                 }
@@ -178,6 +189,7 @@ final class CalendarService: CalendarServicing {
             box.resume(false)
         }
     }
+}
 
 #if DEBUG
 extension CalendarService {

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -195,13 +195,36 @@ final class CalendarService: CalendarServicing {
 extension CalendarService {
     final class _TestPermissionRequestBox: @unchecked Sendable {
         private let box = PermissionRequestBox()
+        private let lock = NSLock()
+        private var installWaiters: [CheckedContinuation<Void, Never>] = []
+        private var hasInstalled = false
 
         func resume(_ value: Bool) {
             self.box.resume(value)
         }
 
+        func waitUntilInstalled() async {
+            self.lock.lock()
+            if self.hasInstalled {
+                self.lock.unlock()
+                return
+            }
+            await withCheckedContinuation { continuation in
+                self.installWaiters.append(continuation)
+                self.lock.unlock()
+            }
+        }
+
         func installAndAwait() async -> Bool {
             await withCheckedContinuation { continuation in
+                self.lock.lock()
+                self.hasInstalled = true
+                let waiters = self.installWaiters
+                self.installWaiters.removeAll()
+                self.lock.unlock()
+                for waiter in waiters {
+                    waiter.resume()
+                }
                 self.box.install(continuation)
             }
         }

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -203,15 +203,27 @@ extension CalendarService {
             self.box.resume(value)
         }
 
-        func waitUntilInstalled() async {
+        private var isInstalled: Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.hasInstalled
+        }
+
+        private func enqueueInstallWaiter(_ continuation: CheckedContinuation<Void, Never>) {
             self.lock.lock()
             if self.hasInstalled {
                 self.lock.unlock()
+                continuation.resume()
                 return
             }
+            self.installWaiters.append(continuation)
+            self.lock.unlock()
+        }
+
+        func waitUntilInstalled() async {
+            guard !self.isInstalled else { return }
             await withCheckedContinuation { continuation in
-                self.installWaiters.append(continuation)
-                self.lock.unlock()
+                self.enqueueInstallWaiter(continuation)
             }
         }
 
@@ -219,13 +231,13 @@ extension CalendarService {
             await withCheckedContinuation { continuation in
                 self.lock.lock()
                 self.hasInstalled = true
+                self.box.install(continuation)
                 let waiters = self.installWaiters
                 self.installWaiters.removeAll()
                 self.lock.unlock()
                 for waiter in waiters {
                     waiter.resume()
                 }
-                self.box.install(continuation)
             }
         }
     }

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -6,7 +6,12 @@ final class CalendarService: CalendarServicing {
     func events(params: OpenClawCalendarEventsParams) async throws -> OpenClawCalendarEventsPayload {
         let store = EKEventStore()
         let status = EKEventStore.authorizationStatus(for: .event)
-        let authorized = EventKitAuthorization.allowsRead(status: status)
+        let authorized: Bool
+        if status == .notDetermined {
+            authorized = await Self.requestEventAccess(store: store)
+        } else {
+            authorized = EventKitAuthorization.allowsRead(status: status)
+        }
         guard authorized else {
             throw NSError(domain: "Calendar", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "CALENDAR_PERMISSION_REQUIRED: grant Calendar permission",
@@ -39,7 +44,12 @@ final class CalendarService: CalendarServicing {
     func add(params: OpenClawCalendarAddParams) async throws -> OpenClawCalendarAddPayload {
         let store = EKEventStore()
         let status = EKEventStore.authorizationStatus(for: .event)
-        let authorized = EventKitAuthorization.allowsWrite(status: status)
+        let authorized: Bool
+        if status == .notDetermined {
+            authorized = await Self.requestEventAccess(store: store)
+        } else {
+            authorized = EventKitAuthorization.allowsWrite(status: status)
+        }
         guard authorized else {
             throw NSError(domain: "Calendar", code: 2, userInfo: [
                 NSLocalizedDescriptionKey: "CALENDAR_PERMISSION_REQUIRED: grant Calendar permission",
@@ -93,6 +103,22 @@ final class CalendarService: CalendarServicing {
             calendarTitle: event.calendar.title)
 
         return OpenClawCalendarAddPayload(event: payload)
+    }
+
+    private static func requestEventAccess(store: EKEventStore) async -> Bool {
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { continuation in
+                store.requestFullAccessToEvents { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+
+        return await withCheckedContinuation { continuation in
+            store.requestAccess(to: .event) { granted, _ in
+                continuation.resume(returning: granted)
+            }
+        }
     }
 
     private static func resolveCalendar(

--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -46,7 +46,7 @@ final class CalendarService: CalendarServicing {
         let status = EKEventStore.authorizationStatus(for: .event)
         let authorized: Bool
         if status == .notDetermined {
-            authorized = await Self.requestEventAccess(store: store)
+            authorized = await Self.requestWriteOnlyEventAccess(store: store)
         } else {
             authorized = EventKitAuthorization.allowsWrite(status: status)
         }
@@ -109,6 +109,22 @@ final class CalendarService: CalendarServicing {
         if #available(iOS 17.0, *) {
             return await withCheckedContinuation { continuation in
                 store.requestFullAccessToEvents { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+
+        return await withCheckedContinuation { continuation in
+            store.requestAccess(to: .event) { granted, _ in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+
+    private static func requestWriteOnlyEventAccess(store: EKEventStore) async -> Bool {
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { continuation in
+                store.requestWriteOnlyAccessToEvents { granted, _ in
                     continuation.resume(returning: granted)
                 }
             }

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -102,9 +102,11 @@ final class ContactsService: ContactsServicing {
         case .authorized, .limited:
             return true
         case .notDetermined:
-            // Don’t prompt during node.invoke; the caller should instruct the user to grant permission.
-            // Prompts block the invoke and lead to timeouts in headless flows.
-            return false
+            return await withCheckedContinuation { continuation in
+                store.requestAccess(for: .contacts) { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
         case .restricted, .denied:
             return false
         @unknown default:

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -102,11 +102,8 @@ final class ContactsService: ContactsServicing {
         case .authorized, .limited:
             return true
         case .notDetermined:
-            return await withCheckedContinuation { continuation in
-                store.requestAccess(for: .contacts) { granted, _ in
-                    continuation.resume(returning: granted)
-                }
-            }
+            // Avoid prompting during node.invoke; headless/unattended flows should fail fast.
+            return false
         case .restricted, .denied:
             return false
         @unknown default:

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -102,8 +102,11 @@ final class ContactsService: ContactsServicing {
         case .authorized, .limited:
             return true
         case .notDetermined:
-            // Avoid prompting during node.invoke; headless/unattended flows should fail fast.
-            return false
+            return await withCheckedContinuation { continuation in
+                store.requestAccess(for: .contacts) { granted, _ in
+                    continuation.resume(returning: granted)
+                }
+            }
         case .restricted, .denied:
             return false
         @unknown default:

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -52,6 +52,12 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>OpenClaw can capture photos or short video clips when requested via the gateway.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>OpenClaw uses your contacts so you can search and reference people while using the assistant.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>OpenClaw discovers and connects to your OpenClaw gateway on the local network.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -56,6 +56,8 @@
 	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>OpenClaw uses your calendars to add events when you enable calendar access.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>OpenClaw uses your contacts so you can search and reference people while using the assistant.</string>
 	<key>NSLocalNetworkUsageDescription</key>

--- a/apps/ios/Tests/CalendarServiceTests.swift
+++ b/apps/ios/Tests/CalendarServiceTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized) struct CalendarServiceTests {
+    @Test func permissionRequestBoxResumesImmediatelyWhenCancelledBeforeInstall() async {
+        let box = CalendarService._TestPermissionRequestBox()
+        box.resume(false)
+        let granted = await box.installAndAwait()
+        #expect(granted == false)
+    }
+
+    @Test func permissionRequestBoxResumesInstalledContinuationOnce() async {
+        let box = CalendarService._TestPermissionRequestBox()
+
+        async let granted: Bool = box.installAndAwait()
+        await Task.yield()
+        box.resume(true)
+
+        #expect(await granted == true)
+    }
+}

--- a/apps/ios/Tests/CalendarServiceTests.swift
+++ b/apps/ios/Tests/CalendarServiceTests.swift
@@ -13,7 +13,7 @@ import Testing
         let box = CalendarService._TestPermissionRequestBox()
 
         async let granted: Bool = box.installAndAwait()
-        await Task.yield()
+        await box.waitUntilInstalled()
         box.resume(true)
 
         #expect(await granted == true)

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -138,6 +138,7 @@ targets:
         NSCameraUsageDescription: OpenClaw can capture photos or short video clips when requested via the gateway.
         NSCalendarsUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
         NSCalendarsFullAccessUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
+        NSCalendarsWriteOnlyAccessUsageDescription: OpenClaw uses your calendars to add events when you enable calendar access.
         NSContactsUsageDescription: OpenClaw uses your contacts so you can search and reference people while using the assistant.
         NSLocationWhenInUseUsageDescription: OpenClaw uses your location when you allow location sharing.
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -136,6 +136,9 @@ targets:
         NSBonjourServices:
           - _openclaw-gw._tcp
         NSCameraUsageDescription: OpenClaw can capture photos or short video clips when requested via the gateway.
+        NSCalendarsUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
+        NSCalendarsFullAccessUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
+        NSContactsUsageDescription: OpenClaw uses your contacts so you can search and reference people while using the assistant.
         NSLocationWhenInUseUsageDescription: OpenClaw uses your location when you allow location sharing.
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: OpenClaw needs microphone access for voice wake.


### PR DESCRIPTION
## Summary

- Problem: iOS OpenClaw did not reliably surface/request Contacts and Calendar permissions on first use, so node invokes failed with permission-required errors.
- Why it matters: users could pair successfully but still fail on `contacts.search` / `calendar.events` because the permission flow never fully engaged.
- What changed: added missing usage-description keys, requested Contacts access when `.notDetermined`, and requested Calendar access when `.notDetermined` using iOS 17+ full-access APIs with legacy fallback.
- What did NOT change (scope boundary): no gateway protocol changes, no new commands, no token/auth changes, and no background data access.
- AI-assisted: yes (AI-assisted implementation, contributor-reviewed).
- Testing level: locally built and verified on iOS invoke flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51011
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the iOS app was missing required usage-description plist entries and the service-layer permission flow did not fully request Contacts/Calendar access when authorization was `.notDetermined`.
- Missing detection / guardrail: there was no regression test or device-validation gate asserting that first-use invoke flows actually trigger the iOS system permission path for both services.
- Prior context (`git blame`, prior PR, issue, or refactor if known): later expanded by #51011 to give the same permissions explicit in-app management UX.
- Why this regressed now: iOS permission requirements tightened around explicit usage strings and permission request timing, but the app/service flow did not keep the permission prompts wired correctly.
- If unknown, what was ruled out: no gateway-side auth/token issue was involved; the failure was in the iOS permission/request path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `apps/ios/Tests/CalendarServiceTests.swift`
  - device/simulator invoke verification for Contacts + Calendar
- Scenario the test should lock in: fresh install / `.notDetermined` state must request the correct system permission and allow `contacts.search` / `calendar.events` to succeed after grant.
- Why this is the smallest reliable guardrail: the service logic can be unit-tested, but permission prompting still needs iOS runtime verification because plist usage keys and system prompts are platform-mediated.
- Existing test that already covers this (if any): partial Calendar service coverage exists; it was not sufficient to catch the end-to-end permission path break.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- iOS now presents the Contacts/Calendar system permission prompt on first use.
- After granting access, `contacts.search` and `calendar.events` can return successful results instead of permission-required errors.
- Required Contacts/Calendar usage-description strings are now present in the app bundle.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: this restores explicit user-consent access to Contacts and Calendar for existing node capabilities. iOS still gates access with consent prompts; denied/restricted states remain hard failures.

## Repro + Verification

### Environment

- OS: macOS + iOS local dev environment
- Runtime/container: local OpenClaw gateway + iOS node
- Model/provider: N/A
- Integration/channel (if any): iOS node invoke path
- Relevant config (redacted): standard local dev signing/test bundle config

### Steps

1. Build and install the iOS app from this branch.
2. Pair the node and invoke `contacts.search` / `calendar.events`.
3. Grant permissions when prompted.

### Expected

- iOS requests Contacts/Calendar permission on first use.
- After grant, both commands return successful payloads.

### Actual

- Matched expected during local verification.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `openclaw nodes invoke ... calendar.events ... --json` => `"ok": true`
- `openclaw nodes invoke ... contacts.search ... --json` => `"ok": true`

## Human Verification (required)

- Verified scenarios:
  - iOS build/install succeeds
  - live node invokes for Calendar and Contacts succeed after permission grant
  - `.notDetermined` path triggers permission requests
- Edge cases checked:
  - denied/restricted path remains explicit failure
  - iOS 17+ calendar request path with legacy fallback retained
- What you did **not** verify:
  - full repository CI matrix outside this PR scope

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A



## Risks and Mitigations

- Risk: permission prompt timing can still be brittle across iOS versions.
  - Mitigation: the request logic now explicitly handles `.notDetermined`, and the iOS 17+ calendar path retains legacy fallback behavior.

