### PR TITLE
fix: gate TUI debug messages behind isControlUiVisible flag

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -838,7 +838,7 @@ describe("agent event handler", () => {
     expect(nodePayload.runId).toBe("run-fallback-client");
   });
 
-  it("suppresses chat and node session events for non-control-UI-visible runs", () => {
+  it("suppresses chat, agent, and node session events for non-control-UI-visible runs", () => {
     const { broadcast, nodeSendToSession, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-hidden",
     });
@@ -858,6 +858,10 @@ describe("agent event handler", () => {
     emitLifecycleEnd(handler, "run-hidden", 2);
 
     expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    // Agent events must also be suppressed so Control UI does not
+    // render debug messages for runs originating from external channels.
+    const agentBroadcastCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(agentBroadcastCalls).toHaveLength(0);
     expect(nodeSendToSession).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -710,7 +710,7 @@ export function createAgentEventHandler({
               : { ...eventForClients, data };
           })()
         : agentPayload;
-    if (last > 0 && evt.seq !== last + 1) {
+    if (last > 0 && evt.seq !== last + 1 && isControlUiVisible) {
       broadcast("agent", {
         runId: eventRunId,
         stream: "error",
@@ -744,13 +744,13 @@ export function createAgentEventHandler({
       // not know the runId in advance, so they cannot register as run-scoped
       // tool recipients. Mirror tool lifecycle onto a session-scoped event so
       // they can render live pending tool cards without polling history.
-      if (sessionKey) {
+      if (isControlUiVisible && sessionKey) {
         const sessionSubscribers = sessionEventSubscribers.getAll();
         if (sessionSubscribers.size > 0) {
           broadcastToConnIds("session.tool", toolPayload, sessionSubscribers, { dropIfSlow: true });
         }
       }
-    } else {
+    } else if (isControlUiVisible) {
       broadcast("agent", agentPayload);
     }
 


### PR DESCRIPTION
## Summary
- Guard TUI debug messages behind the `isControlUiVisible` flag so they are only shown when the control UI is active, preventing debug information from leaking into standard chat sessions.

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50905