### PR TITLE
fix(onboard): use model-reported context window for LiteLLM

### DIFF
--- a/src/commands/onboard-auth.config-litellm.ts
+++ b/src/commands/onboard-auth.config-litellm.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { LITELLM_DEFAULT_MODEL_REF } from "../plugins/provider-auth-storage.js";
 import {
   applyAgentDefaultModelPrimary,
@@ -7,6 +8,9 @@ import {
 
 export const LITELLM_BASE_URL = "http://localhost:4000";
 export const LITELLM_DEFAULT_MODEL_ID = "claude-opus-4-6";
+// Fallback context window used only when the provider config does not include
+// a model-reported value.  Most LiteLLM deployments proxy models that report
+// their own context window; this constant is a safe last-resort default.
 const LITELLM_DEFAULT_CONTEXT_WINDOW = 128_000;
 const LITELLM_DEFAULT_MAX_TOKENS = 8_192;
 const LITELLM_DEFAULT_COST = {
@@ -16,7 +20,25 @@ const LITELLM_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-function buildLitellmModelDefinition(): {
+/**
+ * Resolve the context window for the default LiteLLM model.
+ *
+ * Preference order:
+ *  1. The contextWindow already defined on the matching model in the existing
+ *     provider config (i.e. a value the user or LiteLLM model-info reported).
+ *  2. {@link LITELLM_DEFAULT_CONTEXT_WINDOW} as a last-resort fallback.
+ */
+function resolveLitellmContextWindow(existingModels: ModelDefinitionConfig[] | undefined): number {
+  if (existingModels) {
+    const match = existingModels.find((m) => m.id === LITELLM_DEFAULT_MODEL_ID);
+    if (match && typeof match.contextWindow === "number" && match.contextWindow > 0) {
+      return match.contextWindow;
+    }
+  }
+  return LITELLM_DEFAULT_CONTEXT_WINDOW;
+}
+
+function buildLitellmModelDefinition(contextWindow: number): {
   id: string;
   name: string;
   reasoning: boolean;
@@ -31,7 +53,7 @@ function buildLitellmModelDefinition(): {
     reasoning: true,
     input: ["text", "image"],
     cost: LITELLM_DEFAULT_COST,
-    contextWindow: LITELLM_DEFAULT_CONTEXT_WINDOW,
+    contextWindow,
     maxTokens: LITELLM_DEFAULT_MAX_TOKENS,
   };
 }
@@ -43,9 +65,11 @@ export function applyLitellmProviderConfig(cfg: OpenClawConfig): OpenClawConfig 
     alias: models[LITELLM_DEFAULT_MODEL_REF]?.alias ?? "LiteLLM",
   };
 
-  const defaultModel = buildLitellmModelDefinition();
-
-  const existingProvider = cfg.models?.providers?.litellm as { baseUrl?: unknown } | undefined;
+  const existingProvider = cfg.models?.providers?.litellm as
+    | { baseUrl?: unknown; models?: ModelDefinitionConfig[] }
+    | undefined;
+  const resolvedContextWindow = resolveLitellmContextWindow(existingProvider?.models);
+  const defaultModel = buildLitellmModelDefinition(resolvedContextWindow);
   const resolvedBaseUrl =
     typeof existingProvider?.baseUrl === "string" ? existingProvider.baseUrl.trim() : "";
 


### PR DESCRIPTION
## Summary
- LiteLLM onboarding hardcoded `contextWindow` to 128k, overwriting the model-reported value on every re-onboard
- Added `resolveLitellmContextWindow()` that prefers the existing model config value and only falls back to the 128k default when none is available

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51055