### PR TITLE
feat(web_search): add SearXNG as zero-config web search provider

### DIFF
--- a/extensions/searxng/index.ts
+++ b/extensions/searxng/index.ts
@@ -1,0 +1,6 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import { createSearxngSearchTool } from "./src/searxng-search-tool.js";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool(createSearxngSearchTool(api) as unknown as AnyAgentTool);
+}

--- a/extensions/searxng/openclaw.plugin.json
+++ b/extensions/searxng/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "searxng",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": {
+            "type": "string",
+            "description": "Base URL of your SearXNG instance (e.g. 'http://localhost:8080'). Leave unset to use public instances."
+          },
+          "language": {
+            "type": "string",
+            "description": "Language code for results (e.g. 'pt-PT', 'en-US'). Default: 'en-US'."
+          },
+          "safeSearch": {
+            "type": "string",
+            "enum": ["0", "1", "2"],
+            "description": "SafeSearch level: 0=off, 1=moderate, 2=strict. Default: 1."
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/searxng",
+  "version": "2026.3.20",
+  "private": true,
+  "description": "OpenClaw SearXNG web search plugin — no API key required, uses public SearXNG instances",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/searxng/skills/searxng/SKILL.md
+++ b/extensions/searxng/skills/searxng/SKILL.md
@@ -1,0 +1,49 @@
+# SearXNG Web Search
+
+Search the web privately using SearXNG — a self-hosted, privacy-respecting meta-search engine that aggregates results from Google, Bing, DuckDuckGo and dozens of other sources simultaneously.
+
+## Key facts
+
+- **No API key required** — works out of the box using public SearXNG instances
+- **Privacy-first** — queries are not tracked or stored
+- **Aggregated results** — combines multiple search engines for better coverage
+- **Bring your own instance** — configure a local or self-hosted SearXNG URL in `openclaw.json` for maximum reliability
+
+## Usage examples
+
+> "search the web for best restaurants in Lisbon"  
+> "find recent news about AI regulation in Europe"  
+> "what is the capital of Mozambique"
+
+## Configuration (optional)
+
+In `~/.openclaw/openclaw.json`, under `plugins.entries.searxng.config.webSearch`:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `baseUrl` | string | (public instances) | URL of your own SearXNG instance |
+| `language` | string | `en-US` | Results language (e.g. `pt-PT`) |
+| `safeSearch` | `"0"`\|`"1"`\|`"2"` | `"1"` | 0=off, 1=moderate, 2=strict |
+
+### Run your own instance (recommended for reliability)
+
+```bash
+docker run -d -p 8080:8080 searxng/searxng
+```
+
+Then add to `openclaw.json`:
+
+```json
+"plugins": {
+  "entries": {
+    "searxng": {
+      "config": {
+        "webSearch": {
+          "baseUrl": "http://localhost:8080",
+          "language": "pt-PT"
+        }
+      }
+    }
+  }
+}
+```

--- a/extensions/searxng/src/config.ts
+++ b/extensions/searxng/src/config.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_SAFE_SEARCH = "1";
+export const DEFAULT_LANGUAGE = "en-US";
+export const DEFAULT_TIMEOUT_SECONDS = 15;
+export const DEFAULT_MAX_RESULTS = 5;
+
+/**
+ * A curated list of reliable public SearXNG instances (tried in order).
+ * Updated March 2026. Each instance runs SearXNG and exposes the JSON API.
+ */
+export const DEFAULT_INSTANCES = [
+  "https://searx.be",
+  "https://search.mdosch.de",
+  "https://paulgo.io",
+  "https://searx.tiekoetter.com",
+  "https://search.sapti.me",
+];
+
+type PluginCfg = {
+  plugins?: { entries?: Record<string, { config?: unknown }> };
+};
+
+type SearchWebConfig = {
+  baseUrl?: string;
+  language?: string;
+  safeSearch?: string;
+};
+
+function getWebConfig(cfg?: PluginCfg): SearchWebConfig | undefined {
+  const entry = cfg?.plugins?.entries?.searxng?.config as
+    | { webSearch?: SearchWebConfig }
+    | undefined;
+  return entry?.webSearch;
+}
+
+export function resolveInstances(cfg?: PluginCfg): string[] {
+  const baseUrl = getWebConfig(cfg)?.baseUrl?.trim();
+  return baseUrl ? [baseUrl] : DEFAULT_INSTANCES;
+}
+
+export function resolveLanguage(cfg?: PluginCfg): string {
+  return getWebConfig(cfg)?.language?.trim() || DEFAULT_LANGUAGE;
+}
+
+export function resolveSafeSearch(cfg?: PluginCfg): string {
+  const val = getWebConfig(cfg)?.safeSearch;
+  return val === "0" || val === "2" ? val : DEFAULT_SAFE_SEARCH;
+}

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -1,0 +1,143 @@
+import {
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_TIMEOUT_SECONDS,
+  resolveInstances,
+  resolveLanguage,
+  resolveSafeSearch,
+} from "./config.js";
+
+export type SearxngSearchParams = {
+  cfg?: { plugins?: { entries?: Record<string, { config?: unknown }> } };
+  query: string;
+  maxResults?: number;
+  language?: string;
+};
+
+type SearxngResult = {
+  title: string;
+  url: string;
+  snippet: string;
+  siteName?: string;
+};
+
+type SearxngJsonResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+  engine?: string;
+};
+
+type SearxngJsonResponse = {
+  results?: SearxngJsonResult[];
+  query?: string;
+};
+
+// Module-level cache: key → { value, expiresAt }
+const SEARCH_CACHE = new Map<string, { value: Record<string, unknown>; expiresAt: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function resolveSiteName(url: string): string | undefined {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildSearchUrl(base: string, params: SearxngSearchParams, language: string, safeSearch: string): string {
+  const url = new URL("/search", base);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("format", "json");
+  url.searchParams.set("categories", "general");
+  url.searchParams.set("language", params.language ?? language);
+  url.searchParams.set("safesearch", safeSearch);
+  return url.toString();
+}
+
+async function tryInstance(
+  base: string,
+  params: SearxngSearchParams,
+  language: string,
+  safeSearch: string,
+  count: number,
+  timeoutMs: number,
+): Promise<SearxngResult[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const url = buildSearchUrl(base, params, language, safeSearch);
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "Accept-Language": language,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+
+    // SearXNG returns JSON; if the instance returns HTML it's misconfigured
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.includes("json")) return null;
+
+    const data = (await response.json()) as SearxngJsonResponse;
+    if (!Array.isArray(data.results)) return null;
+
+    return data.results.slice(0, count).map((r) => ({
+      title: r.title ?? "",
+      url: r.url ?? "",
+      snippet: r.content ?? "",
+      siteName: r.url ? resolveSiteName(r.url) : undefined,
+    }));
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function runSearxngSearch(
+  params: SearxngSearchParams,
+): Promise<Record<string, unknown>> {
+  const count =
+    typeof params.maxResults === "number" && Number.isFinite(params.maxResults)
+      ? Math.max(1, Math.min(25, Math.floor(params.maxResults)))
+      : DEFAULT_MAX_RESULTS;
+  const language = params.language ?? resolveLanguage(params.cfg);
+  const safeSearch = resolveSafeSearch(params.cfg);
+  const instances = resolveInstances(params.cfg);
+  const timeoutMs = DEFAULT_TIMEOUT_SECONDS * 1000;
+
+  const cacheKey = JSON.stringify({ q: params.query, count, language, safeSearch });
+  const cached = SEARCH_CACHE.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return { ...cached.value, cached: true };
+  }
+
+  const start = Date.now();
+  let lastError = "";
+
+  for (const base of instances) {
+    const results = await tryInstance(base, params, language, safeSearch, count, timeoutMs);
+    if (results !== null) {
+      const value: Record<string, unknown> = {
+        query: params.query,
+        provider: "searxng",
+        instance: base,
+        count: results.length,
+        tookMs: Date.now() - start,
+        results,
+      };
+      SEARCH_CACHE.set(cacheKey, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+      return value;
+    }
+    lastError = `instance ${base} failed`;
+  }
+
+  throw new Error(
+    `All SearXNG instances failed (tried ${instances.length}). Last error: ${lastError}. ` +
+      "Consider running a local instance: docker run -d -p 8080:8080 searxng/searxng",
+  );
+}
+
+export const __testing = { SEARCH_CACHE, buildSearchUrl };

--- a/extensions/searxng/src/searxng-search-tool.ts
+++ b/extensions/searxng/src/searxng-search-tool.ts
@@ -1,0 +1,58 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
+import { runSearxngSearch } from "./searxng-client.js";
+
+const SearxngSearchSchema = Type.Object(
+  {
+    query: Type.String({ description: "Search query string." }),
+    max_results: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-25).",
+        minimum: 1,
+        maximum: 25,
+      }),
+    ),
+    language: Type.Optional(
+      Type.String({
+        description:
+          "Language/locale code for results (e.g. 'pt-PT', 'en-US', 'de-DE').",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createSearxngSearchTool(api: OpenClawPluginApi) {
+  return {
+    name: "web_search",
+    label: "Web Search (SearXNG)",
+    description:
+      "Search the web using SearXNG — a privacy-respecting meta-search engine that aggregates results from multiple sources. No API key required.",
+    parameters: SearxngSearchSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const query = typeof rawParams.query === "string" ? rawParams.query : "";
+      if (!query) throw new Error("query is required");
+
+      const maxResultsRaw = rawParams.max_results;
+      const maxResults =
+        typeof maxResultsRaw === "number" && Number.isFinite(maxResultsRaw)
+          ? Math.floor(maxResultsRaw)
+          : undefined;
+
+      const languageRaw = rawParams.language;
+      const language =
+        typeof languageRaw === "string" && languageRaw.trim()
+          ? languageRaw.trim()
+          : undefined;
+
+      const result = await runSearxngSearch({
+        cfg: api.config,
+        query,
+        maxResults,
+        language,
+      });
+
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Replaces the DuckDuckGo Lite scraper (closed #50974) with a SearXNG JSON API integration.

## Why SearXNG instead of DDG Lite scraping

DDG Lite relied on HTML scraping and triggered bot-detection (CAPTCHA) on real queries.
SearXNG uses a clean JSON API endpoint, aggregates from multiple search engines (Google, Bing, DDG, Brave, etc.), requires no API key, and has no CAPTCHA issues.

## How it works

1. Calls /search?format=json on a SearXNG instance
2. If one instance fails, automatically falls back through a curated list of 5 public instances
3. Results cached in-memory for 5 minutes per query
4. Tool registered as web_search (same name as Brave/Tavily)

## Optional local setup (recommended for reliability)

docker run -d -p 8080:8080 searxng/searxng

Then add to openclaw.json: plugins.entries.searxng.config.webSearch.baseUrl = "http://localhost:8080"

## Files changed

- extensions/searxng/index.ts
- extensions/searxng/src/config.ts
- extensions/searxng/src/searxng-client.ts
- extensions/searxng/src/searxng-search-tool.ts
- extensions/searxng/openclaw.plugin.json
- extensions/searxng/skills/searxng/SKILL.md
