### PR TITLE
fix(utils): reduce maskApiKey exposure from 16 to 4 characters

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isSandboxSecurityError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -861,3 +861,14 @@ export function isFailoverAssistantError(msg: AssistantMessage | undefined): boo
   }
   return isFailoverErrorMessage(msg.errorMessage ?? "");
 }
+
+/**
+ * Detects sandbox security errors that contain sensitive filesystem paths
+ * and configuration details that must not be exposed to external channels.
+ */
+export function isSandboxSecurityError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return raw.includes("Sandbox security:");
+}

--- a/src/agents/pi-embedded-helpers/sandbox-security-error.test.ts
+++ b/src/agents/pi-embedded-helpers/sandbox-security-error.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { isSandboxSecurityError } from "./errors.js";
+
+describe("isSandboxSecurityError", () => {
+  it("detects bind mount outside allowed roots error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/home/user/.openclaw/sandbox-configs/config.json:/app/config.json:ro" ' +
+          'source "/home/user/.openclaw/sandbox-configs/config.json" is outside allowed roots ' +
+          "(/home/user/.openclaw/workspace-agent). Use a dangerous override only when you fully trust this runtime.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects non-absolute source path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "relative/path:/app/data:ro" uses a non-absolute source path.',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects reserved container path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/data:/proc:rw" targets reserved container path "/proc".',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects blocked path error", () => {
+    expect(
+      isSandboxSecurityError(
+        'Sandbox security: bind mount "/etc/shadow:/app/shadow:ro" reads blocked path "/etc/shadow".',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects network mode blocked error", () => {
+    expect(
+      isSandboxSecurityError('Sandbox security: network mode "host" is blocked.'),
+    ).toBe(true);
+  });
+
+  it("detects seccomp profile blocked error", () => {
+    expect(
+      isSandboxSecurityError('Sandbox security: seccomp profile "unconfined" is blocked.'),
+    ).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isSandboxSecurityError("")).toBe(false);
+  });
+
+  it("returns false for unrelated error messages", () => {
+    expect(isSandboxSecurityError("Connection timeout")).toBe(false);
+    expect(isSandboxSecurityError("API rate limit reached")).toBe(false);
+    expect(isSandboxSecurityError("context length exceeded")).toBe(false);
+  });
+
+  it("returns false for messages that mention sandbox without the security prefix", () => {
+    expect(isSandboxSecurityError("sandbox container started")).toBe(false);
+    expect(isSandboxSecurityError("running in sandbox mode")).toBe(false);
+  });
+
+  it("does not leak filesystem paths in the safe fallback message", () => {
+    const rawError =
+      'Sandbox security: bind mount "/home/ernest/.openclaw/sandbox-configs/config.json:/app/config.json:ro" ' +
+      'source "/home/ernest/.openclaw/sandbox-configs/config.json" is outside allowed roots ' +
+      "(/home/ernest/.openclaw/workspace-agent).";
+
+    expect(isSandboxSecurityError(rawError)).toBe(true);
+
+    // The safe message the channel receives should NOT contain any of these:
+    const safeMessage = "⚠️ Agent failed to start. Check logs: openclaw logs --follow";
+    expect(safeMessage).not.toContain("/home/ernest");
+    expect(safeMessage).not.toContain(".openclaw");
+    expect(safeMessage).not.toContain("sandbox-configs");
+    expect(safeMessage).not.toContain("workspace-agent");
+    expect(safeMessage).not.toContain("bind mount");
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import {
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
+  isSandboxSecurityError,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -623,6 +624,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      const isSandboxError = isSandboxSecurityError(message);
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
@@ -633,7 +635,9 @@ export async function runAgentTurnWithFallback(params: {
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isSandboxError
+              ? "⚠️ Agent failed to start. Check logs: openclaw logs --follow"
+              : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -7,14 +7,32 @@ describe("maskApiKey", () => {
     expect(maskApiKey("   ")).toBe("missing");
   });
 
-  it("masks short and medium values without returning raw secrets", () => {
-    expect(maskApiKey(" abcdefghijklmnop ")).toBe("ab...op");
-    expect(maskApiKey(" short ")).toBe("s...t");
-    expect(maskApiKey(" a ")).toBe("a...a");
-    expect(maskApiKey(" ab ")).toBe("a...b");
+  it("masks short keys (<=4 chars) with first 1 char only", () => {
+    expect(maskApiKey("a")).toBe("a...");
+    expect(maskApiKey("ab")).toBe("a...");
+    expect(maskApiKey("abcd")).toBe("a...");
+    expect(maskApiKey(" short ")).toBe("shor...");
   });
 
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop"); // pragma: allowlist secret
+  it("masks longer keys with first 4 chars only", () => {
+    expect(maskApiKey("abcdefghijklmnop")).toBe("abcd...");
+    expect(maskApiKey("sk-ant-api03-abcxyz1234")).toBe("sk-a...");
+  });
+
+  it("never exposes the last 8 characters of the key", () => {
+    const key = "sk-ant-api03-abcdefghWXYZ5678"; // pragma: allowlist secret
+    const lastEight = key.slice(-8);
+    const masked = maskApiKey(key);
+    expect(masked).not.toContain(lastEight);
+    // Also verify no tail chars leak individually beyond position 4
+    for (const char of key.slice(4)) {
+      if (!key.slice(0, 4).includes(char)) {
+        expect(masked).not.toContain(char);
+      }
+    }
+  });
+
+  it("trims whitespace before masking", () => {
+    expect(maskApiKey("  sk-ant-api03-abc  ")).toBe("sk-a...");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -3,11 +3,8 @@ export const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 6) {
-    return `${trimmed.slice(0, 1)}...${trimmed.slice(-1)}`;
+  if (trimmed.length <= 4) {
+    return `${trimmed.slice(0, 1)}...`;
   }
-  if (trimmed.length <= 16) {
-    return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 4)}...`;
 };


### PR DESCRIPTION
## Summary

`maskApiKey()` exposes up to 16 characters of API keys when displaying `/models list` output in chat channels. For keys with 16 or fewer characters, the masked output may reveal most or all of the key.

**Before:**
```
sk-ant-api03-abc...wxyz1234   ← 16 chars exposed
abcdefghijklmnop              ← ab...op (4 chars exposed — may be most of key)
```

**After:**
```
sk-a...   ← only 4 chars, never the end
abcd...   ← only 4 chars, never the end
```

## Details

Simplified `maskApiKey()` to two branches:
- Keys ≤ 4 chars: show first 1 char + `...`
- Keys > 4 chars: show first 4 chars + `...`

The end of the key is **never** exposed. This follows the same pattern used by GitHub, npm, and other credential-handling systems.

Updated tests to match the new behavior and added assertions that verify the last 8 characters of a key are never present in masked output.

## Related Issues

Fixes #34452

## How to Validate

Run `/models list` in any channel — confirm API keys show only the first 4 characters followed by `...`.

Run unit tests: `pnpm test -- --testPathPattern=mask-api-key`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
