### PR TITLE
Add Qmemory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -81,7 +81,7 @@ and session state into a connected graph the agent can search and traverse.
 ```bash
 openclaw plugins install qmemory
 openclaw config set plugins.slots.contextEngine "qmemory"
-openclaw config set tools.alsoAllow '["group:plugins"]'
+openclaw config set tools.alsoAllow '["qmemory"]'
 ```
 
 ### QQbot

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -68,6 +68,22 @@ cost, tokens, errors, and more.
 openclaw plugins install @opik/opik-openclaw
 ```
 
+### Qmemory
+
+Context-engine plugin that gives agents persistent, cross-session graph memory
+powered by SurrealDB. Implements the full `ContextEngine` interface with 12
+lifecycle hooks capturing tool calls, cron outcomes, subagent relationships,
+and session state into a connected graph the agent can search and traverse.
+
+- **npm:** `qmemory`
+- **repo:** [github.com/QusaiiSaleem/qmemory](https://github.com/QusaiiSaleem/qmemory)
+
+```bash
+openclaw plugins install qmemory
+openclaw config set plugins.slots.contextEngine "qmemory"
+openclaw config set tools.alsoAllow '["group:plugins"]'
+```
+
 ### QQbot
 
 Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group


### PR DESCRIPTION
## Summary

Adds Qmemory to the community plugins page. One file changed, 16 lines added.

## What changed

Only `docs/plugins/community.md` — inserted the `### Qmemory` section alphabetically between Opik and QQbot. All existing entries are untouched.

## Plugin info

- **npm:** [`qmemory`](https://www.npmjs.com/package/qmemory)
- **repo:** [github.com/QusaiiSaleem/qmemory](https://github.com/QusaiiSaleem/qmemory)
- **License:** MIT
- **Type:** context-engine plugin (implements `ContextEngine` interface)

## Previous submissions

- #49959 — closed by reviewer (docs framing issues, all addressed)
- #51192 — closed by me (stale base, page restructure conflict)

This PR is rebased on current `main` with the review feedback applied:
- No redundant `npm install` step
- No non-standard `kind` field
- Only the entry addition — no page restructure

## Test plan

- [ ] Page renders correctly with Qmemory entry between Opik and QQbot
- [ ] Existing entries unchanged
- [ ] `openclaw plugins install qmemory` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)