### PR TITLE
fix(catalog): mark deepseek-v3.2 as supportsTools: true

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -168,7 +168,7 @@ export const VENICE_MODEL_CATALOG = [
     input: ["text"],
     contextWindow: 160000,
     maxTokens: 32768,
-    supportsTools: false,
+    supportsTools: true,
     privacy: "private",
   },
 


### PR DESCRIPTION
## Summary
- deepseek-v3.2 in the Venice model catalog had `supportsTools: false`, but the model does support tool calling
- Changed to `supportsTools: true` so tool-dependent features work correctly with this model

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #50476