### PR TITLE
feat(tavily): add X-Client-Source attribution header

### DIFF
--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -86,6 +86,7 @@ async function postTavilyJson(params: {
           Accept: "application/json",
           Authorization: `Bearer ${params.apiKey}`,
           "Content-Type": "application/json",
+          "X-Client-Source": "openclaw",
         },
         body: JSON.stringify(params.body),
       },


### PR DESCRIPTION
## Summary

- Problem: Tavily has no way to identify which API requests originate from OpenClaw versus other clients.
- Why it matters: We want to track what requests originate from OpenClaw
- What changed: Added the `X-Client-Source: openclaw` header to all outbound Tavily API requests (search and extract).
- What did NOT change (scope boundary): No new config, no new dependencies, no changes to request bodies or response handling. Other web search providers are untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

None. The header is added server-side on outbound API calls to Tavily and is invisible to users.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: A single static metadata header (`X-Client-Source: openclaw`) is added to existing Tavily API requests. No new endpoints are contacted. The header contains no secrets or user-identifiable information — just the product name. This follows the same pattern Tavily's own SDK uses (`X-Client-Source: tavily-python`).

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun/Node
- Model/provider: N/A (web search provider)
- Integration/channel (if any): Tavily web search + extract
- Relevant config (redacted): N/A

### Steps

1. Configure a Tavily API key
2. Trigger a web search or extract via the Tavily provider
3. Observe outbound request headers

### Expected

- Requests to Tavily include `X-Client-Source: openclaw`

### Actual

- Confirmed via mock calls

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Existing Tavily tests pass (`2 passed, 4 tests`).

## Human Verification (required)

- Verified scenarios: Confirmed `postTavilyJson()` is the only function making HTTP calls to Tavily, used by both `runTavilySearch()` and `runTavilyExtract()`.
- Edge cases checked: No conditional paths bypass `postTavilyJson()` — all Tavily traffic gets the header.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `"X-Client-Source": "openclaw"` line from `extensions/tavily/src/tavily-client.ts`
- Files/config to restore: `extensions/tavily/src/tavily-client.ts`
- Known bad symptoms reviewers should watch for: Tavily API rejecting requests due to unrecognized header (extremely unlikely — the SDK itself sends this header)

## Risks and Mitigations

None.