### PR TITLE
CI: run config docs drift check on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,11 @@ jobs:
         continue-on-error: true
         run: pnpm test:gateway:watch-regression
 
+      - name: Check config docs drift statefile
+        id: config_docs_drift
+        continue-on-error: true
+        run: pnpm config:docs:check
+
       - name: Upload gateway watch regression artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -376,6 +381,7 @@ jobs:
           EXTENSION_PLUGIN_SDK_INTERNAL_BOUNDARY_OUTCOME: ${{ steps.extension_plugin_sdk_internal_boundary.outcome }}
           NO_RAW_WINDOW_OPEN_OUTCOME: ${{ steps.no_raw_window_open.outcome }}
           GATEWAY_WATCH_REGRESSION_OUTCOME: ${{ steps.gateway_watch_regression.outcome }}
+          CONFIG_DOCS_DRIFT_OUTCOME: ${{ steps.config_docs_drift.outcome }}
         run: |
           failures=0
           for result in \
@@ -384,7 +390,8 @@ jobs:
             "extension-src-outside-plugin-sdk-boundary|$EXTENSION_SRC_OUTSIDE_PLUGIN_SDK_BOUNDARY_OUTCOME" \
             "extension-plugin-sdk-internal-boundary|$EXTENSION_PLUGIN_SDK_INTERNAL_BOUNDARY_OUTCOME" \
             "lint:ui:no-raw-window-open|$NO_RAW_WINDOW_OPEN_OUTCOME" \
-            "gateway-watch-regression|$GATEWAY_WATCH_REGRESSION_OUTCOME"; do
+            "gateway-watch-regression|$GATEWAY_WATCH_REGRESSION_OUTCOME" \
+            "config-docs-drift|$CONFIG_DOCS_DRIFT_OUTCOME"; do
             name="${result%%|*}"
             outcome="${result#*|}"
             if [ "$outcome" != "success" ]; then


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: PR CI skipped both `release-check` and the separate config docs drift workflow, so config baseline drift could merge unnoticed.
- Why it matters: schema or metadata changes can break `pnpm release:check` later on `main` even when the PR looked green.
- What changed: I added `pnpm config:docs:check` to the existing `check-additional` PR lane and wired it into the aggregated failure step.
- What did NOT change (scope boundary): I did not move full `pnpm release:check` into PR CI or change packaging/release gates.

## Change Type (select all)

- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51161

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm in the repo worktree
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions CI workflow YAML
- Relevant config (redacted): N/A

### Steps

1. Reproduced the current `pnpm release:check` failure locally and confirmed it was caused by `pnpm config:docs:check`.
2. Inspected the PR CI and workflow-sanity workflow definitions plus the historical PR run for #51161.
3. Added `pnpm config:docs:check` to `check-additional` and included it in the final failure aggregation.

### Expected

- PR CI fails when config docs baseline drift is introduced.

### Actual

- PR CI previously skipped that drift check, so the offending PR merged green.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [x] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified the workflow diff, confirmed the new step is part of `check-additional`, and ran `scripts/committer`, which completed successfully and ran the repo check gate before committing.
- Edge cases checked: I confirmed the step is included in the aggregated failure summary so a drift failure cannot be silently ignored.
- What you did **not** verify: I did not wait for a live GitHub Actions PR run from this branch yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit to remove the added `config:docs:check` step from `check-additional`.
- Files/config to restore: `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for: unexpected PR failures in `check-additional` caused by legitimate config baseline changes that need regenerated baseline files.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: PRs that intentionally change config surfaces will now fail until the generated baseline files are refreshed.
  - Mitigation: the failure message already tells contributors to run `pnpm config:docs:gen` and commit the updated baseline files.
