### PR TITLE
docs: expand tlon extension README

### DIFF
--- a/extensions/tlon/README.md
+++ b/extensions/tlon/README.md
@@ -1,5 +1,24 @@
 # Tlon (OpenClaw plugin)
 
-Tlon/Urbit channel plugin for OpenClaw. Supports DMs, group mentions, and thread replies.
+Tlon/Urbit channel plugin for OpenClaw. Supports DMs, group mentions, and thread replies via decentralized messaging on Urbit.
 
-Docs: https://docs.openclaw.ai/channels/tlon
+## Setup
+
+```bash
+openclaw channel add tlon
+```
+
+Full setup instructions: https://docs.openclaw.ai/channels/tlon
+
+## Features
+
+- Direct messages and group chats
+- Thread replies
+- Media support via S3 presigned URLs
+- Urbit address resolution
+
+## Dependencies
+
+- `@tloncorp/tlon-skill` - Tlon API client
+- `@urbit/aura` - Urbit address parsing
+- `@aws-sdk/client-s3` - Media upload support


### PR DESCRIPTION
Expand the minimal 4-line Tlon extension README with setup instructions, feature list, and dependency docs.