### PR TITLE
fix: guard against null chunks in openai-completions streaming

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -332,8 +332,9 @@ export async function runBtwSideQuestion(
 
     if (event.type === "text_delta") {
       sawTextEvent = true;
-      answerText += event.delta;
-      chunker?.append(event.delta);
+      const delta = event.delta ?? "";
+      answerText += delta;
+      chunker?.append(delta);
       if (chunker && params.resolvedBlockStreamingBreak === "text_end") {
         chunker.drain({ force: false, emit: (chunk) => void emitBlockChunk(chunk) });
       }
@@ -346,7 +347,7 @@ export async function runBtwSideQuestion(
     }
 
     if (event.type === "thinking_delta") {
-      reasoningText += event.delta;
+      reasoningText += event.delta ?? "";
       if (params.resolvedReasoningLevel !== "off") {
         await params.opts?.onReasoningStream?.({ text: reasoningText, isReasoning: true });
       }

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -521,6 +521,10 @@ export function createOllamaStreamFn(
           throw new Error("Ollama API stream ended without a final response");
         }
 
+        // Guard against null/undefined message in final response (#51112)
+        if (!finalResponse.message) {
+          finalResponse.message = { role: "assistant", content: "" };
+        }
         finalResponse.message.content = accumulatedContent;
         if (accumulatedToolCalls.length > 0) {
           finalResponse.message.tool_calls = accumulatedToolCalls;

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -472,6 +472,9 @@ export function buildAssistantMessageFromResponse(
         id: toNonEmptyString(item.call_id) ?? `call_${randomUUID()}`,
         name: toolName,
         arguments: (() => {
+          if (item.arguments == null) {
+            return {} as Record<string, unknown>;
+          }
           try {
             return JSON.parse(item.arguments) as Record<string, unknown>;
           } catch {
@@ -885,17 +888,21 @@ export function createOpenAIWebSocketStreamFn(
             reject(new Error(`OpenAI WebSocket error: ${event.message} (code=${event.code})`));
           } else if (event.type === "response.output_text.delta") {
             // Stream partial text updates for responsive UI
-            const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
-              model,
-              content: [{ type: "text", text: event.delta }],
-              stopReason: "stop",
-            });
-            eventStream.push({
-              type: "text_delta",
-              contentIndex: 0,
-              delta: event.delta,
-              partial: partialMsg,
-            });
+            // Guard against null/undefined delta from custom providers (#51112)
+            const delta = event.delta ?? "";
+            if (delta) {
+              const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
+                model,
+                content: [{ type: "text", text: delta }],
+                stopReason: "stop",
+              });
+              eventStream.push({
+                type: "text_delta",
+                contentIndex: 0,
+                delta,
+                partial: partialMsg,
+              });
+            }
           }
         });
       });


### PR DESCRIPTION
## Summary
- Guard against `null`/`undefined` deltas in streaming responses from OpenAI-compatible providers (btw, ollama, websocket streams)
- Prevents `TypeError: Cannot read properties of null` crashes during streaming when providers send incomplete chunks

Closes #51112

**Change Type:** Bug fix