### PR TITLE
Android: refactor tab screen layouts to use dynamic bottom padding

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -19,14 +19,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.padding
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import ai.openclaw.app.MainViewModel
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
-fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+fun CanvasScreen(
+  viewModel: MainViewModel,
+  modifier: Modifier = Modifier,
+  bottomPadding: Dp,
+) {
   val context = LocalContext.current
+  val density = LocalDensity.current
   val isDebuggable = (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
   val webViewRef = remember { mutableStateOf<WebView?>(null) }
 
@@ -42,7 +51,7 @@ fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   }
 
   AndroidView(
-    modifier = modifier,
+    modifier = modifier.padding(bottom = bottomPadding + 16.dp),
     factory = {
       WebView(context).apply {
         settings.javaScriptEnabled = true

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ChatSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ChatSheet.kt
@@ -3,8 +3,9 @@ package ai.openclaw.app.ui
 import androidx.compose.runtime.Composable
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.ui.chat.ChatSheetContent
+import androidx.compose.ui.unit.Dp
 
 @Composable
-fun ChatSheet(viewModel: MainViewModel) {
-  ChatSheetContent(viewModel = viewModel)
+fun ChatSheet(viewModel: MainViewModel, bottomPadding: Dp) {
+  ChatSheetContent(viewModel = viewModel, bottomPadding = bottomPadding)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import ai.openclaw.app.MainViewModel
-import ai.openclaw.app.ui.mobileCardSurface
+import androidx.compose.ui.unit.Dp
 
 private enum class ConnectInputMode {
   SetupCode,
@@ -59,7 +59,7 @@ private enum class ConnectInputMode {
 }
 
 @Composable
-fun ConnectTabScreen(viewModel: MainViewModel) {
+fun ConnectTabScreen(viewModel: MainViewModel, bottomPadding: Dp) {
   val statusText by viewModel.statusText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
@@ -137,7 +137,14 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   val primaryLabel = if (isConnected) "Disconnect Gateway" else "Connect Gateway"
 
   Column(
-    modifier = Modifier.verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 16.dp),
+    modifier = Modifier
+      .verticalScroll(rememberScrollState())
+      .padding(
+        start = 20.dp,
+        end = 20.dp,
+        top = 16.dp,
+        bottom = bottomPadding + 16.dp,
+      ),
     verticalArrangement = Arrangement.spacedBy(14.dp),
   ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -42,9 +41,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import ai.openclaw.app.MainViewModel
+import androidx.compose.ui.unit.coerceAtLeast
 
 private enum class HomeTab(
   val label: String,
@@ -89,10 +95,6 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       }
     }
 
-  val density = LocalDensity.current
-  val imeVisible = WindowInsets.ime.getBottom(density) > 0
-  val hideBottomTabBar = activeTab == HomeTab.Chat && imeVisible
-
   Scaffold(
     modifier = modifier,
     containerColor = Color.Transparent,
@@ -104,35 +106,41 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       )
     },
     bottomBar = {
-      if (!hideBottomTabBar) {
-        BottomTabBar(
-          activeTab = activeTab,
-          onSelect = { activeTab = it },
-        )
-      }
+      BottomTabBar(
+        activeTab = activeTab,
+        onSelect = { activeTab = it },
+      )
     },
   ) { innerPadding ->
+    val bottomPadding = innerPadding.calculateBottomPadding()
+    val paddingValues = PaddingValues(
+      top = innerPadding.calculateTopPadding(),
+      end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
+      start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
+      bottom = 0.dp,
+    )
+
     Box(
       modifier =
         Modifier
           .fillMaxSize()
-          .padding(innerPadding)
+          .padding(paddingValues)
           .consumeWindowInsets(innerPadding)
           .background(mobileBackgroundGradient),
     ) {
       when (activeTab) {
-        HomeTab.Connect -> ConnectTabScreen(viewModel = viewModel)
-        HomeTab.Chat -> ChatSheet(viewModel = viewModel)
-        HomeTab.Voice -> VoiceTabScreen(viewModel = viewModel)
-        HomeTab.Screen -> ScreenTabScreen(viewModel = viewModel)
-        HomeTab.Settings -> SettingsSheet(viewModel = viewModel)
+        HomeTab.Connect -> ConnectTabScreen(viewModel = viewModel, bottomPadding = bottomPadding)
+        HomeTab.Chat -> ChatSheet(viewModel = viewModel, bottomPadding = bottomPadding)
+        HomeTab.Voice -> VoiceTabScreen(viewModel = viewModel, bottomPadding = bottomPadding)
+        HomeTab.Screen -> ScreenTabScreen(viewModel = viewModel, bottomPadding = bottomPadding)
+        HomeTab.Settings -> SettingsSheet(viewModel = viewModel, bottomPadding = bottomPadding)
       }
     }
   }
 }
 
 @Composable
-private fun ScreenTabScreen(viewModel: MainViewModel) {
+private fun ScreenTabScreen(viewModel: MainViewModel, bottomPadding: Dp) {
   val isConnected by viewModel.isConnected.collectAsState()
   LaunchedEffect(isConnected) {
     if (isConnected) {
@@ -141,7 +149,11 @@ private fun ScreenTabScreen(viewModel: MainViewModel) {
   }
 
   Box(modifier = Modifier.fillMaxSize()) {
-    CanvasScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+    CanvasScreen(
+      viewModel = viewModel,
+      modifier = Modifier.fillMaxSize(),
+      bottomPadding = bottomPadding,
+    )
   }
 }
 
@@ -241,16 +253,24 @@ private fun BottomTabBar(
   onSelect: (HomeTab) -> Unit,
 ) {
   val safeInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
+  val density = LocalDensity.current
+  val layoutDirection = LocalLayoutDirection.current
+  val paddingValues = safeInsets.asPaddingValues(density)
 
   Box(
     modifier =
       Modifier
+        .padding(
+          start = paddingValues.calculateStartPadding(layoutDirection) + 16.dp,
+          end = paddingValues.calculateEndPadding(layoutDirection) + 16.dp,
+          bottom = paddingValues.calculateBottomPadding().coerceAtLeast(16.dp),
+        )
         .fillMaxWidth(),
   ) {
     Surface(
       modifier = Modifier.fillMaxWidth(),
       color = mobileCardSurface.copy(alpha = 0.97f),
-      shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+      shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 24.dp, bottomEnd = 24.dp),
       border = BorderStroke(1.dp, mobileBorder),
       shadowElevation = 6.dp,
     ) {
@@ -258,7 +278,6 @@ private fun BottomTabBar(
         modifier =
           Modifier
             .fillMaxWidth()
-            .windowInsetsPadding(safeInsets)
             .padding(horizontal = 10.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -18,29 +18,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.RadioButton
@@ -54,7 +42,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -69,9 +56,10 @@ import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.node.DeviceNotificationListenerService
+import androidx.compose.ui.unit.Dp
 
 @Composable
-fun SettingsSheet(viewModel: MainViewModel) {
+fun SettingsSheet(viewModel: MainViewModel, bottomPadding: Dp) {
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
   val instanceId by viewModel.instanceId.collectAsState()
@@ -351,13 +339,13 @@ fun SettingsSheet(viewModel: MainViewModel) {
   ) {
     LazyColumn(
       state = listState,
-      modifier =
-        Modifier
-          .fillMaxWidth()
-          .fillMaxHeight()
-          .imePadding()
-          .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
-      contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+      modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+      contentPadding = PaddingValues(
+        start = 20.dp,
+        end = 20.dp,
+        top = 16.dp,
+        bottom = bottomPadding + 16.dp,
+      ),
       verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
       // ── Node ──
@@ -758,8 +746,6 @@ fun SettingsSheet(viewModel: MainViewModel) {
           )
         }
       }
-
-      item { Spacer(modifier = Modifier.height(24.dp)) }
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
@@ -71,10 +71,11 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.voice.VoiceConversationEntry
 import ai.openclaw.app.voice.VoiceConversationRole
+import androidx.compose.ui.unit.Dp
 import kotlin.math.max
 
 @Composable
-fun VoiceTabScreen(viewModel: MainViewModel) {
+fun VoiceTabScreen(viewModel: MainViewModel, bottomPadding: Dp) {
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
   val activity = remember(context) { context.findActivity() }
@@ -135,7 +136,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         .background(mobileBackgroundGradient)
         .imePadding()
         .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
-        .padding(horizontal = 20.dp, vertical = 14.dp),
+        .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = bottomPadding + 12.dp),
     verticalArrangement = Arrangement.spacedBy(10.dp),
   ) {
     LazyColumn(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -34,7 +34,6 @@ import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileAccentBorderStrong
-import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileBorderStrong
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCardSurface
@@ -43,13 +42,13 @@ import ai.openclaw.app.ui.mobileCaption2
 import ai.openclaw.app.ui.mobileDanger
 import ai.openclaw.app.ui.mobileDangerSoft
 import ai.openclaw.app.ui.mobileText
-import ai.openclaw.app.ui.mobileTextSecondary
+import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
-fun ChatSheetContent(viewModel: MainViewModel) {
+fun ChatSheetContent(viewModel: MainViewModel, bottomPadding: Dp) {
   val messages by viewModel.chatMessages.collectAsState()
   val errorText by viewModel.chatError.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
@@ -94,7 +93,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
     modifier =
       Modifier
         .fillMaxSize()
-        .padding(horizontal = 20.dp, vertical = 12.dp),
+        .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = bottomPadding + 12.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     ChatThreadSelector(


### PR DESCRIPTION
## Summary

Android: refactor tab screen layouts to use dynamic bottom padding

- **Problem**: The bottom navigation bar's rounded corners are not visually consistent with the page background. The chat page experiences layout jitter when the soft keyboard is dismissed.
- **Why it matters**: Leading to a poor user experience.
- **What changed**: The bottom navigation bar now floats above the page content, and the chat page no longer jitters when the soft keyboard is shown or hidden.
- **What did NOT change (scope boundary)**: The internal business logic of the tabs remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] UI / DX
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

The bottom navigation bar now floats above the page content, and the chat page no longer jitters when the soft keyboard is shown or hidden.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Android API 29&36
- Runtime/container: N/A
- Model/provider: N/A

### Steps

Open the app home screen, then show and hide the soft keyboard on the chat page.

### Expected

The bottom of the page is laid out correctly with no obstruction, and showing or hiding the soft keyboard on the chat page does not cause UI jitter.

### Actual

The bottom of the page is laid out correctly with no obstruction, and showing or hiding the soft keyboard on the chat page does not cause UI jitter.

## Evidence

- [] Trace/log snippets: Verified that `bottomPadding` correctly receives values from `Scaffold`'s `contentPadding`.
- [x] Screenshot/recording
https://github.com/user-attachments/assets/ec296da2-5157-4b60-be56-e1fab3f9c966

## Human Verification (required)

- Verified scenarios: Bottom padding across the five tabs on the home screen, and the soft keyboard show/hide behavior on the chat page
- Edge cases checked: None.
- What you did **not** verify: None.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: None.
- Files/config to restore: None.

## Risks and Mitigations

- Risk: None.
- Mitigation: None.