### PR TITLE
fix(plugins): use VERSION from version.ts in createPluginRuntime

### DIFF
--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import {
   getApiKeyForModel as getApiKeyForModelRaw,
   resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
@@ -16,6 +15,7 @@ import {
   transcribeAudioFile,
 } from "../../media-understanding/runtime.js";
 import { listSpeechVoices, textToSpeech, textToSpeechTelephony } from "../../tts/runtime.js";
+import { VERSION } from "../../version.js";
 import { listWebSearchProviders, runWebSearch } from "../../web-search/runtime.js";
 import { createRuntimeAgent } from "./runtime-agent.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -26,23 +26,6 @@ import { createRuntimeMedia } from "./runtime-media.js";
 import { createRuntimeSystem } from "./runtime-system.js";
 import { createRuntimeTools } from "./runtime-tools.js";
 import type { PluginRuntime } from "./types.js";
-
-let cachedVersion: string | null = null;
-
-function resolveVersion(): string {
-  if (cachedVersion) {
-    return cachedVersion;
-  }
-  try {
-    const require = createRequire(import.meta.url);
-    const pkg = require("../../../package.json") as { version?: string };
-    cachedVersion = pkg.version ?? "unknown";
-    return cachedVersion;
-  } catch {
-    cachedVersion = "unknown";
-    return cachedVersion;
-  }
-}
 
 function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   const unavailable = () => {
@@ -137,7 +120,7 @@ export type CreatePluginRuntimeOptions = {
 
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
   const runtime = {
-    version: resolveVersion(),
+    version: VERSION,
     config: createRuntimeConfig(),
     agent: createRuntimeAgent(),
     subagent: createLateBindingSubagent(
@@ -171,7 +154,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     modelAuth: {
       // Wrap model-auth helpers so plugins cannot steer credential lookups:
       // - agentDir / store: stripped (prevents reading other agents' stores)
-      // - profileId / preferredProfile: stripped (prevents cross-provider
+      // - profileId / preferredProfile: stripped (prevents cross-profile
       //   credential access via profile steering)
       // Plugins only specify provider/model; the core auth pipeline picks
       // the appropriate credential automatically.


### PR DESCRIPTION
## Problem

`api.runtime.version` always returns `"unknown"` for plugins in npm-installed OpenClaw (fixes #51494).

The root cause is the local `resolveVersion()` function in `src/plugins/runtime/index.ts`, which uses a hardcoded relative path:

```ts
const pkg = require("../../../package.json") as { version?: string };
```

This path is based on the source directory depth (`src/plugins/runtime/` → 3 levels up = repo root). After bundling, all chunks are flattened into `dist/`, so the path overshoots the package boundary entirely and the `require` call throws, causing the catch block to return `"unknown"`.

## Fix

Remove the local `resolveVersion()` helper and import the already-resolved `VERSION` constant from `src/version.ts` directly:

```ts
import { VERSION } from "../../version.js";
// ...
version: VERSION,
```

`src/version.ts` already solved this exact problem via a candidate-list strategy with package name validation (`requirePackageName: true`), and also handles bundled/embedded builds via the `__OPENCLAW_VERSION__` define or `OPENCLAW_BUNDLED_VERSION` env var. Using it as the single source of truth eliminates the redundant, broken path resolution in the plugin runtime.

## Changes

- Remove `import { createRequire } from "node:module"` (no longer needed)
- Remove `cachedVersion` module-level variable
- Remove `resolveVersion()` function
- Add `import { VERSION } from "../../version.js"`
- Replace `version: resolveVersion()` with `version: VERSION`

## Testing

After this change, `api.runtime.version` in the plugin runtime will return the same value as `openclaw --version`, consistent across source, npm-installed, and bundled environments.