### PR TITLE
fix: use American English spelling in comments and test descriptions

### DIFF
--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -99,7 +99,7 @@ export async function updateAuthProfileStoreWithLock(params: {
 }
 
 /**
- * Normalise a raw auth-profiles.json credential entry.
+ * Normalize a raw auth-profiles.json credential entry.
  *
  * The official format uses `type` and (for api_key credentials) `key`.
  * A common mistake — caused by the similarity with the `openclaw.json`

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -272,7 +272,7 @@ describe("lookupContextTokens", () => {
   it("resolveContextTokensForModel prefers exact provider key over alias-normalized match", async () => {
     // When both "qwen" and "qwen-portal" exist as config keys (alias pattern),
     // resolveConfiguredProviderContextWindow must return the exact-key match first,
-    // not the first normalized hit — mirroring pi-embedded-runner/model.ts behaviour.
+    // not the first normalized hit — mirroring pi-embedded-runner/model.ts behavior.
     mockDiscoveryDeps([]);
 
     const cfg = {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -101,12 +101,12 @@ function normalizeAnthropicBaseUrl(baseUrl: string): string {
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
 
-  // Normalise anthropic-messages baseUrl: strip trailing /v1 that users may
+  // Normalize anthropic-messages baseUrl: strip trailing /v1 that users may
   // have included in their config. pi-ai appends /v1/messages itself.
   if (isAnthropicMessagesModel(model) && baseUrl) {
-    const normalised = normalizeAnthropicBaseUrl(baseUrl);
-    if (normalised !== baseUrl) {
-      return { ...model, baseUrl: normalised } as Model<"anthropic-messages">;
+    const normalized = normalizeAnthropicBaseUrl(baseUrl);
+    if (normalized !== baseUrl) {
+      return { ...model, baseUrl: normalized } as Model<"anthropic-messages">;
     }
   }
 

--- a/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
+++ b/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
@@ -78,7 +78,7 @@ describe("models-config: explicit reasoning override", () => {
 
         const m25 = await generateAndReadMinimaxModel(cfg);
         expect(m25).toBeDefined();
-        // Must honour the explicit false — built-in true must NOT win.
+        // Must honor the explicit false — built-in true must NOT win.
         expect(m25?.reasoning).toBe(false);
       });
     });

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  *  - Message format converters (convertMessagesToInputItems, convertTools)
  *  - Response → AssistantMessage parser (buildAssistantMessageFromResponse)
- *  - createOpenAIWebSocketStreamFn behaviour (connect, send, receive, fallback)
+ *  - createOpenAIWebSocketStreamFn behavior (connect, send, receive, fallback)
  *  - Session registry helpers (releaseWsSession, hasWsSession)
  */
 

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -4,7 +4,7 @@
  * Wraps `OpenAIWebSocketManager` in a `StreamFn` that can be plugged into the
  * pi-embedded-runner agent in place of the default `streamSimple` HTTP function.
  *
- * Key behaviours:
+ * Key behaviors:
  *  - Per-session `OpenAIWebSocketManager` (keyed by sessionId)
  *  - Tracks `previous_response_id` to send only incremental tool-result inputs
  *  - Falls back to `streamSimple` (HTTP) if the WebSocket connection fails
@@ -835,7 +835,7 @@ export function createOpenAIWebSocketStreamFn(
       const capturedContextLength = context.messages.length;
 
       await new Promise<void>((resolve, reject) => {
-        // Honour abort signal
+        // Honor abort signal
         const abortHandler = () => {
           cleanup();
           reject(new Error("aborted"));

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -305,7 +305,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           // Flat-params recovery: non-frontier models (e.g. Grok) sometimes flatten
           // job properties to the top level alongside `action` instead of nesting
           // them inside `job`. When `params.job` is missing or empty, reconstruct
-          // a synthetic job object from any recognised top-level job fields.
+          // a synthetic job object from any recognized top-level job fields.
           // See: https://github.com/openclaw/openclaw/issues/11310
           if (
             !params.job ||

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -470,7 +470,7 @@ async function resolveMemoryBootstrapEntry(
   // Prefer MEMORY.md; fall back to memory.md only when absent.
   // Checking both and deduplicating via realpath is unreliable on case-insensitive
   // file systems mounted in Docker (e.g. macOS volumes), where both names pass
-  // fs.access() but realpath does not normalise case through the mount layer,
+  // fs.access() but realpath does not normalize case through the mount layer,
   // causing the same content to be injected twice and wasting tokens.
   for (const name of [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME] as const) {
     const filePath = path.join(resolvedDir, name);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -436,7 +436,7 @@ describe("dispatchReplyFromConfig", () => {
   it("does not resurrect a cleared route thread from origin metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
-    // Simulate the real store: lastThreadId and deliveryContext.threadId may be normalised from
+    // Simulate the real store: lastThreadId and deliveryContext.threadId may be normalized from
     // origin.threadId on read, but a non-thread session key must still route to channel root.
     sessionStoreMocks.currentEntry = {
       deliveryContext: {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -190,8 +190,8 @@ export async function dispatchReplyFromConfig(params: {
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   // Restore route thread context only from the active turn or the thread-scoped session key.
-  // Do not read thread ids from the normalised session store here: `origin.threadId` can be
-  // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
+  // Do not read thread ids from the normalized session store here: `origin.threadId` can be
+  // folded back into lastThreadId/deliveryContext during store normalization and resurrect a
   // stale route after thread delivery was intentionally cleared.
   const routeThreadId =
     ctx.MessageThreadId ?? parseSessionThreadInfo(acpDispatchSessionKey).threadId;

--- a/src/browser/cdp-proxy-bypass.ts
+++ b/src/browser/cdp-proxy-bypass.ts
@@ -19,7 +19,7 @@ const directHttpsAgent = new https.Agent();
 /**
  * Returns a plain (non-proxy) agent for WebSocket or HTTP connections
  * when the target is a loopback address. Returns `undefined` otherwise
- * so callers fall through to their default behaviour.
+ * so callers fall through to their default behavior.
  */
 export function getDirectAgentForCdp(url: string): http.Agent | https.Agent | undefined {
   try {

--- a/src/commands/signal-install.test.ts
+++ b/src/commands/signal-install.test.ts
@@ -41,15 +41,15 @@ const SAMPLE_ASSETS: ReleaseAsset[] = [
 ];
 
 describe("looksLikeArchive", () => {
-  it("recognises .tar.gz", () => {
+  it("recognizes .tar.gz", () => {
     expect(looksLikeArchive("foo.tar.gz")).toBe(true);
   });
 
-  it("recognises .tgz", () => {
+  it("recognizes .tgz", () => {
     expect(looksLikeArchive("foo.tgz")).toBe(true);
   });
 
-  it("recognises .zip", () => {
+  it("recognizes .zip", () => {
     expect(looksLikeArchive("foo.zip")).toBe(true);
   });
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -407,7 +407,7 @@ export async function runCronIsolatedAgentTurn(params: {
   }
 
   // Respect session model override — check session.modelOverride before falling
-  // back to the default config model. This ensures /model changes are honoured
+  // back to the default config model. This ensures /model changes are honored
   // by cron and isolated agent runs.
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = cronSession.sessionEntry.modelOverride?.trim();

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -300,7 +300,7 @@ export function assertGatewayAuthConfigured(
       typeof rawAuthConfig.password !== "string" // pragma: allowlist secret
     ) {
       throw new Error(
-        "gateway auth mode is password, but gateway.auth.password contains a provider reference object instead of a resolved string — bootstrap secrets (gateway.auth.password) must be plaintext strings or set via the OPENCLAW_GATEWAY_PASSWORD environment variable because the secrets provider system has not initialised yet at gateway startup", // pragma: allowlist secret
+        "gateway auth mode is password, but gateway.auth.password contains a provider reference object instead of a resolved string — bootstrap secrets (gateway.auth.password) must be plaintext strings or set via the OPENCLAW_GATEWAY_PASSWORD environment variable because the secrets provider system has not initialized yet at gateway startup", // pragma: allowlist secret
       );
     }
     throw new Error("gateway auth mode is password, but no password was configured");

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -79,7 +79,7 @@ function contentTypeForExt(ext: string): string {
 }
 
 /**
- * Extensions recognised as static assets.  Missing files with these extensions
+ * Extensions recognized as static assets.  Missing files with these extensions
  * return 404 instead of the SPA index.html fallback.  `.html` is intentionally
  * excluded — actual HTML files on disk are served earlier, and missing `.html`
  * paths should fall through to the SPA router (client-side routers may use
@@ -453,7 +453,7 @@ export function handleControlUiHttpRequest(
 
   // If the requested path looks like a static asset (known extension), return
   // 404 rather than falling through to the SPA index.html fallback.  We check
-  // against the same set of extensions that contentTypeForExt() recognises so
+  // against the same set of extensions that contentTypeForExt() recognizes so
   // that dotted SPA routes (e.g. /user/jane.doe, /v2.0) still get the
   // client-side router fallback.
   if (STATIC_ASSET_EXTENSIONS.has(path.extname(fileRel).toLowerCase())) {


### PR DESCRIPTION
## Summary
- Replace British English spellings with American English in code comments and test descriptions
- Follows the coding style guideline: "use American English spelling and grammar in code, comments, docs, and UI strings"
- Changes across 15 files: `normalise` → `normalize`, `behaviour` → `behavior`, `honour` → `honor`, `recognised` → `recognized`, `initialised` → `initialized`

## Test plan
- [x] Comments-only and test-description-only changes — no logic affected
- [x] `pnpm format:check` passes (oxfmt)
- [x] Oxlint passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)