### PR TITLE
Fix Stop button not showing during tool execution

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -527,6 +527,26 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
+  it("shows a stop button when aborting is available during tool execution", () => {
+    const container = document.createElement("div");
+    const onAbort = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          canAbort: true,
+          sending: false,
+          onAbort,
+        }),
+      ),
+      container,
+    );
+
+    const stopButton = container.querySelector<HTMLButtonElement>('button[title="Stop"]');
+    expect(stopButton).not.toBeUndefined();
+    stopButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
   it("shows a new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1299,7 +1299,7 @@ export function renderChat(props: ChatProps) {
             </button>
 
             ${
-              canAbort && (isBusy || props.sending)
+              canAbort
                 ? html`
                   <button class="chat-send-btn chat-send-btn--stop" @click=${props.onAbort} title="Stop">
                     ${icons.stop}


### PR DESCRIPTION
## Problem
The Stop button was not displayed during tool execution because it only showed when a text stream was active. This left users without visual feedback or abort control while tools were running.

## Solution
Simplified the Stop button render condition to just check `canAbort`.

## Changes
- `ui/src/ui/views/chat.ts`: Changed Stop button condition from `canAbort && (isBusy || props.sending)` to just `canAbort`

## Testing
✅ Tested locally: Stop button now correctly displays during tool execution and can successfully abort running tasks.