### PR TITLE
fix(sandbox): fall back to static channel registry for sandbox explain channel resolution

### DIFF
--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -3,7 +3,7 @@ import {
   resolveSandboxConfigForAgent,
   resolveSandboxToolPolicyForAgent,
 } from "../agents/sandbox.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -83,7 +83,7 @@ function inferProviderFromSessionKey(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  return normalizeAnyChannelId(candidate) ?? undefined;
+  return normalizeAnyChannelId(candidate) ?? normalizeChatChannelId(candidate) ?? undefined;
 }
 
 function resolveActiveChannel(params: {


### PR DESCRIPTION
Fixes #51245

## Problem

`openclaw sandbox explain --session telegram:slash:12345` shows `channel: (unknown)` for Telegram slash sessions, causing elevated `allowFrom` checks to fail even when the Telegram sender is correctly allowlisted.

## Root Cause

`inferProviderFromSessionKey()` in `sandbox-explain.ts` uses `normalizeAnyChannelId()` which depends on the **runtime channel plugin registry**. When running from the CLI (`sandbox explain`), channel plugins may not be loaded, so built-in channels like `telegram` don't resolve.

## Fix

Fall back to the static `normalizeChatChannelId()` which uses the hardcoded `CHAT_CHANNEL_META` registry and always resolves built-in channels like `telegram`, `discord`, `slack`, etc.

## Test

```
pnpm test -- src/commands/sandbox-explain.test.ts
✓ 1 test passed
```
