### PR TITLE
fix(media): add HTML, XML, CSS MIME entries to detection map

### DIFF
--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -36,12 +36,17 @@ const EXT_BY_MIME: Record<string, string> = {
   "text/csv": ".csv",
   "text/plain": ".txt",
   "text/markdown": ".md",
+  "text/html": ".html",
+  "text/xml": ".xml",
+  "text/css": ".css",
+  "application/xml": ".xml",
 };
 
 const MIME_BY_EXT: Record<string, string> = {
   ...Object.fromEntries(Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime])),
   // Additional extension aliases
   ".jpeg": "image/jpeg",
+  ".htm": "text/html",
   ".js": "text/javascript",
 };
 


### PR DESCRIPTION
## Summary

Add missing MIME type entries (`text/html`, `text/xml`, `text/css`, `application/xml`) to `EXT_BY_MIME` and `.htm` alias to `MIME_BY_EXT` in `src/media/mime.ts`.

## Problem

HTML files sent via WhatsApp (and potentially other channels) are silently dropped because `detectMime()` returns `undefined` for `.html` files. The `file-type` package cannot detect HTML via magic bytes, so the fallback to `MIME_BY_EXT` is the only detection path — but `.html` was missing from the map.

This also affects `.xml`, `.css`, and `.htm` files.

## Fix

- Add `text/html`, `text/xml`, `text/css`, and `application/xml` to `EXT_BY_MIME`
- Add `.htm` as an alias in `MIME_BY_EXT`

All 44 existing MIME tests pass.

Fixes #51561