### PR TITLE
fix: show all allowFrom entries in channels status --probe

### DIFF
--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -142,7 +142,10 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
         bits.push(`dm:${account.dmPolicy}`);
       }
       if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
-        bits.push(`allow:${account.allowFrom.slice(0, 2).join(",")}`);
+        const MAX_DISPLAY = 5;
+        const displayed = account.allowFrom.slice(0, MAX_DISPLAY).join(",");
+        const remaining = account.allowFrom.length - MAX_DISPLAY;
+        bits.push(`allow:${displayed}${remaining > 0 ? `,+${remaining} more` : ""}`);
       }
       appendTokenSourceBits(bits, account);
       const application = account.application as


### PR DESCRIPTION
## Problem

`openclaw channels status --probe` only displays the first two `allowFrom` entries due to `.slice(0, 2)` in `src/commands/channels/status.ts`. This creates a misleading diagnostic signal for users with 3+ entries configured, as reported in #51174.

## Fix

Show up to 5 entries (configurable via `MAX_DISPLAY`), with a `+N more` suffix when the list is longer. This balances readability with completeness.

**Before:** `allow:+491733826756,+491747230583` (silently drops 3rd+ entries)
**After:** `allow:+491733826756,+491747230583,+491736561045` (shows all when ≤5)
**After (6+ entries):** `allow:+491...,+492...,+493...,+494...,+495...,+2 more`

## Changes

- `src/commands/channels/status.ts`: Replace `.slice(0, 2)` with display limit of 5 + overflow indicator

Fixes #51174