### PR TITLE
fix(model): infer provider from allowlist for bare model IDs to prevent prefix drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/security: block credential-path binds even when sandbox home paths resolve through canonical aliases, so agent containers cannot mount user secret stores through alternate home-directory paths. (#59157) Thanks @eleqtrizit.
 - Gateway/Windows scheduled tasks: preserve Task Scheduler settings on reinstall, fail loud when Scheduled Task `/Run` does not start, and report fast failed restarts with the actual elapsed time instead of a fake 60s timeout. (#59335) Thanks @tmimmanuel.
 - Control UI/model picker: preserve already-qualified `provider/model` refs from the server so models whose ids already contain slashes stop being double-prefixed and remapped to the wrong provider. (#49874) Thanks @ShionEria.
+- Models/selection: resolve bare model ids in session model switches against the configured allowlist before falling back to the current session provider, so Control UI model picks stop drifting into `google/k2p5` and similar wrong-provider refs. (#51580) Thanks @honwee.
 
 ## 2026.4.1-beta.1
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -569,6 +569,34 @@ describe("model-selection", () => {
         ref: { provider: "openai", model: "@cf/openai/gpt-oss-20b" },
       });
     });
+
+    it("infers provider from allowlist for bare model ids to prevent prefix drift (#48369)", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.4": {},
+              "opencode-go/kimi-k2.5": {},
+              "opencode-go/glm-5": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      // When session default is openai-codex, switching to a bare "kimi-k2.5"
+      // should resolve to opencode-go/kimi-k2.5, not openai-codex/kimi-k2.5
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "kimi-k2.5",
+        defaultProvider: "openai-codex", // session's current provider
+      });
+
+      expect(result).toEqual({
+        key: "opencode-go/kimi-k2.5",
+        ref: { provider: "opencode-go", model: "kimi-k2.5" },
+      });
+    });
   });
 
   describe("resolveModelRefFromString", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -660,9 +660,19 @@ export function resolveAllowedModelRef(params: {
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
   });
+
+  // When the model string has no provider prefix ("/"), try to infer the
+  // correct provider from the configured allowlist before falling back to the
+  // session's current default provider. This prevents provider prefix drift
+  // when switching models across different providers (see #48369).
+  const effectiveDefaultProvider = !trimmed.includes("/")
+    ? (inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: trimmed }) ??
+      params.defaultProvider)
+    : params.defaultProvider;
+
   const resolved = resolveModelRefFromString({
     raw: trimmed,
-    defaultProvider: params.defaultProvider,
+    defaultProvider: effectiveDefaultProvider,
     aliasIndex,
   });
   if (!resolved) {


### PR DESCRIPTION
Fixes #48369
Also related: #48096, #48128, #48224, #48256 (5th reported instance of this bug)

## Problem

When switching models across different providers via the Control UI (WebChat), bare model IDs (without `provider/` prefix) get resolved against the **session's current default provider** instead of the correct one from the configured allowlist.

Example: if the session default is `openai-codex/gpt-5.4` and you switch to `kimi-k2.5`, it incorrectly resolves to `openai-codex/kimi-k2.5` instead of `opencode-go/kimi-k2.5`, then fails with `model not allowed`.

## Root Cause

`resolveAllowedModelRef()` in `model-selection.ts` passes `defaultProvider: resolvedDefault.provider` (the session's current provider) to `resolveModelRefFromString()`. When the model string has no `/`, `parseModelRef()` applies this wrong default provider.

## Fix

When the model string has no `/`, use the existing `inferUniqueProviderFromConfiguredModels()` to find the correct provider from the allowlist before falling back to the session's current default provider.

## Test

```
pnpm test -- src/agents/model-selection.test.ts -t 'prefix drift'
✓ 1 test passed

pnpm test -- src/gateway/sessions-patch.test.ts
✓ 27 tests passed
```
