### PR TITLE
fix(gateway): allow microphone in Permissions-Policy for STT

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -14,7 +14,7 @@ export function setDefaultSecurityHeaders(
 ) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
-  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Summary
- Fix speech-to-text not working due to microphone access being blocked by the HTTP Permissions-Policy header
- Update the gateway's common HTTP headers to allow microphone access

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51085