### PR TITLE
Fix Discord `/codex_resume` picker expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat.send: persist uploaded image references across reloads and compaction without delaying first-turn dispatch or double-submitting the same image to vision models. (#51324) Thanks @fuller-stack-dev.
 - Plugins/runtime state: share plugin-facing infra singleton state across duplicate module graphs and keep session-binding adapter ownership stable until the active owner unregisters. (#50725) thanks @huntharo.
 - Agents/compaction safeguard: preserve split-turn context and preserved recent turns when capped retry fallback reuses the last successful summary. (#27727) thanks @Pandadadadazxf.
+- Discord/pickers: keep `/codex_resume --browse-projects` picker callbacks alive in Discord by sharing component callback state across duplicate module graphs, preserving callback fallbacks, and acknowledging matched plugin interactions before dispatch. (#51260) Thanks @huntharo.
 
 ### Breaking
 

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -1,9 +1,23 @@
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
+const DISCORD_COMPONENT_ENTRIES_KEY = Symbol.for("openclaw.discord.componentEntries");
+const DISCORD_MODAL_ENTRIES_KEY = Symbol.for("openclaw.discord.modalEntries");
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+function resolveGlobalMap<TKey, TValue>(key: symbol): Map<TKey, TValue> {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  if (globalStore[key] instanceof Map) {
+    return globalStore[key] as Map<TKey, TValue>;
+  }
+  const created = new Map<TKey, TValue>();
+  globalStore[key] = created;
+  return created;
+}
+
+const componentEntries = resolveGlobalMap<string, DiscordComponentEntry>(
+  DISCORD_COMPONENT_ENTRIES_KEY,
+);
+const modalEntries = resolveGlobalMap<string, DiscordModalEntry>(DISCORD_MODAL_ENTRIES_KEY);
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,5 +1,5 @@
 import { MessageFlags } from "discord-api-types/v10";
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearDiscordComponentEntries,
   registerDiscordComponentEntries,
@@ -78,6 +78,8 @@ describe("discord component registry", () => {
     clearDiscordComponentEntries();
   });
 
+  const componentsRegistryModuleUrl = new URL("./components-registry.ts", import.meta.url).href;
+
   it("registers and consumes component entries", () => {
     registerDiscordComponentEntries({
       entries: [{ id: "btn_1", kind: "button", label: "Confirm" }],
@@ -101,5 +103,29 @@ describe("discord component registry", () => {
     const consumed = resolveDiscordComponentEntry({ id: "btn_1" });
     expect(consumed?.id).toBe("btn_1");
     expect(resolveDiscordComponentEntry({ id: "btn_1" })).toBeNull();
+  });
+
+  it("shares registry state across duplicate module instances", async () => {
+    const first = (await import(
+      `${componentsRegistryModuleUrl}?t=first-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+    const second = (await import(
+      `${componentsRegistryModuleUrl}?t=second-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+
+    first.clearDiscordComponentEntries();
+    first.registerDiscordComponentEntries({
+      entries: [{ id: "btn_shared", kind: "button", label: "Shared" }],
+      modals: [],
+    });
+
+    expect(second.resolveDiscordComponentEntry({ id: "btn_shared", consume: false })).toMatchObject(
+      {
+        id: "btn_shared",
+        label: "Shared",
+      },
+    );
+
+    second.clearDiscordComponentEntries();
   });
 });

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -614,10 +614,11 @@ async function handleDiscordComponentEvent(params: {
       return;
     }
   }
-  // Preserve explicit callback payloads for the built-in fallback path so
-  // Discord behaves like Telegram when buttons carry synthetic command text.
+  // Preserve explicit callback payloads for button fallbacks so Discord
+  // behaves like Telegram when buttons carry synthetic command text. Select
+  // fallbacks still need their chosen values in the synthesized event text.
   const eventText =
-    consumed.callbackData?.trim() ||
+    (consumed.kind === "button" ? consumed.callbackData?.trim() : undefined) ||
     formatDiscordComponentEventText({
       kind: consumed.kind === "select" ? "select" : "button",
       label: consumed.label,

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -121,10 +121,34 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       ? `channel:${params.interactionCtx.channelId}`
       : `user:${params.interactionCtx.userId}`;
   let responded = false;
+  let acknowledged = false;
+  const updateOriginalMessage = async (input: {
+    text?: string;
+    components?: TopLevelComponents[];
+  }) => {
+    const payload = {
+      ...(input.text !== undefined ? { content: input.text } : {}),
+      ...(input.components !== undefined ? { components: input.components } : {}),
+    };
+    if (acknowledged) {
+      // Carbon edits @original on reply() after acknowledge(), which preserves
+      // plugin edit/clear flows without consuming a second interaction callback.
+      await params.interaction.reply(payload);
+      return;
+    }
+    if (!("update" in params.interaction) || typeof params.interaction.update !== "function") {
+      throw new Error("Discord interaction cannot update the source message");
+    }
+    await params.interaction.update(payload);
+  };
   const respond: PluginInteractiveDiscordHandlerContext["respond"] = {
     acknowledge: async () => {
-      responded = true;
+      if (responded) {
+        return;
+      }
       await params.interaction.acknowledge();
+      acknowledged = true;
+      responded = true;
     },
     reply: async ({ text, ephemeral = true }: { text: string; ephemeral?: boolean }) => {
       responded = true;
@@ -141,23 +165,17 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       });
     },
     editMessage: async (input) => {
-      if (!("update" in params.interaction) || typeof params.interaction.update !== "function") {
-        throw new Error("Discord interaction cannot update the source message");
-      }
       const { text, components } = input;
       responded = true;
-      await params.interaction.update({
-        ...(text !== undefined ? { content: text } : {}),
-        ...(components !== undefined ? { components: components as TopLevelComponents[] } : {}),
+      await updateOriginalMessage({
+        text,
+        components: components as TopLevelComponents[] | undefined,
       });
     },
     clearComponents: async (input?: { text?: string }) => {
-      if (!("update" in params.interaction) || typeof params.interaction.update !== "function") {
-        throw new Error("Discord interaction cannot clear components on the source message");
-      }
       responded = true;
-      await params.interaction.update({
-        ...(input?.text !== undefined ? { content: input.text } : {}),
+      await updateOriginalMessage({
+        text: input?.text,
         components: [],
       });
     },
@@ -224,6 +242,13 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       },
     },
     respond,
+    onMatched: async () => {
+      try {
+        await respond.acknowledge();
+      } catch {
+        // Interaction may have expired before the plugin handler ran.
+      }
+    },
   });
   if (!dispatched.matched) {
     return "unmatched";

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -168,10 +168,11 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       decision: pluginBindingApproval.decision,
       senderId: params.interactionCtx.userId,
     });
-    let cleared = false;
     try {
-      await respond.clearComponents();
-      cleared = true;
+      await respond.clearComponents({
+        text: buildPluginBindingResolvedText(resolved),
+      });
+      return "handled";
     } catch {
       try {
         await respond.acknowledge();
@@ -180,21 +181,19 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       }
     }
     try {
-      await respond.followUp({
+      await respond.reply({
         text: buildPluginBindingResolvedText(resolved),
         ephemeral: true,
       });
     } catch (err) {
-      logError(`discord plugin binding approval: failed to follow up: ${String(err)}`);
-      if (!cleared) {
-        try {
-          await respond.reply({
-            text: buildPluginBindingResolvedText(resolved),
-            ephemeral: true,
-          });
-        } catch {
-          // Interaction may no longer accept a direct reply.
-        }
+      logError(`discord plugin binding approval: failed to reply: ${String(err)}`);
+      try {
+        await respond.followUp({
+          text: buildPluginBindingResolvedText(resolved),
+          ephemeral: true,
+        });
+      } catch {
+        // Interaction may no longer accept a follow-up.
       }
     }
     return "handled";

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -59,6 +59,7 @@ import {
   type DiscordComponentEntry,
   type DiscordModalEntry,
 } from "../components.js";
+import { editDiscordComponentMessage } from "../send.components.js";
 import {
   AGENT_BUTTON_KEY,
   AGENT_SELECT_KEY,
@@ -173,6 +174,23 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
       decision: pluginBindingApproval.decision,
       senderId: params.interactionCtx.userId,
     });
+    const approvalMessageId = params.messageId?.trim() || params.interaction.message?.id?.trim();
+    if (approvalMessageId) {
+      try {
+        await editDiscordComponentMessage(
+          normalizedConversationId,
+          approvalMessageId,
+          {
+            text: buildPluginBindingResolvedText(resolved),
+          },
+          {
+            accountId: params.ctx.accountId,
+          },
+        );
+      } catch (err) {
+        logError(`discord plugin binding approval: failed to clear prompt: ${String(err)}`);
+      }
+    }
     if (resolved.status !== "approved") {
       try {
         await respond.followUp({

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -163,37 +163,24 @@ async function dispatchPluginDiscordInteractiveEvent(params: {
   };
   const pluginBindingApproval = parsePluginBindingApprovalCustomId(params.data);
   if (pluginBindingApproval) {
+    try {
+      await respond.acknowledge();
+    } catch {
+      // Interaction may have expired; try to continue anyway.
+    }
     const resolved = await resolvePluginConversationBindingApproval({
       approvalId: pluginBindingApproval.approvalId,
       decision: pluginBindingApproval.decision,
       senderId: params.interactionCtx.userId,
     });
-    try {
-      await respond.clearComponents({
-        text: buildPluginBindingResolvedText(resolved),
-      });
-      return "handled";
-    } catch {
-      try {
-        await respond.acknowledge();
-      } catch {
-        // Interaction may already be acknowledged; continue with best-effort follow-up.
-      }
-    }
-    try {
-      await respond.reply({
-        text: buildPluginBindingResolvedText(resolved),
-        ephemeral: true,
-      });
-    } catch (err) {
-      logError(`discord plugin binding approval: failed to reply: ${String(err)}`);
+    if (resolved.status !== "approved") {
       try {
         await respond.followUp({
           text: buildPluginBindingResolvedText(resolved),
           ephemeral: true,
         });
-      } catch {
-        // Interaction may no longer accept a follow-up.
+      } catch (err) {
+        logError(`discord plugin binding approval: failed to follow up: ${String(err)}`);
       }
     }
     return "handled";

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -509,6 +509,7 @@ async function handleDiscordComponentEvent(params: {
     interaction: params.interaction,
     label: params.label,
     componentLabel: params.componentLabel,
+    defer: false,
   });
   if (!interactionCtx) {
     return;
@@ -814,6 +815,7 @@ export class AgentComponentButton extends Button {
       interaction,
       label: "agent button",
       componentLabel: "button",
+      defer: false,
     });
     if (!interactionCtx) {
       return;
@@ -903,6 +905,7 @@ export class AgentSelectMenu extends StringSelectMenu {
       interaction,
       label: "agent select",
       componentLabel: "select menu",
+      defer: false,
     });
     if (!interactionCtx) {
       return;

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -614,11 +614,15 @@ async function handleDiscordComponentEvent(params: {
       return;
     }
   }
-  const eventText = formatDiscordComponentEventText({
-    kind: consumed.kind === "select" ? "select" : "button",
-    label: consumed.label,
-    values,
-  });
+  // Preserve explicit callback payloads for the built-in fallback path so
+  // Discord behaves like Telegram when buttons carry synthetic command text.
+  const eventText =
+    consumed.callbackData?.trim() ||
+    formatDiscordComponentEventText({
+      kind: consumed.kind === "select" ? "select" : "button",
+      label: consumed.label,
+      values,
+    });
 
   try {
     await params.interaction.reply({ content: "✓", ...replyOpts });

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -885,6 +885,43 @@ describe("discord component interactions", () => {
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
+  it("lets plugin Discord interactions clear components after acknowledging", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry({ callbackData: "codex:approve" })],
+      modals: [],
+    });
+    dispatchPluginInteractiveHandlerMock.mockImplementation(async (params: any) => {
+      await params.respond.acknowledge();
+      await params.respond.clearComponents({ text: "Handled" });
+      return {
+        matched: true,
+        handled: true,
+        duplicate: false,
+      };
+    });
+
+    const button = createDiscordComponentButton(createComponentContext());
+    const acknowledge = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      ...(createComponentButtonInteraction().interaction as any),
+      acknowledge,
+      reply,
+      update,
+    } as ButtonInteraction;
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(reply).toHaveBeenCalledWith({
+      content: "Handled",
+      components: [],
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
   it("falls through to built-in Discord component routing when a plugin declines handling", async () => {
     registerDiscordComponentEntries({
       entries: [createButtonEntry({ callbackData: "codex:approve" })],

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -918,11 +918,13 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(update).toHaveBeenCalledWith({ components: [] });
-    expect(followUp).toHaveBeenCalledWith({
-      content: expect.stringContaining("bind approval"),
-      ephemeral: true,
-    });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.any(String),
+        components: [],
+      }),
+    );
+    expect(followUp).not.toHaveBeenCalled();
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -517,6 +517,22 @@ describe("discord component interactions", () => {
     expect(resolveDiscordComponentEntry({ id: "btn_1" })).toBeNull();
   });
 
+  it("uses raw callbackData for built-in fallback when no plugin handler matches", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry({ callbackData: "/codex_resume --browse-projects" })],
+      modals: [],
+    });
+
+    const button = createDiscordComponentButton(createComponentContext());
+    const { interaction, reply } = createComponentButtonInteraction();
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(lastDispatchCtx?.BodyForAgent).toBe("/codex_resume --browse-projects");
+    expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps reusable buttons active after use", async () => {
     registerDiscordComponentEntries({
       entries: [createButtonEntry({ reusable: true })],

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -19,6 +19,7 @@ import {
   resolveDiscordModalEntry,
 } from "../components-registry.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
+import * as sendComponents from "../send.components.js";
 import {
   createAgentComponentButton,
   createAgentSelectMenu,
@@ -344,6 +345,7 @@ describe("agent components", () => {
 });
 
 describe("discord component interactions", () => {
+  let editDiscordComponentMessageMock: ReturnType<typeof vi.spyOn>;
   const createCfg = (): OpenClawConfig =>
     ({
       channels: {
@@ -486,6 +488,12 @@ describe("discord component interactions", () => {
   });
 
   beforeEach(() => {
+    editDiscordComponentMessageMock = vi
+      .spyOn(sendComponents, "editDiscordComponentMessage")
+      .mockResolvedValue({
+        messageId: "msg-1",
+        channelId: "dm-channel",
+      });
     clearDiscordComponentEntries();
     lastDispatchCtx = undefined;
     readAllowFromStoreMock.mockClear().mockResolvedValue([]);
@@ -919,6 +927,12 @@ describe("discord component interactions", () => {
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
     expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(editDiscordComponentMessageMock).toHaveBeenCalledWith(
+      "user:123456789",
+      "msg-1",
+      { text: expect.any(String) },
+      { accountId: "default" },
+    );
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -23,6 +23,7 @@ import {
   createAgentComponentButton,
   createAgentSelectMenu,
   createDiscordComponentButton,
+  createDiscordComponentStringSelect,
   createDiscordComponentModal,
 } from "./agent-components.js";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
@@ -394,6 +395,31 @@ describe("discord component interactions", () => {
     return { interaction, defer, reply };
   };
 
+  const createComponentSelectInteraction = (
+    overrides: Partial<StringSelectMenuInteraction> = {},
+  ) => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const defer = vi.fn().mockResolvedValue(undefined);
+    const rest = {
+      get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
+      post: vi.fn().mockResolvedValue({}),
+      patch: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = {
+      rawData: { channel_id: "dm-channel", id: "interaction-select-1" },
+      user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
+      customId: "occomp:cid=sel_1",
+      message: { id: "msg-1" },
+      values: ["alpha"],
+      client: { rest },
+      defer,
+      reply,
+      ...overrides,
+    } as unknown as StringSelectMenuInteraction;
+    return { interaction, defer, reply };
+  };
+
   const createModalInteraction = (overrides: Partial<ModalInteraction> = {}) => {
     const reply = vi.fn().mockResolvedValue(undefined);
     const acknowledge = vi.fn().mockResolvedValue(undefined);
@@ -530,6 +556,35 @@ describe("discord component interactions", () => {
 
     expect(reply).toHaveBeenCalledWith({ content: "✓" });
     expect(lastDispatchCtx?.BodyForAgent).toBe("/codex_resume --browse-projects");
+    expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves selected values for select fallback when no plugin handler matches", async () => {
+    registerDiscordComponentEntries({
+      entries: [
+        {
+          id: "sel_1",
+          kind: "select",
+          label: "Pick",
+          messageId: "msg-1",
+          sessionKey: "session-1",
+          agentId: "agent-1",
+          accountId: "default",
+          callbackData: "/codex_resume",
+          selectType: "string",
+          options: [{ value: "alpha", label: "Alpha" }],
+        },
+      ],
+      modals: [],
+    });
+
+    const select = createDiscordComponentStringSelect(createComponentContext());
+    const { interaction, reply } = createComponentSelectInteraction();
+
+    await select.run(interaction, { cid: "sel_1" } as ComponentData);
+
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(lastDispatchCtx?.BodyForAgent).toBe('Selected Alpha from "Pick".');
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -908,23 +908,17 @@ describe("discord component interactions", () => {
       modals: [],
     });
     const button = createDiscordComponentButton(createComponentContext());
-    const update = vi.fn().mockResolvedValue(undefined);
+    const acknowledge = vi.fn().mockResolvedValue(undefined);
     const followUp = vi.fn().mockResolvedValue(undefined);
     const interaction = {
       ...(createComponentButtonInteraction().interaction as any),
-      update,
+      acknowledge,
       followUp,
     } as ButtonInteraction;
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.any(String),
-        components: [],
-      }),
-    );
-    expect(followUp).not.toHaveBeenCalled();
+    expect(acknowledge).toHaveBeenCalledTimes(1);
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -199,7 +199,7 @@ describe("agent components", () => {
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
+    expect(defer).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledTimes(1);
     const pairingText = String(reply.mock.calls[0]?.[0]?.content ?? "");
     expect(pairingText).toContain("Pairing code:");
@@ -220,8 +220,11 @@ describe("agent components", () => {
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "You are not authorized to use this button." });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({
+      content: "You are not authorized to use this button.",
+      ephemeral: true,
+    });
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
@@ -237,8 +240,8 @@ describe("agent components", () => {
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
     expect(upsertPairingRequestMock).not.toHaveBeenCalled();
     expect(readAllowFromStoreMock).toHaveBeenCalledWith("discord", "default");
@@ -255,8 +258,8 @@ describe("agent components", () => {
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
@@ -272,8 +275,11 @@ describe("agent components", () => {
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "DM interactions are disabled." });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({
+      content: "DM interactions are disabled.",
+      ephemeral: true,
+    });
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
@@ -290,8 +296,8 @@ describe("agent components", () => {
 
     await select.run(interaction, { componentId: "hello" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
@@ -307,8 +313,8 @@ describe("agent components", () => {
 
     await button.run(interaction, { cid: "hello_cid" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       expect.stringContaining("hello_cid"),
       expect.any(Object),
@@ -327,8 +333,8 @@ describe("agent components", () => {
 
     await button.run(interaction, { cid: "hello%2G" } as ComponentData);
 
-    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(defer).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       expect.stringContaining("hello%2G"),
       expect.any(Object),
@@ -537,7 +543,7 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(lastDispatchCtx?.BodyForAgent).toBe('Clicked "Approve".');
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
     expect(resolveDiscordComponentEntry({ id: "btn_1" })).toBeNull();
@@ -554,7 +560,7 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(lastDispatchCtx?.BodyForAgent).toBe("/codex_resume --browse-projects");
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
@@ -583,7 +589,7 @@ describe("discord component interactions", () => {
 
     await select.run(interaction, { cid: "sel_1" } as ComponentData);
 
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(lastDispatchCtx?.BodyForAgent).toBe('Selected Alpha from "Pick".');
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
@@ -621,7 +627,10 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).toHaveBeenCalledWith({ content: "You are not authorized to use this button." });
+    expect(reply).toHaveBeenCalledWith({
+      content: "You are not authorized to use this button.",
+      ephemeral: true,
+    });
     expect(dispatchReplyMock).not.toHaveBeenCalled();
     expect(resolveDiscordComponentEntry({ id: "btn_1", consume: false })).not.toBeNull();
   });
@@ -885,7 +894,7 @@ describe("discord component interactions", () => {
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
     expect(dispatchPluginInteractiveHandlerMock).toHaveBeenCalledTimes(1);
-    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -1,7 +1,7 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerDiscordComponentEntries } from "./components-registry.js";
-import { sendDiscordComponentMessage } from "./send.components.js";
+import { editDiscordComponentMessage, sendDiscordComponentMessage } from "./send.components.js";
 import { makeDiscordRest } from "./send.test-harness.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ session: { dmScope: "main" } })));
@@ -51,5 +51,40 @@ describe("sendDiscordComponentMessage", () => {
     expect(registerMock).toHaveBeenCalledTimes(1);
     const args = registerMock.mock.calls[0]?.[0];
     expect(args?.entries[0]?.sessionKey).toBe("agent:main:discord:channel:dm-1");
+  });
+
+  it("edits component messages and refreshes component registry entries", async () => {
+    const { rest, patchMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildText,
+      id: "chan-1",
+    });
+    patchMock.mockResolvedValueOnce({ id: "msg1", channel_id: "chan-1" });
+
+    await editDiscordComponentMessage(
+      "channel:chan-1",
+      "msg1",
+      {
+        text: "Updated picker",
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      },
+      {
+        rest,
+        token: "t",
+        sessionKey: "agent:main:discord:channel:chan-1",
+        agentId: "main",
+      },
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/channels/chan-1/messages/msg1"),
+      expect.objectContaining({
+        body: expect.any(Object),
+      }),
+    );
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    const args = registerMock.mock.calls[0]?.[0];
+    expect(args?.messageId).toBe("msg1");
+    expect(args?.entries[0]?.sessionKey).toBe("agent:main:discord:channel:chan-1");
   });
 });

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -1,7 +1,11 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerDiscordComponentEntries } from "./components-registry.js";
-import { editDiscordComponentMessage, sendDiscordComponentMessage } from "./send.components.js";
+import {
+  editDiscordComponentMessage,
+  registerBuiltDiscordComponentMessage,
+  sendDiscordComponentMessage,
+} from "./send.components.js";
 import { makeDiscordRest } from "./send.test-harness.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ session: { dmScope: "main" } })));
@@ -86,5 +90,22 @@ describe("sendDiscordComponentMessage", () => {
     const args = registerMock.mock.calls[0]?.[0];
     expect(args?.messageId).toBe("msg1");
     expect(args?.entries[0]?.sessionKey).toBe("agent:main:discord:channel:chan-1");
+  });
+
+  it("registers a prebuilt component message against an edited message id", () => {
+    registerBuiltDiscordComponentMessage({
+      messageId: "msg1",
+      buildResult: {
+        components: [],
+        entries: [{ id: "entry-1", kind: "button", label: "Tap" }],
+        modals: [{ id: "modal-1", title: "Modal", fields: [] }],
+      },
+    });
+
+    expect(registerMock).toHaveBeenCalledWith({
+      entries: [{ id: "entry-1", kind: "button", label: "Tap" }],
+      modals: [{ id: "modal-1", title: "Modal", fields: [] }],
+      messageId: "msg1",
+    });
   });
 });

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -54,38 +54,29 @@ type DiscordComponentSendOpts = {
   filename?: string;
 };
 
-export async function sendDiscordComponentMessage(
-  to: string,
-  spec: DiscordComponentMessageSpec,
-  opts: DiscordComponentSendOpts = {},
-): Promise<DiscordSendResult> {
-  const cfg = opts.cfg ?? loadConfig();
-  const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
-  const { token, rest, request } = createDiscordClient(opts, cfg);
-  const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
-  const { channelId } = await resolveChannelId(rest, recipient, request);
-
-  const channelType = await resolveDiscordChannelType(rest, channelId);
-
-  if (channelType && DISCORD_FORUM_LIKE_TYPES.has(channelType)) {
-    throw new Error("Discord components are not supported in forum-style channels");
-  }
-
+async function buildDiscordComponentPayload(params: {
+  spec: DiscordComponentMessageSpec;
+  opts: DiscordComponentSendOpts;
+  accountId: string;
+}): Promise<{
+  body: ReturnType<typeof stripUndefinedFields>;
+  buildResult: ReturnType<typeof buildDiscordComponentMessage>;
+}> {
   const buildResult = buildDiscordComponentMessage({
-    spec,
-    sessionKey: opts.sessionKey,
-    agentId: opts.agentId,
-    accountId: accountInfo.accountId,
+    spec: params.spec,
+    sessionKey: params.opts.sessionKey,
+    agentId: params.opts.agentId,
+    accountId: params.accountId,
   });
   const flags = buildDiscordComponentMessageFlags(buildResult.components);
-  const finalFlags = opts.silent
+  const finalFlags = params.opts.silent
     ? (flags ?? 0) | SUPPRESS_NOTIFICATIONS_FLAG
     : (flags ?? undefined);
-  const messageReference = opts.replyTo
-    ? { message_id: opts.replyTo, fail_if_not_exists: false }
+  const messageReference = params.opts.replyTo
+    ? { message_id: params.opts.replyTo, fail_if_not_exists: false }
     : undefined;
 
-  const attachmentNames = extractComponentAttachmentNames(spec);
+  const attachmentNames = extractComponentAttachmentNames(params.spec);
   const uniqueAttachmentNames = [...new Set(attachmentNames)];
   if (uniqueAttachmentNames.length > 1) {
     throw new Error(
@@ -94,9 +85,11 @@ export async function sendDiscordComponentMessage(
   }
   const expectedAttachmentName = uniqueAttachmentNames[0];
   let files: MessagePayloadFile[] | undefined;
-  if (opts.mediaUrl) {
-    const media = await loadWebMedia(opts.mediaUrl, { localRoots: opts.mediaLocalRoots });
-    const filenameOverride = opts.filename?.trim();
+  if (params.opts.mediaUrl) {
+    const media = await loadWebMedia(params.opts.mediaUrl, {
+      localRoots: params.opts.mediaLocalRoots,
+    });
+    const filenameOverride = params.opts.filename?.trim();
     const fileName = filenameOverride || media.fileName || "upload";
     if (expectedAttachmentName && expectedAttachmentName !== fileName) {
       throw new Error(
@@ -121,6 +114,32 @@ export async function sendDiscordComponentMessage(
     ...(messageReference ? { message_reference: messageReference } : {}),
   });
 
+  return { body, buildResult };
+}
+
+export async function sendDiscordComponentMessage(
+  to: string,
+  spec: DiscordComponentMessageSpec,
+  opts: DiscordComponentSendOpts = {},
+): Promise<DiscordSendResult> {
+  const cfg = opts.cfg ?? loadConfig();
+  const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
+  const { token, rest, request } = createDiscordClient(opts, cfg);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
+  const { channelId } = await resolveChannelId(rest, recipient, request);
+
+  const channelType = await resolveDiscordChannelType(rest, channelId);
+
+  if (channelType && DISCORD_FORUM_LIKE_TYPES.has(channelType)) {
+    throw new Error("Discord components are not supported in forum-style channels");
+  }
+
+  const { body, buildResult } = await buildDiscordComponentPayload({
+    spec,
+    opts,
+    accountId: accountInfo.accountId,
+  });
+
   let result: { id: string; channel_id: string };
   try {
     result = (await request(
@@ -135,7 +154,7 @@ export async function sendDiscordComponentMessage(
       channelId,
       rest,
       token,
-      hasMedia: Boolean(files?.length),
+      hasMedia: Boolean(opts.mediaUrl),
     });
   }
 
@@ -153,6 +172,59 @@ export async function sendDiscordComponentMessage(
 
   return {
     messageId: result.id ?? "unknown",
+    channelId: result.channel_id ?? channelId,
+  };
+}
+
+export async function editDiscordComponentMessage(
+  to: string,
+  messageId: string,
+  spec: DiscordComponentMessageSpec,
+  opts: DiscordComponentSendOpts = {},
+): Promise<DiscordSendResult> {
+  const cfg = opts.cfg ?? loadConfig();
+  const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
+  const { token, rest, request } = createDiscordClient(opts, cfg);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
+  const { channelId } = await resolveChannelId(rest, recipient, request);
+  const { body, buildResult } = await buildDiscordComponentPayload({
+    spec,
+    opts,
+    accountId: accountInfo.accountId,
+  });
+
+  let result: { id: string; channel_id: string };
+  try {
+    result = (await request(
+      () =>
+        rest.patch(Routes.channelMessage(channelId, messageId), {
+          body,
+        }) as Promise<{ id: string; channel_id: string }>,
+      "components",
+    )) as { id: string; channel_id: string };
+  } catch (err) {
+    throw await buildDiscordSendError(err, {
+      channelId,
+      rest,
+      token,
+      hasMedia: Boolean(opts.mediaUrl),
+    });
+  }
+
+  registerDiscordComponentEntries({
+    entries: buildResult.entries,
+    modals: buildResult.modals,
+    messageId: result.id ?? messageId,
+  });
+
+  recordChannelActivity({
+    channel: "discord",
+    accountId: accountInfo.accountId,
+    direction: "outbound",
+  });
+
+  return {
+    messageId: result.id ?? messageId,
     channelId: result.channel_id ?? channelId,
   };
 }

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -14,6 +14,7 @@ import {
   buildDiscordComponentMessage,
   buildDiscordComponentMessageFlags,
   resolveDiscordComponentAttachmentName,
+  type DiscordComponentBuildResult,
   type DiscordComponentMessageSpec,
 } from "./components.js";
 import {
@@ -53,6 +54,17 @@ type DiscordComponentSendOpts = {
   mediaLocalRoots?: readonly string[];
   filename?: string;
 };
+
+export function registerBuiltDiscordComponentMessage(params: {
+  buildResult: DiscordComponentBuildResult;
+  messageId: string;
+}): void {
+  registerDiscordComponentEntries({
+    entries: params.buildResult.entries,
+    modals: params.buildResult.modals,
+    messageId: params.messageId,
+  });
+}
 
 async function buildDiscordComponentPayload(params: {
   spec: DiscordComponentMessageSpec;
@@ -158,9 +170,8 @@ export async function sendDiscordComponentMessage(
     });
   }
 
-  registerDiscordComponentEntries({
-    entries: buildResult.entries,
-    modals: buildResult.modals,
+  registerBuiltDiscordComponentMessage({
+    buildResult,
     messageId: result.id,
   });
 
@@ -211,9 +222,8 @@ export async function editDiscordComponentMessage(
     });
   }
 
-  registerDiscordComponentEntries({
-    entries: buildResult.entries,
-    modals: buildResult.modals,
+  registerBuiltDiscordComponentMessage({
+    buildResult,
     messageId: result.id ?? messageId,
   });
 

--- a/extensions/discord/src/send.ts
+++ b/extensions/discord/src/send.ts
@@ -44,7 +44,11 @@ export {
   sendWebhookMessageDiscord,
   sendVoiceMessageDiscord,
 } from "./send.outbound.js";
-export { editDiscordComponentMessage, sendDiscordComponentMessage } from "./send.components.js";
+export {
+  editDiscordComponentMessage,
+  registerBuiltDiscordComponentMessage,
+  sendDiscordComponentMessage,
+} from "./send.components.js";
 export { sendTypingDiscord } from "./send.typing.js";
 export {
   fetchChannelPermissionsDiscord,

--- a/extensions/discord/src/send.ts
+++ b/extensions/discord/src/send.ts
@@ -44,7 +44,7 @@ export {
   sendWebhookMessageDiscord,
   sendVoiceMessageDiscord,
 } from "./send.outbound.js";
-export { sendDiscordComponentMessage } from "./send.components.js";
+export { editDiscordComponentMessage, sendDiscordComponentMessage } from "./send.components.js";
 export { sendTypingDiscord } from "./send.typing.js";
 export {
   fetchChannelPermissionsDiscord,

--- a/package.json
+++ b/package.json
@@ -245,10 +245,6 @@
       "types": "./dist/plugin-sdk/discord.d.ts",
       "default": "./dist/plugin-sdk/discord.js"
     },
-    "./plugin-sdk/discord-core": {
-      "types": "./dist/plugin-sdk/discord-core.d.ts",
-      "default": "./dist/plugin-sdk/discord-core.js"
-    },
     "./plugin-sdk/extension-shared": {
       "types": "./dist/plugin-sdk/extension-shared.d.ts",
       "default": "./dist/plugin-sdk/extension-shared.js"

--- a/package.json
+++ b/package.json
@@ -241,6 +241,14 @@
       "types": "./dist/plugin-sdk/diffs.d.ts",
       "default": "./dist/plugin-sdk/diffs.js"
     },
+    "./plugin-sdk/discord": {
+      "types": "./dist/plugin-sdk/discord.d.ts",
+      "default": "./dist/plugin-sdk/discord.js"
+    },
+    "./plugin-sdk/discord-core": {
+      "types": "./dist/plugin-sdk/discord-core.d.ts",
+      "default": "./dist/plugin-sdk/discord-core.js"
+    },
     "./plugin-sdk/extension-shared": {
       "types": "./dist/plugin-sdk/extension-shared.d.ts",
       "default": "./dist/plugin-sdk/extension-shared.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -51,7 +51,6 @@
   "diagnostics-otel",
   "diffs",
   "discord",
-  "discord-core",
   "extension-shared",
   "channel-config-helpers",
   "channel-config-schema",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -50,6 +50,8 @@
   "device-bootstrap",
   "diagnostics-otel",
   "diffs",
+  "discord",
+  "discord-core",
   "extension-shared",
   "channel-config-helpers",
   "channel-config-schema",

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -108,6 +108,7 @@ export {
   createScheduledEventDiscord,
   createThreadDiscord,
   deleteChannelDiscord,
+  editDiscordComponentMessage,
   deleteMessageDiscord,
   editChannelDiscord,
   editMessageDiscord,

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -109,6 +109,7 @@ export {
   createThreadDiscord,
   deleteChannelDiscord,
   editDiscordComponentMessage,
+  registerBuiltDiscordComponentMessage,
   deleteMessageDiscord,
   editChannelDiscord,
   editMessageDiscord,

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -9,6 +9,7 @@ export type { DiscordConfig, DiscordPluralKitConfig } from "../config/types.disc
 export type { InspectedDiscordAccount } from "../../extensions/discord/api.js";
 export type { ResolvedDiscordAccount } from "../../extensions/discord/api.js";
 export type { DiscordSendComponents, DiscordSendEmbeds } from "../../extensions/discord/api.js";
+export type { DiscordComponentMessageSpec } from "../../extensions/discord/api.js";
 export type {
   ThreadBindingManager,
   ThreadBindingRecord,
@@ -64,8 +65,10 @@ export {
 } from "./status-helpers.js";
 
 export {
+  buildDiscordComponentMessage,
   createDiscordActionGate,
   listDiscordAccountIds,
+  resolveDiscordAccount,
   resolveDefaultDiscordAccountId,
 } from "../../extensions/discord/api.js";
 export { inspectDiscordAccount } from "../../extensions/discord/api.js";

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -9,6 +9,7 @@ const require = createRequire(import.meta.url);
 const rootSdk = require("./root-alias.cjs") as Record<string, unknown>;
 const rootAliasPath = fileURLToPath(new URL("./root-alias.cjs", import.meta.url));
 const rootAliasSource = fs.readFileSync(rootAliasPath, "utf-8");
+const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
 
 type EmptySchema = {
   safeParse: (value: unknown) =>
@@ -194,6 +195,15 @@ describe("plugin-sdk root alias", () => {
     expect(typeof rootSdk.default).toBe("object");
     expect(rootSdk.default).toBe(rootSdk);
     expect(rootSdk.__esModule).toBe(true);
+  });
+
+  it("publishes Discord plugin-sdk subpaths", () => {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      exports?: Record<string, unknown>;
+    };
+
+    expect(packageJson.exports?.["./plugin-sdk/discord"]).toBeDefined();
+    expect(packageJson.exports?.["./plugin-sdk/discord-core"]).toBeDefined();
   });
 
   it("preserves reflection semantics for lazily resolved exports", { timeout: 240_000 }, () => {

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -197,13 +197,12 @@ describe("plugin-sdk root alias", () => {
     expect(rootSdk.__esModule).toBe(true);
   });
 
-  it("publishes Discord plugin-sdk subpaths", () => {
+  it("publishes the Discord plugin-sdk subpath", () => {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
 
     expect(packageJson.exports?.["./plugin-sdk/discord"]).toBeDefined();
-    expect(packageJson.exports?.["./plugin-sdk/discord-core"]).toBeDefined();
   });
 
   it("preserves reflection semantics for lazily resolved exports", { timeout: 240_000 }, () => {

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -97,7 +97,6 @@ describe("plugin-sdk subpath exports", () => {
     expect(pluginSdkSubpaths).not.toContain("bluebubbles");
     expect(pluginSdkSubpaths).not.toContain("compat");
     expect(pluginSdkSubpaths).not.toContain("device-pair");
-    expect(pluginSdkSubpaths).not.toContain("discord");
     expect(pluginSdkSubpaths).not.toContain("feishu");
     expect(pluginSdkSubpaths).not.toContain("google");
     expect(pluginSdkSubpaths).not.toContain("googlechat");
@@ -132,7 +131,6 @@ describe("plugin-sdk subpath exports", () => {
     expect(pluginSdkSubpaths).not.toContain("secret-input-runtime");
     expect(pluginSdkSubpaths).not.toContain("secret-input-schema");
     expect(pluginSdkSubpaths).not.toContain("zai");
-    expect(pluginSdkSubpaths).not.toContain("discord-core");
     expect(pluginSdkSubpaths).not.toContain("slack-core");
     expect(pluginSdkSubpaths).not.toContain("provider-model-definitions");
   });
@@ -218,6 +216,12 @@ describe("plugin-sdk subpath exports", () => {
 
   it("exports runtime helpers from the dedicated subpath", () => {
     expect(typeof runtimeSdk.createLoggerBackedRuntime).toBe("function");
+  });
+
+  it("exports Discord component helpers from the dedicated subpath", async () => {
+    const discordSdk = await import("openclaw/plugin-sdk/discord");
+    expect(typeof discordSdk.buildDiscordComponentMessage).toBe("function");
+    expect(typeof discordSdk.resolveDiscordAccount).toBe("function");
   });
 
   it("exports channel identity and session helpers from stronger existing homes", () => {

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -221,6 +221,7 @@ describe("plugin-sdk subpath exports", () => {
   it("exports Discord component helpers from the dedicated subpath", async () => {
     const discordSdk = await import("openclaw/plugin-sdk/discord");
     expect(typeof discordSdk.buildDiscordComponentMessage).toBe("function");
+    expect(typeof discordSdk.editDiscordComponentMessage).toBe("function");
     expect(typeof discordSdk.resolveDiscordAccount).toBe("function");
   });
 

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -222,6 +222,7 @@ describe("plugin-sdk subpath exports", () => {
     const discordSdk = await import("openclaw/plugin-sdk/discord");
     expect(typeof discordSdk.buildDiscordComponentMessage).toBe("function");
     expect(typeof discordSdk.editDiscordComponentMessage).toBe("function");
+    expect(typeof discordSdk.registerBuiltDiscordComponentMessage).toBe("function");
     expect(typeof discordSdk.resolveDiscordAccount).toBe("function");
   });
 

--- a/src/plugins/interactive.test.ts
+++ b/src/plugins/interactive.test.ts
@@ -313,6 +313,58 @@ describe("plugin interactive handlers", () => {
     });
   });
 
+  it("acknowledges matched Discord interactions before awaiting plugin handlers", async () => {
+    const callOrder: string[] = [];
+    const handler = vi.fn(async () => {
+      callOrder.push("handler");
+      expect(callOrder).toEqual(["ack", "handler"]);
+      return { handled: true };
+    });
+    expect(
+      registerPluginInteractiveHandler("codex-plugin", {
+        channel: "discord",
+        namespace: "codex",
+        handler,
+      }),
+    ).toEqual({ ok: true });
+
+    await expect(
+      dispatchPluginInteractiveHandler({
+        channel: "discord",
+        data: "codex:approve:thread-1",
+        interactionId: "ix-ack-1",
+        ctx: {
+          accountId: "default",
+          interactionId: "ix-ack-1",
+          conversationId: "channel-1",
+          parentConversationId: "parent-1",
+          guildId: "guild-1",
+          senderId: "user-1",
+          senderUsername: "ada",
+          auth: { isAuthorizedSender: true },
+          interaction: {
+            kind: "button",
+            messageId: "message-1",
+          },
+        },
+        respond: {
+          acknowledge: vi.fn(async () => {}),
+          reply: vi.fn(async () => {}),
+          followUp: vi.fn(async () => {}),
+          editMessage: vi.fn(async () => {}),
+          clearComponents: vi.fn(async () => {}),
+        },
+        onMatched: async () => {
+          callOrder.push("ack");
+        },
+      }),
+    ).resolves.toEqual({
+      matched: true,
+      handled: true,
+      duplicate: false,
+    });
+  });
+
   it("routes Slack interactions by namespace and dedupes interaction ids", async () => {
     const handler = vi.fn(async () => ({ handled: true }));
     expect(

--- a/src/plugins/interactive.ts
+++ b/src/plugins/interactive.ts
@@ -168,6 +168,7 @@ export async function dispatchPluginInteractiveHandler(params: {
     clearButtons: () => Promise<void>;
     deleteMessage: () => Promise<void>;
   };
+  onMatched?: () => Promise<void> | void;
 }): Promise<InteractiveDispatchResult>;
 export async function dispatchPluginInteractiveHandler(params: {
   channel: "discord";
@@ -175,6 +176,7 @@ export async function dispatchPluginInteractiveHandler(params: {
   interactionId: string;
   ctx: DiscordInteractiveDispatchContext;
   respond: PluginInteractiveDiscordHandlerContext["respond"];
+  onMatched?: () => Promise<void> | void;
 }): Promise<InteractiveDispatchResult>;
 export async function dispatchPluginInteractiveHandler(params: {
   channel: "slack";
@@ -182,6 +184,7 @@ export async function dispatchPluginInteractiveHandler(params: {
   interactionId: string;
   ctx: SlackInteractiveDispatchContext;
   respond: PluginInteractiveSlackHandlerContext["respond"];
+  onMatched?: () => Promise<void> | void;
 }): Promise<InteractiveDispatchResult>;
 export async function dispatchPluginInteractiveHandler(params: {
   channel: "telegram" | "discord" | "slack";
@@ -205,6 +208,7 @@ export async function dispatchPluginInteractiveHandler(params: {
       }
     | PluginInteractiveDiscordHandlerContext["respond"]
     | PluginInteractiveSlackHandlerContext["respond"];
+  onMatched?: () => Promise<void> | void;
 }): Promise<InteractiveDispatchResult> {
   const match = resolveNamespaceMatch(params.channel, params.data);
   if (!match) {
@@ -216,6 +220,8 @@ export async function dispatchPluginInteractiveHandler(params: {
   if (dedupeKey && callbackDedupe.peek(dedupeKey)) {
     return { matched: true, handled: true, duplicate: true };
   }
+
+  await params.onMatched?.();
 
   let result:
     | ReturnType<PluginInteractiveTelegramHandlerRegistration["handler"]>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord `/codex_resume` picker buttons could immediately fail with `This component has expired.` even though the picker message had just been sent.
- Why it matters: resume-by-picker worked in Telegram but was broken in Discord, including the thread-in-channel-in-server flow used for real Codex resume.
- What changed: I kept the Discord fallback path from discarding explicit callback payloads, and I moved the Discord component registry onto process-global singleton maps so senders and listeners share the same component state across duplicate module instances.
- What did NOT change (scope boundary): I did not change the Codex app server picker generation logic; it was already emitting the expected `codexapp:<token>` callbacks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Discord Codex resume pickers now stay clickable and can successfully resume a session instead of immediately showing `This component has expired.`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: Codex app server integration
- Integration/channel (if any): Discord thread inside a channel inside a server
- Relevant config (redacted): Discord slash command flow with `/codex_resume`

### Steps

1. Run `/codex_resume` in a Discord thread.
2. Click `Browse Projects` or one of the recent-session buttons from the picker.
3. Repeat the interaction in the same Discord conversation.

### Expected

- The picker action is accepted and the selected Codex session view continues normally.

### Actual

- Before this fix, Discord responded with `This component has expired.` immediately after clicking the picker button.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified the Discord end-to-end `/codex_resume` flow, including clicking the picker in a Discord thread and successfully resuming a session.
- Edge cases checked: I also verified the focused Discord component tests covering callback fallback behavior and duplicate-module registry sharing.
- What you did **not** verify: I did not run the full `pnpm test` suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two Discord component commits on this branch
- Files/config to restore: `extensions/discord/src/components-registry.ts`, `extensions/discord/src/monitor/agent-components.ts`
- Known bad symptoms reviewers should watch for: Discord component clicks failing to resolve, or plugin-owned pickers regressing to immediate `expired` responses

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sharing the registry globally could make stale component state survive duplicate module loads longer than before.
- Mitigation: the existing TTL and explicit clear/consume paths are unchanged, and I added a regression test for cross-module sharing.
