### PR TITLE
[codex] fix telegram session reset followups

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -316,6 +316,95 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
   });
 });
 
+describe("runReplyAgent session supersession", () => {
+  it("drops output when a run is overtaken by a newer session", async () => {
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-old",
+      sessionFile: "/tmp/session-old.jsonl",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: sessionEntry,
+    };
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+      MessageSid: "msg",
+      Surface: "telegram",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session-old",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session-old.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude-opus",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 5_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      sessionStore[sessionKey] = {
+        ...sessionStore[sessionKey],
+        sessionId: "session-new",
+        sessionFile: "/tmp/session-new.jsonl",
+        updatedAt: Date.now(),
+      };
+      return {
+        payloads: [{ text: "stale duplicate" }],
+        meta: {},
+      };
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
 describe("runReplyAgent auto-compaction token update", () => {
   type EmbeddedRunParams = {
     prompt?: string;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -134,7 +134,7 @@ export async function runReplyAgent(params: {
       return;
     }
     followupRun.run.sessionId = latestSessionId;
-    const latestSessionFile = latestEntry.sessionFile?.trim();
+    const latestSessionFile = latestEntry?.sessionFile?.trim();
     if (latestSessionFile) {
       followupRun.run.sessionFile = latestSessionFile;
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -15,6 +15,7 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import { logVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
@@ -121,6 +122,30 @@ export async function runReplyAgent(params: {
   let activeSessionEntry = sessionEntry;
   const activeSessionStore = sessionStore;
   let activeIsNewSession = isNewSession;
+  const resolveCurrentSessionEntry = () =>
+    (sessionKey ? activeSessionStore?.[sessionKey] : undefined) ?? activeSessionEntry;
+  const rebindFollowupRunToCurrentSession = () => {
+    const latestEntry = resolveCurrentSessionEntry();
+    const latestSessionId = latestEntry?.sessionId?.trim();
+    if (latestEntry) {
+      activeSessionEntry = latestEntry;
+    }
+    if (!latestSessionId || latestSessionId === followupRun.run.sessionId) {
+      return;
+    }
+    followupRun.run.sessionId = latestSessionId;
+    const latestSessionFile = latestEntry.sessionFile?.trim();
+    if (latestSessionFile) {
+      followupRun.run.sessionFile = latestSessionFile;
+    }
+    logVerbose(`reply runner: rebound ${sessionKey ?? queueKey} to session ${latestSessionId}`);
+  };
+  const isFollowupRunSuperseded = () => {
+    const latestSessionId = resolveCurrentSessionEntry()?.sessionId?.trim();
+    const runSessionId = followupRun.run.sessionId?.trim();
+    return Boolean(latestSessionId && runSessionId && latestSessionId !== runSessionId);
+  };
+  rebindFollowupRunToCurrentSession();
 
   const isHeartbeat = opts?.isHeartbeat === true;
   const typingSignals = createTypingSignaler({
@@ -374,6 +399,11 @@ export async function runReplyAgent(params: {
       storePath,
       resolvedVerboseLevel,
     });
+
+    if (isFollowupRunSuperseded()) {
+      logVerbose(`reply runner: dropping superseded reply for ${sessionKey ?? queueKey}`);
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    }
 
     if (runOutcome.kind === "final") {
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -42,6 +42,7 @@ const ROUTABLE_TEST_CHANNELS = new Set([
 ]);
 
 beforeEach(() => {
+  runEmbeddedPiAgentMock.mockReset();
   routeReplyMock.mockReset();
   routeReplyMock.mockResolvedValue({ ok: true });
   isRoutableChannelMock.mockReset();
@@ -230,6 +231,100 @@ describe("createFollowupRunner compaction", () => {
     const firstCall = (onBlockReply.mock.calls as unknown as Array<Array<{ text?: string }>>)[0];
     expect(firstCall?.[0]?.text).toBe("final");
     expect(sessionStore.main.compactionCount).toBeUndefined();
+  });
+});
+
+describe("createFollowupRunner session resets", () => {
+  it("rebinds queued followups to the latest session after a reset", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "session-new",
+        sessionFile: "/tmp/session-new.jsonl",
+        updatedAt: Date.now(),
+      },
+    };
+    const onBlockReply = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry: {
+        sessionId: "session-old",
+        sessionFile: "/tmp/session-old.jsonl",
+        updatedAt: Date.now(),
+      },
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          sessionId: "session-old",
+          sessionFile: "/tmp/session-old.jsonl",
+        },
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as {
+      sessionId?: string;
+      sessionFile?: string;
+    };
+    expect(call.sessionId).toBe("session-new");
+    expect(call.sessionFile).toBe("/tmp/session-new.jsonl");
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops followup output when the run is superseded by a newer session", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "session-old",
+        sessionFile: "/tmp/session-old.jsonl",
+        updatedAt: Date.now(),
+      },
+    };
+    const onBlockReply = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      sessionStore.main = {
+        sessionId: "session-new",
+        sessionFile: "/tmp/session-new.jsonl",
+        updatedAt: Date.now(),
+      };
+      return {
+        payloads: [{ text: "stale reply" }],
+        meta: {},
+      };
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          sessionId: "session-old",
+          sessionFile: "/tmp/session-old.jsonl",
+        },
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).not.toHaveBeenCalled();
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -143,7 +143,7 @@ export function createFollowupRunner(params: {
           return latestEntry;
         }
         queued.run.sessionId = latestSessionId;
-        const latestSessionFile = latestEntry.sessionFile?.trim();
+        const latestSessionFile = latestEntry?.sessionFile?.trim();
         if (latestSessionFile) {
           queued.run.sessionFile = latestSessionFile;
         }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -134,6 +134,32 @@ export function createFollowupRunner(params: {
 
   return async (queued: FollowupRun) => {
     try {
+      const resolveLatestSessionEntry = () =>
+        (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
+      const rebindQueuedRunToCurrentSession = () => {
+        const latestEntry = resolveLatestSessionEntry();
+        const latestSessionId = latestEntry?.sessionId?.trim();
+        if (!latestSessionId || latestSessionId === queued.run.sessionId) {
+          return latestEntry;
+        }
+        queued.run.sessionId = latestSessionId;
+        const latestSessionFile = latestEntry.sessionFile?.trim();
+        if (latestSessionFile) {
+          queued.run.sessionFile = latestSessionFile;
+        }
+        logVerbose(
+          `followup queue: rebound ${sessionKey ?? queued.run.sessionId} to session ${latestSessionId}`,
+        );
+        return latestEntry;
+      };
+      const isQueuedRunSuperseded = () => {
+        const latestEntry = resolveLatestSessionEntry();
+        const latestSessionId = latestEntry?.sessionId?.trim();
+        const runSessionId = queued.run.sessionId?.trim();
+        return Boolean(latestSessionId && runSessionId && latestSessionId !== runSessionId);
+      };
+
+      let activeSessionEntry = rebindQueuedRunToCurrentSession();
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
         resolveOriginMessageProvider({
@@ -152,8 +178,6 @@ export function createFollowupRunner(params: {
       let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
-      const activeSessionEntry =
-        (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
@@ -264,8 +288,15 @@ export function createFollowupRunner(params: {
       const contextTokensUsed =
         agentCfgContextTokens ??
         lookupContextTokens(modelUsed) ??
-        sessionEntry?.contextTokens ??
+        activeSessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;
+
+      if (isQueuedRunSuperseded()) {
+        logVerbose(
+          `followup queue: dropping superseded reply for ${sessionKey ?? queued.run.sessionId}`,
+        );
+        return;
+      }
 
       if (storePath && sessionKey) {
         await persistRunSessionUsage({

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -1,6 +1,6 @@
 export { extractQueueDirective } from "./queue/directive.js";
 export { clearSessionQueues } from "./queue/cleanup.js";
-export type { ClearSessionQueueResult } from "./queue/cleanup.js";
+export type { ClearSessionQueueResult, ClearSessionQueuesOptions } from "./queue/cleanup.js";
 export { scheduleFollowupDrain } from "./queue/drain.js";
 export {
   enqueueFollowupRun,

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -3,13 +3,25 @@ import { clearCommandLane } from "../../../process/command-queue.js";
 import { clearFollowupDrainCallback } from "./drain.js";
 import { clearFollowupQueue } from "./state.js";
 
+export type ClearSessionQueuesOptions = {
+  clearFollowups?: boolean;
+  clearDrainCallbacks?: boolean;
+  clearLanes?: boolean;
+};
+
 export type ClearSessionQueueResult = {
   followupCleared: number;
   laneCleared: number;
   keys: string[];
 };
 
-export function clearSessionQueues(keys: Array<string | undefined>): ClearSessionQueueResult {
+export function clearSessionQueues(
+  keys: Array<string | undefined>,
+  options?: ClearSessionQueuesOptions,
+): ClearSessionQueueResult {
+  const clearFollowups = options?.clearFollowups ?? true;
+  const clearDrainCallbacks = options?.clearDrainCallbacks ?? true;
+  const clearLanes = options?.clearLanes ?? true;
   const seen = new Set<string>();
   let followupCleared = 0;
   let laneCleared = 0;
@@ -22,9 +34,15 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     }
     seen.add(cleaned);
     clearedKeys.push(cleaned);
-    followupCleared += clearFollowupQueue(cleaned);
-    clearFollowupDrainCallback(cleaned);
-    laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
+    if (clearFollowups) {
+      followupCleared += clearFollowupQueue(cleaned);
+    }
+    if (clearDrainCallbacks) {
+      clearFollowupDrainCallback(cleaned);
+    }
+    if (clearLanes) {
+      laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
+    }
   }
 
   return { followupCleared, laneCleared, keys: clearedKeys };

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1358,6 +1358,16 @@ describe("gateway server sessions", () => {
       ["main", "agent:main:main", "sess-main"],
       "sess-main",
     );
+    const clearOptions = (
+      sessionCleanupMocks.clearSessionQueues.mock.calls as unknown as Array<[string[], unknown]>
+    )[0]?.[1] as
+      | { clearFollowups?: boolean; clearDrainCallbacks?: boolean; clearLanes?: boolean }
+      | undefined;
+    expect(clearOptions).toMatchObject({
+      clearFollowups: false,
+      clearDrainCallbacks: false,
+      clearLanes: true,
+    });
     expect(waitCallCountAtSnapshotClear).toEqual([1]);
     expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).toHaveBeenCalledTimes(1);
     expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).toHaveBeenCalledWith({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -111,6 +111,7 @@ async function ensureSessionRuntimeCleanup(params: {
   key: string;
   target: ReturnType<typeof resolveGatewaySessionStoreTarget>;
   sessionId?: string;
+  reason: "session-reset" | "session-delete";
 }) {
   const closeTrackedBrowserTabs = async () => {
     const closeKeys = new Set<string>([
@@ -130,7 +131,16 @@ async function ensureSessionRuntimeCleanup(params: {
   if (params.sessionId) {
     queueKeys.add(params.sessionId);
   }
-  clearSessionQueues([...queueKeys]);
+  clearSessionQueues(
+    [...queueKeys],
+    params.reason === "session-reset"
+      ? {
+          clearFollowups: false,
+          clearDrainCallbacks: false,
+          clearLanes: true,
+        }
+      : undefined,
+  );
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     clearBootstrapSnapshot(params.target.canonicalKey);
@@ -238,6 +248,7 @@ export async function cleanupSessionBeforeMutation(params: {
     key: params.key,
     target: params.target,
     sessionId: params.entry?.sessionId,
+    reason: params.reason,
   });
   if (cleanupError) {
     return cleanupError;


### PR DESCRIPTION
This fixes a Telegram reply loss and stale duplicate reply regression that appears when a session is reset while queued or in-flight reply work still exists.

In the failure case, a context overflow or compaction-triggered `session-reset` could happen while an older Telegram reply was still running and while newer follow-up user messages were already queued. The reset cleanup path cleared the session queues too aggressively, which dropped queued follow-up work entirely. That is why a newer Telegram message could receive no reply after the reset.

At the same time, queued and in-flight runs could remain bound to the old `sessionId`, and there was no supersession guard before emitting the final reply. If a replacement session had already been created, the stale run could still finish later and send output anyway. That is why the user-visible symptom could be a delayed duplicate reply to an older message.

This change fixes both sides of that failure mode. Session reset cleanup now preserves follow-up queues and drain callbacks instead of wiping the entire reply queue state. Follow-up execution now rebinds queued work to the latest session after a reset, and both follow-up and main reply runners refuse to emit output once their session has been superseded.

The result is that queued user messages survive session resets, and stale work from an older session can no longer leak a late duplicate reply into Telegram.

Validation:
- `pnpm vitest run --config vitest.config.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`

Note that the separately updated `integration/live` branch also includes a live-only merge repair needed after bringing that branch forward to current `origin/main`. That repair is intentionally not part of this upstream PR.
