### PR TITLE
fix(telegram): add global per-account send queue to prevent 429 crash spirals (#50866)

### DIFF
--- a/extensions/telegram/src/send-queue.ts
+++ b/extensions/telegram/src/send-queue.ts
@@ -1,0 +1,165 @@
+/**
+ * Global per-account Telegram send queue.
+ *
+ * When multiple cron jobs or agent turns fire simultaneously, they can all
+ * hit Telegram at once, triggering 429 "Too Many Requests" errors. Telegram
+ * responds with a `retry_after` value (in seconds). Without serialization,
+ * every concurrent sender independently backs off and retries, causing an
+ * ever-widening crash spiral.
+ *
+ * This module provides:
+ *  - A per-account FIFO queue that serializes outbound sends.
+ *  - Automatic delay injection when a 429 is detected (`retry_after`).
+ *  - A shared global singleton so the queue is effective across module
+ *    boundaries (monorepo bundles, multiple plugin loads, etc.).
+ */
+
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
+
+const SEND_QUEUE_KEY = Symbol.for("openclaw.telegram.sendQueue");
+const DEFAULT_RETRY_AFTER_MS = 1_000;
+const MAX_RETRY_AFTER_MS = 60_000;
+
+const log = createSubsystemLogger("telegram/send-queue");
+
+type SendTask = {
+  run: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+};
+
+type AccountQueue = {
+  queue: SendTask[];
+  draining: boolean;
+  /** Timestamp (ms) until which sends are blocked due to a 429. */
+  blockedUntil: number;
+};
+
+type SendQueueMap = Map<string, AccountQueue>;
+
+declare const globalThis: Record<symbol, unknown>;
+
+function resolveGlobalSendQueue(): SendQueueMap {
+  if (!(SEND_QUEUE_KEY in globalThis)) {
+    (globalThis as Record<symbol, unknown>)[SEND_QUEUE_KEY] = new Map<string, AccountQueue>();
+  }
+  return globalThis[SEND_QUEUE_KEY] as SendQueueMap;
+}
+
+const SEND_QUEUES = resolveGlobalSendQueue();
+
+function getAccountQueue(accountKey: string): AccountQueue {
+  let q = SEND_QUEUES.get(accountKey);
+  if (!q) {
+    q = { queue: [], draining: false, blockedUntil: 0 };
+    SEND_QUEUES.set(accountKey, q);
+  }
+  return q;
+}
+
+function extractRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  // Grammy wraps Telegram errors: err.parameters.retry_after or err.error.parameters.retry_after
+  const candidates: unknown[] = [err];
+  const maybeError = (err as { error?: unknown }).error;
+  if (maybeError && typeof maybeError === "object") {
+    candidates.push(maybeError);
+  }
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const params = (candidate as { parameters?: { retry_after?: unknown } }).parameters;
+    if (params && typeof params.retry_after === "number" && Number.isFinite(params.retry_after)) {
+      return Math.min(Math.max(Math.ceil(params.retry_after * 1_000), DEFAULT_RETRY_AFTER_MS), MAX_RETRY_AFTER_MS);
+    }
+  }
+  return undefined;
+}
+
+function isTelegramRateLimitError(err: unknown): boolean {
+  const msg = formatErrorMessage(err).toLowerCase();
+  if (msg.includes("429") || msg.includes("too many requests") || msg.includes("retry after")) {
+    return true;
+  }
+  // Check error_code on grammy errors
+  if (err && typeof err === "object") {
+    const code = (err as { error_code?: unknown }).error_code;
+    if (code === 429) return true;
+    const inner = (err as { error?: { error_code?: unknown } }).error;
+    if (inner?.error_code === 429) return true;
+  }
+  return false;
+}
+
+async function drainQueue(accountKey: string): Promise<void> {
+  const q = getAccountQueue(accountKey);
+  if (q.draining) {
+    return;
+  }
+  q.draining = true;
+  try {
+    while (q.queue.length > 0) {
+      // Respect 429 backoff window before processing next item
+      const waitMs = q.blockedUntil - Date.now();
+      if (waitMs > 0) {
+        log.warn(`telegram send-queue: account ${accountKey} rate-limited, waiting ${waitMs}ms`);
+        await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+      }
+
+      const task = q.queue.shift();
+      if (!task) {
+        break;
+      }
+
+      try {
+        const result = await task.run();
+        task.resolve(result);
+      } catch (err) {
+        if (isTelegramRateLimitError(err)) {
+          const retryAfterMs = extractRetryAfterMs(err) ?? DEFAULT_RETRY_AFTER_MS;
+          q.blockedUntil = Date.now() + retryAfterMs;
+          log.warn(
+            `telegram send-queue: 429 on account ${accountKey}, blocking for ${retryAfterMs}ms`,
+          );
+          // Re-enqueue the task at the front so it retries after the delay
+          q.queue.unshift(task);
+        } else {
+          task.reject(err);
+        }
+      }
+    }
+  } finally {
+    q.draining = false;
+    // If new items were added while draining, restart
+    if (q.queue.length > 0) {
+      void drainQueue(accountKey);
+    }
+  }
+}
+
+/**
+ * Enqueue a Telegram send operation, serializing per-account to avoid 429 spirals.
+ * Returns the result of `sendFn` once it is executed.
+ */
+export function enqueueTelegramSend<T>(accountKey: string, sendFn: () => Promise<T>): Promise<T> {
+  const q = getAccountQueue(accountKey);
+  return new Promise<T>((resolve, reject) => {
+    q.queue.push({
+      run: sendFn as () => Promise<unknown>,
+      resolve: resolve as (value: unknown) => void,
+      reject,
+    });
+    if (!q.draining) {
+      void drainQueue(accountKey);
+    }
+  });
+}
+
+/** Exposed for testing only. Clears all queues. */
+export function resetTelegramSendQueuesForTests(): void {
+  SEND_QUEUES.clear();
+}

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -41,6 +41,7 @@ import {
   parseTelegramTarget,
 } from "./targets.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
+import { enqueueTelegramSend } from "./send-queue.js";
 
 type TelegramApi = Bot["api"];
 type TelegramApiOverride = Partial<TelegramApi>;
@@ -550,8 +551,10 @@ function createTelegramNonIdempotentRequestWithDiag(params: {
   retry?: RetryConfig;
   verbose?: boolean;
   useApiErrorLogging?: boolean;
+  /** When set, sends are serialized through a global per-account queue to prevent 429 spirals. */
+  queueAccountKey?: string;
 }): TelegramRequestWithDiag {
-  return createTelegramRequestWithDiag({
+  const base = createTelegramRequestWithDiag({
     cfg: params.cfg,
     account: params.account,
     retry: params.retry,
@@ -560,6 +563,12 @@ function createTelegramNonIdempotentRequestWithDiag(params: {
     shouldRetry: (err) => isSafeToRetrySendError(err),
     strictShouldRetry: true,
   });
+  if (!params.queueAccountKey) {
+    return base;
+  }
+  const queueAccountKey = params.queueAccountKey;
+  return <T>(fn: () => Promise<T>, label?: string, options?: { shouldLog?: (err: unknown) => boolean }): Promise<T> =>
+    enqueueTelegramSend(queueAccountKey, () => base(fn, label, options));
 }
 
 export function buildInlineKeyboard(
@@ -620,6 +629,7 @@ export async function sendMessageTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
+    queueAccountKey: account.accountId,
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1533,6 +1543,7 @@ export async function sendPollTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
+    queueAccountKey: account.accountId,
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1646,6 +1657,7 @@ export async function createForumTopicTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
+    queueAccountKey: account.accountId,
   });
 
   const extra: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

- **Problem:** Multiple cron jobs posting to Telegram simultaneously trigger 429 rate limits. Without serialization, each concurrent sender independently backs off and retries, causing an ever-widening crash spiral.
- **Why it matters:** Agents/crons that share a Telegram account (default account) can wedge indefinitely, dropping messages or crashing.
- **What changed:** Added `send-queue.ts` — a global per-account FIFO send queue. Calls are serialized; when a 429 is received, `retry_after` is extracted from Telegram's response and the backoff window is enforced before the next send.
- **What did NOT change:** Typing, sticker, reaction, and delete operations are intentionally not queued (they are low-volume or idempotent).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50866

## User-visible / Behavior Changes

Concurrent Telegram sends are now serialized per account. In high-concurrency scenarios (many crons posting simultaneously), messages will be queued and sent sequentially instead of all-at-once, which may add slight latency but eliminates 429 crash spirals.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js
- Model/provider: any
- Integration/channel: Telegram

### Steps

1. Configure multiple cron jobs to post to Telegram simultaneously
2. Observe 429 errors and crash spiral **before** fix
3. With fix: observe messages queued and sent sequentially, no crash spiral

### Expected

- Messages sent successfully without crash spiral
- 429 rate limit respected via `retry_after`

### Actual (before fix)

- Crash spiral with continuous 429 errors

## Evidence

- [x] Code change: `send-queue.ts` adds global per-account FIFO queue with 429 detection

## Human Verification (required)

- Verified the queue module compiles and builds cleanly (pnpm build passes)
- Verified `retry_after` extraction covers grammy's error nesting patterns
- Edge cases: concurrent sends, 429 with no retry_after (defaults to 1s), max cap at 60s

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable: remove `queueAccountKey: account.accountId` from `createTelegramNonIdempotentRequestWithDiag` calls
- Files to restore: `extensions/telegram/src/send.ts`, delete `extensions/telegram/src/send-queue.ts`
- Bad symptoms: messages not sending at all → check queue drain logic; high latency → expected under load

## Risks and Mitigations

- Risk: Queue serialization adds latency under concurrent load
  - Mitigation: Only non-idempotent sends are queued; latency is bounded by `retry_after` (max 60s)