### PR TITLE
fix: use American English "grayscale" and simplify static error strings

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -485,7 +485,7 @@ export async function runEmbeddedPiAgent(
         runtimeAuthState.refreshInFlight = (async () => {
           const sourceApiKey = runtimeAuthState?.sourceApiKey.trim() ?? "";
           if (!sourceApiKey) {
-            throw new Error(`Runtime auth refresh requires a source credential.`);
+            throw new Error("Runtime auth refresh requires a source credential.");
           }
           log.debug(`Refreshing runtime auth for ${runtimeModel.provider} (${reason})...`);
           const preparedAuth = await prepareProviderRuntimeAuth({

--- a/src/memory/embeddings-ollama.ts
+++ b/src/memory/embeddings-ollama.ts
@@ -92,7 +92,7 @@ export async function createOllamaEmbeddingProvider(
       },
     });
     if (!Array.isArray(json.embedding)) {
-      throw new Error(`Ollama embeddings response missing embedding[]`);
+      throw new Error("Ollama embeddings response missing embedding[]");
     }
     return sanitizeAndNormalizeEmbedding(json.embedding);
   };

--- a/src/tui/theme/theme.test.ts
+++ b/src/tui/theme/theme.test.ts
@@ -155,7 +155,7 @@ describe("light background detection", () => {
     expect(mod.lightMode).toBe(false);
   });
 
-  it("treats 256-color COLORFGBG bg=232 (near-black greyscale) as dark", async () => {
+  it("treats 256-color COLORFGBG bg=232 (near-black grayscale) as dark", async () => {
     const mod = await importThemeWithEnv({
       OPENCLAW_THEME: undefined,
       COLORFGBG: "15;232",
@@ -163,7 +163,7 @@ describe("light background detection", () => {
     expect(mod.lightMode).toBe(false);
   });
 
-  it("treats 256-color COLORFGBG bg=255 (near-white greyscale) as light", async () => {
+  it("treats 256-color COLORFGBG bg=255 (near-white grayscale) as light", async () => {
     const mod = await importThemeWithEnv({
       OPENCLAW_THEME: undefined,
       COLORFGBG: "0;255",


### PR DESCRIPTION
## Summary
- Replace British "greyscale" with American "grayscale" in test descriptions (per coding style guidelines)
- Replace unnecessary template literals with regular strings in two error messages where no interpolation is used

## Test plan
- [x] `pnpm check` passes (all lint, format, type checks)
- [x] No logic changes — only string style fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)