### PR TITLE
feat(ios): add Privacy & Access settings for contacts, calendar, and reminders

### DIFF
--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -52,6 +52,16 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>OpenClaw can capture photos or short video clips when requested via the gateway.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>OpenClaw uses your calendars to add events when you enable calendar access.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>OpenClaw uses your contacts so you can search and reference people while using the assistant.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>OpenClaw discovers and connects to your OpenClaw gateway on the local network.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -1,0 +1,303 @@
+import Contacts
+import EventKit
+import SwiftUI
+import UIKit
+
+struct PrivacyAccessSectionView: View {
+    @State private var contactsStatus: CNAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
+    @State private var calendarStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
+    @State private var remindersStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
+
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        DisclosureGroup("Privacy & Access") {
+            permissionRow(
+                title: "Contacts",
+                icon: "person.crop.circle",
+                status: statusText(for: contactsStatus),
+                detail: "Search and add contacts from the assistant.",
+                actionTitle: actionTitle(for: contactsStatus),
+                action: handleContactsAction
+            )
+
+            permissionRow(
+                title: "Calendar (Add Events)",
+                icon: "calendar.badge.plus",
+                status: calendarWriteStatusText,
+                detail: "Add events with least privilege.",
+                actionTitle: calendarWriteActionTitle,
+                action: handleCalendarWriteAction
+            )
+
+            permissionRow(
+                title: "Calendar (View Events)",
+                icon: "calendar",
+                status: calendarReadStatusText,
+                detail: "List and read calendar events.",
+                actionTitle: calendarReadActionTitle,
+                action: handleCalendarReadAction
+            )
+
+            permissionRow(
+                title: "Reminders",
+                icon: "checklist",
+                status: remindersStatusText,
+                detail: "List, add, and complete reminders.",
+                actionTitle: remindersActionTitle,
+                action: handleRemindersAction
+            )
+        }
+        .onAppear { refreshAll() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { refreshAll() }
+        }
+    }
+
+    // MARK: - Permission Row
+
+    @ViewBuilder
+    private func permissionRow(
+        title: String,
+        icon: String,
+        status: String,
+        detail: String,
+        actionTitle: String?,
+        action: (() -> Void)?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label(title, systemImage: icon)
+                Spacer()
+                Text(status)
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(statusColor(for: status))
+            }
+            Text(detail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .font(.footnote)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func statusColor(for status: String) -> Color {
+        switch status {
+        case "Allowed": return .green
+        case "Not Set": return .orange
+        case "Add-Only": return .yellow
+        default: return .red
+        }
+    }
+
+    // MARK: - Contacts
+
+    private func statusText(for cnStatus: CNAuthorizationStatus) -> String {
+        switch cnStatus {
+        case .authorized, .limited: return "Allowed"
+        case .notDetermined: return "Not Set"
+        case .denied, .restricted: return "Not Allowed"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private func actionTitle(for cnStatus: CNAuthorizationStatus) -> String? {
+        switch cnStatus {
+        case .notDetermined: return "Request Access"
+        case .denied, .restricted: return "Open Settings"
+        default: return nil
+        }
+    }
+
+    private func handleContactsAction() {
+        switch contactsStatus {
+        case .notDetermined:
+            Task {
+                let store = CNContactStore()
+                _ = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+                    store.requestAccess(for: .contacts) { granted, _ in
+                        cont.resume(returning: granted)
+                    }
+                }
+                await MainActor.run { refreshAll() }
+            }
+        case .denied, .restricted:
+            openSettings()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Calendar Write
+
+    private var calendarWriteStatusText: String {
+        switch calendarStatus {
+        case .authorized, .fullAccess, .writeOnly: return "Allowed"
+        case .notDetermined: return "Not Set"
+        case .denied, .restricted: return "Not Allowed"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private var calendarWriteActionTitle: String? {
+        switch calendarStatus {
+        case .notDetermined: return "Request Access"
+        case .denied, .restricted: return "Open Settings"
+        default: return nil
+        }
+    }
+
+    private func handleCalendarWriteAction() {
+        switch calendarStatus {
+        case .notDetermined:
+            Task {
+                _ = await requestCalendarWriteOnly()
+                await MainActor.run { refreshAll() }
+            }
+        case .denied, .restricted:
+            openSettings()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Calendar Read
+
+    private var calendarReadStatusText: String {
+        switch calendarStatus {
+        case .authorized, .fullAccess: return "Allowed"
+        case .writeOnly: return "Add-Only"
+        case .notDetermined: return "Not Set"
+        case .denied, .restricted: return "Not Allowed"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private var calendarReadActionTitle: String? {
+        switch calendarStatus {
+        case .notDetermined: return "Request Full Access"
+        case .writeOnly: return "Upgrade to Full Access"
+        case .denied, .restricted: return "Open Settings"
+        default: return nil
+        }
+    }
+
+    private func handleCalendarReadAction() {
+        switch calendarStatus {
+        case .notDetermined, .writeOnly:
+            Task {
+                _ = await requestCalendarFull()
+                await MainActor.run { refreshAll() }
+            }
+        case .denied, .restricted:
+            openSettings()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Reminders
+
+    private var remindersStatusText: String {
+        switch remindersStatus {
+        case .authorized, .fullAccess: return "Allowed"
+        case .writeOnly: return "Add-Only"
+        case .notDetermined: return "Not Set"
+        case .denied, .restricted: return "Not Allowed"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private var remindersActionTitle: String? {
+        switch remindersStatus {
+        case .notDetermined: return "Request Access"
+        case .writeOnly: return "Upgrade to Full Access"
+        case .denied, .restricted: return "Open Settings"
+        default: return nil
+        }
+    }
+
+    private func handleRemindersAction() {
+        switch remindersStatus {
+        case .notDetermined:
+            Task {
+                _ = await requestRemindersFull()
+                await MainActor.run { refreshAll() }
+            }
+        case .writeOnly:
+            Task {
+                _ = await requestRemindersFull()
+                await MainActor.run { refreshAll() }
+            }
+        case .denied, .restricted:
+            openSettings()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func refreshAll() {
+        contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
+        calendarStatus = EKEventStore.authorizationStatus(for: .event)
+        remindersStatus = EKEventStore.authorizationStatus(for: .reminder)
+    }
+
+    private func requestCalendarWriteOnly() async -> Bool {
+        let store = EKEventStore()
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { cont in
+                store.requestWriteOnlyAccessToEvents { granted, _ in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+        return await withCheckedContinuation { cont in
+            store.requestAccess(to: .event) { granted, _ in
+                cont.resume(returning: granted)
+            }
+        }
+    }
+
+    private func requestCalendarFull() async -> Bool {
+        let store = EKEventStore()
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { cont in
+                store.requestFullAccessToEvents { granted, _ in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+        return await withCheckedContinuation { cont in
+            store.requestAccess(to: .event) { granted, _ in
+                cont.resume(returning: granted)
+            }
+        }
+    }
+
+    private func requestRemindersFull() async -> Bool {
+        let store = EKEventStore()
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { cont in
+                store.requestFullAccessToReminders { granted, _ in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+        return await withCheckedContinuation { cont in
+            store.requestAccess(to: .reminder) { granted, _ in
+                cont.resume(returning: granted)
+            }
+        }
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -223,12 +223,7 @@ struct PrivacyAccessSectionView: View {
 
     private func handleRemindersAction() {
         switch remindersStatus {
-        case .notDetermined:
-            Task {
-                _ = await requestRemindersFull()
-                await MainActor.run { refreshAll() }
-            }
-        case .writeOnly:
+        case .notDetermined, .writeOnly:
             Task {
                 _ = await requestRemindersFull()
                 await MainActor.run { refreshAll() }
@@ -250,15 +245,8 @@ struct PrivacyAccessSectionView: View {
 
     private func requestCalendarWriteOnly() async -> Bool {
         let store = EKEventStore()
-        if #available(iOS 17.0, *) {
-            return await withCheckedContinuation { cont in
-                store.requestWriteOnlyAccessToEvents { granted, _ in
-                    cont.resume(returning: granted)
-                }
-            }
-        }
         return await withCheckedContinuation { cont in
-            store.requestAccess(to: .event) { granted, _ in
+            store.requestWriteOnlyAccessToEvents { granted, _ in
                 cont.resume(returning: granted)
             }
         }
@@ -266,15 +254,8 @@ struct PrivacyAccessSectionView: View {
 
     private func requestCalendarFull() async -> Bool {
         let store = EKEventStore()
-        if #available(iOS 17.0, *) {
-            return await withCheckedContinuation { cont in
-                store.requestFullAccessToEvents { granted, _ in
-                    cont.resume(returning: granted)
-                }
-            }
-        }
         return await withCheckedContinuation { cont in
-            store.requestAccess(to: .event) { granted, _ in
+            store.requestFullAccessToEvents { granted, _ in
                 cont.resume(returning: granted)
             }
         }
@@ -282,15 +263,8 @@ struct PrivacyAccessSectionView: View {
 
     private func requestRemindersFull() async -> Bool {
         let store = EKEventStore()
-        if #available(iOS 17.0, *) {
-            return await withCheckedContinuation { cont in
-                store.requestFullAccessToReminders { granted, _ in
-                    cont.resume(returning: granted)
-                }
-            }
-        }
         return await withCheckedContinuation { cont in
-            store.requestAccess(to: .reminder) { granted, _ in
+            store.requestFullAccessToReminders { granted, _ in
                 cont.resume(returning: granted)
             }
         }

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -399,6 +399,8 @@ struct SettingsTab: View {
                         }
                     }
 
+                    PrivacyAccessSectionView()
+
                     DisclosureGroup("Device Info") {
                         TextField("Name", text: self.$displayName)
                         Text(self.instanceId)

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -135,6 +135,11 @@ targets:
         NSBonjourServices:
           - _openclaw-gw._tcp
         NSCameraUsageDescription: OpenClaw can capture photos or short video clips when requested via the gateway.
+        NSCalendarsUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
+        NSCalendarsFullAccessUsageDescription: OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.
+        NSCalendarsWriteOnlyAccessUsageDescription: OpenClaw uses your calendars to add events when you enable calendar access.
+        NSContactsUsageDescription: OpenClaw uses your contacts so you can search and reference people while using the assistant.
+        NSRemindersFullAccessUsageDescription: OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.
         NSLocationWhenInUseUsageDescription: OpenClaw uses your location when you allow location sharing.
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: OpenClaw needs microphone access for voice wake.


### PR DESCRIPTION
## Summary

- Problem: OpenClaw iOS lacked a dedicated in-app Privacy & Access section for Contacts, Calendar, and Reminders, which made permission state/actionability harder to understand and manage.
- Why it matters: users need a clear in-app place to see current authorization state and trigger the next valid action instead of guessing through system Settings.
- What changed: added a `PrivacyAccessSectionView`, wired it into Settings, surfaced live permission status/action buttons, and added the required Info.plist usage descriptions for the exposed permission flows.
- What did NOT change (scope boundary): no gateway protocol changes, no new remote commands, no background escalation, and no non-iOS platform behavior changes.
- AI-assisted: yes (AI-assisted drafting/coding, contributor-reviewed).
- Testing level: locally built and manually verified on iOS.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #50998
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A — feature work.
- Missing detection / guardrail: N/A.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follows the permission-restoration work in #50998 by adding explicit in-app permission management UX.
- Why this regressed now: N/A.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A.
- Scenario the test should lock in: N/A.
- Why this is the smallest reliable guardrail: N/A — feature work with manual UX verification.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: this PR is primarily user-facing iOS settings UI; validation here is simulator/device build plus manual interaction.

## User-visible / Behavior Changes

- iOS Settings now includes a **Privacy & Access** section for Contacts, Calendar, and Reminders.
- Each row shows live authorization state and the next valid action (request access, upgrade access, or open Settings).
- Returning from iOS Settings refreshes the displayed permission state.
- Required usage-description strings are now present for the surfaced permission flows.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: this exposes and clarifies existing iOS permission paths for Contacts/Calendar/Reminders. Risk is limited by explicit iOS consent prompts and existing system denial/restriction enforcement; no silent/background access was added.

## Repro + Verification

### Environment

- OS: macOS + iOS local dev environment
- Runtime/container: local OpenClaw gateway + iOS app build
- Model/provider: N/A
- Integration/channel (if any): iOS app settings UX
- Relevant config (redacted): standard local iOS signing/dev config

### Steps

1. Build and launch the iOS app with this branch.
2. Open Settings in the app.
3. Inspect the Privacy & Access section and interact with permission actions.

### Expected

- The app shows current permission state for Contacts, Calendar, and Reminders.
- Action buttons reflect the current state and route to the correct next action.
- Usage-description-backed permission flows work without missing-plist crashes/prompts.

### Actual

- Matched expected during local verification.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - local iOS build succeeds
  - permission rows render in Settings
  - status/action state updates correctly after returning from iOS Settings
- Edge cases checked:
  - add-only vs full calendar access state presentation
  - denied/not-determined/settings-reroute states
- What you did **not** verify:
  - full repository CI matrix
  - non-iOS surfaces

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A



## Risks and Mitigations

- Risk: state-driven permission UX can drift from actual iOS authorization behavior if edge states are missed.
  - Mitigation: rows are driven by current authorization status and were manually checked across the main reachable states.

