### PR TITLE
fix(cron): widen top-of-hour stagger to cover step and list expressions

### DIFF
--- a/src/cron/stagger.test.ts
+++ b/src/cron/stagger.test.ts
@@ -15,6 +15,30 @@ describe("cron stagger helpers", () => {
     expect(isRecurringTopOfHourCronExpr("15 * * * *")).toBe(false);
   });
 
+  it("detects step expressions that include minute 0", () => {
+    // every 15 min fires at :00, :15, :30, :45 — includes top-of-hour
+    expect(isRecurringTopOfHourCronExpr("*/15 * * * *")).toBe(true);
+    // every 30 min fires at :00 and :30 — includes top-of-hour
+    expect(isRecurringTopOfHourCronExpr("*/30 * * * *")).toBe(true);
+    // every 2 min fires at :00, :02, ... — includes top-of-hour
+    expect(isRecurringTopOfHourCronExpr("*/2 * * * *")).toBe(true);
+    // every minute — too frequent, skip stagger
+    expect(isRecurringTopOfHourCronExpr("* * * * *")).toBe(false);
+    expect(isRecurringTopOfHourCronExpr("*/1 * * * *")).toBe(false);
+  });
+
+  it("detects comma lists that include minute 0", () => {
+    // fires at :00 and :30 — includes top-of-hour
+    expect(isRecurringTopOfHourCronExpr("0,30 * * * *")).toBe(true);
+    // fires at :15 and :45 — does not include top-of-hour
+    expect(isRecurringTopOfHourCronExpr("15,45 * * * *")).toBe(false);
+  });
+
+  it("detects range expressions starting at 0", () => {
+    expect(isRecurringTopOfHourCronExpr("0-30 * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("5-30 * * * *")).toBe(false);
+  });
+
   it("normalizes explicit stagger values", () => {
     expect(normalizeCronStaggerMs("30000")).toBe(30_000);
     expect(normalizeCronStaggerMs(42.8)).toBe(42);
@@ -27,11 +51,15 @@ describe("cron stagger helpers", () => {
     expect(resolveCronStaggerMs({ kind: "cron", expr: "0 * * * *" })).toBe(
       DEFAULT_TOP_OF_HOUR_STAGGER_MS,
     );
+    expect(resolveCronStaggerMs({ kind: "cron", expr: "*/15 * * * *" })).toBe(
+      DEFAULT_TOP_OF_HOUR_STAGGER_MS,
+    );
     expect(resolveCronStaggerMs({ kind: "cron", expr: "0 * * * *", staggerMs: 30_000 })).toBe(
       30_000,
     );
     expect(resolveCronStaggerMs({ kind: "cron", expr: "0 * * * *", staggerMs: 0 })).toBe(0);
     expect(resolveCronStaggerMs({ kind: "cron", expr: "15 * * * *" })).toBe(0);
+    expect(resolveCronStaggerMs({ kind: "cron", expr: "* * * * *" })).toBe(0);
   });
 
   it("handles missing runtime expr values without throwing", () => {

--- a/src/cron/stagger.ts
+++ b/src/cron/stagger.ts
@@ -6,15 +6,39 @@ function parseCronFields(expr: string) {
   return expr.trim().split(/\s+/).filter(Boolean);
 }
 
+/**
+ * Returns true when the minute field includes minute 0 as a firing point.
+ * Does not match wildcard ("*") since every-minute crons don't benefit from
+ * top-of-hour stagger — they already fire 60 times per hour.
+ */
+function minuteFieldIncludesZero(field: string): boolean {
+  if (field === "0") {
+    return true;
+  }
+  if (field.startsWith("*/")) {
+    const step = parseInt(field.slice(2), 10);
+    // step=1 is equivalent to "*" — skip stagger for every-minute expressions
+    return Number.isFinite(step) && step > 1;
+  }
+  if (field.includes(",")) {
+    return field.split(",").some((v) => v.trim() === "0");
+  }
+  if (field.includes("-")) {
+    const [start] = field.split("-").map(Number);
+    return start === 0;
+  }
+  return parseInt(field, 10) === 0;
+}
+
 export function isRecurringTopOfHourCronExpr(expr: string) {
   const fields = parseCronFields(expr);
   if (fields.length === 5) {
     const [minuteField, hourField] = fields;
-    return minuteField === "0" && hourField.includes("*");
+    return minuteFieldIncludesZero(minuteField) && hourField.includes("*");
   }
   if (fields.length === 6) {
     const [secondField, minuteField, hourField] = fields;
-    return secondField === "0" && minuteField === "0" && hourField.includes("*");
+    return secondField === "0" && minuteFieldIncludesZero(minuteField) && hourField.includes("*");
   }
   return false;
 }


### PR DESCRIPTION
## Summary

`isRecurringTopOfHourCronExpr` only matched `minuteField === "0"`, so cron expressions like `*/15 * * * *` or `0,30 * * * *` that also fire at minute :00 never received the default 5-minute stagger. This could cause thundering-herd spikes when many users configure sub-hourly recurring jobs.

## Root cause

Strict equality check `minuteField === "0"` rejects any minute field that isn't the literal string `"0"`, even when the expression fires at minute 0 (step values, comma lists, ranges starting at 0).

## Fix

Extract a `minuteFieldIncludesZero` helper that handles:
- `"0"` — exact match (existing behavior, preserved)
- `*/n` where n > 1 — step expressions that include minute 0
- Comma lists containing `"0"` (e.g. `0,30`)
- Ranges starting at 0 (e.g. `0-30`)

Every-minute expressions (`*` and `*/1`) are explicitly excluded since they fire 60 times per hour and don't benefit from top-of-hour stagger.

## Files changed

- `src/cron/stagger.ts` — add helper, swap two equality checks
- `src/cron/stagger.test.ts` — add test cases for step, comma, range, and every-minute expressions

## Testing

All existing tests pass unchanged. New tests cover:
- `*/15 * * * *` → true
- `*/30 * * * *` → true  
- `*/2 * * * *` → true
- `* * * * *` → false
- `*/1 * * * *` → false
- `0,30 * * * *` → true
- `15,45 * * * *` → false
- `0-30 * * * *` → true
- `5-30 * * * *` → false

Integration test (`service.jobs.top-of-hour-stagger.test.ts`) also passes.

Closes #51587