### PR TITLE
feat(macos): windowed chat mode, drag-and-drop, resizable composer, Talk       Mode fixes      Feature/windowed chat mode clean

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -176,6 +176,10 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var showSystemMessages: Bool {
+        didSet { self.ifNotPreview { UserDefaults.standard.set(self.showSystemMessages, forKey: "openclaw.showSystemMessages") } }
+    }
+
     var canvasEnabled: Bool {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.canvasEnabled, forKey: canvasEnabledKey) } }
     }
@@ -317,6 +321,7 @@ final class AppState {
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
+        self.showSystemMessages = UserDefaults.standard.object(forKey: "openclaw.showSystemMessages") as? Bool ?? true
         self.canvasEnabled = UserDefaults.standard.object(forKey: canvasEnabledKey) as? Bool ?? true
         let execDefaults = ExecApprovalsStore.resolveDefaults()
         self.execApprovalMode = ExecApprovalQuickMode.from(security: execDefaults.security, ask: execDefaults.ask)

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -338,7 +338,12 @@ final class AppState {
 
         if !self.isPreview {
             Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-            Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }
+            // Defer TalkModeController init to next run loop iteration to prevent
+            // re-entrant access to AppStateStore.shared during init (#36983).
+            let savedTalkEnabled = self.talkEnabled
+            DispatchQueue.main.async {
+                Task { await TalkModeController.shared.setEnabled(savedTalkEnabled) }
+            }
         }
 
         self.isInitializing = false

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -53,6 +53,11 @@ struct GeneralSettings: View {
                         binding: self.$state.iconAnimationsEnabled)
 
                     SettingsToggleRow(
+                        title: "Show system messages",
+                        subtitle: "Show internal system messages in the chat window.",
+                        binding: self.$state.showSystemMessages)
+
+                    SettingsToggleRow(
                         title: "Allow Canvas",
                         subtitle: "Allow the agent to show and control the Canvas panel.",
                         binding: self.$state.canvasEnabled)

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct GeneralSettings: View {
     @Bindable var state: AppState
     @AppStorage(cameraEnabledKey) private var cameraEnabled: Bool = false
+    @AppStorage("openclaw.geminiAPIKey") private var geminiAPIKey: String = ""
+    @AppStorage("openclaw.imageGenSaveFolder") private var imageGenSaveFolder: String = ""
     private let healthStore = HealthStore.shared
     private let gatewayManager = GatewayProcessManager.shared
     @State private var gatewayDiscovery = GatewayDiscoveryModel(
@@ -51,6 +53,45 @@ struct GeneralSettings: View {
                         title: "Play menu bar icon animations",
                         subtitle: "Enable idle blinks and wiggles on the status icon.",
                         binding: self.$state.iconAnimationsEnabled)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Gemini API Key")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("Add Gemini API Key to enable image generation.")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                        SecureField("Enter your Gemini API key", text: self.$geminiAPIKey)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 11, design: .monospaced))
+                    }
+                    .padding(.vertical, 4)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Image Save Folder")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("Automatically save all generated images to this folder.")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                        HStack(spacing: 8) {
+                            TextField(
+                                "Not configured",
+                                text: self.$imageGenSaveFolder)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(size: 11, design: .monospaced))
+                            Button("Browse…") {
+                                let panel = NSOpenPanel()
+                                panel.canChooseFiles = false
+                                panel.canChooseDirectories = true
+                                panel.allowsMultipleSelection = false
+                                panel.prompt = "Select Folder"
+                                if panel.runModal() == .OK, let url = panel.url {
+                                    self.imageGenSaveFolder = url.path
+                                }
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    .padding(.vertical, 4)
 
                     SettingsToggleRow(
                         title: "Show system messages",

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -67,6 +67,13 @@ struct GeneralSettings: View {
                         subtitle: "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
                         binding: self.$state.peekabooBridgeEnabled)
 
+                    if voiceWakeSupported {
+                        SettingsToggleRow(
+                            title: "Talk Mode",
+                            subtitle: "Enable hands-free voice conversation with your assistant.",
+                            binding: self.talkBinding)
+                    }
+
                     SettingsToggleRow(
                         title: "Enable debug tools",
                         subtitle: "Show the Debug tab with development utilities.",
@@ -99,6 +106,14 @@ struct GeneralSettings: View {
         Binding(
             get: { !self.state.isPaused },
             set: { self.state.isPaused = !$0 })
+    }
+
+    private var talkBinding: Binding<Bool> {
+        Binding(
+            get: { self.state.talkEnabled },
+            set: { newValue in
+                Task { await self.state.setTalkEnabled(newValue) }
+            })
     }
 
     private var connectionSection: some View {

--- a/apps/macos/Sources/OpenClaw/GoogleImageGenService.swift
+++ b/apps/macos/Sources/OpenClaw/GoogleImageGenService.swift
@@ -1,0 +1,299 @@
+import Foundation
+import OSLog
+
+/// Direct Google Gemini API client for image generation.
+/// Bypasses the OpenClaw gateway to avoid context bloat and rate limit issues.
+@MainActor
+final class GoogleImageGenService {
+    static let shared = GoogleImageGenService()
+    private let logger = Logger(subsystem: "ai.openclaw", category: "GoogleImageGen")
+
+    /// Rate limiting: minimum interval between requests (12s ≈ 5 RPM with safety margin for Tier 1).
+    private static let minRequestInterval: TimeInterval = 12
+    /// Maximum retry attempts on 429 responses.
+    private static let maxRetries = 2
+    /// Base backoff duration in seconds (doubles each retry).
+    private static let baseBackoff: TimeInterval = 15
+
+    private var lastRequestTime: Date?
+    private var inFlight = false
+
+    private var apiKey: String? {
+        // Check UserDefaults (set in Settings), then env vars, then .env file
+        let stored = UserDefaults.standard.string(forKey: "openclaw.geminiAPIKey")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let stored, !stored.isEmpty { return stored }
+        return ProcessInfo.processInfo.environment["GEMINI_API_KEY"]
+            ?? ProcessInfo.processInfo.environment["GOOGLE_API_KEY"]
+    }
+
+    struct ImageGenResult: Sendable {
+        let imageData: Data
+        let mimeType: String
+        let text: String?
+    }
+
+    enum ImageGenError: LocalizedError {
+        case noAPIKey
+        case invalidResponse(String)
+        case rateLimited(retryAfter: String?)
+        case apiError(code: Int, message: String)
+        case alreadyInFlight
+
+        var errorDescription: String? {
+            switch self {
+            case .noAPIKey:
+                return "No GEMINI_API_KEY or GOOGLE_API_KEY found"
+            case let .invalidResponse(msg):
+                return "Invalid response: \(msg)"
+            case let .rateLimited(retry):
+                return "Image generation rate limit reached. Please wait \(retry ?? "~30 seconds") before trying again."
+            case let .apiError(code, message):
+                return "API error \(code): \(message)"
+            case .alreadyInFlight:
+                return "An image generation request is already in progress."
+            }
+        }
+    }
+
+    /// Generate or edit an image using the Gemini API directly.
+    /// Includes rate limiting (Tier 1: 5 RPM) and exponential backoff on 429s.
+    func generate(
+        prompt: String,
+        model: String,
+        inputImage: Data? = nil,
+        inputMimeType: String = "image/jpeg",
+        resolution: String = "1K",
+        aspectRatio: String = "1:1"
+    ) async throws -> ImageGenResult {
+        // Prevent concurrent requests
+        guard !self.inFlight else {
+            throw ImageGenError.alreadyInFlight
+        }
+
+        guard let apiKey = self.apiKey ?? self.fetchAPIKeyFromGateway() else {
+            Self.debugLog("ERROR: No API key found")
+            throw ImageGenError.noAPIKey
+        }
+
+        self.inFlight = true
+        defer { self.inFlight = false }
+
+        Self.debugLog("API key found (length: \(apiKey.count)), model: \(model)")
+
+        // Rate limit: wait if we sent a request too recently
+        if let last = self.lastRequestTime {
+            let elapsed = Date().timeIntervalSince(last)
+            let wait = Self.minRequestInterval - elapsed
+            if wait > 0 {
+                Self.debugLog("Rate limiting: waiting \(String(format: "%.1f", wait))s")
+                self.logger.info("Rate limiting: waiting \(String(format: "%.1f", wait))s before next request")
+                try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+            }
+        }
+
+        let modelID = model.replacingOccurrences(of: "google/", with: "")
+        Self.debugLog("Resolved modelID: \(modelID)")
+        let request = try self.buildRequest(
+            modelID: modelID, apiKey: apiKey, prompt: prompt,
+            inputImage: inputImage, inputMimeType: inputMimeType,
+            resolution: resolution, aspectRatio: aspectRatio)
+
+        // Attempt with retries on 429
+        var lastRetryAfter: String?
+        for attempt in 0...Self.maxRetries {
+            if attempt > 0 {
+                let backoff = Self.baseBackoff * pow(2.0, Double(attempt - 1))
+                Self.debugLog("Rate limited, backing off \(String(format: "%.0f", backoff))s (attempt \(attempt)/\(Self.maxRetries))")
+                self.logger.warning("Rate limited (attempt \(attempt)/\(Self.maxRetries)). Backing off \(String(format: "%.0f", backoff))s")
+                try await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000))
+            }
+
+            self.lastRequestTime = Date()
+            Self.debugLog("Sending request (attempt \(attempt + 1))...")
+            self.logger.info("Sending image gen request to \(modelID) (attempt \(attempt + 1))")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                Self.debugLog("ERROR: Not an HTTP response")
+                throw ImageGenError.invalidResponse("Not an HTTP response")
+            }
+
+            Self.debugLog("Response status: \(httpResponse.statusCode), body size: \(data.count) bytes")
+            if data.count < 2000 {
+                Self.debugLog("Response body: \(String(data: data, encoding: .utf8) ?? "<binary>")")
+            }
+
+            if httpResponse.statusCode == 429 {
+                lastRetryAfter = self.parseRetryAfter(from: data)
+                Self.debugLog("429 Rate limited. retryAfter: \(lastRetryAfter ?? "nil")")
+                if attempt < Self.maxRetries {
+                    continue  // retry with backoff
+                }
+                throw ImageGenError.rateLimited(retryAfter: lastRetryAfter)
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                let errorMsg = self.parseErrorMessage(from: data)
+                Self.debugLog("ERROR: HTTP \(httpResponse.statusCode): \(errorMsg)")
+                throw ImageGenError.apiError(code: httpResponse.statusCode, message: errorMsg)
+            }
+
+            Self.debugLog("SUCCESS! Parsing response...")
+            return try self.parseResponse(data)
+        }
+
+        throw ImageGenError.rateLimited(retryAfter: lastRetryAfter)
+    }
+
+    private func buildRequest(
+        modelID: String, apiKey: String, prompt: String,
+        inputImage: Data?, inputMimeType: String,
+        resolution: String, aspectRatio: String
+    ) throws -> URLRequest {
+        let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(modelID):generateContent?key=\(apiKey)")!
+
+        var parts: [[String: Any]] = []
+        parts.append(["text": prompt])
+
+        if let imageData = inputImage {
+            parts.append([
+                "inlineData": [
+                    "mimeType": inputMimeType,
+                    "data": imageData.base64EncodedString()
+                ]
+            ])
+        }
+
+        // Map resolution string to Gemini imageSize values
+        let imageSize: String
+        switch resolution {
+        case "0.5K": imageSize = "512"
+        case "2K":   imageSize = "2K"
+        case "4K":   imageSize = "4K"
+        default:     imageSize = "1K"
+        }
+
+        Self.debugLog("Image config: imageSize=\(imageSize), aspectRatio=\(aspectRatio)")
+
+        let body: [String: Any] = [
+            "contents": [
+                ["parts": parts]
+            ],
+            "generationConfig": [
+                "responseModalities": ["TEXT", "IMAGE"],
+                "imageConfig": [
+                    "imageSize": imageSize,
+                    "aspectRatio": aspectRatio,
+                ]
+            ]
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    // MARK: - Debug
+
+    private static func debugLog(_ msg: String) {
+        let line = "[\(ISO8601DateFormatter().string(from: Date()))] [GoogleImageGen] \(msg)\n"
+        if let data = line.data(using: .utf8),
+           let handle = FileHandle(forWritingAtPath: "/tmp/openclaw-debug.log") {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            handle.closeFile()
+        } else {
+            FileManager.default.createFile(atPath: "/tmp/openclaw-debug.log", contents: line.data(using: .utf8))
+        }
+    }
+
+    // MARK: - Private
+
+    private func fetchAPIKeyFromGateway() -> String? {
+        // Try to read from the gateway's .env file
+        let envPath = NSString("~/.openclaw/.env").expandingTildeInPath
+        guard let envContent = try? String(contentsOfFile: envPath, encoding: .utf8) else { return nil }
+        for line in envContent.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("GEMINI_API_KEY=") {
+                return String(trimmed.dropFirst("GEMINI_API_KEY=".count))
+            }
+            if trimmed.hasPrefix("GOOGLE_API_KEY=") {
+                return String(trimmed.dropFirst("GOOGLE_API_KEY=".count))
+            }
+        }
+        return nil
+    }
+
+    private func parseResponse(_ data: Data) throws -> ImageGenResult {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let candidates = json["candidates"] as? [[String: Any]],
+              let first = candidates.first
+        else {
+            throw ImageGenError.invalidResponse("Could not parse candidates")
+        }
+
+        // Check for safety/content filters before trying to parse image data
+        if let finishReason = first["finishReason"] as? String, finishReason != "STOP" {
+            let message = first["finishMessage"] as? String
+                ?? "Image blocked by Google (\(finishReason)). Try a different prompt."
+            throw ImageGenError.invalidResponse(message)
+        }
+
+        guard let content = first["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]]
+        else {
+            throw ImageGenError.invalidResponse("Response contained no image data")
+        }
+
+        var imageData: Data?
+        var mimeType = "image/jpeg"
+        var text: String?
+
+        for part in parts {
+            if let inlineData = part["inlineData"] as? [String: Any],
+               let base64 = inlineData["data"] as? String,
+               let decoded = Data(base64Encoded: base64)
+            {
+                imageData = decoded
+                mimeType = (inlineData["mimeType"] as? String) ?? "image/jpeg"
+            }
+            if let t = part["text"] as? String {
+                text = t
+            }
+        }
+
+        guard let resultImage = imageData else {
+            throw ImageGenError.invalidResponse(text ?? "No image in response")
+        }
+
+        self.logger.info("Image generated: \(resultImage.count) bytes, \(mimeType)")
+        return ImageGenResult(imageData: resultImage, mimeType: mimeType, text: text)
+    }
+
+    private func parseRetryAfter(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = json["error"] as? [String: Any],
+              let details = error["details"] as? [[String: Any]]
+        else { return nil }
+
+        for detail in details {
+            if let retryInfo = detail["retryDelay"] as? String {
+                return retryInfo
+            }
+        }
+        return nil
+    }
+
+    private func parseErrorMessage(from data: Data) -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = json["error"] as? [String: Any],
+              let message = error["message"] as? String
+        else { return "Unknown error" }
+        return String(message.prefix(300))
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -154,6 +154,7 @@ struct OpenClawApp: App {
         handler.onRightClick = { [self] in
             HoverHUDController.shared.dismiss(reason: "statusItemRightClick")
             WebChatManager.shared.closePanel()
+            WebChatManager.shared.closeWindow()
             self.isMenuPresented = true
             self.updateStatusHighlight()
         }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -155,8 +155,12 @@ struct OpenClawApp: App {
             HoverHUDController.shared.dismiss(reason: "statusItemRightClick")
             WebChatManager.shared.closePanel()
             WebChatManager.shared.closeWindow()
-            self.isMenuPresented = true
-            self.updateStatusHighlight()
+            // Deactivate the app briefly so MenuBarExtra menu can appear
+            // (SwiftUI menu won't show while an NSWindow is key)
+            DispatchQueue.main.async {
+                self.isMenuPresented = true
+                self.updateStatusHighlight()
+            }
         }
         handler.onHoverChanged = { [self] inside in
             HoverHUDController.shared.statusItemHoverChanged(

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -178,9 +178,7 @@ struct OpenClawApp: App {
         self.isMenuPresented = false
         Task { @MainActor in
             let sessionKey = await WebChatManager.shared.preferredSessionKey()
-            WebChatManager.shared.togglePanel(
-                sessionKey: sessionKey,
-                anchorProvider: { [self] in self.statusButtonScreenFrame() })
+            WebChatManager.shared.toggleWindow(sessionKey: sessionKey)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -59,6 +59,21 @@ final class WebChatManager {
         controller.show()
     }
 
+    /// Toggle the chat window (show/hide). Used by menu bar left-click.
+    func toggleWindow(sessionKey: String) {
+        self.closePanel()
+        if let controller = self.windowController, self.windowSessionKey == sessionKey {
+            if controller.isVisible {
+                controller.close()
+                self.onPanelVisibilityChanged?(false)
+                return
+            }
+            controller.show()
+            return
+        }
+        self.show(sessionKey: sessionKey)
+    }
+
     func togglePanel(sessionKey: String, anchorProvider: @escaping () -> NSRect?) {
         if let controller = self.panelController {
             if self.panelSessionKey != sessionKey {

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -108,6 +108,11 @@ final class WebChatManager {
         self.panelController?.close()
     }
 
+    func closeWindow() {
+        self.windowController?.close()
+        self.onPanelVisibilityChanged?(false)
+    }
+
     func preferredSessionKey() async -> String {
         if let cachedPreferredSessionKey { return cachedPreferredSessionKey }
         let key = await GatewayConnection.shared.mainSessionKey()

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -232,6 +232,7 @@ final class WebChatSwiftUIWindowController {
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)
             })
+        vm.directImageGenHandler = GoogleImageGenService.shared
         let accent = Self.color(fromHex: AppStateStore.shared.seamColorHex)
         self.hosting = NSHostingController(rootView: OpenClawChatView(
             viewModel: vm,
@@ -588,5 +589,31 @@ extension ChatWindowToolbarDelegate: NSMenuDelegate {
             talkItem.state = enabled ? .on : .off
         }
 
+    }
+}
+
+
+// MARK: - Direct Image Generation Bridge
+
+extension GoogleImageGenService: DirectImageGenHandler {
+    public func generateImage(
+        prompt: String,
+        model: String,
+        inputImage: Data?,
+        inputMimeType: String,
+        resolution: String,
+        aspectRatio: String
+    ) async throws -> DirectImageGenResult {
+        let result = try await self.generate(
+            prompt: prompt,
+            model: model,
+            inputImage: inputImage,
+            inputMimeType: inputMimeType,
+            resolution: resolution,
+            aspectRatio: aspectRatio)
+        return DirectImageGenResult(
+            imageData: result.imageData,
+            mimeType: result.mimeType,
+            text: result.text)
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -367,6 +367,11 @@ final class WebChatSwiftUIWindowController {
             // Add toolbar with gear menu
             let toolbar = NSToolbar(identifier: "OpenClawChatToolbar")
             toolbar.displayMode = .iconOnly
+            if #available(macOS 26.0, *) {
+                window.toolbarStyle = .unifiedCompact
+            } else {
+                window.toolbarStyle = .unified
+            }
             let toolbarDelegate = ChatWindowToolbarDelegate()
             toolbar.delegate = toolbarDelegate
             window.toolbar = toolbar
@@ -487,7 +492,9 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         guard itemIdentifier == .chatGearMenu else { return nil }
 
         let item = NSMenuToolbarItem(itemIdentifier: itemIdentifier)
-        item.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")
+        let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+        item.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")?
+            .withSymbolConfiguration(config)
         item.label = "Settings"
         item.toolTip = "App settings and Talk Mode"
         item.menu = self.buildGearMenu()
@@ -518,19 +525,6 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
             talkItem.isEnabled = false
         }
         menu.addItem(talkItem)
-
-        menu.addItem(.separator())
-
-        // Canvas toggle
-        let canvasItem = NSMenuItem(
-            title: AppStateStore.shared.canvasPanelVisible ? "Close Canvas" : "Open Canvas",
-            action: #selector(toggleCanvas),
-            keyEquivalent: "")
-        canvasItem.target = self
-        canvasItem.image = NSImage(
-            systemSymbolName: "rectangle.inset.filled.on.rectangle",
-            accessibilityDescription: nil)
-        menu.addItem(canvasItem)
 
         menu.addItem(.separator())
 
@@ -593,9 +587,6 @@ extension ChatWindowToolbarDelegate: NSMenuDelegate {
             talkItem.title = enabled ? "Stop Talk Mode" : "Talk Mode"
             talkItem.state = enabled ? .on : .off
         }
-        // Update Canvas item
-        if let canvasItem = menu.items.first(where: { $0.action == #selector(toggleCanvas) }) {
-            canvasItem.title = AppStateStore.shared.canvasPanelVisible ? "Close Canvas" : "Open Canvas"
-        }
+
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import ObjectiveC
 import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
@@ -362,6 +363,16 @@ final class WebChatSwiftUIWindowController {
             window.minSize = WebChatSwiftUILayout.windowMinSize
             window.contentView?.wantsLayer = true
             window.contentView?.layer?.backgroundColor = NSColor.clear.cgColor
+
+            // Add toolbar with gear menu
+            let toolbar = NSToolbar(identifier: "OpenClawChatToolbar")
+            toolbar.displayMode = .iconOnly
+            let toolbarDelegate = ChatWindowToolbarDelegate()
+            toolbar.delegate = toolbarDelegate
+            window.toolbar = toolbar
+            // Retain the delegate (toolbar doesn't retain its delegate)
+            objc_setAssociatedObject(window, &chatToolbarDelegateKey, toolbarDelegate, .OBJC_ASSOCIATION_RETAIN)
+
             return window
         case .panel:
             let panel = WebChatPanel(
@@ -454,5 +465,137 @@ final class WebChatSwiftUIWindowController {
 
     private static func color(fromHex raw: String?) -> Color? {
         ColorHexSupport.color(fromHex: raw)
+    }
+}
+
+
+// MARK: - Chat window toolbar
+
+private var chatToolbarDelegateKey: UInt8 = 0
+
+private extension NSToolbarItem.Identifier {
+    static let chatGearMenu = NSToolbarItem.Identifier("chatGearMenu")
+}
+
+@MainActor
+final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem?
+    {
+        guard itemIdentifier == .chatGearMenu else { return nil }
+
+        let item = NSMenuToolbarItem(itemIdentifier: itemIdentifier)
+        item.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")
+        item.label = "Settings"
+        item.toolTip = "App settings and Talk Mode"
+        item.menu = self.buildGearMenu()
+        item.showsIndicator = true
+        return item
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, .chatGearMenu]
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, .chatGearMenu]
+    }
+
+    private func buildGearMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        // Talk Mode toggle
+        let talkItem = NSMenuItem(
+            title: AppStateStore.shared.talkEnabled ? "Stop Talk Mode" : "Talk Mode",
+            action: #selector(toggleTalkMode),
+            keyEquivalent: "")
+        talkItem.target = self
+        talkItem.state = AppStateStore.shared.talkEnabled ? .on : .off
+        talkItem.image = NSImage(systemSymbolName: "waveform.circle.fill", accessibilityDescription: nil)
+        if !voiceWakeSupported {
+            talkItem.isEnabled = false
+        }
+        menu.addItem(talkItem)
+
+        menu.addItem(.separator())
+
+        // Canvas toggle
+        let canvasItem = NSMenuItem(
+            title: AppStateStore.shared.canvasPanelVisible ? "Close Canvas" : "Open Canvas",
+            action: #selector(toggleCanvas),
+            keyEquivalent: "")
+        canvasItem.target = self
+        canvasItem.image = NSImage(
+            systemSymbolName: "rectangle.inset.filled.on.rectangle",
+            accessibilityDescription: nil)
+        menu.addItem(canvasItem)
+
+        menu.addItem(.separator())
+
+        // Settings
+        let settingsItem = NSMenuItem(
+            title: "Settings…",
+            action: #selector(openSettings),
+            keyEquivalent: ",")
+        settingsItem.keyEquivalentModifierMask = .command
+        settingsItem.target = self
+        settingsItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
+        menu.addItem(settingsItem)
+
+        menu.addItem(.separator())
+
+        // Quit
+        let quitItem = NSMenuItem(
+            title: "Quit OpenClaw",
+            action: #selector(quitApp),
+            keyEquivalent: "q")
+        quitItem.keyEquivalentModifierMask = .command
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        // Refresh menu items each time it opens
+        menu.delegate = self
+
+        return menu
+    }
+
+    @objc private func toggleTalkMode() {
+        Task { await AppStateStore.shared.setTalkEnabled(!AppStateStore.shared.talkEnabled) }
+    }
+
+    @objc private func toggleCanvas() {
+        Task {
+            if AppStateStore.shared.canvasPanelVisible {
+                CanvasManager.shared.hideAll()
+            } else {
+                let sessionKey = await GatewayConnection.shared.mainSessionKey()
+                _ = try? CanvasManager.shared.show(sessionKey: sessionKey, path: nil)
+            }
+        }
+    }
+
+    @objc private func openSettings() {
+        SettingsWindowOpener.shared.open()
+    }
+
+    @objc private func quitApp() {
+        NSApp.terminate(nil)
+    }
+}
+
+extension ChatWindowToolbarDelegate: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        // Update Talk Mode item state
+        if let talkItem = menu.items.first(where: { $0.action == #selector(toggleTalkMode) }) {
+            let enabled = AppStateStore.shared.talkEnabled
+            talkItem.title = enabled ? "Stop Talk Mode" : "Talk Mode"
+            talkItem.state = enabled ? .on : .off
+        }
+        // Update Canvas item
+        if let canvasItem = menu.items.first(where: { $0.action == #selector(toggleCanvas) }) {
+            canvasItem.title = AppStateStore.shared.canvasPanelVisible ? "Close Canvas" : "Open Canvas"
+        }
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -471,7 +471,7 @@ final class WebChatSwiftUIWindowController {
 
 // MARK: - Chat window toolbar
 
-private var chatToolbarDelegateKey: UInt8 = 0
+nonisolated(unsafe) private var chatToolbarDelegateKey: UInt8 = 0
 
 private extension NSToolbarItem.Identifier {
     static let chatGearMenu = NSToolbarItem.Identifier("chatGearMenu")

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import Foundation
 import ObjectiveC
 import OpenClawChatUI
@@ -483,8 +484,32 @@ private extension NSToolbarItem.Identifier {
     static let chatGearMenu = NSToolbarItem.Identifier("chatGearMenu")
 }
 
+// MARK: - Tags for gear menu items
+private enum GearMenuTag {
+    static let connection = 100
+    static let healthStatus = 101
+    static let pairingStatus = 102
+    static let heartbeats = 110
+    static let heartbeatStatus = 111
+    static let browserControl = 112
+    static let camera = 113
+    static let execApprovals = 114
+    static let canvasEnabled = 115
+    static let voiceWake = 116
+    static let micSubmenu = 117
+    static let openDashboard = 120
+    static let openChat = 121
+    static let openCloseCanvas = 122
+    static let talkMode = 123
+    static let debugSubmenu = 130
+    static let about = 131
+    static let update = 132
+}
+
 @MainActor
 final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
+    private var browserControlEnabled = true
+
     func toolbar(
         _ toolbar: NSToolbar,
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
@@ -497,7 +522,7 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         item.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")?
             .withSymbolConfiguration(config)
         item.label = "Settings"
-        item.toolTip = "App settings and Talk Mode"
+        item.toolTip = "App settings and controls"
         item.menu = self.buildGearMenu()
         item.showsIndicator = true
         return item
@@ -511,25 +536,176 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         [.flexibleSpace, .chatGearMenu]
     }
 
+    // MARK: - Build full gear menu (mirrors MenuContentView)
+
     private func buildGearMenu() -> NSMenu {
         let menu = NSMenu()
+        let state = AppStateStore.shared
 
-        // Talk Mode toggle
+        // ── Connection toggle ──
+        let connItem = NSMenuItem(
+            title: state.isPaused ? "OpenClaw Paused" : self.connectionLabel(state),
+            action: #selector(toggleConnection),
+            keyEquivalent: "")
+        connItem.target = self
+        connItem.tag = GearMenuTag.connection
+        connItem.state = state.isPaused ? .off : .on
+        connItem.image = NSImage(systemSymbolName: "antenna.radiowaves.left.and.right", accessibilityDescription: nil)
+        connItem.isEnabled = state.connectionMode != .unconfigured
+        menu.addItem(connItem)
+
+        // Health status (info-only)
+        let healthItem = NSMenuItem(title: "Health pending", action: nil, keyEquivalent: "")
+        healthItem.tag = GearMenuTag.healthStatus
+        healthItem.isEnabled = false
+        menu.addItem(healthItem)
+
+        // Pairing status (info-only, hidden by default)
+        let pairingItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        pairingItem.tag = GearMenuTag.pairingStatus
+        pairingItem.isEnabled = false
+        pairingItem.isHidden = true
+        menu.addItem(pairingItem)
+
+        menu.addItem(.separator())
+
+        // ── Heartbeats toggle ──
+        let hbItem = NSMenuItem(
+            title: "Send Heartbeats",
+            action: #selector(toggleHeartbeats),
+            keyEquivalent: "")
+        hbItem.target = self
+        hbItem.tag = GearMenuTag.heartbeats
+        hbItem.state = state.heartbeatsEnabled ? .on : .off
+        hbItem.image = NSImage(systemSymbolName: "waveform.path.ecg", accessibilityDescription: nil)
+        menu.addItem(hbItem)
+
+        // Heartbeat status (info-only)
+        let hbStatusItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        hbStatusItem.tag = GearMenuTag.heartbeatStatus
+        hbStatusItem.isEnabled = false
+        hbStatusItem.isHidden = true
+        menu.addItem(hbStatusItem)
+
+        // ── Browser Control toggle ──
+        let browserItem = NSMenuItem(
+            title: "Browser Control",
+            action: #selector(toggleBrowserControl),
+            keyEquivalent: "")
+        browserItem.target = self
+        browserItem.tag = GearMenuTag.browserControl
+        browserItem.state = self.browserControlEnabled ? .on : .off
+        browserItem.image = NSImage(systemSymbolName: "globe", accessibilityDescription: nil)
+        menu.addItem(browserItem)
+
+        // ── Allow Camera toggle ──
+        let cameraItem = NSMenuItem(
+            title: "Allow Camera",
+            action: #selector(toggleCamera),
+            keyEquivalent: "")
+        cameraItem.target = self
+        cameraItem.tag = GearMenuTag.camera
+        cameraItem.state = UserDefaults.standard.bool(forKey: cameraEnabledKey) ? .on : .off
+        cameraItem.image = NSImage(systemSymbolName: "camera", accessibilityDescription: nil)
+        menu.addItem(cameraItem)
+
+        // ── Exec Approvals submenu ──
+        let execItem = NSMenuItem(title: "Exec Approvals", action: nil, keyEquivalent: "")
+        execItem.tag = GearMenuTag.execApprovals
+        execItem.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+        let execSub = NSMenu()
+        for mode in ExecApprovalQuickMode.allCases {
+            let modeItem = NSMenuItem(
+                title: mode.title,
+                action: #selector(selectExecApprovalMode(_:)),
+                keyEquivalent: "")
+            modeItem.target = self
+            modeItem.representedObject = mode.rawValue
+            modeItem.state = state.execApprovalMode == mode ? .on : .off
+            execSub.addItem(modeItem)
+        }
+        execItem.submenu = execSub
+        menu.addItem(execItem)
+
+        // ── Allow Canvas toggle ──
+        let canvasItem = NSMenuItem(
+            title: "Allow Canvas",
+            action: #selector(toggleCanvasEnabled),
+            keyEquivalent: "")
+        canvasItem.target = self
+        canvasItem.tag = GearMenuTag.canvasEnabled
+        canvasItem.state = state.canvasEnabled ? .on : .off
+        canvasItem.image = NSImage(systemSymbolName: "rectangle.and.pencil.and.ellipsis", accessibilityDescription: nil)
+        menu.addItem(canvasItem)
+
+        // ── Voice Wake toggle ──
+        let vwItem = NSMenuItem(
+            title: "Voice Wake",
+            action: #selector(toggleVoiceWake),
+            keyEquivalent: "")
+        vwItem.target = self
+        vwItem.tag = GearMenuTag.voiceWake
+        vwItem.state = state.swabbleEnabled ? .on : .off
+        vwItem.image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: nil)
+        vwItem.isEnabled = voiceWakeSupported
+        menu.addItem(vwItem)
+
+        // ── Microphone submenu ──
+        let micItem = NSMenuItem(title: "Microphone", action: nil, keyEquivalent: "")
+        micItem.tag = GearMenuTag.micSubmenu
+        micItem.submenu = NSMenu() // populated dynamically
+        micItem.isHidden = !(voiceWakeSupported && state.swabbleEnabled)
+        menu.addItem(micItem)
+
+        menu.addItem(.separator())
+
+        // ── Open Dashboard ──
+        let dashItem = NSMenuItem(
+            title: "Open Dashboard",
+            action: #selector(openDashboard),
+            keyEquivalent: "")
+        dashItem.target = self
+        dashItem.tag = GearMenuTag.openDashboard
+        dashItem.image = NSImage(systemSymbolName: "gauge", accessibilityDescription: nil)
+        menu.addItem(dashItem)
+
+        // ── Open Chat ──
+        let chatItem = NSMenuItem(
+            title: "Open Chat",
+            action: #selector(openNewChat),
+            keyEquivalent: "")
+        chatItem.target = self
+        chatItem.tag = GearMenuTag.openChat
+        chatItem.image = NSImage(systemSymbolName: "bubble.left.and.bubble.right", accessibilityDescription: nil)
+        menu.addItem(chatItem)
+
+        // ── Open / Close Canvas ──
+        if state.canvasEnabled {
+            let canvasBtnItem = NSMenuItem(
+                title: state.canvasPanelVisible ? "Close Canvas" : "Open Canvas",
+                action: #selector(toggleCanvasPanel),
+                keyEquivalent: "")
+            canvasBtnItem.target = self
+            canvasBtnItem.tag = GearMenuTag.openCloseCanvas
+            canvasBtnItem.image = NSImage(systemSymbolName: "rectangle.inset.filled.on.rectangle", accessibilityDescription: nil)
+            menu.addItem(canvasBtnItem)
+        }
+
+        // ── Talk Mode toggle ──
         let talkItem = NSMenuItem(
-            title: AppStateStore.shared.talkEnabled ? "Stop Talk Mode" : "Talk Mode",
+            title: state.talkEnabled ? "Stop Talk Mode" : "Talk Mode",
             action: #selector(toggleTalkMode),
             keyEquivalent: "")
         talkItem.target = self
-        talkItem.state = AppStateStore.shared.talkEnabled ? .on : .off
+        talkItem.tag = GearMenuTag.talkMode
+        talkItem.state = state.talkEnabled ? .on : .off
         talkItem.image = NSImage(systemSymbolName: "waveform.circle.fill", accessibilityDescription: nil)
-        if !voiceWakeSupported {
-            talkItem.isEnabled = false
-        }
+        talkItem.isEnabled = voiceWakeSupported
         menu.addItem(talkItem)
 
         menu.addItem(.separator())
 
-        // Settings
+        // ── Settings ──
         let settingsItem = NSMenuItem(
             title: "Settings…",
             action: #selector(openSettings),
@@ -539,9 +715,39 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         settingsItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
         menu.addItem(settingsItem)
 
+        // ── Debug submenu (conditional) ──
+        if state.debugPaneEnabled {
+            let debugItem = NSMenuItem(title: "Debug", action: nil, keyEquivalent: "")
+            debugItem.tag = GearMenuTag.debugSubmenu
+            debugItem.submenu = self.buildDebugSubmenu()
+            menu.addItem(debugItem)
+        }
+
+        // ── About ──
+        let aboutItem = NSMenuItem(
+            title: "About OpenClaw",
+            action: #selector(openAbout),
+            keyEquivalent: "")
+        aboutItem.target = self
+        aboutItem.tag = GearMenuTag.about
+        menu.addItem(aboutItem)
+
+        // ── Update ready (conditional) ──
+        if let updater = (NSApp.delegate as? AppDelegate)?.updaterController,
+           updater.isAvailable, updater.updateStatus.isUpdateReady
+        {
+            let updateItem = NSMenuItem(
+                title: "Update ready, restart now?",
+                action: #selector(checkForUpdate),
+                keyEquivalent: "")
+            updateItem.target = self
+            updateItem.tag = GearMenuTag.update
+            menu.addItem(updateItem)
+        }
+
         menu.addItem(.separator())
 
-        // Quit
+        // ── Quit ──
         let quitItem = NSMenuItem(
             title: "Quit OpenClaw",
             action: #selector(quitApp),
@@ -550,18 +756,264 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         quitItem.target = self
         menu.addItem(quitItem)
 
-        // Refresh menu items each time it opens
         menu.delegate = self
-
         return menu
     }
 
-    @objc private func toggleTalkMode() {
-        Task { await AppStateStore.shared.setTalkEnabled(!AppStateStore.shared.talkEnabled) }
+    // MARK: - Debug submenu
+
+    private func buildDebugSubmenu() -> NSMenu {
+        let sub = NSMenu()
+        let state = AppStateStore.shared
+
+        sub.addItem(self.debugMenuItem("Open Config Folder", icon: "folder", action: #selector(debugOpenConfigFolder)))
+        sub.addItem(self.debugMenuItem("Run Health Check Now", icon: "stethoscope", action: #selector(debugRunHealthCheck)))
+        sub.addItem(self.debugMenuItem("Send Test Heartbeat", icon: "waveform.path.ecg", action: #selector(debugSendTestHeartbeat)))
+
+        if state.connectionMode == .remote {
+            sub.addItem(self.debugMenuItem("Reset Remote Tunnel", icon: "arrow.triangle.2.circlepath", action: #selector(debugResetTunnel)))
+        }
+
+        // Verbose Logging (Main)
+        let verboseItem = NSMenuItem(
+            title: DebugActions.verboseLoggingEnabledMain
+                ? "Verbose Logging (Main): On"
+                : "Verbose Logging (Main): Off",
+            action: #selector(debugToggleVerboseMain),
+            keyEquivalent: "")
+        verboseItem.target = self
+        verboseItem.image = NSImage(systemSymbolName: "text.alignleft", accessibilityDescription: nil)
+        sub.addItem(verboseItem)
+
+        // App Logging submenu
+        let logItem = NSMenuItem(title: "App Logging", action: nil, keyEquivalent: "")
+        logItem.image = NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
+        let logSub = NSMenu()
+        let currentLevel = UserDefaults.standard.string(forKey: appLogLevelKey) ?? AppLogLevel.default.rawValue
+        for level in AppLogLevel.allCases {
+            let li = NSMenuItem(
+                title: level.title,
+                action: #selector(selectAppLogLevel(_:)),
+                keyEquivalent: "")
+            li.target = self
+            li.representedObject = level.rawValue
+            li.state = level.rawValue == currentLevel ? .on : .off
+            logSub.addItem(li)
+        }
+        logSub.addItem(.separator())
+        let fileLogItem = NSMenuItem(
+            title: UserDefaults.standard.bool(forKey: debugFileLogEnabledKey)
+                ? "File Logging: On" : "File Logging: Off",
+            action: #selector(debugToggleFileLogging),
+            keyEquivalent: "")
+        fileLogItem.target = self
+        fileLogItem.image = NSImage(systemSymbolName: "doc.text.magnifyingglass", accessibilityDescription: nil)
+        fileLogItem.state = UserDefaults.standard.bool(forKey: debugFileLogEnabledKey) ? .on : .off
+        logSub.addItem(fileLogItem)
+        logItem.submenu = logSub
+        sub.addItem(logItem)
+
+        sub.addItem(self.debugMenuItem("Open Session Store", icon: "externaldrive", action: #selector(debugOpenSessionStore)))
+
+        sub.addItem(.separator())
+
+        sub.addItem(self.debugMenuItem("Open Agent Events…", icon: "bolt.horizontal.circle", action: #selector(debugOpenAgentEvents)))
+        sub.addItem(self.debugMenuItem("Open Log", icon: "doc.text.magnifyingglass", action: #selector(debugOpenLog)))
+        sub.addItem(self.debugMenuItem("Send Debug Voice Text", icon: "waveform.circle", action: #selector(debugSendVoice)))
+        sub.addItem(self.debugMenuItem("Send Test Notification", icon: "bell", action: #selector(debugSendNotification)))
+
+        sub.addItem(.separator())
+
+        if state.connectionMode == .local {
+            sub.addItem(self.debugMenuItem("Restart Gateway", icon: "arrow.clockwise", action: #selector(debugRestartGateway)))
+        }
+        sub.addItem(self.debugMenuItem("Restart Onboarding", icon: "arrow.counterclockwise", action: #selector(debugRestartOnboarding)))
+        sub.addItem(self.debugMenuItem("Restart App", icon: "arrow.triangle.2.circlepath", action: #selector(debugRestartApp)))
+
+        return sub
     }
 
-    @objc private func toggleCanvas() {
+    private func debugMenuItem(_ title: String, icon: String, action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.image = NSImage(systemSymbolName: icon, accessibilityDescription: nil)
+        return item
+    }
+
+    // MARK: - Connection helpers
+
+    private func connectionLabel(_ state: AppState) -> String {
+        switch state.connectionMode {
+        case .unconfigured: "OpenClaw Not Configured"
+        case .remote: "Remote OpenClaw Active"
+        case .local: "OpenClaw Active"
+        }
+    }
+
+    private func healthStatusText() -> (String, Bool) {
+        let store = HealthStore.shared
+        let activity = WorkActivityStore.shared.current
+        if let activity {
+            let roleLabel = activity.role == .main ? "Main" : "Other"
+            return ("    \(roleLabel) · \(activity.label)", false)
+        }
+        switch store.state {
+        case .ok:
+            return ("    ● Health ok", false)
+        case .linkingNeeded:
+            return ("    ● Login required", true)
+        case let .degraded(reason):
+            let detail = store.degradedSummary ?? reason
+            return ("    ● \(detail)", true)
+        case .unknown:
+            return ("    ● Health pending", false)
+        }
+    }
+
+    private func heartbeatStatusText() -> String? {
+        if case .degraded = ControlChannel.shared.state {
+            return "    ● Control channel disconnected"
+        }
+        if let evt = HeartbeatStore.shared.lastEvent {
+            switch evt.status {
+            case "ok-empty", "ok-token": return "    ● Heartbeat ok"
+            case "sent": return "    ● Heartbeat sent"
+            case "skipped": return "    ● Heartbeat skipped"
+            case "failed": return "    ● Heartbeat failed"
+            default: return nil
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Microphone helpers
+
+    private func populateMicSubmenu(_ submenu: NSMenu) {
+        submenu.removeAllItems()
+        let state = AppStateStore.shared
+
+        // System default option
+        let defaultLabel: String
+        if let host = Host.current().localizedName, !host.isEmpty {
+            defaultLabel = "Auto-detect (\(host))"
+        } else {
+            defaultLabel = "System default"
+        }
+        let defaultItem = NSMenuItem(
+            title: defaultLabel,
+            action: #selector(selectMicrophone(_:)),
+            keyEquivalent: "")
+        defaultItem.target = self
+        defaultItem.representedObject = "" as String
+        defaultItem.state = state.voiceWakeMicID.isEmpty ? .on : .off
+        submenu.addItem(defaultItem)
+
+        submenu.addItem(.separator())
+
+        // Discovered mics
+        let discovery = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.external, .microphone],
+            mediaType: .audio,
+            position: .unspecified)
+        let mics = discovery.devices
+            .filter(\.isConnected)
+            .sorted { $0.localizedName.localizedCaseInsensitiveCompare($1.localizedName) == .orderedAscending }
+
+        for mic in mics {
+            let micItem = NSMenuItem(
+                title: mic.localizedName,
+                action: #selector(selectMicrophone(_:)),
+                keyEquivalent: "")
+            micItem.target = self
+            micItem.representedObject = mic.uniqueID
+            micItem.state = state.voiceWakeMicID == mic.uniqueID ? .on : .off
+            submenu.addItem(micItem)
+        }
+    }
+
+    // MARK: - Actions: Connection & Toggles
+
+    @objc private func toggleConnection() {
+        AppStateStore.shared.isPaused.toggle()
+    }
+
+    @objc private func toggleHeartbeats() {
+        AppStateStore.shared.heartbeatsEnabled.toggle()
+    }
+
+    @objc private func toggleBrowserControl() {
+        self.browserControlEnabled.toggle()
+        let enabled = self.browserControlEnabled
         Task {
+            var root = await ConfigStore.load()
+            var browser = root["browser"] as? [String: Any] ?? [:]
+            browser["enabled"] = enabled
+            root["browser"] = browser
+            try? await ConfigStore.save(root)
+        }
+    }
+
+    @objc private func toggleCamera() {
+        let current = UserDefaults.standard.bool(forKey: cameraEnabledKey)
+        UserDefaults.standard.set(!current, forKey: cameraEnabledKey)
+    }
+
+    @objc private func selectExecApprovalMode(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String,
+              let mode = ExecApprovalQuickMode(rawValue: raw)
+        else { return }
+        AppStateStore.shared.execApprovalMode = mode
+    }
+
+    @objc private func toggleCanvasEnabled() {
+        let state = AppStateStore.shared
+        state.canvasEnabled.toggle()
+        if !state.canvasEnabled {
+            CanvasManager.shared.hideAll()
+        }
+    }
+
+    @objc private func toggleVoiceWake() {
+        AppStateStore.shared.swabbleEnabled.toggle()
+    }
+
+    @objc private func selectMicrophone(_ sender: NSMenuItem) {
+        guard let uid = sender.representedObject as? String else { return }
+        let state = AppStateStore.shared
+        state.voiceWakeMicID = uid
+        if uid.isEmpty {
+            state.voiceWakeMicName = ""
+        } else {
+            state.voiceWakeMicName = sender.title
+        }
+    }
+
+    // MARK: - Actions: Navigation
+
+    @objc private func openDashboard() {
+        Task { @MainActor in
+            do {
+                let config = try await GatewayEndpointStore.shared.requireConfig()
+                let url = try GatewayEndpointStore.dashboardURL(for: config, mode: AppStateStore.shared.connectionMode)
+                NSWorkspace.shared.open(url)
+            } catch {
+                let alert = NSAlert()
+                alert.messageText = "Dashboard unavailable"
+                alert.informativeText = error.localizedDescription
+                alert.runModal()
+            }
+        }
+    }
+
+    @objc private func openNewChat() {
+        Task { @MainActor in
+            let sessionKey = await WebChatManager.shared.preferredSessionKey()
+            WebChatManager.shared.show(sessionKey: sessionKey)
+        }
+    }
+
+    @objc private func toggleCanvasPanel() {
+        Task { @MainActor in
             if AppStateStore.shared.canvasPanelVisible {
                 CanvasManager.shared.hideAll()
             } else {
@@ -571,24 +1023,213 @@ final class ChatWindowToolbarDelegate: NSObject, NSToolbarDelegate {
         }
     }
 
+    @objc private func toggleTalkMode() {
+        Task { await AppStateStore.shared.setTalkEnabled(!AppStateStore.shared.talkEnabled) }
+    }
+
+    // MARK: - Actions: Settings / About / Update / Quit
+
     @objc private func openSettings() {
         SettingsWindowOpener.shared.open()
+    }
+
+    @objc private func openAbout() {
+        SettingsTabRouter.request(.about)
+        NSApp.activate(ignoringOtherApps: true)
+        SettingsWindowOpener.shared.open()
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .openclawSelectSettingsTab, object: SettingsTab.about)
+        }
+    }
+
+    @objc private func checkForUpdate() {
+        (NSApp.delegate as? AppDelegate)?.updaterController.checkForUpdates(nil)
     }
 
     @objc private func quitApp() {
         NSApp.terminate(nil)
     }
+
+    // MARK: - Actions: Debug
+
+    @objc private func debugOpenConfigFolder() { DebugActions.openConfigFolder() }
+    @objc private func debugRunHealthCheck() { Task { await DebugActions.runHealthCheckNow() } }
+    @objc private func debugSendTestHeartbeat() { Task { _ = await DebugActions.sendTestHeartbeat() } }
+    @objc private func debugResetTunnel() {
+        Task { @MainActor in
+            let result = await DebugActions.resetGatewayTunnel()
+            let alert = NSAlert()
+            alert.messageText = "Remote Tunnel"
+            switch result {
+            case let .success(msg): alert.informativeText = msg; alert.alertStyle = .informational
+            case let .failure(err): alert.informativeText = err.localizedDescription; alert.alertStyle = .warning
+            }
+            alert.runModal()
+        }
+    }
+    @objc private func debugToggleVerboseMain() { Task { _ = await DebugActions.toggleVerboseLoggingMain() } }
+    @objc private func selectAppLogLevel(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String else { return }
+        UserDefaults.standard.set(raw, forKey: appLogLevelKey)
+    }
+    @objc private func debugToggleFileLogging() {
+        let current = UserDefaults.standard.bool(forKey: debugFileLogEnabledKey)
+        UserDefaults.standard.set(!current, forKey: debugFileLogEnabledKey)
+    }
+    @objc private func debugOpenSessionStore() { DebugActions.openSessionStore() }
+    @objc private func debugOpenAgentEvents() { DebugActions.openAgentEventsWindow() }
+    @objc private func debugOpenLog() { DebugActions.openLog() }
+    @objc private func debugSendVoice() { Task { _ = await DebugActions.sendDebugVoice() } }
+    @objc private func debugSendNotification() { Task { await DebugActions.sendTestNotification() } }
+    @objc private func debugRestartGateway() { DebugActions.restartGateway() }
+    @objc private func debugRestartOnboarding() { DebugActions.restartOnboarding() }
+    @objc private func debugRestartApp() { DebugActions.restartApp() }
 }
+
+// MARK: - NSMenuDelegate: refresh all states on open
 
 extension ChatWindowToolbarDelegate: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
-        // Update Talk Mode item state
-        if let talkItem = menu.items.first(where: { $0.action == #selector(toggleTalkMode) }) {
-            let enabled = AppStateStore.shared.talkEnabled
-            talkItem.title = enabled ? "Stop Talk Mode" : "Talk Mode"
-            talkItem.state = enabled ? .on : .off
+        let state = AppStateStore.shared
+
+        // Connection toggle
+        if let item = menu.item(withTag: GearMenuTag.connection) {
+            item.title = state.isPaused ? "OpenClaw Paused" : self.connectionLabel(state)
+            item.state = state.isPaused ? .off : .on
+            item.isEnabled = state.connectionMode != .unconfigured
         }
 
+        // Health status
+        if let item = menu.item(withTag: GearMenuTag.healthStatus) {
+            let (text, _) = self.healthStatusText()
+            item.title = text
+        }
+
+        // Pairing status
+        if let item = menu.item(withTag: GearMenuTag.pairingStatus) {
+            let nodePending = NodePairingApprovalPrompter.shared.pendingCount
+            let devicePending = DevicePairingApprovalPrompter.shared.pendingCount
+            let total = nodePending + devicePending
+            if total > 0 {
+                item.title = "    ⚠ Pairing approval pending (\(total))"
+                item.isHidden = false
+            } else {
+                item.isHidden = true
+            }
+        }
+
+        // Heartbeats
+        if let item = menu.item(withTag: GearMenuTag.heartbeats) {
+            item.state = state.heartbeatsEnabled ? .on : .off
+        }
+        if let item = menu.item(withTag: GearMenuTag.heartbeatStatus) {
+            if let text = self.heartbeatStatusText() {
+                item.title = text
+                item.isHidden = false
+            } else {
+                item.isHidden = true
+            }
+        }
+
+        // Browser Control
+        Task {
+            let root = await ConfigStore.load()
+            let browser = root["browser"] as? [String: Any]
+            let enabled = browser?["enabled"] as? Bool ?? true
+            await MainActor.run { self.browserControlEnabled = enabled }
+        }
+        if let item = menu.item(withTag: GearMenuTag.browserControl) {
+            item.state = self.browserControlEnabled ? .on : .off
+        }
+
+        // Camera
+        if let item = menu.item(withTag: GearMenuTag.camera) {
+            item.state = UserDefaults.standard.bool(forKey: cameraEnabledKey) ? .on : .off
+        }
+
+        // Exec Approvals
+        if let item = menu.item(withTag: GearMenuTag.execApprovals),
+           let sub = item.submenu
+        {
+            for mi in sub.items {
+                if let raw = mi.representedObject as? String,
+                   let mode = ExecApprovalQuickMode(rawValue: raw)
+                {
+                    mi.state = state.execApprovalMode == mode ? .on : .off
+                }
+            }
+        }
+
+        // Canvas enabled
+        if let item = menu.item(withTag: GearMenuTag.canvasEnabled) {
+            item.state = state.canvasEnabled ? .on : .off
+        }
+
+        // Voice Wake
+        if let item = menu.item(withTag: GearMenuTag.voiceWake) {
+            item.state = state.swabbleEnabled ? .on : .off
+        }
+
+        // Microphone submenu visibility and content
+        if let item = menu.item(withTag: GearMenuTag.micSubmenu) {
+            let shouldShow = voiceWakeSupported && state.swabbleEnabled
+            item.isHidden = !shouldShow
+            if shouldShow, let sub = item.submenu {
+                self.populateMicSubmenu(sub)
+            }
+        }
+
+        // Open / Close Canvas — add or remove dynamically
+        let existingCanvasBtn = menu.item(withTag: GearMenuTag.openCloseCanvas)
+        if state.canvasEnabled {
+            if let item = existingCanvasBtn {
+                item.title = state.canvasPanelVisible ? "Close Canvas" : "Open Canvas"
+            } else {
+                // Insert before Talk Mode
+                if let talkIdx = menu.items.firstIndex(where: { $0.tag == GearMenuTag.talkMode }) {
+                    let canvasBtnItem = NSMenuItem(
+                        title: state.canvasPanelVisible ? "Close Canvas" : "Open Canvas",
+                        action: #selector(toggleCanvasPanel),
+                        keyEquivalent: "")
+                    canvasBtnItem.target = self
+                    canvasBtnItem.tag = GearMenuTag.openCloseCanvas
+                    canvasBtnItem.image = NSImage(systemSymbolName: "rectangle.inset.filled.on.rectangle", accessibilityDescription: nil)
+                    menu.insertItem(canvasBtnItem, at: talkIdx)
+                }
+            }
+        } else {
+            if let item = existingCanvasBtn, let idx = menu.items.firstIndex(of: item) {
+                menu.removeItem(at: idx)
+            }
+        }
+
+        // Talk Mode
+        if let item = menu.item(withTag: GearMenuTag.talkMode) {
+            let enabled = state.talkEnabled
+            item.title = enabled ? "Stop Talk Mode" : "Talk Mode"
+            item.state = enabled ? .on : .off
+        }
+
+        // Update item — show/hide dynamically
+        let existingUpdate = menu.item(withTag: GearMenuTag.update)
+        if let updater = (NSApp.delegate as? AppDelegate)?.updaterController,
+           updater.isAvailable, updater.updateStatus.isUpdateReady
+        {
+            if existingUpdate == nil {
+                // Insert before quit
+                let updateItem = NSMenuItem(
+                    title: "Update ready, restart now?",
+                    action: #selector(checkForUpdate),
+                    keyEquivalent: "")
+                updateItem.target = self
+                updateItem.tag = GearMenuTag.update
+                if let quitIdx = menu.items.lastIndex(where: { $0.title == "Quit OpenClaw" }) {
+                    menu.insertItem(updateItem, at: quitIdx)
+                }
+            }
+        } else if let item = existingUpdate, let idx = menu.items.firstIndex(of: item) {
+            menu.removeItem(at: idx)
+        }
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -460,7 +460,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = .systemFont(ofSize: 14, weight: .regular)
+        textView.font = .systemFont(ofSize: 13, weight: .regular)
         textView.textContainer?.lineBreakMode = .byWordWrapping
         textView.textContainer?.lineFragmentPadding = 0
         textView.textContainerInset = NSSize(width: 2, height: 4)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -557,6 +557,20 @@ private final class ChatComposerNSTextView: NSTextView {
         return types
     }
 
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Ensure Option+key combos (e.g. @ on German keyboard = Option+L) are handled
+        // by the text view, not intercepted by toolbar/menu bar.
+        // Only intercept if it produces a character and doesn't involve Command.
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags.contains(.option) && !flags.contains(.command),
+           let chars = event.characters, !chars.isEmpty
+        {
+            self.interpretKeyEvents([event])
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
     override func keyDown(with event: NSEvent) {
         let isReturn = event.keyCode == 36
         if isReturn {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -32,7 +32,14 @@ struct OpenClawChatComposer: View {
                     if self.viewModel.showsModelPicker {
                         self.modelPicker
                     }
-                    self.thinkingPicker
+                    if self.viewModel.showsImageResolutionPicker {
+                        self.imageResolutionPicker
+                        self.imageAspectRatioPicker
+                        self.imageVariationsPicker
+                    }
+                    if !self.viewModel.showsImageResolutionPicker {
+                        self.thinkingPicker
+                    }
                     Spacer()
                     self.refreshButton
                     self.attachmentPicker
@@ -85,6 +92,26 @@ struct OpenClawChatComposer: View {
         .onAppear {
             self.shouldFocusTextView = true
         }
+        .alert("Large File",
+               isPresented: Binding(
+                   get: { self.viewModel.pendingLargeFile != nil },
+                   set: { if !$0 { self.viewModel.pendingLargeFile = nil } }))
+        {
+            Button("Upload via File API") {
+                if let file = self.viewModel.pendingLargeFile {
+                    // TODO: Implement Google File API upload
+                    self.viewModel.errorText = "Google File API upload not yet implemented — file too large (\(file.sizeMB) MB)"
+                    self.viewModel.pendingLargeFile = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                self.viewModel.pendingLargeFile = nil
+            }
+        } message: {
+            if let file = self.viewModel.pendingLargeFile {
+                Text("\(file.fileName) is \(file.sizeMB) MB — exceeds the 20 MB inline limit.\nUpload via Google File API?")
+            }
+        }
         #endif
     }
 
@@ -106,7 +133,7 @@ struct OpenClawChatComposer: View {
         .labelsHidden()
         .pickerStyle(.menu)
         .controlSize(.small)
-        .frame(maxWidth: 140, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var modelPicker: some View {
@@ -117,15 +144,78 @@ struct OpenClawChatComposer: View {
                 set: { next in self.viewModel.selectModel(next) }))
         {
             Text(self.viewModel.defaultModelLabel).tag(OpenClawChatViewModel.defaultModelSelectionID)
-            ForEach(self.viewModel.modelChoices) { model in
-                Text(model.displayLabel).tag(model.selectionID)
+            ForEach(self.viewModel.filteredModelChoices) { model in
+                Text(self.viewModel.friendlyName(for: model)).tag(model.selectionID)
             }
         }
         .labelsHidden()
         .pickerStyle(.menu)
         .controlSize(.small)
-        .frame(maxWidth: 240, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .help("Model")
+    }
+
+    private var imageResolutionPicker: some View {
+        Picker(
+            "Resolution",
+            selection: Binding(
+                get: { self.viewModel.imageResolution },
+                set: { next in self.viewModel.imageResolution = next }))
+        {
+            Text("0.5K").tag("0.5K")
+            Text("1K").tag("1K")
+            Text("2K").tag("2K")
+            Text("4K").tag("4K")
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .help("Output resolution")
+    }
+
+    private var imageAspectRatioPicker: some View {
+        Picker(
+            "Aspect Ratio",
+            selection: Binding(
+                get: { self.viewModel.imageAspectRatio },
+                set: { next in self.viewModel.imageAspectRatio = next }))
+        {
+            Text("1:1").tag("1:1")
+            Text("3:2").tag("3:2")
+            Text("2:3").tag("2:3")
+            Text("3:4").tag("3:4")
+            Text("4:3").tag("4:3")
+            Text("4:5").tag("4:5")
+            Text("5:4").tag("5:4")
+            Text("9:16").tag("9:16")
+            Text("16:9").tag("16:9")
+            Text("21:9").tag("21:9")
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .help("Aspect ratio")
+    }
+
+    private var imageVariationsPicker: some View {
+        Picker(
+            "Variations",
+            selection: Binding(
+                get: { self.viewModel.imageVariations },
+                set: { next in self.viewModel.imageVariations = next }))
+        {
+            Text("1 Image").tag(1)
+            Text("2 Images").tag(2)
+            Text("3 Images").tag(3)
+            Text("4 Images").tag(4)
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .help("Number of image variations to generate")
     }
 
     private var sessionPicker: some View {
@@ -144,7 +234,7 @@ struct OpenClawChatComposer: View {
         .labelsHidden()
         .pickerStyle(.menu)
         .controlSize(.small)
-        .frame(maxWidth: 160, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .help("Session")
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -280,6 +280,9 @@ struct OpenClawChatComposer: View {
                 },
                 onPasteImageAttachment: { data, fileName, mimeType in
                     self.viewModel.addImageAttachment(data: data, fileName: fileName, mimeType: mimeType)
+                },
+                onDropFileURLs: { urls in
+                    self.viewModel.addAttachments(urls: urls)
                 })
             .frame(minHeight: self.textMinHeight, idealHeight: self.textMinHeight, maxHeight: self.textMaxHeight)
             .padding(.horizontal, 4)
@@ -489,6 +492,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? ChatComposerNSTextView else { return }
         textView.onPasteImageAttachment = self.onPasteImageAttachment
+        textView.onDropFileURLs = self.onDropFileURLs
 
         if self.shouldFocus, let window = scrollView.window {
             window.makeFirstResponder(textView)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -440,6 +440,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
     @Binding var shouldFocus: Bool
     var onSend: () -> Void
     var onPasteImageAttachment: (_ data: Data, _ fileName: String, _ mimeType: String) -> Void
+    var onDropFileURLs: (([URL]) -> Void)?
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -472,12 +473,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
             self.onSend()
         }
         textView.onPasteImageAttachment = self.onPasteImageAttachment
-        textView.onDropFileURLs = { [viewModel = self.viewModel] urls in
-            viewModel.addAttachments(urls: urls)
-        }
-        textView.onDropFileURLs = { [viewModel = self.viewModel] urls in
-            viewModel.addAttachments(urls: urls)
-        }
+        textView.onDropFileURLs = self.onDropFileURLs
 
         let scroll = NSScrollView()
         scroll.drawsBackground = false

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -376,7 +376,11 @@ struct OpenClawChatComposer: View {
     }
 
     private var textMaxHeight: CGFloat {
+        #if os(macOS)
+        self.style == .onboarding ? 52 : .infinity
+        #else
         self.style == .onboarding ? 52 : 64
+        #endif
     }
 
     private var isComposerCompacted: Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -472,6 +472,12 @@ private struct ChatComposerTextView: NSViewRepresentable {
             self.onSend()
         }
         textView.onPasteImageAttachment = self.onPasteImageAttachment
+        textView.onDropFileURLs = { [viewModel = self.viewModel] urls in
+            viewModel.addAttachments(urls: urls)
+        }
+        textView.onDropFileURLs = { [viewModel = self.viewModel] urls in
+            viewModel.addAttachments(urls: urls)
+        }
 
         let scroll = NSScrollView()
         scroll.drawsBackground = false
@@ -525,6 +531,19 @@ private struct ChatComposerTextView: NSViewRepresentable {
 private final class ChatComposerNSTextView: NSTextView {
     var onSend: (() -> Void)?
     var onPasteImageAttachment: ((_ data: Data, _ fileName: String, _ mimeType: String) -> Void)?
+    /// Callback to route dropped file URLs to the attachment handler instead of inserting as text.
+    var onDropFileURLs: (([URL]) -> Void)?
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        let pboard = sender.draggingPasteboard
+        if let urls = pboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true
+        ]) as? [URL], !urls.isEmpty, let handler = self.onDropFileURLs {
+            handler(urls)
+            return true
+        }
+        return super.performDragOperation(sender)
+    }
 
     override var readablePasteboardTypes: [NSPasteboard.PasteboardType] {
         var types = super.readablePasteboardTypes

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -112,6 +112,7 @@ struct OpenClawChatComposer: View {
                 Text("\(file.fileName) is \(file.sizeMB) MB — exceeds the 20 MB inline limit.\nUpload via Google File API?")
             }
         }
+        .modifier(MetadataRestoreAlert(viewModel: self.viewModel))
         #endif
     }
 
@@ -595,10 +596,12 @@ private struct ChatComposerTextView: NSViewRepresentable {
 
         let isEditing = scrollView.window?.firstResponder == textView
 
-        // Always allow clearing the text (e.g. after send), even while editing.
+        // Always allow clearing the text (e.g. after send) or filling empty field
+        // (e.g. metadata restore), even while editing.
         // Only skip other updates while editing to avoid cursor jumps.
         let shouldClear = self.text.isEmpty && !textView.string.isEmpty
-        if isEditing, !shouldClear { return }
+        let shouldFill = !self.text.isEmpty && textView.string.isEmpty
+        if isEditing, !shouldClear, !shouldFill { return }
 
         if textView.string != self.text {
             context.coordinator.isProgrammaticUpdate = true
@@ -882,6 +885,57 @@ enum ChatComposerPasteSupport {
 
     private static func defaultFileName(index: Int, ext: String) -> String {
         "pasted-image-\(index + 1).\(ext)"
+    }
+}
+#endif
+
+// MARK: - Metadata Restore Alert (extracted to help Swift type-checker)
+
+#if os(macOS)
+private struct MetadataRestoreAlert: ViewModifier {
+    @Bindable var viewModel: OpenClawChatViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .alert(
+                "Generation Settings Detected",
+                isPresented: Binding(
+                    get: { self.viewModel.pendingMetadataRestore != nil },
+                    set: { if !$0 { self.viewModel.dismissMetadataRestore() } }
+                )
+            ) {
+                Button("Restore Settings") {
+                    self.viewModel.applyRestoredGenParams()
+                }
+                Button("Use as Input Only") {
+                    self.viewModel.useDroppedImageAsInput()
+                }
+                Button("Cancel", role: .cancel) {
+                    self.viewModel.dismissMetadataRestore()
+                }
+            } message: {
+                Text(self.metadataAlertMessage)
+            }
+    }
+
+    private var metadataAlertMessage: String {
+        guard let pending = self.viewModel.pendingMetadataRestore else {
+            return ""
+        }
+        let p = pending.params
+        let promptExcerpt = p.prompt.count > 60
+            ? String(p.prompt.prefix(57)) + "…"
+            : p.prompt
+        return """
+        This image was generated with OpenClaw.
+
+        Model: \(p.model)
+        Resolution: \(p.resolution) · \(p.aspectRatio)
+        Variations: \(p.variations)
+        Prompt: "\(promptExcerpt)"
+
+        Restore all settings, or use as input for a new generation?
+        """
     }
 }
 #endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -1,6 +1,25 @@
 import SwiftUI
 import Textual
 
+// Custom StructuredText style based on gitHub but with apricot inline code background
+private struct ApricotStyle: StructuredText.Style {
+    let inlineStyle: InlineStyle = InlineStyle()
+        .code(.monospaced, .fontScale(0.85), .backgroundColor(Color(red: 0.35, green: 0.22, blue: 0.04)))
+        .strong(.fontWeight(.semibold))
+        .link(.foregroundColor(.accentColor))
+    let headingStyle: StructuredText.GitHubHeadingStyle = .gitHub
+    let paragraphStyle: StructuredText.GitHubParagraphStyle = .gitHub
+    let blockQuoteStyle: StructuredText.GitHubBlockQuoteStyle = .gitHub
+    let codeBlockStyle: StructuredText.GitHubCodeBlockStyle = .gitHub
+    let listItemStyle: StructuredText.DefaultListItemStyle = .default
+    let unorderedListMarker: StructuredText.HierarchicalSymbolListMarker = .hierarchical(.disc, .circle, .square)
+    let orderedListMarker: StructuredText.DecimalListMarker = .decimal
+    let tableStyle: StructuredText.GitHubTableStyle = .gitHub
+    let tableCellStyle: StructuredText.GitHubTableCellStyle = .gitHub
+    let thematicBreakStyle: StructuredText.GitHubThematicBreakStyle = .gitHub
+}
+
+
 public enum ChatMarkdownVariant: String, CaseIterable, Sendable {
     case standard
     case compact
@@ -47,12 +66,10 @@ private struct ChatMarkdownStyle: ViewModifier {
             if self.variant == .compact {
                 content.textual.structuredTextStyle(.default)
             } else {
-                content.textual.structuredTextStyle(.gitHub)
+                content.textual.structuredTextStyle(ApricotStyle())
             }
         }
         .font(self.font)
-        .foregroundStyle(self.textColor)
-        .textual.inlineStyle(self.inlineStyle)
         .textual.textSelection(.enabled)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -4,7 +4,7 @@ import Textual
 // Custom StructuredText style based on gitHub but with apricot inline code background
 private struct ApricotStyle: StructuredText.Style {
     let inlineStyle: InlineStyle = InlineStyle()
-        .code(.monospaced, .fontScale(0.85), .backgroundColor(Color(red: 0.35, green: 0.22, blue: 0.04)))
+        .code(.monospaced, .foregroundColor(Color(red: 1.0, green: 0.75, blue: 0.2)))
         .strong(.fontWeight(.semibold))
         .link(.foregroundColor(.accentColor))
     let headingStyle: StructuredText.GitHubHeadingStyle = .gitHub

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -6,7 +6,7 @@ private struct ApricotStyle: StructuredText.Style {
     let inlineStyle: InlineStyle = InlineStyle()
         .code(.monospaced, .foregroundColor(Color(red: 1.0, green: 0.75, blue: 0.2)))
         .strong(.fontWeight(.semibold))
-        .link(.foregroundColor(.accentColor))
+        .link(.foregroundColor(Color(red: 0.6, green: 0.4, blue: 1.0)))
     let headingStyle: StructuredText.GitHubHeadingStyle = .gitHub
     let paragraphStyle: StructuredText.GitHubParagraphStyle = .gitHub
     let blockQuoteStyle: StructuredText.GitHubBlockQuoteStyle = .gitHub
@@ -74,7 +74,7 @@ private struct ChatMarkdownStyle: ViewModifier {
     }
 
     private var inlineStyle: InlineStyle {
-        let linkColor: Color = self.context == .user ? self.textColor : .accentColor
+        let linkColor: Color = self.context == .user ? self.textColor : Color(red: 0.6, green: 0.4, blue: 1.0)
         let codeScale: CGFloat = self.variant == .compact ? 0.85 : 0.9
         return InlineStyle()
             .code(.monospaced, .fontScale(codeScale))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -296,7 +296,7 @@ private struct ChatMessageBody: View {
     private var inlineAttachments: [OpenClawChatMessageContent] {
         self.message.content.filter { content in
             switch content.type ?? "text" {
-            case "file", "attachment":
+            case "file", "attachment", "image":
                 true
             default:
                 false
@@ -406,19 +406,113 @@ private struct AttachmentRow: View {
     let att: OpenClawChatMessageContent
     let isUser: Bool
 
+    @State private var isHovered = false
+
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "paperclip")
-            Text(self.att.fileName ?? "Attachment")
-                .font(.system(size: 11, design: .monospaced))
-                .lineLimit(1)
-                .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
-            Spacer()
+        if let image = self.decodedImage {
+            #if os(macOS)
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(maxHeight: 400)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.12), lineWidth: 1))
+                .overlay(alignment: .bottomTrailing) {
+                    if self.isHovered {
+                        HStack(spacing: 6) {
+                            Button {
+                                let pb = NSPasteboard.general
+                                pb.clearContents()
+                                pb.writeObjects([image])
+                            } label: {
+                                Image(systemName: "doc.on.doc")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                            .buttonStyle(.plain)
+                            .help("Copy Image")
+
+                            Button {
+                                self.saveImage(image)
+                            } label: {
+                                Image(systemName: "square.and.arrow.down")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                            .buttonStyle(.plain)
+                            .help("Save Image…")
+                        }
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .padding(8)
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    }
+                }
+                .onHover { hovering in
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        self.isHovered = hovering
+                    }
+                }
+                .contextMenu {
+                    Button("Copy Image") {
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.writeObjects([image])
+                    }
+                    Button("Save Image…") {
+                        self.saveImage(image)
+                    }
+                }
+            #else
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(maxHeight: 400)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            #endif
+        } else {
+            HStack(spacing: 8) {
+                Image(systemName: "paperclip")
+                Text(self.att.fileName ?? "Attachment")
+                    .font(.system(size: 11, design: .monospaced))
+                    .lineLimit(1)
+                    .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
+                Spacer()
+            }
+            .padding(10)
+            .background(self.isUser ? Color.white.opacity(0.2) : Color.black.opacity(0.04))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
-        .padding(10)
-        .background(self.isUser ? Color.white.opacity(0.2) : Color.black.opacity(0.04))
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
+
+    private var decodedImage: OpenClawPlatformImage? {
+        guard let base64 = self.att.content?.value as? String,
+              let data = Data(base64Encoded: base64)
+        else { return nil }
+        #if os(macOS)
+        return NSImage(data: data)
+        #else
+        return UIImage(data: data)
+        #endif
+    }
+
+    #if os(macOS)
+    private func saveImage(_ image: NSImage) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.jpeg, .png]
+        panel.nameFieldStringValue = self.att.fileName ?? "generated_image.jpg"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            if let tiff = image.tiffRepresentation,
+               let rep = NSBitmapImageRep(data: tiff),
+               let data = rep.representation(using: url.pathExtension == "png" ? .png : .jpeg, properties: [:])
+            {
+                try? data.write(to: url)
+            }
+        }
+    }
+    #endif
 }
 
 private struct ToolCallCard: View {
@@ -553,6 +647,64 @@ struct ChatTypingIndicatorBubble: View {
 extension ChatTypingIndicatorBubble: @MainActor Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.style == rhs.style
+    }
+}
+
+// MARK: - Image Generation Progress Bubble
+
+@MainActor
+struct ChatImageGenProgressBubble: View {
+    let phase: String
+    let style: OpenClawChatView.Style
+
+    @State private var shimmerOffset: CGFloat = -1
+
+    private static let accentColor = Color(red: 0.6, green: 0.4, blue: 1.0) // purple tint for image gen
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(Self.accentColor)
+            Text("🎨 \(self.phase)")
+                .font(.custom("Courier New Bold", size: 10))
+                .foregroundStyle(Self.accentColor)
+            ElapsedTimerView()
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, self.style == .standard ? 8 : 6)
+        .padding(.horizontal, self.style == .standard ? 12 : 14)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(OpenClawChatTheme.assistantBubble)
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Self.accentColor.opacity(0),
+                                Self.accentColor.opacity(0.08),
+                                Self.accentColor.opacity(0),
+                            ],
+                            startPoint: UnitPoint(x: self.shimmerOffset, y: 0.5),
+                            endPoint: UnitPoint(x: self.shimmerOffset + 0.4, y: 0.5)))
+            })
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Self.accentColor.opacity(0.15), lineWidth: 1))
+        .frame(maxWidth: ChatUIConstants.bubbleMaxWidth, alignment: .leading)
+        .focusable(false)
+        .onAppear {
+            withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
+                self.shimmerOffset = 1.4
+            }
+        }
+    }
+}
+
+extension ChatImageGenProgressBubble: @MainActor Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.phase == rhs.phase && lhs.style == rhs.style
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -144,8 +144,12 @@ struct ChatMessageBubble: View {
     let markdownVariant: ChatMarkdownVariant
     let userAccent: Color?
     let showsAssistantTrace: Bool
+    @AppStorage("openclaw.showSystemMessages") private var showSystemMessages: Bool = true
 
     var body: some View {
+        if self.isUser && self.isSystemUserMessage && !self.showSystemMessages {
+            EmptyView()
+        } else {
         ChatMessageBody(
             message: self.message,
             isUser: self.isUser,
@@ -153,12 +157,34 @@ struct ChatMessageBubble: View {
             markdownVariant: self.markdownVariant,
             userAccent: self.userAccent,
             showsAssistantTrace: self.showsAssistantTrace)
-            .frame(maxWidth: ChatUIConstants.bubbleMaxWidth, alignment: self.isUser ? .trailing : .leading)
-            .frame(maxWidth: .infinity, alignment: self.isUser ? .trailing : .leading)
+            .frame(maxWidth: ChatUIConstants.bubbleMaxWidth, alignment: self.bubbleAlignment)
+            .frame(maxWidth: .infinity, alignment: self.bubbleAlignment)
             .padding(.horizontal, 2)
+        }
     }
 
     private var isUser: Bool { self.message.role.lowercased() == "user" }
+
+    private var isSystemUserMessage: Bool {
+        guard self.isUser else { return false }
+        let text = self.message.content.compactMap { ($0.type ?? "text").lowercased() == "text" ? $0.text : nil }
+            .joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        let lines = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return false }
+        return lines.allSatisfy { line in
+            line.hasPrefix("System:") ||
+            line.hasPrefix("An async command") ||
+            line.hasPrefix("Current time:") ||
+            line.hasPrefix("Handle the result internally")
+        }
+    }
+
+    private var bubbleAlignment: Alignment {
+        if self.isUser && self.isSystemUserMessage { return .leading }
+        return self.isUser ? .trailing : .leading
+    }
 }
 
 @MainActor

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -183,12 +183,16 @@ private struct ChatMessageBody: View {
                         isUser: self.isUser,
                         toolName: self.message.toolName)
                 }
+            } else if self.isUser, self.isSystemMessage(text) {
+                CollapsibleSystemMessage(text: text)
+            } else if self.isUser, self.isSystemMessage(text) {
+                CollapsibleSystemMessage(text: text)
             } else if self.isUser {
                 ChatMarkdownRenderer(
                     text: text,
                     context: .user,
                     variant: self.markdownVariant,
-                    font: .system(size: 14),
+                    font: .custom("Courier New", size: 12),
                     textColor: textColor)
             } else {
                 ChatAssistantTextBody(
@@ -233,6 +237,25 @@ private struct ChatMessageBody: View {
         .shadow(color: self.bubbleShadowColor, radius: self.bubbleShadowRadius, y: self.bubbleShadowYOffset)
         .padding(.leading, self.tailPaddingLeading)
         .padding(.trailing, self.tailPaddingTrailing)
+    }
+
+    private func isSystemMessage(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lines = trimmed.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return false }
+        return lines.allSatisfy { line in
+            line.hasPrefix("System:") ||
+            line.hasPrefix("An async command") ||
+            line.hasPrefix("Current time:") ||
+            line.hasPrefix("Handle the result internally")
+        }
+    }
+
+    private var isSystemContent: Bool {
+        guard self.isUser else { return false }
+        return self.isSystemMessage(self.primaryText)
     }
 
     private var primaryText: String {
@@ -287,6 +310,9 @@ private struct ChatMessageBody: View {
     }
 
     private var bubbleFillColor: Color {
+        if self.isUser, self.isSystemContent {
+            return Color(red: 38 / 255.0, green: 39 / 255.0, blue: 42 / 255.0)
+        }
         if self.isUser {
             return self.userAccent ?? OpenClawChatTheme.userBubble
         }
@@ -358,7 +384,7 @@ private struct AttachmentRow: View {
         HStack(spacing: 8) {
             Image(systemName: "paperclip")
             Text(self.att.fileName ?? "Attachment")
-                .font(.footnote)
+                .font(.system(size: 11, design: .monospaced))
                 .lineLimit(1)
                 .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
             Spacer()
@@ -377,13 +403,13 @@ private struct ToolCallCard: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Text(self.toolName)
-                    .font(.footnote.weight(.semibold))
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
                 Spacer(minLength: 0)
             }
 
             if let summary = self.summary, !summary.isEmpty {
                 Text(summary)
-                    .font(.footnote.monospaced())
+                    .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
@@ -422,12 +448,12 @@ private struct ToolResultCard: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 6) {
                     Text(self.title)
-                        .font(.footnote.weight(.semibold))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
                     Spacer(minLength: 0)
                 }
 
                 Text(self.displayText)
-                    .font(.footnote.monospaced())
+                    .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
                     .lineLimit(self.expanded ? nil : Self.previewLineLimit)
 
@@ -436,7 +462,7 @@ private struct ToolResultCard: View {
                         self.expanded.toggle()
                     }
                     .buttonStyle(.plain)
-                    .font(.caption)
+                    .font(.system(size: 10, design: .monospaced))
                     .foregroundStyle(.secondary)
                 }
             }
@@ -475,11 +501,17 @@ struct ChatTypingIndicatorBubble: View {
     let style: OpenClawChatView.Style
 
     var body: some View {
-        HStack(spacing: 10) {
-            TypingDots()
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(Color(red: 1.0, green: 0.75, blue: 0.2))
+            Text("⏳ thinking…")
+                .font(.custom("Courier New Bold", size: 10))
+                .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.2))
+            ElapsedTimerView()
             Spacer(minLength: 0)
         }
-        .padding(.vertical, self.style == .standard ? 12 : 10)
+        .padding(.vertical, self.style == .standard ? 8 : 6)
         .padding(.horizontal, self.style == .standard ? 12 : 14)
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -495,6 +527,33 @@ struct ChatTypingIndicatorBubble: View {
 extension ChatTypingIndicatorBubble: @MainActor Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.style == rhs.style
+    }
+}
+
+@MainActor
+private struct ElapsedTimerView: View {
+    @State private var elapsed: TimeInterval = 0
+    @State private var startDate = Date()
+    private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Text(self.formattedTime)
+            .font(.custom("Courier New", size: 10))
+            .foregroundStyle(Color.secondary.opacity(0.6))
+            .onReceive(self.timer) { _ in
+                self.elapsed = Date().timeIntervalSince(self.startDate)
+            }
+    }
+
+    private var formattedTime: String {
+        let secs = Int(self.elapsed)
+        let tenths = Int((self.elapsed - Double(secs)) * 10)
+        if secs < 60 {
+            return String(format: "%d.%ds", secs, tenths)
+        }
+        let mins = secs / 60
+        let remainSecs = secs % 60
+        return String(format: "%d:%02d", mins, remainSecs)
     }
 }
 
@@ -535,34 +594,31 @@ struct ChatPendingToolsBubble: View {
     let toolCalls: [OpenClawChatPendingToolCall]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label("Running tools…", systemImage: "hammer")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
+        VStack(alignment: .leading, spacing: 6) {
             ForEach(self.toolCalls) { call in
                 let display = ToolDisplayRegistry.resolve(name: call.name, args: call.args)
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text("\(display.emoji) \(display.label)")
-                            .font(.footnote.monospaced())
-                            .lineLimit(1)
-                        Spacer(minLength: 0)
-                        ProgressView().controlSize(.mini)
-                    }
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .tint(Color(red: 1.0, green: 0.75, blue: 0.2))
+                    Text("\(display.emoji) \(display.label)")
+                        .font(.custom("Courier New Bold", size: 10))
+                        .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.2))
                     if let detail = display.detailLine, !detail.isEmpty {
                         Text(detail)
-                            .font(.caption.monospaced())
+                            .font(.custom("Courier New", size: 9))
                             .foregroundStyle(.secondary)
-                            .lineLimit(2)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 0)
+                    if let startedAt = call.startedAt {
+                        ToolElapsedView(startedAt: startedAt)
                     }
                 }
-                .padding(10)
-                .background(Color.white.opacity(0.06))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
         }
-        .padding(12)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
         .assistantBubbleContainerStyle()
     }
 }
@@ -572,6 +628,26 @@ extension ChatPendingToolsBubble: @MainActor Equatable {
         lhs.toolCalls == rhs.toolCalls
     }
 }
+
+@MainActor
+private struct ToolElapsedView: View {
+    let startedAt: Double
+    @State private var elapsed: TimeInterval = 0
+    private let timer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+    var body: some View {
+        Text(self.formattedTime)
+            .font(.custom("Courier New", size: 9))
+            .foregroundStyle(Color.secondary.opacity(0.5))
+            .onAppear { self.elapsed = max(0, Date().timeIntervalSince1970 - self.startedAt / 1000) }
+            .onReceive(self.timer) { _ in self.elapsed = max(0, Date().timeIntervalSince1970 - self.startedAt / 1000) }
+    }
+    private var formattedTime: String {
+        let secs = Int(self.elapsed)
+        if secs < 60 { return "\(secs)s" }
+        return String(format: "%d:%02d", secs / 60, secs % 60)
+    }
+}
+
 
 @MainActor
 private struct TypingDots: View {
@@ -613,6 +689,53 @@ private struct TypingDots: View {
     }
 }
 
+@MainActor
+private struct CollapsibleSystemMessage: View {
+    let text: String
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button(action: { withAnimation(.easeInOut(duration: 0.2)) { self.isExpanded.toggle() } }) {
+                HStack(spacing: 6) {
+                    Image(systemName: self.isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(Color.secondary.opacity(0.6))
+                        .frame(width: 10)
+                    Image(systemName: "terminal")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.secondary.opacity(0.5))
+                    Text(self.previewText)
+                        .font(.custom("Courier New", size: 10))
+                        .foregroundStyle(Color.secondary.opacity(0.6))
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if self.isExpanded {
+                Text(self.text)
+                    .font(.custom("Courier New", size: 10))
+                    .foregroundStyle(Color.secondary.opacity(0.7))
+                    .textSelection(.enabled)
+                    .padding(.leading, 16)
+            }
+        }
+    }
+
+    private var previewText: String {
+        let firstLine = self.text.components(separatedBy: .newlines).first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "System message"
+        let cleaned = firstLine
+            .replacingOccurrences(of: "System: ", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.count > 60 {
+            return String(cleaned.prefix(60)) + "…"
+        }
+        return cleaned
+    }
+}
+
 private struct ChatAssistantTextBody: View {
     let text: String
     let markdownVariant: ChatMarkdownVariant
@@ -622,7 +745,7 @@ private struct ChatAssistantTextBody: View {
         let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
         VStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
-                let font = segment.kind == .thinking ? Font.system(size: 14).italic() : Font.system(size: 14)
+                let font = segment.kind == .thinking ? Font.custom("Courier New Italic", size: 12) : Font.custom("Courier New", size: 12)
                 ChatMarkdownRenderer(
                     text: segment.text,
                     context: .assistant,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -504,6 +504,19 @@ private struct AttachmentRow: View {
         panel.nameFieldStringValue = self.att.fileName ?? "generated_image.jpg"
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
+
+            // If saving as PNG and the raw data has OpenClaw metadata, write raw bytes
+            // to preserve the tEXt chunk (NSBitmapImageRep strips it during round-trip).
+            if url.pathExtension.lowercased() == "png",
+               let base64 = self.att.content?.value as? String,
+               let rawData = Data(base64Encoded: base64),
+               OpenClawImageMetadata.extractMetadata(from: rawData) != nil
+            {
+                try? rawData.write(to: url)
+                return
+            }
+
+            // Fallback: re-encode via NSBitmapImageRep (JPEG or PNG without metadata)
             if let tiff = image.tiffRepresentation,
                let rep = NSBitmapImageRep(data: tiff),
                let data = rep.representation(using: url.pathExtension == "png" ? .png : .jpeg, properties: [:])

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -20,8 +20,8 @@ enum OpenClawChatTheme {
         // NSColor semantic colors don't reliably resolve for arbitrary NSAppearance in SwiftPM.
         // Use explicit light/dark values so the bubble updates when the system appearance flips.
         appearance.isDarkAqua
-            ? NSColor(calibratedWhite: 0.18, alpha: 0.88)
-            : NSColor(calibratedWhite: 0.94, alpha: 0.92)
+            ? NSColor(calibratedRed: 0.235, green: 0.231, blue: 0.220, alpha: 0.88)
+            : NSColor(calibratedRed: 0.235, green: 0.231, blue: 0.220, alpha: 0.88)
     }
 
     static func resolvedOnboardingAssistantBubbleColor(for appearance: NSAppearance) -> NSColor {
@@ -101,7 +101,7 @@ enum OpenClawChatTheme {
     }
 
     static var userBubble: Color {
-        Color(red: 127 / 255.0, green: 184 / 255.0, blue: 212 / 255.0)
+        Color(red: 50 / 255.0, green: 53 / 255.0, blue: 57 / 255.0)
     }
 
     static var assistantBubble: Color {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -250,7 +250,13 @@ public struct OpenClawChatView: View {
                     alignment: msg.role.lowercased() == "user" ? .trailing : .leading)
         }
 
-        if self.viewModel.pendingRunCount > 0 {
+        if let phase = self.viewModel.imageGenPhase {
+            HStack {
+                ChatImageGenProgressBubble(phase: phase, style: self.style)
+                    .equatable()
+                Spacer(minLength: 0)
+            }
+        } else if self.viewModel.pendingRunCount > 0 {
             HStack {
                 ChatTypingIndicatorBubble(style: self.style)
                     .equatable()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -76,37 +76,47 @@ public struct OpenClawChatView: View {
                         .padding(.horizontal, Layout.outerPaddingHorizontal)
                         .frame(maxHeight: .infinity)
 
-                    // Draggable divider
-                    Rectangle()
-                        .fill(Color.primary.opacity(0.12))
-                        .frame(height: 1)
-                        .padding(.vertical, 3)
-                        .frame(height: 8)
-                        .contentShape(Rectangle())
-                        #if os(macOS)
-                        .onHover { inside in
-                            if inside {
-                                NSCursor.resizeUpDown.push()
-                            } else {
-                                NSCursor.pop()
+                    // Draggable resize handle
+                    ZStack {
+                        // Background hit area
+                        Color.clear
+                            .frame(height: 12)
+                            .contentShape(Rectangle())
+                        // Visual grab bar (three dots)
+                        HStack(spacing: 2) {
+                            ForEach(0..<3, id: \.self) { _ in
+                                Circle()
+                                    .fill(Color.primary.opacity(0.25))
+                                    .frame(width: 4, height: 4)
                             }
                         }
-                        #endif
-                        .gesture(
-                            DragGesture(minimumDistance: 1)
-                                .onChanged { value in
-                                    if self.composerDragStart == nil {
-                                        self.composerDragStart = self.composerHeight
-                                    }
-                                    let minH: CGFloat = 60
-                                    let maxH: CGFloat = geo.size.height * 0.6
-                                    let proposed = (self.composerDragStart ?? self.composerHeight) - value.translation.height
-                                    self.composerHeight = min(maxH, max(minH, proposed))
+                    }
+                    .frame(height: 12)
+                    .frame(maxWidth: .infinity)
+                    #if os(macOS)
+                    .onHover { inside in
+                        if inside {
+                            NSCursor.resizeUpDown.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    #endif
+                    .gesture(
+                        DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                            .onChanged { value in
+                                if self.composerDragStart == nil {
+                                    self.composerDragStart = self.composerHeight
                                 }
-                                .onEnded { _ in
-                                    self.composerDragStart = nil
-                                }
-                        )
+                                let minH: CGFloat = 60
+                                let maxH: CGFloat = geo.size.height * 0.6
+                                let proposed = (self.composerDragStart ?? self.composerHeight) - value.translation.height
+                                self.composerHeight = min(maxH, max(minH, proposed))
+                            }
+                            .onEnded { _ in
+                                self.composerDragStart = nil
+                            }
+                    )
 
                     OpenClawChatComposer(
                         viewModel: self.viewModel,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -17,7 +17,7 @@ public struct OpenClawChatView: View {
     @State private var hasPerformedInitialScroll = false
     @State private var isPinnedToBottom = true
     @State private var lastUserMessageID: UUID?
-    @State private var composerHeight: CGFloat = 120
+    @State private var composerHeight: CGFloat = 150
     @State private var composerDragStart: CGFloat?
     private let showsSessionSwitcher: Bool
     private let style: Style
@@ -76,41 +76,37 @@ public struct OpenClawChatView: View {
                         .padding(.horizontal, Layout.outerPaddingHorizontal)
                         .frame(maxHeight: .infinity)
 
-                    // Draggable resize handle
-                    ZStack {
-                        // Background hit area
-                        Color.clear
-                            .frame(height: 12)
-                            .contentShape(Rectangle())
-                        // Visual grab bar (three dots)
-                        HStack(spacing: 2) {
+                    // ── Resize handle ──
+                    VStack(spacing: 0) {
+                        Rectangle()
+                            .fill(Color.primary.opacity(0.15))
+                            .frame(height: 1)
+                        HStack(spacing: 3) {
                             ForEach(0..<3, id: \.self) { _ in
-                                Circle()
-                                    .fill(Color.primary.opacity(0.25))
-                                    .frame(width: 4, height: 4)
+                                RoundedRectangle(cornerRadius: 1)
+                                    .fill(Color.primary.opacity(0.3))
+                                    .frame(width: 20, height: 3)
                             }
                         }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 14)
                     }
-                    .frame(height: 12)
-                    .frame(maxWidth: .infinity)
+                    .frame(height: 15)
+                    .contentShape(Rectangle())
                     #if os(macOS)
                     .onHover { inside in
-                        if inside {
-                            NSCursor.resizeUpDown.push()
-                        } else {
-                            NSCursor.pop()
-                        }
+                        if inside { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
                     }
                     #endif
-                    .gesture(
+                    .highPriorityGesture(
                         DragGesture(minimumDistance: 0, coordinateSpace: .global)
                             .onChanged { value in
                                 if self.composerDragStart == nil {
                                     self.composerDragStart = self.composerHeight
                                 }
-                                let minH: CGFloat = 60
-                                let maxH: CGFloat = geo.size.height * 0.6
-                                let proposed = (self.composerDragStart ?? self.composerHeight) - value.translation.height
+                                let minH: CGFloat = 80
+                                let maxH: CGFloat = geo.size.height * 0.65
+                                let proposed = (self.composerDragStart ?? 150) - value.translation.height
                                 self.composerHeight = min(maxH, max(minH, proposed))
                             }
                             .onEnded { _ in
@@ -118,17 +114,17 @@ public struct OpenClawChatView: View {
                             }
                     )
 
+                    // ── Composer ──
                     OpenClawChatComposer(
                         viewModel: self.viewModel,
                         style: self.style,
                         showsSessionSwitcher: self.showsSessionSwitcher)
                         .padding(.horizontal, Layout.composerPaddingHorizontal)
-                        .frame(height: self.composerHeight)
+                        .frame(minHeight: self.composerHeight, maxHeight: self.composerHeight)
                 }
                 .padding(.vertical, Layout.outerPaddingVertical)
             }
-            .frame(maxWidth: .infinity)
-            .frame(maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { self.viewModel.load() }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -71,10 +71,15 @@ public struct OpenClawChatView: View {
             }
 
             GeometryReader { geo in
+                let handleH: CGFloat = 15
+                let padV = Layout.outerPaddingVertical * 2
+                let listH = max(100, geo.size.height - padV - handleH - self.composerHeight)
+
                 VStack(spacing: 0) {
                     self.messageList
                         .padding(.horizontal, Layout.outerPaddingHorizontal)
-                        .frame(maxHeight: .infinity)
+                        .frame(height: listH)
+                        .clipped()
 
                     // ── Resize handle ──
                     VStack(spacing: 0) {
@@ -91,7 +96,7 @@ public struct OpenClawChatView: View {
                         .frame(maxWidth: .infinity)
                         .frame(height: 14)
                     }
-                    .frame(height: 15)
+                    .frame(height: handleH)
                     .contentShape(Rectangle())
                     #if os(macOS)
                     .onHover { inside in
@@ -105,7 +110,7 @@ public struct OpenClawChatView: View {
                                     self.composerDragStart = self.composerHeight
                                 }
                                 let minH: CGFloat = 80
-                                let maxH: CGFloat = geo.size.height * 0.65
+                                let maxH: CGFloat = geo.size.height - padV - handleH - 100
                                 let proposed = (self.composerDragStart ?? 150) - value.translation.height
                                 self.composerHeight = min(maxH, max(minH, proposed))
                             }
@@ -120,7 +125,7 @@ public struct OpenClawChatView: View {
                         style: self.style,
                         showsSessionSwitcher: self.showsSessionSwitcher)
                         .padding(.horizontal, Layout.composerPaddingHorizontal)
-                        .frame(minHeight: self.composerHeight, maxHeight: self.composerHeight)
+                        .frame(height: self.composerHeight)
                 }
                 .padding(.vertical, Layout.outerPaddingVertical)
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -17,6 +17,7 @@ public struct OpenClawChatView: View {
     @State private var hasPerformedInitialScroll = false
     @State private var isPinnedToBottom = true
     @State private var lastUserMessageID: UUID?
+    @State private var composerHeight: CGFloat = 120
     private let showsSessionSwitcher: Bool
     private let style: Style
     private let markdownVariant: ChatMarkdownVariant
@@ -68,16 +69,47 @@ public struct OpenClawChatView: View {
                     .ignoresSafeArea()
             }
 
-            VStack(spacing: Layout.stackSpacing) {
-                self.messageList
-                    .padding(.horizontal, Layout.outerPaddingHorizontal)
-                OpenClawChatComposer(
-                    viewModel: self.viewModel,
-                    style: self.style,
-                    showsSessionSwitcher: self.showsSessionSwitcher)
-                    .padding(.horizontal, Layout.composerPaddingHorizontal)
+            GeometryReader { geo in
+                VStack(spacing: 0) {
+                    self.messageList
+                        .padding(.horizontal, Layout.outerPaddingHorizontal)
+                        .frame(maxHeight: .infinity)
+
+                    // Draggable divider
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.12))
+                        .frame(height: 1)
+                        .padding(.vertical, 3)
+                        .frame(height: 8)
+                        .contentShape(Rectangle())
+                        #if os(macOS)
+                        .onHover { inside in
+                            if inside {
+                                NSCursor.resizeUpDown.push()
+                            } else {
+                                NSCursor.pop()
+                            }
+                        }
+                        #endif
+                        .gesture(
+                            DragGesture(minimumDistance: 1)
+                                .onChanged { value in
+                                    let minH: CGFloat = 60
+                                    let maxH: CGFloat = geo.size.height * 0.6
+                                    let proposed = self.composerHeight - value.translation.height
+                                    self.composerHeight = min(maxH, max(minH, proposed))
+                                }
+                        )
+
+                    OpenClawChatComposer(
+                        viewModel: self.viewModel,
+                        style: self.style,
+                        showsSessionSwitcher: self.showsSessionSwitcher)
+                        .padding(.horizontal, Layout.composerPaddingHorizontal)
+                        .frame(height: self.composerHeight)
+                }
+                .padding(.vertical, Layout.outerPaddingVertical)
             }
-            .padding(.vertical, Layout.outerPaddingVertical)
             .frame(maxWidth: .infinity)
             .frame(maxHeight: .infinity, alignment: .top)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -18,6 +18,7 @@ public struct OpenClawChatView: View {
     @State private var isPinnedToBottom = true
     @State private var lastUserMessageID: UUID?
     @State private var composerHeight: CGFloat = 120
+    @State private var composerDragStart: CGFloat?
     private let showsSessionSwitcher: Bool
     private let style: Style
     private let markdownVariant: ChatMarkdownVariant
@@ -94,10 +95,16 @@ public struct OpenClawChatView: View {
                         .gesture(
                             DragGesture(minimumDistance: 1)
                                 .onChanged { value in
+                                    if self.composerDragStart == nil {
+                                        self.composerDragStart = self.composerHeight
+                                    }
                                     let minH: CGFloat = 60
                                     let maxH: CGFloat = geo.size.height * 0.6
-                                    let proposed = self.composerHeight - value.translation.height
+                                    let proposed = (self.composerDragStart ?? self.composerHeight) - value.translation.height
                                     self.composerHeight = min(maxH, max(minH, proposed))
+                                }
+                                .onEnded { _ in
+                                    self.composerDragStart = nil
                                 }
                         )
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -4,6 +4,31 @@ import Observation
 import OSLog
 import UniformTypeIdentifiers
 
+/// Protocol for direct image generation (bypasses gateway).
+@MainActor
+public protocol DirectImageGenHandler: AnyObject {
+    func generateImage(
+        prompt: String,
+        model: String,
+        inputImage: Data?,
+        inputMimeType: String,
+        resolution: String,
+        aspectRatio: String
+    ) async throws -> DirectImageGenResult
+}
+
+public struct DirectImageGenResult: Sendable {
+    public let imageData: Data
+    public let mimeType: String
+    public let text: String?
+
+    public init(imageData: Data, mimeType: String, text: String?) {
+        self.imageData = imageData
+        self.mimeType = mimeType
+        self.text = text
+    }
+}
+
 #if canImport(AppKit)
 import AppKit
 #elseif canImport(UIKit)
@@ -20,6 +45,23 @@ public final class OpenClawChatViewModel {
     public private(set) var messages: [OpenClawChatMessage] = []
     public var input: String = ""
     public private(set) var thinkingLevel: String
+    public var imageResolution: String = "1K"
+    public var imageAspectRatio: String = "1:1"
+    public var imageVariations: Int = 1
+    public weak var directImageGenHandler: DirectImageGenHandler?
+    public private(set) var imageGenPhase: String?
+    public var pendingLargeFile: PendingLargeFile?
+
+    public struct PendingLargeFile {
+        public let data: Data
+        public let fileName: String
+        public let mimeType: String
+        public let url: URL?
+
+        public var sizeMB: String {
+            String(format: "%.1f", Double(self.data.count) / 1_000_000)
+        }
+    }
     public private(set) var modelSelectionID: String = "__default__"
     public private(set) var modelChoices: [OpenClawChatModelChoice] = []
     public private(set) var isLoading = false
@@ -185,6 +227,90 @@ public final class OpenClawChatViewModel {
 
     public var showsModelPicker: Bool {
         !self.modelChoices.isEmpty
+    }
+
+    /// Show resolution picker when an image generation model is selected.
+    public var showsImageResolutionPicker: Bool {
+        Self.isImageGenModel(self.modelSelectionID)
+    }
+
+    /// Known image generation model ID patterns.
+    private static let imageGenModelPatterns = ["image", "imagen"]
+
+    /// Nano Banana model IDs to keep in the dropdown.
+    private static let allowedImageGenModels = [
+        "gemini-3-pro-image-preview",
+        "gemini-3.1-flash-image-preview",
+    ]
+
+    static func friendlyModelName(_ model: OpenClawChatModelChoice) -> String {
+        let lower = model.modelID.lowercased()
+        // Image gen models: Nano Banana names
+        if lower.contains("gemini-3.1-flash-image-preview") || lower.contains("3.1-flash-image") {
+            return "🍌 Nano Banana 2 (Image)"
+        }
+        if lower.contains("gemini-3-pro-image-preview") || lower.contains("3-pro-image") {
+            return "🍌 Nano Banana Pro (Image)"
+        }
+        // Tag LLMs with provider
+        let provider = model.provider.lowercased()
+        if provider.contains("openai") {
+            return "💬 \(model.name.isEmpty ? model.modelID : model.name) (LLM)"
+        }
+        if provider.contains("anthropic") {
+            return "💬 \(model.name.isEmpty ? model.modelID : model.name) (LLM)"
+        }
+        if provider.contains("google") {
+            return "💬 \(model.name.isEmpty ? model.modelID : model.name) (LLM)"
+        }
+        return "💬 \(model.name.isEmpty ? model.modelID : model.name) (LLM)"
+    }
+
+    /// Build a descriptive image filename from a timestamp and a prompt excerpt.
+    /// Example: `20260322_143012_a_sunset_over_mountains.jpg`
+    private static func imageFileName(prompt: String, ext: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        let timestamp = formatter.string(from: Date())
+
+        // Sanitize prompt: lowercase, keep only alphanumerics/spaces, collapse whitespace, truncate
+        let slug = prompt
+            .lowercased()
+            .unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) || $0 == " " }
+            .map { String($0) }.joined()
+            .split(separator: " ")
+            .prefix(8)
+            .joined(separator: "_")
+
+        if slug.isEmpty {
+            return "\(timestamp)_generated.\(ext)"
+        }
+        return "\(timestamp)_\(slug).\(ext)"
+    }
+
+    private static func isImageGenModel(_ modelID: String) -> Bool {
+        let lower = modelID.lowercased()
+        return self.imageGenModelPatterns.contains(where: { lower.contains($0) })
+    }
+
+    private static func isAllowedImageGenModel(_ modelID: String) -> Bool {
+        let lower = modelID.lowercased()
+        return self.allowedImageGenModels.contains(where: { lower.contains($0) })
+    }
+
+    /// Filtered model choices: keep all LLMs + only Nano Banana image gen models.
+    public func friendlyName(for model: OpenClawChatModelChoice) -> String {
+        Self.friendlyModelName(model)
+    }
+
+    public var filteredModelChoices: [OpenClawChatModelChoice] {
+        self.modelChoices.filter { model in
+            let isImageGen = Self.isImageGenModel(model.modelID)
+            if isImageGen {
+                return Self.isAllowedImageGenModel(model.modelID)
+            }
+            return true  // Keep all non-image-gen models (LLMs)
+        }
     }
 
     public var defaultModelLabel: String {
@@ -392,6 +518,18 @@ public final class OpenClawChatViewModel {
             return
         }
 
+        // Direct image generation: bypass gateway when an image gen model is selected
+        let debugMsg = "[APRICOT-DEBUG] Send check: modelSelectionID=\(self.modelSelectionID) isImageGen=\(Self.isImageGenModel(self.modelSelectionID)) hasHandler=\(self.directImageGenHandler != nil)"
+        NSLog("%@", debugMsg)
+        try? debugMsg.appending("\n").write(toFile: "/tmp/openclaw-debug.log", atomically: false, encoding: .utf8)
+        if Self.isImageGenModel(self.modelSelectionID), let handler = self.directImageGenHandler {
+            NSLog("[APRICOT-DEBUG] >>> Routing to DIRECT image gen!")
+            try? "[APRICOT-DEBUG] >>> Routing to DIRECT image gen!\n".write(toFile: "/tmp/openclaw-debug.log", atomically: false, encoding: .utf8)
+            await self.performDirectImageGen(prompt: trimmed, handler: handler)
+            return
+        }
+        try? "[APRICOT-DEBUG] >>> NOT routing to direct image gen, falling through to gateway\n".write(toFile: "/tmp/openclaw-debug.log", atomically: false, encoding: .utf8)
+
         let sessionKey = self.sessionKey
 
         guard self.healthOK else {
@@ -472,6 +610,156 @@ public final class OpenClawChatViewModel {
             self.clearPendingRun(runId)
             self.errorText = error.localizedDescription
             chatUILogger.error("chat.send failed \(error.localizedDescription, privacy: .public)")
+        }
+
+        self.isSending = false
+    }
+
+    private func performDirectImageGen(prompt: String, handler: DirectImageGenHandler) async {
+        self.isSending = true
+        self.errorText = nil
+        let messageText = prompt.isEmpty && !self.attachments.isEmpty ? "Generate image" : prompt
+        let resolution = self.imageResolution
+        let aspectRatio = self.imageAspectRatio
+
+        // Append user message to UI
+        var userContent: [OpenClawChatMessageContent] = [
+            OpenClawChatMessageContent(
+                type: "text", text: messageText,
+                thinking: nil, thinkingSignature: nil,
+                mimeType: nil, fileName: nil, content: nil,
+                id: nil, name: nil, arguments: nil),
+        ]
+        for att in self.attachments {
+            userContent.append(
+                OpenClawChatMessageContent(
+                    type: att.type, text: nil,
+                    thinking: nil, thinkingSignature: nil,
+                    mimeType: att.mimeType, fileName: att.fileName,
+                    content: AnyCodable(att.data.base64EncodedString()),
+                    id: nil, name: nil, arguments: nil))
+        }
+        self.messages.append(
+            OpenClawChatMessage(
+                id: UUID(), role: "user", content: userContent,
+                timestamp: Date().timeIntervalSince1970 * 1000))
+
+        // Get first image attachment
+        let inputImage = self.attachments.first?.data
+        let inputMimeType = self.attachments.first?.mimeType ?? "image/jpeg"
+
+        self.input = ""
+        let sentAttachments = self.attachments
+        self.attachments = []
+
+        // Show thinking indicator
+        self.pendingRuns.insert("imagegen")
+        self.imageGenPhase = "Preparing request…"
+
+        let dbg = { (msg: String) in
+            let line = "[performDirectImageGen] \(msg)\n"
+            if let data = line.data(using: .utf8),
+               let handle = FileHandle(forWritingAtPath: "/tmp/openclaw-debug.log") {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                handle.closeFile()
+            }
+        }
+
+        let totalVariations = max(1, min(4, self.imageVariations))
+        var successCount = 0
+        var lastError: Error?
+
+        for i in 1...totalVariations {
+            if totalVariations > 1 {
+                self.imageGenPhase = "Generating image \(i) of \(totalVariations)…"
+            } else {
+                self.imageGenPhase = "Generating image…"
+            }
+
+            do {
+                let result = try await handler.generateImage(
+                    prompt: messageText,
+                    model: self.modelSelectionID,
+                    inputImage: inputImage,
+                    inputMimeType: inputMimeType,
+                    resolution: resolution,
+                    aspectRatio: aspectRatio)
+
+                dbg("Variation \(i)/\(totalVariations): imageData=\(result.imageData.count) bytes, mimeType=\(result.mimeType)")
+
+                // Create assistant message with the generated image
+                var assistantContent: [OpenClawChatMessageContent] = []
+                let displayText: String
+                if totalVariations > 1 {
+                    displayText = (result.text?.isEmpty == false) ? result.text! : "Variation \(i) of \(totalVariations):"
+                } else {
+                    displayText = (result.text?.isEmpty == false) ? result.text! : "Generated image:"
+                }
+                assistantContent.append(
+                    OpenClawChatMessageContent(
+                        type: "text", text: displayText,
+                        thinking: nil, thinkingSignature: nil,
+                        mimeType: nil, fileName: nil, content: nil,
+                        id: nil, name: nil, arguments: nil))
+
+                // Build descriptive filename with variation index
+                let ext = result.mimeType == "image/png" ? "png" : "jpg"
+                let imageFileName: String
+                if totalVariations > 1 {
+                    let baseName = Self.imageFileName(prompt: messageText, ext: ext)
+                    imageFileName = baseName.replacingOccurrences(of: ".\(ext)", with: "_v\(i).\(ext)")
+                } else {
+                    imageFileName = Self.imageFileName(prompt: messageText, ext: ext)
+                }
+
+                let base64Str = result.imageData.base64EncodedString()
+                assistantContent.append(
+                    OpenClawChatMessageContent(
+                        type: "image", text: nil,
+                        thinking: nil, thinkingSignature: nil,
+                        mimeType: result.mimeType,
+                        fileName: imageFileName,
+                        content: AnyCodable(base64Str),
+                        id: nil, name: nil, arguments: nil))
+
+                self.messages.append(
+                    OpenClawChatMessage(
+                        id: UUID(), role: "assistant", content: assistantContent,
+                        timestamp: Date().timeIntervalSince1970 * 1000))
+
+                // Auto-save to configured folder
+                if let saveFolder = UserDefaults.standard.string(forKey: "openclaw.imageGenSaveFolder"),
+                   !saveFolder.isEmpty
+                {
+                    let url = URL(fileURLWithPath: saveFolder).appendingPathComponent(imageFileName)
+                    do {
+                        try result.imageData.write(to: url)
+                        dbg("Auto-saved variation \(i) to \(url.path)")
+                    } catch {
+                        dbg("Auto-save failed for variation \(i): \(error.localizedDescription)")
+                    }
+                }
+
+                successCount += 1
+            } catch {
+                dbg("Variation \(i)/\(totalVariations) FAILED: \(error.localizedDescription)")
+                lastError = error
+                // Continue to next variation on safety filter blocks; stop on hard errors like rate limits
+                let desc = error.localizedDescription.lowercased()
+                if desc.contains("rate limit") || desc.contains("rate_limit") {
+                    break  // No point retrying more variations if rate limited
+                }
+            }
+        }
+
+        self.pendingRuns.remove("imagegen")
+        self.imageGenPhase = nil
+
+        if successCount == 0, let error = lastError {
+            self.errorText = error.localizedDescription
+        } else if successCount < totalVariations, let error = lastError {
+            self.errorText = "\(successCount) of \(totalVariations) images generated. Last error: \(error.localizedDescription)"
         }
 
         self.isSending = false
@@ -999,8 +1287,8 @@ public final class OpenClawChatViewModel {
     }
 
     private func addImageAttachment(url: URL?, data: Data, fileName: String, mimeType: String) async {
-        if data.count > 5_000_000 {
-            self.errorText = "Attachment \(fileName) exceeds 5 MB limit"
+        if data.count > 20_000_000 {
+            self.pendingLargeFile = PendingLargeFile(data: data, fileName: fileName, mimeType: mimeType, url: url)
             return
         }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -52,6 +52,16 @@ public final class OpenClawChatViewModel {
     public private(set) var imageGenPhase: String?
     public var pendingLargeFile: PendingLargeFile?
 
+    /// Set when a dropped image contains OpenClaw generation metadata.
+    /// The UI shows a disambiguation dialog to let the user choose how to proceed.
+    public var pendingMetadataRestore: PendingMetadataRestore?
+
+    public struct PendingMetadataRestore {
+        public let params: OpenClawImageGenParams
+        public let imageData: Data
+        public let url: URL?
+    }
+
     public struct PendingLargeFile {
         public let data: Data
         public let fileName: String
@@ -330,6 +340,38 @@ public final class OpenClawChatViewModel {
 
     public func removeAttachment(_ id: OpenClawPendingAttachment.ID) {
         self.attachments.removeAll { $0.id == id }
+    }
+
+    // MARK: - Metadata Restore
+
+    /// Apply restored generation parameters from a dropped image's metadata.
+    public func applyRestoredGenParams() {
+        guard let pending = self.pendingMetadataRestore else { return }
+        let params = pending.params
+        self.pendingMetadataRestore = nil
+        self.input = params.prompt
+        self.modelSelectionID = params.model
+        self.imageResolution = params.resolution
+        self.imageAspectRatio = params.aspectRatio
+        self.imageVariations = params.variations
+        // Attach the dropped image as input, skip metadata re-detection
+        let fileName = pending.url?.lastPathComponent ?? "input.png"
+        self.skipMetadataCheck = true
+        self.addImageAttachment(data: pending.imageData, fileName: fileName, mimeType: "image/png")
+    }
+
+    /// Attach the dropped image as input only (ignore metadata).
+    public func useDroppedImageAsInput() {
+        guard let pending = self.pendingMetadataRestore else { return }
+        self.pendingMetadataRestore = nil
+        let fileName = pending.url?.lastPathComponent ?? "input.png"
+        self.skipMetadataCheck = true
+        self.addImageAttachment(data: pending.imageData, fileName: fileName, mimeType: "image/png")
+    }
+
+    /// Dismiss the metadata restore dialog without attaching.
+    public func dismissMetadataRestore() {
+        self.pendingMetadataRestore = nil
     }
 
     public var canSend: Bool {
@@ -670,6 +712,17 @@ public final class OpenClawChatViewModel {
         var successCount = 0
         var lastError: Error?
 
+        // Build metadata params for PNG embedding
+        let genParams = OpenClawImageGenParams(
+            prompt: messageText,
+            model: self.modelSelectionID,
+            resolution: resolution,
+            aspectRatio: aspectRatio,
+            variations: totalVariations,
+            inputImageThumbnail: inputImage.flatMap { OpenClawImageMetadata.createThumbnail(from: $0) },
+            inputImageMimeType: inputImage != nil ? inputMimeType : nil
+        )
+
         for i in 1...totalVariations {
             if totalVariations > 1 {
                 self.imageGenPhase = "Generating image \(i) of \(totalVariations)…"
@@ -713,13 +766,27 @@ public final class OpenClawChatViewModel {
                     imageFileName = Self.imageFileName(prompt: messageText, ext: ext)
                 }
 
-                let base64Str = result.imageData.base64EncodedString()
+                // Embed generation metadata into PNG
+                let metadataImage = OpenClawImageMetadata.embedMetadata(into: result.imageData, params: genParams)
+                let imageToStore = metadataImage ?? result.imageData
+                let storeMime = metadataImage != nil ? "image/png" : result.mimeType
+                let storeExt = metadataImage != nil ? "png" : ext
+
+                // Update filename extension if we converted to PNG
+                let finalFileName: String
+                if storeExt != ext {
+                    finalFileName = imageFileName.replacingOccurrences(of: ".\(ext)", with: ".\(storeExt)")
+                } else {
+                    finalFileName = imageFileName
+                }
+
+                let base64Str = imageToStore.base64EncodedString()
                 assistantContent.append(
                     OpenClawChatMessageContent(
                         type: "image", text: nil,
                         thinking: nil, thinkingSignature: nil,
-                        mimeType: result.mimeType,
-                        fileName: imageFileName,
+                        mimeType: storeMime,
+                        fileName: finalFileName,
                         content: AnyCodable(base64Str),
                         id: nil, name: nil, arguments: nil))
 
@@ -728,13 +795,13 @@ public final class OpenClawChatViewModel {
                         id: UUID(), role: "assistant", content: assistantContent,
                         timestamp: Date().timeIntervalSince1970 * 1000))
 
-                // Auto-save to configured folder
+                // Auto-save to configured folder (with metadata embedded)
                 if let saveFolder = UserDefaults.standard.string(forKey: "openclaw.imageGenSaveFolder"),
                    !saveFolder.isEmpty
                 {
-                    let url = URL(fileURLWithPath: saveFolder).appendingPathComponent(imageFileName)
+                    let url = URL(fileURLWithPath: saveFolder).appendingPathComponent(finalFileName)
                     do {
-                        try result.imageData.write(to: url)
+                        try imageToStore.write(to: url)
                         dbg("Auto-saved variation \(i) to \(url.path)")
                     } catch {
                         dbg("Auto-save failed for variation \(i): \(error.localizedDescription)")
@@ -1286,6 +1353,8 @@ public final class OpenClawChatViewModel {
         return (UTType(filenameExtension: ext) ?? .data).preferredMIMEType
     }
 
+    private var skipMetadataCheck = false
+
     private func addImageAttachment(url: URL?, data: Data, fileName: String, mimeType: String) async {
         if data.count > 20_000_000 {
             self.pendingLargeFile = PendingLargeFile(data: data, fileName: fileName, mimeType: mimeType, url: url)
@@ -1302,6 +1371,15 @@ public final class OpenClawChatViewModel {
             self.errorText = "Only image attachments are supported right now"
             return
         }
+
+        // Check for OpenClaw generation metadata → show disambiguation dialog
+        if !self.skipMetadataCheck,
+           let genParams = OpenClawImageMetadata.extractMetadata(from: data)
+        {
+            self.pendingMetadataRestore = PendingMetadataRestore(params: genParams, imageData: data, url: url)
+            return
+        }
+        self.skipMetadataCheck = false
 
         let preview = Self.previewImage(data: data)
         self.attachments.append(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ImageMetadata.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ImageMetadata.swift
@@ -1,0 +1,152 @@
+import Foundation
+import ImageIO
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+#endif
+
+// MARK: - Generation Parameters
+
+/// Stores all image generation settings for embedding in PNG tEXt metadata.
+/// Compatible with ComfyUI-style metadata workflows.
+public struct OpenClawImageGenParams: Codable, Sendable {
+    /// Sentinel for identifying OpenClaw metadata in PNG Description field.
+    public let _openclaw: Int
+
+    public let prompt: String
+    public let model: String
+    public let resolution: String
+    public let aspectRatio: String
+    public let variations: Int
+
+    /// Base64-encoded JPEG thumbnail of the input image (~200px wide), nil if none.
+    public let inputImageThumbnail: String?
+    public let inputImageMimeType: String?
+
+    /// When the image was generated (ISO 8601).
+    public let generatedAt: Date
+    /// Schema version for forward compatibility.
+    public let openclawVersion: String
+
+    public init(
+        prompt: String,
+        model: String,
+        resolution: String,
+        aspectRatio: String,
+        variations: Int,
+        inputImageThumbnail: String? = nil,
+        inputImageMimeType: String? = nil,
+        generatedAt: Date = Date(),
+        openclawVersion: String = "1"
+    ) {
+        self._openclaw = 1
+        self.prompt = prompt
+        self.model = model
+        self.resolution = resolution
+        self.aspectRatio = aspectRatio
+        self.variations = variations
+        self.inputImageThumbnail = inputImageThumbnail
+        self.inputImageMimeType = inputImageMimeType
+        self.generatedAt = generatedAt
+        self.openclawVersion = openclawVersion
+    }
+}
+
+// MARK: - Metadata Read/Write
+
+public enum OpenClawImageMetadata {
+
+    // MARK: Write
+
+    /// Embed generation parameters into image data as a PNG tEXt "Description" chunk.
+    /// If the source is JPEG, it is re-encoded as PNG. Returns nil on failure.
+    public static func embedMetadata(into imageData: Data, params: OpenClawImageGenParams) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        guard let jsonData = try? encoder.encode(params),
+              let jsonString = String(data: jsonData, encoding: .utf8)
+        else { return nil }
+
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+              CGImageSourceGetCount(source) > 0,
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else { return nil }
+
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData as CFMutableData,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else { return nil }
+
+        // Copy existing properties and inject our metadata into the PNG Description field
+        let existingProps = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] ?? [:]
+        var props = existingProps
+        var pngDict = (props[kCGImagePropertyPNGDictionary] as? [CFString: Any]) ?? [:]
+        pngDict[kCGImagePropertyPNGDescription] = jsonString
+        props[kCGImagePropertyPNGDictionary] = pngDict
+
+        CGImageDestinationAddImage(destination, cgImage, props as CFDictionary)
+
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return mutableData as Data
+    }
+
+    // MARK: Read
+
+    /// Extract OpenClaw generation parameters from a PNG image's tEXt Description chunk.
+    /// Returns nil if the image has no OpenClaw metadata or is not PNG.
+    public static func extractMetadata(from imageData: Data) -> OpenClawImageGenParams? {
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+              CGImageSourceGetCount(source) > 0
+        else { return nil }
+
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let pngDict = properties[kCGImagePropertyPNGDictionary] as? [CFString: Any],
+              let description = pngDict[kCGImagePropertyPNGDescription] as? String,
+              description.contains("\"_openclaw\"")
+        else { return nil }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let data = description.data(using: .utf8),
+              let params = try? decoder.decode(OpenClawImageGenParams.self, from: data)
+        else { return nil }
+
+        return params
+    }
+
+    // MARK: Thumbnail
+
+    /// Create a small JPEG thumbnail (~200px wide) from image data, returned as base64 string.
+    public static func createThumbnail(from imageData: Data, maxWidth: Int = 200) -> String? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxWidth,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+              let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        else { return nil }
+
+        let mutableData = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(
+            mutableData as CFMutableData,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else { return nil }
+
+        let jpegProps: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: 0.6
+        ]
+        CGImageDestinationAddImage(dest, thumbnail, jpegProps as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else { return nil }
+
+        return (mutableData as Data).base64EncodedString()
+    }
+}


### PR DESCRIPTION
## Summary                                                                   
                                                                                
   Replaces the macOS menu bar NSPopover chat interface with a proper resizable 
 NSWindow, fixes the Talk Mode crash (#36983), adds file drag-and-drop support, 
 and introduces a resizable prompt area.                                        
                                                                                
   These changes address several pain points with the current macOS companion   
 app:                                                                           
                                                                                
   1. **The popover dismisses when clicking outside**, making it impossible to  
 drag files from Finder into the chat                                           
   2. **Talk Mode crashes on launch** when previously enabled (#36983)          
   3. **No way to resize the prompt input area**, which is capped at 64px       
   4. **Talk Mode and app controls are inaccessible** when the popover menu     
 fails to trigger                                                               
                                                                                
   ## Changes                                                                   
                                                                                
   ### Windowed Chat Mode                                                       
   - Left-click the menu bar icon now opens a proper `NSWindow` (titled,        
 closable, resizable, miniaturizable) instead of a borderless `NSPopover`       
   - Window persists when clicking desktop — no more dismissal on focus loss    
   - `WebChatManager.toggleWindow()` and `closeWindow()` for menu bar toggle    
 behavior                                                                       
   - Right-click still opens the dropdown menu (unchanged)                      
                                                                                
   ### Talk Mode Crash Fix (#36983)                                             
   - Defer `TalkModeController.shared.setEn abled()` to the next run loop       
 iteration via `DispatchQueue.main.async` during `AppState.init()`              
   - This breaks the re-entrant access cycle where `TalkOverlayView` accesses   
 `AppStateStore.shared` before construction completes, causing a Swift          
 exclusivity violation                                                          
                                                                                
   ### Gear Menu Toolbar                                                        
   - Adds `NSToolbar` with a gear dropdown (`NSMenuToolbarItem`) to the chat    
 window title bar                                                               
   - Menu includes: Talk Mode toggle (with live state via `NSMenuDelegate`),    
 Settings… (⌘,), Quit (⌘Q)                                                      
   - Replaces the broken right-click `MenuBarExtra` binding which doesn't       
 trigger reliably when an `NSWindow` has focus                                  
   - Talk Mode toggle also added to Settings > General for discoverability      
                                                                                
   ### File Drag-and-Drop                                                       
   - Override `performDragOperation` in `ChatComposerNSTextView` to intercept   
 file URL drops before `NSTextView` inserts the path as plain text              
   - Route dropped files to `viewModel.addAttachments(urls:) ` via              
 `onDropFileURLs` callback                                                      
   - Wire callback through `NSViewRepresentable` (`makeNSView` +                
 `updateNSView`)                                                                
                                                                                
   ### Resizable Prompt Area                                                    
   - Draggable resize handle (three horizontal bars) between message list and   
 composer                                                                       
   - `GeometryReader` with explicit height calculation — both regions resize    
 correctly                                                                      
   - `highPriorityGesture` prevents the scroll view from stealing the drag      
   - Uncap `textMaxHeight` on macOS (was hardcoded to 64pt) so the text area    
 fills the resized frame                                                        
                                                                                
   ## Files Changed (7 files, +267 −17)                                         
                                                                                
   | File | Change |                                                            
   |------|--------|                                                            
   | `AppState.swift` | Defer Talk Mode init to fix #36983 |                    
   | `MenuBar.swift` | Switch left-click from panel → window |                  
   | `WebChatManager.swift` | Add `toggleWindow()`, `closeWindow()` |           
   | `WebChatSwiftUI.swift` | NSToolbar gear menu, compact style |              
   | `GeneralSettings.swift` | Talk Mode toggle in Settings |                   
   | `ChatComposer.swift` | File drop override, `onDropFileURLs` |              
   | `ChatView.swift` | Resizable composer with drag handle |                   
                                                                                
   ## Testing                                                                   
                                                                                
   - Built and tested on macOS 26.3.1 (Apple Silicon)                           
   - Verified: window toggle, file drag-and-drop (images attach correctly),     
 Talk Mode enable/disable without crash, prompt resize via drag handle, gear    
 menu state updates                                                             
                                                                                
   ## Related Issues                                                            
                                                                                
   - Fixes #36983 (macOS app crashes on launch when Talk mode was previously    
 enabled)                                                                       
   - Related to #13121 (menu bar chat crashes with stack overflow on            
 left-click)                        