### PR TITLE
feat(feishu): display group name instead of chat_id in session labels

### DIFF
--- a/extensions/feishu/src/bot-group-name.test.ts
+++ b/extensions/feishu/src/bot-group-name.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveGroupName } from "./bot.js";
+
+/**
+ * Unit tests for resolveGroupName() — the group-name resolution helper
+ * added to support human-readable session labels for Feishu group chats.
+ *
+ * Covers: successful lookup, API failure, empty name, positive cache,
+ *         negative cache, undefined response, and cross-account isolation.
+ */
+
+const mockGetChatInfo = vi.hoisted(() => vi.fn());
+const mockCreateFeishuClient = vi.hoisted(() => vi.fn());
+
+vi.mock("./chat.js", () => ({
+  getChatInfo: mockGetChatInfo,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+function makeAccount(id = "test-account") {
+  return { accountId: id, appId: "cli_test", appSecret: "secret" } as any;
+}
+
+describe("resolveGroupName", () => {
+  const account = makeAccount();
+  const log = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChatInfo.mockReset();
+    mockCreateFeishuClient.mockReset();
+    mockCreateFeishuClient.mockReturnValue({});
+  });
+
+  it("returns the group name on a successful API call", async () => {
+    mockGetChatInfo.mockResolvedValue({ name: "Engineering Team" });
+    const name = await resolveGroupName({
+      account,
+      chatId: "oc_test_001",
+      log,
+    });
+    expect(name).toBe("Engineering Team");
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined and logs on API failure", async () => {
+    mockGetChatInfo.mockRejectedValue(new Error("network error"));
+    const name = await resolveGroupName({
+      account,
+      chatId: "oc_test_002",
+      log,
+    });
+    expect(name).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("getChatInfo failed"),
+    );
+  });
+
+  it("returns undefined when API returns whitespace-only name", async () => {
+    mockGetChatInfo.mockResolvedValue({ name: "   " });
+    const name = await resolveGroupName({
+      account,
+      chatId: "oc_test_003",
+      log,
+    });
+    expect(name).toBeUndefined();
+  });
+
+  it("reuses cached result without additional API call", async () => {
+    mockGetChatInfo.mockResolvedValue({ name: "Cached Group" });
+
+    const first = await resolveGroupName({ account, chatId: "oc_test_004", log });
+    expect(first).toBe("Cached Group");
+
+    const second = await resolveGroupName({ account, chatId: "oc_test_004", log });
+    expect(second).toBe("Cached Group");
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches negative result and skips API on subsequent calls", async () => {
+    mockGetChatInfo.mockRejectedValue(new Error("timeout"));
+
+    await resolveGroupName({ account, chatId: "oc_test_005", log });
+    const second = await resolveGroupName({ account, chatId: "oc_test_005", log });
+
+    expect(second).toBeUndefined();
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when chatInfo is undefined", async () => {
+    mockGetChatInfo.mockResolvedValue(undefined);
+    const name = await resolveGroupName({
+      account,
+      chatId: "oc_test_006",
+      log,
+    });
+    expect(name).toBeUndefined();
+  });
+
+  it("isolates cache entries across different accounts", async () => {
+    const accountA = makeAccount("account-a");
+    const accountB = makeAccount("account-b");
+
+    mockGetChatInfo.mockRejectedValueOnce(new Error("no permission"));
+    const nameA = await resolveGroupName({
+      account: accountA,
+      chatId: "oc_shared_group",
+      log,
+    });
+    expect(nameA).toBeUndefined();
+
+    mockGetChatInfo.mockResolvedValueOnce({ name: "Shared Group" });
+    const nameB = await resolveGroupName({
+      account: accountB,
+      chatId: "oc_shared_group",
+      log,
+    });
+    expect(nameB).toBe("Shared Group");
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -33,6 +33,7 @@ import {
 } from "./bot-content.js";
 import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sender-name.js";
 import { createFeishuClient } from "./client.js";
+import { getChatInfo } from "./chat.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
@@ -54,6 +55,51 @@ export { toMessageResourceType } from "./bot-content.js";
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+// Group name cache keyed by `accountId:chatId` to isolate multi-account deployments.
+// Empty-string sentinel = "lookup failed or returned empty — skip API until TTL expires".
+const groupNameCache = new Map<string, { name: string; expiresAt: number }>();
+const GROUP_NAME_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export async function resolveGroupName(params: {
+  account: ReturnType<typeof resolveFeishuAccount>;
+  chatId: string;
+  log: (...args: unknown[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, log } = params;
+  const cacheKey = `${account.accountId}:${chatId}`;
+  const cached = groupNameCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.name || undefined;
+  }
+  try {
+    const client = createFeishuClient(account);
+    const chatInfo = await getChatInfo(client, chatId);
+    const name = chatInfo?.name?.trim();
+    if (name) {
+      groupNameCache.set(cacheKey, {
+        name,
+        expiresAt: Date.now() + GROUP_NAME_CACHE_TTL_MS,
+      });
+      return name;
+    }
+    // Empty/missing name — cache negative result
+    groupNameCache.set(cacheKey, {
+      name: "",
+      expiresAt: Date.now() + GROUP_NAME_CACHE_TTL_MS,
+    });
+  } catch (err) {
+    log(
+      `feishu[${account.accountId}]: getChatInfo failed for ${chatId}: ${String(err)}`,
+    );
+    // Cache negative result to avoid hammering the API on repeated failures
+    groupNameCache.set(cacheKey, {
+      name: "",
+      expiresAt: Date.now() + GROUP_NAME_CACHE_TTL_MS,
+    });
+  }
+  return undefined;
+}
 export type FeishuMessageEvent = {
   sender: {
     sender_id: {
@@ -318,6 +364,13 @@ export async function handleFeishuMessage(params: {
         permissionErrorForAgent = senderResult.permissionError;
       }
     }
+  }
+
+
+  // Resolve human-readable group name for session labeling
+  let groupName: string | undefined;
+  if (isGroup) {
+    groupName = await resolveGroupName({ account, chatId: ctx.chatId, log });
   }
 
   log(
@@ -904,7 +957,8 @@ export async function handleFeishuMessage(params: {
         SessionKey: agentSessionKey,
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
-        GroupSubject: isGroup ? ctx.chatId : undefined,
+        GroupSubject: isGroup ? (groupName || ctx.chatId) : undefined,
+        ConversationLabel: isGroup && groupName ? groupName : undefined,
         SenderName: ctx.senderName ?? ctx.senderOpenId,
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,


### PR DESCRIPTION
## Summary

Resolves #35675 — Feishu group chats now display their human-readable **group name** instead of the raw `chat_id` in OpenClaw's Chat page session dropdown.

### Problem

When a message arrives from a Feishu group chat, the session label shows a raw identifier (e.g. `oc_***`) which is meaningless to users and makes it difficult to distinguish between conversations.
<img width="1110" height="548" alt="image" src="https://github.com/user-attachments/assets/4f0786bd-8bec-4be6-acdb-250d61342ce3" />



### Solution

Call the existing `getChatInfo()` API (`im.chat.get`) to fetch the group's display name when processing a group message, then:

- Populate **`GroupSubject`** with the resolved name (falling back to `chat_id` on failure).
- Set **`ConversationLabel`** to the group name so the session dropdown shows a friendly label.

#### Caching Strategy

| Aspect | Design |
|--------|--------|
| **Cache type** | In-memory `Map` with per-entry TTL (30 min) |
| **Positive cache** | Stores resolved group name; avoids redundant API calls |
| **Negative cache** | Empty-string sentinel on failure/empty response; prevents hammering the Feishu API |
| **Multi-account isolation** | Cache key is `accountId:chatId` so different Feishu app accounts never pollute each other |
| **Fallback** | On any failure, `GroupSubject` falls back to the original `chat_id` — existing behavior is never degraded |

### Files Changed

| File | Change |
|------|--------|
| `extensions/feishu/src/bot.ts` | Add `resolveGroupName()` with account-scoped TTL + negative cache; wire into `handleFeishuMessage` → `buildCtxPayloadForAgent` |
| `extensions/feishu/src/bot-group-name.test.ts` | **New** — 7 unit tests importing the real exported function |

### Test Coverage

| # | Test Case | What It Verifies |
|---|-----------|-----------------|
| 1 | Successful API call | Returns group name, calls API once |
| 2 | API failure | Returns `undefined`, logs error |
| 3 | Whitespace-only name | Treated as empty, returns `undefined` |
| 4 | Positive cache hit | Second call skips API |
| 5 | Negative cache hit | Failed lookup is cached, second call skips API |
| 6 | Undefined chatInfo | Handles `null`/`undefined` response gracefully |
| 7 | Cross-account isolation | Account A's failure does not block account B |

### AI Contribution Disclosure

- [x] This PR was generated with AI assistance
- [x] All changes have been reviewed and validated
- [x] Tests import and exercise the real production code (not a reimplementation)
