### PR TITLE
fix(agents): forward spawned workspace to child agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/probe: honor caller `--timeout` for active local loopback probes in `gateway status`, keep inactive remote-mode loopback probes fast, and clamp probe timers to JS-safe bounds so slow local/container gateways stop reporting false timeouts. (#47533) Thanks @MonkeyLeeT.
 - Config/startup: keep bundled web-search allowlist compatibility on a lightweight manifest path so config validation no longer pulls bundled web-search registry imports into startup, while still avoiding accidental auto-allow of config-loaded override plugins. (#51574) Thanks @RichardCao.
 - Gateway/chat.send: persist uploaded image references across reloads and compaction without delaying first-turn dispatch or double-submitting the same image to vision models. (#51324) Thanks @fuller-stack-dev.
+- Subagents/sessions_spawn: forward resolved spawned workspaces into the immediate child `agent` run so same-agent spawns keep inherited workspaces and cross-agent runs stay aligned with the workspace already resolved for the child session.
 
 ### Breaking
 

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -649,11 +649,9 @@ export async function spawnSubagentDirect(
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
   try {
-    const {
-      spawnedBy: _spawnedBy,
-      workspaceDir: _workspaceDir,
-      ...publicSpawnedMetadata
-    } = spawnedMetadata;
+    // Keep the resolved workspace override on the immediate child run so same-agent
+    // spawns preserve inherited workspaces instead of falling back to the agent default.
+    const { spawnedBy: _spawnedBy, ...publicSpawnedMetadata } = spawnedMetadata;
     const response = await callGateway<{ runId: string }>({
       method: "agent",
       params: {

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -110,6 +110,12 @@ function getRegisteredRun() {
     | undefined;
 }
 
+function getAgentCallParams() {
+  return hoisted.callGatewayMock.mock.calls
+    .map((call) => call[0] as { method?: string; params?: Record<string, unknown> })
+    .find((entry) => entry.method === "agent")?.params;
+}
+
 async function expectAcceptedWorkspace(params: { agentId: string; expectedWorkspaceDir: string }) {
   const result = await spawnSubagentDirect(
     {
@@ -127,6 +133,9 @@ async function expectAcceptedWorkspace(params: { agentId: string; expectedWorksp
 
   expect(result.status).toBe("accepted");
   expect(getRegisteredRun()).toMatchObject({
+    workspaceDir: params.expectedWorkspaceDir,
+  });
+  expect(getAgentCallParams()).toMatchObject({
     workspaceDir: params.expectedWorkspaceDir,
   });
 }


### PR DESCRIPTION
## Summary

- Problem: `spawnSubagentDirect()` resolves and records a spawned `workspaceDir`, but strips that field before the immediate child `agent` call.
- Why it matters: same-agent `sessions_spawn` runs can fall back to the agent default workspace instead of the requester's inherited workspace, and the initial child run can diverge from the workspace already resolved for the child session.
- What changed: forward the resolved `workspaceDir` into the child `agent` call and add regression coverage that inspects the actual `agent` ingress params for both cross-agent and same-agent spawns.
- What did NOT change: no new bootstrap-file loading rules, no anonymous-spawn context broadening, and no changes to target-agent workspace resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #46595
- Related #50263

## User-visible / Behavior Changes

- Same-agent `sessions_spawn` runs keep an inherited workspace override on the initial child run instead of immediately falling back to the agent default workspace.
- Cross-agent child runs now receive the same resolved workspace at ingress that the spawn path already records for the child session.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: minimal shallow checkout, no local dependencies installed
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): subagent spawn path with inherited `workspaceDir`

### Steps

1. Trace `sessions_spawn -> spawnSubagentDirect -> callGateway({ method: agent }) -> prepareAgentCommandExecution` on current `main`.
2. Observe that `spawnSubagentDirect()` resolves `spawnedMetadata.workspaceDir` and patches it into child-session metadata, but strips `workspaceDir` before the immediate `agent` call.
3. Apply this change and add assertions against the actual `agent` ingress params in `subagent-spawn.workspace.test.ts`.

### Expected

- The child `agent` run receives the same resolved `workspaceDir` that the spawn path already chose for the child session.

### Actual

- Before this patch, the immediate child `agent` call omits `workspaceDir` entirely.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: code-path review of the spawn -> agent ingress handoff, plus targeted regression assertions on the actual `agent` params built by `spawnSubagentDirect()`.
- Edge cases checked: same-agent inherited workspace and cross-agent resolved workspace both stay on the child `agent` call.
- What you did **not** verify: I did not run Vitest/build locally because this minimal checkout has no `node_modules`, and I intentionally avoided installing dependencies to keep disk/download use low.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `workspaceDir` omission change in `src/agents/subagent-spawn.ts`
- Files/config to restore: `src/agents/subagent-spawn.ts`, `src/agents/subagent-spawn.workspace.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: none expected beyond the child `agent` run falling back to agent-default workspace again if reverted

## Risks and Mitigations

- Risk: this is a narrow handoff fix and does not attempt to solve every other subagent bootstrap/context issue.
  - Mitigation: keep the change limited to the already-resolved workspace metadata and add a focused regression test at the `agent` ingress boundary.