### PR TITLE
agents: emit lifecycle usage event with accumulated token/cost data

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -836,6 +836,30 @@ async function agentCommandInternal(
       throw err;
     }
 
+    // Emit supplementary lifecycle "usage" event with accumulated token/cost
+    // data so external observers (dashboards, recorders) can track per-run
+    // resource consumption without needing RPC access to session transcripts.
+    const agentMeta = result.meta.agentMeta;
+    if (agentMeta?.usage) {
+      try {
+        emitAgentEvent({
+          runId,
+          sessionKey,
+          stream: "lifecycle",
+          data: {
+            phase: "usage",
+            provider: agentMeta.provider,
+            model: agentMeta.model,
+            usage: agentMeta.usage,
+            lastCallUsage: agentMeta.lastCallUsage,
+            durationMs: Date.now() - startedAt,
+          },
+        });
+      } catch {
+        // Non-fatal: usage reporting should not surface as a run error.
+      }
+    }
+
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {
       await updateSessionStoreAfterAgentRun({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -183,6 +183,7 @@ export async function runAgentTurnWithFallback(params: {
     params.getActiveSessionEntry()?.systemPromptReport,
   );
 
+  const wallClockStartedAt = Date.now();
   while (true) {
     try {
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
@@ -344,19 +345,45 @@ export async function runAgentTurnWithFallback(params: {
                 });
                 lifecycleTerminalEmitted = true;
 
+                // Emit supplementary usage event with accumulated token/cost data.
+                // Wrapped in its own try/catch so a failure here cannot
+                // propagate to the outer catch and emit a spurious "error" event.
+                const agentMeta = result.meta?.agentMeta;
+                if (agentMeta?.usage) {
+                  try {
+                    emitAgentEvent({
+                      runId,
+                      sessionKey: params.sessionKey,
+                      stream: "lifecycle",
+                      data: {
+                        phase: "usage",
+                        provider: agentMeta.provider,
+                        model: agentMeta.model,
+                        usage: agentMeta.usage,
+                        lastCallUsage: agentMeta.lastCallUsage,
+                        durationMs: Date.now() - wallClockStartedAt,
+                      },
+                    });
+                  } catch {
+                    // Non-fatal: usage reporting should not surface as a run error.
+                  }
+                }
+
                 return result;
               } catch (err) {
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "error",
-                    startedAt,
-                    endedAt: Date.now(),
-                    error: String(err),
-                  },
-                });
-                lifecycleTerminalEmitted = true;
+                if (!lifecycleTerminalEmitted) {
+                  emitAgentEvent({
+                    runId,
+                    stream: "lifecycle",
+                    data: {
+                      phase: "error",
+                      startedAt,
+                      endedAt: Date.now(),
+                      error: String(err),
+                    },
+                  });
+                  lifecycleTerminalEmitted = true;
+                }
                 throw err;
               } finally {
                 // Defensive backstop: never let a CLI run complete without a terminal
@@ -554,6 +581,31 @@ export async function runAgentTurnWithFallback(params: {
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                 result.meta?.systemPromptReport,
               );
+              // Emit supplementary usage event with accumulated token/cost data.
+              // The pi-embedded subscribe handler emits lifecycle start/end but does
+              // not have access to agentMeta; emit a separate usage event now that
+              // the run result is available.
+              const agentMeta = result.meta?.agentMeta;
+              if (agentMeta?.usage) {
+                try {
+                  emitAgentEvent({
+                    runId,
+                    sessionKey: params.sessionKey,
+                    stream: "lifecycle",
+                    data: {
+                      phase: "usage",
+                      provider: agentMeta.provider,
+                      model: agentMeta.model,
+                      usage: agentMeta.usage,
+                      lastCallUsage: agentMeta.lastCallUsage,
+                      durationMs: Date.now() - wallClockStartedAt,
+                    },
+                  });
+                } catch {
+                  // Non-fatal: usage reporting should not surface as a run error.
+                }
+              }
+
               const resultCompactionCount = Math.max(
                 0,
                 result.meta?.agentMeta?.compactionCount ?? 0,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -24,7 +24,7 @@ import {
 } from "../../config/sessions.js";
 import { readSessionMessages } from "../../gateway/session-utils.fs.js";
 import { logVerbose } from "../../globals.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { resolveMemoryFlushPlan } from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -678,7 +678,7 @@ export async function runMemoryFlushIfNeeded(params: {
     .join("\n\n");
   let postCompactionSessionId: string | undefined;
   try {
-    await runWithModelFallback({
+    const flushFallbackResult = await runWithModelFallback({
       ...resolveModelFallbackOptions(params.followupRun.run),
       runId: flushRunId,
       run: async (provider, model, runOptions) => {
@@ -722,6 +722,27 @@ export async function runMemoryFlushIfNeeded(params: {
         return result;
       },
     });
+    // Emit supplementary usage event with accumulated token/cost data.
+    const flushAgentMeta = flushFallbackResult.result?.meta?.agentMeta;
+    if (flushAgentMeta?.usage) {
+      try {
+        emitAgentEvent({
+          runId: flushRunId,
+          sessionKey: params.sessionKey ?? params.followupRun.run.sessionKey,
+          stream: "lifecycle",
+          data: {
+            phase: "usage",
+            provider: flushAgentMeta.provider,
+            model: flushAgentMeta.model,
+            usage: flushAgentMeta.usage,
+            lastCallUsage: flushAgentMeta.lastCallUsage,
+            durationMs: Date.now() - memoryFlushNowMs,
+          },
+        });
+      } catch {
+        // Non-fatal: usage reporting should not surface as a run error.
+      }
+    }
     let memoryFlushCompactionCount =
       activeSessionEntry?.compactionCount ??
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -13,7 +13,7 @@ import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
@@ -171,6 +171,7 @@ export function createFollowupRunner(params: {
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
+      const wallClockStartedAt = Date.now();
       try {
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
@@ -252,6 +253,29 @@ export function createFollowupRunner(params: {
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                 result.meta?.systemPromptReport,
               );
+
+              // Emit supplementary usage event with accumulated token/cost data.
+              const agentMeta = result.meta?.agentMeta;
+              if (agentMeta?.usage) {
+                try {
+                  emitAgentEvent({
+                    runId,
+                    sessionKey: queued.run.sessionKey,
+                    stream: "lifecycle",
+                    data: {
+                      phase: "usage",
+                      provider: agentMeta.provider,
+                      model: agentMeta.model,
+                      usage: agentMeta.usage,
+                      lastCallUsage: agentMeta.lastCallUsage,
+                      durationMs: Date.now() - wallClockStartedAt,
+                    },
+                  });
+                } catch {
+                  // Non-fatal: usage reporting should not surface as a run error.
+                }
+              }
+
               const resultCompactionCount = Math.max(
                 0,
                 result.meta?.agentMeta?.compactionCount ?? 0,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -37,7 +37,7 @@ import {
   setSessionRuntimeModel,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import {
@@ -433,6 +433,17 @@ export async function runCronIsolatedAgentTurn(params: {
   let fallbackModel = model;
   const runStartedAt = Date.now();
   let runEndedAt = runStartedAt;
+  // Accumulate usage across interim-ack follow-up turns so the usage event
+  // reflects total resource consumption, not just the final turn.
+  let accumulatedUsage:
+    | {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheWrite: number;
+        total: number | undefined;
+      }
+    | undefined;
   try {
     const sessionFile = resolveSessionTranscriptPath(cronSession.sessionEntry.sessionId, agentId);
     const resolvedVerboseLevel =
@@ -555,6 +566,42 @@ export async function runCronIsolatedAgentTurn(params: {
       provider = fallbackResult.provider;
       model = fallbackResult.model;
       runEndedAt = Date.now();
+
+      // Accumulate token usage across turns (interim-ack + final).
+      const turnUsage = fallbackResult.result?.meta?.agentMeta?.usage;
+      if (turnUsage) {
+        // CLI providers report a context snapshot (cumulative totals) rather
+        // than per-turn deltas.  Summing snapshots would double-count earlier
+        // tokens, so we take the latest snapshot directly.
+        if (isCliProvider(provider, cfgWithAgentDefaults)) {
+          accumulatedUsage = {
+            input: turnUsage.input ?? 0,
+            output: turnUsage.output ?? 0,
+            cacheRead: turnUsage.cacheRead ?? 0,
+            cacheWrite: turnUsage.cacheWrite ?? 0,
+            total: turnUsage.total,
+          };
+        } else if (accumulatedUsage) {
+          accumulatedUsage.input += turnUsage.input ?? 0;
+          accumulatedUsage.output += turnUsage.output ?? 0;
+          accumulatedUsage.cacheRead += turnUsage.cacheRead ?? 0;
+          accumulatedUsage.cacheWrite += turnUsage.cacheWrite ?? 0;
+          // Preserve undefined when providers don't report total so
+          // dashboards can distinguish "zero" from "not reported".
+          accumulatedUsage.total =
+            turnUsage.total != null
+              ? (accumulatedUsage.total ?? 0) + turnUsage.total
+              : accumulatedUsage.total;
+        } else {
+          accumulatedUsage = {
+            input: turnUsage.input ?? 0,
+            output: turnUsage.output ?? 0,
+            cacheRead: turnUsage.cacheRead ?? 0,
+            cacheWrite: turnUsage.cacheWrite ?? 0,
+            total: turnUsage.total,
+          };
+        }
+      }
     };
 
     await runPrompt(commandBody);
@@ -613,6 +660,31 @@ export async function runCronIsolatedAgentTurn(params: {
     return withRunSession({ status: "error", error: "cron isolated run returned no result" });
   }
   const finalRunResult = runResult;
+
+  // Emit supplementary usage event with accumulated token/cost data.
+  // Uses accumulatedUsage (summed across interim-ack + final turns) so
+  // multi-turn cron runs report total resource consumption.
+  const agentMeta = finalRunResult.meta?.agentMeta;
+  if (accumulatedUsage || agentMeta?.usage) {
+    try {
+      emitAgentEvent({
+        runId: cronSession.sessionEntry.sessionId,
+        sessionKey: agentSessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "usage",
+          provider: agentMeta?.provider,
+          model: agentMeta?.model,
+          usage: accumulatedUsage ?? agentMeta?.usage,
+          lastCallUsage: agentMeta?.lastCallUsage,
+          durationMs: Date.now() - runStartedAt,
+        },
+      });
+    } catch {
+      // Non-fatal: usage reporting should not surface as a run error.
+    }
+  }
+
   const payloads = finalRunResult.payloads ?? [];
 
   // Update token+model fields in the session store.

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -207,6 +207,11 @@ export type ChatRunState = {
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
   abortedRuns: Map<string, number>;
+  /** Stashed sourceRunId → ChatRunEntry for runs that have ended, so late usage
+   *  events can still resolve clientRunId after the registry entry is removed. */
+  finishedRunLinks: Map<string, ChatRunEntry>;
+  /** Timers that evict stale finishedRunLinks entries if no usage event arrives. */
+  finishedRunLinkTimers: Map<string, ReturnType<typeof setTimeout>>;
   clear: () => void;
 };
 
@@ -216,6 +221,8 @@ export function createChatRunState(): ChatRunState {
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
+  const finishedRunLinks = new Map<string, ChatRunEntry>();
+  const finishedRunLinkTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   const clear = () => {
     registry.clear();
@@ -223,6 +230,11 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
+    finishedRunLinks.clear();
+    for (const timer of finishedRunLinkTimers.values()) {
+      clearTimeout(timer);
+    }
+    finishedRunLinkTimers.clear();
   };
 
   return {
@@ -231,6 +243,8 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,
+    finishedRunLinks,
+    finishedRunLinkTimers,
     clear,
   };
 }
@@ -715,7 +729,8 @@ export function createAgentEventHandler({
   };
 
   return (evt: AgentEventPayload) => {
-    const chatLink = chatRunState.registry.peek(evt.runId);
+    const chatLink =
+      chatRunState.registry.peek(evt.runId) ?? chatRunState.finishedRunLinks.get(evt.runId);
     const eventSessionKey =
       typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined;
     const isControlUiVisible = getAgentRunContext(evt.runId)?.isControlUiVisible ?? true;
@@ -817,9 +832,23 @@ export function createAgentEventHandler({
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
+            // Duplicate terminal event (e.g. fallback retry reusing the same
+            // runId).  Still clean up sequence/context tracking so stale
+            // entries don't accumulate on long-lived gateways.
+            toolEventRecipients.markFinal(evt.runId);
             clearAgentRunContext(evt.runId);
+            agentRunSeq.delete(evt.runId);
+            agentRunSeq.delete(clientRunId);
             return;
           }
+          // Stash the link so late usage events can still resolve clientRunId.
+          // Auto-evict after 60s to prevent unbounded growth if no usage event arrives.
+          chatRunState.finishedRunLinks.set(evt.runId, finished);
+          const evictTimer = setTimeout(() => {
+            chatRunState.finishedRunLinks.delete(evt.runId);
+            chatRunState.finishedRunLinkTimers.delete(evt.runId);
+          }, 60_000);
+          chatRunState.finishedRunLinkTimers.set(evt.runId, evictTimer);
           emitChatFinal(
             finished.sessionKey,
             finished.clientRunId,
@@ -856,6 +885,20 @@ export function createAgentEventHandler({
       clearAgentRunContext(evt.runId);
       agentRunSeq.delete(evt.runId);
       agentRunSeq.delete(clientRunId);
+    } else if (lifecyclePhase === "usage") {
+      // Usage events may arrive after the terminal end/error event because
+      // agentMeta is only available after runEmbeddedPiAgent returns. The seq
+      // tracking at the top of this handler re-creates agentRunSeq entries;
+      // clean them up immediately to prevent a permanent leak.
+      clearAgentRunContext(evt.runId);
+      agentRunSeq.delete(evt.runId);
+      agentRunSeq.delete(clientRunId);
+      chatRunState.finishedRunLinks.delete(evt.runId);
+      const evictTimer = chatRunState.finishedRunLinkTimers.get(evt.runId);
+      if (evictTimer) {
+        clearTimeout(evictTimer);
+        chatRunState.finishedRunLinkTimers.delete(evt.runId);
+      }
     }
 
     if (

--- a/src/infra/agent-events.lifecycle-usage.test.ts
+++ b/src/infra/agent-events.lifecycle-usage.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  emitAgentEvent,
+  onAgentEvent,
+  registerAgentRunContext,
+  type AgentEventPayload,
+} from "./agent-events.js";
+
+/**
+ * Validates the lifecycle "usage" event contract added for external observers
+ * (dashboards, recorders). The actual emission sites live in agent-command.ts,
+ * agent-runner-execution.ts, followup-runner.ts, cron/isolated-agent/run.ts,
+ * and agent-runner-memory.ts; this test verifies the shape and fields of the
+ * event as it flows through the agent-events bus.
+ */
+describe("lifecycle usage event", () => {
+  let events: AgentEventPayload[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    events = [];
+    unsubscribe = onAgentEvent((evt) => events.push(evt));
+  });
+
+  afterEach(() => unsubscribe());
+
+  it("emits phase=usage with correct token and model fields", () => {
+    const runId = `usage-test-${Date.now()}`;
+    registerAgentRunContext(runId, { sessionKey: "agent:main:main" });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "usage",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        usage: { input: 100, output: 50, cacheRead: 20, cacheWrite: 10 },
+        lastCallUsage: { input: 30, output: 15 },
+        durationMs: 4500,
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    const evt = events[0];
+    expect(evt.stream).toBe("lifecycle");
+    expect(evt.sessionKey).toBe("agent:main:main");
+    expect(evt.data).toMatchObject({
+      phase: "usage",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      usage: { input: 100, output: 50, cacheRead: 20, cacheWrite: 10 },
+      lastCallUsage: { input: 30, output: 15 },
+      durationMs: 4500,
+    });
+    expect(evt.seq).toBeGreaterThan(0);
+    expect(evt.ts).toBeGreaterThan(0);
+  });
+
+  it("is not emitted when agentMeta.usage is absent", () => {
+    // This mirrors the guard: `if (agentMeta?.usage) { emitAgentEvent(...) }`
+    const agentMeta: { usage?: unknown } = {};
+    if (agentMeta?.usage) {
+      emitAgentEvent({
+        runId: "no-usage",
+        stream: "lifecycle",
+        data: { phase: "usage" },
+      });
+    }
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not throw when wrapped in defensive try/catch", () => {
+    // Simulates the non-fatal pattern used in all emission sites.
+    // Even if the event bus throws, it should not propagate.
+    const badListener = onAgentEvent(() => {
+      throw new Error("listener crash");
+    });
+
+    expect(() => {
+      emitAgentEvent({
+        runId: "defensive-test",
+        stream: "lifecycle",
+        data: { phase: "usage", usage: { input: 1 } },
+      });
+    }).not.toThrow();
+
+    badListener();
+  });
+
+  it("usage event after terminal end does not corrupt tracking state", () => {
+    // Simulates the real flow: end fires first, then usage arrives.
+    // Downstream consumers (server-chat.ts) must handle this gracefully
+    // without leaking agentRunSeq entries.
+    const runId = `post-terminal-${Date.now()}`;
+    registerAgentRunContext(runId, { sessionKey: "agent:main:main" });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: Date.now() },
+    });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "usage",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        usage: { input: 200, output: 100 },
+        durationMs: 3000,
+      },
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].data.phase).toBe("end");
+    expect(events[1].data.phase).toBe("usage");
+    // Both events share the same runId and sessionKey
+    expect(events[1].runId).toBe(runId);
+    expect(events[1].sessionKey).toBe("agent:main:main");
+  });
+
+  it("durationMs reflects wall-clock time, not just last attempt", () => {
+    // Validates the contract: durationMs should be Date.now() - startedAt
+    // (full run including fallback retries), not result.meta.durationMs
+    // (single attempt only).
+    const startedAt = Date.now() - 5000; // Simulate 5s run
+    const runId = `duration-${Date.now()}`;
+    registerAgentRunContext(runId, { sessionKey: "agent:main:main" });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "usage",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        usage: { input: 50, output: 25 },
+        durationMs: Date.now() - startedAt,
+      },
+    });
+
+    const evt = events[0];
+    expect(evt.data.durationMs).toBeGreaterThanOrEqual(5000);
+  });
+});


### PR DESCRIPTION
## Summary

- Emit a supplementary `lifecycle` event with `phase: "usage"` after each agent run completes, containing accumulated token counts (`input`, `output`, `cacheRead`, `cacheWrite`), model, provider, and run duration
- Added to both the primary agent-command path (`src/agents/agent-command.ts`) and the auto-reply/CLI path (`src/auto-reply/reply/agent-runner-execution.ts`)
- Only emitted when `agentMeta.usage` exists (no event for runs that don't report usage)

## Motivation

The lifecycle `end` event currently contains only timing data (`startedAt`, `endedAt`, `aborted`, `stopReason`). Token/cost metrics collected in `agentMeta` during the run are persisted to the session store but never surfaced on the WebSocket event stream. This makes it impossible for external observers (dashboards, recorders, monitoring tools) to track per-run resource consumption without RPC access to session transcripts.

The new `phase: "usage"` event provides this data on the event stream, enabling passive observers to capture token usage without requiring additional API calls.

## Event format

```json
{
  "type": "event",
  "event": "agent",
  "payload": {
    "runId": "...",
    "stream": "lifecycle",
    "data": {
      "phase": "usage",
      "provider": "anthropic",
      "model": "claude-sonnet-4-20250514",
      "usage": {
        "input": 1234,
        "output": 567,
        "cacheRead": 890,
        "cacheWrite": 100,
        "total": 2791
      },
      "lastCallUsage": { ... },
      "durationMs": 4521
    }
  }
}
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (0 warnings, 0 errors)
- [x] `pnpm test -- src/agents/pi-embedded-runner/usage-reporting.test.ts` passes (5/5)
- [x] Tested locally with a custom recorder service — confirmed usage events arrive on the WebSocket stream after runs complete

---

- [x] AI-assisted (Claude Code)
- [x] Fully tested locally
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)