### PR TITLE
docs: add missing README files for 58 extensions

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -211,7 +211,7 @@ Flags are case-insensitive and support wildcards (e.g. `telegram.*` or `*`).
 
 Env override (one-off):
 
-```
+```bash
 OPENCLAW_DIAGNOSTICS=telegram.http,telegram.payload
 ```
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -38,19 +38,19 @@ Full Linux server guide: [Linux Server](/vps). Step-by-step VPS example: [exe.de
 
 Use one of these:
 
-```
+```bash
 openclaw onboard --install-daemon
 ```
 
 Or:
 
-```
+```bash
 openclaw gateway install
 ```
 
 Or:
 
-```
+```bash
 openclaw configure
 ```
 
@@ -58,7 +58,7 @@ Select **Gateway service** when prompted.
 
 Repair/migrate:
 
-```
+```bash
 openclaw doctor
 ```
 
@@ -72,7 +72,7 @@ Minimal setup:
 
 Create `~/.config/systemd/user/openclaw-gateway[-<profile>].service`:
 
-```
+```ini
 [Unit]
 Description=OpenClaw Gateway (profile: <profile>, v<version>)
 After=network-online.target
@@ -89,6 +89,6 @@ WantedBy=default.target
 
 Enable it:
 
-```
+```bash
 systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -121,7 +121,7 @@ Example:
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration-reference) for the full `plugins.*` schema.
 
 ## Notes
 

--- a/docs/prose.md
+++ b/docs/prose.md
@@ -39,7 +39,7 @@ OpenProse registers `/prose` as a user-invocable skill command. It routes to the
 
 Common commands:
 
-```
+```bash
 /prose help
 /prose run <file.prose>
 /prose run <handle/slug>
@@ -78,7 +78,7 @@ context: { findings, draft }
 
 OpenProse keeps state under `.prose/` in your workspace:
 
-```
+```text
 .prose/
 ├── .env
 ├── runs/
@@ -92,7 +92,7 @@ OpenProse keeps state under `.prose/` in your workspace:
 
 User-level persistent agents live at:
 
-```
+```text
 ~/.prose/agents/
 ```
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -196,7 +196,7 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 
 Then run:
 
-```
+```bash
 /tts summary off
 ```
 

--- a/extensions/acpx/README.md
+++ b/extensions/acpx/README.md
@@ -1,0 +1,3 @@
+# Acpx (OpenClaw plugin)
+
+OpenClaw ACP runtime backend via acpx

--- a/extensions/amazon-bedrock/README.md
+++ b/extensions/amazon-bedrock/README.md
@@ -1,0 +1,3 @@
+# Amazon Bedrock (OpenClaw plugin)
+
+OpenClaw Amazon Bedrock provider plugin

--- a/extensions/anthropic/README.md
+++ b/extensions/anthropic/README.md
@@ -1,0 +1,3 @@
+# Anthropic (OpenClaw plugin)
+
+OpenClaw Anthropic provider plugin

--- a/extensions/brave/README.md
+++ b/extensions/brave/README.md
@@ -1,0 +1,3 @@
+# Brave (OpenClaw plugin)
+
+OpenClaw Brave plugin

--- a/extensions/byteplus/README.md
+++ b/extensions/byteplus/README.md
@@ -1,0 +1,3 @@
+# Byteplus (OpenClaw plugin)
+
+OpenClaw BytePlus provider plugin

--- a/extensions/chutes/README.md
+++ b/extensions/chutes/README.md
@@ -1,0 +1,3 @@
+# Chutes (OpenClaw plugin)
+
+OpenClaw Chutes.ai provider plugin

--- a/extensions/cloudflare-ai-gateway/README.md
+++ b/extensions/cloudflare-ai-gateway/README.md
@@ -1,0 +1,3 @@
+# Cloudflare Ai Gateway (OpenClaw plugin)
+
+OpenClaw Cloudflare AI Gateway provider plugin

--- a/extensions/device-pair/README.md
+++ b/extensions/device-pair/README.md
@@ -1,0 +1,3 @@
+# Device Pair (OpenClaw plugin)
+
+Generate setup codes and approve device pairing requests.

--- a/extensions/diagnostics-otel/README.md
+++ b/extensions/diagnostics-otel/README.md
@@ -1,0 +1,3 @@
+# Diagnostics Otel (OpenClaw plugin)
+
+OpenClaw diagnostics OpenTelemetry exporter

--- a/extensions/discord/README.md
+++ b/extensions/discord/README.md
@@ -1,0 +1,3 @@
+# Discord (OpenClaw plugin)
+
+OpenClaw Discord channel plugin

--- a/extensions/elevenlabs/README.md
+++ b/extensions/elevenlabs/README.md
@@ -1,0 +1,3 @@
+# Elevenlabs (OpenClaw plugin)
+
+OpenClaw ElevenLabs speech plugin

--- a/extensions/fal/README.md
+++ b/extensions/fal/README.md
@@ -1,0 +1,3 @@
+# Fal (OpenClaw plugin)
+
+OpenClaw fal provider plugin

--- a/extensions/feishu/README.md
+++ b/extensions/feishu/README.md
@@ -1,0 +1,3 @@
+# Feishu (OpenClaw plugin)
+
+OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)

--- a/extensions/firecrawl/README.md
+++ b/extensions/firecrawl/README.md
@@ -1,0 +1,3 @@
+# Firecrawl (OpenClaw plugin)
+
+OpenClaw Firecrawl plugin

--- a/extensions/github-copilot/README.md
+++ b/extensions/github-copilot/README.md
@@ -1,0 +1,3 @@
+# Github Copilot (OpenClaw plugin)
+
+OpenClaw GitHub Copilot provider plugin

--- a/extensions/google/README.md
+++ b/extensions/google/README.md
@@ -1,0 +1,3 @@
+# Google (OpenClaw plugin)
+
+OpenClaw Google plugin

--- a/extensions/googlechat/README.md
+++ b/extensions/googlechat/README.md
@@ -1,0 +1,3 @@
+# Googlechat (OpenClaw plugin)
+
+OpenClaw Google Chat channel plugin

--- a/extensions/huggingface/README.md
+++ b/extensions/huggingface/README.md
@@ -1,0 +1,3 @@
+# Huggingface (OpenClaw plugin)
+
+OpenClaw Hugging Face provider plugin

--- a/extensions/imessage/README.md
+++ b/extensions/imessage/README.md
@@ -1,0 +1,3 @@
+# Imessage (OpenClaw plugin)
+
+OpenClaw iMessage channel plugin

--- a/extensions/irc/README.md
+++ b/extensions/irc/README.md
@@ -1,0 +1,3 @@
+# Irc (OpenClaw plugin)
+
+OpenClaw IRC channel plugin

--- a/extensions/kilocode/README.md
+++ b/extensions/kilocode/README.md
@@ -1,0 +1,3 @@
+# Kilocode (OpenClaw plugin)
+
+OpenClaw Kilo Gateway provider plugin

--- a/extensions/kimi-coding/README.md
+++ b/extensions/kimi-coding/README.md
@@ -1,0 +1,3 @@
+# Kimi Coding (OpenClaw plugin)
+
+OpenClaw Kimi provider plugin

--- a/extensions/line/README.md
+++ b/extensions/line/README.md
@@ -1,0 +1,3 @@
+# Line (OpenClaw plugin)
+
+OpenClaw LINE channel plugin

--- a/extensions/matrix/README.md
+++ b/extensions/matrix/README.md
@@ -1,0 +1,3 @@
+# Matrix (OpenClaw plugin)
+
+OpenClaw Matrix channel plugin

--- a/extensions/mattermost/README.md
+++ b/extensions/mattermost/README.md
@@ -1,0 +1,3 @@
+# Mattermost (OpenClaw plugin)
+
+OpenClaw Mattermost channel plugin

--- a/extensions/memory-core/README.md
+++ b/extensions/memory-core/README.md
@@ -1,0 +1,3 @@
+# Memory Core (OpenClaw plugin)
+
+OpenClaw core memory search plugin

--- a/extensions/memory-lancedb/README.md
+++ b/extensions/memory-lancedb/README.md
@@ -1,0 +1,3 @@
+# Memory Lancedb (OpenClaw plugin)
+
+OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture

--- a/extensions/microsoft/README.md
+++ b/extensions/microsoft/README.md
@@ -1,0 +1,3 @@
+# Microsoft (OpenClaw plugin)
+
+OpenClaw Microsoft speech plugin

--- a/extensions/mistral/README.md
+++ b/extensions/mistral/README.md
@@ -1,0 +1,3 @@
+# Mistral (OpenClaw plugin)
+
+OpenClaw Mistral provider plugin

--- a/extensions/modelstudio/README.md
+++ b/extensions/modelstudio/README.md
@@ -1,0 +1,3 @@
+# Modelstudio (OpenClaw plugin)
+
+OpenClaw Model Studio provider plugin

--- a/extensions/moonshot/README.md
+++ b/extensions/moonshot/README.md
@@ -1,0 +1,3 @@
+# Moonshot (OpenClaw plugin)
+
+OpenClaw Moonshot provider plugin

--- a/extensions/msteams/README.md
+++ b/extensions/msteams/README.md
@@ -1,0 +1,3 @@
+# Msteams (OpenClaw plugin)
+
+OpenClaw Microsoft Teams channel plugin

--- a/extensions/nextcloud-talk/README.md
+++ b/extensions/nextcloud-talk/README.md
@@ -1,0 +1,3 @@
+# Nextcloud Talk (OpenClaw plugin)
+
+OpenClaw Nextcloud Talk channel plugin

--- a/extensions/nvidia/README.md
+++ b/extensions/nvidia/README.md
@@ -1,0 +1,3 @@
+# Nvidia (OpenClaw plugin)
+
+OpenClaw NVIDIA provider plugin

--- a/extensions/openai/README.md
+++ b/extensions/openai/README.md
@@ -1,0 +1,3 @@
+# Openai (OpenClaw plugin)
+
+OpenClaw OpenAI provider plugins

--- a/extensions/opencode-go/README.md
+++ b/extensions/opencode-go/README.md
@@ -1,0 +1,3 @@
+# Opencode Go (OpenClaw plugin)
+
+OpenClaw OpenCode Go provider plugin

--- a/extensions/opencode/README.md
+++ b/extensions/opencode/README.md
@@ -1,0 +1,3 @@
+# Opencode (OpenClaw plugin)
+
+OpenClaw OpenCode Zen provider plugin

--- a/extensions/openrouter/README.md
+++ b/extensions/openrouter/README.md
@@ -1,0 +1,3 @@
+# Openrouter (OpenClaw plugin)
+
+OpenClaw OpenRouter provider plugin

--- a/extensions/openshell/README.md
+++ b/extensions/openshell/README.md
@@ -1,0 +1,3 @@
+# Openshell (OpenClaw plugin)
+
+OpenClaw OpenShell sandbox backend

--- a/extensions/perplexity/README.md
+++ b/extensions/perplexity/README.md
@@ -1,0 +1,3 @@
+# Perplexity (OpenClaw plugin)
+
+OpenClaw Perplexity plugin

--- a/extensions/phone-control/README.md
+++ b/extensions/phone-control/README.md
@@ -1,0 +1,3 @@
+# Phone Control (OpenClaw plugin)
+
+Arm/disarm high-risk phone node commands (camera/screen/writes) with an optional auto-expiry.

--- a/extensions/qianfan/README.md
+++ b/extensions/qianfan/README.md
@@ -1,0 +1,3 @@
+# Qianfan (OpenClaw plugin)
+
+OpenClaw Qianfan provider plugin

--- a/extensions/signal/README.md
+++ b/extensions/signal/README.md
@@ -1,0 +1,3 @@
+# Signal (OpenClaw plugin)
+
+OpenClaw Signal channel plugin

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -1,0 +1,3 @@
+# Slack (OpenClaw plugin)
+
+OpenClaw Slack channel plugin

--- a/extensions/synology-chat/README.md
+++ b/extensions/synology-chat/README.md
@@ -1,0 +1,3 @@
+# Synology Chat (OpenClaw plugin)
+
+Synology Chat channel plugin for OpenClaw

--- a/extensions/synthetic/README.md
+++ b/extensions/synthetic/README.md
@@ -1,0 +1,3 @@
+# Synthetic (OpenClaw plugin)
+
+OpenClaw Synthetic provider plugin

--- a/extensions/talk-voice/README.md
+++ b/extensions/talk-voice/README.md
@@ -1,0 +1,3 @@
+# Talk Voice (OpenClaw plugin)
+
+Manage Talk voice selection (list/set).

--- a/extensions/tavily/README.md
+++ b/extensions/tavily/README.md
@@ -1,0 +1,3 @@
+# Tavily (OpenClaw plugin)
+
+OpenClaw Tavily plugin

--- a/extensions/telegram/README.md
+++ b/extensions/telegram/README.md
@@ -1,0 +1,3 @@
+# Telegram (OpenClaw plugin)
+
+OpenClaw Telegram channel plugin

--- a/extensions/thread-ownership/README.md
+++ b/extensions/thread-ownership/README.md
@@ -1,0 +1,3 @@
+# Thread Ownership (OpenClaw plugin)
+
+Prevents multiple agents from responding in the same Slack thread. Uses HTTP calls to the slack-forwarder ownership API.

--- a/extensions/together/README.md
+++ b/extensions/together/README.md
@@ -1,0 +1,3 @@
+# Together (OpenClaw plugin)
+
+OpenClaw Together provider plugin

--- a/extensions/venice/README.md
+++ b/extensions/venice/README.md
@@ -1,0 +1,3 @@
+# Venice (OpenClaw plugin)
+
+OpenClaw Venice provider plugin

--- a/extensions/vercel-ai-gateway/README.md
+++ b/extensions/vercel-ai-gateway/README.md
@@ -1,0 +1,3 @@
+# Vercel Ai Gateway (OpenClaw plugin)
+
+OpenClaw Vercel AI Gateway provider plugin

--- a/extensions/volcengine/README.md
+++ b/extensions/volcengine/README.md
@@ -1,0 +1,3 @@
+# Volcengine (OpenClaw plugin)
+
+OpenClaw Volcengine provider plugin

--- a/extensions/whatsapp/README.md
+++ b/extensions/whatsapp/README.md
@@ -1,0 +1,3 @@
+# Whatsapp (OpenClaw plugin)
+
+OpenClaw WhatsApp channel plugin

--- a/extensions/xai/README.md
+++ b/extensions/xai/README.md
@@ -1,0 +1,3 @@
+# Xai (OpenClaw plugin)
+
+OpenClaw xAI plugin

--- a/extensions/xiaomi/README.md
+++ b/extensions/xiaomi/README.md
@@ -1,0 +1,3 @@
+# Xiaomi (OpenClaw plugin)
+
+OpenClaw Xiaomi provider plugin

--- a/extensions/zai/README.md
+++ b/extensions/zai/README.md
@@ -1,0 +1,3 @@
+# Zai (OpenClaw plugin)
+
+OpenClaw Z.AI provider plugin


### PR DESCRIPTION
Add minimal README.md for 58 extensions that were missing them, using the description from package.json. Also fixes a broken /configuration link in plugins/manifest.md.