### PR TITLE
fix(slack): gracefully handle duplicate reaction add attempts

### DIFF
--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -84,11 +84,18 @@ export async function reactSlackMessage(
   opts: SlackActionClientOpts = {},
 ) {
   const client = await getClient(opts);
-  await client.reactions.add({
-    channel: channelId,
-    timestamp: messageId,
-    name: normalizeEmoji(emoji),
-  });
+  try {
+    await client.reactions.add({
+      channel: channelId,
+      timestamp: messageId,
+      name: normalizeEmoji(emoji),
+    });
+  } catch (error: unknown) {
+    const slackError = error as { data?: { error?: string } };
+    if (slackError?.data?.error !== "already_reacted") {
+      throw error;
+    }
+  }
 }
 
 export async function removeSlackReaction(


### PR DESCRIPTION
## Summary
- Wraps `reactions.add` in a try/catch that silently ignores the `already_reacted` Slack API error
- Prevents unhandled errors when the bot attempts to add a reaction emoji that already exists on a message

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50733