### PR TITLE
fix(cli): redirect plugin logs to stderr when --json is set

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -5,6 +5,7 @@ const setVerboseMock = vi.fn();
 const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
+const routeLogsToStderrMock = vi.fn();
 
 const runtimeMock = {
   log: vi.fn(),
@@ -18,6 +19,10 @@ vi.mock("../../globals.js", () => ({
 
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtimeMock,
+}));
+
+vi.mock("../../logging/console.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
 }));
 
 vi.mock("../banner.js", () => ({
@@ -88,6 +93,10 @@ describe("registerPreActionHooks", () => {
     program.command("doctor").action(() => {});
     program.command("completion").action(() => {});
     program.command("secrets").action(() => {});
+    program
+      .command("agent")
+      .option("--json")
+      .action(() => {});
     program.command("agents").action(() => {});
     program.command("configure").action(() => {});
     program.command("onboard").action(() => {});
@@ -270,6 +279,29 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("routes logs to stderr when --json is set", async () => {
+    await runPreAction({
+      parseArgv: ["agent"],
+      processArgv: ["node", "openclaw", "agent", "--json"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalled();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["agent"],
+      suppressDoctorStdout: true,
+    });
+  });
+
+  it("does not route logs to stderr when --json is absent", async () => {
+    await runPreAction({
+      parseArgv: ["agent"],
+      processArgv: ["node", "openclaw", "agent"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
   it("bypasses config guard for backup create", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -144,6 +145,9 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    if (suppressDoctorStdout) {
+      routeLogsToStderr();
+    }
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -156,7 +156,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   );
 
   if (opts.json) {
-    runtime.log(JSON.stringify(response, null, 2));
+    process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
     return response;
   }
 


### PR DESCRIPTION
## Summary
- Plugin loading logs were written to stdout, corrupting JSON output when `--json` flag was used with agent commands
- Redirected plugin logs to stderr when JSON output mode is active
- Added tests to verify stderr redirection behavior

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51076