### PR TITLE
fix(telegram): re-register AbortSignal listener after polling recovery restart

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -251,7 +251,7 @@ export class TelegramPollingSession {
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
 
-    this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    this.opts.abortSignal?.addEventListener("abort", stopOnAbort);
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {


### PR DESCRIPTION
## Summary
Removes the `{ once: true }` option from the AbortSignal `abort` event listener in the Telegram polling session. Previously, after a polling recovery restart, the `once` listener had already been consumed, so subsequent SIGTERM signals were silently ignored and the polling session would not shut down cleanly.

## Change Type
- [x] Bug fix

## Linked Issue
- Closes #51100