### PR TITLE
fix: emit assistant update for tool-call-only messages from OpenAI-compatible providers

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -321,7 +321,15 @@ export function handleMessageEnd(
     }
   }
 
-  if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
+  // Tool-call-only responses from OpenAI-compatible providers (e.g. vLLM) may have
+  // no text or media content. Without this check, handleMessageEnd silently skips
+  // emitting the assistant update, which prevents downstream tool execution from
+  // being signalled. See: https://github.com/openclaw/openclaw/issues/13603
+  const hasToolCalls =
+    Array.isArray(assistantMessage.content) &&
+    assistantMessage.content.some((b: { type?: string }) => b.type === "toolCall");
+
+  if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia || hasToolCalls)) {
     const data = buildAssistantStreamData({
       text: cleanedText,
       delta: cleanedText,


### PR DESCRIPTION
## Summary

When an OpenAI-compatible provider (e.g. vLLM) returns a tool-call-only response with no text content, `handleMessageEnd` silently skips emitting the assistant update event. This prevents tool execution from completing — the session goes idle without executing the requested tools.

## Root Cause

In `pi-embedded-subscribe.handlers.messages.ts`, `handleMessageEnd()` line 324 gates the assistant update emission on `cleanedText || hasMedia`. When vLLM returns a response where `content` is `null` (valid per the [OpenAI spec](https://github.com/openai/openai-python/blob/main/src/openai/types/chat/chat_completion_message.py#L18) — `content: Optional[str] = None`) and only `tool_calls` are present, no text or media is extracted, so the event is never emitted.

**Before:**
\`\`\`typescript
if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
\`\`\`

**After:**
\`\`\`typescript
const hasToolCalls =
  Array.isArray(assistantMessage.content) &&
  assistantMessage.content.some((b: { type?: string }) => b.type === "toolCall");

if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia || hasToolCalls)) {
\`\`\`

## Reproduction

Any vLLM-hosted model with tool calling enabled through the \`openai-completions\` provider:

1. Configure a vLLM model with \`supportsTools: true\` in \`openclaw.json\`
2. Ask the model to use a tool (e.g. "read the file /etc/hosts")
3. The model returns a tool call response with \`content: null\` and valid \`tool_calls\`
4. **Before fix:** Session silently drops to idle — tool never executes
5. **After fix:** Tool executes and result is returned to the model

Tested with:
- **Kimi K2.5** (\`moonshotai/Kimi-K2.5\`) on vLLM v0.17.0 via custom provider — fails before fix, works after
- **GLM-5** (\`zai-org/GLM-5-FP8\`) on vLLM v0.17.0 — already worked because GLM-5 returns \`content: ""\` instead of \`null\`
- **Kimi K2.5 on DeepInfra** — already worked because DeepInfra normalizes \`content: null\` to \`content: "  "\`
- **Kimi K2.5 on Nebius** (also vLLM) — same failure as direct vLLM, same fix resolves it

## Context

This is a targeted fix for one aspect of #13603. The broader issue describes multiple vLLM compatibility problems; this PR addresses the specific case where tool-call-only responses are silently dropped due to the missing \`hasToolCalls\` check in \`handleMessageEnd\`.

The \`pi-ai\` streaming parser and \`pi-agent-core\` agent loop both correctly handle tool-call-only responses — the bug is only in the \`handleMessageEnd\` event emission gate.

## AI-Assisted PR

This PR was developed with AI assistance (Claude Code). The fix was:
- **Fully tested** on a local OpenClaw v2026.3.13 instance with real vLLM inference traffic
- **Validated** by patching the compiled dist bundles and confirming tool calls execute end-to-end
- **Root-caused** by tracing the code path from pi-ai streaming parser to pi-agent-core agent loop to OpenClaw subscription handlers

## Test Plan

- [x] Verified tool-call-only responses from vLLM Kimi K2.5 now execute tools
- [x] Verified text-only responses still work correctly
- [x] Verified mixed text + tool call responses still work
- [x] Verified GLM-5 (which returns content: "") still works
- [ ] \`pnpm build && pnpm check && pnpm test\` (shallow clone — needs full repo for deps)