### PR TITLE
refactor(plugins): route Discord runtime through plugin sdk

### DIFF
--- a/src/plugins/runtime/runtime-discord-ops.runtime.ts
+++ b/src/plugins/runtime/runtime-discord-ops.runtime.ts
@@ -6,7 +6,7 @@ import {
   probeDiscord as probeDiscordImpl,
   resolveDiscordChannelAllowlist as resolveDiscordChannelAllowlistImpl,
   resolveDiscordUserAllowlist as resolveDiscordUserAllowlistImpl,
-} from "../../../extensions/discord/runtime-api.js";
+} from "../../plugin-sdk/discord.js";
 import {
   createThreadDiscord as createThreadDiscordImpl,
   deleteMessageDiscord as deleteMessageDiscordImpl,
@@ -18,7 +18,7 @@ import {
   sendPollDiscord as sendPollDiscordImpl,
   sendTypingDiscord as sendTypingDiscordImpl,
   unpinMessageDiscord as unpinMessageDiscordImpl,
-} from "../../../extensions/discord/runtime-api.js";
+} from "../../plugin-sdk/discord.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 
 type RuntimeDiscordOps = Pick<

--- a/src/plugins/runtime/runtime-discord.ts
+++ b/src/plugins/runtime/runtime-discord.ts
@@ -8,7 +8,7 @@ import {
   setThreadBindingIdleTimeoutBySessionKey,
   setThreadBindingMaxAgeBySessionKey,
   unbindThreadBindingsBySessionKey,
-} from "../../../extensions/discord/runtime-api.js";
+} from "../../plugin-sdk/discord.js";
 import {
   createLazyRuntimeMethodBinder,
   createLazyRuntimeSurface,

--- a/test/fixtures/plugin-extension-import-boundary-inventory.json
+++ b/test/fixtures/plugin-extension-import-boundary-inventory.json
@@ -1,29 +1,5 @@
 [
   {
-    "file": "src/plugins/runtime/runtime-discord-ops.runtime.ts",
-    "line": 9,
-    "kind": "import",
-    "specifier": "../../../extensions/discord/runtime-api.js",
-    "resolvedPath": "extensions/discord/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
-    "file": "src/plugins/runtime/runtime-discord-ops.runtime.ts",
-    "line": 21,
-    "kind": "import",
-    "specifier": "../../../extensions/discord/runtime-api.js",
-    "resolvedPath": "extensions/discord/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
-    "file": "src/plugins/runtime/runtime-discord.ts",
-    "line": 11,
-    "kind": "import",
-    "specifier": "../../../extensions/discord/runtime-api.js",
-    "resolvedPath": "extensions/discord/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
     "file": "src/plugins/runtime/runtime-imessage.ts",
     "line": 5,
     "kind": "import",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `src/plugins/runtime/runtime-discord.ts` and `src/plugins/runtime/runtime-discord-ops.runtime.ts` still imported `extensions/discord/runtime-api.js` directly.
- Why it matters: that keeps Discord on the grandfathered side of the plugin import-boundary tripwire instead of using the public plugin-sdk surface that recent refactors are converging on.
- What changed: rewired both Discord runtime entrypoints to import from `src/plugin-sdk/discord.ts` and refreshed the boundary inventory to remove the 3 Discord direct-import entries.
- What did NOT change (scope boundary): this does not change Discord runtime behavior or the exported Discord runtime-api surface; it only changes which internal boundary `src/plugins/runtime/*` depends on.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #51434
- Related #51425

## User-visible / Behavior Changes

None intended.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: not applicable
- Integration/channel (if any): Discord plugin runtime surface
- Relevant config (redacted): none required

### Steps

1. Replace direct `extensions/discord/runtime-api.js` imports in `src/plugins/runtime/*` with `src/plugin-sdk/discord.ts` imports.
2. Refresh the plugin import-boundary inventory.
3. Run plugin boundary guardrails, Discord-focused tests, direct runtime smoke, and repo `check`/`build`.

### Expected

- Discord disappears from the `src/plugins/** -> extensions/**` inventory.
- The published Discord runtime-api guardrails still pass.
- Discord runtime surface shape stays intact.

### Actual

- After this patch, the import-boundary inventory drops from 8 entries to 5 remaining grandfathered entries.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm lint:plugins:no-extension-imports`
  - `pnpm test -- test/plugin-extension-import-boundary.test.ts`
  - `pnpm test -- src/plugin-sdk/runtime-api-guardrails.test.ts`
  - `pnpm test -- src/plugins/runtime/runtime-discord-typing.test.ts extensions/discord/src/monitor/provider.lifecycle.test.ts`
  - `pnpm check`
  - `pnpm build`
  - direct smoke: instantiated `createRuntimeDiscord()` and confirmed the expected runtime surface methods are present
- Edge cases checked:
  - Discord dropped out of the boundary inventory completely
  - runtime-api allowlist/guardrails still match current exports
  - local build/check remained green after the refactor
- What you did **not** verify:
  - full remote GitHub Actions matrix
  - live Discord bot traffic against a real account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit fc11b66950ae204127a2eb239ad0bdc943c767c3
- Files/config to restore:
  - `src/plugins/runtime/runtime-discord.ts`
  - `src/plugins/runtime/runtime-discord-ops.runtime.ts`
  - `test/fixtures/plugin-extension-import-boundary-inventory.json`
- Known bad symptoms reviewers should watch for:
  - Discord reappearing in the plugin extension import-boundary inventory
  - missing Discord runtime methods in plugin consumers
  - runtime-api guardrail drift for Discord exports

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `src/plugin-sdk/discord.ts` could diverge from the extension runtime surface expected by `src/plugins/runtime/*`.
  - Mitigation: runtime-api guardrails, Discord-focused tests, direct runtime smoke, and full local `check`/`build` all passed.
