### PR TITLE
Gateway UI: prioritize recent and custom chat models in picker

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -300,7 +300,7 @@ describe("buildChatModelOptions", () => {
   });
 
   it("prioritizes recent models from localStorage and ignores stale recent entries", () => {
-    const previousWindow = globalThis.window;
+    const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
     const storage = {
       getItem: () =>
         JSON.stringify([
@@ -314,8 +314,8 @@ describe("buildChatModelOptions", () => {
       length: 1,
     } as unknown as Storage;
 
-    Object.defineProperty(globalThis, "window", {
-      value: { localStorage: storage },
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
       configurable: true,
     });
 
@@ -332,10 +332,9 @@ describe("buildChatModelOptions", () => {
         ).map((entry) => entry.value),
       ).toEqual(["anthropic/claude-sonnet", "custom/foo", "openai/gpt-5"]);
     } finally {
-      Object.defineProperty(globalThis, "window", {
-        value: previousWindow,
-        configurable: true,
-      });
+      if (previous) {
+        Object.defineProperty(globalThis, "localStorage", previous);
+      }
     }
   });
 
@@ -357,18 +356,16 @@ describe("buildChatModelOptions", () => {
 
 describe("rememberResolvedChatModelRecent", () => {
   it("stores the canonical resolved model ref for recent-model tracking", () => {
-    const previousWindow = globalThis.window;
+    const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
     const setItem = vi.fn();
-    Object.defineProperty(globalThis, "window", {
+    Object.defineProperty(globalThis, "localStorage", {
       value: {
-        localStorage: {
-          getItem: () => null,
-          setItem,
-          removeItem: () => undefined,
-          clear: () => undefined,
-          key: () => null,
-          length: 0,
-        },
+        getItem: () => null,
+        setItem,
+        removeItem: () => undefined,
+        clear: () => undefined,
+        key: () => null,
+        length: 0,
       },
       configurable: true,
     });
@@ -380,10 +377,9 @@ describe("rememberResolvedChatModelRecent", () => {
       expect(setItem).toHaveBeenCalled();
       expect(setItem.mock.calls.at(-1)?.[1]).toContain("openai/gpt-5-mini");
     } finally {
-      Object.defineProperty(globalThis, "window", {
-        value: previousWindow,
-        configurable: true,
-      });
+      if (previous) {
+        Object.defineProperty(globalThis, "localStorage", previous);
+      }
     }
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildChatModelOptions,
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
@@ -282,5 +283,72 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+
+describe("buildChatModelOptions", () => {
+  it("preserves the active override when it is missing from the catalog", () => {
+    expect(
+      buildChatModelOptions(
+        [{ id: "gpt-5", name: "GPT-5", provider: "openai" }],
+        "custom/missing-model",
+        "",
+      ).map((entry) => entry.value),
+    ).toContain("custom/missing-model");
+  });
+
+  it("prioritizes recent models from localStorage and ignores stale recent entries", () => {
+    const previousWindow = globalThis.window;
+    const storage = {
+      getItem: () =>
+        JSON.stringify([
+          { value: "anthropic/claude-sonnet", usedAt: 200 },
+          { value: "missing/old-model", usedAt: 100 },
+        ]),
+      setItem: () => undefined,
+      removeItem: () => undefined,
+      clear: () => undefined,
+      key: () => null,
+      length: 1,
+    } as unknown as Storage;
+
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+    });
+
+    try {
+      expect(
+        buildChatModelOptions(
+          [
+            { id: "gpt-5", name: "GPT-5", provider: "openai" },
+            { id: "foo", name: "Foo", provider: "custom" },
+            { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
+          ],
+          "",
+          "",
+        ).map((entry) => entry.value),
+      ).toEqual(["anthropic/claude-sonnet", "custom/foo", "openai/gpt-5"]);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        value: previousWindow,
+        configurable: true,
+      });
+    }
+  });
+
+  it("orders custom-provider models before built-ins when no recents are stored", () => {
+    expect(
+      buildChatModelOptions(
+        [
+          { id: "gpt-5", name: "GPT-5", provider: "openai" },
+          { id: "foo", name: "Foo", provider: "custom" },
+          { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
+        ],
+        "",
+        "",
+      ).map((entry) => entry.value),
+    ).toEqual(["custom/foo", "openai/gpt-5", "anthropic/claude-sonnet"]);
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildChatModelOptions,
+  rememberResolvedChatModelRecent,
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
@@ -350,5 +351,39 @@ describe("buildChatModelOptions", () => {
         "",
       ).map((entry) => entry.value),
     ).toEqual(["custom/foo", "openai/gpt-5", "anthropic/claude-sonnet"]);
+  });
+});
+
+
+describe("rememberResolvedChatModelRecent", () => {
+  it("stores the canonical resolved model ref for recent-model tracking", () => {
+    const previousWindow = globalThis.window;
+    const setItem = vi.fn();
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        localStorage: {
+          getItem: () => null,
+          setItem,
+          removeItem: () => undefined,
+          clear: () => undefined,
+          key: () => null,
+          length: 0,
+        },
+      },
+      configurable: true,
+    });
+
+    try {
+      rememberResolvedChatModelRecent({
+        resolved: { modelProvider: "openai", model: "gpt-5-mini" },
+      });
+      expect(setItem).toHaveBeenCalled();
+      expect(setItem.mock.calls.at(-1)?.[1]).toContain("openai/gpt-5-mini");
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        value: previousWindow,
+        configurable: true,
+      });
+    }
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -287,7 +287,6 @@ describe("isCronSessionKey", () => {
   });
 });
 
-
 describe("buildChatModelOptions", () => {
   it("preserves the active override when it is missing from the catalog", () => {
     expect(
@@ -352,7 +351,6 @@ describe("buildChatModelOptions", () => {
     ).toEqual(["custom/foo", "openai/gpt-5", "anthropic/claude-sonnet"]);
   });
 });
-
 
 describe("rememberResolvedChatModelRecent", () => {
   it("stores the canonical resolved model ref for recent-model tracking", () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -594,6 +594,23 @@ export function buildChatModelOptions(
   }));
 }
 
+export function rememberResolvedChatModelRecent(patched?: {
+  resolved?: { modelProvider?: string | null; model?: string | null } | null;
+}) {
+  const resolvedModel = resolveServerChatModelValue(
+    patched?.resolved?.model ?? undefined,
+    patched?.resolved?.modelProvider ?? undefined,
+  );
+  if (!resolvedModel) {
+    return;
+  }
+  try {
+    rememberRecentChatModel(resolvedModel);
+  } catch {
+    // Non-critical: local storage may be unavailable or quota-limited.
+  }
+}
+
 function renderChatModelSelect(state: AppViewState) {
   const currentOverride = resolveModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
@@ -650,17 +667,13 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
     [targetSessionKey]: createChatModelOverride(nextModel),
   };
   try {
-    await state.client.request("sessions.patch", {
+    const patched = await state.client.request<{
+      resolved?: { modelProvider?: string | null; model?: string | null } | null;
+    }>("sessions.patch", {
       key: targetSessionKey,
       model: nextModel || null,
     });
-    if (nextModel) {
-      try {
-        rememberRecentChatModel(nextModel);
-      } catch {
-        // Non-critical: local storage may be unavailable or quota-limited.
-      }
-    }
+    rememberResolvedChatModelRecent(patched);
     await refreshSessionOptions(state);
   } catch (err) {
     // Roll back so the picker reflects the actual server model.

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -7,12 +7,19 @@ import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
 import {
-  buildChatModelOption,
   createChatModelOverride,
   formatChatModelDisplay,
   normalizeChatModelOverrideValue,
   resolveServerChatModelValue,
 } from "./chat-model-ref.ts";
+import {
+  createCatalogRankedChatModelOption,
+  createSyntheticRankedChatModelOption,
+  loadRecentChatModels,
+  normalizeChatModelKey,
+  rememberRecentChatModel,
+  sortRankedChatModelOptions,
+} from "./chat-model-recents.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
@@ -549,38 +556,42 @@ function resolveDefaultModelValue(state: AppViewState): string {
   return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
 }
 
-function buildChatModelOptions(
+export function buildChatModelOptions(
   catalog: ModelCatalogEntry[],
   currentOverride: string,
   defaultModel: string,
 ): Array<{ value: string; label: string }> {
   const seen = new Set<string>();
-  const options: Array<{ value: string; label: string }> = [];
-  const addOption = (value: string, label?: string) => {
-    const trimmed = value.trim();
+  const options: ReturnType<typeof createCatalogRankedChatModelOption>[] = [];
+
+  const addOption = (option: ReturnType<typeof createCatalogRankedChatModelOption>) => {
+    const trimmed = option.value.trim();
     if (!trimmed) {
       return;
     }
-    const key = trimmed.toLowerCase();
+    const key = normalizeChatModelKey(trimmed);
     if (seen.has(key)) {
       return;
     }
     seen.add(key);
-    options.push({ value: trimmed, label: label ?? trimmed });
+    options.push({ ...option, value: trimmed });
   };
 
   for (const entry of catalog) {
-    const option = buildChatModelOption(entry);
-    addOption(option.value, option.label);
+    addOption(createCatalogRankedChatModelOption(entry));
   }
 
   if (currentOverride) {
-    addOption(currentOverride);
+    addOption(createSyntheticRankedChatModelOption(currentOverride));
   }
   if (defaultModel) {
-    addOption(defaultModel);
+    addOption(createSyntheticRankedChatModelOption(defaultModel));
   }
-  return options;
+
+  return sortRankedChatModelOptions(options, loadRecentChatModels()).map((option) => ({
+    value: option.value,
+    label: option.label,
+  }));
 }
 
 function renderChatModelSelect(state: AppViewState) {
@@ -643,6 +654,9 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
       key: targetSessionKey,
       model: nextModel || null,
     });
+    if (nextModel) {
+      rememberRecentChatModel(nextModel);
+    }
     await refreshSessionOptions(state);
   } catch (err) {
     // Roll back so the picker reflects the actual server model.

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -655,7 +655,11 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
       model: nextModel || null,
     });
     if (nextModel) {
-      rememberRecentChatModel(nextModel);
+      try {
+        rememberRecentChatModel(nextModel);
+      } catch {
+        // Non-critical: local storage may be unavailable or quota-limited.
+      }
     }
     await refreshSessionOptions(state);
   } catch (err) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -7,12 +7,6 @@ import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
 import {
-  createChatModelOverride,
-  formatChatModelDisplay,
-  normalizeChatModelOverrideValue,
-  resolveServerChatModelValue,
-} from "./chat-model-ref.ts";
-import {
   createCatalogRankedChatModelOption,
   createSyntheticRankedChatModelOption,
   loadRecentChatModels,
@@ -20,6 +14,12 @@ import {
   rememberRecentChatModel,
   sortRankedChatModelOptions,
 } from "./chat-model-recents.ts";
+import {
+  createChatModelOverride,
+  formatChatModelDisplay,
+  normalizeChatModelOverrideValue,
+  resolveServerChatModelValue,
+} from "./chat-model-ref.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";

--- a/ui/src/ui/chat-model-recents.node.test.ts
+++ b/ui/src/ui/chat-model-recents.node.test.ts
@@ -117,4 +117,22 @@ describe("chat-model-recents", () => {
 
     expect(ranked.map((entry) => entry.value)).toEqual(["custom/foo", "openai/gpt-5"]);
   });
+
+  it("returns an empty list when localStorage access throws", () => {
+    const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked");
+      },
+    });
+
+    try {
+      expect(loadRecentChatModels()).toEqual([]);
+    } finally {
+      if (previous) {
+        Object.defineProperty(globalThis, "localStorage", previous);
+      }
+    }
+  });
 });

--- a/ui/src/ui/chat-model-recents.node.test.ts
+++ b/ui/src/ui/chat-model-recents.node.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCustomProvider,
+  loadRecentChatModels,
+  rememberRecentChatModel,
+  sortRankedChatModelOptions,
+} from "./chat-model-recents.ts";
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+
+  get length(): number {
+    return this.data.size;
+  }
+
+  clear(): void {
+    this.data.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.data.has(key) ? this.data.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.data.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+describe("chat-model-recents", () => {
+  it("stores most recent models first", () => {
+    const storage = new MemoryStorage();
+    rememberRecentChatModel("openai/gpt-5", storage, 100);
+    rememberRecentChatModel("anthropic/claude-sonnet", storage, 200);
+
+    expect(loadRecentChatModels(storage)).toEqual([
+      { value: "anthropic/claude-sonnet", usedAt: 200 },
+      { value: "openai/gpt-5", usedAt: 100 },
+    ]);
+  });
+
+  it("deduplicates and bumps existing models to the front", () => {
+    const storage = new MemoryStorage();
+    rememberRecentChatModel("openai/gpt-5", storage, 100);
+    rememberRecentChatModel("anthropic/claude-sonnet", storage, 200);
+    rememberRecentChatModel("openai/gpt-5", storage, 300);
+
+    expect(loadRecentChatModels(storage)).toEqual([
+      { value: "openai/gpt-5", usedAt: 300 },
+      { value: "anthropic/claude-sonnet", usedAt: 200 },
+    ]);
+  });
+
+  it("treats unknown providers as custom", () => {
+    expect(isCustomProvider("openai")).toBe(false);
+    expect(isCustomProvider("anthropic")).toBe(false);
+    expect(isCustomProvider("my-company")).toBe(true);
+  });
+
+  it("sorts recent first, then custom providers, then remaining models", () => {
+    const ranked = sortRankedChatModelOptions(
+      [
+        {
+          value: "openai/gpt-5",
+          label: "OpenAI / GPT-5",
+          provider: "openai",
+          isCustomProvider: false,
+        },
+        {
+          value: "custom/foo",
+          label: "Custom / Foo",
+          provider: "custom",
+          isCustomProvider: true,
+        },
+        {
+          value: "anthropic/claude-sonnet",
+          label: "Anthropic / Claude Sonnet",
+          provider: "anthropic",
+          isCustomProvider: false,
+        },
+      ],
+      [{ value: "anthropic/claude-sonnet", usedAt: 100 }],
+    );
+
+    expect(ranked.map((entry) => entry.value)).toEqual([
+      "anthropic/claude-sonnet",
+      "custom/foo",
+      "openai/gpt-5",
+    ]);
+  });
+
+  it("does not duplicate a recent custom-provider model", () => {
+    const ranked = sortRankedChatModelOptions(
+      [
+        {
+          value: "custom/foo",
+          label: "Custom / Foo",
+          provider: "custom",
+          isCustomProvider: true,
+        },
+        {
+          value: "openai/gpt-5",
+          label: "OpenAI / GPT-5",
+          provider: "openai",
+          isCustomProvider: false,
+        },
+      ],
+      [{ value: "custom/foo", usedAt: 100 }],
+    );
+
+    expect(ranked.map((entry) => entry.value)).toEqual(["custom/foo", "openai/gpt-5"]);
+  });
+});

--- a/ui/src/ui/chat-model-recents.ts
+++ b/ui/src/ui/chat-model-recents.ts
@@ -1,4 +1,3 @@
-import { normalizeProviderId } from "../../../src/agents/provider-id.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { buildChatModelOption } from "./chat-model-ref.ts";
 import type { ModelCatalogEntry } from "./types.ts";
@@ -17,6 +16,32 @@ export type RankedChatModelOption = {
 
 const RECENT_CHAT_MODELS_KEY = "openclaw.chat.recentModels";
 const MAX_RECENT_CHAT_MODELS = 8;
+function normalizeProviderId(provider: string): string {
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "z.ai" || normalized === "z-ai") {
+    return "zai";
+  }
+  if (normalized === "opencode-zen") {
+    return "opencode";
+  }
+  if (normalized === "opencode-go-auth") {
+    return "opencode-go";
+  }
+  if (normalized === "qwen") {
+    return "qwen-portal";
+  }
+  if (normalized === "kimi" || normalized === "kimi-code" || normalized === "kimi-coding") {
+    return "kimi";
+  }
+  if (normalized === "bedrock" || normalized === "aws-bedrock") {
+    return "amazon-bedrock";
+  }
+  if (normalized === "bytedance" || normalized === "doubao") {
+    return "volcengine";
+  }
+  return normalized;
+}
+
 const BUILTIN_PROVIDER_IDS = new Set([
   "amazon-bedrock",
   "anthropic",
@@ -115,10 +140,7 @@ export function saveRecentChatModels(entries: RecentChatModelEntry[], storage?: 
   if (!target) {
     return;
   }
-  target.setItem(
-    RECENT_CHAT_MODELS_KEY,
-    JSON.stringify(entries.slice(0, MAX_RECENT_CHAT_MODELS)),
-  );
+  target.setItem(RECENT_CHAT_MODELS_KEY, JSON.stringify(entries.slice(0, MAX_RECENT_CHAT_MODELS)));
 }
 
 export function rememberRecentChatModel(value: string, storage?: Storage, now = Date.now()): void {
@@ -135,7 +157,11 @@ export function rememberRecentChatModel(value: string, storage?: Storage, now = 
   saveRecentChatModels(next, storage);
 }
 
-function buildRankedChatModelOption(value: string, label: string, provider?: string): RankedChatModelOption {
+function buildRankedChatModelOption(
+  value: string,
+  label: string,
+  provider?: string,
+): RankedChatModelOption {
   return {
     value,
     label,
@@ -144,7 +170,9 @@ function buildRankedChatModelOption(value: string, label: string, provider?: str
   };
 }
 
-export function createCatalogRankedChatModelOption(entry: ModelCatalogEntry): RankedChatModelOption {
+export function createCatalogRankedChatModelOption(
+  entry: ModelCatalogEntry,
+): RankedChatModelOption {
   const option = buildChatModelOption(entry);
   return buildRankedChatModelOption(option.value, option.label, entry.provider);
 }

--- a/ui/src/ui/chat-model-recents.ts
+++ b/ui/src/ui/chat-model-recents.ts
@@ -1,0 +1,184 @@
+import { buildChatModelOption } from "./chat-model-ref.ts";
+import type { ModelCatalogEntry } from "./types.ts";
+
+export type RecentChatModelEntry = {
+  value: string;
+  usedAt: number;
+};
+
+export type RankedChatModelOption = {
+  value: string;
+  label: string;
+  provider?: string;
+  isCustomProvider: boolean;
+};
+
+const RECENT_CHAT_MODELS_KEY = "openclaw.chat.recentModels";
+const MAX_RECENT_CHAT_MODELS = 8;
+const BUILTIN_PROVIDER_IDS = new Set([
+  "anthropic",
+  "azure-openai",
+  "bedrock",
+  "deepseek",
+  "fireworks",
+  "google",
+  "groq",
+  "huggingface",
+  "mistral",
+  "ollama",
+  "openai",
+  "openrouter",
+  "sglang",
+  "together",
+  "vertex",
+  "vllm",
+  "xai",
+]);
+
+function storageOrNull(storage?: Storage): Storage | null {
+  if (storage) {
+    return storage;
+  }
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+}
+
+export function normalizeChatModelKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function isCustomProvider(provider?: string | null): boolean {
+  const normalized = String(provider ?? "").trim().toLowerCase();
+  return normalized.length > 0 && !BUILTIN_PROVIDER_IDS.has(normalized);
+}
+
+export function inferProviderFromModelRef(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const separator = trimmed.indexOf("/");
+  if (separator <= 0) {
+    return undefined;
+  }
+  return trimmed.slice(0, separator);
+}
+
+export function loadRecentChatModels(storage?: Storage): RecentChatModelEntry[] {
+  const target = storageOrNull(storage);
+  if (!target) {
+    return [];
+  }
+  try {
+    const raw = target.getItem(RECENT_CHAT_MODELS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .filter(
+        (entry): entry is RecentChatModelEntry =>
+          Boolean(entry) &&
+          typeof entry.value === "string" &&
+          entry.value.trim().length > 0 &&
+          typeof entry.usedAt === "number" &&
+          Number.isFinite(entry.usedAt),
+      )
+      .sort((a, b) => b.usedAt - a.usedAt)
+      .slice(0, MAX_RECENT_CHAT_MODELS);
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentChatModels(entries: RecentChatModelEntry[], storage?: Storage): void {
+  const target = storageOrNull(storage);
+  if (!target) {
+    return;
+  }
+  target.setItem(
+    RECENT_CHAT_MODELS_KEY,
+    JSON.stringify(entries.slice(0, MAX_RECENT_CHAT_MODELS)),
+  );
+}
+
+export function rememberRecentChatModel(value: string, storage?: Storage, now = Date.now()): void {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+  const key = normalizeChatModelKey(trimmed);
+  const current = loadRecentChatModels(storage);
+  const next: RecentChatModelEntry[] = [
+    { value: trimmed, usedAt: now },
+    ...current.filter((entry) => normalizeChatModelKey(entry.value) !== key),
+  ].slice(0, MAX_RECENT_CHAT_MODELS);
+  saveRecentChatModels(next, storage);
+}
+
+function buildRankedChatModelOption(value: string, label: string, provider?: string): RankedChatModelOption {
+  return {
+    value,
+    label,
+    provider,
+    isCustomProvider: isCustomProvider(provider),
+  };
+}
+
+export function createCatalogRankedChatModelOption(entry: ModelCatalogEntry): RankedChatModelOption {
+  const option = buildChatModelOption(entry);
+  return buildRankedChatModelOption(option.value, option.label, entry.provider);
+}
+
+export function createSyntheticRankedChatModelOption(value: string): RankedChatModelOption {
+  const provider = inferProviderFromModelRef(value);
+  return buildRankedChatModelOption(value, value, provider);
+}
+
+export function sortRankedChatModelOptions(
+  options: RankedChatModelOption[],
+  recentEntries: RecentChatModelEntry[],
+): RankedChatModelOption[] {
+  const optionByKey = new Map<string, RankedChatModelOption>();
+  for (const option of options) {
+    optionByKey.set(normalizeChatModelKey(option.value), option);
+  }
+
+  const ranked: RankedChatModelOption[] = [];
+  const used = new Set<string>();
+
+  for (const entry of recentEntries) {
+    const key = normalizeChatModelKey(entry.value);
+    const option = optionByKey.get(key);
+    if (!option || used.has(key)) {
+      continue;
+    }
+    ranked.push(option);
+    used.add(key);
+  }
+
+  for (const option of options) {
+    const key = normalizeChatModelKey(option.value);
+    if (used.has(key) || !option.isCustomProvider) {
+      continue;
+    }
+    ranked.push(option);
+    used.add(key);
+  }
+
+  for (const option of options) {
+    const key = normalizeChatModelKey(option.value);
+    if (used.has(key)) {
+      continue;
+    }
+    ranked.push(option);
+    used.add(key);
+  }
+
+  return ranked;
+}

--- a/ui/src/ui/chat-model-recents.ts
+++ b/ui/src/ui/chat-model-recents.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "../../../src/agents/provider-id.ts";
 import { buildChatModelOption } from "./chat-model-ref.ts";
 import type { ModelCatalogEntry } from "./types.ts";
 
@@ -16,23 +17,34 @@ export type RankedChatModelOption = {
 const RECENT_CHAT_MODELS_KEY = "openclaw.chat.recentModels";
 const MAX_RECENT_CHAT_MODELS = 8;
 const BUILTIN_PROVIDER_IDS = new Set([
+  "amazon-bedrock",
   "anthropic",
   "azure-openai",
-  "bedrock",
+  "cerebras",
   "deepseek",
   "fireworks",
+  "github-copilot",
   "google",
   "groq",
   "huggingface",
+  "kimi",
+  "lmstudio",
+  "minimax",
   "mistral",
   "ollama",
   "openai",
+  "openai-codex",
+  "opencode",
+  "opencode-go",
   "openrouter",
+  "qwen-portal",
   "sglang",
+  "synthetic",
   "together",
   "vertex",
   "vllm",
   "xai",
+  "zai",
 ]);
 
 function storageOrNull(storage?: Storage): Storage | null {
@@ -50,7 +62,11 @@ export function normalizeChatModelKey(value: string): string {
 }
 
 export function isCustomProvider(provider?: string | null): boolean {
-  const normalized = String(provider ?? "").trim().toLowerCase();
+  const raw = String(provider ?? "").trim();
+  if (!raw) {
+    return false;
+  }
+  const normalized = normalizeProviderId(raw);
   return normalized.length > 0 && !BUILTIN_PROVIDER_IDS.has(normalized);
 }
 

--- a/ui/src/ui/chat-model-recents.ts
+++ b/ui/src/ui/chat-model-recents.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "../../../src/agents/provider-id.ts";
+import { getSafeLocalStorage } from "../local-storage.ts";
 import { buildChatModelOption } from "./chat-model-ref.ts";
 import type { ModelCatalogEntry } from "./types.ts";
 
@@ -51,10 +52,7 @@ function storageOrNull(storage?: Storage): Storage | null {
   if (storage) {
     return storage;
   }
-  if (typeof window === "undefined" || !window.localStorage) {
-    return null;
-  }
-  return window.localStorage;
+  return getSafeLocalStorage();
 }
 
 export function normalizeChatModelKey(value: string): string {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -58,7 +58,14 @@ function createChatHeaderState(
             matchingProviders.length === 1 ? matchingProviders[0] : currentModelProvider;
         }
       }
-      return { ok: true, key: "main" };
+      return {
+        ok: true,
+        key: "main",
+        resolved: {
+          modelProvider: currentModelProvider,
+          model: currentModel,
+        },
+      };
     }
     if (method === "chat.history") {
       return { messages: [], thinkingLevel: null };


### PR DESCRIPTION
## Summary
- prioritize recently used chat models in the gateway/control UI model picker
- rank custom-provider models ahead of remaining built-in models
- persist successful picker selections in browser-local recent model storage

## Details
This keeps the existing `Default (...)` option pinned at the top and only changes the ordering of the concrete model options below it:
1. recently used models (browser-local MRU)
2. custom-provider models
3. remaining models in existing order

The change preserves current behavior for active overrides/defaults that are not present in the current catalog and ignores stale recent entries that no longer resolve to available options.

## Testing
- `npm test -- --run src/ui/chat-model-recents.node.test.ts src/ui/app-render.helpers.node.test.ts src/ui/chat-model-ref.test.ts`
