### PR TITLE
fix(providers): only send store param when supportsStore is true

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -790,7 +790,7 @@ export function createOpenAIWebSocketStreamFn(
       const payload: Record<string, unknown> = {
         type: "response.create",
         model: model.id,
-        ...(supportsStore !== false ? { store: false } : {}),
+        ...(supportsStore === true ? { store: false } : {}),
         input: inputItems,
         instructions: context.systemPrompt ?? undefined,
         tools: tools.length > 0 ? tools : undefined,


### PR DESCRIPTION
## Summary
- The condition `supportsStore !== false` incorrectly sent the `store` parameter when `supportsStore` was `undefined` (e.g. Cerebras), causing 400 errors from providers that reject unknown fields
- Changed to `supportsStore === true` so `store` is only included when explicitly opted in

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51058