### PR TITLE
fix(cron): clear stale running markers using per-job timeouts

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -137,6 +137,39 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     expect(job.state.nextRunAtMs).toBe(futureTime);
   });
 
+  it("should clear stale running markers shortly after the configured job timeout", () => {
+    const now = Date.now();
+    const timeoutSeconds = 15 * 60;
+    const staleRunningAt = now - (timeoutSeconds * 1000 + 61_000);
+    const futureTime = now + 3600_000;
+
+    const job: CronJob = {
+      id: "short-timeout-agent-turn",
+      name: "short timeout agent turn",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 30 * 60_000 },
+      payload: {
+        kind: "agentTurn",
+        message: "monitor",
+        timeoutSeconds,
+      },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: futureTime,
+        runningAtMs: staleRunningAt,
+      },
+    };
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state);
+
+    expect(job.state.runningAtMs).toBeUndefined();
+    expect(job.state.nextRunAtMs).toBe(futureTime);
+  });
+
   it("isolates schedule errors while filling missing nextRunAtMs", () => {
     const now = Date.now();
     const pastDue = now - 1_000;

--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -118,7 +118,7 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
 
   it("should clear stuck running markers during maintenance", () => {
     const now = Date.now();
-    const stuckTime = now - 3 * 60 * 60_000; // 3 hours ago (> 2 hour threshold)
+    const stuckTime = now - 3 * 60 * 60_000; // 3 hours ago (> effective stale threshold)
     const futureTime = now + 3600_000;
 
     const job = createCronSystemEventJob(now, {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -31,13 +31,24 @@ import {
   normalizeRequiredName,
 } from "./normalize.js";
 import type { CronServiceState } from "./state.js";
+import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 
-const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_STUCK_RUN_MS = 2 * 60 * 60 * 1000;
+const STUCK_RUN_GRACE_MS = 60 * 1000;
+const MIN_STUCK_RUN_MS = 2 * 60 * 1000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
 
 function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function resolveStuckRunMs(job: CronJob): number {
+  const timeoutMs = resolveCronJobTimeoutMs(job);
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_STUCK_RUN_MS;
+  }
+  return Math.max(MIN_STUCK_RUN_MS, Math.floor(timeoutMs) + STUCK_RUN_GRACE_MS);
 }
 
 function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
@@ -377,9 +388,10 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   }
 
   const runningAt = job.state.runningAtMs;
-  if (typeof runningAt === "number" && nowMs - runningAt > STUCK_RUN_MS) {
+  const staleAfterMs = resolveStuckRunMs(job);
+  if (typeof runningAt === "number" && nowMs - runningAt > staleAfterMs) {
     state.deps.log.warn(
-      { jobId: job.id, runningAtMs: runningAt },
+      { jobId: job.id, runningAtMs: runningAt, staleAfterMs },
       "cron: clearing stuck running marker",
     );
     job.state.runningAtMs = undefined;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -45,6 +45,9 @@ function isFiniteTimestamp(value: unknown): value is number {
 
 function resolveStuckRunMs(job: CronJob): number {
   const timeoutMs = resolveCronJobTimeoutMs(job);
+  // In practice most job types resolve to a finite execution timeout here.
+  // Preserve the conservative 2-hour fallback only for effectively unlimited
+  // jobs (for example timeoutSeconds <= 0).
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
     return DEFAULT_STUCK_RUN_MS;
   }


### PR DESCRIPTION
## Summary

- AI-assisted: yes. I verified the affected cron behavior locally and added a targeted regression test for this change.
- Problem: cron stale-run recovery uses a fixed 2 hour threshold for `state.runningAtMs`, even when a job has a much shorter explicit timeout.
- Why it matters: if a cron run finalizes incompletely, short-timeout jobs can stay stuck as `running` for far longer than their own execution budget, which blocks rescheduling and makes recovery depend on gateway restart or manual job toggling.
- What changed: stale `runningAtMs` recovery now uses a per-job threshold derived from `resolveCronJobTimeoutMs(job)`, with a small grace window and a minimum floor to avoid over-eager cleanup.
- What did NOT change (scope boundary): this does not change cron scheduling semantics, job timeout behavior, delivery behavior, or run result handling; it only tightens stale-marker cleanup for jobs that are already past their own timeout window.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Cron jobs recover stale `running` markers based on their effective execution timeout window instead of a fixed 2 hour threshold.
- Jobs with short explicit timeouts recover much sooner.
- Jobs with effectively unlimited timeouts keep the conservative long fallback behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway and local source checkout
- Model/provider: OpenAI Codex / cron isolated agent jobs
- Integration/channel (if any): Feishu announce delivery configured on the affected cron job
- Relevant config (redacted): affected cron job used `payload.kind="agentTurn"` with `timeoutSeconds: 900`

### Steps

1. Create or use a cron job with `payload.kind="agentTurn"` and a short explicit timeout, for example `timeoutSeconds: 900`.
2. Let the run reach a state where execution is effectively over but `job.state.runningAtMs` is left behind as stale state.
3. Inspect cron state and scheduler behavior before the fix.

### Expected

- Once the job is clearly past its own timeout window plus a small grace period, stale `runningAtMs` should be cleared automatically.
- The job should become schedulable again without requiring a full gateway restart.

### Actual

- Before this change, stale-marker cleanup waited for a fixed 2 hour threshold even for jobs with much shorter explicit timeouts.
- That could leave the job blocked in `running` long after its configured timeout had already passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the stuck-marker behavior locally on a cron `agentTurn` job with `timeoutSeconds: 900`.
  - Confirmed the stale marker was represented by persisted `job.state.runningAtMs`.
  - Confirmed the old logic used a fixed 2 hour stale threshold.
  - Added a regression test covering short-timeout stale-marker cleanup.
- Edge cases checked:
  - Jobs with effectively unlimited timeouts still use the long fallback threshold.
  - The change does not alter `nextRunAtMs` for future-scheduled jobs when only the stale running marker is cleared.
- What you did **not** verify:
  - I did not run the full OpenClaw test suite in this environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/cron/service/jobs.ts`
  - `src/cron/service.issue-13992-regression.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimately long-running cron jobs having `runningAtMs` cleared too early.

## Risks and Mitigations

- Risk: jobs with unusually low explicit timeouts could have stale-marker cleanup happen earlier than before.
  - Mitigation: cleanup still uses `timeout + grace`, and also enforces a minimum floor before clearing.