### PR TITLE
fix(status): detect actual global install PM instead of repo packageManager field

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { detectPackageManager } from "./detect-package-manager.js";
+import { detectGlobalInstallManager, detectPackageManager } from "./detect-package-manager.js";
 
 describe("detectPackageManager", () => {
   it("prefers packageManager from package.json when supported", async () => {
@@ -41,5 +41,41 @@ describe("detectPackageManager", () => {
     await fs.writeFile(path.join(root, "package.json"), "{not-json}", "utf8");
 
     await expect(detectPackageManager(root)).resolves.toBeNull();
+  });
+});
+
+describe("detectGlobalInstallManager", () => {
+  it("detects pnpm global install from .pnpm path", () => {
+    expect(
+      detectGlobalInstallManager(
+        "/home/user/.local/share/pnpm/global/5/.pnpm/openclaw@2026.3.13/node_modules/openclaw",
+      ),
+    ).toBe("pnpm");
+  });
+
+  it("detects pnpm global install from pnpm/global path", () => {
+    expect(
+      detectGlobalInstallManager("/home/user/.local/share/pnpm/global/5/node_modules/openclaw"),
+    ).toBe("pnpm");
+  });
+
+  it("detects bun global install from .bun path", () => {
+    expect(detectGlobalInstallManager("/home/user/.bun/install/global/node_modules/openclaw")).toBe(
+      "bun",
+    );
+  });
+
+  it("detects npm global install (default) from Homebrew path", () => {
+    expect(detectGlobalInstallManager("/opt/homebrew/lib/node_modules/openclaw")).toBe("npm");
+  });
+
+  it("detects npm global install from standard global path", () => {
+    expect(detectGlobalInstallManager("/usr/lib/node_modules/openclaw")).toBe("npm");
+  });
+
+  it("detects npm global install from nvm path", () => {
+    expect(
+      detectGlobalInstallManager("/home/user/.nvm/versions/node/v22.0.0/lib/node_modules/openclaw"),
+    ).toBe("npm");
   });
 });

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -27,3 +27,32 @@ export async function detectPackageManager(root: string): Promise<DetectedPackag
   }
   return null;
 }
+
+/**
+ * Detect the actual global package manager that installed a package,
+ * based on the resolved package root path. This is used for `installKind === "package"`
+ * to avoid reading `package.json.packageManager` (which reflects the repo's build tool,
+ * not the user's install method).
+ *
+ * Path heuristics:
+ * - pnpm global: contains `/.pnpm/` in the resolved path
+ * - bun global:  contains `/.bun/` in the resolved path
+ * - npm global:  default fallback (npm doesn't add unique path markers)
+ */
+export function detectGlobalInstallManager(resolvedRoot: string): DetectedPackageManager {
+  const normalized = resolvedRoot.split(path.sep).join("/");
+
+  // pnpm global store uses .pnpm/ virtual store layout
+  if (normalized.includes("/.pnpm/") || normalized.includes("/pnpm/global/")) {
+    return "pnpm";
+  }
+
+  // bun global installs live under ~/.bun/
+  if (normalized.includes("/.bun/")) {
+    return "bun";
+  }
+
+  // npm global is the default — it installs into lib/node_modules/<pkg>
+  // without distinctive path markers
+  return "npm";
+}

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
-import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
+import {
+  detectGlobalInstallManager,
+  detectPackageManager as detectPackageManagerImpl,
+} from "./detect-package-manager.js";
 import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
 
 export type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
@@ -463,11 +466,16 @@ export async function checkUpdateStatus(params: {
     };
   }
 
-  const pm = await detectPackageManager(root);
   const gitRoot = await detectGitRoot(root);
   const isGit = gitRoot && path.resolve(gitRoot) === root;
 
   const installKind: UpdateCheckResult["installKind"] = isGit ? "git" : "package";
+
+  // For git installs, detect the repo's build-tool PM (pnpm/bun/npm).
+  // For package installs, detect the actual global installer from the
+  // resolved path — package.json.packageManager reflects the repo's
+  // build tool, not the user's install method (see #51401).
+  const pm = isGit ? await detectPackageManager(root) : detectGlobalInstallManager(root);
   const git = isGit
     ? await checkGitUpdateStatus({
         root,


### PR DESCRIPTION
Fixes #51401

`openclaw update status` incorrectly reports `Install: pnpm` for npm global installs because `detectPackageManager()` reads `package.json.packageManager` — which reflects the **repo's build tool**, not the user's install method.

### Changes

- **`src/infra/detect-package-manager.ts`**: Add `detectGlobalInstallManager(resolvedRoot)` that infers the actual global package manager from path heuristics:
  - `/.pnpm/` or `/pnpm/global/` → pnpm
  - `/.bun/` → bun
  - Default → npm (no distinctive path markers)
- **`src/infra/update-check.ts`**: For `installKind === "package"`, use `detectGlobalInstallManager(root)` instead of `detectPackageManager(root)`
- **`src/infra/detect-package-manager.test.ts`**: Add 6 new tests covering pnpm global, bun global, npm global (Homebrew, standard, nvm paths)

### Test

```
pnpm test -- src/infra/detect-package-manager.test.ts src/commands/status.update.test.ts src/infra/update-check.test.ts
✓ src/infra/detect-package-manager.test.ts (9 tests) 6ms
✓ src/commands/status.update.test.ts (6 tests) 3ms
✓ src/infra/update-check.test.ts (11 tests) 17ms
Test Files  3 passed (3)
Tests       21 passed (21) → 0 failed
```