### PR TITLE
refactor(doctor): extract telegram provider warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/MiniMax: merge the bundled MiniMax API and MiniMax OAuth plugin surfaces into a single default-on `minimax` plugin, while keeping legacy `minimax-portal-auth` config ids aliased for compatibility.
 - Telegram/actions: add `topic-edit` for forum-topic renames and icon updates while sharing the same Telegram topic-edit transport used by the plugin runtime. (#47798) Thanks @obviyus.
 - Telegram/error replies: add a default-off `channels.telegram.silentErrorReplies` setting so bot error replies can be delivered silently across regular replies, native commands, and fallback sends. (#19776) Thanks @ImLukeF.
+- Doctor/refactor: start splitting doctor provider checks into `src/commands/doctor/providers/*` by extracting Telegram first-run and group allowlist warnings into a provider-specific module, keeping the current setup guidance and warning behavior intact. Thanks @vincentkoc.
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) Thanks @scoootscooob.
 - Docs/Zalo: clarify the Marketplace-bot support matrix and config guidance so the Zalo channel docs match current Bot Creator behavior more closely. (#47552) Thanks @No898.
 - secrets: harden read-only SecretRef command paths and diagnostics. (#47794) Thanks @joshavant.

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -76,6 +76,7 @@ import {
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
+import { collectTelegramGroupPolicyWarnings } from "./doctor/providers/telegram.js";
 
 type TelegramAllowFromUsernameHit = { path: string; entry: string };
 
@@ -1330,16 +1331,6 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     );
   };
 
-  const hasConfiguredGroups = (
-    account: Record<string, unknown>,
-    parent?: Record<string, unknown>,
-  ): boolean => {
-    const groups =
-      (account.groups as Record<string, unknown> | undefined) ??
-      (parent?.groups as Record<string, unknown> | undefined);
-    return Boolean(groups) && Object.keys(groups ?? {}).length > 0;
-  };
-
   const checkAccount = (
     account: Record<string, unknown>,
     prefix: string,
@@ -1382,18 +1373,15 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       undefined;
 
     if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
-      if (channelName === "telegram" && !hasConfiguredGroups(account, parent)) {
-        const effectiveDmPolicy = dmPolicy ?? "pairing";
-        const dmSetupLine =
-          effectiveDmPolicy === "pairing"
-            ? `DMs use pairing mode, so new senders must start a chat and be approved before regular messages are accepted.`
-            : effectiveDmPolicy === "allowlist"
-              ? `DMs use allowlist mode, so only sender IDs in ${prefix}.allowFrom are accepted.`
-              : effectiveDmPolicy === "open"
-                ? `DMs are open.`
-                : `DMs are disabled.`;
+      if (channelName === "telegram") {
         warnings.push(
-          `- ${prefix}: Telegram is in first-time setup mode. ${dmSetupLine} Group messages stay blocked until you add allowed chats under ${prefix}.groups (and optional sender IDs under ${prefix}.groupAllowFrom), or set ${prefix}.groupPolicy to "open" if you want broad group access.`,
+          ...collectTelegramGroupPolicyWarnings({
+            account,
+            prefix,
+            effectiveAllowFrom,
+            dmPolicy,
+            parent,
+          }),
         );
         return;
       }

--- a/src/commands/doctor/providers/telegram.test.ts
+++ b/src/commands/doctor/providers/telegram.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { collectTelegramGroupPolicyWarnings } from "./telegram.js";
+
+describe("doctor telegram provider warnings", () => {
+  it("shows first-run guidance when groups are not configured yet", () => {
+    const warnings = collectTelegramGroupPolicyWarnings({
+      account: {
+        botToken: "123:abc",
+        groupPolicy: "allowlist",
+      },
+      prefix: "channels.telegram",
+      dmPolicy: "pairing",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining("channels.telegram: Telegram is in first-time setup mode."),
+    ]);
+    expect(warnings[0]).toContain("DMs use pairing mode");
+    expect(warnings[0]).toContain("channels.telegram.groups");
+  });
+
+  it("warns when configured groups still have no usable sender allowlist", () => {
+    const warnings = collectTelegramGroupPolicyWarnings({
+      account: {
+        botToken: "123:abc",
+        groupPolicy: "allowlist",
+        groups: {
+          ops: { allow: true },
+        },
+      },
+      prefix: "channels.telegram",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining(
+        'channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty',
+      ),
+    ]);
+  });
+
+  it("stays quiet when allowFrom can satisfy group allowlist mode", () => {
+    const warnings = collectTelegramGroupPolicyWarnings({
+      account: {
+        botToken: "123:abc",
+        groupPolicy: "allowlist",
+        groups: {
+          ops: { allow: true },
+        },
+      },
+      prefix: "channels.telegram",
+      effectiveAllowFrom: ["123456"],
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/src/commands/doctor/providers/telegram.ts
+++ b/src/commands/doctor/providers/telegram.ts
@@ -1,0 +1,55 @@
+type DoctorAccountRecord = Record<string, unknown>;
+
+function hasAllowFromEntries(list?: Array<string | number>) {
+  return Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
+}
+
+function hasConfiguredGroups(account: DoctorAccountRecord, parent?: DoctorAccountRecord): boolean {
+  const groups =
+    (account.groups as Record<string, unknown> | undefined) ??
+    (parent?.groups as Record<string, unknown> | undefined);
+  return Boolean(groups) && Object.keys(groups ?? {}).length > 0;
+}
+
+type CollectTelegramGroupPolicyWarningsParams = {
+  account: DoctorAccountRecord;
+  prefix: string;
+  effectiveAllowFrom?: Array<string | number>;
+  dmPolicy?: string;
+  parent?: DoctorAccountRecord;
+};
+
+export function collectTelegramGroupPolicyWarnings(
+  params: CollectTelegramGroupPolicyWarningsParams,
+): string[] {
+  if (!hasConfiguredGroups(params.account, params.parent)) {
+    const effectiveDmPolicy = params.dmPolicy ?? "pairing";
+    const dmSetupLine =
+      effectiveDmPolicy === "pairing"
+        ? "DMs use pairing mode, so new senders must start a chat and be approved before regular messages are accepted."
+        : effectiveDmPolicy === "allowlist"
+          ? `DMs use allowlist mode, so only sender IDs in ${params.prefix}.allowFrom are accepted.`
+          : effectiveDmPolicy === "open"
+            ? "DMs are open."
+            : "DMs are disabled.";
+    return [
+      `- ${params.prefix}: Telegram is in first-time setup mode. ${dmSetupLine} Group messages stay blocked until you add allowed chats under ${params.prefix}.groups (and optional sender IDs under ${params.prefix}.groupAllowFrom), or set ${params.prefix}.groupPolicy to "open" if you want broad group access.`,
+    ];
+  }
+
+  const rawGroupAllowFrom =
+    (params.account.groupAllowFrom as Array<string | number> | undefined) ??
+    (params.parent?.groupAllowFrom as Array<string | number> | undefined);
+  // Match runtime semantics: resolveGroupAllowFromSources treats empty arrays as
+  // unset and falls back to allowFrom.
+  const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
+  const effectiveGroupAllowFrom = groupAllowFrom ?? params.effectiveAllowFrom;
+
+  if (hasAllowFromEntries(effectiveGroupAllowFrom)) {
+    return [];
+  }
+
+  return [
+    `- ${params.prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${params.prefix}.groupAllowFrom or ${params.prefix}.allowFrom, or set ${params.prefix}.groupPolicy to "open".`,
+  ];
+}


### PR DESCRIPTION
## Summary

- Problem: `src/commands/doctor-config-flow.ts` still owns Telegram-specific setup and allowlist warning logic, which makes Doctor harder to split by provider.
- Why it matters: adding provider-specific onboarding/warning behavior currently requires editing the monolithic config flow instead of extending provider-local doctor code.
- What changed: extracted Telegram first-run and group allowlist warnings into `src/commands/doctor/providers/telegram.ts`, added a provider-local test file, and left `doctor-config-flow.ts` as the orchestrator/delegator for this slice.
- What did NOT change (scope boundary): broader Doctor registry/orchestrator refactor, non-Telegram provider extraction, and warning text/runtime semantics.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- None intended. This is a refactor of existing Telegram Doctor warning/guidance behavior plus a changelog entry.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm
- Model/provider: n/a
- Integration/channel (if any): Telegram Doctor config flow
- Relevant config (redacted): Telegram fresh-install and allowlist configs via unit tests

### Steps

1. Move Telegram-specific Doctor warning logic behind a provider-local module.
2. Run focused tests for `doctor-config-flow` and the new Telegram provider test file.
3. Run repo validation lanes that plausibly cover the touched surface.

### Expected

- Telegram Doctor warning behavior stays unchanged.
- Doctor flow delegates this provider-specific slice to a provider-local module.

### Actual

- Focused Doctor tests passed.
- `pnpm build` and `pnpm check` currently fail on unrelated latest-`main` baseline issues noted below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Telegram fresh-install guidance still appears; configured-group empty allowlist warning still appears; allowFrom fallback still suppresses the warning.
- Edge cases checked: top-level Telegram config and provider-local unit coverage.
- What you did **not** verify: full Doctor refactor beyond Telegram, unrelated repo-wide build/check baseline failures.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `6762e48ed1` and `65d215aa7d`.
- Files/config to restore: `src/commands/doctor-config-flow.ts`, `src/commands/doctor/providers/telegram.ts`, `src/commands/doctor/providers/telegram.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: missing Telegram first-run Doctor guidance or duplicate/changed group allowlist warnings.

## Risks and Mitigations

- Risk: provider extraction could subtly change warning copy or fallback behavior.
  - Mitigation: kept the delegated logic behavior-identical and added provider-local tests alongside existing flow tests.
- Risk: reviewers may assume this is the full Doctor refactor.
  - Mitigation: scope is explicitly phase-1 Telegram-only extraction.

## Validation Notes

- Passed: `pnpm exec vitest run src/commands/doctor-config-flow.test.ts src/commands/doctor/providers/telegram.test.ts`
- Fails on latest `origin/main`, unrelated to this PR:
  - `pnpm build`: `src/memory/embeddings-openai.ts` missing `DEFAULT_OPENAI_EMBEDDING_MODEL`; `src/memory/manager-sync-ops.ts` imports it.
  - `pnpm check`: `oxfmt --check` reports `src/tts/tts.ts` formatting with no diff in this branch.
