### PR TITLE
feat(config): add llm shorthand config key for custom model providers

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -9,7 +9,7 @@ import {
   resolveTalkApiKey,
 } from "./talk.js";
 import type { OpenClawConfig } from "./types.js";
-import type { ModelDefinitionConfig } from "./types.models.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "./types.models.js";
 import { hasConfiguredSecretInput } from "./types.secrets.js";
 
 type WarnState = { warned: boolean };
@@ -533,4 +533,91 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
 
 export function resetSessionDefaultsWarningForTests() {
   defaultWarnState = { warned: false };
+}
+
+const LLM_PROVIDER_API_MAP: Record<string, string> = {
+  "openai-compatible": "openai-completions",
+  "anthropic-compatible": "anthropic-messages",
+};
+
+/**
+ * Expand the `llm` shorthand config into `models.providers`,
+ * `agents.defaults.model.primary`, and `agents.defaults.models[ref].params`.
+ *
+ * The `llm` key is non-destructive: existing values in `models.providers` or
+ * `agents.defaults.model.primary` are NOT overwritten, so users can still
+ * override individual fields via the full `models`/`agents` config keys.
+ */
+export function applyLlmConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const llm = cfg.llm;
+  if (!llm) {
+    return cfg;
+  }
+
+  const providerId = llm.provider_id?.trim() || "custom";
+  const modelId = llm.model.trim();
+  const modelRef = `${providerId}/${modelId}`;
+
+  // Resolve API type from provider shorthand or pass through as-is.
+  const api = LLM_PROVIDER_API_MAP[llm.provider] ?? llm.provider;
+
+  // Build the provider entry. Only fill fields that were specified.
+  const providerEntry: ModelProviderConfig = {
+    baseUrl: llm.base_url ?? "",
+    api: api as ModelProviderConfig["api"],
+    models: [{ id: modelId, name: modelId } as ModelDefinitionConfig],
+    ...(llm.api_key !== undefined ? { apiKey: llm.api_key } : {}),
+  };
+
+  // Merge into models.providers — do not overwrite an existing provider entry.
+  const existingProviders = cfg.models?.providers ?? {};
+  const nextProviders = existingProviders[providerId]
+    ? existingProviders
+    : { ...existingProviders, [providerId]: providerEntry };
+
+  let nextCfg: OpenClawConfig = {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      providers: nextProviders,
+    },
+  };
+
+  // Set agents.defaults.model.primary only if not already configured.
+  const existingDefaults = nextCfg.agents?.defaults;
+  const existingPrimary = resolveAgentModelPrimaryValue(existingDefaults?.model);
+  if (!existingPrimary) {
+    const nextDefaults = existingDefaults ? { ...existingDefaults } : {};
+    nextDefaults.model = { primary: modelRef };
+    nextCfg = {
+      ...nextCfg,
+      agents: { ...nextCfg.agents, defaults: nextDefaults },
+    };
+  }
+
+  // Inject temperature into agents.defaults.models[ref].params if provided.
+  if (typeof llm.temperature === "number") {
+    const defaults = nextCfg.agents?.defaults;
+    const existingModels = (defaults?.models ?? {}) as Record<string, Record<string, unknown>>;
+    const existingEntry = existingModels[modelRef] ?? {};
+    const existingParams = (existingEntry.params as Record<string, unknown> | undefined) ?? {};
+    // Only set temperature if not already explicitly configured.
+    if (typeof existingParams.temperature !== "number") {
+      const nextModels = {
+        ...existingModels,
+        [modelRef]: {
+          ...existingEntry,
+          params: { ...existingParams, temperature: llm.temperature },
+        },
+      };
+      const nextDefaults = defaults ? { ...defaults } : {};
+      nextDefaults.models = nextModels as typeof nextDefaults.models;
+      nextCfg = {
+        ...nextCfg,
+        agents: { ...nextCfg.agents, defaults: nextDefaults },
+      };
+    }
+  }
+
+  return nextCfg;
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -21,6 +21,7 @@ import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
   applyAgentDefaults,
+  applyLlmConfig,
   applyLoggingDefaults,
   applyMessageDefaults,
   applyModelDefaults,
@@ -801,7 +802,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           applyCompactionDefaults(
             applyContextPruningDefaults(
               applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+                applyLlmConfig(
+                  applySessionDefaults(
+                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                  ),
+                ),
               ),
             ),
           ),
@@ -892,7 +897,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           applyModelDefaults(
             applyCompactionDefaults(
               applyContextPruningDefaults(
-                applyAgentDefaults(applySessionDefaults(applyMessageDefaults({}))),
+                applyAgentDefaults(applyLlmConfig(applySessionDefaults(applyMessageDefaults({})))),
               ),
             ),
           ),
@@ -1004,7 +1009,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           applyTalkConfigNormalization(
             applyModelDefaults(
               applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+                applyLlmConfig(
+                  applySessionDefaults(
+                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                  ),
+                ),
               ),
             ),
           ),

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -74,3 +74,38 @@ export type ModelsConfig = {
   providers?: Record<string, ModelProviderConfig>;
   bedrockDiscovery?: BedrockDiscoveryConfig;
 };
+
+/**
+ * Simplified LLM configuration shorthand.
+ * Expands into `models.providers` + `agents.defaults.model.primary` at runtime.
+ *
+ * Example:
+ *   { llm: { provider: "openai-compatible", model: "deepseek-chat",
+ *            api_key: "sk-...", base_url: "https://api.deepseek.com",
+ *            temperature: 0.7 } }
+ */
+export type LlmConfig = {
+  /**
+   * API protocol type. Supported shorthands:
+   *   "openai-compatible"    → api: "openai-completions"
+   *   "anthropic-compatible" → api: "anthropic-messages"
+   * Any raw ModelApi value is also accepted directly.
+   */
+  provider: string;
+  /** Model ID, e.g. "deepseek-chat" or "claude-opus-4-6". */
+  model: string;
+  /** API key. Accepts plain string or SecretInput ref. */
+  api_key?: SecretInput;
+  /** Provider base URL, e.g. "https://api.deepseek.com". */
+  base_url?: string;
+  /**
+   * Inference temperature (0–2).
+   * Stored in agents.defaults.models[ref].params.temperature.
+   */
+  temperature?: number;
+  /**
+   * Custom provider key written to models.json.
+   * Defaults to "custom".
+   */
+  provider_id?: string;
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -21,7 +21,7 @@ import type {
   CommandsConfig,
   MessagesConfig,
 } from "./types.messages.js";
-import type { ModelsConfig } from "./types.models.js";
+import type { LlmConfig, ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
@@ -94,6 +94,8 @@ export type OpenClawConfig = {
   secrets?: SecretsConfig;
   skills?: SkillsConfig;
   plugins?: PluginsConfig;
+  /** Shorthand single-LLM config. Expanded into models.providers at runtime. */
+  llm?: LlmConfig;
   models?: ModelsConfig;
   nodeHost?: NodeHostConfig;
   agents?: AgentsConfig;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -260,6 +260,19 @@ export const ModelsConfigSchema = z
   .strict()
   .optional();
 
+/** Shorthand single-LLM config. Expanded into models.providers at runtime. */
+export const LlmConfigSchema = z
+  .object({
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    api_key: SecretInputSchema.optional().register(sensitive),
+    base_url: z.string().min(1).optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    provider_id: z.string().min(1).optional(),
+  })
+  .strict()
+  .optional();
+
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -6,6 +6,7 @@ import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zo
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
 import {
   HexColorSchema,
+  LlmConfigSchema,
   ModelsConfigSchema,
   SecretInputSchema,
   SecretsConfigSchema,
@@ -468,6 +469,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    llm: LlmConfigSchema,
     models: ModelsConfigSchema,
     nodeHost: NodeHostSchema,
     agents: AgentsSchema,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -372,7 +372,10 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    // Use the full provider/id ref as the option value so sessions.patch receives
+    // an unambiguous model ref and doesn't fall back to the session's default provider.
+    const value = provider ? `${provider}/${entry.id}` : entry.id;
+    addOption(value, provider ? `${entry.id} · ${provider}` : entry.id);
   }
 
   if (currentOverride) {


### PR DESCRIPTION
## Summary

- Adds a top-level `llm` shorthand key to `openclaw.json` so users can configure a custom model provider without manually editing `models.providers` + `agents.defaults`.
- Fixes the chat model picker sending a bare model ID (e.g. `deepseek-chat`) instead of the full `provider/model` ref, which caused sessions to resolve the model against the wrong default provider (e.g. `kimi/deepseek-chat`).

### Config example

```json
{
  "llm": {
    "provider": "openai-compatible",
    "model": "deepseek-chat",
    "api_key": "sk-xxx",
    "base_url": "https://api.deepseek.com/v1",
    "temperature": 0.7,
    "provider_id": "deepseek"
  }
}
```

This automatically expands into `models.providers` and sets `agents.defaults.model.primary` without overwriting existing config values.

## Changes

- `src/config/types.models.ts` — add `LlmConfig` type
- `src/config/zod-schema.core.ts` — add `LlmConfigSchema` with validation
- `src/config/types.openclaw.ts` — add `llm?: LlmConfig` field to `OpenClawConfig`
- `src/config/zod-schema.ts` — wire `LlmConfigSchema` into `OpenClawSchema`
- `src/config/defaults.ts` — add `applyLlmConfig()` pipeline step
- `src/config/io.ts` — call `applyLlmConfig` in all three config load paths
- `ui/src/ui/app-render.helpers.ts` — fix model picker to use `provider/id` as option value

## Test plan

- [ ] Add `llm` block to `openclaw.json`, restart gateway, verify `models.providers` is populated and agent uses the configured model
- [ ] Verify existing `models.providers` entries are not overwritten when `llm` is also set
- [ ] Open chat model picker, select a non-default provider model, verify no `model not allowed: wrongprovider/model` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)