### PR TITLE
Fix session_status runtime model display

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -408,4 +408,23 @@ describe("session_status tool", () => {
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();
   });
+
+  it("shows the runtime session model instead of the agent default", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        modelProvider: "anthropic",
+        model: "claude-sonnet-4-5",
+      },
+    });
+
+    const tool = getSessionStatusTool();
+
+    const result = await tool.execute("call7", {});
+    const details = result.details as { ok?: boolean; statusText?: string };
+    expect(details.ok).toBe(true);
+    expect(details.statusText).toContain("🧠 Model: anthropic/claude-sonnet-4-5");
+    expect(details.statusText).not.toContain("🧠 Model: anthropic/claude-opus-4-5");
+  });
 });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -10,7 +10,10 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { loadCombinedSessionStoreForGateway } from "../../gateway/session-utils.js";
+import {
+  loadCombinedSessionStoreForGateway,
+  resolveSessionModelIdentityRef,
+} from "../../gateway/session-utils.js";
 import {
   formatUsageWindowSummary,
   loadProviderUsageSummary,
@@ -364,8 +367,12 @@ export function createSessionStatusTool(opts?: {
         }
       }
 
+      const runtimeModelRef = resolveSessionModelIdentityRef(cfg, resolved.entry, agentId);
+      const selectedProviderForCard =
+        resolved.entry.providerOverride?.trim() || runtimeModelRef.provider || configured.provider;
+      const selectedModelForCard = resolved.entry.modelOverride?.trim() || runtimeModelRef.model;
       const agentDir = resolveAgentDir(cfg, agentId);
-      const providerForCard = resolved.entry.providerOverride?.trim() || configured.provider;
+      const providerForCard = selectedProviderForCard;
       const usageProvider = resolveUsageProviderId(providerForCard);
       let usageLine: string | undefined;
       if (usageProvider) {
@@ -419,7 +426,7 @@ export function createSessionStatusTool(opts?: {
         : `🕒 Time zone: ${userTimezone}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};
-      const defaultLabel = `${configured.provider}/${configured.model}`;
+      const defaultLabel = `${selectedProviderForCard}/${selectedModelForCard || configured.model}`;
       const agentModel =
         typeof agentDefaults.model === "object" && agentDefaults.model
           ? { ...agentDefaults.model, primary: defaultLabel }


### PR DESCRIPTION
# Fix session_status to show runtime session model instead of agent default

## Summary

This PR fixes `session_status` reporting the agent default model on the `🧠 Model:` line even when the session store already records a different runtime model.

Before this change:

- `openclaw sessions` could show the correct runtime model
- `session_status` could still show the configured default model

After this change:

- `session_status` resolves the session runtime model via `resolveSessionModelIdentityRef(...)`
- when there is no explicit per-session override, the status card uses that runtime identity
- auth/usage provider selection is aligned to the same resolved model provider

## Root Cause

`session_status` was constructing its card from `resolveDefaultModelForAgent(...)` plus `providerOverride/modelOverride`, but it ignored `sessionEntry.modelProvider/model`.

So a persisted runtime switch such as:

- default: `openai-codex/gpt-5.4`
- actual session runtime: `anthropic/claude-opus-4-6`

would still render the default model in the status card.

## Fix

In `src/agents/tools/session-status-tool.ts`:

- import and use `resolveSessionModelIdentityRef(...)`
- derive `selectedProviderForCard` from:
  - `providerOverride`
  - else runtime `modelProvider`
  - else configured default provider
- derive `selectedModelForCard` from:
  - `modelOverride`
  - else runtime `model`
- build the status card primary model from that resolved pair
- use the same provider for auth/usage lookup

## Tests

Added regression coverage in:

- `src/agents/openclaw-tools.session-status.test.ts`

New test verifies that when the session entry contains:

- `modelProvider: "anthropic"`
- `model: "claude-sonnet-4-5"`

the status card shows:

- `🧠 Model: anthropic/claude-sonnet-4-5`

and does not fall back to the configured default model line.

## Verification

Ran:

- `pnpm exec vitest run src/agents/openclaw-tools.session-status.test.ts`
- `pnpm exec vitest run src/gateway/session-utils.test.ts -t "resolveSessionModelIdentityRef"`

Both passed locally.

## Issue

Closes #51526
