### PR TITLE
fix(process): auto-detect PTY cursor key mode for send-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/auth: require auth for canvas routes and admin scope for agent session reset, so anonymous canvas access and non-admin reset requests fail closed.
 - Release/install: keep previously released bundled plugins and Control UI assets in published openclaw npm installs, and fail release checks when those shipped artifacts are missing. Thanks @vincentkoc.
 - WhatsApp/outbound sends: keep the active Web listener on a direct process-global symbol so split runtime chunks keep sharing the connected Baileys session and `openclaw message send --channel whatsapp` stops failing after connect. Fixes #52574. Thanks @MonkeyLeeT.
+- Agents/process: fail loud when `send-keys` tries cursor-sensitive keys before a background PTY reports its cursor mode, so startup races no longer silently send the wrong arrow/Home/End sequences. (#51490) Thanks @liuy.
 
 ## 2026.3.22
 

--- a/src/agents/bash-process-registry.test-helpers.ts
+++ b/src/agents/bash-process-registry.test-helpers.ts
@@ -11,6 +11,7 @@ export function createProcessSessionFixture(params: {
   backgrounded?: boolean;
   pid?: number;
   child?: ChildProcessWithoutNullStreams;
+  cursorKeyMode?: ProcessSession["cursorKeyMode"];
 }): ProcessSession {
   const session: ProcessSession = {
     id: params.id,
@@ -31,6 +32,7 @@ export function createProcessSessionFixture(params: {
     exitSignal: undefined,
     truncated: false,
     backgrounded: params.backgrounded ?? false,
+    cursorKeyMode: params.cursorKeyMode ?? "normal",
   };
   if (params.pid !== undefined) {
     session.pid = params.pid;

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -122,6 +122,7 @@ describe("cursorKeyMode", () => {
     maxOutputChars: number;
     pendingMaxOutputChars: number;
     backgrounded: boolean;
+    cursorKeyMode?: ProcessSession["cursorKeyMode"];
   }): ProcessSession {
     return createProcessSessionFixture({
       id: params.id ?? "sess",
@@ -130,16 +131,18 @@ describe("cursorKeyMode", () => {
       maxOutputChars: params.maxOutputChars,
       pendingMaxOutputChars: params.pendingMaxOutputChars,
       backgrounded: params.backgrounded,
+      cursorKeyMode: params.cursorKeyMode,
     });
   }
 
-  it("session defaults to undefined cursorKeyMode (normal)", () => {
+  it("session cursorKeyMode can start unknown", () => {
     const session = createRegistrySession({
       maxOutputChars: 100,
       pendingMaxOutputChars: 30_000,
       backgrounded: false,
+      cursorKeyMode: "unknown",
     });
-    expect(session.cursorKeyMode).toBeUndefined();
+    expect(session.cursorKeyMode).toBe("unknown");
   });
 
   it("session cursorKeyMode can be set to application", () => {
@@ -157,8 +160,9 @@ describe("cursorKeyMode", () => {
       maxOutputChars: 100,
       pendingMaxOutputChars: 30_000,
       backgrounded: false,
+      cursorKeyMode: "unknown",
     });
-    expect(session.cursorKeyMode).toBeUndefined();
+    expect(session.cursorKeyMode).toBe("unknown");
 
     session.cursorKeyMode = "application";
     expect(session.cursorKeyMode).toBe("application");

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -115,3 +115,55 @@ describe("bash process registry", () => {
     expect(listFinishedSessions()).toHaveLength(1);
   });
 });
+
+describe("cursorKeyMode", () => {
+  function createRegistrySession(params: {
+    id?: string;
+    maxOutputChars: number;
+    pendingMaxOutputChars: number;
+    backgrounded: boolean;
+  }): ProcessSession {
+    return createProcessSessionFixture({
+      id: params.id ?? "sess",
+      command: "echo test",
+      child: { pid: 123, removeAllListeners: vi.fn() } as unknown as ChildProcessWithoutNullStreams,
+      maxOutputChars: params.maxOutputChars,
+      pendingMaxOutputChars: params.pendingMaxOutputChars,
+      backgrounded: params.backgrounded,
+    });
+  }
+
+  it("session defaults to undefined cursorKeyMode (normal)", () => {
+    const session = createRegistrySession({
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: false,
+    });
+    expect(session.cursorKeyMode).toBeUndefined();
+  });
+
+  it("session cursorKeyMode can be set to application", () => {
+    const session = createRegistrySession({
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: false,
+    });
+    session.cursorKeyMode = "application";
+    expect(session.cursorKeyMode).toBe("application");
+  });
+
+  it("session cursorKeyMode can be toggled between normal and application", () => {
+    const session = createRegistrySession({
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: false,
+    });
+    expect(session.cursorKeyMode).toBeUndefined();
+
+    session.cursorKeyMode = "application";
+    expect(session.cursorKeyMode).toBe("application");
+
+    session.cursorKeyMode = "normal";
+    expect(session.cursorKeyMode).toBe("normal");
+  });
+});

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -52,6 +52,8 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
+  /** PTY cursor key mode: 'normal' (CSI sequences) or 'application' (SS3 sequences). */
+  cursorKeyMode?: "normal" | "application";
 }
 
 export interface FinishedSession {

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -52,8 +52,8 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
-  /** PTY cursor key mode: 'normal' (CSI sequences) or 'application' (SS3 sequences). */
-  cursorKeyMode?: "normal" | "application";
+  /** PTY cursor key mode: unknown until a PTY reports smkx/rmkx. */
+  cursorKeyMode: "unknown" | "normal" | "application";
 }
 
 export interface FinishedSession {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -4,8 +4,41 @@ const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
+let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
 let emitExecSystemEvent: typeof import("./bash-tools.exec-runtime.js").emitExecSystemEvent;
 let formatExecFailureReason: typeof import("./bash-tools.exec-runtime.js").formatExecFailureReason;
+
+describe("detectCursorKeyMode", () => {
+  beforeEach(async () => {
+    ({ detectCursorKeyMode } = await import("./bash-tools.exec-runtime.js"));
+  });
+
+  it("returns null when no toggle found", () => {
+    expect(detectCursorKeyMode("hello world")).toBe(null);
+    expect(detectCursorKeyMode("")).toBe(null);
+  });
+
+  it("detects smkx (application mode)", () => {
+    expect(detectCursorKeyMode("\x1b[?1h")).toBe("application");
+    expect(detectCursorKeyMode("\x1b[?1h\x1b=")).toBe("application");
+    expect(detectCursorKeyMode("before \x1b[?1h after")).toBe("application");
+  });
+
+  it("detects rmkx (normal mode)", () => {
+    expect(detectCursorKeyMode("\x1b[?1l")).toBe("normal");
+    expect(detectCursorKeyMode("\x1b[?1l\x1b>")).toBe("normal");
+    expect(detectCursorKeyMode("before \x1b[?1l after")).toBe("normal");
+  });
+
+  it("last toggle wins when both present", () => {
+    // smkx first, then rmkx - should be normal
+    expect(detectCursorKeyMode("\x1b[?1h\x1b[?1l")).toBe("normal");
+    // rmkx first, then smkx - should be application
+    expect(detectCursorKeyMode("\x1b[?1l\x1b[?1h")).toBe("application");
+    // Multiple toggles - last one wins
+    expect(detectCursorKeyMode("\x1b[?1h\x1b[?1l\x1b[?1h")).toBe("application");
+  });
+});
 
 describe("emitExecSystemEvent", () => {
   beforeEach(async () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -36,6 +36,25 @@ import {
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 
+const SMKX = "\x1b[?1h";
+const RMKX = "\x1b[?1l";
+
+/**
+ * Detect cursor key mode from PTY output chunk.
+ * Uses lastIndexOf to find the *last* toggle in the chunk.
+ * Returns "application" if smkx is the last toggle, "normal" if rmkx is last,
+ * or null if no toggle is found.
+ */
+export function detectCursorKeyMode(raw: string): "application" | "normal" | null {
+  const lastSmkx = raw.lastIndexOf(SMKX);
+  const lastRmkx = raw.lastIndexOf(RMKX);
+  if (lastSmkx === -1 && lastRmkx === -1) {
+    return null;
+  }
+  // Whichever appears later in the chunk wins.
+  return lastSmkx > lastRmkx ? "application" : "normal";
+}
+
 // Sanitize inherited host env before merge so dangerous variables from process.env
 // are not propagated into non-sandboxed executions.
 export function sanitizeHostBaseEnv(env: Record<string, string>): Record<string, string> {
@@ -497,7 +516,15 @@ export async function runExecProcess(opts: {
   };
 
   const handleStdout = (data: string) => {
-    const str = sanitizeBinaryOutput(data.toString());
+    const raw = data.toString();
+    // Detect smkx/rmkx BEFORE sanitizeBinaryOutput strips ESC sequences.
+    // Note: PTY chunking is arbitrary, but smkx/rmkx sequences are typically short (4-5 bytes)
+    // and sent atomically by terminals. Split across chunks is rare in practice.
+    const mode = detectCursorKeyMode(raw);
+    if (mode) {
+      session.cursorKeyMode = mode;
+    }
+    const str = sanitizeBinaryOutput(raw);
     for (const chunk of chunkString(str)) {
       appendOutput(session, "stdout", chunk);
       emitUpdate();

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -493,6 +493,7 @@ export async function runExecProcess(opts: {
     exitSignal: undefined as NodeJS.Signals | number | null | undefined,
     truncated: false,
     backgrounded: false,
+    cursorKeyMode: opts.usePty ? "unknown" : "normal",
   };
   addSession(session);
 

--- a/src/agents/bash-tools.process.send-keys.test.ts
+++ b/src/agents/bash-tools.process.send-keys.test.ts
@@ -1,7 +1,18 @@
 import { afterEach, expect, test } from "vitest";
-import { resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { addSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { createExecTool } from "./bash-tools.exec.js";
 import { createProcessTool } from "./bash-tools.process.js";
+
+function createWritableStdinStub() {
+  return {
+    write(_data: string, cb?: (err?: Error | null) => void) {
+      cb?.();
+    },
+    end() {},
+    destroyed: false,
+  };
+}
 
 afterEach(() => {
   resetProcessRegistryForTests();
@@ -75,4 +86,48 @@ test("process submit sends Enter for pty sessions", async () => {
   });
 
   await waitForSessionCompletion({ processTool, sessionId, expectedText: "submitted" });
+});
+
+test("process send-keys fails loud for unknown cursor mode when arrows depend on it", async () => {
+  const session = createProcessSessionFixture({
+    id: "sess-unknown-mode",
+    command: "vim",
+    backgrounded: true,
+    cursorKeyMode: "unknown",
+  });
+  session.stdin = createWritableStdinStub();
+  addSession(session);
+
+  const processTool = createProcessTool();
+  const result = await processTool.execute("toolcall", {
+    action: "send-keys",
+    sessionId: "sess-unknown-mode",
+    keys: ["up"],
+  });
+
+  expect(result.details).toMatchObject({ status: "failed" });
+  expect(result.content[0]).toMatchObject({
+    type: "text",
+    text: expect.stringContaining("cursor key mode is not known yet"),
+  });
+});
+
+test("process send-keys still sends non-cursor keys while mode is unknown", async () => {
+  const session = createProcessSessionFixture({
+    id: "sess-unknown-enter",
+    command: "vim",
+    backgrounded: true,
+    cursorKeyMode: "unknown",
+  });
+  session.stdin = createWritableStdinStub();
+  addSession(session);
+
+  const processTool = createProcessTool();
+  const result = await processTool.execute("toolcall", {
+    action: "send-keys",
+    sessionId: "sess-unknown-enter",
+    keys: ["Enter"],
+  });
+
+  expect(result.details).toMatchObject({ status: "running" });
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -477,11 +477,17 @@ export function createProcessTool(
           if (!resolved.ok) {
             return resolved.result;
           }
-          const { data, warnings } = encodeKeySequence({
-            keys: params.keys,
-            hex: params.hex,
-            literal: params.literal,
-          });
+          // Use session's cursor key mode to select correct escape sequences.
+          // 'application' mode (smkx) uses SS3 sequences, 'normal' mode uses CSI.
+          const cursorKeyMode = resolved.session.cursorKeyMode ?? "normal";
+          const { data, warnings } = encodeKeySequence(
+            {
+              keys: params.keys,
+              hex: params.hex,
+              literal: params.literal,
+            },
+            cursorKeyMode,
+          );
           if (!data) {
             return {
               content: [
@@ -496,7 +502,7 @@ export function createProcessTool(
           await writeToStdin(resolved.stdin, data);
           return runningSessionResult(
             resolved.session,
-            `Sent ${data.length} bytes to session ${params.sessionId}.` +
+            `Sent ${data.length} bytes to session ${params.sessionId} (cursor mode: ${cursorKeyMode}).` +
               (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
           );
         }

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -17,7 +17,7 @@ import {
 } from "./bash-process-registry.js";
 import { deriveSessionName, pad, sliceLogLines, truncateMiddle } from "./bash-tools.shared.js";
 import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
-import { encodeKeySequence, encodePaste } from "./pty-keys.js";
+import { encodeKeySequence, encodePaste, hasCursorModeSensitiveKeys } from "./pty-keys.js";
 
 export type ProcessToolDefaults = {
   cleanupMs?: number;
@@ -477,17 +477,21 @@ export function createProcessTool(
           if (!resolved.ok) {
             return resolved.result;
           }
-          // Use session's cursor key mode to select correct escape sequences.
-          // 'application' mode (smkx) uses SS3 sequences, 'normal' mode uses CSI.
-          const cursorKeyMode = resolved.session.cursorKeyMode ?? "normal";
-          const { data, warnings } = encodeKeySequence(
-            {
-              keys: params.keys,
-              hex: params.hex,
-              literal: params.literal,
-            },
-            cursorKeyMode,
-          );
+          const request = {
+            keys: params.keys,
+            hex: params.hex,
+            literal: params.literal,
+          };
+          if (resolved.session.cursorKeyMode === "unknown" && hasCursorModeSensitiveKeys(request)) {
+            return failText(
+              `Session ${params.sessionId} cursor key mode is not known yet. Poll or log until startup output appears, then retry send-keys.`,
+            );
+          }
+          const cursorKeyMode =
+            resolved.session.cursorKeyMode === "unknown"
+              ? undefined
+              : resolved.session.cursorKeyMode;
+          const { data, warnings } = encodeKeySequence(request, cursorKeyMode);
           if (!data) {
             return {
               content: [
@@ -502,7 +506,7 @@ export function createProcessTool(
           await writeToStdin(resolved.stdin, data);
           return runningSessionResult(
             resolved.session,
-            `Sent ${data.length} bytes to session ${params.sessionId} (cursor mode: ${cursorKeyMode}).` +
+            `Sent ${data.length} bytes to session ${params.sessionId}.` +
               (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
           );
         }

--- a/src/agents/pty-keys.test.ts
+++ b/src/agents/pty-keys.test.ts
@@ -7,6 +7,8 @@ import {
   encodePaste,
 } from "./pty-keys.js";
 
+const ESC = "\x1b";
+
 test("encodeKeySequence maps common keys and modifiers", () => {
   const enter = encodeKeySequence({ keys: ["Enter"] });
   expect(enter.data).toBe("\r");
@@ -22,6 +24,84 @@ test("encodeKeySequence maps common keys and modifiers", () => {
 
   const kpEnter = encodeKeySequence({ keys: ["KPEnter"] });
   expect(kpEnter.data).toBe("\x1bOM");
+});
+
+test("encodeKeySequence uses CSI sequences in normal cursor key mode (default)", () => {
+  // Default mode (cursorKeyMode not specified) uses CSI sequences.
+  const up = encodeKeySequence({ keys: ["up"] });
+  expect(up.data).toBe(`${ESC}[A`);
+
+  const down = encodeKeySequence({ keys: ["down"] });
+  expect(down.data).toBe(`${ESC}[B`);
+
+  const right = encodeKeySequence({ keys: ["right"] });
+  expect(right.data).toBe(`${ESC}[C`);
+
+  const left = encodeKeySequence({ keys: ["left"] });
+  expect(left.data).toBe(`${ESC}[D`);
+
+  // Home/End use CSI sequences in normal mode.
+  const home = encodeKeySequence({ keys: ["home"] });
+  expect(home.data).toBe(`${ESC}[1~`);
+
+  const end = encodeKeySequence({ keys: ["end"] });
+  expect(end.data).toBe(`${ESC}[4~`);
+});
+
+test("encodeKeySequence uses CSI sequences in explicit normal cursor key mode", () => {
+  const up = encodeKeySequence({ keys: ["up"] }, "normal");
+  expect(up.data).toBe(`${ESC}[A`);
+
+  const down = encodeKeySequence({ keys: ["down"] }, "normal");
+  expect(down.data).toBe(`${ESC}[B`);
+
+  const right = encodeKeySequence({ keys: ["right"] }, "normal");
+  expect(right.data).toBe(`${ESC}[C`);
+
+  const left = encodeKeySequence({ keys: ["left"] }, "normal");
+  expect(left.data).toBe(`${ESC}[D`);
+
+  // Home/End use CSI sequences in explicit normal mode.
+  const home = encodeKeySequence({ keys: ["home"] }, "normal");
+  expect(home.data).toBe(`${ESC}[1~`);
+
+  const end = encodeKeySequence({ keys: ["end"] }, "normal");
+  expect(end.data).toBe(`${ESC}[4~`);
+});
+
+test("encodeKeySequence uses SS3 sequences in application cursor key mode", () => {
+  // Application mode (smkx) uses SS3 sequences.
+  const up = encodeKeySequence({ keys: ["up"] }, "application");
+  expect(up.data).toBe(`${ESC}OA`);
+
+  const down = encodeKeySequence({ keys: ["down"] }, "application");
+  expect(down.data).toBe(`${ESC}OB`);
+
+  const right = encodeKeySequence({ keys: ["right"] }, "application");
+  expect(right.data).toBe(`${ESC}OC`);
+
+  const left = encodeKeySequence({ keys: ["left"] }, "application");
+  expect(left.data).toBe(`${ESC}OD`);
+
+  // Home/End also use SS3 sequences in application mode.
+  const home = encodeKeySequence({ keys: ["home"] }, "application");
+  expect(home.data).toBe(`${ESC}OH`);
+
+  const end = encodeKeySequence({ keys: ["end"] }, "application");
+  expect(end.data).toBe(`${ESC}OF`);
+});
+
+test("encodeKeySequence applies xterm modifiers to arrows in application mode", () => {
+  // Modified arrow keys use xterm modifier scheme even in application mode.
+  // DECCKM only affects unmodified cursor keys.
+  const altUp = encodeKeySequence({ keys: ["M-up"] }, "application");
+  expect(altUp.data).toBe(`${ESC}[1;3A`);
+
+  const ctrlRight = encodeKeySequence({ keys: ["C-right"] }, "application");
+  expect(ctrlRight.data).toBe(`${ESC}[1;5C`);
+
+  const shiftDown = encodeKeySequence({ keys: ["S-down"] }, "application");
+  expect(shiftDown.data).toBe(`${ESC}[1;2B`);
 });
 
 test("encodeKeySequence supports hex + literal with warnings", () => {

--- a/src/agents/pty-keys.ts
+++ b/src/agents/pty-keys.ts
@@ -14,6 +14,16 @@ type Modifiers = {
   shift: boolean;
 };
 
+/** SS3 sequences for DECCKM application cursor key mode (smkx). */
+const DECCKM_SS3_KEYS: Record<string, string> = {
+  up: `${ESC}OA`,
+  down: `${ESC}OB`,
+  right: `${ESC}OC`,
+  left: `${ESC}OD`,
+  home: `${ESC}OH`,
+  end: `${ESC}OF`,
+};
+
 const namedKeyMap = new Map<string, string>([
   ["enter", CR],
   ["return", CR],
@@ -102,7 +112,10 @@ export type KeyEncodingResult = {
   warnings: string[];
 };
 
-export function encodeKeySequence(request: KeyEncodingRequest): KeyEncodingResult {
+export function encodeKeySequence(
+  request: KeyEncodingRequest,
+  cursorKeyMode?: "normal" | "application",
+): KeyEncodingResult {
   const warnings: string[] = [];
   let data = "";
 
@@ -123,7 +136,7 @@ export function encodeKeySequence(request: KeyEncodingRequest): KeyEncodingResul
 
   if (request.keys?.length) {
     for (const token of request.keys) {
-      data += encodeKeyToken(token, warnings);
+      data += encodeKeyToken(token, warnings, cursorKeyMode);
     }
   }
 
@@ -137,7 +150,11 @@ export function encodePaste(text: string, bracketed = true): string {
   return `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`;
 }
 
-function encodeKeyToken(raw: string, warnings: string[]): string {
+function encodeKeyToken(
+  raw: string,
+  warnings: string[],
+  cursorKeyMode?: "normal" | "application",
+): string {
   const token = raw.trim();
   if (!token) {
     return "";
@@ -156,6 +173,19 @@ function encodeKeyToken(raw: string, warnings: string[]): string {
 
   if (baseLower === "tab" && parsed.mods.shift) {
     return `${ESC}[Z`;
+  }
+
+  // Handle arrow keys specially based on cursor key mode.
+  // DECCKM only changes unmodified cursor keys; modified keys use xterm modifier scheme.
+  if (
+    modifiableNamedKeys.has(baseLower) &&
+    cursorKeyMode === "application" &&
+    !hasAnyModifier(parsed.mods)
+  ) {
+    const ss3Seq = DECCKM_SS3_KEYS[baseLower];
+    if (ss3Seq) {
+      return ss3Seq;
+    }
   }
 
   const baseSeq = namedKeyMap.get(baseLower);

--- a/src/agents/pty-keys.ts
+++ b/src/agents/pty-keys.ts
@@ -112,6 +112,22 @@ export type KeyEncodingResult = {
   warnings: string[];
 };
 
+export function hasCursorModeSensitiveKeys(request: KeyEncodingRequest): boolean {
+  return (
+    request.keys?.some((raw) => {
+      const token = raw.trim();
+      if (!token) {
+        return false;
+      }
+      const parsed = parseModifiers(token);
+      if (hasAnyModifier(parsed.mods)) {
+        return false;
+      }
+      return parsed.base.toLowerCase() in DECCKM_SS3_KEYS;
+    }) ?? false
+  );
+}
+
 export function encodeKeySequence(
   request: KeyEncodingRequest,
   cursorKeyMode?: "normal" | "application",


### PR DESCRIPTION
Fixes #51488

### Solution

1. **Detect smkx/rmkx before `sanitizeBinaryOutput`**
   - Scan PTY output for smkx (`\x1b[?1h`) / rmkx (`\x1b[?1l`) sequences
   - Update `ProcessSession.cursorKeyMode` state before sanitization strips ESC

2. **Encode arrow keys based on current mode**
   - `encodeKeySequence(request, cursorKeyMode)` accepts mode parameter
   - application mode → SS3 sequences (`\x1bOA/B/C/D`)
   - normal mode → CSI sequences (`\x1b[A/B/C/D`) (default)

### Files Changed

- `src/agents/bash-process-registry.ts` - track `cursorKeyMode` in ProcessSession
- `src/agents/bash-tools.exec-runtime.ts` - smkx/rmkx detection before sanitization
- `src/agents/bash-tools.process.ts` - send-keys uses detected mode
- `src/agents/pty-keys.ts` - encode arrow keys with correct sequence
- `src/agents/bash-process-registry.test.ts` - cursorKeyMode property tests
- `src/agents/pty-keys.test.ts` - CSI/SS3 sequence encoding tests

### Testing

- Verified with `snake.py` game - arrow keys correctly control snake direction
- Unit tests: 17 tests pass (CSI/SS3 sequences, cursorKeyMode property)