### PR TITLE
fix(agents): accept model `options` in config and recover Ollama tool calls from text (#50894)

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -4,6 +4,7 @@ import {
   createOllamaStreamFn,
   convertToOllamaMessages,
   buildAssistantMessage,
+  recoverToolCallsFromText,
   parseNdjsonStream,
   resolveOllamaBaseUrlForRun,
 } from "./ollama-stream.js";
@@ -181,6 +182,99 @@ describe("buildAssistantMessage", () => {
       cacheWrite: 0,
       total: 0,
     });
+  });
+
+  it("recovers tool calls from <tool_call> tags in text when tool_calls is empty", () => {
+    const response = {
+      model: "qwen3.5:9b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          'I\'ll save that for you.\n<tool_call>\n{"name": "write_file", "arguments": {"path": "/tmp/note.md", "content": "hello"}}\n</tool_call>',
+      },
+      done: true,
+      prompt_eval_count: 50,
+      eval_count: 30,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "qwen3.5:9b",
+    });
+    expect(result.stopReason).toBe("toolUse");
+    const toolCalls = result.content.filter((c) => c.type === "toolCall");
+    expect(toolCalls.length).toBe(1);
+    const tc = toolCalls[0] as { name: string; arguments: Record<string, unknown> };
+    expect(tc.name).toBe("write_file");
+    expect(tc.arguments).toEqual({ path: "/tmp/note.md", content: "hello" });
+  });
+
+  it("does not recover tool calls when proper tool_calls exist", () => {
+    const response = {
+      model: "qwen3.5:9b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: '<tool_call>{"name": "ghost", "arguments": {}}</tool_call>',
+        tool_calls: [{ function: { name: "bash", arguments: { command: "ls" } } }],
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    const toolCalls = result.content.filter((c) => c.type === "toolCall");
+    expect(toolCalls.length).toBe(1);
+    expect((toolCalls[0] as { name: string }).name).toBe("bash");
+  });
+});
+
+describe("recoverToolCallsFromText", () => {
+  it("extracts tool calls from <tool_call> XML tags", () => {
+    const text =
+      'Sure!\n<tool_call>\n{"name": "bash", "arguments": {"command": "ls"}}\n</tool_call>';
+    const result = recoverToolCallsFromText(text);
+    expect(result).toEqual([{ function: { name: "bash", arguments: { command: "ls" } } }]);
+  });
+
+  it("extracts tool calls from JSON code blocks", () => {
+    const text =
+      'I\'ll run that.\n```json\n{"name": "write_file", "arguments": {"path": "a.txt", "content": "hi"}}\n```';
+    const result = recoverToolCallsFromText(text);
+    expect(result).toEqual([
+      { function: { name: "write_file", arguments: { path: "a.txt", content: "hi" } } },
+    ]);
+  });
+
+  it("handles function-wrapped format", () => {
+    const text =
+      '<tool_call>{"function": {"name": "bash", "arguments": {"command": "pwd"}}}</tool_call>';
+    const result = recoverToolCallsFromText(text);
+    expect(result).toEqual([{ function: { name: "bash", arguments: { command: "pwd" } } }]);
+  });
+
+  it("handles parameters key instead of arguments", () => {
+    const text = '<tool_call>{"name": "read", "parameters": {"path": "/tmp/x"}}</tool_call>';
+    const result = recoverToolCallsFromText(text);
+    expect(result).toEqual([{ function: { name: "read", arguments: { path: "/tmp/x" } } }]);
+  });
+
+  it("returns empty for plain text without tool patterns", () => {
+    expect(recoverToolCallsFromText("Just a normal reply.")).toEqual([]);
+  });
+
+  it("returns empty for malformed JSON inside tags", () => {
+    expect(recoverToolCallsFromText("<tool_call>not json</tool_call>")).toEqual([]);
+  });
+
+  it("extracts multiple tool calls from text", () => {
+    const text = [
+      '<tool_call>{"name": "bash", "arguments": {"command": "ls"}}</tool_call>',
+      '<tool_call>{"name": "read", "arguments": {"path": "a.txt"}}</tool_call>',
+    ].join("\n");
+    const result = recoverToolCallsFromText(text);
+    expect(result.length).toBe(2);
+    expect(result[0]!.function.name).toBe("bash");
+    expect(result[1]!.function.name).toBe("read");
   });
 });
 
@@ -481,6 +575,66 @@ describe("createOllamaStreamFn", () => {
         expect(requestInit.headers).toMatchObject({
           Authorization: "Bearer real-token",
         });
+      },
+    );
+  });
+
+  it("merges user-specified model options into Ollama request", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434", undefined, {
+          num_ctx: 16384,
+          top_p: 0.9,
+        });
+        const stream = await Promise.resolve(
+          streamFn(
+            { id: "qwen3.5:9b", api: "ollama", provider: "ollama" } as never,
+            { messages: [{ role: "user", content: "hi" }] } as never,
+            {} as never,
+          ),
+        );
+        await collectStreamEvents(stream);
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const body = JSON.parse(requestInit.body as string) as {
+          options: Record<string, unknown>;
+        };
+        // num_ctx defaults to 65536 because model.contextWindow is undefined
+        expect(body.options.num_ctx).toBe(65536);
+        // user-specified top_p is preserved
+        expect(body.options.top_p).toBe(0.9);
+      },
+    );
+  });
+
+  it("uses model options num_ctx when contextWindow is not set", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434", undefined, {
+          num_ctx: 8192,
+        });
+        const stream = await Promise.resolve(
+          streamFn(
+            { id: "qwen3.5:9b", api: "ollama", provider: "ollama" } as never,
+            { messages: [{ role: "user", content: "hi" }] } as never,
+            {} as never,
+          ),
+        );
+        await collectStreamEvents(stream);
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const body = JSON.parse(requestInit.body as string) as {
+          options: Record<string, unknown>;
+        };
+        // model.contextWindow is undefined, so options.num_ctx (8192) should be used
+        expect(body.options.num_ctx).toBe(8192);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -334,6 +334,60 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
 
 // ── Response conversion ─────────────────────────────────────────────────────
 
+/**
+ * Attempt to recover structured tool calls from model text output.
+ *
+ * Some smaller local models (e.g. Qwen3.5-9B) understand tool definitions but
+ * emit the call as text instead of a proper `tool_calls` array.  Common
+ * patterns include `<tool_call>{ ... }</tool_call>` blocks and bare JSON
+ * objects with `name` + `arguments` keys.
+ */
+export function recoverToolCallsFromText(text: string): OllamaToolCall[] {
+  const recovered: OllamaToolCall[] = [];
+
+  // Pattern 1: <tool_call>{ "name": "...", "arguments": { ... } }</tool_call>
+  const tagRegex = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/gi;
+  let tagMatch: RegExpExecArray | null;
+  while ((tagMatch = tagRegex.exec(text)) !== null) {
+    const parsed = tryParseToolCallJson(tagMatch[1]!);
+    if (parsed) {
+      recovered.push(parsed);
+    }
+  }
+  if (recovered.length > 0) {
+    return recovered;
+  }
+
+  // Pattern 2: ```json\n{"name": "...", "arguments": {...}}\n```
+  const codeBlockRegex = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/gi;
+  let codeMatch: RegExpExecArray | null;
+  while ((codeMatch = codeBlockRegex.exec(text)) !== null) {
+    const parsed = tryParseToolCallJson(codeMatch[1]!);
+    if (parsed) {
+      recovered.push(parsed);
+    }
+  }
+
+  return recovered;
+}
+
+function tryParseToolCallJson(raw: string): OllamaToolCall | null {
+  try {
+    const obj = JSON.parse(raw.trim()) as Record<string, unknown>;
+    const name = obj.name ?? (obj.function as Record<string, unknown> | undefined)?.name;
+    const args =
+      obj.arguments ??
+      obj.parameters ??
+      (obj.function as Record<string, unknown> | undefined)?.arguments;
+    if (typeof name === "string" && name && args && typeof args === "object") {
+      return { function: { name, arguments: args as Record<string, unknown> } };
+    }
+  } catch {
+    // Not valid JSON – skip.
+  }
+  return null;
+}
+
 export function buildAssistantMessage(
   response: OllamaChatResponse,
   modelInfo: { api: string; provider: string; id: string },
@@ -344,11 +398,27 @@ export function buildAssistantMessage(
   // `reasoning` with an empty `content`. Fall back so replies are not dropped.
   const text =
     response.message.content || response.message.thinking || response.message.reasoning || "";
+
+  let toolCalls = response.message.tool_calls;
+
+  // Fallback: if the model emitted no structured tool_calls but embedded
+  // tool-call-like JSON in its text output, try to recover them.  This helps
+  // smaller local models (e.g. Qwen3.5-9B) that understand tools semantically
+  // but lack native tool_call output support.
+  if ((!toolCalls || toolCalls.length === 0) && text) {
+    const recovered = recoverToolCallsFromText(text);
+    if (recovered.length > 0) {
+      toolCalls = recovered;
+      log.info(
+        `Recovered ${recovered.length} tool call(s) from text output for model ${modelInfo.id}`,
+      );
+    }
+  }
+
   if (text) {
     content.push({ type: "text", text });
   }
 
-  const toolCalls = response.message.tool_calls;
   if (toolCalls && toolCalls.length > 0) {
     for (const tc of toolCalls) {
       content.push({
@@ -434,6 +504,7 @@ function resolveOllamaModelHeaders(model: {
 export function createOllamaStreamFn(
   baseUrl: string,
   defaultHeaders?: Record<string, string>,
+  modelOptions?: Record<string, unknown>,
 ): StreamFn {
   const chatUrl = resolveOllamaChatUrl(baseUrl);
 
@@ -449,9 +520,19 @@ export function createOllamaStreamFn(
 
         const ollamaTools = extractOllamaTools(context.tools);
 
-        // Ollama defaults to num_ctx=4096 which is too small for large
-        // system prompts + many tool definitions. Use model's contextWindow.
-        const ollamaOptions: Record<string, unknown> = { num_ctx: model.contextWindow ?? 65536 };
+        // Merge user-specified model options (from openclaw.json
+        // `models.providers.*.models[].options`) as a base, then layer on
+        // computed values so contextWindow / temperature / maxTokens always win.
+        const userNumCtx =
+          modelOptions &&
+          typeof modelOptions.num_ctx === "number" &&
+          Number.isFinite(modelOptions.num_ctx)
+            ? modelOptions.num_ctx
+            : undefined;
+        const ollamaOptions: Record<string, unknown> = {
+          ...(modelOptions ?? {}),
+          num_ctx: model.contextWindow ?? userNumCtx ?? 65536,
+        };
         if (typeof options?.temperature === "number") {
           ollamaOptions.temperature = options.temperature;
         }
@@ -569,7 +650,7 @@ export function createOllamaStreamFn(
 }
 
 export function createConfiguredOllamaStreamFn(params: {
-  model: { baseUrl?: string; headers?: unknown };
+  model: { baseUrl?: string; headers?: unknown; options?: Record<string, unknown> };
   providerBaseUrl?: string;
 }): StreamFn {
   const modelBaseUrl = typeof params.model.baseUrl === "string" ? params.model.baseUrl : undefined;
@@ -579,5 +660,6 @@ export function createConfiguredOllamaStreamFn(params: {
       providerBaseUrl: params.providerBaseUrl,
     }),
     resolveOllamaModelHeaders(params.model),
+    params.model.options,
   );
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1194,12 +1194,21 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      const contextGuardOptionsNumCtx =
+        params.model.options &&
+        typeof params.model.options === "object" &&
+        typeof (params.model.options as Record<string, unknown>).num_ctx === "number"
+          ? ((params.model.options as Record<string, unknown>).num_ctx as number)
+          : undefined;
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
         contextWindowTokens: Math.max(
           1,
           Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            params.model.contextWindow ??
+              contextGuardOptionsNumCtx ??
+              params.model.maxTokens ??
+              DEFAULT_CONTEXT_TOKENS,
           ),
         ),
       });
@@ -1265,10 +1274,19 @@ export async function runEmbeddedAttempt(
         providerId: providerIdForNumCtx,
       });
       if (shouldInjectNumCtx) {
+        const modelOptionsNumCtx =
+          params.model.options &&
+          typeof params.model.options === "object" &&
+          typeof (params.model.options as Record<string, unknown>).num_ctx === "number"
+            ? ((params.model.options as Record<string, unknown>).num_ctx as number)
+            : undefined;
         const numCtx = Math.max(
           1,
           Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            params.model.contextWindow ??
+              modelOptionsNumCtx ??
+              params.model.maxTokens ??
+              DEFAULT_CONTEXT_TOKENS,
           ),
         );
         activeSession.agent.streamFn = wrapOllamaCompatNumCtx(activeSession.agent.streamFn, numCtx);

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -47,6 +47,7 @@ export type ModelDefinitionConfig = {
   maxTokens: number;
   headers?: Record<string, string>;
   compat?: ModelCompatConfig;
+  options?: Record<string, unknown>;
 };
 
 export type ModelProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -221,6 +221,7 @@ export const ModelDefinitionSchema = z
     maxTokens: z.number().positive().optional(),
     headers: z.record(z.string(), z.string()).optional(),
     compat: ModelCompatSchema,
+    options: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Problem: Users configuring local Ollama models (e.g. Qwen3.5-9B) in `openclaw.json` hit two blockers: (1) adding `"options": {"num_ctx": 8192}` to a model definition is rejected with `Unrecognized key: "options"`, and (2) smaller models that understand tools semantically but lack native `tool_calls` output silently fail to dispatch tool calls.
- Why it matters: Without `num_ctx` passthrough, Ollama defaults to a tiny context window (2048–4096 tokens), silently truncating conversation history and appearing as complete memory loss. Without tool-call recovery, local models cannot interact with the filesystem or execute tools at all.
- What changed:
  - `ModelDefinitionSchema` now accepts an optional `options` record for provider-specific passthrough settings.
  - `options.num_ctx` is used as a fallback for `contextWindow` in both the native Ollama stream path and the OpenAI-compat `num_ctx` injection path.
  - New `recoverToolCallsFromText()` parser in `ollama-stream.ts` extracts structured tool calls from `<tool_call>` XML tags and fenced JSON code blocks when the model response contains no `tool_calls` array.
- What did NOT change (scope boundary): Cloud provider paths, existing `contextWindow` behavior when explicitly set, tool schema generation, and the OpenAI-completions/responses tool-call parsing remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50894

## User-visible / Behavior Changes

1. Users can now add `"options": {"num_ctx": 8192, ...}` to model definitions in `openclaw.json` without config validation errors.
2. When `contextWindow` is not set but `options.num_ctx` is, the value is used as context window size for Ollama requests — preventing silent conversation history truncation.
3. Smaller local models that emit tool-call-like JSON in text output (e.g. `<tool_call>{"name":"write_file",...}</tool_call>`) now have those calls recovered and dispatched as real tool invocations.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — tool calls recovered from text go through the same dispatch and policy pipeline as native tool calls.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11 + WSL 2 + Ubuntu 24.04
- Runtime/container: Ollama (local)
- Model/provider: qwen3.5:9b via Ollama
- Relevant config (redacted):
```json
{
  "models": {
    "providers": {
      "my-ollama": {
        "baseUrl": "http://localhost:11434/v1",
        "models": [{
          "id": "qwen3.5:9b",
          "name": "Qwen3.5 9B",
          "api": "ollama",
          "options": { "num_ctx": 32768 }
        }]
      }
    }
  }
}