### PR TITLE
fix(discord): preserve requireMention for ACP thread sessions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -111,6 +111,7 @@ async function runThreadBoundPreflight(params: {
   threadBinding: import("../../../../src/infra/outbound/session-binding-service.js").SessionBindingRecord;
   discordConfig: DiscordConfig;
   registerBindingAdapter?: boolean;
+  guildEntries?: Parameters<typeof preflightDiscordMessage>[0]["guildEntries"];
 }) {
   if (params.registerBindingAdapter) {
     registerSessionBindingAdapter({
@@ -139,6 +140,7 @@ async function runThreadBoundPreflight(params: {
       }),
       client,
     }),
+    guildEntries: params.guildEntries,
     threadBindings: {
       getByThreadId: (id: string) => (id === params.threadId ? params.threadBinding : undefined),
     } as import("./thread-bindings.js").ThreadBindingManager,
@@ -376,6 +378,87 @@ describe("preflightDiscordMessage", () => {
 
     expect(result).not.toBeNull();
     expect(result?.boundSessionKey).toBe(threadBinding.targetSessionKey);
+  });
+
+  it("keeps requireMention enabled for ACP-bound threads", async () => {
+    const threadBinding = createThreadBinding({
+      targetKind: "session",
+      targetSessionKey: "agent:main:acp:discord-thread-mention-1",
+    });
+    const threadId = "thread-mention-1";
+    const parentId = "channel-parent-mention-1";
+    const message = createDiscordMessage({
+      id: "m-thread-mention-1",
+      channelId: threadId,
+      content: "hello there",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "alice",
+      },
+    });
+
+    const result = await runThreadBoundPreflight({
+      threadId,
+      parentId,
+      message,
+      threadBinding,
+      discordConfig: {} as DiscordConfig,
+      registerBindingAdapter: true,
+      guildEntries: {
+        "guild-1": {
+          channels: {
+            [parentId]: {
+              allow: true,
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps mention bypass for subagent-bound threads", async () => {
+    const threadBinding = createThreadBinding({
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:discord-thread-mention-2",
+    });
+    const threadId = "thread-mention-2";
+    const parentId = "channel-parent-mention-2";
+    const message = createDiscordMessage({
+      id: "m-thread-mention-2",
+      channelId: threadId,
+      content: "hello there",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "alice",
+      },
+    });
+
+    const result = await runThreadBoundPreflight({
+      threadId,
+      parentId,
+      message,
+      threadBinding,
+      discordConfig: {} as DiscordConfig,
+      registerBindingAdapter: true,
+      guildEntries: {
+        "guild-1": {
+          channels: {
+            [parentId]: {
+              allow: true,
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.shouldRequireMention).toBe(false);
   });
 
   it("drops hydrated bound-thread webhook echoes after fetching an empty payload", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -107,6 +107,19 @@ export function resolvePreflightMentionRequirement(params: {
   return !params.bypassMentionRequirement;
 }
 
+function shouldBypassMentionRequirementForBinding(
+  binding?: SessionBindingRecord | null,
+  isBotAuthor = false,
+): boolean {
+  if (!binding) {
+    return false;
+  }
+  if (binding.targetKind === "subagent") {
+    return true;
+  }
+  return isBotAuthor;
+}
+
 export function shouldIgnoreBoundThreadWebhookMessage(params: {
   accountId?: string;
   threadId?: string;
@@ -499,7 +512,10 @@ export async function preflightDiscordMessage(
   });
   const boundAgentId = boundSessionKey ? effectiveRoute.agentId : undefined;
   const isBoundThreadSession = Boolean(threadBinding && earlyThreadChannel);
-  const bypassMentionRequirement = isBoundThreadSession || Boolean(configuredBinding);
+  const bypassMentionRequirement =
+    (isBoundThreadSession &&
+      shouldBypassMentionRequirementForBinding(threadBinding, Boolean(author.bot))) ||
+    shouldBypassMentionRequirementForBinding(configuredBinding?.record, Boolean(author.bot));
   if (
     isBoundThreadBotSystemMessage({
       isBoundThreadSession,

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -515,7 +515,7 @@ export async function preflightDiscordMessage(
   const bypassMentionRequirement =
     (isBoundThreadSession &&
       shouldBypassMentionRequirementForBinding(threadBinding, Boolean(author.bot))) ||
-    shouldBypassMentionRequirementForBinding(configuredBinding?.record, Boolean(author.bot));
+    Boolean(configuredBinding);
   if (
     isBoundThreadBotSystemMessage({
       isBoundThreadSession,


### PR DESCRIPTION
Fixes #50990.

Preserves Discord `requireMention` for ACP-bound thread sessions by narrowing the bound-thread mention bypass to subagent bindings and bot-authored ACP relay/system messages only.

Adds regression coverage for both cases:
- ACP-bound threads still require mention for user-authored messages
- subagent-bound threads keep the existing mention bypass behavior
