### PR TITLE
fix(discord): clarify startup readiness log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replay: sanitize malformed assistant tool-call replay blocks before provider replay so follow-up Anthropic requests do not inherit the downstream `replace` crash. (#50005) Thanks @jalehman.
 - Plugins/context engines: retry strict legacy `assemble()` calls without the new `prompt` field when older engines reject it, preserving prompt-aware retrieval compatibility for pre-prompt plugins. (#50848) thanks @danhdoan.
 - Agents/embedded transport errors: distinguish common network failures like connection refused, DNS lookup failure, and interrupted sockets from true timeouts in embedded-run user messaging and lifecycle diagnostics. (#51419) Thanks @scoootscooob.
+- Discord/startup logging: report client initialization while the gateway is still connecting instead of claiming Discord is logged in before readiness is reached. (#51425) Thanks @scoootscooob.
 
 ### Breaking
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -92,6 +92,7 @@ import { resolveDiscordPresenceUpdate } from "./presence.js";
 import { resolveDiscordAllowlistConfig } from "./provider.allowlist.js";
 import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import { formatDiscordStartupStatusMessage } from "./startup-status.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 import {
   createNoopThreadBindingManager,
@@ -972,7 +973,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     const botIdentity =
       botUserId && botUserName ? `${botUserId} (${botUserName})` : (botUserId ?? botUserName ?? "");
-    runtime.log?.(`logged in to discord${botIdentity ? ` as ${botIdentity}` : ""}`);
+    runtime.log?.(
+      formatDiscordStartupStatusMessage({
+        gatewayReady: lifecycleGateway?.isConnected === true,
+        botIdentity: botIdentity || undefined,
+      }),
+    );
     if (lifecycleGateway?.isConnected) {
       opts.setStatus?.(createConnectedChannelStatusPatch());
     }

--- a/extensions/discord/src/monitor/startup-status.test.ts
+++ b/extensions/discord/src/monitor/startup-status.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatDiscordStartupStatusMessage } from "./startup-status.js";
+
+describe("formatDiscordStartupStatusMessage", () => {
+  it("reports logged-in status only after the gateway is ready", () => {
+    expect(
+      formatDiscordStartupStatusMessage({
+        gatewayReady: true,
+        botIdentity: "bot-1 (Molty)",
+      }),
+    ).toBe("logged in to discord as bot-1 (Molty)");
+  });
+
+  it("reports client initialization while gateway readiness is still pending", () => {
+    expect(
+      formatDiscordStartupStatusMessage({
+        gatewayReady: false,
+        botIdentity: "bot-1 (Molty)",
+      }),
+    ).toBe("discord client initialized as bot-1 (Molty); awaiting gateway readiness");
+  });
+
+  it("handles missing identity without awkward punctuation", () => {
+    expect(
+      formatDiscordStartupStatusMessage({
+        gatewayReady: false,
+      }),
+    ).toBe("discord client initialized; awaiting gateway readiness");
+  });
+});

--- a/extensions/discord/src/monitor/startup-status.ts
+++ b/extensions/discord/src/monitor/startup-status.ts
@@ -1,0 +1,10 @@
+export function formatDiscordStartupStatusMessage(params: {
+  gatewayReady: boolean;
+  botIdentity?: string;
+}): string {
+  const identitySuffix = params.botIdentity ? ` as ${params.botIdentity}` : "";
+  if (params.gatewayReady) {
+    return `logged in to discord${identitySuffix}`;
+  }
+  return `discord client initialized${identitySuffix}; awaiting gateway readiness`;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Discord startup logging could say `logged in to discord` before the gateway was actually READY.
- Why it matters: during startup network failures or delayed gateway readiness, that message is misleading and makes operators think the channel is healthy when it is still waiting to connect.
- What changed: extracted startup status formatting into a tiny helper and now log either `discord client initialized ...; awaiting gateway readiness` or `logged in to discord ...` based on actual gateway readiness.
- What did NOT change (scope boundary): this does not alter Discord reconnect logic, startup retry behavior, or lifecycle state transitions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #51370

## User-visible / Behavior Changes

- Discord startup no longer claims the bot is logged in before the gateway is ready.
- When identity is known but the gateway is still connecting, logs now say `discord client initialized ...; awaiting gateway readiness`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm test wrapper
- Model/provider: not applicable
- Integration/channel (if any): Discord monitor startup logging
- Relevant config (redacted): Discord default account with bot identity present

### Steps

1. Evaluate the startup status message with a known bot identity before gateway readiness.
2. Evaluate the startup status message again after gateway readiness.
3. Run focused Discord tests for the new helper and the existing lifecycle behavior.

### Expected

- Before READY: `discord client initialized ...; awaiting gateway readiness`
- After READY: `logged in to discord ...`

### Actual

- Before this patch, startup always logged `logged in to discord...` even when the gateway was not yet ready.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- extensions/discord/src/monitor/startup-status.test.ts`
  - `pnpm test -- extensions/discord/src/monitor/provider.lifecycle.test.ts`
  - manual smoke via `node --import tsx` for both helper outputs
- Edge cases checked:
  - missing identity stays punctuation-clean
  - existing Discord lifecycle tests remain green
- What you did **not** verify:
  - full repo test suite
  - live Discord gateway traffic against a real bot account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit f7da963fa8f2649c53178f0f08bb03cddfc1e977
- Files/config to restore:
  - `extensions/discord/src/monitor/provider.ts`
  - `extensions/discord/src/monitor/startup-status.ts`
- Known bad symptoms reviewers should watch for:
  - Discord startup still claiming logged-in status while the gateway is not ready
  - startup logs missing identity or showing awkward punctuation

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: callers could accidentally diverge from the helper and reintroduce inconsistent startup wording later.
  - Mitigation: the status formatting now lives in one tiny helper with direct tests.
