### PR TITLE
fix(plugins): emit message_sent hook in reply-dispatcher for all channels

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -598,6 +598,11 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     createReplyDispatcherWithTyping({
       ...replyPipeline,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      hookContext: {
+        channelId: "discord",
+        to: messageChannelId,
+        accountId: route.accountId,
+      },
       deliver: async (payload: ReplyPayload, info) => {
         if (isProcessAborted(abortSignal)) {
           return;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -353,6 +353,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
+      hookContext: {
+        channelId: "feishu",
+        to: chatId,
+        accountId,
+      },
       onReplyStart: async () => {
         deliveredFinalTexts.clear();
         if (streamingEnabled && renderMode === "card") {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -871,6 +871,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         core.channel.reply.createReplyDispatcherWithTyping({
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, _route.agentId),
+          hookContext: {
+            channelId: "matrix",
+            to: roomId,
+            accountId,
+          },
           deliver: async (payload: ReplyPayload) => {
             await deliverMatrixReplies({
               cfg,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -482,6 +482,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           core.channel.reply.createReplyDispatcherWithTyping({
             ...replyPipeline,
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+            hookContext: {
+              channelId: "mattermost",
+              to,
+              accountId: account.accountId,
+            },
             deliver: async (payload: ReplyPayload) => {
               await deliverMattermostReplyPayload({
                 core,
@@ -677,6 +682,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       core.channel.reply.createReplyDispatcherWithTyping({
         ...replyPipeline,
         // Picker-triggered confirmations should stay immediate.
+        hookContext: {
+          channelId: "mattermost",
+          to,
+          accountId: account.accountId,
+        },
         deliver: async (payload: ReplyPayload) => {
           const trimmedPayload = {
             ...payload,
@@ -1400,6 +1410,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         ...replyPipeline,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
+        hookContext: {
+          channelId: "mattermost",
+          to,
+          accountId: account.accountId,
+        },
         deliver: async (payload: ReplyPayload) => {
           await deliverMattermostReplyPayload({
             core,

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -488,6 +488,11 @@ async function handleSlashCommandAsync(params: {
     core.channel.reply.createReplyDispatcherWithTyping({
       ...replyPipeline,
       humanDelay,
+      hookContext: {
+        channelId: "mattermost",
+        to,
+        accountId: account.accountId,
+      },
       deliver: async (payload: ReplyPayload) => {
         await deliverMattermostReplyPayload({
           core,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -290,6 +290,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ...replyPipeline,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
+      hookContext: {
+        channelId: "signal",
+        to: ctxPayload.To,
+        accountId: route.accountId,
+      },
       deliver: async (payload) => {
         await deps.deliverReplies({
           replies: [payload],

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -302,6 +302,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
     ...replyPipeline,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+    hookContext: {
+      channelId: "slack",
+      to: message.channel,
+      accountId: route.accountId,
+    },
     deliver: async (payload) => {
       if (useStreaming) {
         await deliverWithStreaming(payload);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -586,6 +586,11 @@ export const dispatchTelegramMessage = async ({
       cfg,
       dispatcherOptions: {
         ...replyPipeline,
+        hookContext: {
+          channelId: "telegram",
+          to: String(chatId),
+          accountId: route.accountId,
+        },
         deliver: async (payload, info) => {
           if (payload.isError === true) {
             hadErrorReplyFailureOrSkip = true;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -66,6 +66,7 @@ function emitMessageSentHookFromDispatcher(
       {
         channelId: hookContext.channelId,
         accountId: hookContext.accountId,
+        conversationId: hookContext.to,
       },
     )
     .catch(() => {
@@ -216,11 +217,15 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         await options.deliver(normalized, { kind });
         // Emit message_sent hook after successful delivery (#47472).
         // This covers the dispatcher path that bypasses deliver.ts.
+        // Skip tool-kind deliveries — they are internal tool-result coordination,
+        // not user-visible messages. Matches the deliver.ts path behavior.
         try {
-          if (options.onDelivered) {
-            options.onDelivered(normalized, { kind });
-          } else if (options.hookContext) {
-            emitMessageSentHookFromDispatcher(options.hookContext, normalized);
+          if (kind !== "tool") {
+            if (options.onDelivered) {
+              options.onDelivered(normalized, { kind });
+            } else if (options.hookContext) {
+              emitMessageSentHookFromDispatcher(options.hookContext, normalized);
+            }
           }
         } catch {
           // Swallow errors — delivery already succeeded.

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,5 +1,6 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
@@ -40,6 +41,38 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+/**
+ * Emit message_sent plugin hook from the dispatcher path (#47472).
+ * Fire-and-forget: errors are swallowed since delivery already succeeded.
+ */
+function emitMessageSentHookFromDispatcher(
+  hookContext: NonNullable<ReplyDispatcherOptions["hookContext"]>,
+  payload: ReplyPayload,
+): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("message_sent")) {
+    return;
+  }
+  const content =
+    typeof payload.text === "string" ? payload.text : "";
+  // Fire-and-forget: don't await, don't throw.
+  hookRunner
+    .runMessageSent(
+      {
+        to: hookContext.to,
+        content,
+        success: true,
+      },
+      {
+        channelId: hookContext.channelId,
+        accountId: hookContext.accountId,
+      },
+    )
+    .catch(() => {
+      // Swallow — delivery already succeeded, hook errors are non-fatal.
+    });
+}
+
 export type ReplyDispatcherOptions = {
   deliver: ReplyDispatchDeliverer;
   responsePrefix?: string;
@@ -56,6 +89,22 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /**
+   * Called after each successful delivery.
+   * Used to emit message_sent plugin hooks from the dispatcher path,
+   * which does not go through deliver.ts (see #47472).
+   */
+  onDelivered?: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => void;
+  /**
+   * Channel and destination metadata for automatic message_sent hook emission.
+   * When provided (and onDelivered is not), the dispatcher will automatically
+   * emit the message_sent plugin hook after each successful delivery.
+   */
+  hookContext?: {
+    channelId: string;
+    to: string;
+    accountId?: string;
+  };
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -165,6 +214,17 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        // Emit message_sent hook after successful delivery (#47472).
+        // This covers the dispatcher path that bypasses deliver.ts.
+        try {
+          if (options.onDelivered) {
+            options.onDelivered(normalized, { kind });
+          } else if (options.hookContext) {
+            emitMessageSentHookFromDispatcher(options.hookContext, normalized);
+          }
+        } catch {
+          // Swallow errors — delivery already succeeded.
+        }
       })
       .catch((err) => {
         options.onError?.(err, { kind });


### PR DESCRIPTION
## Problem

Fixes #47472

The `message_sent` plugin hook never fires for extension plugins. Root cause: the hook was only emitted inside `deliver.ts` (`deliverOutboundPayloadsCore`), which is only reached via `routeReply` for **cross-channel routing** (e.g., Telegram → Slack).

Most channels dispatch replies through `reply-dispatcher → channel-specific deliver callback`, which bypasses `deliver.ts` entirely. This means `message_sent` never fires for same-channel replies — which is the common case.

## Solution

Added `hookContext` option to `ReplyDispatcherOptions`:
```typescript
hookContext?: {
  channelId: string;
  to: string;
  accountId?: string;
};
```

When provided, the reply-dispatcher automatically emits the `message_sent` plugin hook (fire-and-forget) after each successful delivery, using the global hook runner.

Also added a lower-level `onDelivered` callback for channels that need custom hook emission logic.

## Changes

- `src/auto-reply/reply/reply-dispatcher.ts` — Core fix: `hookContext` + `onDelivered` options, `emitMessageSentHookFromDispatcher` helper
- 8 channel dispatchers wired with `hookContext`:
  - Discord, Feishu, Telegram, Slack, Signal, Mattermost (4 call sites), Matrix

## Verification

Tested locally with a custom plugin listening on `message_received`, `message_sent`, and `agent_end`:
- Before fix: `message_received` ✅, `agent_end` ✅, `message_sent` ❌
- After fix: all three hooks fire correctly

## Notes

- The existing `deliver.ts` hook emission is preserved for the cross-channel routing path
- Hook errors are swallowed (fire-and-forget) since delivery already succeeded
- No breaking changes — `hookContext` is optional