### PR TITLE
fix(plugins/runtime): fix api.runtime.version in bundled and npm installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded transport errors: distinguish common network failures like connection refused, DNS lookup failure, and interrupted sockets from true timeouts in embedded-run user messaging and lifecycle diagnostics. (#51419) Thanks @scoootscooob.
 - Discord/startup logging: report client initialization while the gateway is still connecting instead of claiming Discord is logged in before readiness is reached. (#51425) Thanks @scoootscooob.
 - Gateway/probe: honor caller `--timeout` for active local loopback probes in `gateway status`, keep inactive remote-mode loopback probes fast, and clamp probe timers to JS-safe bounds so slow local/container gateways stop reporting false timeouts. (#47533) Thanks @MonkeyLeeT.
+- Plugins/runtime: fix `api.runtime.version` returning `"unknown"` in bundled and npm-installed OpenClaw, so version-aware plugins can detect the host version correctly again. Fixes #51494. Thanks @sparkyrider.
 
 ### Breaking
 

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -4,6 +4,7 @@ import { onAgentEvent } from "../../infra/agent-events.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { VERSION, resolveUsableRuntimeVersion } from "../../version.js";
 import {
   clearGatewaySubagentRuntime,
   createPluginRuntime,
@@ -90,6 +91,11 @@ describe("plugin runtime command execution", () => {
     expect(typeof runtime.agent.runEmbeddedPiAgent).toBe("function");
     expect(typeof runtime.agent.resolveAgentDir).toBe("function");
     expect(typeof runtime.agent.session.resolveSessionFilePath).toBe("function");
+  });
+
+  it("exposes runtime.version from the shared version resolver", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.version).toBe(resolveUsableRuntimeVersion(VERSION) ?? "unknown");
   });
 
   it("exposes runtime.modelAuth with getApiKeyForModel and resolveApiKeyForProvider", () => {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import {
   getApiKeyForModel as getApiKeyForModelRaw,
   resolveApiKeyForProvider as resolveApiKeyForProviderRaw,
@@ -16,6 +15,7 @@ import {
   transcribeAudioFile,
 } from "../../media-understanding/runtime.js";
 import { listSpeechVoices, textToSpeech, textToSpeechTelephony } from "../../tts/runtime.js";
+import { VERSION, resolveUsableRuntimeVersion } from "../../version.js";
 import { listWebSearchProviders, runWebSearch } from "../../web-search/runtime.js";
 import { createRuntimeAgent } from "./runtime-agent.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -33,15 +33,9 @@ function resolveVersion(): string {
   if (cachedVersion) {
     return cachedVersion;
   }
-  try {
-    const require = createRequire(import.meta.url);
-    const pkg = require("../../../package.json") as { version?: string };
-    cachedVersion = pkg.version ?? "unknown";
-    return cachedVersion;
-  } catch {
-    cachedVersion = "unknown";
-    return cachedVersion;
-  }
+
+  cachedVersion = resolveUsableRuntimeVersion(VERSION) ?? "unknown";
+  return cachedVersion;
 }
 
 function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -53,6 +53,15 @@ describe("version resolution", () => {
     });
   });
 
+  it("resolves package version from a shared dist root chunk module URL", async () => {
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "7.8.9" });
+      const moduleUrl = await ensureModuleFixture(root, "dist/chunk.js");
+      expect(readVersionFromPackageJsonForModuleUrl(moduleUrl)).toBe("7.8.9");
+      expect(resolveVersionFromModuleUrl(moduleUrl)).toBe("7.8.9");
+    });
+  });
+
   it("ignores unrelated nearby package.json files", async () => {
     await withTempDir(async (root) => {
       await writeJsonFixture(root, "package.json", { name: "openclaw", version: "2.3.4" });


### PR DESCRIPTION
## TL;DR

`api.runtime.version` was broken for bundled/npm installs because plugin runtime used a source-tree-relative `package.json` path. This PR switches it to the shared version resolver, keeps the `"unknown"` fallback behavior, and adds regression coverage.

## Summary

- Problem: `api.runtime.version` returned `"unknown"` for plugins in npm-installed/bundled OpenClaw because the plugin runtime resolved `../../../package.json` relative to a bundled root chunk.
- Why it matters: plugins that gate behavior on the host OpenClaw version could not reliably detect compatibility and had to special-case `"unknown"`.
- What changed: the plugin runtime now uses the shared `VERSION` resolver from `src/version.ts`, and regression tests cover both the shared `dist/*.js` chunk layout and plugin-runtime alignment.
- What did NOT change (scope boundary): no gateway routing, auth, persistence, channel delivery, or plugin loader behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51494
- Related #None

## User-visible / Behavior Changes

Plugins that read `api.runtime.version` now receive the actual OpenClaw version in npm-installed/bundled environments instead of `"unknown"`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin runtime
- Relevant config (redacted): N/A

### Steps

1. Build or inspect the bundled OpenClaw runtime where plugin runtime code is emitted into a root `dist/*.js` chunk.
2. Read `api.runtime.version` from `createPluginRuntime()`.
3. Observe the old runtime resolves `../../../package.json` from the bundled chunk and returns `"unknown"`.

### Expected

- `api.runtime.version` matches the installed OpenClaw version.

### Actual

- `api.runtime.version` returned `"unknown"` before this fix.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the old bundled-path failure mode; ran targeted regression tests; built the repo; imported `dist/plugins/runtime/index.js` and confirmed the built artifact returns the real package version.
- Edge cases checked: shared `dist/chunk.js` root-chunk layout; plugin runtime fallback still normalizes unusable versions to `"unknown"`.
- What you did **not** verify: third-party plugin end-to-end behavior in a separate npm-global install.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/plugins/runtime/index.ts`
- Known bad symptoms reviewers should watch for: plugins reporting `"unknown"` again for `api.runtime.version` in bundled/npm installs.

## Risks and Mitigations

- Risk: plugin runtime version now depends on the shared resolver path.
- Mitigation: added regression coverage for both the shared root-chunk bundle layout and the plugin runtime contract.
