### PR TITLE
fix: don't parse /model subcommands as model IDs

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -322,6 +322,28 @@ describe("/model chat UX", () => {
     expect(resolved.profileOverride).toBeUndefined();
   });
 
+  it.each(["list", "status", "show"])("does not parse /model %s as a model ID", (subcommand) => {
+    const resolved = resolveModelSelectionForCommand({
+      command: `/model ${subcommand}`,
+      allowedModelKeys: new Set(["anthropic/claude-opus-4-5"]),
+      allowedModelCatalog: [{ provider: "anthropic", id: "claude-opus-4-5" }],
+    });
+
+    expect(resolved.modelSelection).toBeUndefined();
+    expect(resolved.errorText).toBeUndefined();
+  });
+
+  it("does not parse /model LIST (case-insensitive) as a model ID", () => {
+    const resolved = resolveModelSelectionForCommand({
+      command: "/model LIST",
+      allowedModelKeys: new Set(["anthropic/claude-opus-4-5"]),
+      allowedModelCatalog: [{ provider: "anthropic", id: "claude-opus-4-5" }],
+    });
+
+    expect(resolved.modelSelection).toBeUndefined();
+    expect(resolved.errorText).toBeUndefined();
+  });
+
   it("persists inferred numeric auth-profile overrides for mixed-content messages", async () => {
     setAuthProfiles({
       "20251001": {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -413,6 +413,14 @@ export function resolveModelSelectionFromDirective(params: {
   }
 
   const raw = params.directives.rawModelDirective.trim();
+
+  // Reserved subcommand keywords handled by maybeHandleModelDirectiveInfo —
+  // never attempt to resolve them as model identifiers.
+  const MODEL_SUBCOMMANDS = new Set(["list", "status", "show"]);
+  if (MODEL_SUBCOMMANDS.has(raw.toLowerCase())) {
+    return {};
+  }
+
   const storedNumericProfile =
     params.directives.rawModelProfile === undefined
       ? resolveStoredNumericProfileModelDirective({


### PR DESCRIPTION
## Summary
- `/model list` and `/model status` were incorrectly parsed as model ID arguments instead of recognized subcommands
- Added early return for known subcommands before attempting model ID parsing
- Added tests covering the subcommand detection

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51126