### PR TITLE
feat(outbound): gateway-layer secret sanitization with named reference handles

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -39,6 +39,12 @@ import type { DeliveryMirror } from "./mirror.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
+import {
+  buildCredentialIndex,
+  isSecretSanitizationEnabled,
+  sanitizeSecrets,
+  type CredentialIndex,
+} from "./sanitize-secrets.js";
 import { resolveOutboundSendDep, type OutboundSendDeps } from "./send-deps.js";
 import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
@@ -302,6 +308,7 @@ function normalizePayloadsForChannelDelivery(
   payloads: ReplyPayload[],
   channel: Exclude<OutboundChannel, "none">,
   handler: ChannelHandler,
+  credIndex?: CredentialIndex,
 ): ReplyPayload[] {
   const normalizedPayloads: ReplyPayload[] = [];
   for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
@@ -315,6 +322,16 @@ function normalizePayloadsForChannelDelivery(
           ...sanitizedPayload,
           text: sanitizeForPlainText(sanitizedPayload.text),
         };
+      }
+    }
+    // Replace secret values with reference handles before channel delivery.
+    // Applies to all channels — chat is not a secure transport regardless of recipient.
+    // Named credentials produce key(<name>); unknown high-entropy tokens produce [REDACTED:...].
+    // See https://github.com/openclaw/openclaw/issues/50718
+    if (credIndex && sanitizedPayload.text) {
+      const { text, redacted } = sanitizeSecrets(sanitizedPayload.text, credIndex);
+      if (redacted) {
+        sanitizedPayload = { ...sanitizedPayload, text };
       }
     }
     const normalizedPayload = handler.normalizePayload
@@ -607,7 +624,8 @@ async function deliverOutboundPayloadsCore(
       results.push(await handler.sendText(chunk, overrides));
     }
   };
-  const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
+  const credIndex = isSecretSanitizationEnabled(cfg) ? buildCredentialIndex(cfg) : undefined;
+  const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler, credIndex);
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;

--- a/src/infra/outbound/sanitize-secrets.test.ts
+++ b/src/infra/outbound/sanitize-secrets.test.ts
@@ -64,6 +64,13 @@ describe("sanitizeSecrets — known prefixes", () => {
     expect(result.redacted).toBe(false);
   });
 
+  it("redacts secrets embedded after = sign", () => {
+    const result = sanitizeSecrets("TOKEN=ghp_abc123XYZ456789abcdef", emptyIndex);
+    expect(result.redacted).toBe(true);
+    expect(result.text).toContain("TOKEN=");
+    expect(result.text).not.toContain("ghp_abc123XYZ456789abcdef");
+  });
+
   it("preserves surrounding text", () => {
     const result = sanitizeSecrets(
       "Done. NEXTAUTH_SECRET = ghp_abc123XYZ456789abcdef stored for Rosie.",

--- a/src/infra/outbound/sanitize-secrets.test.ts
+++ b/src/infra/outbound/sanitize-secrets.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCredentialIndex,
+  isSecretSanitizationEnabled,
+  sanitizeSecrets,
+} from "./sanitize-secrets.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyIndex = new Map<string, string>();
+
+function makeConfig(messages?: Record<string, unknown>): OpenClawConfig {
+  return { messages } as unknown as OpenClawConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Known prefix detection
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSecrets — known prefixes", () => {
+  it("redacts GitHub PAT (ghp_)", () => {
+    const result = sanitizeSecrets("token is ghp_abc123XYZ456789abcdef", emptyIndex);
+    expect(result.redacted).toBe(true);
+    expect(result.text).not.toContain("ghp_abc123XYZ456789abcdef");
+    expect(result.text).toContain("key(ghp");
+  });
+
+  it("redacts Anthropic key (sk-ant-)", () => {
+    const result = sanitizeSecrets("key=sk-ant-api03-longsecretkeyvalue123456789", emptyIndex);
+    expect(result.redacted).toBe(true);
+    expect(result.text).not.toContain("sk-ant-");
+  });
+
+  it("redacts OpenAI project key (sk-proj-)", () => {
+    const result = sanitizeSecrets("sk-proj-abcdefghijklmnopqrstuvwxyz123456", emptyIndex);
+    expect(result.redacted).toBe(true);
+  });
+
+  it("redacts Slack bot token (xoxb-)", () => {
+    // Fake token — xoxb- prefix with sufficient length triggers detection
+    const fakeSlackToken = ["xoxb", "FAKEFAKEFAKE", "FAKEFAKEFAKE", "FAKEFAKEFAKE"].join("-");
+    const result = sanitizeSecrets(fakeSlackToken, emptyIndex);
+    expect(result.redacted).toBe(true);
+  });
+
+  it("redacts AWS access key (AKIA)", () => {
+    const result = sanitizeSecrets("aws key: AKIAIOSFODNN7EXAMPLE", emptyIndex);
+    expect(result.redacted).toBe(true);
+  });
+
+  it("redacts Leantime API key (lt_)", () => {
+    const result = sanitizeSecrets(
+      "lt_kindred-agents_ed463114443aed155df0a12829196429efb51d35beca0477",
+      emptyIndex,
+    );
+    expect(result.redacted).toBe(true);
+  });
+
+  it("does not redact short tokens below minLength", () => {
+    const result = sanitizeSecrets("ghp_short", emptyIndex);
+    expect(result.redacted).toBe(false);
+  });
+
+  it("preserves surrounding text", () => {
+    const result = sanitizeSecrets(
+      "Done. NEXTAUTH_SECRET = ghp_abc123XYZ456789abcdef stored for Rosie.",
+      emptyIndex,
+    );
+    expect(result.text).toContain("Done.");
+    expect(result.text).toContain("NEXTAUTH_SECRET");
+    expect(result.text).toContain("stored for Rosie.");
+    expect(result.text).not.toContain("ghp_abc123XYZ456789abcdef");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Named credential index
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSecrets — named credentials", () => {
+  it("produces key(<name>) handle for named credential", () => {
+    const index = new Map([["mysupersecrettoken12345678901234", "github-pat"]]);
+    const result = sanitizeSecrets("token: mysupersecrettoken12345678901234", index);
+    expect(result.redacted).toBe(true);
+    expect(result.text).toContain("key(github-pat)");
+    expect(result.text).not.toContain("mysupersecrettoken12345678901234");
+  });
+
+  it("key() handle is more useful than opaque handle", () => {
+    const index = new Map([["sk-ant-api03-longsecretkeyvalue123456789", "anthropic-main"]]);
+    const result = sanitizeSecrets("sk-ant-api03-longsecretkeyvalue123456789", index);
+    expect(result.text).toBe("key(anthropic-main)");
+  });
+
+  it("count reflects number of redactions", () => {
+    const index = new Map([
+      ["secret1_abcdefghij12345678", "cred-a"],
+      ["secret2_abcdefghij12345678", "cred-b"],
+    ]);
+    const result = sanitizeSecrets(
+      "a=secret1_abcdefghij12345678 b=secret2_abcdefghij12345678",
+      index,
+    );
+    expect(result.count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// High-entropy fallback
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSecrets — high entropy fallback", () => {
+  it("redacts high-entropy token not matching known prefixes", () => {
+    // Simulate a random 32-char hex secret
+    const secret = "a3f8b2c1d4e5f6a7b8c9d0e1f2a3b4c5";
+    const result = sanitizeSecrets(`secret=${secret}`, emptyIndex);
+    expect(result.redacted).toBe(true);
+    expect(result.text).toContain("[REDACTED:high-entropy]");
+  });
+
+  it("does not redact natural language text", () => {
+    const result = sanitizeSecrets("The quick brown fox jumps over the lazy dog", emptyIndex);
+    expect(result.redacted).toBe(false);
+    expect(result.text).toBe("The quick brown fox jumps over the lazy dog");
+  });
+
+  it("does not redact short tokens", () => {
+    const result = sanitizeSecrets("abc123def456", emptyIndex);
+    expect(result.redacted).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSecrets — edge cases", () => {
+  it("handles empty string", () => {
+    const result = sanitizeSecrets("", emptyIndex);
+    expect(result.text).toBe("");
+    expect(result.redacted).toBe(false);
+    expect(result.count).toBe(0);
+  });
+
+  it("handles text with no secrets", () => {
+    const result = sanitizeSecrets("Hello, the task is complete.", emptyIndex);
+    expect(result.redacted).toBe(false);
+    expect(result.text).toBe("Hello, the task is complete.");
+  });
+
+  it("handles multiple secrets in one message", () => {
+    const result = sanitizeSecrets(
+      "GitHub: ghp_abc123XYZ456789abcdef, Anthropic: sk-ant-api03-longsecretkeyvalue123456789",
+      emptyIndex,
+    );
+    expect(result.count).toBe(2);
+    expect(result.redacted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCredentialIndex
+// ---------------------------------------------------------------------------
+
+describe("buildCredentialIndex", () => {
+  it("indexes auth token values", () => {
+    const cfg = {
+      auth: {
+        anthropic: { apiKey: "sk-ant-api03-longsecretkeyvalue123456789" },
+      },
+    } as unknown as OpenClawConfig;
+    const index = buildCredentialIndex(cfg);
+    expect(index.has("sk-ant-api03-longsecretkeyvalue123456789")).toBe(true);
+    expect(index.get("sk-ant-api03-longsecretkeyvalue123456789")).toBe("anthropic:apiKey");
+  });
+
+  it("skips short values", () => {
+    const cfg = {
+      auth: { provider: { short: "abc" } },
+    } as unknown as OpenClawConfig;
+    const index = buildCredentialIndex(cfg);
+    expect(index.has("abc")).toBe(false);
+  });
+
+  it("indexes channel tokens", () => {
+    const cfg = {
+      channels: {
+        telegram: { token: "1234567890:ABCdefGHIjklMNOpqrSTUvwxYZ_longtoken" },
+      },
+    } as unknown as OpenClawConfig;
+    const index = buildCredentialIndex(cfg);
+    expect(index.has("1234567890:ABCdefGHIjklMNOpqrSTUvwxYZ_longtoken")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSecretSanitizationEnabled
+// ---------------------------------------------------------------------------
+
+describe("isSecretSanitizationEnabled", () => {
+  it("defaults to true when not configured", () => {
+    expect(isSecretSanitizationEnabled(makeConfig())).toBe(true);
+  });
+
+  it("returns true when explicitly enabled", () => {
+    expect(isSecretSanitizationEnabled(makeConfig({ sanitizeSecrets: true }))).toBe(true);
+  });
+
+  it("returns false when explicitly disabled", () => {
+    expect(isSecretSanitizationEnabled(makeConfig({ sanitizeSecrets: false }))).toBe(false);
+  });
+});

--- a/src/infra/outbound/sanitize-secrets.ts
+++ b/src/infra/outbound/sanitize-secrets.ts
@@ -1,0 +1,220 @@
+/**
+ * Sanitize outbound message content to prevent secret values from being
+ * transmitted over channel transports.
+ *
+ * Replaces detected secrets with reference handles before delivery.
+ * Named credentials produce `key(<name>)` handles; unknown high-entropy
+ * strings produce `[REDACTED:high-entropy]`.
+ *
+ * This is a defense-in-depth layer: even if a message routes to the wrong
+ * recipient, it carries no exploitable value.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/50718
+ */
+
+import type { OpenClawConfig } from "../../config/config.js";
+
+// ---------------------------------------------------------------------------
+// Known secret prefixes — deterministic pattern match
+// ---------------------------------------------------------------------------
+
+type PrefixRule = {
+  prefix: string;
+  /** Minimum total length (prefix + token body) to avoid false positives. */
+  minLength: number;
+};
+
+const SECRET_PREFIX_RULES: PrefixRule[] = [
+  { prefix: "ghp_", minLength: 20 },   // GitHub personal access token
+  { prefix: "ghr_", minLength: 20 },   // GitHub refresh token
+  { prefix: "ghu_", minLength: 20 },   // GitHub user token
+  { prefix: "ghs_", minLength: 20 },   // GitHub server token
+  { prefix: "github_pat_", minLength: 30 }, // GitHub fine-grained PAT
+  { prefix: "sk-ant-", minLength: 30 }, // Anthropic API key
+  { prefix: "sk-proj-", minLength: 30 }, // OpenAI project key
+  { prefix: "sk-", minLength: 30 },     // Generic OpenAI-style key (after more specific)
+  { prefix: "xoxb-", minLength: 20 },   // Slack bot token
+  { prefix: "xoxp-", minLength: 20 },   // Slack user token
+  { prefix: "xoxa-", minLength: 20 },   // Slack app token
+  { prefix: "AKIA", minLength: 20 },    // AWS access key
+  { prefix: "lt_", minLength: 30 },     // Leantime API key
+];
+
+// ---------------------------------------------------------------------------
+// Shannon entropy — catch unknown high-entropy tokens
+// ---------------------------------------------------------------------------
+
+function shannonEntropy(str: string): number {
+  const freq: Record<string, number> = {};
+  for (const ch of str) {
+    freq[ch] = (freq[ch] ?? 0) + 1;
+  }
+  const len = str.length;
+  return -Object.values(freq).reduce((acc, count) => {
+    const p = count / len;
+    return acc + p * Math.log2(p);
+  }, 0);
+}
+
+/**
+ * Returns true when the string looks like a high-entropy secret token:
+ * long enough to be a token, alphanumeric-ish, and high entropy.
+ */
+function isHighEntropyToken(token: string): boolean {
+  if (token.length < 20) return false;
+  // Must be mostly alphanumeric + a few symbol chars (not natural language)
+  const alphanumRatio = (token.match(/[a-zA-Z0-9]/g)?.length ?? 0) / token.length;
+  if (alphanumRatio < 0.8) return false;
+  return shannonEntropy(token) > 3.5;
+}
+
+// ---------------------------------------------------------------------------
+// Named credential index — match configured credential values to names
+// ---------------------------------------------------------------------------
+
+type CredentialIndex = Map<string, string>; // value → name
+
+/**
+ * Build an index of known credential values from the gateway config.
+ * Only includes values long enough (≥16 chars) to be worth matching.
+ */
+export function buildCredentialIndex(cfg: OpenClawConfig): CredentialIndex {
+  const index: CredentialIndex = new Map();
+
+  // Auth tokens
+  const auth = cfg.auth as Record<string, unknown> | undefined;
+  if (auth) {
+    for (const [provider, providerCfg] of Object.entries(auth)) {
+      if (typeof providerCfg === "object" && providerCfg !== null) {
+        for (const [key, value] of Object.entries(providerCfg as Record<string, unknown>)) {
+          if (typeof value === "string" && value.length >= 16) {
+            index.set(value, `${provider}:${key}`);
+          }
+        }
+      }
+    }
+  }
+
+  // Channel configs (tokens, webhooks, etc.)
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  if (channels) {
+    for (const [channelId, channelCfg] of Object.entries(channels)) {
+      if (typeof channelCfg === "object" && channelCfg !== null) {
+        for (const [key, value] of Object.entries(channelCfg as Record<string, unknown>)) {
+          if (typeof value === "string" && value.length >= 16) {
+            index.set(value, `${channelId}:${key}`);
+          }
+        }
+      }
+    }
+  }
+
+  return index;
+}
+
+// ---------------------------------------------------------------------------
+// Reference handle generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `key(<name>)` for a named credential, or `[REDACTED:high-entropy]`
+ * for an unknown high-entropy token.
+ */
+function toReferenceHandle(value: string, credIndex: CredentialIndex): string {
+  const name = credIndex.get(value);
+  if (name) {
+    return `key(${name})`;
+  }
+  // Try prefix match for well-known formats
+  for (const rule of SECRET_PREFIX_RULES) {
+    if (value.startsWith(rule.prefix) && value.length >= rule.minLength) {
+      // Known format but not in index — use prefix as hint
+      return `key(${rule.prefix.replace(/_$/, "").replace(/-$/, "")}...)`;
+    }
+  }
+  return "[REDACTED:high-entropy]";
+}
+
+// ---------------------------------------------------------------------------
+// Token-level scanner
+// ---------------------------------------------------------------------------
+
+/**
+ * Word-boundary aware tokenizer. Splits on whitespace and common delimiters
+ * while preserving the surrounding structure for reconstruction.
+ */
+function tokenize(text: string): Array<{ token: string; sep: string }> {
+  const result: Array<{ token: string; sep: string }> = [];
+  const re = /([^\s,;|]+)([\s,;|]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    result.push({ token: m[1], sep: m[2] });
+  }
+  return result;
+}
+
+function isSecretToken(token: string, credIndex: CredentialIndex): boolean {
+  // Named credential exact match
+  if (credIndex.has(token)) return true;
+  // Known prefix match
+  for (const rule of SECRET_PREFIX_RULES) {
+    if (token.startsWith(rule.prefix) && token.length >= rule.minLength) return true;
+  }
+  // High-entropy fallback
+  return isHighEntropyToken(token);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type SecretSanitizationResult = {
+  text: string;
+  redacted: boolean;
+  count: number;
+};
+
+/**
+ * Scan `text` for secret values and replace them with reference handles.
+ *
+ * @param text    Raw outbound message text
+ * @param credIndex  Named credential index built from gateway config
+ * @returns Sanitized text and metadata
+ */
+export function sanitizeSecrets(
+  text: string,
+  credIndex: CredentialIndex,
+): SecretSanitizationResult {
+  const tokens = tokenize(text);
+  let count = 0;
+  const parts: string[] = [];
+
+  for (const { token, sep } of tokens) {
+    if (isSecretToken(token, credIndex)) {
+      parts.push(toReferenceHandle(token, credIndex));
+      count++;
+    } else {
+      parts.push(token);
+    }
+    parts.push(sep);
+  }
+
+  const sanitized = parts.join("");
+  return {
+    text: sanitized,
+    redacted: count > 0,
+    count,
+  };
+}
+
+/**
+ * Returns true when secret sanitization is enabled for this config.
+ * Default: true (secure by default).
+ */
+export function isSecretSanitizationEnabled(cfg: OpenClawConfig): boolean {
+  const messages = cfg.messages as Record<string, unknown> | undefined;
+  if (messages && "sanitizeSecrets" in messages) {
+    return messages.sanitizeSecrets !== false;
+  }
+  return true;
+}

--- a/src/infra/outbound/sanitize-secrets.ts
+++ b/src/infra/outbound/sanitize-secrets.ts
@@ -72,7 +72,7 @@ function isHighEntropyToken(token: string): boolean {
 // Named credential index — match configured credential values to names
 // ---------------------------------------------------------------------------
 
-type CredentialIndex = Map<string, string>; // value → name
+export type CredentialIndex = Map<string, string>; // value → name
 
 /**
  * Build an index of known credential values from the gateway config.
@@ -145,7 +145,9 @@ function toReferenceHandle(value: string, credIndex: CredentialIndex): string {
  */
 function tokenize(text: string): Array<{ token: string; sep: string }> {
   const result: Array<{ token: string; sep: string }> = [];
-  const re = /([^\s,;|]+)([\s,;|]*)/g;
+  // Split on whitespace and common delimiters including '=' so that
+  // key=value pairs like `TOKEN=ghp_abc123` surface the value as a token.
+  const re = /([^\s,;|=]+)([\s,;|=]*)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
     result.push({ token: m[1], sep: m[2] });


### PR DESCRIPTION
## Summary

Implements Option C from #50718 — a gateway-level outbound transform that replaces secret values with reference handles before any channel delivery.

This covers all outbound paths (not just the `message` tool), so a correctly-formed message routed to the wrong recipient carries no exploitable value regardless of how it was sent.

## What changed

### `src/infra/outbound/sanitize-secrets.ts` (new)

Secret detection engine with three layers:
1. **Known prefix detection** — `ghp_`, `sk-ant-`, `sk-proj-`, `xoxb-`, `AKIA`, `lt_`, and others with minimum length guards to avoid false positives
2. **Named credential index** — built from gateway config at delivery time; produces `key(<name>)` handles for identifiable credentials
3. **Shannon entropy fallback** — catches unknown high-entropy tokens with `[REDACTED:high-entropy]`

Enabled by default; opt-out via `messages.sanitizeSecrets: false`.

### `src/infra/outbound/deliver.ts`

Wired into `normalizePayloadsForChannelDelivery` alongside the existing plain-text surface sanitization. Credential index is built once per delivery call and passed through.

### `src/infra/outbound/sanitize-secrets.test.ts` (new)

23 tests covering prefix detection, named handles, entropy fallback, config opt-out, edge cases.

## Reference handle format

This PR uses named handles rather than opaque IDs:

```
# Named credential (matched against gateway config)
Done. token = key(anthropic:apiKey)

# Unknown high-entropy token
Done. value = [REDACTED:high-entropy]
```

Named handles are more useful for incident response — you know exactly which credential surfaced and which vault entry to rotate, without the value being exploitable. Discussed in #50718.

## Relationship to other work

This is complementary to any message-tool-layer approach, not a replacement. The gateway layer catches paths the tool layer cannot; both together are defense in depth.

Closes #50718