### PR TITLE
perf: add in-memory usage cache for session transcript reads

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -801,6 +801,156 @@ describe("readLatestSessionUsageFromTranscript", () => {
   });
 });
 
+describe("readLatestSessionUsageFromTranscript cache", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore("openclaw-session-usage-cache-test-", (nextTmpDir, nextStorePath) => {
+    tmpDir = nextTmpDir;
+    storePath = nextStorePath;
+  });
+
+  test("returns cached result without re-reading file on second call", () => {
+    const sessionId = "usage-cache-hit";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: { input: 100, output: 50, cost: { total: 0.001 } },
+        },
+      },
+    ]);
+
+    const readFileSpy = vi.spyOn(fs, "readFileSync");
+
+    const first = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    const readsAfterFirst = readFileSpy.mock.calls.length;
+    expect(readsAfterFirst).toBeGreaterThan(0);
+    expect(first).toMatchObject({
+      modelProvider: "anthropic",
+      model: "claude-sonnet-4-6",
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    const second = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    expect(second).toEqual(first);
+    expect(readFileSpy.mock.calls.length).toBe(readsAfterFirst);
+
+    readFileSpy.mockRestore();
+  });
+
+  test("invalidates cache when file mtime changes", () => {
+    const sessionId = "usage-cache-mtime";
+    const transcriptPath = writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: { input: 200, output: 100, cost: { total: 0.002 } },
+        },
+      },
+    ]);
+
+    const first = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    expect(first).toMatchObject({ modelProvider: "openai", model: "gpt-5.4" });
+
+    // Touch the file to change mtime without changing size
+    const futureTime = Date.now() + 10_000;
+    fs.utimesSync(transcriptPath, futureTime / 1000, futureTime / 1000);
+
+    const readFileSpy = vi.spyOn(fs, "readFileSync");
+    const second = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    // Should have re-read the file since mtime changed
+    expect(readFileSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(second).toEqual(first);
+
+    readFileSpy.mockRestore();
+  });
+
+  test("invalidates cache when file size changes", () => {
+    const sessionId = "usage-cache-size";
+    const transcriptPath = writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: { input: 300, output: 150, cost: { total: 0.003 } },
+        },
+      },
+    ]);
+
+    const first = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    expect(first).toMatchObject({ inputTokens: 300, outputTokens: 150 });
+
+    // Append to the file to change size
+    fs.appendFileSync(
+      transcriptPath,
+      `\n${JSON.stringify({
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: { input: 500, output: 200, cost: { total: 0.005 } },
+        },
+      })}`,
+      "utf-8",
+    );
+
+    const readFileSpy = vi.spyOn(fs, "readFileSync");
+    const second = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    // Should have re-read the file since size changed
+    expect(readFileSpy.mock.calls.length).toBeGreaterThan(0);
+    // Aggregated usage should now include both entries
+    expect(second).toMatchObject({ inputTokens: 800, outputTokens: 350 });
+
+    readFileSpy.mockRestore();
+  });
+
+  test("does not cache null from transient I/O errors", () => {
+    const sessionId = "usage-cache-transient-error";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: { input: 100, output: 50 },
+        },
+      },
+    ]);
+
+    // Simulate a transient I/O error by making openSync fail once
+    const originalOpenSync = fs.openSync;
+    let openCallCount = 0;
+    const openSpy = vi.spyOn(fs, "openSync").mockImplementation((...args: unknown[]) => {
+      openCallCount++;
+      if (openCallCount === 1) {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }
+      return originalOpenSync.apply(fs, args as Parameters<typeof fs.openSync>);
+    });
+
+    // First call — transient error, should return null but NOT cache it
+    const firstResult = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    expect(firstResult).toBeNull();
+
+    // Second call — error resolved, should re-read and succeed (not serve cached null)
+    const secondResult = readLatestSessionUsageFromTranscript(sessionId, storePath);
+    expect(secondResult).toMatchObject({ inputTokens: 100, outputTokens: 50 });
+
+    openSpy.mockRestore();
+  });
+});
+
 describe("resolveSessionTranscriptCandidates", () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -762,6 +762,52 @@ function extractLatestUsageFromTranscriptChunk(
   return snapshot;
 }
 
+type SessionUsageCacheEntry = {
+  result: SessionTranscriptUsageSnapshot | null;
+  mtimeMs: number;
+  size: number;
+};
+
+const sessionUsageCache = new Map<string, SessionUsageCacheEntry>();
+const MAX_SESSION_USAGE_CACHE_ENTRIES = 5000;
+
+function getCachedSessionUsage(
+  cacheKey: string,
+  stat: fs.Stats,
+): SessionTranscriptUsageSnapshot | null | undefined {
+  const cached = sessionUsageCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  if (cached.mtimeMs !== stat.mtimeMs || cached.size !== stat.size) {
+    sessionUsageCache.delete(cacheKey);
+    return undefined;
+  }
+  // LRU bump
+  sessionUsageCache.delete(cacheKey);
+  sessionUsageCache.set(cacheKey, cached);
+  return cached.result;
+}
+
+function setCachedSessionUsage(
+  cacheKey: string,
+  stat: fs.Stats,
+  result: SessionTranscriptUsageSnapshot | null,
+) {
+  sessionUsageCache.set(cacheKey, {
+    result,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  });
+  while (sessionUsageCache.size > MAX_SESSION_USAGE_CACHE_ENTRIES) {
+    const oldestKey = sessionUsageCache.keys().next().value;
+    if (typeof oldestKey !== "string" || !oldestKey) {
+      break;
+    }
+    sessionUsageCache.delete(oldestKey);
+  }
+}
+
 export function readLatestSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -773,14 +819,37 @@ export function readLatestSessionUsageFromTranscript(
     return null;
   }
 
-  return withOpenTranscriptFd(filePath, (fd) => {
-    const stat = fs.fstatSync(fd);
-    if (stat.size === 0) {
-      return null;
-    }
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    return null;
+  }
+
+  const cached = getCachedSessionUsage(filePath, stat);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (stat.size === 0) {
+    setCachedSessionUsage(filePath, stat, null);
+    return null;
+  }
+
+  // Distinguish "file read succeeded but no usage data" (cache the null)
+  // from "transient I/O error" (don't cache). withOpenTranscriptFd returns
+  // null for both cases, so we track success explicitly.
+  let readSucceeded = false;
+  const result = withOpenTranscriptFd(filePath, (fd) => {
     const chunk = fs.readFileSync(fd, "utf-8");
+    readSucceeded = true;
     return extractLatestUsageFromTranscriptChunk(chunk);
   });
+
+  if (readSucceeded) {
+    setCachedSessionUsage(filePath, stat, result);
+  }
+  return result;
 }
 
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];


### PR DESCRIPTION
> **Status:** All review feedback addressed. Ready to merge.

> **Dependency:** This PR can be reviewed independently but applies cleanly after #51193 (fallback concurrency).

## Summary

- Problem: `sessions.list` re-reads and re-parses entire transcript files on every call to extract usage metadata (tokens, cost), even when files haven't changed.
- Why it matters: With many sessions, this causes `sessions.list` to take 46+ seconds, exceeding the 10-second gateway timeout.
- What changed: Added an in-memory cache for `readLatestSessionUsageFromTranscript` results, using the same mtime+size invalidation pattern as the existing `sessionTitleFieldsCache`.
- What did NOT change (scope boundary): No changes to the fallback decision logic, session store writes, or any other gateway behavior. Cache is read-only and side-effect-free.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #51193

## User-visible / Behavior Changes

None. Cache is entirely internal — same responses, just faster on repeated calls.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows host + Docker gateway container (Linux)
- Runtime/container: Node 24 / Docker
- Model/provider: any
- Integration/channel: Discord (multi-agent)
- Relevant config: default (no special config needed)

### Steps

1. Start gateway with multiple sessions that have missing usage metadata in the store
2. Call `sessions.list` twice in quick succession
3. Observe that the second call is significantly faster

### Expected

- Second `sessions.list` call avoids re-reading transcript files that haven't changed
- Cache invalidates correctly when transcript files are modified (new messages)

### Actual

- Without this change: both calls take 46+ seconds
- With this change: second call returns in milliseconds (cache hit)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Tests added in `session-utils.fs.test.ts`:
- Cache hit test: verifies second call skips file read
- mtime invalidation test: verifies cache invalidates on file modification
- size invalidation test: verifies cache invalidates on file growth

## Human Verification (required)

- Verified scenarios: cache hit, mtime invalidation, size invalidation via unit tests
- Edge cases checked: empty files, missing files, cache eviction at max entries
- What you did **not** verify: production load testing with large session stores

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit
- Files/config to restore: `src/gateway/session-utils.fs.ts`
- Known bad symptoms reviewers should watch for: stale usage data in session list (would indicate cache invalidation bug)

## Risks and Mitigations

- Risk: Cache could serve stale data if file changes without mtime/size changing
  - Mitigation: Extremely unlikely — same invalidation pattern used by `sessionTitleFieldsCache` with proven track record