### PR TITLE
docs(channels): add connection architecture overview and transport notes

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -9,6 +9,8 @@ title: "Discord"
 
 Status: ready for DMs and guild channels via the official Discord gateway.
 
+**Transport:** Outbound WebSocket. The gateway maintains a persistent WebSocket connection to Discord's gateway (`wss://gateway.discord.gg`). No inbound HTTP endpoint, reverse proxy, or public URL is needed — all traffic is outbound. Responses are sent via the Discord REST API.
+
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">
     Discord DMs default to pairing mode.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -36,6 +36,28 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (plugin, installed separately).
 
+## Connection architecture
+
+Channels use different transport modes to communicate with their upstream services. Understanding this helps with firewall rules, reverse proxy setup, and debugging.
+
+| Transport | How it works | Inbound infra needed | Channels |
+|---|---|---|---|
+| **Outbound WebSocket** | Gateway opens a persistent WebSocket to the service. All messages flow over this single connection. | None — outbound only. | Discord, Mattermost, Feishu, Slack, Matrix, IRC, Twitch, Tlon |
+| **Long polling** | Gateway repeatedly polls the service API for new messages. | None — outbound only. | Telegram (default), Signal |
+| **Inbound webhook** | Service pushes messages to a URL you expose. Requires a public endpoint (reverse proxy, ALB, tunnel, etc.). | Yes — public HTTPS endpoint. | Telegram (optional), WhatsApp, Google Chat, LINE, Synology Chat, Zalo |
+| **Local API / CLI** | Gateway talks to a local process or REST API on the same machine. | None — localhost only. | BlueBubbles, iMessage (legacy), Signal (signal-cli) |
+| **Browser session** | Gateway maintains a headless or QR-paired browser session. | None — outbound only. | WhatsApp (Baileys), Zalo Personal |
+
+<Note>
+Some channels support multiple transports. For example, Telegram defaults to long polling but can switch to webhook mode by setting `channels.telegram.webhookUrl`. Check each channel's docs for options.
+</Note>
+
+### What this means in practice
+
+- **Outbound-only channels** (Discord, Slack, IRC, etc.) work behind NATs and firewalls with no extra infra. The gateway initiates all connections.
+- **Webhook channels** (Telegram webhook mode, WhatsApp, Google Chat) need a publicly reachable HTTPS endpoint — typically a reverse proxy (nginx, Caddy) or cloud load balancer (ALB, Cloud Run) forwarding to the gateway.
+- **Local channels** (BlueBubbles, signal-cli) need the companion service running on the same host or reachable on the local network.
+
 ## Notes
 
 - Channels can run simultaneously; configure multiple and OpenClaw will route per chat.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -9,6 +9,8 @@ title: "Telegram"
 
 Status: production-ready for bot DMs + groups via grammY. Long polling is the default mode; webhook mode is optional.
 
+**Transport:** Long polling (default) or inbound webhook. In long-polling mode, the gateway polls the Telegram Bot API for updates — no public endpoint needed. In webhook mode, Telegram pushes updates to a URL you provide, which requires a publicly reachable HTTPS endpoint (reverse proxy, ALB, tunnel, etc.). See [Long polling vs webhook](#long-polling-vs-webhook) below for configuration.
+
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">
     Default DM policy for Telegram is pairing.


### PR DESCRIPTION
## Summary

Adds a **Connection architecture** section to the channels index page (`docs/channels/index.md`) with a table mapping each channel to its transport mode and whether inbound infrastructure is required.

Also adds brief **Transport** notes at the top of the Discord and Telegram channel pages so users immediately understand how the gateway connects.

## Motivation

The current docs explain *how to set up* each channel but not *how the connection works*. This matters for:
- **Firewall/security planning** — knowing Discord is outbound-only WebSocket while Telegram webhook mode needs a public endpoint
- **Infrastructure decisions** — whether you need a reverse proxy, ALB, or nothing at all
- **Debugging** — understanding the transport model helps diagnose connectivity issues

## Changes

| File | Change |
|---|---|
| `docs/channels/index.md` | New "Connection architecture" section with transport table and practical notes |
| `docs/channels/discord.md` | One-line transport note (outbound WebSocket, no inbound infra needed) |
| `docs/channels/telegram.md` | One-line transport note (long polling default, webhook optional) |

## Notes

- Transport classifications are based on reading the source (`systemd-*.js`, `auth-profiles-*.js`) and the existing channel docs
- The table covers all 22+ supported channels; some are approximate (plugins may vary)
- Happy to adjust categorizations if any are wrong