### PR TITLE
fix(usage): preserve deleted-agent history when transcripts remain

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -4,14 +4,13 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 
-vi.mock("../../config/config.js", () => {
+vi.mock("../../agents/session-dirs.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/session-dirs.js")>(
+    "../../agents/session-dirs.js",
+  );
   return {
-    getRuntimeConfig: vi.fn(() => ({
-      agents: {
-        list: [{ id: "main" }, { id: "opus" }],
-      },
-      session: {},
-    })),
+    ...actual,
+    resolveAgentSessionDirsFromAgentsDir: vi.fn(actual.resolveAgentSessionDirsFromAgentsDir),
   };
 });
 
@@ -73,6 +72,7 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
   };
 });
 
+import { resolveAgentSessionDirsFromAgentsDir } from "../../agents/session-dirs.js";
 import {
   discoverAllSessions,
   loadSessionCostSummary,
@@ -82,19 +82,24 @@ import {
 import { loadCombinedSessionStoreForGateway } from "../session-utils.js";
 import { usageHandlers } from "./usage.js";
 
-const TEST_RUNTIME_CONFIG = {
-  agents: {
-    list: [{ id: "main" }, { id: "opus" }],
-  },
-  session: {},
+type TestAgentConfig = {
+  id: string;
+  default?: boolean;
 };
+
+const buildRuntimeConfig = (agents: TestAgentConfig[] = [{ id: "main" }, { id: "opus" }]) => ({
+  agents: { list: agents },
+  session: {},
+});
+
+let runtimeConfig = buildRuntimeConfig();
 
 async function runSessionsUsage(params: Record<string, unknown>) {
   const respond = vi.fn();
   await usageHandlers["sessions.usage"]({
     respond,
     params,
-    context: { getRuntimeConfig: () => TEST_RUNTIME_CONFIG },
+    context: { getRuntimeConfig: () => runtimeConfig },
   } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
   return respond;
 }
@@ -104,7 +109,7 @@ async function runSessionsUsageTimeseries(params: Record<string, unknown>) {
   await usageHandlers["sessions.usage.timeseries"]({
     respond,
     params,
-    context: { getRuntimeConfig: () => TEST_RUNTIME_CONFIG },
+    context: { getRuntimeConfig: () => runtimeConfig },
   } as unknown as Parameters<(typeof usageHandlers)["sessions.usage.timeseries"]>[0]);
   return respond;
 }
@@ -114,7 +119,7 @@ async function runSessionsUsageLogs(params: Record<string, unknown>) {
   await usageHandlers["sessions.usage.logs"]({
     respond,
     params,
-    context: { getRuntimeConfig: () => TEST_RUNTIME_CONFIG },
+    context: { getRuntimeConfig: () => runtimeConfig },
   } as unknown as Parameters<(typeof usageHandlers)["sessions.usage.logs"]>[0]);
   return respond;
 }
@@ -140,23 +145,200 @@ describe("sessions.usage", () => {
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    runtimeConfig = buildRuntimeConfig();
+    vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+      storePath: "(multiple)",
+      store: {},
+    });
+    vi.mocked(discoverAllSessions).mockImplementation(
+      async (params?: { agentId?: string; sessionsDir?: string }) => {
+        if (params?.agentId === "main") {
+          return [
+            {
+              sessionId: "s-main",
+              sessionFile: "/tmp/agents/main/sessions/s-main.jsonl",
+              mtime: 100,
+              firstUserMessage: "hello",
+            },
+          ];
+        }
+        if (params?.agentId === "opus") {
+          return [
+            {
+              sessionId: "s-opus",
+              sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
+              mtime: 200,
+              firstUserMessage: "hi",
+            },
+          ];
+        }
+        return [];
+      },
+    );
   });
 
   it("discovers sessions across configured agents and keeps agentId in key", async () => {
-    const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-configured-agents-"));
 
-    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.agentId).toBe("main");
-    expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.agentId).toBe("opus");
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const respond = await runSessionsUsage(BASE_USAGE_RANGE);
 
-    const sessions = expectSuccessfulSessionsUsage(respond);
-    expect(sessions).toHaveLength(2);
+        expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.agentId).toBe("main");
+        expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.agentId).toBe("opus");
 
-    // Sorted by most recent first (mtime=200 -> opus first).
-    expect(sessions[0].key).toBe("agent:opus:s-opus");
-    expect(sessions[0].agentId).toBe("opus");
-    expect(sessions[1].key).toBe("agent:main:s-main");
-    expect(sessions[1].agentId).toBe("main");
+        const sessions = expectSuccessfulSessionsUsage(respond);
+        expect(sessions).toHaveLength(2);
+
+        // Sorted by most recent first (mtime=200 -> opus first).
+        expect(sessions[0].key).toBe("agent:opus:s-opus");
+        expect(sessions[0].agentId).toBe("opus");
+        expect(sessions[1].key).toBe("agent:main:s-main");
+        expect(sessions[1].agentId).toBe("main");
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps usage for deleted agents when session transcripts remain on disk", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-deleted-agent-"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        fs.mkdirSync(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+        fs.mkdirSync(path.join(stateDir, "agents", "retired", "sessions"), { recursive: true });
+        runtimeConfig = buildRuntimeConfig([{ id: "main", default: true }]);
+
+        vi.mocked(discoverAllSessions).mockImplementation(
+          async (params?: { agentId?: string; sessionsDir?: string }) => {
+            if (params?.agentId === "main") {
+              return [
+                {
+                  sessionId: "s-main",
+                  sessionFile: path.join(stateDir, "agents", "main", "sessions", "s-main.jsonl"),
+                  mtime: 100,
+                  firstUserMessage: "hello",
+                },
+              ];
+            }
+            if (params?.agentId === "retired") {
+              return [
+                {
+                  sessionId: "s-retired",
+                  sessionFile: path.join(
+                    stateDir,
+                    "agents",
+                    "retired",
+                    "sessions",
+                    "s-retired.jsonl",
+                  ),
+                  mtime: 200,
+                  firstUserMessage: "historical",
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+        const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+        const sessions = expectSuccessfulSessionsUsage(respond);
+
+        expect(vi.mocked(discoverAllSessions).mock.calls.map((call) => call[0]?.agentId)).toEqual([
+          "main",
+          "retired",
+        ]);
+        expect(sessions.map((session) => session.key)).toEqual([
+          "agent:retired:s-retired",
+          "agent:main:s-main",
+        ]);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps usage for deleted agent dirs that do not round-trip through normalizeAgentId", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-retired-agent-dir-"));
+    const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        fs.mkdirSync(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+        fs.mkdirSync(retiredSessionsDir, { recursive: true });
+        runtimeConfig = buildRuntimeConfig([{ id: "main", default: true }]);
+
+        vi.mocked(discoverAllSessions).mockImplementation(
+          async (params?: { agentId?: string; sessionsDir?: string }) => {
+            if (params?.agentId === "main") {
+              return [
+                {
+                  sessionId: "s-main",
+                  sessionFile: path.join(stateDir, "agents", "main", "sessions", "s-main.jsonl"),
+                  mtime: 100,
+                  firstUserMessage: "hello",
+                },
+              ];
+            }
+            if (params?.agentId === "retired-agent" && params?.sessionsDir === retiredSessionsDir) {
+              return [
+                {
+                  sessionId: "s-retired",
+                  sessionFile: path.join(retiredSessionsDir, "s-retired.jsonl"),
+                  mtime: 200,
+                  firstUserMessage: "historical",
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+        const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+        const sessions = expectSuccessfulSessionsUsage(respond);
+
+        expect(
+          vi
+            .mocked(discoverAllSessions)
+            .mock.calls.some(
+              (call) =>
+                call[0]?.agentId === "retired-agent" && call[0]?.sessionsDir === retiredSessionsDir,
+            ),
+        ).toBe(true);
+        expect(sessions.map((session) => session.key)).toEqual([
+          "agent:retired-agent:s-retired",
+          "agent:main:s-main",
+        ]);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-fatal disk scan errors and still scans configured agents", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-disk-scan-error-"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        vi.mocked(resolveAgentSessionDirsFromAgentsDir).mockRejectedValueOnce(
+          Object.assign(new Error("blocked"), { code: "EACCES" }),
+        );
+
+        const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+        const sessions = expectSuccessfulSessionsUsage(respond);
+
+        expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(discoverAllSessions).mock.calls.map((call) => call[0]?.agentId)).toEqual([
+          "main",
+          "opus",
+        ]);
+        expect(sessions).toHaveLength(2);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("resolves store entries by sessionId when queried via discovered agent-prefixed key", async () => {
@@ -239,6 +421,50 @@ describe("sessions.usage", () => {
     }
   });
 
+  it("resolves transcript-only discovered keys from non-round-tripping deleted agent dirs", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-discovered-key-"));
+    const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
+    const retiredSessionFile = path.join(retiredSessionsDir, "s-retired.jsonl");
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        fs.mkdirSync(retiredSessionsDir, { recursive: true });
+        fs.writeFileSync(retiredSessionFile, "", "utf-8");
+        runtimeConfig = buildRuntimeConfig([{ id: "main", default: true }]);
+
+        vi.mocked(discoverAllSessions).mockImplementation(
+          async (params?: { agentId?: string; sessionsDir?: string }) => {
+            if (params?.agentId === "retired-agent" && params?.sessionsDir === retiredSessionsDir) {
+              return [
+                {
+                  sessionId: "s-retired",
+                  sessionFile: retiredSessionFile,
+                  mtime: 200,
+                  firstUserMessage: "historical",
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+        const respond = await runSessionsUsage({
+          ...BASE_USAGE_RANGE,
+          key: "agent:retired-agent:s-retired",
+        });
+        const sessions = expectSuccessfulSessionsUsage(respond);
+
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0]?.key).toBe("agent:retired-agent:s-retired");
+        expect(vi.mocked(loadSessionCostSummary).mock.calls[0]?.[0]?.sessionFile).toBe(
+          retiredSessionFile,
+        );
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects traversal-style keys in specific session usage lookups", async () => {
     const respond = await runSessionsUsage({
       ...BASE_USAGE_RANGE,
@@ -249,6 +475,50 @@ describe("sessions.usage", () => {
     expect(respond.mock.calls[0]?.[0]).toBe(false);
     const error = respond.mock.calls[0]?.[2] as { message?: string } | undefined;
     expect(error?.message).toContain("Invalid session reference");
+  });
+
+  it("passes discovered sessionFile into sessions.usage.timeseries for retired agent dirs", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-timeseries-retired-"));
+    const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
+    const retiredSessionFile = path.join(retiredSessionsDir, "s-retired.jsonl");
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        fs.mkdirSync(retiredSessionsDir, { recursive: true });
+        fs.writeFileSync(retiredSessionFile, "", "utf-8");
+        runtimeConfig = buildRuntimeConfig([{ id: "main", default: true }]);
+
+        vi.mocked(discoverAllSessions).mockImplementation(
+          async (params?: { agentId?: string; sessionsDir?: string }) => {
+            if (params?.agentId === "retired-agent" && params?.sessionsDir === retiredSessionsDir) {
+              return [
+                {
+                  sessionId: "s-retired",
+                  sessionFile: retiredSessionFile,
+                  mtime: 200,
+                  firstUserMessage: "historical",
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+        await runSessionsUsageTimeseries({
+          key: "agent:retired-agent:s-retired",
+        });
+
+        expect(vi.mocked(loadSessionUsageTimeSeries)).toHaveBeenCalled();
+        expect(vi.mocked(loadSessionUsageTimeSeries).mock.calls[0]?.[0]?.agentId).toBe(
+          "retired-agent",
+        );
+        expect(vi.mocked(loadSessionUsageTimeSeries).mock.calls[0]?.[0]?.sessionFile).toBe(
+          retiredSessionFile,
+        );
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("passes parsed agentId into sessions.usage.timeseries", async () => {
@@ -267,6 +537,46 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadSessionLogs)).toHaveBeenCalled();
     expect(vi.mocked(loadSessionLogs).mock.calls[0]?.[0]?.agentId).toBe("opus");
+  });
+
+  it("passes discovered sessionFile into sessions.usage.logs for retired agent dirs", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-logs-retired-"));
+    const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
+    const retiredSessionFile = path.join(retiredSessionsDir, "s-retired.jsonl");
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        fs.mkdirSync(retiredSessionsDir, { recursive: true });
+        fs.writeFileSync(retiredSessionFile, "", "utf-8");
+        runtimeConfig = buildRuntimeConfig([{ id: "main", default: true }]);
+
+        vi.mocked(discoverAllSessions).mockImplementation(
+          async (params?: { agentId?: string; sessionsDir?: string }) => {
+            if (params?.agentId === "retired-agent" && params?.sessionsDir === retiredSessionsDir) {
+              return [
+                {
+                  sessionId: "s-retired",
+                  sessionFile: retiredSessionFile,
+                  mtime: 200,
+                  firstUserMessage: "historical",
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+        await runSessionsUsageLogs({
+          key: "agent:retired-agent:s-retired",
+        });
+
+        expect(vi.mocked(loadSessionLogs)).toHaveBeenCalled();
+        expect(vi.mocked(loadSessionLogs).mock.calls[0]?.[0]?.agentId).toBe("retired-agent");
+        expect(vi.mocked(loadSessionLogs).mock.calls[0]?.[0]?.sessionFile).toBe(retiredSessionFile);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects traversal-style keys in timeseries/log lookups", async () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
+import path from "node:path";
+import { resolveAgentSessionDirsFromAgentsDir } from "../../agents/session-dirs.js";
+import { resolveStateDir } from "../../config/paths.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveSessionTranscriptsDirForAgent,
 } from "../../config/sessions/paths.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -21,7 +25,11 @@ import {
   resolveExistingUsageSessionFile,
   type DiscoveredSession,
 } from "../../infra/session-cost-usage.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
+import {
+  DEFAULT_AGENT_ID,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
@@ -63,6 +71,14 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+const NON_FATAL_USAGE_DISCOVERY_ERROR_CODES = new Set([
+  "EACCES",
+  "ELOOP",
+  "ENOENT",
+  "ENOTDIR",
+  "EPERM",
+  "ESTALE",
+]);
 
 function findCostUsageCacheEvictionKey(): string | undefined {
   for (const [key, entry] of costUsageCache) {
@@ -85,17 +101,39 @@ function setCostUsageCache(cacheKey: string, entry: CostUsageCacheEntry): void {
   costUsageCache.set(cacheKey, entry);
 }
 
-function resolveSessionUsageFileOrRespond(
+async function resolveDiscoveredSessionFile(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  sessionId: string;
+}): Promise<string | undefined> {
+  const targets = await listUsageDiscoveryTargets(params.config);
+  for (const target of targets) {
+    if (target.agentId !== params.agentId) {
+      continue;
+    }
+    const sessions = await discoverAllSessions({
+      agentId: target.agentId,
+      sessionsDir: target.sessionsDir,
+    });
+    const match = sessions.find((session) => session.sessionId === params.sessionId);
+    if (match?.sessionFile) {
+      return match.sessionFile;
+    }
+  }
+  return undefined;
+}
+
+async function resolveSessionUsageFileOrRespond(
   key: string,
   respond: RespondFn,
   config: OpenClawConfig,
-): {
+): Promise<{
   config: OpenClawConfig;
   entry: SessionEntry | undefined;
   agentId: string | undefined;
   sessionId: string;
   sessionFile: string;
-} | null {
+} | null> {
   const { entry, storePath } = loadSessionEntry(key);
 
   // For discovered sessions (not in store), try using key as sessionId directly
@@ -114,6 +152,17 @@ function resolveSessionUsageFileOrRespond(
       errorShape(ErrorCodes.INVALID_REQUEST, `Invalid session key: ${key}`),
     );
     return null;
+  }
+
+  if (!fs.existsSync(sessionFile) && agentId) {
+    const discoveredSessionFile = await resolveDiscoveredSessionFile({
+      config,
+      agentId,
+      sessionId,
+    });
+    if (discoveredSessionFile) {
+      sessionFile = discoveredSessionFile;
+    }
   }
 
   return { config, entry, agentId, sessionId, sessionFile };
@@ -273,6 +322,7 @@ const parseDateRange = (params: {
 };
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
+type UsageDiscoveryTarget = { agentId: string; sessionsDir: string };
 
 function buildStoreBySessionId(
   store: Record<string, SessionEntry>,
@@ -301,20 +351,78 @@ function buildStoreBySessionId(
   return storeBySessionId;
 }
 
+function shouldSkipUsageDiscoveryError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return typeof code === "string" && NON_FATAL_USAGE_DISCOVERY_ERROR_CODES.has(code);
+}
+
+function shouldSkipUsageDiscoveredAgentDirName(dirName: string, agentId: string): boolean {
+  return agentId === DEFAULT_AGENT_ID && dirName.trim().toLowerCase() !== DEFAULT_AGENT_ID;
+}
+
+async function listUsageDiscoveryTargets(config: OpenClawConfig): Promise<UsageDiscoveryTarget[]> {
+  const seenSessionsDirs = new Set<string>();
+  const orderedTargets: UsageDiscoveryTarget[] = [];
+  const addTarget = (target: UsageDiscoveryTarget) => {
+    const resolvedSessionsDir = path.resolve(target.sessionsDir);
+    if (seenSessionsDirs.has(resolvedSessionsDir)) {
+      return;
+    }
+    seenSessionsDirs.add(resolvedSessionsDir);
+    orderedTargets.push(target);
+  };
+
+  for (const agent of listAgentsForGateway(config).agents) {
+    addTarget({
+      agentId: agent.id,
+      sessionsDir: resolveSessionTranscriptsDirForAgent(agent.id),
+    });
+  }
+
+  try {
+    const diskTargets = (
+      await resolveAgentSessionDirsFromAgentsDir(path.join(resolveStateDir(), "agents"))
+    )
+      .map((sessionsDir) => {
+        const dirName = path.basename(path.dirname(sessionsDir));
+        const agentId = normalizeAgentId(dirName);
+        if (!agentId || shouldSkipUsageDiscoveredAgentDirName(dirName, agentId)) {
+          return undefined;
+        }
+        return { agentId, sessionsDir };
+      })
+      .filter((target): target is UsageDiscoveryTarget => Boolean(target))
+      .toSorted(
+        (a, b) => a.agentId.localeCompare(b.agentId) || a.sessionsDir.localeCompare(b.sessionsDir),
+      );
+
+    for (const target of diskTargets) {
+      addTarget(target);
+    }
+  } catch (err) {
+    if (!shouldSkipUsageDiscoveryError(err)) {
+      throw err;
+    }
+  }
+
+  return orderedTargets;
+}
+
 async function discoverAllSessionsForUsage(params: {
   config: OpenClawConfig;
   startMs: number;
   endMs: number;
 }): Promise<DiscoveredSessionWithAgent[]> {
-  const agents = listAgentsForGateway(params.config).agents;
+  const targets = await listUsageDiscoveryTargets(params.config);
   const results = await Promise.all(
-    agents.map(async (agent) => {
+    targets.map(async (target) => {
       const sessions = await discoverAllSessions({
-        agentId: agent.id,
+        agentId: target.agentId,
+        sessionsDir: target.sessionsDir,
         startMs: params.startMs,
         endMs: params.endMs,
       });
-      return sessions.map((session) => Object.assign({}, session, { agentId: agent.id }));
+      return sessions.map((session) => Object.assign({}, session, { agentId: target.agentId }));
     }),
   );
   return results.flat().toSorted((a, b) => b.mtime - a.mtime);
@@ -485,6 +593,17 @@ export const usageHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.INVALID_REQUEST, `Invalid session reference: ${specificKey}`),
         );
         return;
+      }
+
+      if ((!sessionFile || !fs.existsSync(sessionFile)) && agentIdFromKey) {
+        const discoveredSessionFile = await resolveDiscoveredSessionFile({
+          config,
+          agentId: agentIdFromKey,
+          sessionId,
+        });
+        if (discoveredSessionFile) {
+          sessionFile = discoveredSessionFile;
+        }
       }
 
       if (sessionFile) {
@@ -858,7 +977,11 @@ export const usageHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const resolved = resolveSessionUsageFileOrRespond(key, respond, context.getRuntimeConfig());
+    const resolved = await resolveSessionUsageFileOrRespond(
+      key,
+      respond,
+      context.getRuntimeConfig(),
+    );
     if (!resolved) {
       return;
     }
@@ -896,7 +1019,11 @@ export const usageHandlers: GatewayRequestHandlers = {
         ? Math.min(params.limit, 1000)
         : 200;
 
-    const resolved = resolveSessionUsageFileOrRespond(key, respond, context.getRuntimeConfig());
+    const resolved = await resolveSessionUsageFileOrRespond(
+      key,
+      respond,
+      context.getRuntimeConfig(),
+    );
     if (!resolved) {
       return;
     }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -492,10 +492,11 @@ export async function loadCostUsageSummary(params?: {
  */
 export async function discoverAllSessions(params?: {
   agentId?: string;
+  sessionsDir?: string;
   startMs?: number;
   endMs?: number;
 }): Promise<DiscoveredSession[]> {
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
+  const sessionsDir = params?.sessionsDir ?? resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
 
   const discovered = new Map<string, DiscoveredSession>();


### PR DESCRIPTION
## Summary

- `sessions.usage` currently walks the visible gateway agent list.
- After `agents.delete` with `deleteFiles=false`, the deleted agent's transcripts remain under `agents/<id>/sessions`, but that agent drops out of usage discovery, so historical usage disappears.
- This keeps the fix scoped to usage discovery only: it also scans disk-backed agent session directories so preserved transcripts still contribute to usage/history.
- `listAgentsForGateway()` and agent visibility elsewhere are unchanged.

## Testing

- `pnpm exec vitest run src/gateway/server-methods/usage.sessions-usage.test.ts`
- `pnpm exec vitest run src/gateway/session-utils.test.ts -t 'listAgentsForGateway keeps explicit agents.list scope over disk-only agents'`
- `pnpm exec vitest run src/gateway/server-methods/agents-mutate.test.ts -t 'agents.delete'`
- `pnpm exec oxfmt --check src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `pnpm exec oxlint --type-aware src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `pnpm build`

Closes #50553