### PR TITLE
fix(sessions): prevent stale cache read in updateLastRoute

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -883,7 +883,8 @@ export async function updateLastRoute(params: {
 }) {
   const { storePath, sessionKey, channel, to, accountId, threadId, ctx } = params;
   return await withSessionStoreLock(storePath, async () => {
-    const store = loadSessionStore(storePath);
+    // Always re-read inside the lock to avoid clobbering concurrent writers.
+    const store = loadSessionStore(storePath, { skipCache: true });
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
     const now = Date.now();


### PR DESCRIPTION
## Summary

- `updateLastRoute` acquires `withSessionStoreLock` but calls `loadSessionStore(storePath)` **without `{ skipCache: true }`**, reading from cache instead of disk
- Both `updateSessionStore` (line 592) and `updateSessionStoreEntry` (line 806) correctly pass `skipCache: true` inside the lock, with the comment "Always re-read inside the lock to avoid clobbering concurrent writers"
- `updateLastRoute` was the only lock-holding writer missing this safeguard, allowing it to operate on a stale cached snapshot and silently overwrite concurrent writes

## Root cause

When the session store cache is enabled, `loadSessionStore` returns a cached in-memory copy. If another process/coroutine wrote to the store file between the cache population and the lock acquisition, the cached data is stale. The lock serializes disk writes, but the stale read means the write is based on outdated data — effectively a lost update.

## Fix

Add `{ skipCache: true }` to the `loadSessionStore` call inside `updateLastRoute`, matching the established pattern used by all other lock-holding session store writers.

## Test plan

- [x] Scoped session store tests pass (`pnpm test -- src/config/sessions/` — 26 tests pass; 6 failures are pre-existing dependency issues unrelated to this change)
- [x] TypeScript type check passes (no new errors)
- [x] Code inspection confirms all 3 `withSessionStoreLock` + `loadSessionStore` call sites now consistently use `skipCache: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)