### PR TITLE
fix(tui): handle /model list and /model status as commands

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -202,4 +202,24 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
+
+  it("handles /model list by opening model selector instead of setting model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "openai", model: "gpt-4" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model list");
+
+    expect(addSystem).toHaveBeenCalledWith(expect.stringContaining("model"));
+  });
+
+  it("handles /model status by showing current model", async () => {
+    const harness = createHarness();
+    harness.state.sessionInfo = { modelProvider: "anthropic", model: "claude-3" };
+    const { handleCommand, addSystem } = harness;
+
+    await handleCommand("/model status");
+
+    expect(addSystem).toHaveBeenCalledWith("model: anthropic/claude-3");
+  });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -295,8 +295,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openSessionSelector();
         break;
       case "model":
-        if (!args) {
+        if (!args || args === "list") {
           await openModelSelector();
+        } else if (args === "status") {
+          const { modelProvider, model } = state.sessionInfo;
+          chatLog.addSystem(`model: ${modelProvider}/${model}`);
         } else {
           try {
             const result = await client.patchSession({


### PR DESCRIPTION
## Summary
- Fix `/model list` being parsed as model ID "list" instead of opening model selector
- Fix `/model status` being parsed as model ID "status" instead of showing current model

## Testing
- Tests verify both commands work correctly