### PR TITLE
msteams: extract structured quote/reply context

### DIFF
--- a/extensions/msteams/src/inbound.test.ts
+++ b/extensions/msteams/src/inbound.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  decodeHtmlEntities,
+  extractMSTeamsQuoteInfo,
+  htmlToPlainText,
   normalizeMSTeamsConversationId,
   parseMSTeamsActivityTimestamp,
   stripMSTeamsMentionTags,
@@ -61,6 +64,125 @@ describe("msteams inbound", () => {
           entities: [{ type: "mention", mentioned: { id: "other" } }],
         }),
       ).toBe(false);
+    });
+  });
+
+  describe("decodeHtmlEntities", () => {
+    it("decodes common entities", () => {
+      expect(decodeHtmlEntities("&amp;&lt;&gt;&quot;&#39;&#x27;&nbsp;")).toBe("&<>\"'' ");
+    });
+
+    it("leaves plain text unchanged", () => {
+      expect(decodeHtmlEntities("hello world")).toBe("hello world");
+    });
+  });
+
+  describe("htmlToPlainText", () => {
+    it("strips tags and decodes entities", () => {
+      expect(htmlToPlainText("<strong>Hello &amp; world</strong>")).toBe("Hello & world");
+    });
+
+    it("collapses whitespace from tag removal", () => {
+      expect(htmlToPlainText("<p>foo</p><p>bar</p>")).toBe("foo bar");
+    });
+
+    it("trims leading and trailing whitespace", () => {
+      expect(htmlToPlainText("  <span>hi</span>  ")).toBe("hi");
+    });
+  });
+
+  describe("extractMSTeamsQuoteInfo", () => {
+    const replyAttachment = (overrides?: { content?: string; contentType?: string }) => ({
+      contentType: overrides?.contentType ?? "text/html",
+      content:
+        overrides?.content ??
+        '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+          '<strong itemprop="mri">Alice</strong>' +
+          '<p itemprop="copy">Hello world</p>' +
+          "</blockquote>",
+    });
+
+    it("extracts sender and body from a Teams reply attachment", () => {
+      const result = extractMSTeamsQuoteInfo([replyAttachment()]);
+      expect(result).toEqual({ sender: "Alice", body: "Hello world" });
+    });
+
+    it("returns undefined for empty attachments array", () => {
+      expect(extractMSTeamsQuoteInfo([])).toBeUndefined();
+    });
+
+    it("returns undefined when no reply blockquote is present", () => {
+      expect(
+        extractMSTeamsQuoteInfo([{ contentType: "text/html", content: "<p>just a message</p>" }]),
+      ).toBeUndefined();
+    });
+
+    it("uses 'unknown' as sender when sender element is absent", () => {
+      const result = extractMSTeamsQuoteInfo([
+        {
+          contentType: "text/html",
+          content:
+            '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+            '<p itemprop="copy">quoted text</p>' +
+            "</blockquote>",
+        },
+      ]);
+      expect(result).toEqual({ sender: "unknown", body: "quoted text" });
+    });
+
+    it("returns undefined when body element is absent", () => {
+      const result = extractMSTeamsQuoteInfo([
+        {
+          contentType: "text/html",
+          content:
+            '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+            '<strong itemprop="mri">Alice</strong>' +
+            "</blockquote>",
+        },
+      ]);
+      expect(result).toBeUndefined();
+    });
+
+    it("decodes HTML entities in body text", () => {
+      const result = extractMSTeamsQuoteInfo([
+        {
+          contentType: "text/html",
+          content:
+            '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+            '<strong itemprop="mri">Bob</strong>' +
+            '<p itemprop="copy">2 &lt; 3 &amp; 4 &gt; 1</p>' +
+            "</blockquote>",
+        },
+      ]);
+      expect(result).toEqual({ sender: "Bob", body: "2 < 3 & 4 > 1" });
+    });
+
+    it("handles multiline body by collapsing whitespace", () => {
+      const result = extractMSTeamsQuoteInfo([
+        {
+          contentType: "text/html",
+          content:
+            '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+            '<strong itemprop="mri">Carol</strong>' +
+            '<p itemprop="copy">line one\nline two</p>' +
+            "</blockquote>",
+        },
+      ]);
+      expect(result?.body).toBe("line one line two");
+    });
+
+    it("skips non-string content values", () => {
+      expect(
+        extractMSTeamsQuoteInfo([{ contentType: "application/json", content: { foo: "bar" } }]),
+      ).toBeUndefined();
+    });
+
+    it("finds quote in second attachment when first has no quote", () => {
+      const result = extractMSTeamsQuoteInfo([
+        { contentType: "text/plain", content: "plain text" },
+        replyAttachment(),
+      ]);
+      expect(result).toEqual({ sender: "Alice", body: "Hello world" });
     });
   });
 });

--- a/extensions/msteams/src/inbound.test.ts
+++ b/extensions/msteams/src/inbound.test.ts
@@ -75,6 +75,12 @@ describe("msteams inbound", () => {
     it("leaves plain text unchanged", () => {
       expect(decodeHtmlEntities("hello world")).toBe("hello world");
     });
+
+    it("prevents double-decoding: &amp;lt; should become &lt; not <", () => {
+      // If &amp; were decoded first, &amp;lt; → &lt; → < (wrong).
+      // With &amp; decoded last, &amp;lt; stays as &lt; (correct).
+      expect(decodeHtmlEntities("&amp;lt;b&amp;gt;")).toBe("&lt;b&gt;");
+    });
   });
 
   describe("htmlToPlainText", () => {
@@ -175,6 +181,30 @@ describe("msteams inbound", () => {
       expect(
         extractMSTeamsQuoteInfo([{ contentType: "application/json", content: { foo: "bar" } }]),
       ).toBeUndefined();
+    });
+
+    it("handles object content with .text property containing the reply HTML", () => {
+      const htmlContent =
+        '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+        '<strong itemprop="mri">Dave</strong>' +
+        '<p itemprop="copy">hello from object</p>' +
+        "</blockquote>";
+      const result = extractMSTeamsQuoteInfo([
+        { contentType: "text/html", content: { text: htmlContent } },
+      ]);
+      expect(result).toEqual({ sender: "Dave", body: "hello from object" });
+    });
+
+    it("handles object content with .body property containing the reply HTML", () => {
+      const htmlContent =
+        '<blockquote itemtype="http://schema.skype.com/Reply" itemscope>' +
+        '<strong itemprop="mri">Eve</strong>' +
+        '<p itemprop="copy">hello from body field</p>' +
+        "</blockquote>";
+      const result = extractMSTeamsQuoteInfo([
+        { contentType: "text/html", content: { body: htmlContent } },
+      ]);
+      expect(result).toEqual({ sender: "Eve", body: "hello from body field" });
     });
 
     it("finds quote in second attachment when first has no quote", () => {

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -1,3 +1,63 @@
+export type MSTeamsQuoteInfo = {
+  sender: string;
+  body: string;
+};
+
+/**
+ * Decode common HTML entities to plain text.
+ */
+export function decodeHtmlEntities(html: string): string {
+  return html
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+/**
+ * Strip HTML tags, preserving text content.
+ */
+export function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<[^>]*>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
+}
+
+/**
+ * Extract quote info from MS Teams HTML reply attachments.
+ * Teams wraps quoted content in a blockquote with itemtype="http://schema.skype.com/Reply".
+ */
+export function extractMSTeamsQuoteInfo(
+  attachments: Array<{ contentType?: string | null; content?: unknown }>,
+): MSTeamsQuoteInfo | undefined {
+  for (const att of attachments) {
+    const content = typeof att.content === "string" ? att.content : "";
+    if (!content) continue;
+
+    // Look for the Skype Reply schema blockquote.
+    if (!content.includes("http://schema.skype.com/Reply")) continue;
+
+    // Extract sender from <strong itemprop="mri">.
+    const senderMatch = /<strong[^>]*itemprop=["']mri["'][^>]*>(.*?)<\/strong>/i.exec(content);
+    const sender = senderMatch?.[1] ? htmlToPlainText(senderMatch[1]) : undefined;
+
+    // Extract body from <p itemprop="copy">.
+    const bodyMatch = /<p[^>]*itemprop=["']copy["'][^>]*>(.*?)<\/p>/is.exec(content);
+    const body = bodyMatch?.[1] ? htmlToPlainText(bodyMatch[1]) : undefined;
+
+    if (body) {
+      return { sender: sender ?? "unknown", body };
+    }
+  }
+  return undefined;
+}
+
 export type MentionableActivity = {
   recipient?: { id?: string } | null;
   entities?: Array<{

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -8,13 +8,13 @@ export type MSTeamsQuoteInfo = {
  */
 export function decodeHtmlEntities(html: string): string {
   return html
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&#x27;/g, "'")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&"); // must be last to prevent double-decoding (e.g. &amp;lt; → &lt; not <)
 }
 
 /**
@@ -37,7 +37,17 @@ export function extractMSTeamsQuoteInfo(
   attachments: Array<{ contentType?: string | null; content?: unknown }>,
 ): MSTeamsQuoteInfo | undefined {
   for (const att of attachments) {
-    const content = typeof att.content === "string" ? att.content : "";
+    // Content may be a plain string or an object with .text/.body (e.g. Adaptive Card payloads).
+    const content =
+      typeof att.content === "string"
+        ? att.content
+        : typeof att.content === "object" && att.content !== null
+          ? String(
+              (att.content as Record<string, unknown>).text ??
+                (att.content as Record<string, unknown>).body ??
+                "",
+            )
+          : "";
     if (!content) continue;
 
     // Look for the Skype Reply schema blockquote.

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -30,6 +30,7 @@ import type { StoredConversationReference } from "../conversation-store.js";
 import { formatUnknownError } from "../errors.js";
 import {
   extractMSTeamsConversationMessageId,
+  extractMSTeamsQuoteInfo,
   normalizeMSTeamsConversationId,
   parseMSTeamsActivityTimestamp,
   stripMSTeamsMentionTags,
@@ -103,6 +104,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     const attachments = params.attachments;
     const attachmentPlaceholder = buildMSTeamsAttachmentPlaceholder(attachments);
     const rawBody = text || attachmentPlaceholder;
+    const quoteInfo = extractMSTeamsQuoteInfo(attachments);
     const from = activity.from;
     const conversation = activity.conversation;
 
@@ -533,6 +535,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "msteams" as const,
       OriginatingTo: teamsTo,
+      ReplyToId: activity.replyToId ?? undefined,
+      ReplyToBody: quoteInfo?.body,
+      ReplyToSender: quoteInfo?.sender,
+      ReplyToIsQuote: quoteInfo ? true : undefined,
       ...mediaPayload,
     });
 


### PR DESCRIPTION
## What

Extract quoted message content from Teams HTML reply attachments and provide it as structured context to the agent, matching the pattern used by Telegram, Discord, iMessage, and WhatsApp.

**Quote extraction (`inbound.ts`):**
- `extractMSTeamsQuoteInfo()` — searches HTML attachments for `<blockquote itemtype="http://schema.skype.com/Reply">`
- Parses `<strong itemprop="mri">` for sender name, `<p itemprop="copy">` for body
- `htmlToPlainText()` and `decodeHtmlEntities()` helpers

**Integration (`message-handler.ts`):**
- Calls `extractMSTeamsQuoteInfo()` early in processing
- Populates `ReplyToId`, `ReplyToBody`, `ReplyToSender`, `ReplyToIsQuote` in inbound context payload
- The framework's `buildInboundUserContextPrefix()` automatically renders this as "Replied message" context for the agent

## Why

When users reply to messages in Teams, the agent previously had no visibility into what was being replied to. This brings parity with other channels where reply context is extracted and provided to the agent for better conversational understanding.

## Test plan

- [x] `pnpm test -- extensions/msteams` — 27 files, 252 tests passing
- [x] `pnpm format:fix` — clean
- [x] `pnpm check` — all lint/type checks pass
- [x] New tests in `inbound.test.ts`: quote extraction (standard, missing sender, missing body, HTML entities, multiline, multiple attachments, non-string content)
- [x] New tests for `decodeHtmlEntities` and `htmlToPlainText` helpers

## Notes

- Reference community PR: #44739

> This PR was authored with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)