### PR TITLE
fix(config): tighten JSON and JSON5 parsing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.
 - CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.
 - Plugins/bundler TDZ: fix `RESERVED_COMMANDS` temporal dead zone error that prevented device-pair, phone-control, and talk-voice plugins from registering when the bundler placed the commands module after call sites in the same output chunk. Thanks @BunsDev.
 - Plugins/imports: fix stale googlechat runtime-api import paths and signal SDK circular re-exports broken by recent plugin-sdk refactors. Thanks @BunsDev.

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -76,6 +76,33 @@ describe("getSubagentDepthFromSessionStore", () => {
     expect(depth).toBe(2);
   });
 
+  it("accepts JSON5 syntax in the on-disk depth store for backward compatibility", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-subagent-depth-json5-"));
+    const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+    const storePath = storeTemplate.replaceAll("{agentId}", "main");
+    fs.writeFileSync(
+      storePath,
+      `{
+        // hand-edited legacy store
+        "agent:main:subagent:flat": {
+          sessionId: "subagent-flat",
+          spawnDepth: 2,
+        },
+      }`,
+      "utf-8",
+    );
+
+    const depth = getSubagentDepthFromSessionStore("subagent:flat", {
+      cfg: {
+        session: {
+          store: storeTemplate,
+        },
+      },
+    });
+
+    expect(depth).toBe(2);
+  });
+
   it("falls back to session-key segment counting when metadata is missing", () => {
     const key = "agent:main:subagent:flat";
     const depth = getSubagentDepthFromSessionStore(key, {

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -11,6 +11,14 @@ type SessionDepthEntry = {
   spawnedBy?: unknown;
 };
 
+function parseSessionDepthStore(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON5.parse(raw);
+  }
+}
+
 function normalizeSpawnDepth(value: unknown): number | undefined {
   if (typeof value === "number") {
     return Number.isInteger(value) && value >= 0 ? value : undefined;
@@ -37,7 +45,7 @@ function normalizeSessionKey(value: unknown): string | undefined {
 function readSessionStore(storePath: string): Record<string, SessionDepthEntry> {
   try {
     const raw = fs.readFileSync(storePath, "utf-8");
-    const parsed = JSON5.parse(raw);
+    const parsed = parseSessionDepthStore(raw);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return parsed as Record<string, SessionDepthEntry>;
     }

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -442,6 +442,15 @@ describe("config cli", () => {
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
     });
 
+    it("rejects JSON5-only object syntax when strict parsing is enabled", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "gateway.auth", "{mode:'token'}", "--strict-json"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+    });
+
     it("accepts --strict-json with batch mode and applies batch payload", async () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };
       setSnapshot(resolved, resolved);
@@ -470,6 +479,8 @@ describe("config cli", () => {
       expect(helpText).toContain("--strict-json");
       expect(helpText).toContain("--json");
       expect(helpText).toContain("Legacy alias for --strict-json");
+      expect(helpText).toContain("Value (JSON/JSON5 or raw string)");
+      expect(helpText).toContain("Strict JSON parsing (error instead of");
       expect(helpText).toContain("--ref-provider");
       expect(helpText).toContain("--provider-source");
       expect(helpText).toContain("--batch-json");

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -159,9 +159,9 @@ function parseValue(raw: string, opts: ConfigSetParseOpts): unknown {
   const trimmed = raw.trim();
   if (opts.strictJson) {
     try {
-      return JSON5.parse(trimmed);
+      return JSON.parse(trimmed);
     } catch (err) {
-      throw new Error(`Failed to parse JSON5 value: ${String(err)}`, { cause: err });
+      throw new Error(`Failed to parse JSON value: ${String(err)}`, { cause: err });
     }
   }
 
@@ -1280,8 +1280,8 @@ export function registerConfigCli(program: Command) {
     .command("set")
     .description(CONFIG_SET_DESCRIPTION)
     .argument("[path]", "Config path (dot or bracket notation)")
-    .argument("[value]", "Value (JSON5 or raw string)")
-    .option("--strict-json", "Strict JSON5 parsing (error instead of raw string fallback)", false)
+    .argument("[value]", "Value (JSON/JSON5 or raw string)")
+    .option("--strict-json", "Strict JSON parsing (error instead of raw string fallback)", false)
     .option("--json", "Legacy alias for --strict-json", false)
     .option(
       "--dry-run",

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -99,7 +99,7 @@ function resolveUserPath(
 export const STATE_DIR = resolveStateDir();
 
 /**
- * Config file path (JSON5).
+ * Config file path (JSON or JSON5).
  * Can be overridden via OPENCLAW_CONFIG_PATH.
  * Default: ~/.openclaw/openclaw.json (or $OPENCLAW_STATE_DIR/openclaw.json)
  */

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -56,6 +56,38 @@ describe("cron store", () => {
     await expect(loadCronStore(store.storePath)).rejects.toThrow(/Failed to parse cron store/i);
   });
 
+  it("accepts JSON5 syntax when loading an existing cron store", async () => {
+    const store = await makeStorePath();
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      `{
+        // hand-edited legacy store
+        version: 1,
+        jobs: [
+          {
+            id: 'job-1',
+            name: 'Job 1',
+            enabled: true,
+            createdAtMs: 1,
+            updatedAtMs: 1,
+            schedule: { kind: 'every', everyMs: 60000 },
+            sessionTarget: 'main',
+            wakeMode: 'next-heartbeat',
+            payload: { kind: 'systemEvent', text: 'tick-job-1' },
+            state: {},
+          },
+        ],
+      }`,
+      "utf-8",
+    );
+
+    await expect(loadCronStore(store.storePath)).resolves.toMatchObject({
+      version: 1,
+      jobs: [{ id: "job-1", enabled: true }],
+    });
+  });
+
   it("does not create a backup file when saving unchanged content", async () => {
     const store = await makeStorePath();
     const payload = makeStore("job-1", true);

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -10,6 +10,14 @@ export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
 export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
 const serializedStoreCache = new Map<string, string>();
 
+function parseCronStoreRaw(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON5.parse(raw);
+  }
+}
+
 export function resolveCronStorePath(storePath?: string) {
   if (storePath?.trim()) {
     const raw = storePath.trim();
@@ -26,7 +34,7 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
     const raw = await fs.promises.readFile(storePath, "utf-8");
     let parsed: unknown;
     try {
-      parsed = JSON5.parse(raw);
+      parsed = parseCronStoreRaw(raw);
     } catch (err) {
       throw new Error(`Failed to parse cron store at ${storePath}: ${String(err)}`, {
         cause: err,

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1062,7 +1062,7 @@ export function renderConfig(props: ConfigProps) {
                     }
                     <div class="field config-raw-field">
                       <span style="display:flex;align-items:center;gap:8px;">
-                        Raw JSON5
+                        Raw config (JSON/JSON5)
                         ${
                           sensitiveCount > 0
                             ? html`
@@ -1087,7 +1087,7 @@ export function renderConfig(props: ConfigProps) {
                       </span>
                       <textarea
                         class="${blurred ? "config-raw-redacted" : ""}"
-                        placeholder=${blurred ? REDACTED_PLACEHOLDER : "Raw JSON5 config"}
+                        placeholder=${blurred ? REDACTED_PLACEHOLDER : "Raw config (JSON/JSON5)"}
                         .value=${blurred ? "" : props.raw}
                         ?readonly=${blurred}
                         @input=${(e: Event) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: JSON vs JSON5 behavior drifted across the config CLI, machine-written stores, and the Control UI copy, which made strict-mode expectations and Linux/tooling assumptions harder to reason about.
- Why it matters: `config set --strict-json` did not actually enforce JSON, machine-written stores still paid a JSON5 parse path even though they are emitted as plain JSON, and the UI/docs overstated JSON5 as the only raw-config contract.
- What changed: `config set --strict-json` now uses real `JSON.parse`, cron/subagent on-disk stores now prefer `JSON.parse` with JSON5 fallback for backward compatibility, and raw-config labels now say `JSON/JSON5`.
- What did NOT change (scope boundary): this PR does not make `openclaw.json` JSON-only, does not remove JSON5 support from main config reads, and does not attempt to fix the broader Control UI config-state drift or `$include` write-preservation issues.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48415
- Related #43127
- Related #14529
- Related #21332
- Related #41050
- Related #41096

## User-visible / Behavior Changes

- `openclaw config set --strict-json` now rejects JSON5-only syntax instead of silently accepting it.
- Raw config surfaces are labeled as `JSON/JSON5` rather than `JSON5` only.
- Existing hand-edited JSON5 cron/subagent stores still load, but machine-written JSON takes the fast native parse path first.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime/container: local checkout via `pnpm` / Node 22
- Model/provider: n/a
- Integration/channel (if any): config CLI, Control UI copy, cron store, subagent depth store
- Relevant config (redacted): n/a

### Steps

1. Run `openclaw config set gateway.auth '{mode:"token"}' --strict-json`.
2. Load a hand-edited JSON5 cron store or subagent-depth session store.
3. Open the raw config surface in the Control UI.

### Expected

- Strict mode should reject JSON5-only syntax.
- Existing JSON5 machine-store files should still load.
- Raw config copy should reflect the actual `JSON/JSON5` compatibility.

### Actual

- Before this PR, strict mode still used `JSON5.parse`, machine-store readers did not prefer native JSON, and the UI/docs still said `JSON5` only.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `config set --strict-json` rejects JSON5-only object syntax; cron store JSON5 fallback still loads; subagent depth JSON5 fallback still loads; raw config labels match the actual supported formats.
- Edge cases checked: invalid strict JSON still errors; batch `--strict-json` flow still works; machine-written JSON stores still round-trip.
- What you did **not** verify: I did not reproduce the full Control UI save-drift issue from #48415 or the broader `$include` write-flattening path from #41050 in a live gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `7ca80d9b5c`.
- Files/config to restore: `src/cli/config-cli.ts`, `src/cron/store.ts`, `src/agents/subagent-depth.ts`, `ui/src/ui/views/config.ts`, and the added tests/changelog line.
- Known bad symptoms reviewers should watch for: strict JSON still accepting JSON5 object syntax, or hand-edited JSON5 cron/subagent stores failing to load.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: operators who were unintentionally relying on JSON5-only inline values with `config set --strict-json` will now see failures.
  - Mitigation: that flag now matches its name, `--json` remains as the legacy alias, non-strict mode still keeps JSON5 parsing, and tests pin both the reject and accept paths.
