### PR TITLE
fix(imessage): clear stop timeout timer to prevent leak

### DIFF
--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -128,17 +128,22 @@ export class IMessageRpcClient {
     const child = this.child;
     this.child = null;
 
-    await Promise.race([
-      this.closed,
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          if (!child.killed) {
-            child.kill("SIGTERM");
-          }
-          resolve();
-        }, 500);
-      }),
-    ]);
+    let stopTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.closed,
+        new Promise<void>((resolve) => {
+          stopTimer = setTimeout(() => {
+            if (!child.killed) {
+              child.kill("SIGTERM");
+            }
+            resolve();
+          }, 500);
+        }),
+      ]);
+    } finally {
+      clearTimeout(stopTimer);
+    }
   }
 
   async waitForClose(): Promise<void> {


### PR DESCRIPTION
## Summary

The `stop()` method in `IMessageRpcClient` creates a 500ms `setTimeout` inside a `Promise.race` but never stores or clears the timer handle. When `this.closed` resolves before the timeout, the orphaned timer fires after the client has already shut down — a resource leak that can also trigger a `SIGTERM` on an already-exited child process.

This stores the timer ID and clears it in a `finally` block, consistent with how the same file's `request()` method already manages its pending timers (line 173).

## Changes

- `extensions/imessage/src/client.ts`: capture `setTimeout` return value in `stopTimer`, wrap `Promise.race` in `try/finally`, call `clearTimeout(stopTimer)` on exit.