### PR TITLE
fix: trim config validation startup imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded transport errors: distinguish common network failures like connection refused, DNS lookup failure, and interrupted sockets from true timeouts in embedded-run user messaging and lifecycle diagnostics. (#51419) Thanks @scoootscooob.
 - Discord/startup logging: report client initialization while the gateway is still connecting instead of claiming Discord is logged in before readiness is reached. (#51425) Thanks @scoootscooob.
 - Gateway/probe: honor caller `--timeout` for active local loopback probes in `gateway status`, keep inactive remote-mode loopback probes fast, and clamp probe timers to JS-safe bounds so slow local/container gateways stop reporting false timeouts. (#47533) Thanks @MonkeyLeeT.
+- Config/startup: keep bundled web-search allowlist compatibility on a lightweight manifest path so config validation no longer pulls bundled web-search registry imports into startup, while still avoiding accidental auto-allow of config-loaded override plugins. (#51574) Thanks @RichardCao.
 
 ### Breaking
 

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -78,6 +78,7 @@ describe("config plugin validation", () => {
   let badPluginDir = "";
   let enumPluginDir = "";
   let bluebubblesPluginDir = "";
+  let googleOverridePluginDir = "";
   let voiceCallSchemaPluginDir = "";
   let bundlePluginDir = "";
   let manifestlessClaudeBundleDir = "";
@@ -133,6 +134,17 @@ describe("config plugin validation", () => {
       id: "bluebubbles-plugin",
       channels: ["bluebubbles"],
       schema: { type: "object" },
+    });
+    googleOverridePluginDir = path.join(suiteHome, "google");
+    await writePluginFixture({
+      dir: googleOverridePluginDir,
+      id: "google",
+      schema: {
+        type: "object",
+        properties: {
+          apiKey: { type: "string" },
+        },
+      },
     });
     bundlePluginDir = path.join(suiteHome, "bundle-plugin");
     await writeBundleFixture({
@@ -320,6 +332,33 @@ describe("config plugin validation", () => {
         ]),
       );
     }
+  });
+
+  it("does not auto-allow config-loaded overrides of bundled web search plugin ids", async () => {
+    const res = validateInSuite({
+      plugins: {
+        allow: ["bluebubbles", "memory-core"],
+        load: {
+          paths: [googleOverridePluginDir],
+        },
+        entries: {
+          google: {
+            config: {
+              apiKey: "test-google-key",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.warnings).toContainEqual({
+      path: "plugins.entries.google",
+      message: "plugin disabled (not in allowlist) but config is present",
+    });
   });
 
   it("surfaces plugin config diagnostics", async () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -360,9 +360,33 @@ function validateConfigObjectWithPluginsBase(
       return compatConfig ?? config;
     }
 
+    const allow = config.plugins?.allow;
+    if (!Array.isArray(allow) || allow.length === 0) {
+      compatConfig = config;
+      return config;
+    }
+
+    const bundledWebSearchPluginIds = new Set(listBundledWebSearchPluginIds());
+    const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+    const seenCompatPluginIds = new Set<string>();
+    const compatPluginIds = loadPluginManifestRegistry({
+      config,
+      workspaceDir: workspaceDir ?? undefined,
+      env: opts.env,
+    })
+      .plugins.filter((plugin) => {
+        if (seenCompatPluginIds.has(plugin.id)) {
+          return false;
+        }
+        seenCompatPluginIds.add(plugin.id);
+        return plugin.origin === "bundled" && bundledWebSearchPluginIds.has(plugin.id);
+      })
+      .map((plugin) => plugin.id)
+      .toSorted((left, right) => left.localeCompare(right));
+
     compatConfig = withBundledPluginAllowlistCompat({
       config,
-      pluginIds: listBundledWebSearchPluginIds(),
+      pluginIds: compatPluginIds,
     });
     return compatConfig ?? config;
   };

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
-import { resolveBundledWebSearchPluginIds } from "../plugins/bundled-web-search.js";
+import { listBundledWebSearchPluginIds } from "../plugins/bundled-web-search-ids.js";
 import {
   normalizePluginsConfig,
   resolveEffectiveEnableState,
@@ -360,15 +360,9 @@ function validateConfigObjectWithPluginsBase(
       return compatConfig ?? config;
     }
 
-    const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
-    const bundledWebSearchPluginIds = resolveBundledWebSearchPluginIds({
-      config,
-      workspaceDir: workspaceDir ?? undefined,
-      env: opts.env,
-    });
     compatConfig = withBundledPluginAllowlistCompat({
       config,
-      pluginIds: bundledWebSearchPluginIds,
+      pluginIds: listBundledWebSearchPluginIds(),
     });
     return compatConfig ?? config;
   };

--- a/src/plugins/bundled-web-search-ids.ts
+++ b/src/plugins/bundled-web-search-ids.ts
@@ -1,0 +1,13 @@
+export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [
+  "brave",
+  "firecrawl",
+  "google",
+  "moonshot",
+  "perplexity",
+  "tavily",
+  "xai",
+] as const;
+
+export function listBundledWebSearchPluginIds(): string[] {
+  return [...BUNDLED_WEB_SEARCH_PLUGIN_IDS];
+}

--- a/src/plugins/bundled-web-search.test.ts
+++ b/src/plugins/bundled-web-search.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { bundledWebSearchPluginRegistrations } from "../bundled-web-search-registry.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { BUNDLED_WEB_SEARCH_PLUGIN_IDS } from "./bundled-web-search-ids.js";
 import {
   listBundledWebSearchProviders,
   resolveBundledWebSearchPluginIds,
@@ -74,6 +76,14 @@ describe("bundled web search metadata", () => {
       "tavily",
       "xai",
     ]);
+  });
+
+  it("keeps bundled web search fast-path ids aligned with the registry", () => {
+    expect([...BUNDLED_WEB_SEARCH_PLUGIN_IDS]).toEqual(
+      bundledWebSearchPluginRegistrations
+        .map(({ plugin }) => plugin.id)
+        .toSorted((left, right) => left.localeCompare(right)),
+    );
   });
 
   it("keeps fast-path bundled provider metadata aligned with bundled plugin contracts", async () => {

--- a/src/plugins/bundled-web-search.ts
+++ b/src/plugins/bundled-web-search.ts
@@ -1,4 +1,5 @@
 import { bundledWebSearchPluginRegistrations } from "../bundled-web-search-registry.js";
+import { listBundledWebSearchPluginIds as listBundledWebSearchPluginIdsFromIds } from "./bundled-web-search-ids.js";
 import { capturePluginRegistration } from "./captured-registration.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
@@ -8,7 +9,6 @@ type BundledWebSearchProviderEntry = PluginWebSearchProviderEntry & { pluginId: 
 type BundledWebSearchPluginRegistration = (typeof bundledWebSearchPluginRegistrations)[number];
 
 let bundledWebSearchProvidersCache: BundledWebSearchProviderEntry[] | null = null;
-let bundledWebSearchPluginIdsCache: string[] | null = null;
 
 function resolveBundledWebSearchPlugin(
   entry: BundledWebSearchPluginRegistration,
@@ -35,19 +35,6 @@ function listBundledWebSearchPluginRegistrations() {
     );
 }
 
-function loadBundledWebSearchPluginIds(): string[] {
-  if (!bundledWebSearchPluginIdsCache) {
-    bundledWebSearchPluginIdsCache = listBundledWebSearchPluginRegistrations()
-      .map(({ plugin }) => plugin.id)
-      .toSorted((left, right) => left.localeCompare(right));
-  }
-  return bundledWebSearchPluginIdsCache;
-}
-
-export function listBundledWebSearchPluginIds(): string[] {
-  return loadBundledWebSearchPluginIds();
-}
-
 function loadBundledWebSearchProviders(): BundledWebSearchProviderEntry[] {
   if (!bundledWebSearchProvidersCache) {
     bundledWebSearchProvidersCache = listBundledWebSearchPluginRegistrations().flatMap(
@@ -71,11 +58,15 @@ export function resolveBundledWebSearchPluginIds(params: {
     workspaceDir: params.workspaceDir,
     env: params.env,
   });
-  const bundledWebSearchPluginIdSet = new Set<string>(loadBundledWebSearchPluginIds());
+  const bundledWebSearchPluginIdSet = new Set<string>(listBundledWebSearchPluginIdsFromIds());
   return registry.plugins
     .filter((plugin) => plugin.origin === "bundled" && bundledWebSearchPluginIdSet.has(plugin.id))
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listBundledWebSearchPluginIds(): string[] {
+  return listBundledWebSearchPluginIdsFromIds();
 }
 
 export function listBundledWebSearchProviders(): PluginWebSearchProviderEntry[] {


### PR DESCRIPTION
## Summary
- avoid loading bundled web-search registry from config validation startup paths
- move bundled web-search plugin ids to a lightweight static module
- keep the existing bundled-web-search export surface compatible

## Verification
- corepack pnpm --dir /Users/create/.codex/openclaw-main-buildfix build
- corepack pnpm --dir /Users/create/.codex/openclaw-main-buildfix test:startup:memory
  - --help: 72.2 MB RSS
  - status --json: 183.0 MB RSS
  - gateway status: 329.0 MB RSS