### PR TITLE
fix(sandbox): include workspace dir in container name to prevent cross-instance collisions

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -141,11 +141,14 @@ export async function ensureSandboxBrowser(params: {
     return null;
   }
 
-  // Include workspaceDir in the slug so co-hosted instances with different HOME
-  // dirs produce distinct container names (fixes #51363).
+  // Include workspaceDir in the slug for shared/agent scopes so co-hosted
+  // instances with different HOME dirs produce distinct container names
+  // (fixes #51363). Session-scope containers are already collision-free via
+  // their per-session unique key, so we leave those names unchanged to avoid
+  // orphaning existing containers on upgrade.
   const slug = slugifySessionKey(
-    params.cfg.scope === "shared"
-      ? `shared:${params.workspaceDir}`
+    params.cfg.scope === "session"
+      ? params.scopeKey
       : `${params.scopeKey}:${params.workspaceDir}`,
   );
   const name = `${params.cfg.browser.containerPrefix}${slug}`;

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -141,7 +141,13 @@ export async function ensureSandboxBrowser(params: {
     return null;
   }
 
-  const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(params.scopeKey);
+  // Include workspaceDir in the slug so co-hosted instances with different HOME
+  // dirs produce distinct container names (fixes #51363).
+  const slug = slugifySessionKey(
+    params.cfg.scope === "shared"
+      ? `shared:${params.workspaceDir}`
+      : `${params.scopeKey}:${params.workspaceDir}`,
+  );
   const name = `${params.cfg.browser.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
   const state = await dockerContainerState(containerName);

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { computeSandboxConfigHash } from "./config-hash.js";
 import { ensureSandboxContainer } from "./docker.js";
+import { slugifySessionKey } from "./shared.js";
 import { collectDockerFlagValues } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
 
@@ -146,6 +147,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
 
   it("recreates shared container when array-order change alters hash", async () => {
     const workspaceDir = "/tmp/workspace";
+    const expectedName = `oc-test-${slugifySessionKey(`shared:${workspaceDir}`)}`.slice(0, 63);
     const oldCfg = createSandboxConfig(["1.1.1.1", "8.8.8.8"]);
     const newCfg = createSandboxConfig(["8.8.8.8", "1.1.1.1"]);
 
@@ -167,7 +169,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     registryMocks.readRegistry.mockResolvedValue({
       entries: [
         {
-          containerName: "oc-test-shared",
+          containerName: expectedName,
           sessionKey: "shared",
           createdAtMs: 1,
           lastUsedAtMs: 0,
@@ -184,12 +186,11 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       cfg: newCfg,
     });
 
-    expect(containerName).toBe("oc-test-shared");
+    expect(containerName).toBe(expectedName);
     const dockerCalls = spawnState.calls.filter((call) => call.command === "docker");
     expect(
       dockerCalls.some(
-        (call) =>
-          call.args[0] === "rm" && call.args[1] === "-f" && call.args[2] === "oc-test-shared",
+        (call) => call.args[0] === "rm" && call.args[1] === "-f" && call.args[2] === expectedName,
       ),
     ).toBe(true);
     const createCall = dockerCalls.find((call) => call.args[0] === "create");
@@ -197,7 +198,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(createCall?.args).toContain(`openclaw.configHash=${newHash}`);
     expect(registryMocks.updateRegistry).toHaveBeenCalledWith(
       expect.objectContaining({
-        containerName: "oc-test-shared",
+        containerName: expectedName,
         configHash: newHash,
       }),
     );
@@ -205,6 +206,10 @@ describe("ensureSandboxContainer config-hash recreation", () => {
 
   it("applies custom binds after workspace mounts so overlapping binds can override", async () => {
     const workspaceDir = "/tmp/workspace";
+    const expectedContainerName = `oc-test-${slugifySessionKey(`shared:${workspaceDir}`)}`.slice(
+      0,
+      63,
+    );
     const cfg = createSandboxConfig(
       ["1.1.1.1"],
       ["/tmp/workspace-shared/USER.md:/workspace/USER.md:ro"],
@@ -222,7 +227,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     registryMocks.readRegistry.mockResolvedValue({
       entries: [
         {
-          containerName: "oc-test-shared",
+          containerName: expectedContainerName,
           sessionKey: "shared",
           createdAtMs: 1,
           lastUsedAtMs: 0,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -496,7 +496,13 @@ export async function ensureSandboxContainer(params: {
   cfg: SandboxConfig;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
-  const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
+  // Include workspaceDir in the slug so co-hosted instances with different HOME
+  // dirs produce distinct container names (fixes #51363).
+  const slug = slugifySessionKey(
+    params.cfg.scope === "shared"
+      ? `shared:${params.workspaceDir}`
+      : `${scopeKey}:${params.workspaceDir}`,
+  );
   const name = `${params.cfg.docker.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
   const expectedHash = computeSandboxConfigHash({

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -496,11 +496,14 @@ export async function ensureSandboxContainer(params: {
   cfg: SandboxConfig;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
-  // Include workspaceDir in the slug so co-hosted instances with different HOME
-  // dirs produce distinct container names (fixes #51363).
+  // Include workspaceDir in the slug for shared/agent scopes so co-hosted
+  // instances with different HOME dirs produce distinct container names
+  // (fixes #51363). Session-scope containers are already collision-free via
+  // their per-session unique key, so we leave those names unchanged to avoid
+  // orphaning existing containers on upgrade.
   const slug = slugifySessionKey(
-    params.cfg.scope === "shared"
-      ? `shared:${params.workspaceDir}`
+    params.cfg.scope === "session"
+      ? scopeKey
       : `${scopeKey}:${params.workspaceDir}`,
   );
   const name = `${params.cfg.docker.containerPrefix}${slug}`;


### PR DESCRIPTION
## Problem

When multiple OpenClaw instances run on the same host with different `HOME` dirs and Docker sandbox enabled, they all produce the **same container name** (e.g. `openclaw-sbx-agent-main-f331f052`). Every instance shares a single Docker container, so `exec` tool operations in one instance can read/write files from another instance's workspace.

## Root cause

`ensureSandboxContainer` (docker.ts) and `ensureSandboxBrowser` (browser.ts) derive the container name slug from the scope key alone (`"shared"` or `"agent:main"`). Since all instances using the default agent key produce the same scope key, the slug hash is identical.

## Fix

Mix `workspaceDir` (which is derived from `$HOME` and already passed into both functions) into the slug input. This makes each instance produce a distinct container name while keeping the same name stable across restarts for a given instance.

For `scope="session"`, the session key already contains a per-session UUID, so no collision was possible there.

**Migration note:** Existing single-instance deployments will get a new container name on the first `exec` call after upgrading. The old container will be orphaned and cleaned up by the existing prune logic.

## Changes

- **`src/agents/sandbox/docker.ts`** — include `workspaceDir` in slug hash input
- **`src/agents/sandbox/browser.ts`** — same change for browser containers  
- **`src/agents/sandbox/docker.config-hash-recreate.test.ts`** — update expected container names to use dynamic slug

Fixes #51363