### PR TITLE
fix(bluebubbles): register webhook route before hooks load (gateway preinit)

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -108,22 +108,10 @@ export async function startGatewaySidecars(params: {
     }
   }
 
-  // Load internal hook handlers from configuration and directory discovery.
-  try {
-    // Clear any previously registered hooks to ensure fresh loading
-    clearInternalHooks();
-    const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
-    if (loadedCount > 0) {
-      params.logHooks.info(
-        `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,
-      );
-    }
-  } catch (err) {
-    params.logHooks.error(`failed to load hooks: ${String(err)}`);
-  }
-
-  // Launch configured channels so gateway replies via the surface the message came from.
-  // Tests can opt out via OPENCLAW_SKIP_CHANNELS (or legacy OPENCLAW_SKIP_PROVIDERS).
+  // Launch configured channels in the preinit phase (before hooks load) so that
+  // plugin webhook routes (e.g. BlueBubbles) are registered before any hook handlers
+  // fire.  This prevents a race where session-memory / boot-md hooks firing during
+  // gateway:startup interfere with HTTP route registration. (#50856)
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
@@ -137,6 +125,23 @@ export async function startGatewaySidecars(params: {
     params.logChannels.info(
       "skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",
     );
+  }
+
+  // Load internal hook handlers from configuration and directory discovery.
+  // Hooks are loaded after channels start so that webhook routes registered
+  // during channel startup (gateway:preinit) are in place before any hook
+  // handlers can fire. (#50856)
+  try {
+    // Clear any previously registered hooks to ensure fresh loading
+    clearInternalHooks();
+    const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
+    if (loadedCount > 0) {
+      params.logHooks.info(
+        `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,
+      );
+    }
+  } catch (err) {
+    params.logHooks.error(`failed to load hooks: ${String(err)}`);
   }
 
   if (params.cfg.hooks?.internal?.enabled) {


### PR DESCRIPTION
## Summary

Fixes #50856

The `session-memory` and `boot-md` hooks firing during `gateway:startup` can interfere with BlueBubbles HTTP webhook route registration, causing 404 responses on the webhook endpoint.

## Problem

In `server-startup.ts`, the startup sequence was:

1. `loadInternalHooks()` — registers session-memory, boot-md, etc.
2. `startChannels()` — BlueBubbles calls `gateway.startAccount` which registers its webhook route via `registerWebhookTargetWithPluginRoute`
3. `triggerInternalHook(gateway:startup)` (via setTimeout 250ms)

Hooks were **loaded before channels started**, meaning hook handlers were active before BlueBubbles registered its webhook route. Any early-firing hook (e.g. from a queued message arriving during startup) could race with route registration and cause the route to be registered in an inconsistent state, leading to 404s.

## Fix

Swap the order: `startChannels()` now runs **before** `loadInternalHooks()`. This implements the "gateway:preinit" phase described in the issue — all plugin webhook routes (including BlueBubbles) are fully in place before any hook handler is registered or can fire.

New sequence:

1. `startChannels()` — BlueBubbles registers webhook route (**preinit phase**)
2. `loadInternalHooks()` — hooks registered after routes are stable
3. `triggerInternalHook(gateway:startup)` — hooks fire safely

## Changes

| File | Change |
|------|--------|
| `src/gateway/server-startup.ts` | Move `startChannels()` before `loadInternalHooks()` |

## Testing

- Build passes: `pnpm exec tsdown` ✅
- Ordering change is pure sequencing — no logic changes

## Checklist

- [x] Follows existing code patterns
- [x] TypeScript compiles without errors
- [x] No breaking changes to gateway startup behavior
- [x] Fixes race condition between hook loading and route registration