### PR TITLE
fix(ios): prevent CheckedContinuation double-resume crash in WebSocket ping

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -13,10 +13,14 @@ private final class OneShotContinuation: @unchecked Sendable {
 
     func resume(error: Error?) {
         lock.lock()
+        defer { lock.unlock() }
         let cont = self.continuation
         self.continuation = nil
-        lock.unlock()
-        guard let cont else { return }
+        guard let cont else {
+            // URLSessionWebSocketTask fired pong handler more than once (iOS 18+ race).
+            // The continuation was already resumed; silently drop the duplicate.
+            return
+        }
         ThrowingContinuationSupport.resumeVoid(cont, error: error)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -2,6 +2,25 @@ import OpenClawProtocol
 import Foundation
 import OSLog
 
+/// Thread-safe one-shot wrapper around CheckedContinuation to prevent double-resume crashes.
+private final class OneShotContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(_ continuation: CheckedContinuation<Void, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(error: Error?) {
+        lock.lock()
+        let cont = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        guard let cont else { return }
+        ThrowingContinuationSupport.resumeVoid(cont, error: error)
+    }
+}
+
 public protocol WebSocketTasking: AnyObject {
     var state: URLSessionTask.State { get }
     func resume()
@@ -44,8 +63,12 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 
     public func sendPing() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            // URLSessionWebSocketTask.sendPing can invoke the handler more than once when
+            // the task is cancelled mid-flight (observed on iOS 18+). Guard with a one-shot
+            // wrapper to avoid a CheckedContinuation double-resume crash.
+            let once = OneShotContinuation(continuation)
             self.task.sendPing { error in
-                ThrowingContinuationSupport.resumeVoid(continuation, error: error)
+                once.resume(error: error)
             }
         }
     }


### PR DESCRIPTION
## Summary

`WebSocketTaskBox.sendPing()` crashes with `EXC_BREAKPOINT` due to a `CheckedContinuation` being resumed twice.

## Root Cause

`URLSessionWebSocketTask.sendPing` can invoke the pong handler more than once when the task is cancelled mid-flight (observed on iOS 18+). Since `CheckedContinuation` traps on double-resume, this causes an immediate crash.

Typical scenario: app backgrounds while a ping is in-flight → task cancellation races with the pong response → handler fires twice → crash.

## Fix

Wraps the continuation in a thread-safe `OneShotContinuation` (NSLock-guarded) that only allows the first resume and silently drops duplicates.

## Crash Log (redacted)

```
Exception Type: EXC_BREAKPOINT (SIGTRAP)
Exception Codes: 0x0000000000000001, 0x00000001a42dd1f0

Thread 4 Crashed:
0   libswift_Concurrency.dylib  CheckedContinuation.resume(returning:)
1   OpenClawKit                 WebSocketTaskBox.sendPing()
```