### PR TITLE
feat: sync Claude Code CLI keychain credentials for Anthropic auth

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -168,7 +168,7 @@ Common property formats for database items:
 
 Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API. Three steps: create upload → send file → attach to block/page.
 
-> **Note:** File upload requires `Notion-Version: 2022-06-28` or later. Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
+> **Note:** Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
 
 **Step 1 — Create a file upload object:**
 
@@ -176,18 +176,18 @@ Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API
 curl -X POST "https://api.notion.com/v1/file_uploads" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{}'
 ```
 
-Save the returned `id` and `upload_url`.
+Save the returned `id`.
 
 **Step 2 — Upload the file binary:**
 
 ```bash
 curl -X POST "https://api.notion.com/v1/file_uploads/{file_upload_id}/send" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -F "file=@/path/to/file.pdf"
 ```
 
@@ -200,7 +200,7 @@ Status changes from `pending` → `uploaded`. Note: this endpoint expects `multi
 curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{
     "children": [{
       "type": "file",
@@ -219,7 +219,7 @@ Works with `file`, `image`, `video`, `audio`, and `pdf` block types. Also works 
 curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{
     "properties": {
       "Attachments": {
@@ -234,6 +234,7 @@ curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
 ```
 
 **Tips:**
+
 - Files must be attached within **1 hour** of creation or they expire
 - Upload once, attach many times — the same `file_upload` ID is reusable
 - After first attachment, the file becomes permanent (no more expiry)

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -164,6 +164,81 @@ Common property formats for database items:
 - **Parent in responses:** Pages show `parent.data_source_id` alongside `parent.database_id`
 - **Finding the data_source_id:** Search for the database, or call `GET /v1/data_sources/{data_source_id}`
 
+## File Uploads
+
+Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API. Three steps: create upload → send file → attach to block/page.
+
+> **Note:** File upload requires `Notion-Version: 2022-06-28` or later. Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
+
+**Step 1 — Create a file upload object:**
+
+```bash
+curl -X POST "https://api.notion.com/v1/file_uploads" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{}'
+```
+
+Save the returned `id` and `upload_url`.
+
+**Step 2 — Upload the file binary:**
+
+```bash
+curl -X POST "https://api.notion.com/v1/file_uploads/{file_upload_id}/send" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Notion-Version: 2022-06-28" \
+  -F "file=@/path/to/file.pdf"
+```
+
+Status changes from `pending` → `uploaded`. Note: this endpoint expects `multipart/form-data`, not JSON.
+
+**Step 3 — Attach to a page or block:**
+
+```bash
+# As a file block
+curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{
+    "children": [{
+      "type": "file",
+      "file": {
+        "type": "file_upload",
+        "file_upload": {"id": "file_upload_id"},
+        "name": "document.pdf"
+      }
+    }]
+  }'
+```
+
+Works with `file`, `image`, `video`, `audio`, and `pdf` block types. Also works with `files` properties on database pages:
+
+```bash
+curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{
+    "properties": {
+      "Attachments": {
+        "files": [{
+          "type": "file_upload",
+          "file_upload": {"id": "file_upload_id"},
+          "name": "receipt.pdf"
+        }]
+      }
+    }
+  }'
+```
+
+**Tips:**
+- Files must be attached within **1 hour** of creation or they expire
+- Upload once, attach many times — the same `file_upload` ID is reusable
+- After first attachment, the file becomes permanent (no more expiry)
+- Download URLs from Notion expire after 1 hour — re-fetch the block to refresh
+
 ## Notes
 
 - Page/database IDs are UUIDs (with or without dashes)

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,8 +1,10 @@
 import {
   readQwenCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
+  readClaudeCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
+  CLAUDE_CLI_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -37,7 +39,11 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (
+    cred.provider !== "anthropic" &&
+    cred.provider !== "qwen-portal" &&
+    cred.provider !== "minimax-portal"
+  ) {
     return false;
   }
   if (typeof cred.expires !== "number") {
@@ -82,13 +88,34 @@ function syncExternalCliCredentialsForProvider(
 }
 
 /**
- * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI) into the store.
+ * Sync OAuth credentials from external CLI tools (Claude Code CLI, Qwen Code CLI, MiniMax CLI)
+ * into the store.
  *
  * Returns true if any credentials were updated.
  */
 export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   let mutated = false;
   const now = Date.now();
+
+  // Sync from Claude Code CLI (keychain / credentials file)
+  if (
+    syncExternalCliCredentialsForProvider(
+      store,
+      CLAUDE_CLI_PROFILE_ID,
+      "anthropic",
+      () => {
+        const cred = readClaudeCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS });
+        // Only sync OAuth credentials (not static tokens — those aren't refreshable)
+        if (!cred || cred.type !== "oauth") {
+          return null;
+        }
+        return cred;
+      },
+      now,
+    )
+  ) {
+    mutated = true;
+  }
 
   // Sync from Qwen Code CLI
   const existingQwen = store.profiles[QWEN_CLI_PROFILE_ID];

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -4,7 +4,6 @@ import {
   formatRemainingShort,
 } from "../agents/auth-health.js";
 import {
-  CLAUDE_CLI_PROFILE_ID,
   CODEX_CLI_PROFILE_ID,
   ensureAuthProfileStore,
   repairOAuthProfileIdMismatch,
@@ -115,9 +114,7 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
 ): Promise<OpenClawConfig> {
   const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
   const deprecated = new Set<string>();
-  if (store.profiles[CLAUDE_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CLAUDE_CLI_PROFILE_ID]) {
-    deprecated.add(CLAUDE_CLI_PROFILE_ID);
-  }
+  // Claude CLI profile is no longer deprecated — it is actively synced from the keychain.
   if (store.profiles[CODEX_CLI_PROFILE_ID] || cfg.auth?.profiles?.[CODEX_CLI_PROFILE_ID]) {
     deprecated.add(CODEX_CLI_PROFILE_ID);
   }
@@ -127,11 +124,6 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
   }
 
   const lines = ["Deprecated external CLI auth profiles detected (no longer supported):"];
-  if (deprecated.has(CLAUDE_CLI_PROFILE_ID)) {
-    lines.push(
-      `- ${CLAUDE_CLI_PROFILE_ID} (Anthropic): use setup-token → ${formatCliCommand("openclaw models auth setup-token")}`,
-    );
-  }
   if (deprecated.has(CODEX_CLI_PROFILE_ID)) {
     lines.push(
       `- ${CODEX_CLI_PROFILE_ID} (OpenAI Codex): use OAuth → ${formatCliCommand(
@@ -207,11 +199,6 @@ type AuthIssue = {
 };
 
 function formatAuthIssueHint(issue: AuthIssue): string | null {
-  if (issue.provider === "anthropic" && issue.profileId === CLAUDE_CLI_PROFILE_ID) {
-    return `Deprecated profile. Use ${formatCliCommand("openclaw models auth setup-token")} or ${formatCliCommand(
-      "openclaw configure",
-    )}.`;
-  }
   if (issue.provider === "openai-codex" && issue.profileId === CODEX_CLI_PROFILE_ID) {
     return `Deprecated profile. Use ${formatCliCommand(
       "openclaw models auth login --provider openai-codex",


### PR DESCRIPTION
## Summary

- Add Claude CLI OAuth credential syncing to `syncExternalCliCredentials()`, matching the existing Qwen/MiniMax pattern
- Reads tokens from the macOS keychain via `readClaudeCliCredentialsCached()` and stores them as the `anthropic:claude-cli` profile
- Remove Claude CLI from deprecated profiles in doctor-auth since it is now actively synced and supported

## Details

OpenClaw already had `readClaudeCliKeychainCredentials()` and the `CLAUDE_CLI_PROFILE_ID` constant, but `syncExternalCliCredentials()` only synced Qwen and MiniMax. This PR wires up the Claude CLI sync using the same `syncExternalCliCredentialsForProvider()` helper.

The pi-ai library already detects OAuth tokens (`sk-ant-oat*`) and handles Bearer auth + token refresh, so no downstream changes are needed.

Auth resolution order becomes: `anthropic:claude-cli` (OAuth, auto-refreshing) → `anthropic:manual` (setup-token) → `anthropic:default` (API key).