### PR TITLE
feat: surface session label/displayName in /status and TUI

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -607,7 +607,7 @@ export async function statusCommand(
       rows:
         summary.sessions.recent.length > 0
           ? summary.sessions.recent.map((sess) => ({
-              Key: shortenText(sess.key, 32),
+              Key: shortenText(sess.displayName ?? sess.label ?? sess.key, 32),
               Kind: sess.kind,
               Age: sess.updatedAt ? formatTimeAgo(sess.age) : "no activity",
               Model: sess.model ?? "unknown",

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -292,6 +292,8 @@ export async function getStatusSummary(
           model,
           contextTokens,
           flags: buildFlags(entry),
+          label: entry?.label,
+          displayName: entry?.displayName,
         } satisfies SessionStatus;
       })
       .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -25,6 +25,8 @@ export type SessionStatus = {
   model: string | null;
   contextTokens: number | null;
   flags: string[];
+  label?: string;
+  displayName?: string;
 };
 
 export type HeartbeatStatus = {

--- a/src/tui/tui-status-summary.ts
+++ b/src/tui/tui-status-summary.ts
@@ -76,7 +76,7 @@ export function formatStatusSummary(summary: GatewayStatusSummary) {
       });
       const flags = entry.flags?.length ? ` | flags: ${entry.flags.join(", ")}` : "";
       lines.push(
-        `- ${entry.key}${entry.kind ? ` [${entry.kind}]` : ""} | ${ageLabel} | model ${model} | ${usage}${flags}`,
+        `- ${entry.displayName ?? entry.label ?? entry.key}${entry.kind ? ` [${entry.kind}]` : ""} | ${ageLabel} | model ${model} | ${usage}${flags}`,
       );
     }
   }

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -86,6 +86,8 @@ export type GatewayStatusSummary = {
     recent?: Array<{
       agentId?: string;
       key: string;
+      label?: string;
+      displayName?: string;
       kind?: string;
       updatedAt?: number | null;
       age?: number | null;


### PR DESCRIPTION
## Summary

Shows friendly session labels instead of raw UUID-heavy session keys in the `/status` command and TUI status summary.

**Before:**
```
- agent:main:cron:b03cbb21-9519-416c-8af0-effe954ae672:run:446baffc... [direct] | 25m ago | model claude-opus-4-6 | tokens 15k/1.0m
```

**After:**
```
- Cron: claude-keepalive [direct] | 25m ago | model claude-opus-4-6 | tokens 15k/1.0m
```

## Changes

The session store already has `label` and `displayName` fields (set by cron jobs, subagents via `sessions_spawn`, etc.) but they weren't being passed through to the status display layer.

This adds them to the pipeline:

1. **`SessionStatus` type** — added optional `label` and `displayName` fields
2. **Status summary builder** — reads `label`/`displayName` from session store entries
3. **CLI status command** — prefers `displayName → label → key` for the Key column
4. **TUI status summary** — same fallback chain for the session list
5. **TUI client types** — added fields to `GatewayStatusSummary` recent session type

Fallback chain ensures raw keys still display when no label is set.

Closes #51184