### PR TITLE
fix: guard content.filter() calls with Array.isArray check

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -269,7 +269,8 @@ async function probeTool(
       } satisfies OpenAICompletionsOptions),
     );
 
-    const hasToolCall = message.content.some((block) => block.type === "toolCall");
+    const hasToolCall =
+      Array.isArray(message.content) && message.content.some((block) => block.type === "toolCall");
     if (!hasToolCall) {
       return {
         ok: false,

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -380,7 +380,11 @@ export async function handleBashChatCommand(params: {
     const output =
       result.details?.status === "completed"
         ? result.details.aggregated
-        : result.content.map((chunk) => (chunk.type === "text" ? chunk.text : "")).join("\n");
+        : Array.isArray(result.content)
+          ? result.content.map((chunk) => (chunk.type === "text" ? chunk.text : "")).join("\n")
+          : typeof result.content === "string"
+            ? result.content
+            : "";
     return {
       text: [
         `⚙️ bash: ${commandText}`,

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1044,12 +1044,15 @@
       if (!result) {
         return "";
       }
+      if (!Array.isArray(result.content)) {
+        return typeof result.content === "string" ? result.content : "";
+      }
       const textBlocks = result.content.filter((c) => c.type === "text");
       return textBlocks.map((c) => c.text).join("\n");
     };
 
     const getResultImages = () => {
-      if (!result) {
+      if (!result || !Array.isArray(result.content)) {
         return [];
       }
       return result.content.filter((c) => c.type === "image");
@@ -1474,7 +1477,7 @@
               cost.cacheWrite += msg.usage.cost.cacheWrite || 0;
             }
           }
-          toolCalls += msg.content.filter((c) => c.type === "toolCall").length;
+          toolCalls += Array.isArray(msg.content) ? msg.content.filter((c) => c.type === "toolCall").length : 0;
         }
         if (msg.role === "toolResult") {
           toolResults++;


### PR DESCRIPTION
## Summary
- Add `Array.isArray` guards before `.filter()` calls on `content` fields that may not be arrays
- Prevents `TypeError: content.filter is not a function` crashes when content is a string or other non-array type

Closes #50484

**Change Type:** Bug fix