### PR TITLE
fix: enable tool call ID sanitization for Moonshot/Kimi provider

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -126,6 +126,8 @@ describe("resolveProviderCapabilities", () => {
       }),
     ).toBe(true);
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("moonshot", "kimi-k2.5")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("moonshot", "moonshot-v1")).toBe("strict9");
   });
 
   it("treats kimi aliases as native anthropic tool payload providers", () => {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -58,6 +58,10 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
       "mistralai",
     ],
   },
+  moonshot: {
+    transcriptToolCallIdMode: "strict9",
+    transcriptToolCallIdModelHints: ["kimi", "moonshot", "moonshotai"],
+  },
   opencode: {
     openAiCompatTurnValidation: false,
     geminiThoughtSignatureSanitization: true,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -92,7 +92,11 @@ export function resolveTranscriptPolicy(params: {
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
 
   const sanitizeToolCallIds =
-    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization;
+    isGoogle ||
+    isMistral ||
+    isAnthropic ||
+    requiresOpenAiCompatibleToolIdSanitization ||
+    !!providerToolCallIdMode;
   const toolCallIdMode: ToolCallIdMode | undefined = providerToolCallIdMode
     ? providerToolCallIdMode
     : isMistral


### PR DESCRIPTION
## Summary
- Add Moonshot/Kimi to `PLUGIN_CAPABILITIES_FALLBACKS` with `strict9` tool call ID sanitization
- Fixes issue where Moonshot's tool call IDs weren't being properly sanitized

## Testing
- Provider capabilities tests verify Moonshot returns `strict9` mode