### PR TITLE
LINE: harden Express webhook parsing to verified raw body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: stabilize pairing/session/forum routing and reply formatting tests (#50155) Thanks @joshavant.
 - Hardening: refresh stale device pairing requests and pending metadata (#50695) Thanks @smaeljaish771 and @joshavant.
 - Gateway: harden OpenResponses file-context escaping (#50782) Thanks @YLChen-007 and @joshavant.
+- LINE: harden Express webhook parsing to verified raw body (#51202) Thanks @gladiator9797 and @joshavant.
 - xAI/models: rename the bundled Grok 4.20 catalog entries to the GA IDs and normalize saved deprecated beta IDs at runtime so existing configs and sessions keep resolving. (#50772) thanks @Jaaneek
 
 ### Fixes

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -51,6 +51,7 @@ If you need a custom path, set `channels.line.webhookPath` or
 Security note:
 
 - LINE signature verification is body-dependent (HMAC over the raw body), so OpenClaw applies strict pre-auth body limits and timeout before verification.
+- OpenClaw processes webhook events from the verified raw request bytes. Upstream middleware-transformed `req.body` values are ignored for signature-integrity safety.
 
 ## Configure
 

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -1,52 +1,41 @@
 ---
 title: "Plugin SDK Migration"
 sidebarTitle: "SDK Migration"
-summary: "Migrate from the legacy backwards-compatibility layer to the modern plugin SDK"
+summary: "Migrate from legacy compat surfaces to focused plugin-sdk subpaths and injected runtime helpers"
 read_when:
   - You see the OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED warning
   - You see the OPENCLAW_EXTENSION_API_DEPRECATED warning
-  - You are updating a plugin to the modern plugin architecture
+  - You are updating a plugin from the monolithic plugin-sdk import to scoped subpaths
+  - You are updating a plugin away from openclaw/extension-api
   - You maintain an external OpenClaw plugin
 ---
 
 # Plugin SDK Migration
 
-OpenClaw has moved from a broad backwards-compatibility layer to a modern plugin
-architecture with focused, documented imports. If your plugin was built before
-the new architecture, this guide helps you migrate.
+OpenClaw is migrating from broad compatibility surfaces to narrower, documented
+contracts:
 
-## What is changing
+- `openclaw/plugin-sdk/compat` -> focused `openclaw/plugin-sdk/<subpath>` imports
+- `openclaw/extension-api` -> injected runtime helpers such as `api.runtime.agent.*`
 
-The old plugin system provided two wide-open surfaces that let plugins import
-anything they needed from a single entry point:
+This page explains what changed, why, and how to migrate.
 
-- **`openclaw/plugin-sdk/compat`** — a single import that re-exported dozens of
-  helpers. It was introduced to keep older hook-based plugins working while the
-  new plugin architecture was being built.
-- **`openclaw/extension-api`** — a bridge that gave plugins direct access to
-  host-side helpers like the embedded agent runner.
-
-Both surfaces are now **deprecated**. They still work at runtime, but new
-plugins must not use them, and existing plugins should migrate before the next
-major release removes them.
-
-<Warning>
-  The backwards-compatibility layer will be removed in a future major release.
-  Plugins that still import from these surfaces will break when that happens.
-</Warning>
+<Info>
+  The compat import still works at runtime. This is a deprecation warning, not
+  a breaking change yet. But new plugins **must not** use it, and existing
+  plugins should migrate before the next major release removes it.
+</Info>
 
 ## Why this changed
 
-The old approach caused problems:
+The old monolithic `openclaw/plugin-sdk/compat` re-exported everything from one
+entry point. This caused slow startup (importing one helper loaded dozens of
+unrelated modules), circular dependency risk, and an unclear API surface.
 
-- **Slow startup** — importing one helper loaded dozens of unrelated modules
-- **Circular dependencies** — broad re-exports made it easy to create import cycles
-- **Unclear API surface** — no way to tell which exports were stable vs internal
+Focused subpaths fix all three: each subpath is a small, self-contained module
+with a clear purpose.
 
-The modern plugin SDK fixes this: each import path (`openclaw/plugin-sdk/\<subpath\>`)
-is a small, self-contained module with a clear purpose and documented contract.
-
-## How to migrate
+## Migration steps
 
 <Steps>
   <Step title="Find deprecated imports">
@@ -54,66 +43,91 @@ is a small, self-contained module with a clear purpose and documented contract.
 
     ```bash
     grep -r "plugin-sdk/compat" my-plugin/
-    grep -r "openclaw/extension-api" my-plugin/
+    grep -r "openclaw/extension-api" extensions/my-plugin/
     ```
 
   </Step>
 
-  <Step title="Replace with focused imports">
-    Each export from the old surface maps to a specific modern import path:
+  <Step title="Replace with focused subpaths or runtime injection">
+    Each export from compat maps to a specific subpath. Replace the import
+    source:
 
     ```typescript
-    // Before (deprecated backwards-compatibility layer)
+    // Before (compat entry)
     import {
       createChannelReplyPipeline,
       createPluginRuntimeStore,
       resolveControlCommandGate,
     } from "openclaw/plugin-sdk/compat";
 
-    // After (modern focused imports)
+    // After (focused subpaths)
     import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
     import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
     import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
     ```
 
-    For host-side helpers, use the injected plugin runtime instead of importing
-    directly:
+    If your plugin imports from `openclaw/extension-api`, you will now see:
+
+    ```text
+    [OPENCLAW_EXTENSION_API_DEPRECATED] Warning: openclaw/extension-api is deprecated.
+    Migrate to api.runtime.agent.* or focused openclaw/plugin-sdk/<subpath> imports.
+    ```
+
+    That bridge also still works at runtime today. It exists to preserve older
+    plugins while they migrate to the injected plugin runtime.
+
+    Move host-side helpers onto the injected plugin runtime instead of
+    importing them directly:
 
     ```typescript
     // Before (deprecated extension-api bridge)
     import { runEmbeddedPiAgent } from "openclaw/extension-api";
-    const result = await runEmbeddedPiAgent({ sessionId, prompt });
 
-    // After (injected runtime)
-    const result = await api.runtime.agent.runEmbeddedPiAgent({ sessionId, prompt });
+    const result = await runEmbeddedPiAgent({
+      sessionId,
+      sessionFile,
+      workspaceDir,
+      prompt,
+      timeoutMs,
+    });
+
+    // After (preferred injected runtime)
+    const result = await api.runtime.agent.runEmbeddedPiAgent({
+      sessionId,
+      sessionFile,
+      workspaceDir,
+      prompt,
+      timeoutMs,
+    });
     ```
 
-    The same pattern applies to other legacy bridge helpers:
+    The same pattern applies to the other legacy `extension-api` helpers:
 
-    | Old import | Modern equivalent |
-    | --- | --- |
-    | `resolveAgentDir` | `api.runtime.agent.resolveAgentDir` |
-    | `resolveAgentWorkspaceDir` | `api.runtime.agent.resolveAgentWorkspaceDir` |
-    | `resolveAgentIdentity` | `api.runtime.agent.resolveAgentIdentity` |
-    | `resolveThinkingDefault` | `api.runtime.agent.resolveThinkingDefault` |
-    | `resolveAgentTimeoutMs` | `api.runtime.agent.resolveAgentTimeoutMs` |
-    | `ensureAgentWorkspace` | `api.runtime.agent.ensureAgentWorkspace` |
-    | session store helpers | `api.runtime.agent.session.*` |
+    - `resolveAgentDir` -> `api.runtime.agent.resolveAgentDir`
+    - `resolveAgentWorkspaceDir` -> `api.runtime.agent.resolveAgentWorkspaceDir`
+    - `resolveAgentIdentity` -> `api.runtime.agent.resolveAgentIdentity`
+    - `resolveThinkingDefault` -> `api.runtime.agent.resolveThinkingDefault`
+    - `resolveAgentTimeoutMs` -> `api.runtime.agent.resolveAgentTimeoutMs`
+    - `ensureAgentWorkspace` -> `api.runtime.agent.ensureAgentWorkspace`
+    - session store helpers -> `api.runtime.agent.session.*`
+
+    See the [subpath reference](#subpath-reference) below for the scoped import
+    mapping.
 
   </Step>
 
   <Step title="Build and test">
     ```bash
     pnpm build
-    pnpm test -- my-plugin/
+    pnpm test -- extensions/my-plugin/
     ```
   </Step>
 </Steps>
 
-## Import path reference
+## Subpath reference
 
-<Accordion title="Full import path table">
-  | Import path | Purpose | Key exports |
+<Accordion title="Full subpath table">
+  | Subpath | Purpose | Key exports |
   | --- | --- | --- |
   | `plugin-sdk/core` | Plugin entry definitions, base types | `defineChannelPluginEntry`, `definePluginEntry` |
   | `plugin-sdk/channel-setup` | Setup wizard adapters | `createOptionalChannelSetupSurface` |
@@ -137,22 +151,22 @@ is a small, self-contained module with a clear purpose and documented contract.
   | `plugin-sdk/testing` | Test utilities | Test helpers and mocks |
 </Accordion>
 
-Use the narrowest import that matches the job. If you cannot find an export,
+Use the narrowest subpath that matches the job. If you cannot find an export,
 check the source at `src/plugin-sdk/` or ask in Discord.
 
 ## Removal timeline
 
 | When                   | What happens                                                            |
 | ---------------------- | ----------------------------------------------------------------------- |
-| **Now**                | Deprecated surfaces emit runtime warnings                               |
-| **Next major release** | Deprecated surfaces will be removed; plugins still using them will fail |
+| **Now**                | Compat import and `openclaw/extension-api` emit runtime warnings        |
+| **Next major release** | These legacy bridges may be removed; plugins still using them will fail |
 
 All core plugins have already been migrated. External plugins should migrate
 before the next major release.
 
-## Suppressing the warnings temporarily
+## Suppressing the warning temporarily
 
-Set these environment variables while you work on migrating:
+Set this environment variable while you work on migrating:
 
 ```bash
 OPENCLAW_SUPPRESS_PLUGIN_SDK_COMPAT_WARNING=1 openclaw gateway run
@@ -164,5 +178,5 @@ This is a temporary escape hatch, not a permanent solution.
 ## Related
 
 - [Building Plugins](/plugins/building-plugins)
-- [Plugin Internals](/plugins/architecture)
+- [Plugin Architecture](/plugins/architecture)
 - [Plugin Manifest](/plugins/manifest)

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -1,41 +1,52 @@
 ---
 title: "Plugin SDK Migration"
 sidebarTitle: "SDK Migration"
-summary: "Migrate from legacy compat surfaces to focused plugin-sdk subpaths and injected runtime helpers"
+summary: "Migrate from the legacy backwards-compatibility layer to the modern plugin SDK"
 read_when:
   - You see the OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED warning
   - You see the OPENCLAW_EXTENSION_API_DEPRECATED warning
-  - You are updating a plugin from the monolithic plugin-sdk import to scoped subpaths
-  - You are updating a plugin away from openclaw/extension-api
+  - You are updating a plugin to the modern plugin architecture
   - You maintain an external OpenClaw plugin
 ---
 
 # Plugin SDK Migration
 
-OpenClaw is migrating from broad compatibility surfaces to narrower, documented
-contracts:
+OpenClaw has moved from a broad backwards-compatibility layer to a modern plugin
+architecture with focused, documented imports. If your plugin was built before
+the new architecture, this guide helps you migrate.
 
-- `openclaw/plugin-sdk/compat` -> focused `openclaw/plugin-sdk/<subpath>` imports
-- `openclaw/extension-api` -> injected runtime helpers such as `api.runtime.agent.*`
+## What is changing
 
-This page explains what changed, why, and how to migrate.
+The old plugin system provided two wide-open surfaces that let plugins import
+anything they needed from a single entry point:
 
-<Info>
-  The compat import still works at runtime. This is a deprecation warning, not
-  a breaking change yet. But new plugins **must not** use it, and existing
-  plugins should migrate before the next major release removes it.
-</Info>
+- **`openclaw/plugin-sdk/compat`** — a single import that re-exported dozens of
+  helpers. It was introduced to keep older hook-based plugins working while the
+  new plugin architecture was being built.
+- **`openclaw/extension-api`** — a bridge that gave plugins direct access to
+  host-side helpers like the embedded agent runner.
+
+Both surfaces are now **deprecated**. They still work at runtime, but new
+plugins must not use them, and existing plugins should migrate before the next
+major release removes them.
+
+<Warning>
+  The backwards-compatibility layer will be removed in a future major release.
+  Plugins that still import from these surfaces will break when that happens.
+</Warning>
 
 ## Why this changed
 
-The old monolithic `openclaw/plugin-sdk/compat` re-exported everything from one
-entry point. This caused slow startup (importing one helper loaded dozens of
-unrelated modules), circular dependency risk, and an unclear API surface.
+The old approach caused problems:
 
-Focused subpaths fix all three: each subpath is a small, self-contained module
-with a clear purpose.
+- **Slow startup** — importing one helper loaded dozens of unrelated modules
+- **Circular dependencies** — broad re-exports made it easy to create import cycles
+- **Unclear API surface** — no way to tell which exports were stable vs internal
 
-## Migration steps
+The modern plugin SDK fixes this: each import path (`openclaw/plugin-sdk/\<subpath\>`)
+is a small, self-contained module with a clear purpose and documented contract.
+
+## How to migrate
 
 <Steps>
   <Step title="Find deprecated imports">
@@ -43,91 +54,66 @@ with a clear purpose.
 
     ```bash
     grep -r "plugin-sdk/compat" my-plugin/
-    grep -r "openclaw/extension-api" extensions/my-plugin/
+    grep -r "openclaw/extension-api" my-plugin/
     ```
 
   </Step>
 
-  <Step title="Replace with focused subpaths or runtime injection">
-    Each export from compat maps to a specific subpath. Replace the import
-    source:
+  <Step title="Replace with focused imports">
+    Each export from the old surface maps to a specific modern import path:
 
     ```typescript
-    // Before (compat entry)
+    // Before (deprecated backwards-compatibility layer)
     import {
       createChannelReplyPipeline,
       createPluginRuntimeStore,
       resolveControlCommandGate,
     } from "openclaw/plugin-sdk/compat";
 
-    // After (focused subpaths)
+    // After (modern focused imports)
     import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
     import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
     import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
     ```
 
-    If your plugin imports from `openclaw/extension-api`, you will now see:
-
-    ```text
-    [OPENCLAW_EXTENSION_API_DEPRECATED] Warning: openclaw/extension-api is deprecated.
-    Migrate to api.runtime.agent.* or focused openclaw/plugin-sdk/<subpath> imports.
-    ```
-
-    That bridge also still works at runtime today. It exists to preserve older
-    plugins while they migrate to the injected plugin runtime.
-
-    Move host-side helpers onto the injected plugin runtime instead of
-    importing them directly:
+    For host-side helpers, use the injected plugin runtime instead of importing
+    directly:
 
     ```typescript
     // Before (deprecated extension-api bridge)
     import { runEmbeddedPiAgent } from "openclaw/extension-api";
+    const result = await runEmbeddedPiAgent({ sessionId, prompt });
 
-    const result = await runEmbeddedPiAgent({
-      sessionId,
-      sessionFile,
-      workspaceDir,
-      prompt,
-      timeoutMs,
-    });
-
-    // After (preferred injected runtime)
-    const result = await api.runtime.agent.runEmbeddedPiAgent({
-      sessionId,
-      sessionFile,
-      workspaceDir,
-      prompt,
-      timeoutMs,
-    });
+    // After (injected runtime)
+    const result = await api.runtime.agent.runEmbeddedPiAgent({ sessionId, prompt });
     ```
 
-    The same pattern applies to the other legacy `extension-api` helpers:
+    The same pattern applies to other legacy bridge helpers:
 
-    - `resolveAgentDir` -> `api.runtime.agent.resolveAgentDir`
-    - `resolveAgentWorkspaceDir` -> `api.runtime.agent.resolveAgentWorkspaceDir`
-    - `resolveAgentIdentity` -> `api.runtime.agent.resolveAgentIdentity`
-    - `resolveThinkingDefault` -> `api.runtime.agent.resolveThinkingDefault`
-    - `resolveAgentTimeoutMs` -> `api.runtime.agent.resolveAgentTimeoutMs`
-    - `ensureAgentWorkspace` -> `api.runtime.agent.ensureAgentWorkspace`
-    - session store helpers -> `api.runtime.agent.session.*`
-
-    See the [subpath reference](#subpath-reference) below for the scoped import
-    mapping.
+    | Old import | Modern equivalent |
+    | --- | --- |
+    | `resolveAgentDir` | `api.runtime.agent.resolveAgentDir` |
+    | `resolveAgentWorkspaceDir` | `api.runtime.agent.resolveAgentWorkspaceDir` |
+    | `resolveAgentIdentity` | `api.runtime.agent.resolveAgentIdentity` |
+    | `resolveThinkingDefault` | `api.runtime.agent.resolveThinkingDefault` |
+    | `resolveAgentTimeoutMs` | `api.runtime.agent.resolveAgentTimeoutMs` |
+    | `ensureAgentWorkspace` | `api.runtime.agent.ensureAgentWorkspace` |
+    | session store helpers | `api.runtime.agent.session.*` |
 
   </Step>
 
   <Step title="Build and test">
     ```bash
     pnpm build
-    pnpm test -- extensions/my-plugin/
+    pnpm test -- my-plugin/
     ```
   </Step>
 </Steps>
 
-## Subpath reference
+## Import path reference
 
-<Accordion title="Full subpath table">
-  | Subpath | Purpose | Key exports |
+<Accordion title="Full import path table">
+  | Import path | Purpose | Key exports |
   | --- | --- | --- |
   | `plugin-sdk/core` | Plugin entry definitions, base types | `defineChannelPluginEntry`, `definePluginEntry` |
   | `plugin-sdk/channel-setup` | Setup wizard adapters | `createOptionalChannelSetupSurface` |
@@ -151,22 +137,22 @@ with a clear purpose.
   | `plugin-sdk/testing` | Test utilities | Test helpers and mocks |
 </Accordion>
 
-Use the narrowest subpath that matches the job. If you cannot find an export,
+Use the narrowest import that matches the job. If you cannot find an export,
 check the source at `src/plugin-sdk/` or ask in Discord.
 
 ## Removal timeline
 
 | When                   | What happens                                                            |
 | ---------------------- | ----------------------------------------------------------------------- |
-| **Now**                | Compat import and `openclaw/extension-api` emit runtime warnings        |
-| **Next major release** | These legacy bridges may be removed; plugins still using them will fail |
+| **Now**                | Deprecated surfaces emit runtime warnings                               |
+| **Next major release** | Deprecated surfaces will be removed; plugins still using them will fail |
 
 All core plugins have already been migrated. External plugins should migrate
 before the next major release.
 
-## Suppressing the warning temporarily
+## Suppressing the warnings temporarily
 
-Set this environment variable while you work on migrating:
+Set these environment variables while you work on migrating:
 
 ```bash
 OPENCLAW_SUPPRESS_PLUGIN_SDK_COMPAT_WARNING=1 openclaw gateway run
@@ -178,5 +164,5 @@ This is a temporary escape hatch, not a permanent solution.
 ## Related
 
 - [Building Plugins](/plugins/building-plugins)
-- [Plugin Architecture](/plugins/architecture)
+- [Plugin Internals](/plugins/architecture)
 - [Plugin Manifest](/plugins/manifest)

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -138,6 +138,61 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
+  it("uses the signed raw body instead of a pre-parsed req.body object", async () => {
+    const onEvents = vi.fn(async (_body: WebhookRequestBody) => {});
+    const rawBody = JSON.stringify({
+      events: [{ type: "message", source: { userId: "signed-user" } }],
+    });
+    const reqBody = {
+      events: [{ type: "message", source: { userId: "tampered-user" } }],
+    };
+    const middleware = createLineWebhookMiddleware({
+      channelSecret: SECRET,
+      onEvents,
+    });
+
+    const req = {
+      headers: { "x-line-signature": sign(rawBody, SECRET) },
+      rawBody,
+      body: reqBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(onEvents).toHaveBeenCalledTimes(1);
+    const processedBody = onEvents.mock.calls[0]?.[0] as WebhookRequestBody | undefined;
+    expect(processedBody?.events?.[0]?.source?.userId).toBe("signed-user");
+    expect(processedBody?.events?.[0]?.source?.userId).not.toBe("tampered-user");
+  });
+
+  it("rejects invalid signed raw JSON even when req.body is a valid object", async () => {
+    const onEvents = vi.fn(async (_body: WebhookRequestBody) => {});
+    const rawBody = "not-json";
+    const middleware = createLineWebhookMiddleware({
+      channelSecret: SECRET,
+      onEvents,
+    });
+
+    const req = {
+      headers: { "x-line-signature": sign(rawBody, SECRET) },
+      rawBody,
+      body: { events: [{ type: "message" }] },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid webhook payload" });
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
   it("returns 500 when event processing fails and does not acknowledge with 200", async () => {
     const onEvents = vi.fn(async () => {
       throw new Error("boom");

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -169,6 +169,37 @@ describe("createLineWebhookMiddleware", () => {
     expect(processedBody?.events?.[0]?.source?.userId).not.toBe("tampered-user");
   });
 
+  it("uses signed raw buffer body instead of a pre-parsed req.body object", async () => {
+    const onEvents = vi.fn(async (_body: WebhookRequestBody) => {});
+    const rawBodyText = JSON.stringify({
+      events: [{ type: "message", source: { userId: "signed-buffer-user" } }],
+    });
+    const reqBody = {
+      events: [{ type: "message", source: { userId: "tampered-user" } }],
+    };
+    const middleware = createLineWebhookMiddleware({
+      channelSecret: SECRET,
+      onEvents,
+    });
+
+    const req = {
+      headers: { "x-line-signature": sign(rawBodyText, SECRET) },
+      rawBody: Buffer.from(rawBodyText, "utf-8"),
+      body: reqBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(onEvents).toHaveBeenCalledTimes(1);
+    const processedBody = onEvents.mock.calls[0]?.[0] as WebhookRequestBody | undefined;
+    expect(processedBody?.events?.[0]?.source?.userId).toBe("signed-buffer-user");
+    expect(processedBody?.events?.[0]?.source?.userId).not.toBe("tampered-user");
+  });
+
   it("rejects invalid signed raw JSON even when req.body is a valid object", async () => {
     const onEvents = vi.fn(async (_body: WebhookRequestBody) => {});
     const rawBody = "not-json";

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -23,10 +23,7 @@ function readRawBody(req: Request): string | null {
   return Buffer.isBuffer(rawBody) ? rawBody.toString("utf-8") : rawBody;
 }
 
-function parseWebhookBody(req: Request, rawBody?: string | null): WebhookRequestBody | null {
-  if (req.body && typeof req.body === "object" && !Buffer.isBuffer(req.body)) {
-    return req.body as WebhookRequestBody;
-  }
+function parseWebhookBody(rawBody?: string | null): WebhookRequestBody | null {
   if (!rawBody) {
     return null;
   }
@@ -64,7 +61,8 @@ export function createLineWebhookMiddleware(
         return;
       }
 
-      const body = parseWebhookBody(req, rawBody);
+      // Keep processing tied to the exact bytes that passed signature verification.
+      const body = parseWebhookBody(rawBody);
 
       if (!body) {
         res.status(400).json({ error: "Invalid webhook payload" });


### PR DESCRIPTION
## Summary

- Problem: the LINE Express webhook helper could process middleware-transformed `req.body` instead of the signed raw request bytes.
- Why it matters: processing should stay bound to the same bytes that passed signature validation.
- What changed: `src/line/webhook.ts` now parses only from `rawBody` after signature validation.
- What changed: regression tests were added in `src/line/webhook.test.ts` for raw-body precedence, raw-buffer precedence, and invalid raw JSON handling.
- What changed: docs now note that upstream middleware-transformed `req.body` values are ignored for this path.
- What did NOT change (scope boundary): the Node webhook handler path and route registration flow are unchanged.

## Change Type

- [x] Bug fix
- [x] Docs
- [x] Hardening

## Scope

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- None

## User-visible / Behavior Changes

For Express LINE webhook usage, event processing now always uses verified raw request bytes. Middleware-transformed `req.body` values are ignored for event processing.

## Hardening Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, Bun/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): LINE
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test -- src/line/webhook.test.ts`.
2. Run `pnpm build`.
3. Run `pnpm test`.

### Expected

- LINE Express middleware parses from the signed raw body.
- Conflicting `req.body` object values do not affect processed events.
- Invalid raw JSON is rejected even when `req.body` is a valid object.

### Actual

- Matched expected behavior.

## Evidence

- [x] Failing test/log before + passing after

Added regression tests:
- `uses the signed raw body instead of a pre-parsed req.body object`
- `uses signed raw buffer body instead of a pre-parsed req.body object`
- `rejects invalid signed raw JSON even when req.body is a valid object`

## Human Verification (required)

- Verified scenarios:
  - signed raw body is the authoritative parse source in `src/line/webhook.ts`
  - conflicting `req.body` is ignored in processing
  - conflicting `req.body` is ignored when signed raw body is provided as `Buffer`
  - invalid raw JSON is rejected with `400`
- Edge cases checked:
  - normal signed request path still returns `200`
  - missing raw body still returns `400`
- What I did **not** verify:
  - live external LINE delivery in a remote deployment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`, except for setups that intentionally relied on transformed `req.body` semantics)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commits `58583e6162` and `fd7e264d10`
- Files/config to restore:
  - `src/line/webhook.ts`
  - `src/line/webhook.test.ts`
  - `docs/channels/line.md`
- Known bad symptoms reviewers should watch for:
  - Express integrations that relied on transformed `req.body` values may observe behavior drift

## Risks and Mitigations

- Risk:
  - some custom Express middleware stacks may have depended on transformed object semantics
  - Mitigation:
  - keep parsing tied to raw bytes and retain explicit regression tests for this invariant

