### PR TITLE
fix(ui): constrain delete confirmation dialog within viewport

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -427,6 +427,8 @@ img.chat-avatar {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   z-index: 100;
   animation: scale-in 0.15s ease-out;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .chat-delete-confirm--left {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -363,6 +363,24 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
           `;
           wrap.appendChild(popover);
 
+          // Clamp popover within viewport bounds
+          requestAnimationFrame(() => {
+            const rect = popover.getBoundingClientRect();
+            if (rect.left < 8) {
+              popover.style.left = "0";
+              popover.style.right = "auto";
+              popover.style.transform = `translateX(${8 - rect.left}px)`;
+            } else if (rect.right > window.innerWidth - 8) {
+              popover.style.right = "0";
+              popover.style.left = "auto";
+              popover.style.transform = `translateX(${window.innerWidth - 8 - rect.right}px)`;
+            }
+            if (rect.top < 8) {
+              popover.style.bottom = "auto";
+              popover.style.top = "calc(100% + 6px)";
+            }
+          });
+
           const cancel = popover.querySelector(".chat-delete-confirm__cancel")!;
           const yes = popover.querySelector(".chat-delete-confirm__yes")!;
           const check = popover.querySelector(".chat-delete-confirm__check") as HTMLInputElement;


### PR DESCRIPTION
## Summary
- Fix the delete confirmation dialog overflowing outside the viewport on smaller screens or when triggered near screen edges
- Add CSS constraints and JS repositioning logic to keep the dialog fully visible

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50277