### PR TITLE
fix(feishu): respect blockStreamingDefault config instead of hardcoding

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -479,7 +479,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
-      disableBlockStreaming: true,
+      disableBlockStreaming: !streamingEnabled
+        ? true
+        : cfg.agents?.defaults?.blockStreamingDefault === "on"
+          ? false
+          : undefined,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary
- The Feishu reply dispatcher was unconditionally setting `disableBlockStreaming: true`, ignoring the `blockStreamingDefault` agent config
- Now correctly reads the config value so that block streaming can be enabled when configured as `"on"`

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51117