### PR TITLE
fix(ui): update context percentage and token count after compaction

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -58,6 +58,7 @@ export type SessionListRow = {
   updatedAt?: number | null;
   sessionId?: string;
   model?: string;
+  inputTokens?: number;
   contextTokens?: number | null;
   totalTokens?: number | null;
   estimatedCostUsd?: number;

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -202,6 +202,7 @@ export function createSessionsListTool(opts?: {
           updatedAt: typeof entry.updatedAt === "number" ? entry.updatedAt : undefined,
           sessionId,
           model: typeof entry.model === "string" ? entry.model : undefined,
+          inputTokens: typeof entry.inputTokens === "number" ? entry.inputTokens : undefined,
           contextTokens: typeof entry.contextTokens === "number" ? entry.contextTokens : undefined,
           totalTokens: typeof entry.totalTokens === "number" ? entry.totalTokens : undefined,
           estimatedCostUsd:

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -286,8 +286,9 @@ export async function incrementCompactionCount(params: {
   if (tokensAfter != null && tokensAfter > 0) {
     updates.totalTokens = tokensAfter;
     updates.totalTokensFresh = true;
-    // Clear input/output breakdown since we only have the total estimate after compaction
-    updates.inputTokens = undefined;
+    // Set inputTokens to the post-compaction estimate so the UI context
+    // percentage reflects the compacted context size, not the pre-compaction value.
+    updates.inputTokens = tokensAfter;
     updates.outputTokens = undefined;
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -300,7 +300,7 @@ async function executeUsage(
     if (!session) {
       return { content: "No active session." };
     }
-    const input = session.inputTokens ?? 0;
+    const input = session.inputTokens ?? session.totalTokens ?? 0;
     const output = session.outputTokens ?? 0;
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,9 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  // After compaction inputTokens is cleared; fall back to totalTokens which
+  // reflects the post-compaction context estimate.
+  const used = session?.inputTokens ?? session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary
- Fix context percentage and token count not refreshing in the UI after session compaction
- Ensure session list and chat view reflect updated values when context is compacted

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51060
- Closes #50795
- Closes #50726