### PR TITLE
fix: Add Moonshot provider tool call ID sanitization

### DIFF
--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -46,6 +46,10 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
     providerFamily: "anthropic",
     dropThinkingBlockModelHints: ["claude"],
   },
+  moonshot: {
+    transcriptToolCallIdMode: "strict",
+    transcriptToolCallIdModelHints: ["kimi", "moonshot"],
+  },
   mistral: {
     transcriptToolCallIdMode: "strict9",
     transcriptToolCallIdModelHints: [
@@ -193,10 +197,10 @@ export function resolveTranscriptToolCallIdMode(
   provider?: string | null,
   modelId?: string | null,
   options?: ProviderCapabilityLookupOptions,
-): "strict9" | undefined {
+): "strict9" | "strict" | undefined {
   const capabilities = resolveProviderCapabilities(provider, options);
   const mode = capabilities.transcriptToolCallIdMode;
-  if (mode === "strict9") {
+  if (mode === "strict9" || mode === "strict") {
     return mode;
   }
   if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -92,7 +92,7 @@ export function resolveTranscriptPolicy(params: {
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
 
   const sanitizeToolCallIds =
-    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization;
+    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization || !!providerToolCallIdMode;
   const toolCallIdMode: ToolCallIdMode | undefined = providerToolCallIdMode
     ? providerToolCallIdMode
     : isMistral


### PR DESCRIPTION
## Problem
When using Moonshot/Kimi provider (e.g., `moonshot/kimi-k2.5`), requests fail with:
```
HTTP 400: Invalid request: tool call id write:XXX is duplicated
```

This occurs because Moonshot has stricter tool call ID requirements than typical OpenAI-compatible APIs, but OpenClaw was not sanitizing tool call IDs for this provider.

## Solution
1. **Add Moonshot to PLUGIN_CAPABILITIES_FALLBACKS** with `transcriptToolCallIdMode: 'strict'`
2. **Update resolveTranscriptToolCallIdMode** to return 'strict' mode (not just 'strict9')
3. **Enable sanitizeToolCallIds** when providerToolCallIdMode is set

## Changes
- `src/agents/provider-capabilities.ts`: Add moonshot entry with tool call ID mode
- `src/agents/transcript-policy.ts`: Enable sanitization when providerToolCallIdMode is set

## Testing
- Verified fix resolves the 'duplicated' error
- Tool calls now work correctly with Moonshot/Kimi provider

Fixes #51148