### PR TITLE
Slack: fix interactive reply buttons not rendering as Block Kit

### DIFF
--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -40,7 +40,7 @@ export function buildSlackInteractiveBlocks(interactive?: InteractiveReply): Sla
         block_id: `openclaw_reply_buttons_${++state.buttonIndex}`,
         elements: block.buttons.map((button, choiceIndex) => ({
           type: "button",
-          action_id: SLACK_REPLY_BUTTON_ACTION_ID,
+          action_id: `${SLACK_REPLY_BUTTON_ACTION_ID}:${state.buttonIndex}_${choiceIndex}`,
           text: {
             type: "plain_text",
             text: truncateSlackText(button.label, SLACK_PLAIN_TEXT_MAX),

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -47,6 +47,9 @@ export function buildSlackInteractiveBlocks(interactive?: InteractiveReply): Sla
             emoji: true,
           },
           value: button.value,
+          ...(button.style === "primary" || button.style === "danger"
+            ? { style: button.style }
+            : {}),
         })),
       });
       return state;

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -414,6 +414,9 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     enableInteractiveReplies: ({ cfg, accountId }) =>
       isSlackInteractiveRepliesEnabled({ cfg, accountId }),
     hasStructuredReplyPayload: ({ payload }) => {
+      if (payload.interactive?.blocks?.length) {
+        return true;
+      }
       const slackData = payload.channelData?.slack;
       if (!slackData || typeof slackData !== "object" || Array.isArray(slackData)) {
         return false;

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -343,8 +343,10 @@ function buildSlackPluginInteractionData(params: {
     params.summary.selectedValues?.map((value) => value.trim()).find(Boolean) ||
     "";
   if (
-    actionId.startsWith(SLACK_REPLY_BUTTON_ACTION_ID) ||
-    actionId.startsWith(SLACK_REPLY_SELECT_ACTION_ID)
+    actionId === SLACK_REPLY_BUTTON_ACTION_ID ||
+    actionId.startsWith(`${SLACK_REPLY_BUTTON_ACTION_ID}:`) ||
+    actionId === SLACK_REPLY_SELECT_ACTION_ID ||
+    actionId.startsWith(`${SLACK_REPLY_SELECT_ACTION_ID}:`)
   ) {
     return payload || null;
   }

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -342,7 +342,10 @@ function buildSlackPluginInteractionData(params: {
     params.summary.value?.trim() ||
     params.summary.selectedValues?.map((value) => value.trim()).find(Boolean) ||
     "";
-  if (actionId === SLACK_REPLY_BUTTON_ACTION_ID || actionId === SLACK_REPLY_SELECT_ACTION_ID) {
+  if (
+    actionId.startsWith(SLACK_REPLY_BUTTON_ACTION_ID) ||
+    actionId.startsWith(SLACK_REPLY_SELECT_ACTION_ID)
+  ) {
     return payload || null;
   }
   return payload ? `${actionId}:${payload}` : actionId;

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -503,6 +503,50 @@ describe("registerSlackInteractionEvents", () => {
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
   });
 
+  it("routes suffixed reply_button action_id as system event", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "Pick an option",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "openclaw_reply_buttons_1",
+              elements: [
+                { type: "button", action_id: "openclaw:reply_button:1_0" },
+                { type: "button", action_id: "openclaw:reply_button:1_1" },
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:reply_button:1_0",
+        block_id: "openclaw_reply_buttons_1",
+        value: "approve",
+        text: { type: "plain_text", text: "Approve" },
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [eventText] = enqueueSystemEventMock.mock.calls[0] as [string];
+    expect(eventText).toContain("approve");
+  });
+
   it("drops block actions when mismatch guard triggers", async () => {
     enqueueSystemEventMock.mockClear();
     const { ctx, app, getHandler } = createContext({

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -94,4 +94,81 @@ describe("deliverReplies identity passthrough", () => {
       }),
     );
   });
+
+  it("merges interactive blocks into delivery when payload has interactive field", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "Pick one",
+            interactive: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [
+                    { label: "Yes", value: "yes" },
+                    { label: "No", value: "no" },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const sentBlocks = sendMock.mock.calls[0][2].blocks;
+    expect(sentBlocks).toHaveLength(1);
+    expect(sentBlocks[0].type).toBe("actions");
+    expect(sentBlocks[0].elements).toHaveLength(2);
+    expect(sentBlocks[0].elements[0].type).toBe("button");
+    expect(sentBlocks[0].elements[0].value).toBe("yes");
+    expect(sentBlocks[0].elements[1].value).toBe("no");
+  });
+
+  it("merges channelData blocks with interactive blocks", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "context",
+            channelData: {
+              slack: {
+                blocks: [{ type: "divider" }],
+              },
+            },
+            interactive: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [{ label: "Go", value: "go" }],
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const sentBlocks = sendMock.mock.calls[0][2].blocks;
+    expect(sentBlocks).toHaveLength(2);
+    expect(sentBlocks[0].type).toBe("divider");
+    expect(sentBlocks[1].type).toBe("actions");
+  });
+
+  it("delivers text-only reply when no blocks or interactive", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "just text" }],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).not.toHaveProperty("blocks");
+  });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -10,19 +10,30 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { parseSlackBlocksInput } from "../blocks-input.js";
+import { buildSlackInteractiveBlocks, type SlackBlock } from "../blocks-render.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
 
-export function readSlackReplyBlocks(payload: ReplyPayload) {
+export function readSlackReplyBlocks(payload: ReplyPayload): SlackBlock[] | undefined {
   const slackData = payload.channelData?.slack;
-  if (!slackData || typeof slackData !== "object" || Array.isArray(slackData)) {
-    return undefined;
+  let existingBlocks: SlackBlock[] | undefined;
+  if (slackData && typeof slackData === "object" && !Array.isArray(slackData)) {
+    try {
+      existingBlocks = parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks) as
+        | SlackBlock[]
+        | undefined;
+    } catch {
+      // ignore malformed blocks
+    }
   }
-  try {
-    return parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks);
-  } catch {
-    return undefined;
-  }
+  const interactiveBlocks = payload.interactive
+    ? buildSlackInteractiveBlocks(payload.interactive)
+    : undefined;
+  const merged = [
+    ...(existingBlocks ?? []),
+    ...(interactiveBlocks?.length ? interactiveBlocks : []),
+  ];
+  return merged.length > 0 ? merged : undefined;
 }
 
 export async function deliverReplies(params: {

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -77,9 +77,49 @@ describe("buildSlackInteractiveBlocks", () => {
       }>;
     };
 
-    expect(buttonBlock.elements?.[0]?.action_id).toBe("openclaw:reply_button");
+    expect(buttonBlock.elements?.[0]?.action_id).toBe("openclaw:reply_button:1_0");
     expect(buttonBlock.elements?.[0]?.value).toBe("pluginbind:approval-123:o");
     expect(selectBlock.elements?.[0]?.action_id).toBe("openclaw:reply_select");
     expect(selectBlock.elements?.[0]?.options?.[0]?.value).toBe("codex:approve:thread-1");
+  });
+
+  it("assigns unique action_ids to multiple buttons in the same block", () => {
+    const blocks = buildSlackInteractiveBlocks({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "A", value: "a" },
+            { label: "B", value: "b" },
+            { label: "C", value: "c" },
+          ],
+        },
+      ],
+    });
+
+    const buttonBlock = blocks[0] as {
+      elements?: Array<{ action_id?: string }>;
+    };
+    expect(buttonBlock.elements?.[0]?.action_id).toBe("openclaw:reply_button:1_0");
+    expect(buttonBlock.elements?.[1]?.action_id).toBe("openclaw:reply_button:1_1");
+    expect(buttonBlock.elements?.[2]?.action_id).toBe("openclaw:reply_button:1_2");
+  });
+
+  it("assigns unique action_ids across multiple button blocks", () => {
+    const blocks = buildSlackInteractiveBlocks({
+      blocks: [
+        { type: "buttons", buttons: [{ label: "First", value: "first" }] },
+        { type: "buttons", buttons: [{ label: "Second", value: "second" }] },
+      ],
+    });
+
+    const block1 = blocks[0] as {
+      elements?: Array<{ action_id?: string }>;
+    };
+    const block2 = blocks[1] as {
+      elements?: Array<{ action_id?: string }>;
+    };
+    expect(block1.elements?.[0]?.action_id).toBe("openclaw:reply_button:1_0");
+    expect(block2.elements?.[0]?.action_id).toBe("openclaw:reply_button:2_0");
   });
 });

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -122,4 +122,26 @@ describe("buildSlackInteractiveBlocks", () => {
     expect(block1.elements?.[0]?.action_id).toBe("openclaw:reply_button:1_0");
     expect(block2.elements?.[0]?.action_id).toBe("openclaw:reply_button:2_0");
   });
+
+  it("maps button style to Block Kit style field", () => {
+    const blocks = buildSlackInteractiveBlocks({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Approve", value: "approve", style: "primary" },
+            { label: "Reject", value: "reject", style: "danger" },
+            { label: "Skip", value: "skip" },
+          ],
+        },
+      ],
+    });
+
+    const buttonBlock = blocks[0] as {
+      elements?: Array<{ value?: string; style?: string }>;
+    };
+    expect(buttonBlock.elements?.[0]?.style).toBe("primary");
+    expect(buttonBlock.elements?.[1]?.style).toBe("danger");
+    expect(buttonBlock.elements?.[2]?.style).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -646,6 +646,23 @@ describe("parseSlackDirectives", () => {
     ]);
   });
 
+  it("does not strip style-like suffixes from select option values", () => {
+    const result = parseSlackDirectives({
+      text: "[[slack_select: Pick | Danger path:workflow:danger, Safe:safe:primary]]",
+    });
+
+    expect(getSlackInteractive(result)).toEqual([
+      {
+        type: "select",
+        placeholder: "Pick",
+        options: [
+          { label: "Danger path", value: "workflow:danger" },
+          { label: "Safe", value: "safe:primary" },
+        ],
+      },
+    ]);
+  });
+
   it("leaves existing slack blocks in channelData and appends shared interactive blocks", () => {
     const result = parseSlackDirectives({
       text: "Act now [[slack_buttons: Retry:retry]]",

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -734,6 +734,35 @@ describe("parseSlackDirectives", () => {
     ]);
   });
 
+  it("parses button style suffix from slack_buttons directives", () => {
+    const result = parseSlackDirectives({
+      text: "Review [[slack_buttons: Approve:approve:primary, Reject:reject:danger, Skip:skip]]",
+    });
+
+    expect(result.text).toBe("Review");
+    expect(getSlackInteractive(result)).toEqual([
+      { type: "text", text: "Review" },
+      {
+        type: "buttons",
+        buttons: [
+          { label: "Approve", value: "approve", style: "primary" },
+          { label: "Reject", value: "reject", style: "danger" },
+          { label: "Skip", value: "skip" },
+        ],
+      },
+    ]);
+  });
+
+  it("ignores invalid button style suffixes", () => {
+    const result = parseSlackDirectives({
+      text: "[[slack_buttons: Go:go:blue]]",
+    });
+
+    const blocks = getSlackInteractive(result);
+    const buttons = blocks[0] as { buttons?: Array<{ style?: string }> };
+    expect(buttons.buttons?.[0]?.style).toBeUndefined();
+  });
+
   it("ignores malformed directive choices when none remain", () => {
     const result = parseSlackDirectives({
       text: "Choose [[slack_buttons: : , : ]]",

--- a/src/auto-reply/reply/slack-directives.ts
+++ b/src/auto-reply/reply/slack-directives.ts
@@ -12,7 +12,7 @@ type SlackChoice = {
 
 const VALID_BUTTON_STYLES = new Set(["primary", "danger"]);
 
-function parseChoice(raw: string): SlackChoice | null {
+function parseChoice(raw: string, parseStyle?: boolean): SlackChoice | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;
@@ -29,24 +29,26 @@ function parseChoice(raw: string): SlackChoice | null {
   if (!label || !rest) {
     return null;
   }
-  // Check for optional style suffix: Label:value:style
-  const lastColon = rest.lastIndexOf(":");
-  if (lastColon > 0) {
-    const maybestyle = rest.slice(lastColon + 1).trim().toLowerCase();
-    if (VALID_BUTTON_STYLES.has(maybestyle)) {
-      const value = rest.slice(0, lastColon).trim();
-      if (value) {
-        return { label, value, style: maybestyle as "primary" | "danger" };
+  // Check for optional style suffix: Label:value:style (buttons only)
+  if (parseStyle) {
+    const lastColon = rest.lastIndexOf(":");
+    if (lastColon > 0) {
+      const maybestyle = rest.slice(lastColon + 1).trim().toLowerCase();
+      if (VALID_BUTTON_STYLES.has(maybestyle)) {
+        const value = rest.slice(0, lastColon).trim();
+        if (value) {
+          return { label, value, style: maybestyle as "primary" | "danger" };
+        }
       }
     }
   }
   return { label, value: rest };
 }
 
-function parseChoices(raw: string, maxItems: number): SlackChoice[] {
+function parseChoices(raw: string, maxItems: number, parseStyle?: boolean): SlackChoice[] {
   return raw
     .split(",")
-    .map((entry) => parseChoice(entry))
+    .map((entry) => parseChoice(entry, parseStyle))
     .filter((entry): entry is SlackChoice => Boolean(entry))
     .slice(0, maxItems);
 }
@@ -64,7 +66,7 @@ function buildTextBlock(
 function buildButtonsBlock(
   raw: string,
 ): NonNullable<ReplyPayload["interactive"]>["blocks"][number] | null {
-  const choices = parseChoices(raw, SLACK_BUTTON_MAX_ITEMS);
+  const choices = parseChoices(raw, SLACK_BUTTON_MAX_ITEMS, true);
   if (choices.length === 0) {
     return null;
   }

--- a/src/auto-reply/reply/slack-directives.ts
+++ b/src/auto-reply/reply/slack-directives.ts
@@ -7,7 +7,10 @@ const SLACK_DIRECTIVE_RE = /\[\[(slack_buttons|slack_select):\s*([^\]]+)\]\]/gi;
 type SlackChoice = {
   label: string;
   value: string;
+  style?: "primary" | "danger";
 };
+
+const VALID_BUTTON_STYLES = new Set(["primary", "danger"]);
 
 function parseChoice(raw: string): SlackChoice | null {
   const trimmed = raw.trim();
@@ -22,11 +25,22 @@ function parseChoice(raw: string): SlackChoice | null {
     };
   }
   const label = trimmed.slice(0, delimiter).trim();
-  const value = trimmed.slice(delimiter + 1).trim();
-  if (!label || !value) {
+  const rest = trimmed.slice(delimiter + 1).trim();
+  if (!label || !rest) {
     return null;
   }
-  return { label, value };
+  // Check for optional style suffix: Label:value:style
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon > 0) {
+    const maybestyle = rest.slice(lastColon + 1).trim().toLowerCase();
+    if (VALID_BUTTON_STYLES.has(maybestyle)) {
+      const value = rest.slice(0, lastColon).trim();
+      if (value) {
+        return { label, value, style: maybestyle as "primary" | "danger" };
+      }
+    }
+  }
+  return { label, value: rest };
 }
 
 function parseChoices(raw: string, maxItems: number): SlackChoice[] {
@@ -59,6 +73,7 @@ function buildButtonsBlock(
     buttons: choices.map((choice) => ({
       label: choice.label,
       value: choice.value,
+      ...(choice.style ? { style: choice.style } : {}),
     })),
   };
 }


### PR DESCRIPTION
## Summary

- **Fix `readSlackReplyBlocks`** to merge `payload.interactive` blocks (from `parseSlackDirectives`) with `channelData` blocks, so both streaming and normal delivery paths emit Block Kit actions
- **Unique button `action_id`s** — append block and choice indices (`openclaw:reply_button:1_0`, `:1_1`) to satisfy Slack's per-block uniqueness requirement
- **Fix `startsWith()` matching** in `buildSlackPluginInteractionData` so suffixed action IDs still route as system events
- **Fix `hasStructuredReplyPayload`** to check `payload.interactive` so the streaming path correctly falls back to normal delivery for interactive replies
- **Button style support** — `[[slack_buttons: Approve:approve:primary, Reject:reject:danger]]` renders green/red Slack buttons. The directive parser accepts an optional `:primary` or `:danger` suffix, and the Block Kit renderer maps it to Slack's `style` field

## Change type
Bug fix + enhancement — interactive reply buttons (`[[slack_buttons:]]`) now render as clickable Slack buttons instead of raw text, with optional color styling via `:primary` (green) and `:danger` (red) suffixes.

## Scope
Integrations (Slack extension) + core directive parser

## Changed files

### Commit 1: Fix button rendering (4 source + 3 test)
| File | Change |
|------|--------|
| `extensions/slack/src/monitor/replies.ts` | `readSlackReplyBlocks` merges `payload.interactive` via `buildSlackInteractiveBlocks` |
| `extensions/slack/src/blocks-render.ts` | Button `action_id` now includes block + choice index suffix |
| `extensions/slack/src/monitor/events/interactions.block-actions.ts` | `===` → `startsWith()` for reply button/select action ID matching |
| `extensions/slack/src/channel.ts` | `hasStructuredReplyPayload` early-returns true for `payload.interactive` |
| `extensions/slack/src/shared-interactive.test.ts` | Update expected action_id, add unique ID tests |
| `extensions/slack/src/monitor/replies.test.ts` | Add interactive merge + text-only delivery tests |
| `extensions/slack/src/monitor/events/interactions.test.ts` | Add suffixed action_id routing test |

### Commit 2: Button style support (2 source + 2 test)
| File | Change |
|------|--------|
| `src/auto-reply/reply/slack-directives.ts` | `parseChoice` accepts optional `:primary`/`:danger` style suffix |
| `extensions/slack/src/blocks-render.ts` | Renderer maps `button.style` to Block Kit `style` field |
| `src/auto-reply/reply/reply-flow.test.ts` | Add style parsing + invalid style tests |
| `extensions/slack/src/shared-interactive.test.ts` | Add Block Kit style mapping test |

## Security impact
None — no new permissions, secrets, network calls, or data access changes.

## Compatibility
Fully backward compatible. Existing `[[slack_buttons: Label:value]]` syntax unchanged. The new `:style` suffix is opt-in. The `action_id` format changes from `openclaw:reply_button` to `openclaw:reply_button:N_M`, but the interaction handler uses `startsWith()`. Since buttons were already broken (never rendered), no existing users are affected.

## Test plan
- [x] Scoped unit tests pass (45 total across changed files)
- [x] Broader Slack test suite: 467/469 pass (2 pre-existing failures in `slash.test.ts`, unrelated)
- [x] E2E verified with real Slack bot:
  - Buttons render as Block Kit actions with correct styles (green/red/gray)
  - `[[slack_buttons: Approve:approve:primary, Reject:reject:danger, Skip:skip]]` renders 3 buttons
  - Button clicks route back as system events with correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)