### PR TITLE
fix(status): disambiguate update output when local == latest

### DIFF
--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -103,7 +103,9 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
     ...(gitLabel ? [{ Item: "Git", Value: gitLabel }] : []),
     {
       Item: "Update",
-      Value: updateAvailability.available ? theme.warn(`available · ${updateLine}`) : updateLine,
+      Value: updateAvailability.available
+        ? theme.warn(`available · ${updateLine}`)
+        : theme.success(`✓ up to date · ${updateLine}`),
     },
   ];
 

--- a/src/commands/status.update.test.ts
+++ b/src/commands/status.update.test.ts
@@ -90,7 +90,7 @@ describe("formatUpdateOneLiner", () => {
     });
 
     expect(formatUpdateOneLiner(update)).toBe(
-      `Update: git main · ↔ origin/main · dirty · behind 2 · npm latest ${VERSION} · deps ok`,
+      `Update: git main · ↔ origin/main · dirty · behind 2 · npm latest ${VERSION} (up to date) · deps ok`,
     );
   });
 

--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -76,7 +76,7 @@ export function formatUpdateOneLiner(update: UpdateCheckResult): string {
     if (update.registry?.latestVersion) {
       const cmp = compareSemverStrings(VERSION, update.registry.latestVersion);
       if (cmp === 0) {
-        parts.push(`npm latest ${update.registry.latestVersion}`);
+        parts.push(`npm latest ${update.registry.latestVersion} (up to date)`);
       } else if (cmp != null && cmp < 0) {
         parts.push(`npm update ${update.registry.latestVersion}`);
       } else {


### PR DESCRIPTION
Fixes #51403

When `openclaw update status` is run and the local version already equals npm latest, the output now clearly indicates \[(up to date)\](cci:1://file:///Users/honwee/project/openclaw/src/commands/status.update.test.ts:9:0-16:1) instead of just showing the version number.

### Changes
- \[formatUpdateOneLiner()\](cci:1://file:///Users/honwee/project/openclaw/src/commands/status.update.ts:71:0-132:1): append \[(up to date)\](cci:1://file:///Users/honwee/project/openclaw/src/commands/status.update.test.ts:9:0-16:1) when `cmp === 0`
- Status table: show `✓ up to date` with green styling when no update available
- Updated test expectations to match

### Test
```
pnpm test -- src/commands/status.update.test.ts
✓ src/commands/status.update.test.ts (6 tests) 3ms
Test Files  1 passed (1)
Tests       6 passed (6)
```