### PR TITLE
fix: sanitize internal tool errors before sending to chat

### DIFF
--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -42,8 +42,7 @@ describe("pi tool definition adapter", () => {
       status: "error",
       tool: "boom",
     });
-    expect(result.details).toMatchObject({ error: "nope" });
-    expect(JSON.stringify(result.details)).not.toContain("\n    at ");
+    expect(result.details).toMatchObject({ error: "Tool execution failed." });
   });
 
   it("normalizes exec tool aliases in error results", async () => {
@@ -52,7 +51,7 @@ describe("pi tool definition adapter", () => {
     expect(result.details).toMatchObject({
       status: "error",
       tool: "exec",
-      error: "nope",
+      error: "Tool execution failed.",
     });
   });
 

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -185,7 +185,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           return jsonResult({
             status: "error",
             tool: normalizedName,
-            error: described.message,
+            error: "Tool execution failed.",
           });
         }
       },


### PR DESCRIPTION
## Summary
- Sanitize internal error details from tool execution failures before they reach the chat stream, preventing internal stack traces and system paths from leaking to end users.

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51149