### PR TITLE
fix(config): prevent synthetic raw content in redaction fallback

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -344,11 +344,16 @@ describe("redactConfigSnapshot", () => {
     // synthetic content from failing config.set validation (#48415).
     expect(result.raw).toBeNull();
     // Redacted config is still correct for form-mode editing.
-    const redactedCfg = result.config as Record<string, unknown>;
-    expect((redactedCfg as { gateway?: { mode?: string } }).gateway?.mode).toBe("default");
+    const redactedCfg = result.config as {
+      gateway?: { mode?: string; auth?: { password?: string } };
+      models?: { providers?: { default?: { apiKey?: { id?: string; source?: string } } } };
+    };
+    expect(redactedCfg.gateway?.mode).toBe("default");
+    expect(redactedCfg.gateway?.auth?.password).toBe(REDACTED_SENTINEL);
     // SecretRef id is redacted in the config object.
-    expect(result.raw).toBeNull();
-    expect(result.config).toBeDefined();
+    expect(redactedCfg.models?.providers?.default?.apiKey?.id).toBe(REDACTED_SENTINEL);
+    expect(redactedCfg.models?.providers?.default?.apiKey?.source).toBe("env");
+    expect(JSON.stringify(result.config)).not.toContain("OPENAI_API_KEY");
   });
 
   it("redacts parsed and resolved objects", () => {

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -281,7 +281,7 @@ describe("redactConfigSnapshot", () => {
     expect(result.raw).toContain(REDACTED_SENTINEL);
   });
 
-  it("keeps non-sensitive raw fields intact when secret values overlap", () => {
+  it("returns null raw when secret values overlap non-sensitive text (forces form-only mode)", () => {
     const config = {
       gateway: {
         mode: "local",
@@ -290,14 +290,16 @@ describe("redactConfigSnapshot", () => {
     };
     const snapshot = makeSnapshot(config, JSON.stringify(config));
     const result = redactConfigSnapshot(snapshot, mainSchemaHints);
-    const parsed: {
+    // When text-level redaction can't round-trip cleanly (overlap corrupts
+    // non-sensitive "mode" field), raw is set to null to force form-only mode
+    // in the UI, preventing the config.set validation failures from #48415.
+    expect(result.raw).toBeNull();
+    // The redacted config and parsed objects are still available for form mode.
+    const redactedCfg = result.config as {
       gateway?: { mode?: string; auth?: { password?: string } };
-    } = JSON5.parse(result.raw ?? "{}");
-    expect(parsed.gateway?.mode).toBe("local");
-    expect(parsed.gateway?.auth?.password).toBe(REDACTED_SENTINEL);
-    const restored = restoreRedactedValues(parsed, snapshot.config, mainSchemaHints);
-    expect(restored.gateway.mode).toBe("local");
-    expect(restored.gateway.auth.password).toBe("local");
+    };
+    expect(redactedCfg.gateway?.mode).toBe("local");
+    expect(redactedCfg.gateway?.auth?.password).toBe(REDACTED_SENTINEL);
   });
 
   it("preserves SecretRef structural fields while redacting SecretRef id", () => {
@@ -323,7 +325,7 @@ describe("redactConfigSnapshot", () => {
     expect(restored).toEqual(snapshot.config);
   });
 
-  it("handles overlap fallback and SecretRef in the same snapshot", () => {
+  it("returns null raw when overlap fallback triggers with SecretRef", () => {
     const config = {
       gateway: { mode: "default", auth: { password: "default" } }, // pragma: allowlist secret
       models: {
@@ -337,14 +339,16 @@ describe("redactConfigSnapshot", () => {
     };
     const snapshot = makeSnapshot(config, JSON.stringify(config, null, 2));
     const result = redactConfigSnapshot(snapshot, mainSchemaHints);
-    const parsed = JSON5.parse(result.raw ?? "{}");
-    expect(parsed.gateway?.mode).toBe("default");
-    expect(parsed.gateway?.auth?.password).toBe(REDACTED_SENTINEL);
-    expect(parsed.models?.providers?.default?.apiKey?.source).toBe("env");
-    expect(parsed.models?.providers?.default?.apiKey?.provider).toBe("default");
-    expect(result.raw).not.toContain("OPENAI_API_KEY");
-    const restored = restoreRedactedValues(parsed, snapshot.config, mainSchemaHints);
-    expect(restored).toEqual(snapshot.config);
+    // Overlap fallback triggers because "default" appears in both password
+    // (sensitive) and mode/provider (non-sensitive). Raw is null to prevent
+    // synthetic content from failing config.set validation (#48415).
+    expect(result.raw).toBeNull();
+    // Redacted config is still correct for form-mode editing.
+    const redactedCfg = result.config as Record<string, unknown>;
+    expect((redactedCfg as { gateway?: { mode?: string } }).gateway?.mode).toBe("default");
+    // SecretRef id is redacted in the config object.
+    expect(result.raw).toBeNull();
+    expect(result.config).toBeDefined();
   });
 
   it("redacts parsed and resolved objects", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -1,4 +1,3 @@
-import JSON5 from "json5";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { stripUrlUserInfo } from "../shared/net/url-userinfo.js";
 import {
@@ -416,7 +415,13 @@ export function redactConfigSnapshot(
         ),
     })
   ) {
-    redactedRaw = JSON5.stringify(redactedParsed ?? redactedConfig, null, 2);
+    // When the raw text cannot round-trip cleanly through redaction and restore,
+    // do not fall back to JSON5.stringify(redactedConfig) — that injects runtime
+    // defaults (model, session, logging) that were never in the on-disk file,
+    // producing a synthetic document that fails config.set validation (#48415).
+    // Setting raw to null forces the Control UI into form-only editing mode,
+    // which is already handled by applyConfigSnapshot() in the UI controller.
+    redactedRaw = null;
   }
   // Also redact the resolved config (contains values after ${ENV} substitution)
   const redactedResolved = redactConfigObject(snapshot.resolved, uiHints);


### PR DESCRIPTION
## Summary

**Problem**: When the Control UI saves config, the gateway rejects it with `SyntaxError: JSON5: invalid character` or SecretRef validation failures. The line numbers in errors don't match the file length — because the UI is sending a different document than what's on disk.

**Why it matters**: Config editing in the Control UI is completely broken for configs where sensitive values overlap non-sensitive text (e.g. `gateway.mode: "local"` + `auth.password: "local"`), configs with `$include` directives, or configs with environment variable references.

**Root cause**: `redactConfigSnapshot()` falls back to `JSON5.stringify(redactedParsed ?? redactedConfig)` when text-level redaction can't round-trip cleanly. This "synthetic raw" diverges from the on-disk file because:
- `redactedConfig` injects runtime defaults (model, session, logging, message defaults) that were never in the file
- `redactedParsed` loses comments, `$include` directives, and formatting
- The structural drift causes `restoreRedactedValues()` path mapping to fail, leaking `***` sentinels through Zod validation

**What changed**:
- Set `redactedRaw = null` when the structured fallback triggers, instead of generating synthetic content
- Updated 2 tests to verify null-raw behavior and form-mode fallback

**What did NOT change**:
- Text-level redaction (the happy path when no overlap exists) is untouched
- `redactObject()`, `restoreRedactedValues()`, `shouldFallbackToStructuredRawRedaction()` are untouched
- The `config` and `parsed` objects in the snapshot are still correctly redacted (form-mode editing works)
- The UI's `applyConfigSnapshot()` already handles `raw: null` — it falls back to `serializeConfigForm(snapshot.config)`

## Change Type
- [x] Bug fix (non-breaking)

## Scope
Gateway (config redaction pipeline)

## Linked Issue
Closes #48415

## Security Impact
- New permissions requested: none
- Secrets handling changes: The fix is MORE conservative — when in doubt about redaction safety, we now hide the raw editor entirely rather than risking a synthetic document that might leak or corrupt credential paths
- New network calls: none
- New command/tool execution: none
- Data access changes: none

## Human Verification
I personally verified:
- [x] `pnpm build` passes
- [x] `pnpm test -- src/config/redact-snapshot` — 42/42 tests pass (3 test files)
- [x] The 2 updated tests verify: (a) raw is null when overlap triggers, (b) redacted config objects are still correct for form mode
- [x] Existing test "handles null raw gracefully" (line 366) already confirms the UI codepath handles null raw

## Evidence

```
Test Files  3 passed (3)
     Tests  42 passed (42)
  Duration  9.07s
```

`git diff --stat upstream/main...HEAD`: 2 files changed, 27 insertions(+), 19 deletions(-)

## What I Did NOT Verify
- Not verified: end-to-end Control UI save with a real config containing `$include` directives (tested redaction pipeline in isolation only)
- Not verified: whether form-only mode preserves all user-editable fields correctly when raw mode is disabled (the UI's `serializeConfigForm` path was not changed)
- Not verified: configs with mixed JSON5 features (trailing commas, comments, hex literals) — these are handled by the text-level redaction path which was not changed

## Failure Recovery
If this breaks in production:
- **Detection**: Users in the overlap-redaction path see form-only mode instead of raw+form mode
- **Rollback**: Revert the single line change in `redact-snapshot.ts`
- **Blast radius**: Only affects configs where sensitive values overlap non-sensitive text. Most configs have unique passwords and won't trigger the fallback at all.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>