### PR TITLE
test(tui): strengthen /model list test to verify listModels is called

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -65,14 +65,14 @@ marketplace source with `--marketplace`.
 
 These are published to npm and installed with `openclaw plugins install`:
 
-| Plugin          | Package                | Docs                               |
-| --------------- | ---------------------- | ---------------------------------- |
-| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)         |
+| Plugin          | Package                | Docs                                 |
+| --------------- | ---------------------- | ------------------------------------ |
+| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)           |
 | Microsoft Teams | `@openclaw/msteams`    | [Microsoft Teams](/channels/msteams) |
-| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)           |
-| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)  |
-| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)             |
-| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser) |
+| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)             |
+| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)    |
+| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)               |
+| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser)   |
 
 Microsoft Teams is plugin-only as of 2026.1.15.
 

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -156,6 +156,7 @@ describe("serveAcpGateway startup", () => {
   beforeEach(() => {
     mockState.gateways.length = 0;
     mockState.gatewayAuth.length = 0;
+    mockState.gatewayDeviceIdentity.length = 0;
     mockState.agentSideConnectionCtor.mockReset();
     mockState.agentStart.mockReset();
     mockState.resolveGatewayConnectionAuth.mockReset();
@@ -256,7 +257,6 @@ describe("serveAcpGateway startup", () => {
     const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
 
     try {
-      mockState.gatewayDeviceIdentity.length = 0;
       const servePromise = serveAcpGateway({ noDeviceIdentity: true });
       await Promise.resolve();
 
@@ -275,7 +275,6 @@ describe("serveAcpGateway startup", () => {
     const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
 
     try {
-      mockState.gatewayDeviceIdentity.length = 0;
       const servePromise = serveAcpGateway({ noDeviceIdentity: false });
       await Promise.resolve();
 

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -15,6 +15,7 @@ type ResolveGatewayConnectionAuth = (params: unknown) => Promise<GatewayClientAu
 const mockState = {
   gateways: [] as MockGatewayClient[],
   gatewayAuth: [] as GatewayClientAuth[],
+  gatewayDeviceIdentity: [] as unknown[],
   agentSideConnectionCtor: vi.fn(),
   agentStart: vi.fn(),
   resolveGatewayConnectionAuth: vi.fn<ResolveGatewayConnectionAuth>(async (_params) => ({
@@ -25,10 +26,13 @@ const mockState = {
 
 class MockGatewayClient {
   private callbacks: GatewayClientCallbacks;
+  public deviceIdentity: unknown;
 
-  constructor(opts: GatewayClientCallbacks & GatewayClientAuth) {
+  constructor(opts: GatewayClientCallbacks & GatewayClientAuth & { deviceIdentity?: unknown }) {
     this.callbacks = opts;
+    this.deviceIdentity = opts.deviceIdentity;
     mockState.gatewayAuth.push({ token: opts.token, password: opts.password });
+    mockState.gatewayDeviceIdentity.push(opts.deviceIdentity);
     mockState.gateways.push(this);
   }
 
@@ -240,6 +244,43 @@ describe("serveAcpGateway startup", () => {
           urlOverrideSource: "cli",
         }),
       );
+
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("passes deviceIdentity: null when noDeviceIdentity is true", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      mockState.gatewayDeviceIdentity.length = 0;
+      const servePromise = serveAcpGateway({ noDeviceIdentity: true });
+      await Promise.resolve();
+
+      const gateway = getMockGateway();
+      expect(gateway.deviceIdentity).toBeNull();
+      expect(mockState.gatewayDeviceIdentity[0]).toBeNull();
+
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("passes deviceIdentity: undefined (triggers auto-load) when noDeviceIdentity is false", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      mockState.gatewayDeviceIdentity.length = 0;
+      const servePromise = serveAcpGateway({ noDeviceIdentity: false });
+      await Promise.resolve();
+
+      const gateway = getMockGateway();
+      expect(gateway.deviceIdentity).toBeUndefined();
 
       await emitHelloAndWaitForAgentSideConnection();
       await stopServeWithSigint(signalHandlers, servePromise);

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -71,6 +71,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     clientDisplayName: "ACP",
     clientVersion: "acp",
     mode: GATEWAY_CLIENT_MODES.CLI,
+    deviceIdentity: opts.noDeviceIdentity ? null : undefined,
     onEvent: (evt) => {
       void agent?.handleGatewayEvent(evt);
     },
@@ -199,6 +200,10 @@ function parseArgs(args: string[]): AcpServerOptions {
       opts.verbose = true;
       continue;
     }
+    if (arg === "--no-device-identity") {
+      opts.noDeviceIdentity = true;
+      continue;
+    }
     if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -236,6 +241,7 @@ Options:
   --reset-session         Reset the session key before first use
   --no-prefix-cwd         Do not prefix prompts with the working directory
   --provenance <mode>     ACP provenance mode: off, meta, or meta+receipt
+  --no-device-identity    Skip device identity (use token-only auth)
   --verbose, -v           Verbose logging to stderr
   --help, -h              Show this help message
 `);

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -37,6 +37,7 @@ export type AcpServerOptions = {
   resetSession?: boolean;
   prefixCwd?: boolean;
   provenanceMode?: AcpProvenanceMode;
+  noDeviceIdentity?: boolean;
   sessionCreateRateLimit?: {
     maxRequests?: number;
     windowMs?: number;

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -47,6 +47,7 @@ export function registerAcpCli(program: Command) {
     .option("--reset-session", "Reset the session key before first use", false)
     .option("--no-prefix-cwd", "Do not prefix prompts with the working directory", false)
     .option("--provenance <mode>", "ACP provenance mode: off, meta, or meta+receipt")
+    .option("--no-device-identity", "Skip device identity (use token-only auth)", false)
     .option("-v, --verbose", "Verbose logging to stderr", false)
     .addHelpText(
       "after",
@@ -89,6 +90,7 @@ export function registerAcpCli(program: Command) {
           prefixCwd: !opts.noPrefixCwd,
           provenanceMode,
           verbose: Boolean(opts.verbose),
+          noDeviceIdentity: Boolean(opts.noDeviceIdentity),
         });
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -202,4 +202,24 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
+
+  it("handles /model list by opening model selector instead of setting model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "openai", model: "gpt-4" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model list");
+
+    expect(addSystem).toHaveBeenCalledWith(expect.stringContaining("model"));
+  });
+
+  it("handles /model status by showing current model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "anthropic", model: "claude-3" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model status");
+
+    expect(addSystem).toHaveBeenCalledWith("model: anthropic/claude-3");
+  });
 });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -13,6 +13,7 @@ function createHarness(params?: {
   setActivityStatus?: SetActivityStatusMock;
   isConnected?: boolean;
   activeChatRunId?: string | null;
+  client?: Record<string, unknown>;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
@@ -31,9 +32,10 @@ function createHarness(params?: {
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
   };
+  const client = { sendChat, resetSession, ...params?.client } as never;
 
   const { handleCommand } = createCommandHandlers({
-    client: { sendChat, resetSession } as never,
+    client,
     chatLog: { addUser, addSystem } as never,
     tui: { requestRender } as never,
     opts: {},
@@ -204,13 +206,18 @@ describe("tui command handlers", () => {
   });
 
   it("handles /model list by opening model selector instead of setting model", async () => {
-    const harness = createHarness();
+    const listModels = vi.fn().mockResolvedValue([
+      { id: "gpt-4", provider: "openai", name: "GPT-4" },
+      { id: "claude-3", provider: "anthropic", name: "Claude 3" },
+    ]);
+    const client = { listModels } as never;
+    const harness = createHarness({ client });
     harness.state.sessionInfo = { modelProvider: "openai", model: "gpt-4" };
-    const { handleCommand, addSystem } = harness;
+    const { handleCommand } = harness;
 
     await handleCommand("/model list");
 
-    expect(addSystem).toHaveBeenCalledWith(expect.stringContaining("model"));
+    expect(listModels).toHaveBeenCalled();
   });
 
   it("handles /model status by showing current model", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -295,8 +295,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openSessionSelector();
         break;
       case "model":
-        if (!args) {
+        if (!args || args === "list") {
           await openModelSelector();
+        } else if (args === "status") {
+          const { modelProvider, model } = state.sessionInfo;
+          chatLog.addSystem(`model: ${modelProvider}/${model}`);
         } else {
           try {
             const result = await client.patchSession({


### PR DESCRIPTION
## Summary
- Strengthen the `/model list` test to actually verify that `listModels` is called
- Previously the test only checked that `addSystem` was called with something containing "model", which would pass even if the bug wasn't fixed
- Added `listModels` mock to the test harness to properly validate the fix

## Issue
This PR addresses the review feedback on PR #51152.