### PR TITLE
docs(channels): add connection architecture overview and transport notes

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -9,6 +9,8 @@ title: "Discord"
 
 Status: ready for DMs and guild channels via the official Discord gateway.
 
+**Transport:** WebSocket + HTTPS API. The gateway maintains a persistent WebSocket for inbound events and sends outbound messages via the Discord REST API. No inbound endpoint or public URL is needed — all traffic is outbound. Voice features additionally require a voice WebSocket and UDP egress.
+
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">
     Discord DMs default to pairing mode.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -36,6 +36,35 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (plugin, installed separately).
 
+## Connection architecture
+
+Channels use different transport modes to communicate with their upstream services. Understanding this helps with firewall rules, reverse proxy setup, and debugging.
+
+| Transport                     | How it works                                                                                                              | Inbound infra needed                       | Channels                                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **WebSocket + HTTPS API**     | Persistent WebSocket for inbound events; outbound sends use the service's HTTPS API. Both egress paths required.          | None — outbound only.                      | Discord, Slack (Socket Mode), Mattermost, Feishu (default)                                                                                      |
+| **WebSocket (bidirectional)** | All traffic flows over a single persistent WebSocket connection (both inbound events and outbound sends).                 | None — outbound only.                      | Twitch (IRC protocol over WebSocket), Nostr                                                                                                     |
+| **Outbound TCP/TLS**          | Gateway opens a persistent TCP connection to the server (classic IRC protocol).                                           | None — outbound only.                      | IRC                                                                                                                                             |
+| **Outbound HTTP/SSE**         | Gateway connects over HTTP; inbound events arrive via a long-lived SSE stream with automatic reconnects.                  | None — outbound only.                      | Tlon (Urbit ship API)                                                                                                                           |
+| **Long polling**              | Gateway repeatedly polls the service API for new messages.                                                                | None — outbound only.                      | Telegram (default), Zalo (default)                                                                                                              |
+| **Inbound webhook**           | Service pushes messages to a URL you expose. Gateway must be reachable by the sending service.                            | Depends — public or local network.         | Telegram (optional), Slack (HTTP Events), Feishu (optional), Google Chat, Microsoft Teams, LINE, Nextcloud Talk, Synology Chat, Zalo (optional) |
+| **Local REST + webhook**      | Gateway talks to a companion app via REST; incoming messages arrive via webhook. Can be co-located or split across hosts. | Local or remote network.                   | BlueBubbles                                                                                                                                     |
+| **Local CLI / JSON-RPC**      | Gateway communicates with a local process via JSON-RPC + SSE or stdio. Remote operation possible via SSH or HTTP.         | None by default (localhost, SSH, or HTTP). | Signal (signal-cli), iMessage (legacy, imsg)                                                                                                    |
+| **Linked session**            | Gateway maintains a linked device session (like WhatsApp Web). QR pairing required.                                       | None — outbound only.                      | WhatsApp (Baileys), Zalo Personal                                                                                                               |
+| **Gateway WebSocket**         | Client (browser or native app) connects **to** the gateway's own WebSocket endpoint.                                      | Gateway must be reachable by client.       | WebChat                                                                                                                                         |
+| **Matrix SDK**                | Gateway uses the Matrix client SDK to sync with a homeserver (outbound long-polling via `/sync`).                         | None — outbound only.                      | Matrix                                                                                                                                          |
+
+<Note>
+Some channels support multiple transports. For example, Telegram defaults to long polling but can switch to webhook mode by setting `channels.telegram.webhookUrl` and `channels.telegram.webhookSecret` (both required). Slack defaults to Socket Mode (WebSocket) but also supports HTTP Events API. Mattermost uses WebSocket for messages but its optional native slash commands require inbound HTTP callbacks. Discord voice features additionally require a voice WebSocket and UDP egress. Signal's remote daemon mode uses a long-lived SSE stream for inbound events. Check each channel's docs for options.
+</Note>
+
+### What this means in practice
+
+- **Outbound-only channels** work behind NATs and firewalls with no extra infra. Channels using WebSocket + HTTPS API (Discord, Slack, Mattermost, Feishu) require both WebSocket and HTTPS egress. Bidirectional WebSocket channels (Twitch, Nostr) only need WebSocket egress.
+- **Webhook channels** need the gateway to be reachable by the sending service. Cloud-hosted services (Google Chat, Microsoft Teams, Telegram webhook mode, LINE, Zalo webhook mode) require a public HTTPS endpoint. Self-hosted services (Nextcloud Talk, Synology Chat) only need local network reachability.
+- **Local channels** (BlueBubbles, Signal, iMessage) often run on the same host but support remote setups. BlueBubbles can split across hosts; Signal supports external HTTP daemons (with SSE for inbound events); iMessage supports remote Macs over SSH.
+- **WebChat** requires the gateway to be reachable by the browser or native app — either on localhost, via Tailscale, or through an SSH tunnel.
+
 ## Notes
 
 - Channels can run simultaneously; configure multiple and OpenClaw will route per chat.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -9,6 +9,8 @@ title: "Telegram"
 
 Status: production-ready for bot DMs + groups via grammY. Long polling is the default mode; webhook mode is optional.
 
+**Transport:** Long polling (default) or inbound webhook. In long-polling mode, the gateway polls the Telegram Bot API for updates — no public endpoint needed. In webhook mode, Telegram pushes updates to a URL you provide, which requires a publicly reachable HTTPS endpoint (reverse proxy, ALB, tunnel, etc.). See the **Long polling vs webhook** section below for configuration.
+
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">
     Default DM policy for Telegram is pairing.


### PR DESCRIPTION
## What

Adds a **Connection architecture** section to `docs/channels/index.md` with a transport table covering all 22 supported channels across 10 transport categories. Also adds one-line transport notes to the Discord and Telegram channel pages.

## Why

The current docs explain how to *set up* each channel but not how the connection works. Users planning firewall rules, reverse proxy configurations, or debugging connectivity issues have no single reference for understanding which channels are outbound-only versus which require inbound infrastructure.

## Changes

- `docs/channels/index.md` — New "Connection architecture" section with transport table and practical guidance
- `docs/channels/discord.md` — One-line transport note (outbound WebSocket, no inbound infra needed)
- `docs/channels/telegram.md` — One-line transport note (long polling default, webhook optional)

## Transport classifications

All 22 channels mapped to 10 transport categories, verified against each channel's documentation and source code:

- **Outbound WebSocket:** Discord, Slack (Socket Mode), Mattermost, Feishu (default), Twitch (IRC protocol over WebSocket), Nostr
- **Outbound TCP/TLS:** IRC
- **Outbound HTTP:** Tlon (Urbit ship API)
- **Long polling:** Telegram (default), Zalo (default)
- **Inbound webhook:** Telegram (optional), Slack (HTTP Events), Feishu (optional), Google Chat, Microsoft Teams, LINE, Nextcloud Talk, Synology Chat, Zalo (optional)
- **Local REST + webhook:** BlueBubbles
- **Local CLI / JSON-RPC:** Signal (signal-cli), iMessage (legacy, imsg)
- **Linked session:** WhatsApp (Baileys), Zalo Personal
- **Gateway WebSocket:** WebChat (client connects to gateway)
- **Matrix SDK:** Matrix (outbound /sync)

Multi-transport channels (Telegram, Slack, Feishu, Zalo) noted in both the table and a callout. Mattermost's optional inbound HTTP for slash commands noted separately.

## AI-assisted PR 🤖

- [x] This PR is AI-assisted (authored by an OpenClaw agent running Claude Opus, directed by a human)
- [x] Testing: docs-only change, verified `oxfmt --check` passes locally
- [x] I (the human author) understand what the changes do
- [x] Codex GitHub review addressed (all P2 items resolved — see review history below)
- [x] Bot review conversations resolved

## Review history

This PR went through 4 rounds of automated review and iteration:

1. **v1 (#51501):** Greptile found WhatsApp misclassified, 4 channels missing, anchor link issue — closed
2. **v2 (#51504):** Fixed above, but force-push included unrelated files — auto-closed by barnacle bot
3. **v3 (initial `5e7ec7f`):** Clean branch, all Greptile and prior Codex feedback addressed. Claude Code (Opus) verified all 22 channels against source. Greptile 4/5.
4. **v4 (current `1c92df7`):** Addressed Codex P2 review comments:
   - Inbound webhook row: changed from "requires public HTTPS" to "depends — public or local network" (self-hosted channels like Nextcloud Talk don't need public endpoints)
   - Local CLI/JSON-RPC row: added "remote operation possible via SSH or HTTP" (iMessage supports remote Mac over SSH, Signal supports external HTTP daemon)
   - Mattermost: noted optional inbound HTTP for slash commands in \<Note\> block
   - Twitch: kept in Outbound WebSocket (confirmed `@twurple/chat` uses WebSocket transport) with "(IRC protocol over WebSocket)" parenthetical