### PR TITLE
docs: alphabetize channel listing and fix extension spelling

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -26,8 +26,8 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
 - [Signal](/channels/signal) — signal-cli; privacy-focused.
-- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via outgoing+incoming webhooks (plugin, installed separately).
 - [Slack](/channels/slack) — Bolt SDK; workspace apps.
+- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via outgoing+incoming webhooks (plugin, installed separately).
 - [Telegram](/channels/telegram) — Bot API via grammY; supports groups.
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).

--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -59,7 +59,7 @@ export function parseColorMarkup(content: string): Segment[] {
   // pattern like \[([^\]]+)\] would match any bracket token — e.g. [Q1] —
   // and cause it to consume a later real closing tag ([/red]), silently
   // corrupting the surrounding styled spans.  Restricting the opening tag to
-  // the set of recognised colour/style names prevents that: [Q1] does not
+  // the set of recognized color/style names prevents that: [Q1] does not
   // match the tag alternative and each of its characters falls through to the
   // plain-text alternatives instead.
   //

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -162,7 +162,7 @@ async function writeCachedCommandHash(
     await fs.writeFile(filePath, hash, "utf-8");
   } catch {
     // Best-effort: failing to cache the hash just means the next restart
-    // will sync commands again, which is the pre-fix behaviour.
+    // will sync commands again, which is the pre-fix behavior.
   }
 }
 


### PR DESCRIPTION
Alphabetize the Slack/Synology Chat entries in docs/channels/index.md per coding guidelines. Also fixes American English spelling in extension comments.