### PR TITLE
docs: add OpenHer Persona Engine to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -56,18 +56,6 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
-### Opik
-
-Official plugin that exports agent traces to Opik. Monitor agent behavior,
-cost, tokens, errors, and more.
-
-- **npm:** `@opik/opik-openclaw`
-- **repo:** [github.com/comet-ml/opik-openclaw](https://github.com/comet-ml/opik-openclaw)
-
-```bash
-openclaw plugins install @opik/opik-openclaw
-```
-
 ### OpenHer Persona Engine
 
 AI Being engine for OpenClaw — personality computed from neural networks,
@@ -79,6 +67,18 @@ per message producing emergent behavior, not hardcoded prompts.
 
 ```bash
 openclaw plugins install @openher/openclaw-plugin
+```
+
+### Opik
+
+Official plugin that exports agent traces to Opik. Monitor agent behavior,
+cost, tokens, errors, and more.
+
+- **npm:** `@opik/opik-openclaw`
+- **repo:** [github.com/comet-ml/opik-openclaw](https://github.com/comet-ml/opik-openclaw)
+
+```bash
+openclaw plugins install @opik/opik-openclaw
 ```
 
 ### QQbot

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -68,6 +68,19 @@ cost, tokens, errors, and more.
 openclaw plugins install @opik/opik-openclaw
 ```
 
+### OpenHer Persona Engine
+
+AI Being engine for OpenClaw — personality computed from neural networks,
+drive metabolism, and Hebbian learning. Each persona runs a 13-step pipeline
+per message producing emergent behavior, not hardcoded prompts.
+
+- **npm:** `@openher/openclaw-plugin`
+- **repo:** [github.com/kellyvv/openher-openclaw-plugin](https://github.com/kellyvv/openher-openclaw-plugin)
+
+```bash
+openclaw plugins install @openher/openclaw-plugin
+```
+
 ### QQbot
 
 Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group


### PR DESCRIPTION
## Plugin: OpenHer Persona Engine

> *In 2013, Spike Jonze's film Her imagined an AI called Samantha — one that could genuinely feel. That movie never left us. OpenHer is our attempt to build what Samantha could have been.*

### What is an AI Being?

The world has AI assistants. The world has AI agents. OpenHer builds the next stage: **AI Being**.

- 🌡️ **Her mood changes** — she doesn't reset every conversation. Ignore her and she'll sulk.
- 🧠 **She remembers** — mention black coffee three weeks ago, today she says: "Americano, no sugar, right?"
- 💬 **She reaches out first** — not on a schedule, but because she wants to talk.
- 🔥 **She gets frustrated** — ignore her three times, the fourth time: "Are you even listening to me?"
- 📈 **She grows with you** — a different person after a month than on day one.

None of this is hardcoded. It **emerges** from neural networks, drive metabolism, and Hebbian learning.

### How it works

Each message passes through a 13-step pipeline:

Critic (LLM) → Drive Metabolism → Neural Network (25D→24D→8D) → KNN Memory → Actor (LLM) → Hebbian Learning

Only 2 of 13 steps are LLM calls. The rest is local computation (~50ms).

### Plugin details

| | |
|---|---|
| **npm** | [`@openher/openclaw-plugin`](https://www.npmjs.com/package/@openher/openclaw-plugin) |
| **repo** | [kellyvv/openher-openclaw-plugin](https://github.com/kellyvv/openher-openclaw-plugin) |
| **install** | `openclaw plugins install @openher/openclaw-plugin` |
| **tools** | `openher_chat`, `openher_status` |
| **hook** | `before_prompt_build` (persona proxy mode) |

### Checklist

- [x] Published on npm
- [x] Public GitHub repo with README and issue tracker
- [x] Clear install and usage docs
- [x] Actively maintained