### PR TITLE
fix(sandbox): normalize non-agent-scoped session keys in sandbox explain

### DIFF
--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -73,6 +73,9 @@ describe("sandbox explain command", () => {
       const parsed = JSON.parse(out);
       // The session key should have been normalized to agent-scoped format.
       expect(parsed.sessionKey).toBe("agent:main:telegram:slash:200");
+      // Core bug: channel must be inferred correctly and config must allow it.
+      expect(parsed.elevated.channel).toBe("telegram");
+      expect(parsed.elevated.allowedByConfig).toBe(true);
     },
   );
 

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -45,4 +45,37 @@ describe("sandbox explain command", () => {
     expect(parsed.fixIt).toContain("agents.defaults.sandbox.mode=off");
     expect(parsed.fixIt).toContain("tools.sandbox.tools.deny");
   });
+
+  it(
+    "normalizes non-agent-scoped colon keys (e.g. telegram:slash:200)",
+    { timeout: SANDBOX_EXPLAIN_TEST_TIMEOUT_MS },
+    async () => {
+      mockCfg = {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent", workspaceAccess: "none" },
+          },
+        },
+        tools: {
+          elevated: { enabled: true, allowFrom: { telegram: ["200"] } },
+        },
+        session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+      };
+
+      const logs: string[] = [];
+      await sandboxExplainCommand(
+        { json: true, session: "telegram:slash:200" },
+        {
+          log: (msg: string) => logs.push(msg),
+          error: (msg: string) => logs.push(msg),
+          exit: (_code: number) => {},
+        } as unknown as Parameters<typeof sandboxExplainCommand>[1],
+      );
+
+      const out = logs.join("");
+      const parsed = JSON.parse(out);
+      // The session key should have been normalized to agent-scoped format.
+      expect(parsed.sessionKey).toBe("agent:main:telegram:slash:200");
+    },
+  );
 });

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -63,14 +63,11 @@ describe("sandbox explain command", () => {
       };
 
       const logs: string[] = [];
-      await sandboxExplainCommand(
-        { json: true, session: "telegram:slash:200" },
-        {
-          log: (msg: string) => logs.push(msg),
-          error: (msg: string) => logs.push(msg),
-          exit: (_code: number) => {},
-        } as unknown as Parameters<typeof sandboxExplainCommand>[1],
-      );
+      await sandboxExplainCommand({ json: true, session: "telegram:slash:200" }, {
+        log: (msg: string) => logs.push(msg),
+        error: (msg: string) => logs.push(msg),
+        exit: (_code: number) => {},
+      } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
 
       const out = logs.join("");
       const parsed = JSON.parse(out);
@@ -96,14 +93,11 @@ describe("sandbox explain command", () => {
       };
 
       const logs: string[] = [];
-      await sandboxExplainCommand(
-        { json: true, session: "agent:main:telegram:slash:200" },
-        {
-          log: (msg: string) => logs.push(msg),
-          error: (msg: string) => logs.push(msg),
-          exit: (_code: number) => {},
-        } as unknown as Parameters<typeof sandboxExplainCommand>[1],
-      );
+      await sandboxExplainCommand({ json: true, session: "agent:main:telegram:slash:200" }, {
+        log: (msg: string) => logs.push(msg),
+        error: (msg: string) => logs.push(msg),
+        exit: (_code: number) => {},
+      } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
 
       const out = logs.join("");
       const parsed = JSON.parse(out);

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -78,4 +78,37 @@ describe("sandbox explain command", () => {
       expect(parsed.sessionKey).toBe("agent:main:telegram:slash:200");
     },
   );
+
+  it(
+    "preserves already agent-scoped colon keys unchanged",
+    { timeout: SANDBOX_EXPLAIN_TEST_TIMEOUT_MS },
+    async () => {
+      mockCfg = {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent", workspaceAccess: "none" },
+          },
+        },
+        tools: {
+          elevated: { enabled: true },
+        },
+        session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+      };
+
+      const logs: string[] = [];
+      await sandboxExplainCommand(
+        { json: true, session: "agent:main:telegram:slash:200" },
+        {
+          log: (msg: string) => logs.push(msg),
+          error: (msg: string) => logs.push(msg),
+          exit: (_code: number) => {},
+        } as unknown as Parameters<typeof sandboxExplainCommand>[1],
+      );
+
+      const out = logs.join("");
+      const parsed = JSON.parse(out);
+      // Already agent-scoped — should pass through unchanged.
+      expect(parsed.sessionKey).toBe("agent:main:telegram:slash:200");
+    },
+  );
 });

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -45,7 +45,16 @@ function normalizeExplainSessionKey(params: {
     });
   }
   if (raw.includes(":")) {
-    return raw;
+    // Keys like "agent:main:telegram:slash:200" are already agent-scoped.
+    // Keys like "telegram:slash:200" contain colons but need wrapping so the
+    // session-store lookup and channel inference use the correct agent-scoped key.
+    if (parseAgentSessionKey(raw)) {
+      return raw;
+    }
+    return buildAgentMainSessionKey({
+      agentId: params.agentId,
+      mainKey: normalizeMainKey(raw),
+    });
   }
   if (raw === "global") {
     return "global";


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw sandbox explain --session telegram:slash:<id>` reports `channel: (unknown)` and `allowedByConfig: false`, blocking elevated commands from Telegram slash sessions
- **Why it matters:** Users with correctly configured `tools.elevated.allowFrom.telegram` cannot use elevated host commands from Telegram DM/slash sessions
- **What changed:** `normalizeExplainSessionKey` now checks whether colon-containing keys are already agent-scoped; if not, wraps them via `buildAgentMainSessionKey` so store lookup and channel inference succeed
- **What did NOT change (scope boundary):** Agent-scoped keys, plain keys, and the `global` special case are unaffected

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #51245
- Related #17607, #23748

## User-visible / Behavior Changes

`openclaw sandbox explain --session telegram:slash:<id>` now correctly resolves to `channel: telegram` instead of `channel: (unknown)`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu Server
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel: Telegram DM / slash session

### Steps

1. Configure `tools.elevated.enabled=true` and `tools.elevated.allowFrom.telegram=[<id>]`
2. Run `openclaw sandbox explain --session telegram:slash:<id>`

### Expected

`channel: telegram`, `allowedByConfig: true`

### Actual (before fix)

`channel: (unknown)`, `allowedByConfig: false`

## Evidence

- [x] Added test: non-agent-scoped colon keys normalize to agent-scoped format
- [x] Added test: already agent-scoped colon keys pass through unchanged

## Human Verification (required)

- Verified: traced the full code path from CLI input through `normalizeExplainSessionKey` -> `resolveActiveChannel` -> `inferProviderFromSessionKey`
- Edge cases: agent-scoped keys pass through unchanged; plain keys without colons still use existing path; `global` unaffected; arbitrary colon keys (e.g. `discord:dm:456`) also correctly normalize
- Not verified: live Telegram gateway (no Telegram bot access); maintainer with Telegram access should validate end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Known bad symptoms: wrong session key format in sandbox explain output

## Risks and Mitigations

None. The fix adds a guard before an existing code path and uses existing utility functions. The normalization is correctly general: all non-agent-scoped colon keys need agent-scoping because the session store exclusively uses agent-scoped keys.

## AI Disclosure

- [x] AI-assisted (analysis and implementation)
- [x] Degree of testing: unit tests added; no live Telegram verification
- [x] I understand what the code does