### PR TITLE
feat(config): add enforceFinalTag option to agent defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Config/agents: add `agents.defaults.enforceFinalTag` to opt into `<final>` tag delivery filtering for any provider, preventing intermediate reasoning between tool calls from leaking to messaging channels. Previously only auto-enabled for tag-based reasoning providers (DeepSeek, Gemini CLI). (#51156) Thanks @unisone.
 - LINE/outbound media: add LINE image, video, and audio outbound sends on the LINE-specific delivery path, including explicit preview/tracking handling for videos while keeping generic media sends on the existing image-only route. (#45826) Thanks @masatohoshino.
 - WhatsApp/reactions: agents can now react with emoji on incoming WhatsApp messages, enabling more natural conversational interactions like acknowledging a photo with ❤️ instead of typing a reply. Thanks @mcaxtr.
 - MCP: add remote HTTP/SSE server support for `mcp.servers` URL configs, including auth headers and safer config redaction for MCP credentials. (#50396) Thanks @dhananjai1729.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -928,6 +928,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       thinkingDefault: "low",
       verboseDefault: "off",
       elevatedDefault: "on",
+      enforceFinalTag: false,
       timeoutSeconds: 600,
       mediaMaxMb: 5,
       contextTokens: 200000,
@@ -1147,6 +1148,24 @@ See [Session Pruning](/concepts/session-pruning) for behavior details.
 - `humanDelay`: randomized pause between block replies. `natural` = 800–2500ms. Per-agent override: `agents.list[].humanDelay`.
 
 See [Streaming](/concepts/streaming) for behavior + chunking details.
+
+### Final-tag enforcement
+
+```json5
+{
+  agents: {
+    defaults: {
+      enforceFinalTag: false, // true | false
+    },
+  },
+}
+```
+
+- When `true`, instructs the model to wrap all user-visible output in `<final>` tags and all reasoning in `<think>` tags.
+- Only text inside `<final>` is delivered to the user; intermediate reasoning between tool calls is discarded.
+- Prevents reasoning leakage in messaging channels where multi-turn streaming is not desired.
+- Automatically enabled for reasoning-tag providers (DeepSeek, Gemini CLI).
+- Use this setting to enable the same behavior for any provider (e.g., Anthropic, OpenAI).
 
 ### Typing indicators
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -560,7 +560,8 @@ export async function runEmbeddedAttempt(
           })
         : undefined;
     const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
-    const reasoningTagHint = isReasoningTagProvider(params.provider);
+    const reasoningTagHint =
+      isReasoningTagProvider(params.provider) || params.enforceFinalTag === true;
     // Resolve channel-specific message actions for system prompt
     const channelActions = runtimeChannel
       ? listChannelSupportedActions(

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -17,6 +17,7 @@ const {
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
   resolveProviderScopedAuthProfile,
+  resolveEnforceFinalTag,
 } = await import("./agent-runner-utils.js");
 
 function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"] {
@@ -212,6 +213,30 @@ describe("agent-runner-utils", () => {
     expect(context).toMatchObject({
       currentChannelId: "channel:123456789012345678",
       currentMessageId: "msg-9",
+    });
+  });
+
+  describe("resolveEnforceFinalTag", () => {
+    it("returns true when run.enforceFinalTag is true", () => {
+      const run = makeRun({ enforceFinalTag: true });
+      expect(resolveEnforceFinalTag(run, "openai")).toBe(true);
+    });
+
+    it("returns true for reasoning-tag providers even without config flag", () => {
+      const run = makeRun({ enforceFinalTag: false });
+      expect(resolveEnforceFinalTag(run, "google")).toBe(true);
+      expect(resolveEnforceFinalTag(run, "google-gemini-cli")).toBe(true);
+    });
+
+    it("returns false for non-tag providers without config flag", () => {
+      const run = makeRun({ enforceFinalTag: false });
+      expect(resolveEnforceFinalTag(run, "openai")).toBe(false);
+      expect(resolveEnforceFinalTag(run, "anthropic")).toBe(false);
+    });
+
+    it("returns false when enforceFinalTag is false and provider is not tag-based", () => {
+      const run = makeRun({ enforceFinalTag: false });
+      expect(resolveEnforceFinalTag(run, "openai")).toBe(false);
     });
   });
 });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -580,7 +580,9 @@ export async function runPreparedReply(
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       inputProvenance: ctx.InputProvenance ?? sessionCtx.InputProvenance,
       extraSystemPrompt: extraSystemPromptParts.join("\n\n") || undefined,
-      ...(isReasoningTagProvider(provider) ? { enforceFinalTag: true } : {}),
+      ...(isReasoningTagProvider(provider) || agentCfg?.enforceFinalTag === true
+        ? { enforceFinalTag: true }
+        : {}),
     },
   };
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -193,6 +193,12 @@ export type AgentDefaultsConfig = {
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
+  /**
+   * When true, instructs the model to wrap user-visible output in `<final>` tags
+   * and reasoning in `<think>` tags. Only text inside `<final>` is delivered.
+   * Prevents intermediate reasoning between tool calls from leaking to users.
+   */
+  enforceFinalTag?: boolean;
   /** Default block streaming level when no override is present. */
   blockStreamingDefault?: "off" | "on";
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -165,6 +165,7 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    enforceFinalTag: z.boolean().optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -47,6 +47,7 @@ import {
   isExternalHookSession,
   resolveHookExternalContentSource,
 } from "../../security/external-content.js";
+import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
 import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
@@ -542,6 +543,9 @@ export async function runCronIsolatedAgentTurn(params: {
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
+            ...(isReasoningTagProvider(providerOverride) || agentCfg?.enforceFinalTag === true
+              ? { enforceFinalTag: true }
+              : {}),
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,


### PR DESCRIPTION
## Problem

Text produced between tool calls leaks to messaging channels as visible messages (#25592). The `assistantTexts[]` array accumulates text from every assistant turn in the agentic loop, and all entries are delivered as separate messages — with no filter distinguishing intermediate reasoning from the final response.

For tag-based reasoning providers (DeepSeek, Gemini CLI, Minimax), the existing `enforceFinalTag` mechanism solves this by instructing the model to wrap output in `<final>` tags and discarding everything else. But for providers with native thinking blocks (Anthropic, OpenAI), `enforceFinalTag` is never activated — leaving no defense against plain-text reasoning that appears in `type: "text"` content blocks.

**Real-world impact**: Reasoning text like *"Let me check the database..."*, *"The tool is failing..."*, and *"I should flag this contact..."* was delivered to WhatsApp customers in production over multiple incidents.

## Solution

Add `agents.defaults.enforceFinalTag` (boolean) to the config schema, allowing users to opt into `<final>` tag enforcement regardless of provider.

When enabled:
1. The system prompt instructs the model to wrap reasoning in `<think>` tags and user-visible output in `<final>` tags
2. Only text inside `<final>` is delivered — intermediate reasoning between tool calls is discarded
3. Works for both interactive messages and cron job delivery
4. Propagates to subagents automatically

```json5
{
  agents: {
    defaults: {
      enforceFinalTag: true, // default: false
    },
  },
}
```

## Changes (8 files, +56 -2)

### Code (5 files)
| File | Change |
|------|--------|
| `src/config/zod-schema.agent-defaults.ts` | Add `enforceFinalTag: z.boolean().optional()` to Zod schema |
| `src/config/types.agent-defaults.ts` | Add `enforceFinalTag?: boolean` with JSDoc to TypeScript type |
| `src/auto-reply/reply/get-reply-run.ts` | Read config value alongside `isReasoningTagProvider()` check |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Enable `reasoningTagHint` in system prompt when config flag is set |
| `src/cron/isolated-agent/run.ts` | Pass `enforceFinalTag` to cron agent runs when config flag is set |

### Docs + Tests (3 files)
| File | Change |
|------|--------|
| `docs/gateway/configuration-reference.md` | Add "Final-tag enforcement" section + example in defaults block |
| `CHANGELOG.md` | Add entry under Unreleased/Changes |
| `src/auto-reply/reply/agent-runner-utils.test.ts` | Add 4 tests for `resolveEnforceFinalTag` covering config flag, tag providers, and defaults |

## How it works

The `<final>` tag mechanism already exists and is well-tested (see `pi-embedded-subscribe.*.filters-final-*.test.ts`). This PR makes it configurable rather than provider-gated:

1. `enforceFinalTag: true` in config
2. `get-reply-run.ts` / `cron/isolated-agent/run.ts` set `enforceFinalTag: true` on the run params
3. `attempt.ts` sees `enforceFinalTag === true` → enables `reasoningTagHint` → system prompt includes `<think>/<final>` instructions
4. `subscribeEmbeddedPiSession` sees `enforceFinalTag: true` → only extracts text inside `<final>` tags → reasoning discarded

The `resolveEnforceFinalTag` helper in `agent-runner-utils.ts` already ORs `run.enforceFinalTag` with `isReasoningTagProvider(provider)`, so the followup-runner path was already compatible without modification.

## Testing

- 4 new unit tests for `resolveEnforceFinalTag` covering: config flag on, tag provider without flag, non-tag provider without flag, undefined flag
- Existing `enforceFinalTag` test suite covers the core delivery filtering behavior
- CI: typecheck, lint, build-smoke, all test shards pass

Fixes #25592