### PR TITLE
Refresh Community plugins - QQ Bot official repo transfer

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -68,17 +68,17 @@ cost, tokens, errors, and more.
 openclaw plugins install @opik/opik-openclaw
 ```
 
-### QQbot
+### QQ Bot
 
-Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group
-mentions, channel messages, and rich media including voice, images, videos,
-and files.
+Official QQ Bot channel plugin. Connect OpenClaw to QQ with support for
+private chats, groups, guild channels, rich media (images, voice, video,
+files), and more.
 
-- **npm:** `@sliverp/qqbot`
-- **repo:** [github.com/sliverp/qqbot](https://github.com/sliverp/qqbot)
+- **npm:** `@tencent-connect/openclaw-qqbot`
+- **repo:** [github.com/tencent-connect/openclaw-qqbot](https://github.com/tencent-connect/openclaw-qqbot)
 
 ```bash
-openclaw plugins install @sliverp/qqbot
+openclaw plugins install @tencent-connect/openclaw-qqbot
 ```
 
 ### wecom


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `QQ Bot` entry in `docs/plugins/community.md` still pointed to older community-owned package/repo metadata and no longer matched the current official project home.
- Why it matters: The QQ Bot plugin repository has since been transferred into the official Tencent Connect GitHub organization, so the Community Plugins page should reflect the new official source to avoid confusing users.
- What changed: Updated the `QQ Bot` entry name/copy and switched the npm package, GitHub repository link, and install command to the current official Tencent Connect listing.
- What did NOT change (scope boundary): This PR does not change plugin code, runtime behavior, configuration, auth flows, or installation logic. It is a docs-only metadata/copy update.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- The Community Plugins page now points users to the official Tencent Connect QQ Bot plugin listing.
- Updated plugin metadata:
  - name: `QQ Bot`
  - npm: `@tencent-connect/openclaw-qqbot`
  - repo: `https://github.com/tencent-connect/openclaw-qqbot`
  - install: `openclaw plugins install @tencent-connect/openclaw-qqbot`
- Updated the short description to reflect the official channel plugin positioning and current supported surfaces.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Docs only
- Relevant config (redacted): N/A

### Steps

1. Open `docs/plugins/community.md`.
2. Find the `QQ Bot` entry under `Community Plugins`.
3. Verify the entry uses the official Tencent Connect package/repo/install command instead of the previous community-owned listing.

### Expected

- The docs point to the current official QQ Bot project home after the repository transfer into the official GitHub organization.

### Actual

- Verified locally: the `QQ Bot` entry now points to `@tencent-connect/openclaw-qqbot` and `tencent-connect/openclaw-qqbot`, with updated copy aligned to the official listing.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the current public repository is under the `tencent-connect` GitHub organization.
  - Confirmed the official npm package `@tencent-connect/openclaw-qqbot` exists.
  - Reviewed the final `QQ Bot` entry in `docs/plugins/community.md` for updated name, copy, repo URL, package name, and install command.
  - Completed the repo commit checks successfully for this docs change.
- Edge cases checked:
  - Normalized the display name to `QQ Bot`.
  - Updated the copy to match the current plugin positioning without over-specifying behavior.
- What you did **not** verify:
  - End-to-end plugin installation/runtime behavior.
  - Mintlify deployed preview rendering.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR/commit.
- Files/config to restore: `docs/plugins/community.md`
- Known bad symptoms reviewers should watch for:
  - The docs still point to the previous community-owned repo/package.
  - The plugin entry does not reflect the current official Tencent Connect listing.

## Risks and Mitigations

- Risk: External plugin metadata may drift again if ownership/package details change in the future.
  - Mitigation: This PR updates the docs to the current official Tencent Connect repo/package and re-verifies both before submission.
