### PR TITLE
fix: show all allowFrom entries in channel status probe

### DIFF
--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -211,7 +211,7 @@ const buildAccountNotes = (params: {
       cfg,
       accountId: snapshot.accountId,
       allowFrom,
-    }).slice(0, 3);
+    });
     if (formatted.length > 0) {
       notes.push(`allow:${formatted.join(",")}`);
     }

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -97,7 +97,7 @@ const buildAccountDetails = (params: {
       cfg: params.cfg,
       accountId: snapshot.accountId,
       allowFrom: snapshot.allowFrom,
-    }).slice(0, 2);
+    });
     if (formatted.length > 0) {
       details.push(`allow:${formatted.join(",")}`);
     }


### PR DESCRIPTION
## Summary
- Removes `.slice(0, 3)` and `.slice(0, 2)` truncation when formatting `allowFrom` entries in channel status/probe output
- Previously only the first 2-3 entries were shown, hiding legitimate allowlist members from diagnostics

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51174