### PR TITLE
fix(config): use static channel metadata in docs baseline

### DIFF
--- a/src/config/doc-baseline.integration.test.ts
+++ b/src/config/doc-baseline.integration.test.ts
@@ -70,6 +70,26 @@ describe("config doc baseline integration", () => {
     expect(tokenEntry?.tags).toContain("security");
   });
 
+  it("uses human-readable channel metadata for top-level channel sections", async () => {
+    const baseline = await getSharedBaseline();
+    const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));
+
+    expect(byPath.get("channels.discord")).toMatchObject({
+      label: "Discord",
+      help: "very well supported right now.",
+    });
+    expect(byPath.get("channels.msteams")).toMatchObject({
+      label: "Microsoft Teams",
+      help: "Bot Framework; enterprise support.",
+    });
+    expect(byPath.get("channels.matrix")).toMatchObject({
+      label: "Matrix",
+      help: "open protocol; install the plugin to enable.",
+    });
+    expect(byPath.get("channels.msteams")?.label).not.toContain("@openclaw/");
+    expect(byPath.get("channels.matrix")?.help).not.toContain("homeserver");
+  });
+
   it("matches array help hints that still use [] notation", async () => {
     const baseline = await getSharedBaseline();
     const byPath = new Map(baseline.entries.map((entry) => [entry.path, entry]));

--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -269,7 +269,12 @@ function resolveFirstExistingPath(candidates: string[]): string | null {
 }
 
 async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> {
-  const [{ loadPluginManifestRegistry }, { buildConfigSchema }] = await Promise.all([
+  const [
+    { listChannelPluginCatalogEntries },
+    { loadPluginManifestRegistry },
+    { buildConfigSchema },
+  ] = await Promise.all([
+    import("../channels/plugins/catalog.js"),
     import("../plugins/manifest-registry.js"),
     import("./schema.js"),
   ]);
@@ -286,6 +291,12 @@ async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> 
     env,
     config: {},
   });
+  const channelCatalogById = new Map(
+    listChannelPluginCatalogEntries({
+      workspaceDir: repoRoot,
+      env,
+    }).map((entry) => [entry.id, entry.meta] as const),
+  );
   logConfigDocBaselineDebug(`loaded ${manifestRegistry.plugins.length} bundled plugin manifests`);
   const bundledChannelPlugins = manifestRegistry.plugins.filter(
     (plugin) => plugin.origin === "bundled" && plugin.channels.length > 0,
@@ -295,16 +306,20 @@ async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> 
       ? await bundledChannelPlugins.reduce<Promise<ChannelSurfaceMetadata[]>>(
           async (promise, plugin) => {
             const loaded = await promise;
+            const catalogMeta = channelCatalogById.get(plugin.id);
+            const label = catalogMeta?.label ?? plugin.name ?? plugin.id;
+            const description = catalogMeta?.blurb ?? plugin.description;
             loaded.push(
               (await loadChannelSurfaceMetadata(
                 plugin.rootDir,
                 plugin.id,
-                plugin.name ?? plugin.id,
+                label,
+                description,
                 repoRoot,
               )) ?? {
                 id: plugin.id,
-                label: plugin.name ?? plugin.id,
-                description: plugin.description,
+                label,
+                description,
                 configSchema: plugin.configSchema,
                 configUiHints: plugin.configUiHints,
               },
@@ -314,21 +329,26 @@ async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> 
           Promise.resolve([]),
         )
       : await Promise.all(
-          bundledChannelPlugins.map(
-            async (plugin) =>
+          bundledChannelPlugins.map(async (plugin) => {
+            const catalogMeta = channelCatalogById.get(plugin.id);
+            const label = catalogMeta?.label ?? plugin.name ?? plugin.id;
+            const description = catalogMeta?.blurb ?? plugin.description;
+            return (
               (await loadChannelSurfaceMetadata(
                 plugin.rootDir,
                 plugin.id,
-                plugin.name ?? plugin.id,
+                label,
+                description,
                 repoRoot,
               )) ?? {
                 id: plugin.id,
-                label: plugin.name ?? plugin.id,
-                description: plugin.description,
+                label,
+                description,
                 configSchema: plugin.configSchema,
                 configUiHints: plugin.configUiHints,
-              },
-          ),
+              }
+            );
+          }),
         );
   logConfigDocBaselineDebug(
     `loaded ${channelPlugins.length} bundled channel entries from channel surfaces`,
@@ -359,6 +379,7 @@ async function loadChannelSurfaceMetadata(
   rootDir: string,
   id: string,
   label: string,
+  description: string | undefined,
   repoRoot: string,
 ): Promise<ChannelSurfaceMetadata | null> {
   logConfigDocBaselineDebug(`resolve channel config surface ${rootDir}`);
@@ -386,6 +407,7 @@ async function loadChannelSurfaceMetadata(
     return {
       id,
       label,
+      description,
       configSchema: configSurface.schema,
       configUiHints: configSurface.uiHints as ConfigSchemaResponse["uiHints"] | undefined,
     };


### PR DESCRIPTION
## Summary

- Problem: `pnpm release:check` failed because config-doc baseline generation could pick up channel label/help from config-schema import side effects instead of the static metadata we actually want.
- Why it matters: that path is brittle around plugin-loading boundaries and caused baseline drift for channels like Matrix where runtime blurbs differ from package metadata.
- What changed: config doc baseline generation now sources channel label/help from the static channel catalog (`openclaw.channel.label` / `blurb`) and uses config-surface imports only for schema shape.
- What did NOT change (scope boundary): no plugin loader/runtime behavior changed, and no channel config schema contract changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo worktree
- Model/provider: n/a
- Integration/channel (if any): config docs / bundled channel plugins
- Relevant config (redacted): n/a

### Steps

1. Run `pnpm build`.
2. Run `pnpm test -- src/config/doc-baseline.integration.test.ts src/config/doc-baseline.test.ts src/config/schema.test.ts`.
3. Run `pnpm release:check`.

### Expected

- Config baseline generation stays stable on static channel metadata.
- `release:check` passes.

### Actual

- Passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: regenerated config baseline, confirmed no diff, confirmed `channels.matrix` baseline help stays on the static package blurb instead of the runtime homeserver blurb.
- Edge cases checked: targeted schema tests, repo `check`, fresh branch-from-`origin/main` rebuild, and `release:check` pack validation.
- What you did **not** verify: full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/config/doc-baseline.ts`, `src/config/doc-baseline.integration.test.ts`.
- Known bad symptoms reviewers should watch for: config baseline drift reappears or top-level plugin channel help starts reflecting runtime-side-effect blurbs/package names again.

## Risks and Mitigations

- Risk: static channel catalog metadata and runtime channel blurbs diverge intentionally for a given plugin.
  - Mitigation: the docs baseline now consistently follows the static package metadata seam; the added regression test locks that expectation for Matrix.
