### PR TITLE
fix(agent): forward configured tool choice into stream params

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -1,5 +1,6 @@
 import type { Model } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { runExtraParamsCase } from "./extra-params.test-support.js";
 
@@ -91,5 +92,37 @@ describe("extra-params: OpenAI attribution", () => {
       originator: "openclaw",
       "User-Agent": "openclaw/2026.3.14",
     });
+  });
+});
+
+describe("extra-params: tool choice forwarding", () => {
+  it("forwards tool_choice from agent model params into stream options", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.4": {
+              params: {
+                tool_choice: "required",
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const capture = runExtraParamsCase({
+      applyModelId: "gpt-5.4",
+      applyProvider: "openai",
+      cfg,
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5.4",
+      } as Model<"openai-completions">,
+      payload: {},
+    });
+
+    expect((capture.options as { toolChoice?: string } | undefined)?.toolChoice).toBe("required");
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.test-support.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test-support.ts
@@ -5,6 +5,7 @@ import { applyExtraParamsToAgent } from "./extra-params.js";
 
 export type ExtraParamsCapture<TPayload extends Record<string, unknown>> = {
   headers?: Record<string, string>;
+  options?: SimpleStreamOptions;
   payload: TPayload;
 };
 
@@ -32,6 +33,7 @@ export function runExtraParamsCase<
 
   const baseStreamFn: StreamFn = (model, _context, options) => {
     captured.headers = options?.headers;
+    captured.options = options;
     options?.onPayload?.(params.payload, model);
     return {} as ReturnType<StreamFn>;
   };

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -90,6 +90,14 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;
   }
+  const resolvedToolChoice = resolveAliasedParamValue(
+    [extraParams],
+    "tool_choice",
+    "toolChoice",
+  );
+  if (resolvedToolChoice !== undefined) {
+    streamParams.toolChoice = resolvedToolChoice as CacheRetentionStreamOptions["toolChoice"];
+  }
   const transport = extraParams.transport;
   if (transport === "sse" || transport === "websocket" || transport === "auto") {
     streamParams.transport = transport;


### PR DESCRIPTION
## Summary
- Forward `tool_choice` and `toolChoice` from agent model params into the embedded runner's stream options.
- Add a focused regression test that proves configured model params can force `toolChoice` through to the underlying stream call.

## Why
OpenClaw already allows agent model params such as:

```json
{
  "agents": {
    "defaults": {
      "models": {
        "openai/gpt-5.4": {
          "params": {
            "tool_choice": "required"
          }
        }
      }
    }
  }
}
```

but that setting was not being forwarded by `createStreamFnWithExtraParams()`.

In practice this means a deployment can appear to require tool use at the config layer while the underlying OpenAI-compatible request still behaves as if no tool-choice override was provided.

This patch makes `tool_choice` behave like the other forwarded stream params such as `temperature` and `maxTokens`.

## Test Plan
- Added a regression test in `src/agents/pi-embedded-runner/extra-params.openai.test.ts`
- Verified the edited files are free of IDE diagnostics
- Local targeted Vitest execution in this environment hung before test collection, so CI should provide the authoritative test run for this repo

## Notes
- This change is intentionally narrow: it only forwards the already-configured value and does not alter provider-specific tool behavior beyond that

Made with [Cursor](https://cursor.com)