### PR TITLE
fix(telegram): include reply_to_message_id for replyToMode in groups

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -461,6 +461,7 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    fallbackReplyToId: draftReplyToMessageId,
   };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -586,6 +586,13 @@ export async function deliverReplies(params: {
   replyQuoteText?: string;
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
+  /**
+   * Fallback reply-to message id used when the individual reply payload does
+   * not carry its own replyToId. This is typically the trigger message id so
+   * that replyToMode "all" / "first" can thread the response back to the
+   * user's original message in group/forum topic chats.
+   */
+  fallbackReplyToId?: number;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -649,7 +656,9 @@ export async function deliverReplies(params: {
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
       const replyToId =
-        params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+        params.replyToMode === "off"
+          ? undefined
+          : (resolveTelegramReplyId(reply.replyToId) ?? params.fallbackReplyToId);
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);


### PR DESCRIPTION
## Summary
- Adds a `fallbackReplyToId` parameter to the Telegram reply delivery pipeline, set to the trigger message id
- When `replyToMode` is `"all"` or `"first"`, replies in group/forum topic chats now correctly thread back to the user's original message via `reply_to_message_id`
- Previously the reply-to id was lost because individual reply payloads don't always carry their own `replyToId`

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50326