### PR TITLE
feat(cron): add retry support for recurring jobs without affecting schedule cadence

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2744,6 +2744,8 @@ public struct CronJob: Codable, Sendable {
     public let description: String?
     public let enabled: Bool
     public let deleteafterrun: Bool?
+    public let retrycount: Int?
+    public let retrydelayms: Int?
     public let createdatms: Int
     public let updatedatms: Int
     public let schedule: AnyCodable
@@ -2762,6 +2764,8 @@ public struct CronJob: Codable, Sendable {
         description: String?,
         enabled: Bool,
         deleteafterrun: Bool?,
+        retrycount: Int?,
+        retrydelayms: Int?,
         createdatms: Int,
         updatedatms: Int,
         schedule: AnyCodable,
@@ -2779,6 +2783,8 @@ public struct CronJob: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.retrycount = retrycount
+        self.retrydelayms = retrydelayms
         self.createdatms = createdatms
         self.updatedatms = updatedatms
         self.schedule = schedule
@@ -2798,6 +2804,8 @@ public struct CronJob: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case retrycount = "retryCount"
+        case retrydelayms = "retryDelayMs"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
         case schedule
@@ -2857,6 +2865,8 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let retrycount: Int?
+    public let retrydelayms: Int?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2871,6 +2881,8 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        retrycount: Int?,
+        retrydelayms: Int?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2884,6 +2896,8 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.retrycount = retrycount
+        self.retrydelayms = retrydelayms
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2899,6 +2913,8 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case retrycount = "retryCount"
+        case retrydelayms = "retryDelayMs"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2744,6 +2744,8 @@ public struct CronJob: Codable, Sendable {
     public let description: String?
     public let enabled: Bool
     public let deleteafterrun: Bool?
+    public let retrycount: Int?
+    public let retrydelayms: Int?
     public let createdatms: Int
     public let updatedatms: Int
     public let schedule: AnyCodable
@@ -2762,6 +2764,8 @@ public struct CronJob: Codable, Sendable {
         description: String?,
         enabled: Bool,
         deleteafterrun: Bool?,
+        retrycount: Int?,
+        retrydelayms: Int?,
         createdatms: Int,
         updatedatms: Int,
         schedule: AnyCodable,
@@ -2779,6 +2783,8 @@ public struct CronJob: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.retrycount = retrycount
+        self.retrydelayms = retrydelayms
         self.createdatms = createdatms
         self.updatedatms = updatedatms
         self.schedule = schedule
@@ -2798,6 +2804,8 @@ public struct CronJob: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case retrycount = "retryCount"
+        case retrydelayms = "retryDelayMs"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
         case schedule
@@ -2857,6 +2865,8 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let retrycount: Int?
+    public let retrydelayms: Int?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2871,6 +2881,8 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        retrycount: Int?,
+        retrydelayms: Int?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2884,6 +2896,8 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.retrycount = retrycount
+        self.retrydelayms = retrydelayms
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2899,6 +2913,8 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case retrycount = "retryCount"
+        case retrydelayms = "retryDelayMs"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { callGateway } from "../gateway/call.js";
-import { validateSecretsResolveResult } from "../gateway/protocol/index.js";
+import { validateSecretsResolveResult } from "../gateway/protocol/validate-secrets-resolve-result.js";
 import {
   analyzeCommandSecretAssignmentsFromSnapshot,
   type UnresolvedCommandSecretAssignment,

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -40,6 +40,8 @@ const { registerCronCli } = await import("./cron-cli.js");
 type CronUpdatePatch = {
   patch?: {
     schedule?: { kind?: string; expr?: string; tz?: string; staggerMs?: number };
+    retryCount?: number;
+    retryDelayMs?: number;
     payload?: {
       kind?: string;
       message?: string;
@@ -59,6 +61,8 @@ type CronUpdatePatch = {
 
 type CronAddParams = {
   schedule?: { kind?: string; staggerMs?: number };
+  retryCount?: number;
+  retryDelayMs?: number;
   payload?: { model?: string; thinking?: string; lightContext?: boolean };
   delivery?: { mode?: string; accountId?: string };
   deleteAfterRun?: boolean;
@@ -318,6 +322,26 @@ describe("cron cli", () => {
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { deleteAfterRun?: boolean };
     expect(params?.deleteAfterRun).toBe(false);
+  });
+
+  it("parses retry policy on cron add", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Retrying job",
+      "--every",
+      "1h",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--retry-count",
+      "3",
+      "--retry-delay",
+      "10m",
+    ]);
+
+    expect(params?.retryCount).toBe(3);
+    expect(params?.retryDelayMs).toBe(600_000);
   });
 
   it("includes --account on isolated cron add delivery", async () => {
@@ -677,6 +701,12 @@ describe("cron cli", () => {
     expect(patch?.patch?.failureAlert?.cooldownMs).toBe(3_600_000);
     expect(patch?.patch?.failureAlert?.channel).toBe("telegram");
     expect(patch?.patch?.failureAlert?.to).toBe("19098680");
+  });
+
+  it("patches retry policy on cron edit", async () => {
+    const patch = await runCronEditAndGetPatch(["--retry-count", "2", "--retry-delay", "15m"]);
+    expect(patch?.patch?.retryCount).toBe(2);
+    expect(patch?.patch?.retryDelayMs).toBe(900_000);
   });
 
   it("supports --no-failure-alert on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -87,6 +87,8 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
+      .option("--retry-count <n>", "Fixed-delay retry attempts for this job")
+      .option("--retry-delay <duration>", "Fixed retry delay (e.g. 10m, 1h)")
       .option("--light-context", "Use lightweight bootstrap context for agent jobs", false)
       .option("--announce", "Announce summary to a chat (subagent-style)", false)
       .option("--deliver", "Deprecated (use --announce). Announces a summary to a chat.")
@@ -151,6 +153,15 @@ export function registerCronAddCommand(cron: Command) {
             typeof opts.agent === "string" && opts.agent.trim()
               ? sanitizeAgentId(opts.agent.trim())
               : undefined;
+          const retryCount = parsePositiveIntOrUndefined(opts.retryCount);
+          if (opts.retryCount !== undefined && retryCount === undefined) {
+            throw new Error("Invalid --retry-count; must be a positive integer");
+          }
+          const retryDelayMs =
+            typeof opts.retryDelay === "string" ? parseDurationMs(opts.retryDelay) : undefined;
+          if (opts.retryDelay !== undefined && !retryDelayMs) {
+            throw new Error("Invalid --retry-delay; use e.g. 10m, 1h");
+          }
 
           const hasAnnounce = Boolean(opts.announce) || opts.deliver === true;
           const hasNoDeliver = opts.deliver === false;
@@ -260,6 +271,8 @@ export function registerCronAddCommand(cron: Command) {
             enabled: !opts.disabled,
             deleteAfterRun: opts.deleteAfterRun ? true : opts.keepAfterRun ? false : undefined,
             agentId,
+            retryCount,
+            retryDelayMs,
             sessionKey,
             schedule,
             sessionTarget,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -55,6 +55,8 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--model <model>", "Model override for agent jobs")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
+      .option("--retry-count <n>", "Set fixed-delay retry attempts")
+      .option("--retry-delay <duration>", "Set fixed retry delay (e.g. 10m, 1h)")
       .option("--light-context", "Enable lightweight bootstrap context for agent jobs")
       .option("--no-light-context", "Disable lightweight bootstrap context for agent jobs")
       .option("--announce", "Announce summary to a chat (subagent-style)")
@@ -134,6 +136,20 @@ export function registerCronEditCommand(cron: Command) {
           }
           if (typeof opts.wake === "string") {
             patch.wakeMode = opts.wake;
+          }
+          if (opts.retryCount !== undefined) {
+            const retryCount = Number.parseInt(String(opts.retryCount), 10);
+            if (!Number.isFinite(retryCount) || retryCount <= 0) {
+              throw new Error("Invalid --retry-count (must be a positive integer).");
+            }
+            patch.retryCount = retryCount;
+          }
+          if (typeof opts.retryDelay === "string") {
+            const retryDelayMs = parseDurationMs(String(opts.retryDelay));
+            if (!retryDelayMs) {
+              throw new Error("Invalid --retry-delay.");
+            }
+            patch.retryDelayMs = retryDelayMs;
           }
           if (opts.agent && opts.clearAgent) {
             throw new Error("Use --agent or --clear-agent, not both");

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1967,6 +1967,94 @@ describe("Cron issue regressions", () => {
     expect(job.enabled).toBe(true);
   });
 
+  it("does not let a stale preserved natural slot block a later valid recurring retry", () => {
+    const previousNaturalRunAtMs = Date.parse("2026-03-03T10:00:00.000Z");
+    const staleNaturalNextRunAtMs = Date.parse("2026-03-03T11:00:00.000Z");
+    const startedAt = staleNaturalNextRunAtMs;
+    const endedAt = startedAt + 5_000;
+    const retryNextRunAtMs = Date.parse("2026-03-03T11:10:05.000Z");
+    const trueNaturalNextRunAtMs = Date.parse("2026-03-03T12:00:00.000Z");
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-stale-preserved-natural-slot.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "stale-preserved-natural-slot",
+      name: "stale-preserved-natural-slot",
+      scheduledAt: previousNaturalRunAtMs,
+      schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: previousNaturalRunAtMs },
+      payload: { kind: "agentTurn", message: "retry me later" },
+      state: {
+        lastRunAtMs: previousNaturalRunAtMs,
+        nextRunAtMs: staleNaturalNextRunAtMs,
+        naturalNextRunAtMs: staleNaturalNextRunAtMs,
+      },
+    });
+    job.retryCount = 1;
+    job.retryDelayMs = 10 * 60_000;
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "temporary upstream error",
+      startedAt,
+      endedAt,
+    });
+
+    expect(job.state.retryAttempt).toBe(1);
+    expect(job.state.retryNextRunAtMs).toBe(retryNextRunAtMs);
+    expect(job.state.naturalNextRunAtMs).toBe(trueNaturalNextRunAtMs);
+    expect(job.state.nextRunAtMs).toBe(retryNextRunAtMs);
+  });
+
+  it("restores anchored recurring cadence when a retry succeeds after the preserved slot passes", () => {
+    const originalRunAtMs = Date.parse("2026-03-03T10:00:00.000Z");
+    const preservedNaturalNextRunAtMs = Date.parse("2026-03-03T11:00:00.000Z");
+    const retryStartedAt = Date.parse("2026-03-03T10:10:00.000Z");
+    const retryEndedAt = Date.parse("2026-03-03T11:05:00.000Z");
+    const restoredAnchoredNextRunAtMs = Date.parse("2026-03-03T12:00:00.000Z");
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-retry-overrun-cadence.json",
+      log: noopLogger,
+      nowMs: () => retryEndedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "retry-overrun-cadence",
+      name: "retry-overrun-cadence",
+      scheduledAt: originalRunAtMs,
+      schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: originalRunAtMs },
+      payload: { kind: "agentTurn", message: "stay anchored" },
+      state: {
+        lastRunAtMs: originalRunAtMs,
+        nextRunAtMs: retryStartedAt,
+        naturalNextRunAtMs: preservedNaturalNextRunAtMs,
+        retryNextRunAtMs: retryStartedAt,
+        retryAttempt: 1,
+      },
+    });
+
+    applyJobResult(state, job, {
+      status: "ok",
+      startedAt: retryStartedAt,
+      endedAt: retryEndedAt,
+    });
+
+    expect(job.state.retryAttempt).toBeUndefined();
+    expect(job.state.retryNextRunAtMs).toBeUndefined();
+    expect(job.state.naturalNextRunAtMs).toBe(restoredAnchoredNextRunAtMs);
+    expect(job.state.nextRunAtMs).toBe(restoredAnchoredNextRunAtMs);
+  });
+
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {
     const nowMs = Date.now();
     const everyMs = 24 * 60 * 60 * 1_000;

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -85,6 +85,49 @@ describe("Cron issue regressions", () => {
     cron.stop();
   });
 
+  it("persists retry policy through real add and update service paths", async () => {
+    const store = makeStorePath();
+    const cron = await startCronForStore({ storePath: store.storePath, cronEnabled: false });
+
+    const created = await cron.add({
+      name: "retrying hourly",
+      enabled: true,
+      schedule: {
+        kind: "every",
+        everyMs: 60 * 60_000,
+        anchorMs: Date.parse("2026-02-06T10:00:00.000Z"),
+      },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "retry me" },
+      retryCount: 1,
+      retryDelayMs: 10 * 60_000,
+    });
+
+    expect(created.retryCount).toBe(1);
+    expect(created.retryDelayMs).toBe(10 * 60_000);
+
+    let listed = await cron.list({ includeDisabled: true });
+    let stored = listed.find((job) => job.id === created.id);
+    expect(stored?.retryCount).toBe(1);
+    expect(stored?.retryDelayMs).toBe(10 * 60_000);
+
+    const updated = await cron.update(created.id, {
+      retryCount: 3,
+      retryDelayMs: 15 * 60_000,
+    });
+
+    expect(updated.retryCount).toBe(3);
+    expect(updated.retryDelayMs).toBe(15 * 60_000);
+
+    listed = await cron.list({ includeDisabled: true });
+    stored = listed.find((job) => job.id === created.id);
+    expect(stored?.retryCount).toBe(3);
+    expect(stored?.retryDelayMs).toBe(15 * 60_000);
+
+    cron.stop();
+  });
+
   it("repairs isolated every jobs missing createdAtMs and sets nextWakeAtMs", async () => {
     const store = makeStorePath();
     await writeCronStoreSnapshot(store.storePath, [
@@ -667,6 +710,182 @@ describe("Cron issue regressions", () => {
     expect(overloadedJob).toBeDefined();
     expect(overloadedJob!.state.lastStatus).toBe("ok");
     expect(overloadedResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("recurring every job schedules an earlier retry without shifting cadence", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const naturalNextRunAtMs = Date.parse("2026-02-06T11:00:00.000Z");
+    const retryNextRunAtMs = Date.parse("2026-02-06T10:10:00.000Z");
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "recurring-every-retry-before-natural",
+      name: "hourly reminder",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "remind me hourly" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    cronJob.retryCount = 1;
+    cronJob.retryDelayMs = 10 * 60_000;
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "temporary upstream error",
+      })
+      .mockResolvedValueOnce({ status: "ok", summary: "done" });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    const jobAfterFailure = state.store?.jobs.find(
+      (j) => j.id === "recurring-every-retry-before-natural",
+    );
+    expect(jobAfterFailure).toBeDefined();
+    expect(jobAfterFailure!.enabled).toBe(true);
+    expect(jobAfterFailure!.state.lastStatus).toBe("error");
+    expect(jobAfterFailure!.state.naturalNextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(jobAfterFailure!.state.retryNextRunAtMs).toBe(retryNextRunAtMs);
+    expect(jobAfterFailure!.state.retryAttempt).toBe(1);
+    expect(jobAfterFailure!.state.nextRunAtMs).toBe(retryNextRunAtMs);
+
+    now = retryNextRunAtMs + 1;
+    await onTimer(state);
+
+    const jobAfterRetrySuccess = state.store?.jobs.find(
+      (j) => j.id === "recurring-every-retry-before-natural",
+    );
+    expect(jobAfterRetrySuccess).toBeDefined();
+    expect(jobAfterRetrySuccess!.state.lastStatus).toBe("ok");
+    expect(jobAfterRetrySuccess!.state.retryNextRunAtMs).toBeUndefined();
+    expect(jobAfterRetrySuccess!.state.retryAttempt).toBeUndefined();
+    expect(jobAfterRetrySuccess!.state.nextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(jobAfterRetrySuccess!.state.naturalNextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("recurring every job does not schedule a retry when retryAt equals the natural next run", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const naturalNextRunAtMs = Date.parse("2026-02-06T10:10:00.000Z");
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "recurring-every-retry-equals-natural",
+      name: "ten minute reminder",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 10 * 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "remind me every ten minutes" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    cronJob.retryCount = 1;
+    cronJob.retryDelayMs = 10 * 60_000;
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn().mockResolvedValueOnce({
+      status: "error",
+      error: "temporary upstream error",
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    const jobAfterFailure = state.store?.jobs.find(
+      (j) => j.id === "recurring-every-retry-equals-natural",
+    );
+    expect(jobAfterFailure).toBeDefined();
+    expect(jobAfterFailure!.enabled).toBe(true);
+    expect(jobAfterFailure!.state.lastStatus).toBe("error");
+    expect(jobAfterFailure!.state.naturalNextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(jobAfterFailure!.state.retryNextRunAtMs).toBeUndefined();
+    expect(jobAfterFailure!.state.retryAttempt).toBeUndefined();
+    expect(jobAfterFailure!.state.nextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  });
+
+  it("recurring every job clears retry state and falls back to the natural schedule after retry exhaustion", async () => {
+    const store = makeStorePath();
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const naturalNextRunAtMs = Date.parse("2026-02-06T11:00:00.000Z");
+    const retryNextRunAtMs = Date.parse("2026-02-06T10:10:00.000Z");
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "recurring-every-retry-exhaustion",
+      name: "hourly reminder exhaustion",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "keep retrying" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    cronJob.retryCount = 1;
+    cronJob.retryDelayMs = 10 * 60_000;
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({
+      status: "error",
+      error: "temporary upstream error",
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    const jobAfterFirstFailure = state.store?.jobs.find(
+      (j) => j.id === "recurring-every-retry-exhaustion",
+    );
+    expect(jobAfterFirstFailure).toBeDefined();
+    expect(jobAfterFirstFailure!.state.lastStatus).toBe("error");
+    expect(jobAfterFirstFailure!.state.naturalNextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(jobAfterFirstFailure!.state.retryNextRunAtMs).toBe(retryNextRunAtMs);
+    expect(jobAfterFirstFailure!.state.retryAttempt).toBe(1);
+    expect(jobAfterFirstFailure!.state.nextRunAtMs).toBe(retryNextRunAtMs);
+
+    now = retryNextRunAtMs + 1;
+    await onTimer(state);
+
+    const jobAfterExhaustion = state.store?.jobs.find(
+      (j) => j.id === "recurring-every-retry-exhaustion",
+    );
+    expect(jobAfterExhaustion).toBeDefined();
+    expect(jobAfterExhaustion!.enabled).toBe(true);
+    expect(jobAfterExhaustion!.state.lastStatus).toBe("error");
+    expect(jobAfterExhaustion!.state.lastError).toBe("temporary upstream error");
+    expect(jobAfterExhaustion!.state.retryNextRunAtMs).toBeUndefined();
+    expect(jobAfterExhaustion!.state.retryAttempt).toBeUndefined();
+    expect(jobAfterExhaustion!.state.naturalNextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(jobAfterExhaustion!.state.nextRunAtMs).toBe(naturalNextRunAtMs);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
   it("#24355: one-shot job disabled after max transient retries", async () => {

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -283,6 +283,74 @@ describe("CronService restart catch-up", () => {
     );
   });
 
+  it("preserves a persisted recurring retry wake across restart and runs at the retry time", async () => {
+    vi.setSystemTime(new Date("2025-12-13T10:05:00.000Z"));
+
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "retried" }));
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "restart-recurring-retry",
+        name: "hourly retrying job",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T10:00:00.000Z"),
+        updatedAtMs: Date.parse("2025-12-13T10:00:00.000Z"),
+        schedule: {
+          kind: "every",
+          everyMs: 60 * 60_000,
+          anchorMs: Date.parse("2025-12-13T10:00:00.000Z"),
+        },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "retry me" },
+        delivery: { mode: "none" },
+        retryCount: 1,
+        retryDelayMs: 10 * 60_000,
+        state: {
+          lastRunAtMs: Date.parse("2025-12-13T10:00:00.000Z"),
+          lastStatus: "error",
+          consecutiveErrors: 1,
+          naturalNextRunAtMs: Date.parse("2025-12-13T11:00:00.000Z"),
+          retryNextRunAtMs: Date.parse("2025-12-13T10:10:00.000Z"),
+          retryAttempt: 1,
+          nextRunAtMs: Date.parse("2025-12-13T10:10:00.000Z"),
+        },
+      },
+    ]);
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: runIsolatedAgentJob as never,
+    });
+
+    try {
+      await cron.start();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+
+      vi.setSystemTime(new Date("2025-12-13T10:10:01.000Z"));
+      await cron.run("restart-recurring-retry", "due");
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+
+      const listedJobs = await cron.list({ includeDisabled: true });
+      const updated = listedJobs.find((job) => job.id === "restart-recurring-retry");
+      expect(updated?.state.naturalNextRunAtMs).toBe(Date.parse("2025-12-13T11:00:00.000Z"));
+      expect(updated?.state.retryNextRunAtMs).toBeUndefined();
+      expect(updated?.state.retryAttempt).toBeUndefined();
+      expect(updated?.state.nextRunAtMs).toBe(Date.parse("2025-12-13T11:00:00.000Z"));
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
   it("replays missed cron slot after restart when error backoff has already elapsed", async () => {
     vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
     await withRestartedCron(

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -548,6 +548,14 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     description: normalizeOptionalText(input.description),
     enabled,
     deleteAfterRun,
+    retryCount:
+      typeof input.retryCount === "number" && Number.isFinite(input.retryCount)
+        ? Math.max(0, Math.floor(input.retryCount))
+        : undefined,
+    retryDelayMs:
+      typeof input.retryDelayMs === "number" && Number.isFinite(input.retryDelayMs)
+        ? Math.max(0, Math.floor(input.retryDelayMs))
+        : undefined,
     createdAtMs: now,
     updatedAtMs: now,
     schedule,
@@ -584,6 +592,12 @@ export function applyJobPatch(
   }
   if (typeof patch.deleteAfterRun === "boolean") {
     job.deleteAfterRun = patch.deleteAfterRun;
+  }
+  if (typeof patch.retryCount === "number" && Number.isFinite(patch.retryCount)) {
+    job.retryCount = Math.max(0, Math.floor(patch.retryCount));
+  }
+  if (typeof patch.retryDelayMs === "number" && Number.isFinite(patch.retryDelayMs)) {
+    job.retryDelayMs = Math.max(0, Math.floor(patch.retryDelayMs));
   }
   if (patch.schedule) {
     if (patch.schedule.kind === "cron") {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -347,6 +347,8 @@ export function applyJobResult(
   const recurringRetryState = getRecurringRetryState(job);
   const priorNaturalNextRunAtMs = recurringRetryState.naturalNextRunAtMs;
   const priorRetryNextRunAtMs = recurringRetryState.retryNextRunAtMs;
+  const completedRetryCycle =
+    typeof priorRetryNextRunAtMs === "number" || recurringRetryState.retryAttempt !== undefined;
   const computeNextWithPreservedLastRun = (nowMs: number) => {
     const saved = job.state.lastRunAtMs;
     job.state.lastRunAtMs = prevLastRunAtMs;
@@ -455,7 +457,9 @@ export function applyJobResult(
     } else if (result.status === "error" && job.enabled) {
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
       const preservedNaturalNextRunAtMs =
-        typeof priorNaturalNextRunAtMs === "number" ? priorNaturalNextRunAtMs : undefined;
+        completedRetryCycle && typeof priorNaturalNextRunAtMs === "number"
+          ? priorNaturalNextRunAtMs
+          : undefined;
       let normalNext: number | undefined;
       try {
         normalNext =
@@ -501,7 +505,8 @@ export function applyJobResult(
       let naturalNext: number | undefined;
       try {
         naturalNext =
-          opts?.preserveSchedule && job.schedule.kind === "every"
+          (opts?.preserveSchedule || (completedRetryCycle && job.schedule.kind === "every")) &&
+          job.schedule.kind === "every"
             ? computeNextWithPreservedLastRun(result.endedAt)
             : computeJobNextRunAtMs(job, result.endedAt);
       } catch (err) {
@@ -510,12 +515,8 @@ export function applyJobResult(
         // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
         recordScheduleComputeError({ state, job, err });
       }
-      const completedRetry =
-        typeof priorRetryNextRunAtMs === "number" &&
-        (typeof priorNaturalNextRunAtMs === "number" ||
-          recurringRetryState.retryAttempt !== undefined);
       if (
-        completedRetry &&
+        completedRetryCycle &&
         typeof priorNaturalNextRunAtMs === "number" &&
         priorNaturalNextRunAtMs > result.endedAt
       ) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -62,6 +62,42 @@ type StartupCatchupPlan = {
   deferredJobIds: string[];
 };
 
+type RecurringRetryState = {
+  naturalNextRunAtMs?: number;
+  retryNextRunAtMs?: number;
+  retryAttempt?: number;
+};
+
+function getRecurringRetryPolicy(job: CronJob): {
+  retryCount?: number;
+  retryDelayMs?: number;
+} {
+  const candidate = job as CronJob & {
+    retryCount?: unknown;
+    retryDelayMs?: unknown;
+  };
+  return {
+    retryCount:
+      typeof candidate.retryCount === "number" && Number.isFinite(candidate.retryCount)
+        ? Math.max(0, Math.floor(candidate.retryCount))
+        : undefined,
+    retryDelayMs:
+      typeof candidate.retryDelayMs === "number" && Number.isFinite(candidate.retryDelayMs)
+        ? Math.max(0, Math.floor(candidate.retryDelayMs))
+        : undefined,
+  };
+}
+
+function getRecurringRetryState(job: CronJob): RecurringRetryState {
+  return job.state as CronRunOutcome["status"] extends never ? never : RecurringRetryState;
+}
+
+function clearRecurringRetryState(job: CronJob) {
+  const state = getRecurringRetryState(job);
+  state.retryNextRunAtMs = undefined;
+  state.retryAttempt = undefined;
+}
+
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
@@ -308,6 +344,9 @@ export function applyJobResult(
   },
 ): boolean {
   const prevLastRunAtMs = job.state.lastRunAtMs;
+  const recurringRetryState = getRecurringRetryState(job);
+  const priorNaturalNextRunAtMs = recurringRetryState.naturalNextRunAtMs;
+  const priorRetryNextRunAtMs = recurringRetryState.retryNextRunAtMs;
   const computeNextWithPreservedLastRun = (nowMs: number) => {
     const saved = job.state.lastRunAtMs;
     job.state.lastRunAtMs = prevLastRunAtMs;
@@ -414,8 +453,9 @@ export function applyJobResult(
         }
       }
     } else if (result.status === "error" && job.enabled) {
-      // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
+      const preservedNaturalNextRunAtMs =
+        typeof priorNaturalNextRunAtMs === "number" ? priorNaturalNextRunAtMs : undefined;
       let normalNext: number | undefined;
       try {
         normalNext =
@@ -428,19 +468,35 @@ export function applyJobResult(
         // and fall back to backoff-only schedule so the state update is not lost.
         recordScheduleComputeError({ state, job, err });
       }
-      const backoffNext = result.endedAt + backoff;
-      // Use whichever is later: the natural next run or the backoff delay.
-      job.state.nextRunAtMs =
-        normalNext !== undefined ? Math.max(normalNext, backoffNext) : backoffNext;
-      state.deps.log.info(
-        {
-          jobId: job.id,
-          consecutiveErrors: job.state.consecutiveErrors,
-          backoffMs: backoff,
-          nextRunAtMs: job.state.nextRunAtMs,
-        },
-        "cron: applying error backoff",
-      );
+      const effectiveNaturalNextRunAtMs =
+        preservedNaturalNextRunAtMs !== undefined ? preservedNaturalNextRunAtMs : normalNext;
+      recurringRetryState.naturalNextRunAtMs = effectiveNaturalNextRunAtMs;
+      const { retryCount, retryDelayMs } = getRecurringRetryPolicy(job);
+      const canRetry =
+        typeof retryCount === "number" &&
+        retryCount > 0 &&
+        typeof retryDelayMs === "number" &&
+        retryDelayMs > 0;
+      const nextAttempt = (recurringRetryState.retryAttempt ?? 0) + 1;
+      const retryAt = result.endedAt + (retryDelayMs ?? 0);
+      const fallbackNextRunAtMs = result.endedAt + backoff;
+      if (
+        canRetry &&
+        nextAttempt <= retryCount &&
+        typeof effectiveNaturalNextRunAtMs === "number" &&
+        retryAt < effectiveNaturalNextRunAtMs
+      ) {
+        recurringRetryState.retryAttempt = nextAttempt;
+        recurringRetryState.retryNextRunAtMs = retryAt;
+        job.state.nextRunAtMs = retryAt;
+      } else if (typeof effectiveNaturalNextRunAtMs === "number") {
+        clearRecurringRetryState(job);
+        job.state.nextRunAtMs = effectiveNaturalNextRunAtMs;
+      } else {
+        recurringRetryState.naturalNextRunAtMs = undefined;
+        clearRecurringRetryState(job);
+        job.state.nextRunAtMs = fallbackNextRunAtMs;
+      }
     } else if (job.enabled) {
       let naturalNext: number | undefined;
       try {
@@ -454,18 +510,36 @@ export function applyJobResult(
         // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
         recordScheduleComputeError({ state, job, err });
       }
-      if (job.schedule.kind === "cron") {
+      const completedRetry =
+        typeof priorRetryNextRunAtMs === "number" &&
+        (typeof priorNaturalNextRunAtMs === "number" ||
+          recurringRetryState.retryAttempt !== undefined);
+      if (
+        completedRetry &&
+        typeof priorNaturalNextRunAtMs === "number" &&
+        priorNaturalNextRunAtMs > result.endedAt
+      ) {
+        recurringRetryState.naturalNextRunAtMs = priorNaturalNextRunAtMs;
+        clearRecurringRetryState(job);
+        job.state.nextRunAtMs = priorNaturalNextRunAtMs;
+      } else if (job.schedule.kind === "cron") {
         // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
         // after the current run ended.  Prevents spin-loops when the
         // schedule computation lands in the same second due to
         // timezone/croner edge cases (see #17821).
         const minNext = result.endedAt + MIN_REFIRE_GAP_MS;
-        job.state.nextRunAtMs =
+        recurringRetryState.naturalNextRunAtMs =
           naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
+        clearRecurringRetryState(job);
+        job.state.nextRunAtMs = recurringRetryState.naturalNextRunAtMs;
       } else {
+        recurringRetryState.naturalNextRunAtMs = naturalNext;
+        clearRecurringRetryState(job);
         job.state.nextRunAtMs = naturalNext;
       }
     } else {
+      recurringRetryState.naturalNextRunAtMs = undefined;
+      clearRecurringRetryState(job);
       job.state.nextRunAtMs = undefined;
     }
   }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -491,7 +491,7 @@ export function applyJobResult(
         job.state.nextRunAtMs = retryAt;
       } else if (typeof effectiveNaturalNextRunAtMs === "number") {
         clearRecurringRetryState(job);
-        job.state.nextRunAtMs = effectiveNaturalNextRunAtMs;
+        job.state.nextRunAtMs = Math.max(effectiveNaturalNextRunAtMs, fallbackNextRunAtMs);
       } else {
         recurringRetryState.naturalNextRunAtMs = undefined;
         clearRecurringRetryState(job);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -78,6 +78,13 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
+export type CronRetryPolicy = {
+  /** Maximum fixed-delay retries for this job after a failure. */
+  retryCount?: number;
+  /** Fixed retry delay in milliseconds. */
+  retryDelayMs?: number;
+};
+
 export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
 
 export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
@@ -108,6 +115,12 @@ type CronAgentTurnPayloadPatch = {
 } & Partial<CronAgentTurnPayloadFields>;
 export type CronJobState = {
   nextRunAtMs?: number;
+  /** Preserved natural next run for recurring schedules while a retry is pending. */
+  naturalNextRunAtMs?: number;
+  /** Pending fixed-delay retry wake for recurring schedules. */
+  retryNextRunAtMs?: number;
+  /** Current retry attempt within the active recurring failure cycle. */
+  retryAttempt?: number;
   runningAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */
@@ -140,6 +153,8 @@ export type CronJob = CronJobBase<
   CronDelivery,
   CronFailureAlert | false
 > & {
+  retryCount?: number;
+  retryDelayMs?: number;
   state: CronJobState;
 };
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -33,7 +33,7 @@ import {
   type OperatorScope,
 } from "./method-scopes.js";
 import { isSecureWebSocketUrl } from "./net.js";
-import { PROTOCOL_VERSION } from "./protocol/index.js";
+import { PROTOCOL_VERSION } from "./protocol/version.js";
 
 type CallGatewayBaseOptions = {
   url?: string;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -228,6 +228,9 @@ export const CronDeliveryPatchSchema = Type.Object(
 export const CronJobStateSchema = Type.Object(
   {
     nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    naturalNextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    retryNextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    retryAttempt: Type.Optional(Type.Integer({ minimum: 0 })),
     runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     lastRunStatus: Type.Optional(CronRunStatusSchema),
@@ -253,6 +256,8 @@ export const CronJobSchema = Type.Object(
     description: Type.Optional(Type.String()),
     enabled: Type.Boolean(),
     deleteAfterRun: Type.Optional(Type.Boolean()),
+    retryCount: Type.Optional(Type.Integer({ minimum: 1 })),
+    retryDelayMs: Type.Optional(Type.Integer({ minimum: 1 })),
     createdAtMs: Type.Integer({ minimum: 0 }),
     updatedAtMs: Type.Integer({ minimum: 0 }),
     schedule: CronScheduleSchema,
@@ -285,6 +290,8 @@ export const CronAddParamsSchema = Type.Object(
   {
     name: NonEmptyString,
     ...CronCommonOptionalFields,
+    retryCount: Type.Optional(Type.Integer({ minimum: 1 })),
+    retryDelayMs: Type.Optional(Type.Integer({ minimum: 1 })),
     schedule: CronScheduleSchema,
     sessionTarget: CronSessionTargetSchema,
     wakeMode: CronWakeModeSchema,
@@ -299,6 +306,8 @@ export const CronJobPatchSchema = Type.Object(
   {
     name: Type.Optional(NonEmptyString),
     ...CronCommonOptionalFields,
+    retryCount: Type.Optional(Type.Integer({ minimum: 1 })),
+    retryDelayMs: Type.Optional(Type.Integer({ minimum: 1 })),
     schedule: Type.Optional(CronScheduleSchema),
     sessionTarget: Type.Optional(CronSessionTargetSchema),
     wakeMode: Type.Optional(CronWakeModeSchema),

--- a/src/gateway/protocol/validate-secrets-resolve-result.ts
+++ b/src/gateway/protocol/validate-secrets-resolve-result.ts
@@ -1,8 +1,6 @@
 import AjvPkg from "ajv";
 import { type SecretsResolveResult, SecretsResolveResultSchema } from "./schema/secrets.js";
 
-// Keep status/startup paths from pulling in the full protocol validator bundle
-// when they only need the secrets.resolve result schema.
 const ajv = new (AjvPkg as unknown as new (opts?: object) => import("ajv").default)({
   allErrors: true,
   strict: false,

--- a/src/gateway/protocol/validate-secrets-resolve-result.ts
+++ b/src/gateway/protocol/validate-secrets-resolve-result.ts
@@ -1,0 +1,14 @@
+import AjvPkg from "ajv";
+import { type SecretsResolveResult, SecretsResolveResultSchema } from "./schema/secrets.js";
+
+// Keep status/startup paths from pulling in the full protocol validator bundle
+// when they only need the secrets.resolve result schema.
+const ajv = new (AjvPkg as unknown as new (opts?: object) => import("ajv").default)({
+  allErrors: true,
+  strict: false,
+  removeAdditional: false,
+});
+
+export const validateSecretsResolveResult = ajv.compile<SecretsResolveResult>(
+  SecretsResolveResultSchema,
+);

--- a/src/gateway/protocol/version.ts
+++ b/src/gateway/protocol/version.ts
@@ -1,0 +1,1 @@
+export const PROTOCOL_VERSION = 3 as const;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: recurring cron jobs stayed in error after failure and waited until the next scheduled run, which could be much later.
- Why it matters: transient upstream/provider failures could delay recurring jobs by hours or a full day.
- What changed: added fixed-delay retry support for recurring cron jobs, preserved natural schedule cadence, wired retry options through cron add/edit, and added targeted regression coverage.
- What did NOT change (scope boundary): no exponential backoff, no UI/status changes, no new scheduler subsystem, no broad refactors.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49740
- Related #

## User-visible / Behavior Changes

- `openclaw cron add` and `openclaw cron edit` now accept retry settings for cron jobs:
  - `--retry-count`
  - `--retry-delay`
- Recurring jobs can retry after failure before the next natural scheduled run.
- Retries are only scheduled when the retry wake is earlier than the next natural scheduled run.
- Retry handling preserves recurring cadence and does not shift the normal schedule.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace / Node test environment
- Model/provider: N/A
- Integration/channel (if any): CLI cron add/edit and cron service runtime
- Relevant config (redacted): retryCount / retryDelay on cron jobs in tests

### Steps

1. Create a recurring cron/every job with retry settings.
2. Trigger a failure and verify retry is scheduled only when earlier than the natural next run.
3. Verify successful retry clears retry state and restores the preserved natural schedule.
4. Verify exhausted retries fall back to the preserved natural schedule without cadence drift.
5. Verify retry state survives persistence/restart.
6. Verify CLI add/edit preserves retry settings.

### Expected

- Recurring retries happen only when useful and never distort normal cron cadence.
- Retry config persists through create/update flows.
- Existing fallback/backoff behavior remains intact when natural next-run computation throws.

### Actual

- Implemented and verified with focused regression and CLI tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - recurring retry scheduled before natural next run
  - retry skipped when equal to natural next run
  - retry exhaustion restores preserved natural schedule
  - retry state survives restart/persistence
  - CLI add/edit accepts and preserves retry settings
  - fallback backoff behavior remains intact when next-run computation throws
- Edge cases checked:
  - retry wake equal to natural next run
  - recurring retry exhaustion without cadence drift
  - persisted retry state after restart
- What you did **not** verify:
  - exponential backoff
  - UI/status presentation for retry state
  - broader end-to-end/manual runtime scenarios outside focused tests

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: omit retry settings on cron jobs or revert this PR
- Files/config to restore: retry-related changes in cron runtime, job persistence, CLI option wiring, and associated tests
- Known bad symptoms reviewers should watch for:
  - recurring jobs drifting from their natural schedule after a retry
  - retries being scheduled even when equal to or later than the natural next run
  - retry state not clearing after success or exhaustion

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: retry logic could accidentally shift recurring cadence after retry success or exhaustion
  - Mitigation: added targeted regression tests covering success, skip, exhaustion, and restart persistence
- Risk: retry config could be parsed by CLI but dropped during create/update flows
  - Mitigation: added persistence coverage through jobs create/update paths
- Risk: retry changes could regress existing fallback scheduling when next-run computation throws
  - Mitigation: preserved and tested fallback backoff behavior