### PR TITLE
fix(tui): handle /model list and /model status as commands

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -202,4 +202,24 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
+
+  it("handles /model list by opening model selector instead of setting model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "openai", model: "gpt-4" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model list");
+
+    expect(addSystem).toHaveBeenCalledWith(expect.stringContaining("model"));
+  });
+
+  it("handles /model status by showing current model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "anthropic", model: "claude-3" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model status");
+
+    expect(addSystem).toHaveBeenCalledWith("model: anthropic/claude-3");
+  });
 });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -13,6 +13,7 @@ function createHarness(params?: {
   setActivityStatus?: SetActivityStatusMock;
   isConnected?: boolean;
   activeChatRunId?: string | null;
+  client?: Record<string, unknown>;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
@@ -31,9 +32,10 @@ function createHarness(params?: {
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
   };
+  const client = { sendChat, resetSession, ...params?.client } as never;
 
   const { handleCommand } = createCommandHandlers({
-    client: { sendChat, resetSession } as never,
+    client,
     chatLog: { addUser, addSystem } as never,
     tui: { requestRender } as never,
     opts: {},
@@ -204,13 +206,18 @@ describe("tui command handlers", () => {
   });
 
   it("handles /model list by opening model selector instead of setting model", async () => {
-    const harness = createHarness();
+    const listModels = vi.fn().mockResolvedValue([
+      { id: "gpt-4", provider: "openai", name: "GPT-4" },
+      { id: "claude-3", provider: "anthropic", name: "Claude 3" },
+    ]);
+    const client = { listModels } as never;
+    const harness = createHarness({ client });
     harness.state.sessionInfo = { modelProvider: "openai", model: "gpt-4" };
-    const { handleCommand, addSystem } = harness;
+    const { handleCommand } = harness;
 
     await handleCommand("/model list");
 
-    expect(addSystem).toHaveBeenCalledWith(expect.stringContaining("model"));
+    expect(listModels).toHaveBeenCalled();
   });
 
   it("handles /model status by showing current model", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -299,7 +299,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           await openModelSelector();
         } else if (args === "status") {
           const { modelProvider, model } = state.sessionInfo;
-          chatLog.addSystem(`model: ${modelProvider}/${model}`);
+          if (modelProvider && model) {
+            chatLog.addSystem(`model: ${modelProvider}/${model}`);
+          } else {
+            chatLog.addSystem("model: unknown (session not loaded)");
+          }
         } else {
           try {
             const result = await client.patchSession({

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -295,8 +295,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openSessionSelector();
         break;
       case "model":
-        if (!args) {
+        if (!args || args === "list") {
           await openModelSelector();
+        } else if (args === "status") {
+          const { modelProvider, model } = state.sessionInfo;
+          chatLog.addSystem(`model: ${modelProvider}/${model}`);
         } else {
           try {
             const result = await client.patchSession({


### PR DESCRIPTION
## Summary
- Fix `/model list` being parsed as model ID "list" instead of opening model selector
- Fix `/model status` being parsed as model ID "status" instead of showing current model
- Add guard to prevent `undefined/undefined` output when session info not loaded
- Strengthen test to verify `listModels` is actually called

## Testing
- Tests verify both commands work correctly
- `/model status` handles missing session info gracefully