### PR TITLE
fix(ui): use server total for cron badge count on fresh load

### DIFF
--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -288,7 +288,7 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
       hasMoreRaw: res.hasMore,
       pageCount: jobs.length,
     });
-    state.cronJobsTotal = Math.max(meta.total, state.cronJobs.length);
+    state.cronJobsTotal = append ? Math.max(meta.total, state.cronJobs.length) : meta.total;
     state.cronJobsHasMore = meta.hasMore;
     state.cronJobsNextOffset = meta.nextOffset;
     if (


### PR DESCRIPTION
lobster-biscuit

Closes #51382

## Problem

The cron badge in the Control UI nav shows a stale count after jobs are deleted. User reports badge showing 4 while the actual job list shows 3.

## Root cause

`ui/src/ui/controllers/cron.ts:291` — `state.cronJobsTotal = Math.max(meta.total, state.cronJobs.length)` uses `Math.max` on every load, including fresh (non-paginated) loads. When a job is deleted between loads, `Math.max` preserves the old higher count from the stale `cronJobs` array length.

## User impact

Badge count drifts upward and never corrects down after job deletion. Users see wrong number, lose trust in the UI.

## Fix

On fresh load (`append=false`): use `meta.total` directly — the server total is authoritative.
On paginated append: keep `Math.max` — correct for accumulating across pages.

1 file, 1 line changed.

## How to verify

1. Create 4 cron jobs. Badge shows 4.
2. Delete 1 job. Refresh the cron view.
3. Before fix: badge still shows 4. After fix: badge shows 3.

## Tests

No dedicated test for badge count rendering. The cron controller has existing tests covering the list/pagination flow — this change preserves paginated behavior and only affects the fresh-load path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)