### PR TITLE
zalo: use photo_url for inbound images

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -25,7 +25,9 @@ export type ZaloMessage = {
   from: {
     id: string;
     name?: string;
+    display_name?: string;
     avatar?: string;
+    is_bot?: boolean;
   };
   chat: {
     id: string;
@@ -33,9 +35,10 @@ export type ZaloMessage = {
   };
   date: number;
   text?: string;
-  photo?: string;
+  photo_url?: string;
   caption?: string;
   sticker?: string;
+  message_type?: string;
 };
 
 export type ZaloUpdate = {

--- a/extensions/zalo/src/monitor.image.polling.test.ts
+++ b/extensions/zalo/src/monitor.image.polling.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../../test/helpers/extensions/plugin-runtime-mock.js";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+import type { ResolvedZaloAccount } from "./accounts.js";
+
+const getWebhookInfoMock = vi.hoisted(() => vi.fn(async () => ({ ok: true, result: { url: "" } })));
+const deleteWebhookMock = vi.hoisted(() => vi.fn(async () => ({ ok: true, result: { url: "" } })));
+const setWebhookMock = vi.hoisted(() => vi.fn(async () => ({ ok: true, result: { url: "" } })));
+const getUpdatesMock = vi.hoisted(() => vi.fn(() => new Promise(() => {})));
+const getZaloRuntimeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    deleteWebhook: deleteWebhookMock,
+    getUpdates: getUpdatesMock,
+    getWebhookInfo: getWebhookInfoMock,
+    setWebhook: setWebhookMock,
+  };
+});
+
+vi.mock("./runtime.js", () => ({
+  getZaloRuntime: getZaloRuntimeMock,
+}));
+
+const TEST_ACCOUNT: ResolvedZaloAccount = {
+  accountId: "default",
+  enabled: true,
+  token: "zalo-token", // pragma: allowlist secret
+  tokenSource: "config",
+  config: {
+    dmPolicy: "open",
+  },
+};
+
+const TEST_CONFIG = {
+  channels: {
+    zalo: {
+      enabled: true,
+      accounts: {
+        default: {
+          enabled: true,
+          dmPolicy: "open",
+        },
+      },
+    },
+  },
+} as OpenClawConfig;
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn<(message: string) => void>(),
+    error: vi.fn<(message: string) => void>(),
+  };
+}
+
+describe("Zalo polling image handling", () => {
+  const finalizeInboundContextMock = vi.fn((ctx: Record<string, unknown>) => ctx);
+  const recordInboundSessionMock = vi.fn(async () => undefined);
+  const fetchRemoteMediaMock = vi.fn(async () => ({
+    buffer: Buffer.from("image-bytes"),
+    contentType: "image/jpeg",
+  }));
+  const saveMediaBufferMock = vi.fn(async () => ({
+    path: "/tmp/zalo-photo.jpg",
+    contentType: "image/jpeg",
+  }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getZaloRuntimeMock.mockReturnValue(
+      createPluginRuntimeMock({
+        channel: {
+          media: {
+            fetchRemoteMedia:
+              fetchRemoteMediaMock as unknown as PluginRuntime["channel"]["media"]["fetchRemoteMedia"],
+            saveMediaBuffer:
+              saveMediaBufferMock as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
+          },
+          reply: {
+            finalizeInboundContext:
+              finalizeInboundContextMock as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+            dispatchReplyWithBufferedBlockDispatcher: vi.fn(
+              async () => undefined,
+            ) as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
+          },
+          session: {
+            recordInboundSession:
+              recordInboundSessionMock as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
+          },
+          commands: {
+            shouldComputeCommandAuthorized: vi.fn(
+              () => false,
+            ) as unknown as PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"],
+            resolveCommandAuthorizedFromAuthorizers: vi.fn(
+              () => false,
+            ) as unknown as PluginRuntime["channel"]["commands"]["resolveCommandAuthorizedFromAuthorizers"],
+            isControlCommandMessage: vi.fn(
+              () => false,
+            ) as unknown as PluginRuntime["channel"]["commands"]["isControlCommandMessage"],
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("downloads inbound image media from photo_url and preserves display_name", async () => {
+    getUpdatesMock
+      .mockResolvedValueOnce({
+        ok: true,
+        result: {
+          event_name: "message.image.received",
+          message: {
+            chat: {
+              id: "chat-123",
+              chat_type: "PRIVATE" as const,
+            },
+            message_id: "msg-123",
+            date: 1774084566880,
+            message_type: "CHAT_PHOTO",
+            from: {
+              id: "user-123",
+              is_bot: false,
+              display_name: "Test User",
+            },
+            photo_url: "https://example.com/test-image.jpg",
+            caption: "",
+          },
+        },
+      })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = createRuntimeEnv();
+    const run = monitorZaloProvider({
+      token: "zalo-token", // pragma: allowlist secret
+      account: TEST_ACCOUNT,
+      config: TEST_CONFIG,
+      runtime,
+      abortSignal: abort.signal,
+    });
+
+    await vi.waitFor(() =>
+      expect(fetchRemoteMediaMock).toHaveBeenCalledWith({
+        url: "https://example.com/test-image.jpg",
+        maxBytes: 5 * 1024 * 1024,
+      }),
+    );
+    expect(saveMediaBufferMock).toHaveBeenCalledTimes(1);
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "Test User",
+        MediaPath: "/tmp/zalo-photo.jpg",
+        MediaType: "image/jpeg",
+      }),
+    );
+    expect(recordInboundSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SenderName: "Test User",
+          MediaPath: "/tmp/zalo-photo.jpg",
+          MediaType: "image/jpeg",
+        }),
+      }),
+    );
+
+    abort.abort();
+    await run;
+  });
+});

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -284,15 +284,15 @@ async function handleTextMessage(
 
 async function handleImageMessage(params: ZaloImageMessageParams): Promise<void> {
   const { message, mediaMaxMb, account, core, runtime } = params;
-  const { photo, caption } = message;
+  const { photo_url, caption } = message;
 
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
 
-  if (photo) {
+  if (photo_url) {
     try {
       const maxBytes = mediaMaxMb * 1024 * 1024;
-      const fetched = await core.channel.media.fetchRemoteMedia({ url: photo, maxBytes });
+      const fetched = await core.channel.media.fetchRemoteMedia({ url: photo_url, maxBytes });
       const saved = await core.channel.media.saveMediaBuffer(
         fetched.buffer,
         fetched.contentType,
@@ -338,7 +338,7 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
   const isGroup = chat.chat_type === "GROUP";
   const chatId = chat.id;
   const senderId = from.id;
-  const senderName = from.name;
+  const senderName = from.display_name ?? from.name;
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const configAllowFrom = (account.config.allowFrom ?? []).map((v) => String(v));

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
 import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
+import { createPluginRuntimeMock } from "../../../test/helpers/extensions/plugin-runtime-mock.js";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import {
   clearZaloWebhookSecurityStateForTest,
@@ -26,6 +27,13 @@ async function withServer(handler: RequestListener, fn: (baseUrl: string) => Pro
     await fn(`http://127.0.0.1:${address.port}`);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function settleAsyncWork(): Promise<void> {
+  for (let i = 0; i < 6; i += 1) {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
   }
 }
 
@@ -259,6 +267,114 @@ describe("handleZaloWebhookRequest", () => {
     } finally {
       unregister();
     }
+  });
+
+  it("downloads inbound image media from webhook photo_url and preserves display_name", async () => {
+    const finalizeInboundContextMock = vi.fn((ctx: Record<string, unknown>) => ctx);
+    const recordInboundSessionMock = vi.fn(async () => undefined);
+    const fetchRemoteMediaMock = vi.fn(async () => ({
+      buffer: Buffer.from("image-bytes"),
+      contentType: "image/jpeg",
+    }));
+    const saveMediaBufferMock = vi.fn(async () => ({
+      path: "/tmp/zalo-photo.jpg",
+      contentType: "image/jpeg",
+    }));
+    const core = createPluginRuntimeMock({
+      channel: {
+        media: {
+          fetchRemoteMedia:
+            fetchRemoteMediaMock as unknown as PluginRuntime["channel"]["media"]["fetchRemoteMedia"],
+          saveMediaBuffer:
+            saveMediaBufferMock as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
+        },
+        reply: {
+          finalizeInboundContext:
+            finalizeInboundContextMock as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn(
+            async () => undefined,
+          ) as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
+        },
+        session: {
+          recordInboundSession:
+            recordInboundSessionMock as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
+        },
+        commands: {
+          shouldComputeCommandAuthorized: vi.fn(
+            () => false,
+          ) as unknown as PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"],
+          resolveCommandAuthorizedFromAuthorizers: vi.fn(
+            () => false,
+          ) as unknown as PluginRuntime["channel"]["commands"]["resolveCommandAuthorizedFromAuthorizers"],
+          isControlCommandMessage: vi.fn(
+            () => false,
+          ) as unknown as PluginRuntime["channel"]["commands"]["isControlCommandMessage"],
+        },
+      },
+    });
+    const unregister = registerTarget({
+      path: "/hook-image",
+      core,
+      account: {
+        ...DEFAULT_ACCOUNT,
+        config: {
+          dmPolicy: "open",
+        },
+      },
+    });
+
+    const payload = {
+      event_name: "message.image.received",
+      message: {
+        date: 1774086023728,
+        chat: { chat_type: "PRIVATE", id: "chat-123" },
+        caption: "",
+        message_id: "msg-123",
+        message_type: "CHAT_PHOTO",
+        from: { id: "user-123", is_bot: false, display_name: "Test User" },
+        photo_url: "https://example.com/test-image.jpg",
+      },
+    };
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/hook-image`, {
+          method: "POST",
+          headers: {
+            "x-bot-api-secret-token": "secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(200);
+        await settleAsyncWork();
+      });
+    } finally {
+      unregister();
+    }
+
+    expect(fetchRemoteMediaMock).toHaveBeenCalledWith({
+      url: "https://example.com/test-image.jpg",
+      maxBytes: 5 * 1024 * 1024,
+    });
+    expect(saveMediaBufferMock).toHaveBeenCalledTimes(1);
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "Test User",
+        MediaPath: "/tmp/zalo-photo.jpg",
+        MediaType: "image/jpeg",
+      }),
+    );
+    expect(recordInboundSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SenderName: "Test User",
+          MediaPath: "/tmp/zalo-photo.jpg",
+          MediaType: "image/jpeg",
+        }),
+      }),
+    );
   });
 
   it("returns 429 when per-path request rate exceeds threshold", async () => {

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -30,13 +30,6 @@ async function withServer(handler: RequestListener, fn: (baseUrl: string) => Pro
   }
 }
 
-async function settleAsyncWork(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
-    await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
 const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   accountId: "default",
   enabled: true,
@@ -348,16 +341,17 @@ describe("handleZaloWebhookRequest", () => {
         });
 
         expect(response.status).toBe(200);
-        await settleAsyncWork();
       });
     } finally {
       unregister();
     }
 
-    expect(fetchRemoteMediaMock).toHaveBeenCalledWith({
-      url: "https://example.com/test-image.jpg",
-      maxBytes: 5 * 1024 * 1024,
-    });
+    await vi.waitFor(() =>
+      expect(fetchRemoteMediaMock).toHaveBeenCalledWith({
+        url: "https://example.com/test-image.jpg",
+        maxBytes: 5 * 1024 * 1024,
+      }),
+    );
     expect(saveMediaBufferMock).toHaveBeenCalledTimes(1);
     expect(finalizeInboundContextMock).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Zalo inbound image events arrived with `message.photo_url`, but the plugin parsed `message.photo`, so inbound images were dropped.
- Why it matters: OpenClaw received the image event but never downloaded or attached the media to the inbound context.
- What changed: Updated the Zalo inbound message shape to use `photo_url`, preserved `display_name`, and added polling + webhook regression tests with sanitized payloads.
- What did NOT change (scope boundary): No outbound Zalo send behavior, no voice-message support, and no broader channel-routing changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49171
- Related #49171

## User-visible / Behavior Changes

Zalo inbound image messages now attach image media correctly when Zalo sends `message.photo_url` in polling or webhook mode.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Zalo
- Relevant config (redacted): Zalo account with polling + webhook tested against live bot

### Steps

1. Send an image to the Zalo bot.
2. Observe inbound `message.image.received` payload from polling or webhook.
3. Before the fix, the payload contains `photo_url`, but the plugin reads `photo`, so media is dropped.
4. After the fix, the plugin downloads the image from `photo_url` and records media in the inbound context.

### Expected

- Inbound Zalo image messages include media in the OpenClaw inbound context.

### Actual

- Before the fix, the media URL was ignored because the handler looked for the wrong field.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced live polling and live webhook payloads for Zalo text + image messages; confirmed both image payloads use `photo_url`; confirmed voice notes arrive as `message.unsupported.received` without usable media metadata.
- Edge cases checked: sanitized polling regression test; sanitized webhook regression test; changed-extension test lane; full `pnpm test`; `pnpm check`; `pnpm build`; `pnpm build:strict-smoke`; `pnpm protocol:check`.
- What you did **not** verify: outbound Zalo image sending changes were not part of this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d0f309e461` or temporarily restore the prior inbound field parsing in `extensions/zalo/src/monitor.ts`.
- Files/config to restore: `extensions/zalo/src/api.ts`, `extensions/zalo/src/monitor.ts`
- Known bad symptoms reviewers should watch for: Zalo inbound image messages arrive but no media path is recorded in the inbound context.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Another Zalo environment could still emit the older documented `photo` field instead of `photo_url`.
  - Mitigation: this PR is based on live polling and live webhook payloads captured from the target environment, and both regression tests lock the observed `photo_url` behavior in place.
