### PR TITLE
fix(matrix): pass agentId to buildMentionRegexes for agent-level patterns

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -12,6 +12,7 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
     setMatrixRuntime({
       channel: {
         mentions: {
+          buildMentionRegexes: () => [],
           matchesMentionPatterns: () => false,
         },
         media: {

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -27,6 +27,9 @@ function createHandlerHarness() {
   } as unknown as RuntimeEnv;
   const core = {
     channel: {
+      mentions: {
+        buildMentionRegexes: () => [],
+      },
       pairing: {
         readAllowFromStore: vi.fn().mockResolvedValue([]),
         upsertPairingRequest: vi.fn().mockResolvedValue(undefined),
@@ -90,7 +93,6 @@ function createHandlerHarness() {
     allowFrom: [],
     groupAllowFrom: [],
     roomsConfig: undefined,
-    mentionRegexes: [],
     groupPolicy: "open",
     replyToMode: "first",
     threadReplies: "inbound",
@@ -135,6 +137,7 @@ describe("createMatrixRoomMessageHandler media failures", () => {
     setMatrixRuntime({
       channel: {
         mentions: {
+          buildMentionRegexes: () => [],
           matchesMentionPatterns: (text: string, patterns: RegExp[]) =>
             patterns.some((pattern) => pattern.test(text)),
         },

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -26,7 +26,7 @@ type MatrixHandlerTestHarnessOptions = {
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: Set<string>;
-  mentionRegexes?: MatrixMonitorHandlerParams["mentionRegexes"];
+  mentionRegexes?: RegExp[];
   groupPolicy?: "open" | "allowlist" | "disabled";
   replyToMode?: ReplyToMode;
   threadReplies?: "off" | "inbound" | "always";
@@ -107,6 +107,9 @@ export function createMatrixHandlerTestHarness(
     } as never,
     core: {
       channel: {
+        mentions: {
+          buildMentionRegexes: () => options.mentionRegexes ?? [],
+        },
         pairing: {
           readAllowFromStore,
           upsertPairingRequest,
@@ -168,7 +171,6 @@ export function createMatrixHandlerTestHarness(
     roomsConfig: options.roomsConfig,
     accountAllowBots: options.accountAllowBots,
     configuredBotUserIds: options.configuredBotUserIds,
-    mentionRegexes: options.mentionRegexes ?? [],
     groupPolicy: options.groupPolicy ?? "open",
     replyToMode: options.replyToMode ?? "off",
     threadReplies: options.threadReplies ?? "inbound",

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
   setMatrixRuntime({
     channel: {
       mentions: {
+        buildMentionRegexes: () => [],
         matchesMentionPatterns: (text: string, patterns: RegExp[]) =>
           patterns.some((pattern) => pattern.test(text)),
       },
@@ -351,7 +352,7 @@ describe("matrix monitor handler pairing account scope", () => {
       }),
     );
 
-    expect(resolveAgentRoute).not.toHaveBeenCalled();
+    expect(resolveAgentRoute).toHaveBeenCalled();
     expect(recordInboundSession).not.toHaveBeenCalled();
   });
 
@@ -442,7 +443,7 @@ describe("matrix monitor handler pairing account scope", () => {
       }),
     );
 
-    expect(resolveAgentRoute).not.toHaveBeenCalled();
+    expect(resolveAgentRoute).toHaveBeenCalled();
     expect(recordInboundSession).not.toHaveBeenCalled();
   });
 
@@ -479,7 +480,7 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(downloadContent).not.toHaveBeenCalled();
     expect(getMemberDisplayName).not.toHaveBeenCalled();
     expect(getRoomInfo).not.toHaveBeenCalled();
-    expect(resolveAgentRoute).not.toHaveBeenCalled();
+    expect(resolveAgentRoute).toHaveBeenCalled();
   });
 
   it("skips poll snapshot fetches for unmentioned group poll responses", async () => {
@@ -535,7 +536,7 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(getRelations).not.toHaveBeenCalled();
     expect(getMemberDisplayName).not.toHaveBeenCalled();
     expect(getRoomInfo).not.toHaveBeenCalled();
-    expect(resolveAgentRoute).not.toHaveBeenCalled();
+    expect(resolveAgentRoute).toHaveBeenCalled();
   });
 
   it("records thread starter context for inbound thread replies", async () => {
@@ -685,6 +686,9 @@ describe("matrix monitor handler pairing account scope", () => {
       } as never,
       core: {
         channel: {
+          mentions: {
+            buildMentionRegexes: () => [],
+          },
           pairing: {
             readAllowFromStore: async () => [] as string[],
             upsertPairingRequest: async () => ({ code: "ABCDEFGH", created: false }),
@@ -746,7 +750,6 @@ describe("matrix monitor handler pairing account scope", () => {
       } as never,
       logVerboseMessage: () => {},
       allowFrom: [],
-      mentionRegexes: [],
       groupPolicy: "open",
       replyToMode: "off",
       threadReplies: "inbound",

--- a/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
@@ -10,6 +10,7 @@ describe("createMatrixRoomMessageHandler thread root media", () => {
     setMatrixRuntime({
       channel: {
         mentions: {
+          buildMentionRegexes: () => [],
           matchesMentionPatterns: (text: string, patterns: RegExp[]) =>
             patterns.some((pattern) => pattern.test(text)),
         },
@@ -32,6 +33,9 @@ describe("createMatrixRoomMessageHandler thread root media", () => {
 
     const core = {
       channel: {
+        mentions: {
+          buildMentionRegexes: () => [],
+        },
         pairing: {
           readAllowFromStore: vi.fn().mockResolvedValue([]),
           upsertPairingRequest: vi.fn().mockResolvedValue(undefined),
@@ -105,7 +109,6 @@ describe("createMatrixRoomMessageHandler thread root media", () => {
       allowFrom: [],
       groupAllowFrom: [],
       roomsConfig: undefined,
-      mentionRegexes: [],
       groupPolicy: "open",
       replyToMode: "first",
       threadReplies: "inbound",

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -61,7 +61,6 @@ export type MatrixMonitorHandlerParams = {
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: ReadonlySet<string>;
-  mentionRegexes: ReturnType<PluginRuntime["channel"]["mentions"]["buildMentionRegexes"]>;
   groupPolicy: "open" | "allowlist" | "disabled";
   replyToMode: ReplyToMode;
   threadReplies: "off" | "inbound" | "always";
@@ -152,7 +151,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     roomsConfig,
     accountAllowBots,
     configuredBotUserIds = new Set<string>(),
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,
@@ -494,6 +492,23 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      // Resolve route early so agent-level mentionPatterns are included in the
+      // mention check that gates room messages.
+      const messageId = event.event_id ?? "";
+      const threadRootId = resolveMatrixThreadRootId({ event, content });
+      const { route, configuredBinding } = resolveMatrixInboundRoute({
+        cfg,
+        accountId,
+        roomId,
+        senderId,
+        isDirectMessage,
+        messageId,
+        threadRootId,
+        eventTs: eventTs ?? undefined,
+        resolveAgentRoute: core.channel.routing.resolveAgentRoute,
+      });
+
+      const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
@@ -637,9 +652,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
       const roomName = roomInfo?.name;
 
-      const messageId = event.event_id ?? "";
       const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
-      const threadRootId = resolveMatrixThreadRootId({ event, content });
       const threadTarget = resolveMatrixThreadTarget({
         threadReplies,
         messageId,
@@ -650,17 +663,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ? await resolveThreadContext({ roomId, threadRootId })
         : undefined;
 
-      const { route, configuredBinding } = resolveMatrixInboundRoute({
-        cfg,
-        accountId,
-        roomId,
-        senderId,
-        isDirectMessage,
-        messageId,
-        threadRootId,
-        eventTs: eventTs ?? undefined,
-        resolveAgentRoute: core.channel.routing.resolveAgentRoute,
-      });
       if (configuredBinding) {
         const ensured = await ensureConfiguredAcpBindingReady({
           cfg,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -149,7 +149,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     }
   };
 
-  const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg);
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy: groupPolicyRaw, providerMissingFallbackApplied } =
     resolveAllowlistProviderRuntimeGroupPolicy({
@@ -208,7 +207,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     roomsConfig,
     accountAllowBots,
     configuredBotUserIds,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,


### PR DESCRIPTION
## Summary
- Moves route resolution earlier in the Matrix monitor handler so that the resolved `agentId` is available when building mention regexes
- Without this fix, agent-level mention patterns were never evaluated because `buildMentionRegexes` was called before the agent route was known
- Updates tests to reflect the new call order and provide the `buildMentionRegexes` stub on the `mentions` service

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51082