### PR TITLE
fix(telegram): improve 403 bot not member/blocked error messages and regex grouping

### DIFF
--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -507,7 +507,7 @@ function createTelegramRequestWithDiag(params: {
 
 function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; input: string }) {
   const errorMsg = formatErrorMessage(err);
-  
+
   // Check for 403 "bot is not a member" or "bot was blocked" errors
   if (/403.*(bot.*not.*member|bot.*blocked)/i.test(errorMsg)) {
     return new Error(
@@ -518,7 +518,7 @@ function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; i
       ].join(" "),
     );
   }
-  
+
   if (!CHAT_NOT_FOUND_RE.test(errorMsg)) {
     return err;
   }

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -506,7 +506,20 @@ function createTelegramRequestWithDiag(params: {
 }
 
 function wrapTelegramChatNotFoundError(err: unknown, params: { chatId: string; input: string }) {
-  if (!CHAT_NOT_FOUND_RE.test(formatErrorMessage(err))) {
+  const errorMsg = formatErrorMessage(err);
+  
+  // Check for 403 "bot is not a member" or "bot was blocked" errors
+  if (/403.*(bot.*not.*member|bot.*blocked)/i.test(errorMsg)) {
+    return new Error(
+      [
+        `Telegram send failed: bot is not a member of the chat or has been blocked (chat_id=${params.chatId}).`,
+        "Fix: Add the bot to the channel/group, ensure it has not been removed, or ask the user to unblock the bot.",
+        `Input was: ${JSON.stringify(params.input)}.`,
+      ].join(" "),
+    );
+  }
+  
+  if (!CHAT_NOT_FOUND_RE.test(errorMsg)) {
     return err;
   }
   return new Error(

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1487,12 +1487,12 @@ export async function runSubagentAnnounceFlow(params: {
     });
 
     // Apply maxAnnounceChars truncation if specified
+    const TRUNCATION_MARKER = "\n\n[truncated — full output in transcript]";
     const truncatedFindings =
       typeof params.maxAnnounceChars === "number" &&
       params.maxAnnounceChars >= 1 &&
       findings.length > params.maxAnnounceChars
-        ? findings.slice(0, params.maxAnnounceChars) +
-          "\n\n[truncated — full output in transcript]"
+        ? findings.slice(0, params.maxAnnounceChars - TRUNCATION_MARKER.length) + TRUNCATION_MARKER
         : findings;
 
     const internalEvents: AgentInternalEvent[] = [

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1268,6 +1268,7 @@ export async function runSubagentAnnounceFlow(params: {
   wakeOnDescendantSettle?: boolean;
   signal?: AbortSignal;
   bestEffortDeliver?: boolean;
+  maxAnnounceChars?: number;
 }): Promise<boolean> {
   let didAnnounce = false;
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
@@ -1484,6 +1485,16 @@ export async function runSubagentAnnounceFlow(params: {
       startedAt: params.startedAt,
       endedAt: params.endedAt,
     });
+
+    // Apply maxAnnounceChars truncation if specified
+    const truncatedFindings =
+      typeof params.maxAnnounceChars === "number" &&
+      params.maxAnnounceChars >= 1 &&
+      findings.length > params.maxAnnounceChars
+        ? findings.slice(0, params.maxAnnounceChars) +
+          "\n\n[truncated — full output in transcript]"
+        : findings;
+
     const internalEvents: AgentInternalEvent[] = [
       {
         type: "task_completion",
@@ -1494,7 +1505,7 @@ export async function runSubagentAnnounceFlow(params: {
         taskLabel,
         status: outcome.status,
         statusLabel,
-        result: findings,
+        result: truncatedFindings,
         statsLine,
         replyInstruction,
       },

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -666,6 +666,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     spawnMode: entry.spawnMode,
     expectsCompletionMessage: entry.expectsCompletionMessage,
     wakeOnDescendantSettle: entry.wakeOnDescendantSettle === true,
+    maxAnnounceChars: entry.maxAnnounceChars,
   })
     .then((didAnnounce) => {
       finalizeAnnounceCleanup(didAnnounce);
@@ -1349,6 +1350,7 @@ export function registerSubagentRun(params: {
   runTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
   spawnMode?: "run" | "session";
+  maxAnnounceChars?: number;
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
@@ -1388,6 +1390,10 @@ export function registerSubagentRun(params: {
     archiveAtMs,
     cleanupHandled: false,
     wakeOnDescendantSettle: undefined,
+    maxAnnounceChars:
+      typeof params.maxAnnounceChars === "number" && Number.isFinite(params.maxAnnounceChars)
+        ? Math.max(1, Math.floor(params.maxAnnounceChars))
+        : undefined,
     attachmentsDir: params.attachmentsDir,
     attachmentsRootDir: params.attachmentsRootDir,
     retainAttachmentsOnKeep: params.retainAttachmentsOnKeep,

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -60,4 +60,6 @@ export type SubagentRunRecord = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  /** Maximum character limit for announce message delivery (truncates with marker if exceeded). */
+  maxAnnounceChars?: number;
 };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -62,6 +62,7 @@ export type SpawnSubagentParams = {
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
   expectsCompletionMessage?: boolean;
+  maxAnnounceChars?: number;
   attachments?: Array<{
     name: string;
     content: string;
@@ -753,6 +754,7 @@ export async function spawnSubagentDirect(
       runTimeoutSeconds,
       expectsCompletionMessage,
       spawnMode,
+      maxAnnounceChars: params.maxAnnounceChars,
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -63,6 +63,13 @@ const SessionsSpawnToolSchema = Type.Object({
       mountPath: Type.Optional(Type.String()),
     }),
   ),
+  maxAnnounceChars: Type.Optional(
+    Type.Number({
+      minimum: 1,
+      description:
+        "Maximum character limit for the sub-agent completion announce message. If exceeded, the message is truncated with a marker.",
+    }),
+  ),
 });
 
 export function createSessionsSpawnTool(
@@ -81,7 +88,7 @@ export function createSessionsSpawnTool(
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically.',
+      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically. Use maxAnnounceChars to limit completion message length for platforms with character limits (e.g., Telegram 4096 chars).',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -118,6 +125,10 @@ export function createSessionsSpawnTool(
           ? Math.max(0, Math.floor(timeoutSecondsCandidate))
           : undefined;
       const thread = params.thread === true;
+      const maxAnnounceCharsCandidate =
+        typeof params.maxAnnounceChars === "number" && Number.isFinite(params.maxAnnounceChars)
+          ? Math.max(1, Math.floor(params.maxAnnounceChars))
+          : undefined;
       const attachments = Array.isArray(params.attachments)
         ? (params.attachments as Array<{
             name: string;
@@ -186,6 +197,7 @@ export function createSessionsSpawnTool(
           cleanup,
           sandbox,
           expectsCompletionMessage: true,
+          maxAnnounceChars: maxAnnounceCharsCandidate,
           attachments,
           attachMountPath:
             params.attachAs && typeof params.attachAs === "object"


### PR DESCRIPTION
Fixes #48273

## Issues Fixed
1. Regex alternation precedence - second alternative lacked 403 requirement
2. Misleading error message for "bot was blocked" scenario

## Changes
- Fix regex grouping: `/403.*(bot.*not.*member|bot.*blocked)/i`
- Improve error message to cover both scenarios:
  - "bot is not a member" → Add bot to channel/group
  - "bot was blocked" → Ask user to unblock

## Error Message
Telegram send failed: bot is not a member of the chat or has been blocked (chat_id=${chatId}).
Fix: Add the bot to the channel/group, ensure it has not been removed, or ask the user to unblock the bot.