### PR TITLE
fix(session-memory): emit session:idle_reset and session:daily_reset events for automatic resets

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -5,7 +5,7 @@ import {
   normalizeConversationText,
   parseTelegramChatIdFromTarget,
 } from "../../acp/conversation-id.js";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -36,6 +36,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
@@ -333,9 +334,10 @@ export async function initSessionState(params: {
     resetType,
     resetOverride: channelReset,
   });
-  const freshEntry = entry
-    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
-    : false;
+  const freshnessResult = entry
+    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy })
+    : { fresh: false, dailyResetAt: undefined, idleExpiresAt: undefined };
+  const freshEntry = freshnessResult.fresh;
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)
   // and for scheduled/daily resets where the session has become stale (!freshEntry).
@@ -365,6 +367,22 @@ export async function initSessionState(params: {
     isNewSession = true;
     systemSent = false;
     abortedLastRun = false;
+    // Emit session reset events for idle/daily resets (not explicit /new or /reset commands)
+    // so that session-memory and other hooks can save context on automatic resets.
+    if (!resetTriggered && entry) {
+      const staleIdle =
+        freshnessResult.idleExpiresAt != null && now > freshnessResult.idleExpiresAt;
+      const resetEventAction = staleIdle ? "idle_reset" : "daily_reset";
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+      const hookEvent = createInternalHookEvent("session", resetEventAction, sessionKey ?? "", {
+        sessionEntry: entry,
+        previousSessionEntry: entry,
+        workspaceDir,
+        cfg,
+      });
+      void triggerInternalHook(hookEvent).catch(() => {});
+    }
+
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory when /new or /reset command is issued, or on idle/daily automatic resets"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:idle_reset", "session:daily_reset"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -194,17 +194,20 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when /new or /reset command is triggered,
+ * or when an idle/daily session reset occurs automatically.
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  // Trigger on explicit reset/new commands
+  const isResetCommand = event.type === "command" && (event.action === "new" || event.action === "reset");
+  // Trigger on automatic idle/daily resets
+  const isAutoReset = event.type === "session" && (event.action === "idle_reset" || event.action === "daily_reset");
+  if (!isResetCommand && !isAutoReset) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered for session reset", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;


### PR DESCRIPTION
## Summary

Fixes #50891

The session-memory hook only subscribed to `command:new` and `command:reset` events. Idle timeout and daily reset bypass the hook system entirely, so session context was never saved on automatic resets.

## Problem

When a session becomes stale due to idle timeout or daily reset policy (not an explicit `/new` or `/reset` command), no `command:new` or `command:reset` event is emitted. The session-memory hook never fires, so conversation context is lost without being saved to memory.

## Solution

- **Emit new events**: In `session.ts`, after detecting a stale session (non-command reset), emit `session:idle_reset` or `session:daily_reset` via `triggerInternalHook`. The choice between the two is determined by whether `idleExpiresAt` has elapsed (idle) or the daily reset threshold was crossed (daily).
- **Handler update**: Updated `session-memory/handler.ts` to accept both `session:idle_reset` and `session:daily_reset` event types in addition to the existing `command:new` / `command:reset`.
- **HOOK.md metadata**: Added `session:idle_reset` and `session:daily_reset` to the events list so the hook loader registers these subscriptions at gateway startup.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/session.ts` | Capture full `SessionFreshness` result; emit `session:idle_reset` or `session:daily_reset` on stale non-command resets |
| `src/hooks/bundled/session-memory/handler.ts` | Accept `session:idle_reset` and `session:daily_reset` alongside command events |
| `src/hooks/bundled/session-memory/HOOK.md` | Register new event keys in metadata |

## Testing

- Build passes: `pnpm exec tsdown` ✅
- Existing tests unaffected (new events fire only on stale non-command resets)

## Checklist

- [x] Follows existing code patterns
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing hook API
- [x] Both idle and daily reset cases are covered