### PR TITLE
fix(tool-policy): include alsoAllow entries in plugin tool allowlist …

### DIFF
--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -89,7 +89,7 @@ export function resolveSubagentToolPolicy(cfg?: OpenClawConfig, depth?: number):
     ...(Array.isArray(configured?.deny) ? configured.deny : []),
   ];
   const mergedAllow = allow && alsoAllow ? Array.from(new Set([...allow, ...alsoAllow])) : allow;
-  return { allow: mergedAllow, deny };
+  return { allow: mergedAllow, alsoAllow, deny };
 }
 
 export function resolveSubagentToolPolicyForSession(
@@ -109,8 +109,13 @@ export function resolveSubagentToolPolicyForSession(
     ),
     ...(Array.isArray(configured?.deny) ? configured.deny : []),
   ];
+  // Merge allow + alsoAllow when both are present (keeps allow list accurate for
+  // access gating). When only alsoAllow is set, preserve it on the returned
+  // object so collectExplicitAllowlist() can build the plugin tool allowlist —
+  // callers that only gate on `allow` remain unaffected because allow stays
+  // undefined, but the alsoAllow entries are no longer silently dropped.
   const mergedAllow = allow && alsoAllow ? Array.from(new Set([...allow, ...alsoAllow])) : allow;
-  return { allow: mergedAllow, deny };
+  return { allow: mergedAllow, alsoAllow, deny };
 }
 
 export function filterToolsByPolicy(tools: AnyAgentTool[], policy?: SandboxToolPolicy) {

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -6,6 +6,7 @@ export type { SandboxDockerConfig } from "./types.docker.js";
 
 export type SandboxToolPolicy = {
   allow?: string[];
+  alsoAllow?: string[];
   deny?: string[];
 };
 

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -5,6 +5,7 @@ import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance.js";
 import {
   applyOwnerOnlyToolPolicy,
+  collectExplicitAllowlist,
   expandToolGroups,
   isOwnerOnlyToolName,
   normalizeToolName,
@@ -223,5 +224,40 @@ describe("resolveSandboxToolPolicyForAgent", () => {
     const resolved = resolveSandboxToolPolicyForAgent(cfg, undefined);
     expect(resolved.allow).toEqual(["read"]);
     expect(resolved.deny).toEqual(["image"]);
+  });
+});
+
+describe("collectExplicitAllowlist", () => {
+  it("collects entries from allow", () => {
+    expect(collectExplicitAllowlist([{ allow: ["read", "write"] }])).toEqual(["read", "write"]);
+  });
+
+  it("collects entries from alsoAllow when allow is absent", () => {
+    expect(collectExplicitAllowlist([{ alsoAllow: ["openrag_search"] }])).toEqual([
+      "openrag_search",
+    ]);
+  });
+
+  it("collects entries from both allow and alsoAllow", () => {
+    expect(
+      collectExplicitAllowlist([{ allow: ["read"], alsoAllow: ["openrag_search"] }]),
+    ).toEqual(["read", "openrag_search"]);
+  });
+
+  it("returns empty array when policy has neither allow nor alsoAllow", () => {
+    expect(collectExplicitAllowlist([{ deny: ["exec"] }])).toEqual([]);
+  });
+
+  it("returns empty array for undefined policies", () => {
+    expect(collectExplicitAllowlist([undefined, undefined])).toEqual([]);
+  });
+
+  it("collects alsoAllow across multiple policies", () => {
+    expect(
+      collectExplicitAllowlist([
+        { alsoAllow: ["openrag_search"] },
+        { alsoAllow: ["custom_tool"] },
+      ]),
+    ).toEqual(["openrag_search", "custom_tool"]);
   });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -58,6 +58,7 @@ export function applyOwnerOnlyToolPolicy(tools: AnyAgentTool[], senderIsOwner: b
 
 export type ToolPolicyLike = {
   allow?: string[];
+  alsoAllow?: string[];
   deny?: string[];
 };
 
@@ -75,10 +76,14 @@ export type AllowlistResolution = {
 export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefined>): string[] {
   const entries: string[] = [];
   for (const policy of policies) {
-    if (!policy?.allow) {
-      continue;
-    }
-    for (const value of policy.allow) {
+    // Collect both `allow` and `alsoAllow` entries. `alsoAllow` is the additive
+    // form used when a profile is set and the user wants to extend it with
+    // additional tools (e.g. plugin tools for subagents) without replacing the
+    // full allow list. Without including `alsoAllow` here, plugin tools listed
+    // in `tools.subagents.tools.alsoAllow` are silently ignored and never reach
+    // subagent sessions.
+    const sources = [...(policy?.allow ?? []), ...(policy?.alsoAllow ?? [])];
+    for (const value of sources) {
       if (typeof value !== "string") {
         continue;
       }
@@ -149,6 +154,7 @@ export function expandPolicyWithPluginGroups(
   }
   return {
     allow: expandPluginGroups(policy.allow, groups),
+    alsoAllow: expandPluginGroups(policy.alsoAllow, groups),
     deny: expandPluginGroups(policy.deny, groups),
   };
 }


### PR DESCRIPTION
…for subagents

Problem:
Plugin tools (e.g. custom tools) registered via the plugin system were silently unavailable in subagent sessions even when explicitly listed in tools.subagents.tools.alsoAllow. Users following the documented alsoAllow pattern would add the config, observe no error, but find their subagents unable to call the plugin tools they expected.

Root cause:
collectExplicitAllowlist() in src/agents/tool-policy.ts — the function that builds the pluginToolAllowlist passed to both pi-tools.ts and tools-invoke-http.ts — only iterated over policy.allow. The alsoAllow field was schema-validated, stored in ToolPolicyLike (now fixed), and honoured in mergeAlsoAllow() elsewhere in the same file, but was never read by collectExplicitAllowlist(). Every policy in the pipeline (global, agent, provider, group, subagent) had the same blind spot.

Fix:
- Add alsoAllow to the ToolPolicyLike type so it is recognized at the type level throughout the policy pipeline.
- In collectExplicitAllowlist(), merge policy.allow and policy.alsoAllow into a single source array before iterating. This mirrors the existing mergeAlsoAllow() helper in the same file, which already combined the two fields correctly for a different code path.

Impact:
Any user who installs a plugin tool and wants it available inside spawned subagent sessions must currently patch the running binary to work around this. With this fix, the documented config pattern works as intended:

  tools:
    subagents:
      tools:
        alsoAllow: ["MY_CUSTOM_TOOL"]

All 31 existing tool-policy tests pass. No behavior change for callers that only use policy.allow — the merged array is deduplicated downstream.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
