### PR TITLE
test: mock embedded runtime setup in compact hooks harness

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -252,6 +252,10 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveContextEngine: resolveContextEngineMock,
   }));
 
+  vi.doMock("../../plugins/provider-runtime.js", () => ({
+    prepareProviderRuntimeAuth: vi.fn(async () => undefined),
+  }));
+
   vi.doMock("../../process/command-queue.js", () => ({
     enqueueCommandInLane: vi.fn((_lane: unknown, task: () => unknown) => task()),
   }));
@@ -373,6 +377,14 @@ export async function loadCompactHooksHarness(): Promise<{
     createPreparedEmbeddedPiSettingsManager: vi.fn(() => ({
       getGlobalSettings: vi.fn(() => ({})),
     })),
+  }));
+
+  vi.doMock("../pi-bundle-mcp-tools.js", () => ({
+    createBundleMcpToolRuntime: vi.fn(async () => undefined),
+  }));
+
+  vi.doMock("../pi-bundle-lsp-runtime.js", () => ({
+    createBundleLspToolRuntime: vi.fn(async () => undefined),
   }));
 
   vi.doMock("./sandbox-info.js", () => ({


### PR DESCRIPTION
## Summary

- Problem: `compact.hooks.test.ts` could enter real embedded runtime setup instead of staying inside the hook harness.
- Why it matters: the hook-only test for skipping compaction could appear to hang before reaching the branch under test.
- What changed: the harness now mocks provider runtime auth and bundled MCP/LSP runtime setup.
- What did NOT change (scope boundary): no production compaction logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #42119

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1`

### Steps

1. Run `pnpm test -- src/agents/pi-embedded-runner/compact.hooks.test.ts` before the harness mocks are present.
2. Observe the hook test path can stall in embedded runtime setup before reaching the compaction skip branch.
3. Add the missing harness mocks and rerun the hook test.

### Expected

- Hook tests stay inside the harness and complete deterministically.

### Actual

- The hook path could drift into real runtime setup and appear hung.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: on the rebased PR worktree, the previously hanging `compact.hooks.test.ts` case passed after adding these mocks, and the full `src/agents/pi-embedded-runner/compact.hooks.test.ts` file passed.
- Edge cases checked: the related `src/agents/pi-extensions/compaction-safeguard.test.ts` suite also remained green after the harness fix.
- What you did **not** verify: I did not rerun the suites in this standalone branch because this PR isolates the same already-verified harness-only change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this single commit.
- Files/config to restore: `src/agents/pi-embedded-runner/compact.hooks.harness.ts`
- Known bad symptoms reviewers should watch for: hook tests resuming the old stall before reaching compaction assertions.

## Risks and Mitigations

- Risk: the harness could diverge from runtime setup seams added elsewhere.
  - Mitigation: this change mocks only the currently reached setup seams and leaves production code untouched.
