### PR TITLE
docs: fix broken /configuration link in plugin manifest

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -121,7 +121,7 @@ Example:
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration) for the full `plugins.*` schema.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Fixed broken internal link in `docs/plugins/manifest.md`: `/configuration` -> `/gateway/configuration`
- The old path has no corresponding doc file; the canonical path is `/gateway/configuration`

## Test plan
- [ ] Verify the link resolves correctly on docs.openclaw.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)