### PR TITLE
fix(heartbeat): force execution after 5min queue contention timeout

### DIFF
--- a/src/infra/heartbeat-runner.force-timeout.test.ts
+++ b/src/infra/heartbeat-runner.force-timeout.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  setHeartbeatsEnabled,
+  startHeartbeatRunner,
+} from "./heartbeat-runner.js";
+import { resetHeartbeatWakeStateForTests } from "./heartbeat-wake.js";
+
+const HEARTBEAT_INTERVAL_MS = 30 * 60_000;
+const HEARTBEAT_FORCE_TIMEOUT_MS = 5 * 60_000;
+const FORCE_TIMEOUT_BUFFER_MS = 61_000;
+const PRE_TIMEOUT_MS = HEARTBEAT_FORCE_TIMEOUT_MS - FORCE_TIMEOUT_BUFFER_MS;
+const RETRY_MS = 1_000;
+
+describe("startHeartbeatRunner force timeout", () => {
+  type RunOnce = Parameters<typeof startHeartbeatRunner>[0]["runOnce"];
+
+  function useFakeHeartbeatTime() {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+  }
+
+  function heartbeatConfig(): OpenClawConfig {
+    return {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+      },
+    } as OpenClawConfig;
+  }
+
+  async function advanceToFirstInterval() {
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + RETRY_MS);
+  }
+
+  async function advanceRetries(ms: number) {
+    for (let elapsed = 0; elapsed < ms; elapsed += RETRY_MS) {
+      await vi.advanceTimersByTimeAsync(RETRY_MS);
+    }
+  }
+
+  function forcedCalls(runSpy: Mock<NonNullable<RunOnce>>) {
+    return runSpy.mock.calls.filter(([opts]) => opts?.forceBypassQueue === true);
+  }
+
+  afterEach(() => {
+    setHeartbeatsEnabled(true);
+    resetHeartbeatWakeStateForTests();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("re-invokes runOnce with forceBypassQueue after 5 minutes of queue contention", async () => {
+    useFakeHeartbeatTime();
+
+    const runSpy = vi.fn().mockImplementation(async (opts?: { forceBypassQueue?: boolean }) => {
+      if (opts?.forceBypassQueue) {
+        return { status: "ran", durationMs: 1 } as const;
+      }
+      return { status: "skipped", reason: "requests-in-flight" } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce: runSpy,
+    });
+
+    await advanceToFirstInterval();
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(forcedCalls(runSpy)).toHaveLength(0);
+
+    await advanceRetries(PRE_TIMEOUT_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(0);
+
+    await advanceRetries(FORCE_TIMEOUT_BUFFER_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(1);
+    expect(forcedCalls(runSpy)[0]?.[0]).toEqual(
+      expect.objectContaining({
+        agentId: "main",
+        forceBypassQueue: true,
+        reason: "interval",
+      }),
+    );
+
+    runner.stop();
+  });
+
+  it("resets forced-timeout tracking after a successful forced execution", async () => {
+    useFakeHeartbeatTime();
+
+    const runSpy = vi.fn().mockImplementation(async (opts?: { forceBypassQueue?: boolean }) => {
+      if (opts?.forceBypassQueue) {
+        return { status: "ran", durationMs: 1 } as const;
+      }
+      return { status: "skipped", reason: "requests-in-flight" } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce: runSpy,
+    });
+
+    await advanceToFirstInterval();
+    await advanceRetries(HEARTBEAT_FORCE_TIMEOUT_MS + RETRY_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + RETRY_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(1);
+
+    await advanceRetries(PRE_TIMEOUT_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(1);
+
+    await advanceRetries(FORCE_TIMEOUT_BUFFER_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(2);
+
+    runner.stop();
+  });
+
+  it("resets forced-timeout tracking after a normal non-skip execution", async () => {
+    useFakeHeartbeatTime();
+
+    let nonForcedCalls = 0;
+    const runSpy = vi.fn().mockImplementation(async (opts?: { forceBypassQueue?: boolean }) => {
+      if (opts?.forceBypassQueue) {
+        return { status: "ran", durationMs: 1 } as const;
+      }
+      nonForcedCalls += 1;
+      if (nonForcedCalls <= 3) {
+        return { status: "skipped", reason: "requests-in-flight" } as const;
+      }
+      if (nonForcedCalls === 4) {
+        return { status: "ran", durationMs: 1 } as const;
+      }
+      return { status: "skipped", reason: "requests-in-flight" } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce: runSpy,
+    });
+
+    await advanceToFirstInterval();
+    await vi.advanceTimersByTimeAsync(RETRY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + RETRY_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(0);
+
+    await advanceRetries(PRE_TIMEOUT_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(0);
+
+    await advanceRetries(FORCE_TIMEOUT_BUFFER_MS);
+    expect(forcedCalls(runSpy)).toHaveLength(1);
+
+    runner.stop();
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -82,6 +82,9 @@ import {
 } from "./outbound/targets.js";
 import { peekSystemEventEntries, resolveSystemEventDeliveryContext } from "./system-events.js";
 
+/** Force heartbeat execution after this many ms of continuous queue contention. */
+const HEARTBEAT_FORCE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
     runtime?: RuntimeEnv;
@@ -111,6 +114,7 @@ type HeartbeatAgentState = {
   agentId: string;
   heartbeat?: HeartbeatConfig;
   intervalMs: number;
+  firstSkippedMs?: number;
   lastRunMs?: number;
   nextDueMs: number;
 };
@@ -529,6 +533,7 @@ export async function runHeartbeatOnce(opts: {
   sessionKey?: string;
   heartbeat?: HeartbeatConfig;
   reason?: string;
+  forceBypassQueue?: boolean;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? loadConfig();
@@ -555,7 +560,7 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main);
-  if (queueSize > 0) {
+  if (queueSize > 0 && !opts.forceBypassQueue) {
     return { status: "skipped", reason: "requests-in-flight" };
   }
 
@@ -1037,6 +1042,7 @@ export function startHeartbeatRunner(opts: {
         agentId: agent.agentId,
         heartbeat: agent.heartbeat,
         intervalMs,
+        firstSkippedMs: prevState?.firstSkippedMs,
         lastRunMs: prevState?.lastRunMs,
         nextDueMs,
       });
@@ -1112,6 +1118,7 @@ export function startHeartbeatRunner(opts: {
           });
           if (res.status !== "skipped" || res.reason !== "disabled") {
             advanceAgentSchedule(targetAgent, now);
+            targetAgent.firstSkippedMs = undefined;
           }
           return res.status === "ran" ? { status: "ran", durationMs: Date.now() - startedAt } : res;
         } catch (err) {
@@ -1120,6 +1127,7 @@ export function startHeartbeatRunner(opts: {
             error: errMsg,
           });
           advanceAgentSchedule(targetAgent, now);
+          targetAgent.firstSkippedMs = undefined;
           return { status: "failed", reason: errMsg };
         }
       }
@@ -1142,9 +1150,41 @@ export function startHeartbeatRunner(opts: {
           const errMsg = formatErrorMessage(err);
           log.error(`heartbeat runner: runOnce threw unexpectedly: ${errMsg}`, { error: errMsg });
           advanceAgentSchedule(agent, now);
+          agent.firstSkippedMs = undefined;
           continue;
         }
         if (res.status === "skipped" && res.reason === "requests-in-flight") {
+          agent.firstSkippedMs ??= now;
+          if (now - agent.firstSkippedMs >= HEARTBEAT_FORCE_TIMEOUT_MS) {
+            log.warn("heartbeat runner: forcing execution after queue contention timeout", {
+              agentId: agent.agentId,
+              skippedForMs: now - agent.firstSkippedMs,
+            });
+            try {
+              const forced = await runOnce({
+                cfg: state.cfg,
+                agentId: agent.agentId,
+                heartbeat: agent.heartbeat,
+                reason,
+                forceBypassQueue: true,
+                deps: { runtime: state.runtime },
+              });
+              agent.firstSkippedMs = undefined;
+              if (forced.status !== "skipped" || forced.reason !== "disabled") {
+                advanceAgentSchedule(agent, now);
+              }
+              if (forced.status === "ran") {
+                ran = true;
+              }
+              continue;
+            } catch (err) {
+              const errMsg = formatErrorMessage(err);
+              log.error(`heartbeat runner: forced runOnce threw: ${errMsg}`, { error: errMsg });
+              agent.firstSkippedMs = undefined;
+              advanceAgentSchedule(agent, now);
+              continue;
+            }
+          }
           // Do not advance the schedule — the main lane is busy and the wake
           // layer will retry shortly (DEFAULT_RETRY_MS = 1 s).  Calling
           // scheduleNext() here would register a 0 ms timer that races with
@@ -1154,6 +1194,7 @@ export function startHeartbeatRunner(opts: {
         }
         if (res.status !== "skipped" || res.reason !== "disabled") {
           advanceAgentSchedule(agent, now);
+          agent.firstSkippedMs = undefined;
         }
         if (res.status === "ran") {
           ran = true;


### PR DESCRIPTION
## Summary

- Force heartbeat execution after 5 minutes of continuous `requests-in-flight` skips, preventing indefinite heartbeat starvation
- Add `forceBypassQueue` option to `runHeartbeatOnce` — when set, skips the queue size guard
- Track contention duration via `firstSkippedMs` on the agent state object, reset on any successful execution

Fixes #40113
Supersedes #40149 (which has two critical bugs identified by reviewers)

## Why PR #40149 doesn't work

As identified by Greptile (0/5 confidence) and confirmed by @Sirius1942:

1. **Stale reference bug**: The force path creates a spread copy `{ ...agent }` and stores it in the map, but then calls `advanceAgentSchedule` on the original `agent` reference — mutating a detached object
2. **Missing re-invocation**: The force block resets tracking and advances the schedule but never calls `runOnce` again, so the heartbeat still doesn't execute

## How this PR fixes it

- **No spread copy**: `firstSkippedMs` is tracked directly on the `HeartbeatAgentState` object in the `state.agents` map — same object reference throughout
- **Re-invokes `runOnce`**: When the 5-minute threshold is exceeded, calls `runOnce` again with `forceBypassQueue: true`, which bypasses the `queueSize > 0` guard in `runHeartbeatOnce`
- **Proper reset**: `firstSkippedMs` is set to `undefined` after any successful execution (forced or normal) and after error recovery

## Test plan

- [ ] `pnpm test -- src/infra/heartbeat-runner.force-timeout.test.ts` — 3 new tests:
  - Re-invokes `runOnce` with `forceBypassQueue` after 5min contention
  - Resets tracking after successful forced execution
  - Resets tracking after normal non-skip execution
- [ ] Existing heartbeat runner tests still pass
- [ ] Manual: configure heartbeat at 10min interval, observe forced execution after 5min of queue contention

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex)