### PR TITLE
fix(providers): strip store param for non-Responses APIs when supportsStore=false

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2143,6 +2143,27 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.context_management).toEqual([{ type: "compaction", compact_threshold: 12_345 }]);
   });
 
+  it("strips store from payload for openai-completions providers with supportsStore=false (#51058)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "cerebras",
+      applyModelId: "llama3.1-8b",
+      model: {
+        api: "openai-completions",
+        provider: "cerebras",
+        id: "llama3.1-8b",
+        name: "llama3.1-8b",
+        baseUrl: "https://api.cerebras.ai/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 8_192,
+        compat: { supportsStore: false },
+      } as unknown as Model<"openai-completions">,
+    });
+    expect(payload).not.toHaveProperty("store");
+  });
+
   it("auto-injects OpenAI Responses context_management compaction for direct OpenAI models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -148,10 +148,9 @@ function shouldStripResponsesStore(
   if (forceStore) {
     return false;
   }
-  if (typeof model.api !== "string") {
-    return false;
-  }
-  return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsStore === false;
+  // Strip store for ANY API type when the model declares supportsStore=false.
+  // Providers like Cerebras reject unknown parameters including `store` (#51058).
+  return model.compat?.supportsStore === false;
 }
 
 function shouldStripResponsesPromptCache(model: { api?: unknown; baseUrl?: unknown }): boolean {


### PR DESCRIPTION
## Summary

Remove the `OPENAI_RESPONSES_APIS` guard from `shouldStripResponsesStore` so the `store` parameter is stripped for any model that declares `compat.supportsStore: false`, regardless of API type.

## Why this matters

- Issue #51058: Cerebras provider returns HTTP 400 on every request because OpenClaw sends `store: false` in the request body - Cerebras API does not support the `store` parameter
- The `compat.supportsStore: false` model config is supposed to prevent this, but `shouldStripResponsesStore` at `src/agents/pi-embedded-runner/openai-stream-wrappers.ts:144-155` only checks for `openai-responses` API
- Cerebras uses `openai-completions` API, so the strip never fires
- The upstream `pi-ai` library hardcodes `store: false` (noted at `src/agents/pi-embedded-runner/extra-params.ts:290`)

## Changes

- `shouldStripResponsesStore`: removed the `typeof model.api` and `OPENAI_RESPONSES_APIS.has(model.api)` checks. Now strips `store` whenever `compat.supportsStore === false` and `forceStore` is not active
- Added test for `openai-completions` API path with `supportsStore=false` (Cerebras model config)
- All 4 existing `supportsStore` tests continue to pass

## Testing

- `pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts -t supportsStore` - 4/4 pass
- New test: "strips store from payload for openai-completions providers with supportsStore=false (#51058)"

This contribution was developed with AI assistance (Claude Code).

Fixes #51058