### PR TITLE
fix(whatsapp): add HTML/XML/CSS to MIME map + fallback for unknown media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1030,6 +1030,7 @@ Docs: https://docs.openclaw.ai
 - Exec: harden host env override handling across gateway and node (#51207) Thanks @gladiator9797 and @joshavant.
 - Voice Call: enforce spoken-output contract and fix stream TTS silence regression (#51500) Thanks @joshavant.
 - xAI/models: rename the bundled Grok 4.20 catalog entries to the GA IDs and normalize saved deprecated beta IDs at runtime so existing configs and sessions keep resolving. (#50772) thanks @Jaaneek
+- WhatsApp/outbound media: fix HTML, XML, and CSS files being silently dropped on outbound send by adding missing MIME entries and falling back to `application/octet-stream` for unknown media types. (#51562) Thanks @bobbyt74
 - Agents/bootstrap warnings: move bootstrap truncation warnings out of the system prompt and into the per-turn prompt body so prompt-cache reuse stays stable when truncation warnings appear or disappear. (#48753) Thanks @scoootscooob and @obviyus.
 - Telegram/DM topic session keys: route named-account DM topics through the same per-account base session key across inbound messages, native commands, and session-state lookups so `/status` and thread recovery stop creating phantom `agent:main:main:thread:...` sessions. (#48204) Thanks @vincentkoc.
 - ACP/configured bindings: reinitialize configured ACP sessions that are stuck in `error` state instead of reusing the failed runtime.

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -162,4 +162,24 @@ describe("createWebSendApi", () => {
     await api.sendComposingTo("+1555");
     expect(sendPresenceUpdate).toHaveBeenCalledWith("composing", "1555@s.whatsapp.net");
   });
+
+  it("sends media as document when mediaType is undefined", async () => {
+    const mediaBuffer = Buffer.from("test");
+
+    await api.sendMessage("123", "hello", mediaBuffer, undefined);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123@s.whatsapp.net",
+      expect.objectContaining({
+        document: mediaBuffer,
+        mimetype: "application/octet-stream",
+      }),
+    );
+  });
+
+  it("does not set mediaType when mediaBuffer is absent", async () => {
+    await api.sendMessage("123", "hello");
+
+    expect(sendMessage).toHaveBeenCalledWith("123@s.whatsapp.net", { text: "hello" });
+  });
 });

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -34,7 +34,7 @@ export function createWebSendApi(params: {
     ): Promise<{ messageId: string }> => {
       const jid = toWhatsappJid(to);
       let payload: AnyMessageContent;
-      if (mediaBuffer && mediaType) {
+      if (mediaBuffer && (mediaType ??= "application/octet-stream")) {
         if (mediaType.startsWith("image/")) {
           payload = {
             image: mediaBuffer,

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -34,7 +34,8 @@ export function createWebSendApi(params: {
     ): Promise<{ messageId: string }> => {
       const jid = toWhatsappJid(to);
       let payload: AnyMessageContent;
-      if (mediaBuffer && (mediaType ??= "application/octet-stream")) {
+      mediaType ??= "application/octet-stream";
+      if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {
           payload = {
             image: mediaBuffer,

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -34,7 +34,9 @@ export function createWebSendApi(params: {
     ): Promise<{ messageId: string }> => {
       const jid = toWhatsappJid(to);
       let payload: AnyMessageContent;
-      mediaType ??= "application/octet-stream";
+      if (mediaBuffer) {
+        mediaType ??= "application/octet-stream";
+      }
       if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {
           payload = {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -73,7 +73,7 @@ export async function sendMessageWhatsApp(
       });
       const caption = text || undefined;
       mediaBuffer = media.buffer;
-      mediaType = media.contentType;
+      mediaType = media.contentType ?? "application/octet-stream";
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -88,6 +88,28 @@ describe("mime detection", () => {
       expected,
     });
   });
+
+  it("detects HTML files by extension (no magic bytes)", async () => {
+    const buf = Buffer.from("<!DOCTYPE html><html><body>test</body></html>");
+    const mime = await detectMime({ buffer: buf, filePath: "/tmp/report.html" });
+    expect(mime).toBe("text/html");
+  });
+
+  it("detects .htm files by extension", async () => {
+    const buf = Buffer.from("<html><body>test</body></html>");
+    const mime = await detectMime({ buffer: buf, filePath: "/tmp/page.htm" });
+    expect(mime).toBe("text/html");
+  });
+
+  it("detects XML files by extension", async () => {
+    const mime = await detectMime({ filePath: "/tmp/data.xml" });
+    expect(mime).toBe("text/xml");
+  });
+
+  it("detects CSS files by extension", async () => {
+    const mime = await detectMime({ filePath: "/tmp/style.css" });
+    expect(mime).toBe("text/css");
+  });
 });
 
 describe("extensionForMime", () => {
@@ -113,6 +135,9 @@ describe("extensionForMime", () => {
     { mime: "application/pdf", expected: ".pdf" },
     { mime: "text/plain", expected: ".txt" },
     { mime: "text/markdown", expected: ".md" },
+    { mime: "text/html", expected: ".html" },
+    { mime: "text/xml", expected: ".xml" },
+    { mime: "text/css", expected: ".css" },
     { mime: "IMAGE/JPEG", expected: ".jpg" },
     { mime: "Audio/X-M4A", expected: ".m4a" },
     { mime: "Video/QuickTime", expected: ".mov" },

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -138,6 +138,7 @@ describe("extensionForMime", () => {
     { mime: "text/html", expected: ".html" },
     { mime: "text/xml", expected: ".xml" },
     { mime: "text/css", expected: ".css" },
+    { mime: "application/xml", expected: ".xml" },
     { mime: "IMAGE/JPEG", expected: ".jpg" },
     { mime: "Audio/X-M4A", expected: ".m4a" },
     { mime: "Video/QuickTime", expected: ".mov" },

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -36,6 +36,10 @@ const EXT_BY_MIME: Record<string, string> = {
   "text/csv": ".csv",
   "text/plain": ".txt",
   "text/markdown": ".md",
+  "text/html": ".html",
+  "text/xml": ".xml",
+  "text/css": ".css",
+  "application/xml": ".xml",
 };
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -43,6 +47,7 @@ const MIME_BY_EXT: Record<string, string> = {
   // Additional extension aliases
   ".jpeg": "image/jpeg",
   ".js": "text/javascript",
+  ".htm": "text/html",
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -48,6 +48,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".js": "text/javascript",
   ".htm": "text/html",
+  ".xml": "text/xml", // pin text/xml as canonical (application/xml also maps to .xml in EXT_BY_MIME)
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Summary

HTML files sent via the `message` tool are silently dropped — recipients get text without any attachment. No error is logged. This also affects `.xml`, `.css`, and `.htm` files.

### Root Cause

**1. Missing MIME entries (`src/media/mime.ts`)**

`EXT_BY_MIME` maps MIME types to extensions, then is reversed into `MIME_BY_EXT` for detection. HTML and several other common web types were missing:

- `text/html` → `.html`
- `text/xml` → `.xml`
- `text/css` → `.css`
- `application/xml` → `.xml`

Since HTML has no magic bytes, `file-type` returns `undefined`, and the extension-based fallback also fails → `detectMime()` returns `undefined`.

**2. Silent media drop (`extensions/whatsapp/src/send.ts` + `send-api.ts`)**

When `mediaType` is `undefined`:
- In `send.ts`: `mediaType = media.contentType` stays undefined, passed to `sendMessage(to, text, mediaBuffer, undefined)`
- In `send-api.ts`: the guard `if (mediaBuffer && mediaType)` is false → falls through to `payload = { text }` → media silently dropped

### Fix

1. Add missing entries to `EXT_BY_MIME` + `.htm` alias in `MIME_BY_EXT`
2. Add `?? "application/octet-stream"` fallback in both send paths so unknown file types are sent as documents instead of silently dropped
3. Added test coverage for HTML/XML/CSS detection

### Why not use a MIME database package?

Considered `mime-types` or `mime-db` packages, but:
- The current hand-maintained map is intentionally small (focuses on types OpenClaw actually handles)
- Adding a full MIME database (~1000 entries) for 4 missing entries is overkill
- The `application/octet-stream` fallback in the send path is the real safety net — it ensures **any** future missing type still gets delivered

### Test plan

- [x] New tests: `detectMime` for `.html`, `.htm`, `.xml`, `.css` files
- [x] New tests: `extensionForMime` for `text/html`, `text/xml`, `text/css`
- [x] Verified locally: HTML files now arrive as WhatsApp document attachments
- [x] Verified: PDF, PNG, TXT still work correctly (no regression)

Fixes #51561