### PR TITLE
fix(sandbox): sanitize security errors before posting to channels

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isSandboxSecurityError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -861,3 +861,14 @@ export function isFailoverAssistantError(msg: AssistantMessage | undefined): boo
   }
   return isFailoverErrorMessage(msg.errorMessage ?? "");
 }
+
+/**
+ * Detects sandbox security errors that contain sensitive filesystem paths
+ * and configuration details that must not be exposed to external channels.
+ */
+export function isSandboxSecurityError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return raw.includes("Sandbox security:");
+}

--- a/src/agents/pi-embedded-helpers/sandbox-security-error.test.ts
+++ b/src/agents/pi-embedded-helpers/sandbox-security-error.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { isSandboxSecurityError } from "./errors.js";
+
+describe("isSandboxSecurityError", () => {
+  it("detects bind mount outside allowed roots error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/home/user/.openclaw/sandbox-configs/config.json:/app/config.json:ro" ' +
+          'source "/home/user/.openclaw/sandbox-configs/config.json" is outside allowed roots ' +
+          "(/home/user/.openclaw/workspace-agent). Use a dangerous override only when you fully trust this runtime.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects non-absolute source path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "relative/path:/app/data:ro" uses a non-absolute source path.',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects reserved container path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/data:/proc:rw" targets reserved container path "/proc".',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects blocked path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/etc/shadow:/app/shadow:ro" reads blocked path "/etc/shadow".',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects network mode blocked error", () => {
+    expect(
+      isSandboxSecurityError('Sandbox security: network mode "host" is blocked.'),
+    ).toBe(true);
+  });
+
+  it("detects seccomp profile blocked error", () => {
+    expect(
+      isSandboxSecurityError('Sandbox security: seccomp profile "unconfined" is blocked.'),
+    ).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isSandboxSecurityError("")).toBe(false);
+  });
+
+  it("returns false for unrelated error messages", () => {
+    expect(isSandboxSecurityError("Connection timeout")).toBe(false);
+    expect(isSandboxSecurityError("API rate limit reached")).toBe(false);
+    expect(isSandboxSecurityError("context length exceeded")).toBe(false);
+  });
+
+  it("returns false for messages that mention sandbox without the security prefix", () => {
+    expect(isSandboxSecurityError("sandbox container started")).toBe(false);
+    expect(isSandboxSecurityError("running in sandbox mode")).toBe(false);
+  });
+
+  it("does not leak filesystem paths in the safe fallback message", () => {
+    const rawError =
+      'Sandbox security: bind mount "/home/ernest/.openclaw/sandbox-configs/config.json:/app/config.json:ro" ' +
+      'source "/home/ernest/.openclaw/sandbox-configs/config.json" is outside allowed roots ' +
+      "(/home/ernest/.openclaw/workspace-agent).";
+
+    expect(isSandboxSecurityError(rawError)).toBe(true);
+
+    // The safe message the channel receives should NOT contain any of these:
+    const safeMessage = "⚠️ Agent failed to start. Check logs: openclaw logs --follow";
+    expect(safeMessage).not.toContain("/home/ernest");
+    expect(safeMessage).not.toContain(".openclaw");
+    expect(safeMessage).not.toContain("sandbox-configs");
+    expect(safeMessage).not.toContain("workspace-agent");
+    expect(safeMessage).not.toContain("bind mount");
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import {
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
+  isSandboxSecurityError,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -623,6 +624,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      const isSandboxError = isSandboxSecurityError(message);
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
@@ -633,7 +635,9 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isSandboxError
+              ? "⚠️ Agent failed to start. Check logs: openclaw logs --follow"
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",


### PR DESCRIPTION
## Summary

When an agent fails to start due to a sandbox security violation, the full raw error message was being posted to the configured channel (Discord, Telegram, etc.) as if it were the agent's reply. This leaks sensitive internal information to public-facing channels.

**Example of what was leaking:**
```
⚠️ Agent failed before reply: Sandbox security: bind mount "/home/user/.openclaw/sandbox-configs/config.json:/app/config.json:ro" source "/home/user/.openclaw/sandbox-configs/config.json" is outside allowed roots (/home/user/.openclaw/workspace-agent).
```

This exposes full filesystem paths including OS usernames, sandbox configuration details, workspace directory structure, and config file names.

## Details

Added `isSandboxSecurityError()` to the error classification module. When a sandbox security error is detected in `runAgentTurnWithFallback`, the channel receives a safe generic message instead of the raw error:

```
⚠️ Agent failed to start. Check logs: openclaw logs --follow
```

The original error is still logged internally via `defaultRuntime` — it is only redacted from the outbound channel payload.

The fix follows the same pattern already used for billing errors, rate limit errors, and other sensitive failure modes in `agent-runner-execution.ts`.

## Related Issues

Fixes #51275

## How to Validate

1. Configure a sandbox bind mount with a source path outside the allowed workspace root
2. Trigger the agent via a channel (Discord, Telegram, etc.)
3. Confirm the channel receives the generic message, not the raw path
4. Confirm `openclaw logs --follow` still shows the full error internally

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
