### PR TITLE
fix(agent-loop): terminate loop after final response when queue items predate run start (#50956)

### DIFF
--- a/src/auto-reply/reply/agent-runner-helpers.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.ts
@@ -58,8 +58,9 @@ export const finalizeWithFollowup = <T>(
   value: T,
   queueKey: string,
   runFollowupTurn: Parameters<typeof scheduleFollowupDrain>[1],
+  runStartedAt?: number,
 ): T => {
-  scheduleFollowupDrain(queueKey, runFollowupTurn);
+  scheduleFollowupDrain(queueKey, runFollowupTurn, runStartedAt);
   return value;
 };
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -376,7 +376,7 @@ export async function runReplyAgent(params: {
     });
 
     if (runOutcome.kind === "final") {
-      return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
+      return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn, runStartedAt);
     }
 
     const {
@@ -490,7 +490,7 @@ export async function runReplyAgent(params: {
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
     if (payloadArray.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn, runStartedAt);
     }
 
     const payloadResult = await buildReplyPayloads({
@@ -519,7 +519,7 @@ export async function runReplyAgent(params: {
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     if (replyPayloads.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn, runStartedAt);
     }
 
     const successfulCronAdds = runResult.successfulCronAdds ?? 0;
@@ -713,11 +713,12 @@ export async function runReplyAgent(params: {
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
       queueKey,
       runFollowupTurn,
+      runStartedAt,
     );
   } catch (error) {
     // Keep the followup queue moving even when an unexpected exception escapes
     // the run path; the caller still receives the original error.
-    finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    finalizeWithFollowup(undefined, queueKey, runFollowupTurn, runStartedAt);
     throw error;
   } finally {
     blockReplyPipeline?.stop();

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -71,6 +71,13 @@ function resolveCrossChannelKey(item: FollowupRun): { cross?: true; key?: string
 export function scheduleFollowupDrain(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
+  /**
+   * Timestamp (ms) at which the current agent run started.
+   * Items enqueued *before* this time are considered stale (pre-existing context
+   * from a prior run) and will be dropped to prevent infinite replay loops.
+   * When undefined, no stale filtering is applied.
+   */
+  runStartedAt?: number,
 ): void {
   const queue = beginQueueDrain(FOLLOWUP_QUEUES, key);
   if (!queue) {
@@ -81,6 +88,17 @@ export function scheduleFollowupDrain(
   FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
   void (async () => {
     try {
+      // Drop items that were enqueued before this run started. These are
+      // messages that already existed in the session context before the current
+      // turn began — replaying them would cause an infinite loop where the agent
+      // re-processes the previous task after completing it.
+      if (typeof runStartedAt === "number") {
+        const staleCount = queue.items.filter((item) => item.enqueuedAt <= runStartedAt).length;
+        if (staleCount > 0) {
+          queue.items = queue.items.filter((item) => item.enqueuedAt > runStartedAt);
+          defaultRuntime.log?.(`followup queue: dropped ${staleCount} stale item(s) for ${key} (enqueued before run started)`);
+        }
+      }
       const collectState = { forceIndividualCollect: false };
       while (queue.items.length > 0 || queue.droppedCount > 0) {
         await waitForQueueDebounce(queue);


### PR DESCRIPTION
## Summary

- **Problem:** When queued messages exist in session history, the agent loop replays the previous task infinitely after completing. Items enqueued before the current run started are treated as new messages, causing the agent to re-process them.
- **Why it matters:** Agents enter an infinite loop after completing their task, consuming tokens and possibly producing duplicate responses.
- **What changed:** Added `runStartedAt` timestamp to `scheduleFollowupDrain` and `finalizeWithFollowup`. In the drain loop, items enqueued before the run started are dropped (stale context). Only items enqueued AFTER the run started are processed.
- **What did NOT change:** New messages (enqueued after run start) still flow normally. All other queue logic unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50956

## User-visible / Behavior Changes

Agent loops that previously ran infinitely after completing will now terminate correctly. The agent will only respond to messages that arrived after the current run ended.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js
- Model/provider: any
- Integration/channel: any

### Steps

1. Have a session with queued messages in context from a previous run
2. Send a new message that produces a final text-only response (no tool calls)
3. **Before fix:** agent loop replays the previous task infinitely
4. **After fix:** agent terminates after the final response

### Expected

- Agent terminates after sending final text-only response
- New messages arriving AFTER run ends are still processed

### Actual (before fix)

- Agent replays previous task in infinite loop

## Evidence

- [x] Code change: stale queue items filtered in `drain.ts` by comparing `enqueuedAt` vs `runStartedAt`

## Human Verification (required)

- Verified build compiles cleanly (pnpm build passes)
- Logic: `runStartedAt = Date.now()` captured before agent run; items with `enqueuedAt <= runStartedAt` are stale
- Edge case: `runStartedAt` is optional; when not passed (e.g. `kickFollowupDrainIfIdle`), no filtering applied (backward compatible)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (runStartedAt is optional)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable: remove `runStartedAt` parameter from `finalizeWithFollowup` calls in `agent-runner.ts`
- Files to restore: `src/auto-reply/reply/agent-runner.ts`, `src/auto-reply/reply/agent-runner-helpers.ts`, `src/auto-reply/reply/queue/drain.ts`
- Bad symptoms: messages dropped unexpectedly → check `runStartedAt` timestamp accuracy

## Risks and Mitigations

- Risk: A message enqueued exactly at `runStartedAt` (same millisecond) could be dropped
  - Mitigation: Extremely unlikely in practice; uses `<=` to drop items from before/at run start, ensuring items arriving strictly after are processed