### PR TITLE
fix(ci): remove stale runtime-matrix.ts from plugin-extension-boundary baseline

### DIFF
--- a/test/fixtures/plugin-extension-import-boundary-inventory.json
+++ b/test/fixtures/plugin-extension-import-boundary-inventory.json
@@ -32,14 +32,6 @@
     "reason": "imports extension-owned file from src/plugins"
   },
   {
-    "file": "src/plugins/runtime/runtime-matrix.ts",
-    "line": 4,
-    "kind": "import",
-    "specifier": "../../../extensions/matrix/runtime-api.js",
-    "resolvedPath": "extensions/matrix/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
     "file": "src/plugins/runtime/runtime-slack-ops.runtime.ts",
     "line": 10,
     "kind": "import",


### PR DESCRIPTION
## Summary
Remove stale `runtime-matrix.ts` entry from the plugin-extension-boundary baseline inventory.

## Problem
`runtime-matrix.ts` was refactored and no longer imports from `extensions/matrix/runtime-api.js`, but the baseline inventory (`test/fixtures/plugin-extension-import-boundary-inventory.json`) still lists it. This causes `check-plugin-extension-import-boundary.mjs` to fail with:

```
Baseline mismatch (0 unexpected, 1 missing).
Missing baseline entries:
- src/plugins/runtime/runtime-matrix.ts:4 [import] imports extension-owned file from src/plugins
```

This failure cascades through `check`, `check-additional`, `build-smoke`, and all test jobs — **breaking CI for every open PR**.

## Fix
Remove the stale entry from the baseline JSON. After this fix, `Baseline matches (8 entries).` passes cleanly.

## Impact
This is a 1-line baseline fix. No code logic changes. Unblocks CI for all open PRs.