### PR TITLE
feat(github-copilot): resolve any model ID dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/context engines: add transcript maintenance rewrites for context engines, preserve active-branch transcript metadata during rewrites, and harden overflow-recovery truncation to rewrite sessions under the normal session write lock. (#51191) Thanks @jalehman.
 - Telegram/apiRoot: add per-account custom Bot API endpoint support across send, probe, setup, doctor repair, and inbound media download paths so proxied or self-hosted Telegram deployments work end to end. (#48842) Thanks @Cypherm.
 - Telegram/topics: auto-rename DM forum topics on first message with LLM-generated labels, with per-account and per-DM `autoTopicLabel` overrides. (#51502) Thanks @Lukavyi.
+- Models/GitHub Copilot: allow forward-compat dynamic model ids without code updates, while preserving configured provider and per-model overrides for those synthetic models. (#51325) Thanks @fuller-stack-dev.
 
 ### Fixes
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -51,25 +51,58 @@ function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.Proces
   return { githubToken: "", hasProfile };
 }
 
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8192;
+
 function resolveCopilotForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
   const trimmedModelId = ctx.modelId.trim();
-  if (trimmedModelId.toLowerCase() !== CODEX_GPT_53_MODEL_ID) {
+  if (!trimmedModelId) {
     return undefined;
   }
-  for (const templateId of CODEX_TEMPLATE_MODEL_IDS) {
-    const template = ctx.modelRegistry.find(PROVIDER_ID, templateId) as ProviderRuntimeModel | null;
-    if (!template) {
-      continue;
-    }
-    return normalizeModelCompat({
-      ...template,
-      id: trimmedModelId,
-      name: trimmedModelId,
-    } as ProviderRuntimeModel);
+
+  // If the model is already in the registry, let the normal path handle it.
+  const existing = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
+  if (existing) {
+    return undefined;
   }
-  return undefined;
+
+  // For gpt-5.3-codex specifically, clone from the gpt-5.2-codex template
+  // to preserve any special settings the registry has for codex models.
+  if (trimmedModelId.toLowerCase() === CODEX_GPT_53_MODEL_ID) {
+    for (const templateId of CODEX_TEMPLATE_MODEL_IDS) {
+      const template = ctx.modelRegistry.find(
+        PROVIDER_ID,
+        templateId,
+      ) as ProviderRuntimeModel | null;
+      if (!template) {
+        continue;
+      }
+      return normalizeModelCompat({
+        ...template,
+        id: trimmedModelId,
+        name: trimmedModelId,
+      } as ProviderRuntimeModel);
+    }
+  }
+
+  // Catch-all: create a synthetic model definition for any unknown model ID.
+  // The Copilot API is OpenAI-compatible and will return its own error if the
+  // model isn't available on the user's plan. This lets new models be used
+  // by simply adding them to agents.defaults.models in openclaw.json — no
+  // code change required.
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    provider: PROVIDER_ID,
+    api: "openai-responses",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  } as ProviderRuntimeModel);
 }
 
 async function runGitHubCopilotAuth(ctx: ProviderAuthContext) {

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -1,20 +1,12 @@
 import { ensureAuthProfileStore, listProfilesForProvider } from "openclaw/plugin-sdk/agent-runtime";
-import {
-  definePluginEntry,
-  type ProviderAuthContext,
-  type ProviderResolveDynamicModelContext,
-  type ProviderRuntimeModel,
-} from "openclaw/plugin-sdk/core";
+import { definePluginEntry, type ProviderAuthContext } from "openclaw/plugin-sdk/core";
 import { coerceSecretRef } from "openclaw/plugin-sdk/provider-auth";
 import { githubCopilotLoginCommand } from "openclaw/plugin-sdk/provider-auth-login";
-import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-models";
+import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } from "./token.js";
 import { fetchCopilotUsage } from "./usage.js";
 
-const PROVIDER_ID = "github-copilot";
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
-const CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
-const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.2", "gpt-5.2-codex"] as const;
 
 function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
@@ -49,60 +41,6 @@ function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.Proces
     };
   }
   return { githubToken: "", hasProfile };
-}
-
-const DEFAULT_CONTEXT_WINDOW = 128_000;
-const DEFAULT_MAX_TOKENS = 8192;
-
-function resolveCopilotForwardCompatModel(
-  ctx: ProviderResolveDynamicModelContext,
-): ProviderRuntimeModel | undefined {
-  const trimmedModelId = ctx.modelId.trim();
-  if (!trimmedModelId) {
-    return undefined;
-  }
-
-  // If the model is already in the registry, let the normal path handle it.
-  const existing = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
-  if (existing) {
-    return undefined;
-  }
-
-  // For gpt-5.3-codex specifically, clone from the gpt-5.2-codex template
-  // to preserve any special settings the registry has for codex models.
-  if (trimmedModelId.toLowerCase() === CODEX_GPT_53_MODEL_ID) {
-    for (const templateId of CODEX_TEMPLATE_MODEL_IDS) {
-      const template = ctx.modelRegistry.find(
-        PROVIDER_ID,
-        templateId,
-      ) as ProviderRuntimeModel | null;
-      if (!template) {
-        continue;
-      }
-      return normalizeModelCompat({
-        ...template,
-        id: trimmedModelId,
-        name: trimmedModelId,
-      } as ProviderRuntimeModel);
-    }
-  }
-
-  // Catch-all: create a synthetic model definition for any unknown model ID.
-  // The Copilot API is OpenAI-compatible and will return its own error if the
-  // model isn't available on the user's plan. This lets new models be used
-  // by simply adding them to agents.defaults.models in openclaw.json — no
-  // code change required.
-  return normalizeModelCompat({
-    id: trimmedModelId,
-    name: trimmedModelId,
-    provider: PROVIDER_ID,
-    api: "openai-responses",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
-  } as ProviderRuntimeModel);
 }
 
 async function runGitHubCopilotAuth(ctx: ProviderAuthContext) {

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: vi.fn(() => []),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-models", () => ({
+  normalizeModelCompat: (model: Record<string, unknown>) => model,
+}));
+
+import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/core";
+import { resolveCopilotForwardCompatModel } from "./models.js";
+
+function createMockCtx(
+  modelId: string,
+  registryModels: Record<string, Record<string, unknown>> = {},
+): ProviderResolveDynamicModelContext {
+  return {
+    modelId,
+    provider: "github-copilot",
+    config: {},
+    modelRegistry: {
+      find: (provider: string, id: string) => registryModels[`${provider}/${id}`] ?? null,
+    },
+  } as unknown as ProviderResolveDynamicModelContext;
+}
+
+describe("resolveCopilotForwardCompatModel", () => {
+  it("returns undefined for empty modelId", () => {
+    expect(resolveCopilotForwardCompatModel(createMockCtx(""))).toBeUndefined();
+    expect(resolveCopilotForwardCompatModel(createMockCtx("  "))).toBeUndefined();
+  });
+
+  it("returns undefined when model is already in registry", () => {
+    const ctx = createMockCtx("gpt-4o", {
+      "github-copilot/gpt-4o": { id: "gpt-4o", name: "gpt-4o" },
+    });
+    expect(resolveCopilotForwardCompatModel(ctx)).toBeUndefined();
+  });
+
+  it("clones gpt-5.2-codex template for gpt-5.3-codex", () => {
+    const template = {
+      id: "gpt-5.2-codex",
+      name: "gpt-5.2-codex",
+      provider: "github-copilot",
+      api: "openai-responses",
+      reasoning: true,
+      contextWindow: 200_000,
+    };
+    const ctx = createMockCtx("gpt-5.3-codex", {
+      "github-copilot/gpt-5.2-codex": template,
+    });
+    const result = resolveCopilotForwardCompatModel(ctx);
+    expect(result).toBeDefined();
+    expect(result!.id).toBe("gpt-5.3-codex");
+    expect(result!.name).toBe("gpt-5.3-codex");
+    expect((result as unknown as Record<string, unknown>).reasoning).toBe(true);
+  });
+
+  it("falls through to synthetic catch-all when codex template is missing", () => {
+    const ctx = createMockCtx("gpt-5.3-codex");
+    const result = resolveCopilotForwardCompatModel(ctx);
+    expect(result).toBeDefined();
+    expect(result!.id).toBe("gpt-5.3-codex");
+  });
+
+  it("creates synthetic model for arbitrary unknown model ID", () => {
+    const ctx = createMockCtx("gpt-5.4-mini");
+    const result = resolveCopilotForwardCompatModel(ctx);
+    expect(result).toBeDefined();
+    expect(result!.id).toBe("gpt-5.4-mini");
+    expect(result!.name).toBe("gpt-5.4-mini");
+    expect((result as unknown as Record<string, unknown>).api).toBe("openai-responses");
+  });
+
+  it("infers reasoning=true for o1/o3 model IDs", () => {
+    for (const id of ["o1", "o3-mini", "o1-preview"]) {
+      const ctx = createMockCtx(id);
+      const result = resolveCopilotForwardCompatModel(ctx);
+      expect(result).toBeDefined();
+      expect((result as unknown as Record<string, unknown>).reasoning).toBe(true);
+    }
+  });
+
+  it("sets reasoning=false for non-reasoning model IDs", () => {
+    for (const id of ["gpt-5.4-mini", "claude-sonnet-4.6", "gpt-4o"]) {
+      const ctx = createMockCtx(id);
+      const result = resolveCopilotForwardCompatModel(ctx);
+      expect(result).toBeDefined();
+      expect((result as unknown as Record<string, unknown>).reasoning).toBe(false);
+    }
+  });
+});

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -72,7 +72,7 @@ describe("resolveCopilotForwardCompatModel", () => {
     expect(result!.id).toBe("gpt-5.4-mini");
     expect(result!.name).toBe("gpt-5.4-mini");
     expect((result as unknown as Record<string, unknown>).api).toBe("openai-responses");
-    expect((result as unknown as Record<string, unknown>).input).toEqual(["text"]);
+    expect((result as unknown as Record<string, unknown>).input).toEqual(["text", "image"]);
   });
 
   it("infers reasoning=true for o1/o3 model IDs", () => {

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -72,6 +72,7 @@ describe("resolveCopilotForwardCompatModel", () => {
     expect(result!.id).toBe("gpt-5.4-mini");
     expect(result!.name).toBe("gpt-5.4-mini");
     expect((result as unknown as Record<string, unknown>).api).toBe("openai-responses");
+    expect((result as unknown as Record<string, unknown>).input).toEqual(["text", "image"]);
   });
 
   it("infers reasoning=true for o1/o3 model IDs", () => {

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -72,7 +72,7 @@ describe("resolveCopilotForwardCompatModel", () => {
     expect(result!.id).toBe("gpt-5.4-mini");
     expect(result!.name).toBe("gpt-5.4-mini");
     expect((result as unknown as Record<string, unknown>).api).toBe("openai-responses");
-    expect((result as unknown as Record<string, unknown>).input).toEqual(["text", "image"]);
+    expect((result as unknown as Record<string, unknown>).input).toEqual(["text"]);
   });
 
   it("infers reasoning=true for o1/o3 model IDs", () => {

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -76,7 +76,7 @@ describe("resolveCopilotForwardCompatModel", () => {
   });
 
   it("infers reasoning=true for o1/o3 model IDs", () => {
-    for (const id of ["o1", "o3-mini", "o1-preview"]) {
+    for (const id of ["o1", "o3", "o3-mini", "o1-preview"]) {
       const ctx = createMockCtx(id);
       const result = resolveCopilotForwardCompatModel(ctx);
       expect(result).toBeDefined();

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -84,8 +84,14 @@ describe("resolveCopilotForwardCompatModel", () => {
     }
   });
 
-  it("sets reasoning=false for non-reasoning model IDs", () => {
-    for (const id of ["gpt-5.4-mini", "claude-sonnet-4.6", "gpt-4o"]) {
+  it("sets reasoning=false for non-reasoning model IDs including mid-string o1/o3", () => {
+    for (const id of [
+      "gpt-5.4-mini",
+      "claude-sonnet-4.6",
+      "gpt-4o",
+      "audio-o1-hd",
+      "turbo-o3-voice",
+    ]) {
       const ctx = createMockCtx(id);
       const result = resolveCopilotForwardCompatModel(ctx);
       expect(result).toBeDefined();

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -58,7 +58,7 @@ export function resolveCopilotForwardCompatModel(
     provider: PROVIDER_ID,
     api: "openai-responses",
     reasoning,
-    input: ["text"],
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -58,7 +58,9 @@ export function resolveCopilotForwardCompatModel(
     provider: PROVIDER_ID,
     api: "openai-responses",
     reasoning,
-    input: ["text"],
+    // Optimistic: most Copilot models support images, and the API rejects
+    // image payloads for text-only models rather than failing silently.
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -58,7 +58,7 @@ export function resolveCopilotForwardCompatModel(
     provider: PROVIDER_ID,
     api: "openai-responses",
     reasoning,
-    input: ["text", "image"],
+    input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -1,0 +1,66 @@
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/core";
+import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-models";
+
+export const PROVIDER_ID = "github-copilot";
+export const CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+export const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8192;
+
+export function resolveCopilotForwardCompatModel(
+  ctx: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel | undefined {
+  const trimmedModelId = ctx.modelId.trim();
+  if (!trimmedModelId) {
+    return undefined;
+  }
+
+  // If the model is already in the registry, let the normal path handle it.
+  const existing = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
+  if (existing) {
+    return undefined;
+  }
+
+  // For gpt-5.3-codex specifically, clone from the gpt-5.2-codex template
+  // to preserve any special settings the registry has for codex models.
+  if (trimmedModelId.toLowerCase() === CODEX_GPT_53_MODEL_ID) {
+    for (const templateId of CODEX_TEMPLATE_MODEL_IDS) {
+      const template = ctx.modelRegistry.find(
+        PROVIDER_ID,
+        templateId,
+      ) as ProviderRuntimeModel | null;
+      if (!template) {
+        continue;
+      }
+      return normalizeModelCompat({
+        ...template,
+        id: trimmedModelId,
+        name: trimmedModelId,
+      } as ProviderRuntimeModel);
+    }
+    // Template not found — fall through to synthetic catch-all below.
+  }
+
+  // Catch-all: create a synthetic model definition for any unknown model ID.
+  // The Copilot API is OpenAI-compatible and will return its own error if the
+  // model isn't available on the user's plan. This lets new models be used
+  // by simply adding them to agents.defaults.models in openclaw.json — no
+  // code change required.
+  const lowerModelId = trimmedModelId.toLowerCase();
+  const reasoning = /\bo[13]\b/.test(lowerModelId);
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    provider: PROVIDER_ID,
+    api: "openai-responses",
+    reasoning,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  } as ProviderRuntimeModel);
+}

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -5,8 +5,8 @@ import type {
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-models";
 
 export const PROVIDER_ID = "github-copilot";
-export const CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
-export const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 8192;
@@ -51,7 +51,7 @@ export function resolveCopilotForwardCompatModel(
   // by simply adding them to agents.defaults.models in openclaw.json — no
   // code change required.
   const lowerModelId = trimmedModelId.toLowerCase();
-  const reasoning = /\bo[13]\b/.test(lowerModelId);
+  const reasoning = /^o[13](\b|$)/.test(lowerModelId);
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -20,7 +20,7 @@ export function resolveCopilotForwardCompatModel(
   }
 
   // If the model is already in the registry, let the normal path handle it.
-  const existing = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
+  const existing = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId.toLowerCase());
   if (existing) {
     return undefined;
   }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -753,9 +753,53 @@ describe("resolveModel", () => {
       api: "openai-responses",
       baseUrl: "https://proxy.example.com/v1",
     });
-    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
-      "X-Proxy-Auth": "token-123",
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toMatchObject(
+      {
+        "X-Proxy-Auth": "token-123",
+      },
+    );
+  });
+
+  it("applies configured overrides to github-copilot dynamic models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://proxy.example.com/v1",
+            api: "openai-completions",
+            headers: { "X-Proxy-Auth": "token-123" },
+            models: [
+              {
+                ...makeModel("gpt-5.4-mini"),
+                reasoning: true,
+                input: ["text"],
+                contextWindow: 256000,
+                maxTokens: 32000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("github-copilot", "gpt-5.4-mini", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "github-copilot",
+      id: "gpt-5.4-mini",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.com/v1",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 256000,
+      maxTokens: 32000,
     });
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toMatchObject(
+      {
+        "X-Proxy-Auth": "token-123",
+      },
+    );
   });
 
   it("builds an openai fallback for gpt-5.4 mini from the gpt-5-mini template", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -266,7 +266,11 @@ export function resolveModelWithRegistry(params: {
       provider,
       cfg,
       agentDir,
-      model: pluginDynamicModel,
+      model: applyConfiguredProviderOverrides({
+        discoveredModel: pluginDynamicModel as Model<Api>,
+        providerConfig,
+        modelId,
+      }),
     });
   }
 


### PR DESCRIPTION
## Summary

- Makes the GitHub Copilot extension's `resolveDynamicModel` handler a catch-all: any model ID not already in the Pi SDK registry gets a synthetic definition created automatically
- New Copilot models (e.g. `gpt-5.4-mini`, `claude-opus-4.6-fast`) can now be used by adding them to `agents.defaults.models` in config — no code change or release required
- Preserves the existing `gpt-5.3-codex` → `gpt-5.2-codex` template cloning for backward compat (falls through to synthetic catch-all if template is missing)
- Infers `reasoning: true` for o1/o3 model IDs via heuristic, matching the existing `supportsXHighThinking` pattern
- The Copilot API is OpenAI-compatible and returns its own error if a model isn't available on the user's plan, so there's no risk of silent failures

## Motivation

Currently, every time GitHub adds a new model to Copilot, users hit `Unknown model: github-copilot/<new-model>` until a code change adds it to the registry or a forward-compat resolver. This is unnecessary friction — the extension should accept any model ID and let the API validate availability.

## Test plan

- [x] Unit tests for all branches in `models.test.ts`
- [ ] Verify `github-copilot/gpt-5.4-mini` resolves without "Unknown model" error
- [ ] Verify existing models (e.g. `claude-sonnet-4.6`, `gpt-4o`) still resolve via the registry path
- [ ] Verify `gpt-5.3-codex` still uses the template cloning path
- [ ] Verify an invalid model ID gets a clean API error from Copilot rather than a gateway crash