### PR TITLE
test: fix setup finalize web search mocks

### DIFF
--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -154,6 +154,21 @@ function createRuntime(): RuntimeEnv {
   };
 }
 
+function createWebSearchProviderEntry(
+  provider: Pick<
+    PluginWebSearchProviderEntry,
+    "id" | "label" | "hint" | "envVars" | "placeholder" | "signupUrl" | "credentialPath"
+  >,
+): PluginWebSearchProviderEntry {
+  return {
+    pluginId: `plugin-${provider.id}`,
+    getCredentialValue: () => undefined,
+    setCredentialValue: () => {},
+    createTool: () => null,
+    ...provider,
+  };
+}
+
 function expectFirstOnboardingInstallPlanCallOmitsToken() {
   const [firstArg] =
     (buildGatewayInstallPlan.mock.calls.at(0) as [Record<string, unknown>] | undefined) ?? [];
@@ -414,7 +429,7 @@ describe("finalizeSetupWizard", () => {
 
   it("only reports legacy auto-detect for runtime-visible providers", async () => {
     listConfiguredWebSearchProviders.mockReturnValue([
-      {
+      createWebSearchProviderEntry({
         id: "perplexity",
         label: "Perplexity Search",
         hint: "Fast web answers",
@@ -422,7 +437,7 @@ describe("finalizeSetupWizard", () => {
         placeholder: "pplx-...",
         signupUrl: "https://www.perplexity.ai/",
         credentialPath: "plugins.entries.perplexity.config.webSearch.apiKey",
-      },
+      }),
     ]);
     hasExistingKey.mockImplementation((_config, provider) => provider === "perplexity");
 
@@ -463,7 +478,7 @@ describe("finalizeSetupWizard", () => {
 
   it("uses configured provider resolution instead of the active runtime registry", async () => {
     listConfiguredWebSearchProviders.mockReturnValue([
-      {
+      createWebSearchProviderEntry({
         id: "firecrawl",
         label: "Firecrawl Search",
         hint: "Structured results",
@@ -471,7 +486,7 @@ describe("finalizeSetupWizard", () => {
         placeholder: "fc-...",
         signupUrl: "https://www.firecrawl.dev/",
         credentialPath: "plugins.entries.firecrawl.config.webSearch.apiKey",
-      },
+      }),
     ]);
     hasExistingKey.mockImplementation((_config, provider) => provider === "firecrawl");
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm tsgo` fails on current `origin/main` because `src/wizard/setup.finalize.test.ts` still mocks web-search providers with an outdated partial shape.
- Why it matters: the stale mock blocks repo typechecking even though the production provider contract is correct.
- What changed: added a small test helper that creates fully typed `PluginWebSearchProviderEntry` mocks, then reused it in the two affected cases.
- What did NOT change (scope boundary): no production runtime behavior, plugin contracts, or provider implementations changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51191

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 via pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Run `pnpm tsgo` on current `origin/main`.
2. Observe TypeScript errors in `src/wizard/setup.finalize.test.ts` for mocked `PluginWebSearchProviderEntry` values.
3. Apply this patch and rerun the same checks.

### Expected

- `pnpm tsgo` passes.
- `pnpm test -- src/wizard/setup.finalize.test.ts` passes.

### Actual

- Before: the test file failed typechecking because two mocks were missing required provider fields.
- After: both commands pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm tsgo` and `pnpm test -- src/wizard/setup.finalize.test.ts` both pass in this worktree.
- Edge cases checked: the helper preserves provider-specific metadata while satisfying the newer required runtime hook fields.
- What you did **not** verify: full `pnpm check` is currently blocked on an unrelated baseline mismatch in `src/plugins/bundled-web-search-registry.ts` already present on current `origin/main`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; it only affects test code.
- Files/config to restore: `src/wizard/setup.finalize.test.ts`
- Known bad symptoms reviewers should watch for: none beyond the original `pnpm tsgo` failure returning.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the helper could accidentally hide a future required field addition if its construction path stops matching the test intent.
  - Mitigation: it still returns a typed `PluginWebSearchProviderEntry`, so future required contract changes will continue surfacing at this single seam.
