### PR TITLE
test: refresh plugin import boundary baseline

### DIFF
--- a/test/fixtures/plugin-extension-import-boundary-inventory.json
+++ b/test/fixtures/plugin-extension-import-boundary-inventory.json
@@ -32,14 +32,6 @@
     "reason": "imports extension-owned file from src/plugins"
   },
   {
-    "file": "src/plugins/runtime/runtime-matrix.ts",
-    "line": 4,
-    "kind": "import",
-    "specifier": "../../../extensions/matrix/runtime-api.js",
-    "resolvedPath": "extensions/matrix/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
     "file": "src/plugins/runtime/runtime-slack-ops.runtime.ts",
     "line": 10,
     "kind": "import",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: the plugin import-boundary tripwire baseline still expected `src/plugins/runtime/runtime-matrix.ts` to import `extensions/matrix/runtime-api.js` directly.
- Why it matters: `runtime-matrix.ts` already routes through `runtime-matrix-boundary.ts`, so the stale baseline made CI fail even though the code now follows the intended plugin boundary direction.
- What changed: removed the stale Matrix entry from `test/fixtures/plugin-extension-import-boundary-inventory.json`.
- What did NOT change (scope boundary): this does not relax the tripwire rule or change plugin runtime behavior; it only refreshes the checked-in inventory to match current architecture.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #51419
- Related #51425

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: not applicable
- Integration/channel (if any): plugin runtime boundary inventory
- Relevant config (redacted): none

### Steps

1. Run `pnpm lint:plugins:no-extension-imports` on current `main`.
2. Observe the stale baseline entry for `src/plugins/runtime/runtime-matrix.ts`.
3. Refresh the inventory by removing the outdated Matrix entry and rerun the lint.

### Expected

- The import-boundary lint should match the actual current `src/plugins/**` inventory.

### Actual

- Before this patch, the baseline still expected a Matrix direct extension import that no longer exists.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm lint:plugins:no-extension-imports`
  - full pre-commit gate via `scripts/committer`, including `pnpm check`
- Edge cases checked:
  - confirmed `src/plugins/runtime/runtime-matrix.ts` now imports `./runtime-matrix-boundary.js`, not `extensions/matrix/runtime-api.js`
  - confirmed the tripwire still reports the remaining intentional boundary entries and matches baseline
- What you did **not** verify:
  - full remote GitHub Actions matrix

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 7705b7bdcf278d61db306269627c2973f6f0907e
- Files/config to restore:
  - `test/fixtures/plugin-extension-import-boundary-inventory.json`
- Known bad symptoms reviewers should watch for:
  - the tripwire reporting a new unexpected or missing plugin boundary entry after merge

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the inventory could drift again if plugin runtime boundary changes land without refreshing the fixture.
  - Mitigation: this PR restores the fixture to match current architecture, and the tripwire will keep surfacing future drift.
