### PR TITLE
fix(feishu): honor blockStreamingDefault config instead of hardcoding disable

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -604,6 +604,28 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(1);
   });
 
+  it("respects blockStreamingDefault: on from agents config", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: { agents: { defaults: { blockStreamingDefault: "on" } } } as never,
+      agentId: "agent",
+      runtime: createRuntimeLogger(),
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(false);
+  });
+
+  it("disables block streaming by default when blockStreamingDefault is not set", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: { agents: { defaults: {} } } as never,
+      agentId: "agent",
+      runtime: createRuntimeLogger(),
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(true);
+  });
+
   it("passes replyToMessageId and replyInThread to streaming.start()", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -479,7 +479,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
-      disableBlockStreaming: true,
+      disableBlockStreaming: cfg.agents?.defaults?.blockStreamingDefault !== "on",
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

Feishu was hardcoding `disableBlockStreaming: true` in replyOptions, ignoring the user's `agents.defaults.blockStreamingDefault` setting.

## Fix

Changed `disableBlockStreaming` from hardcoded `true` to:
```typescript
disableBlockStreaming: cfg.agents?.defaults?.blockStreamingDefault !== "on",
```

This mirrors how Telegram and Discord already handle this config:
- `blockStreamingDefault: "on"` -> `disableBlockStreaming: false` (enables block streaming)
- `blockStreamingDefault: "off"` or unset -> `disableBlockStreaming: true` (default behavior)

## Test

Added two new tests verifying:
1. `blockStreamingDefault: "on"` results in `disableBlockStreaming: false`
2. Unset `blockStreamingDefault` results in `disableBlockStreaming: true`

All 31 Feishu reply-dispatcher tests pass.

## References

Fixes #51117