### PR TITLE
fix(minimax): correct inverted usage percentage calculation

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -96,7 +96,7 @@ describe("fetchMinimaxUsage", () => {
       expected: {
         plan: "Starter",
         windows: [
-          { label: "30m", usedPercent: 25, resetAt: new Date("2026-01-08T00:00:00Z").getTime() },
+          { label: "30m", usedPercent: 75, resetAt: new Date("2026-01-08T00:00:00Z").getTime() },
         ],
       },
     },
@@ -127,7 +127,7 @@ describe("fetchMinimaxUsage", () => {
       },
       expected: {
         plan: "Payload Plan",
-        windows: [{ label: "2h", usedPercent: 40, resetAt: 1_700_000_100_000 }],
+        windows: [{ label: "2h", usedPercent: 60, resetAt: 1_700_000_100_000 }],
       },
     },
   ])("$name", async ({ payload, expected }) => {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -290,7 +290,9 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
       // Count-derived usage is more stable across provider percent field variations.
       return fromCounts;
     }
-    return normalized;
+    // MiniMax's "remains" endpoint reports percent fields as the *remaining*
+    // share of the quota, not the *used* share.  Invert so callers see used%.
+    return clampPercent(100 - normalized);
   }
 
   return fromCounts;

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -234,7 +234,7 @@ describe("provider usage loading", () => {
           },
         },
       },
-      expected: { usedPercent: 40, plan: "Payload Plan", label: "2h" },
+      expected: { usedPercent: 60, plan: "Payload Plan", label: "2h" },
     },
   ])("$name", async ({ payload, expected }) => {
     await expectMinimaxUsage(payload, expected);


### PR DESCRIPTION
## Summary
- Fix Minimax provider usage percentage being calculated inverted (showing remaining instead of used, or vice versa)
- Correct the formula and update corresponding tests

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50372