### PR TITLE
web UI: fix context notice using accumulated inputTokens instead of p…

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -312,6 +312,34 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("757.3k / 200k");
   });
 
+  it("hides the context notice when totalTokens is missing even if inputTokens is high", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: 200_000 },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                inputTokens: 500_000,
+                contextTokens: 200_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).not.toContain("context used");
+  });
+
   it("uses the assistant avatar URL for the welcome state when the identity avatar is only initials", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,7 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.totalTokens ?? session?.inputTokens ?? 0;
+  const used = session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
web UI: fix context notice using accumulated inputTokens instead of prompt snapshot

The context-usage banner in the web UI fell back to inputTokens when totalTokens was missing. inputTokens is accumulated across all API calls in a run (tool-use loops, compaction retries), so it overstates actual context window utilization -- e.g. showing "100% context used 757.3k / 200k" when the real prompt snapshot is only 46k/200k (23%).

Drop the inputTokens fallback so the banner only fires when a genuine prompt snapshot (totalTokens) is available.

## Summary

- **Problem:** The web UI context-usage banner fell back to `inputTokens` (accumulated across all API calls in a run) when `totalTokens` (prompt snapshot) was missing, showing false alarms like "100% context used 757.3k / 200k".
- **Why it matters:** Users see a scary red "context full" warning when the actual context window is only 23% used, creating confusion and unnecessary session resets.
- **What changed:** Removed the `inputTokens` fallback in `renderContextNotice` so the banner only fires when a genuine `totalTokens` prompt snapshot is available. Added a test covering the missing-`totalTokens` edge case.
- **What did NOT change (scope boundary):** The status card text (`Context: 46k/200k (23%)`) was already correct and is untouched. Token accumulation, session storage, and per-message context % in grouped-render are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #(none identified)

## User-visible / Behavior Changes

- The amber/red "X% context used" banner in the web UI no longer appears when `totalTokens` is unavailable, instead of falsely reporting accumulated `inputTokens` as context utilization.
- When `totalTokens` is present and genuinely high (>=85% of context window), the banner continues to display correctly.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun / Node 22+
- Model/provider: minimax-portal/MiniMax-M2.5 (any provider reproduces)
- Integration/channel: Web UI (control-ui)
- Relevant config: default context window 200k

### Steps

1. Start a session with a model that has a 200k context window.
2. Run several tool-use loops so `inputTokens` accumulates well past 200k (e.g. 757k).
3. Observe the context notice banner at the bottom of the chat view.

### Expected

- Banner hidden (or showing accurate context % based on prompt snapshot).

### Actual (before fix)

- Banner shows "100% context used 757.3k / 200k" even though real context utilization is 23%.

## Evidence

- [x] Failing test/log before + passing after
  - Existing test "hides the context notice when only cumulative inputTokens exceed the limit" already encoded the correct expectation and passes with the fix.
  - New test "hides the context notice when totalTokens is missing even if inputTokens is high" covers the undefined-totalTokens edge case.
- [x] Screenshot/recording
  - User-provided screenshot showing the mismatch between status card (23%) and banner (100%).

## Human Verification (required)

- **Verified scenarios:** All 29 chat view tests pass (28 existing + 1 new). Format and lint clean on touched files.
- **Edge cases checked:** `totalTokens` undefined with high `inputTokens`; `totalTokens` present and above 85% threshold; `totalTokens` present but below threshold.
- **What you did not verify:** Live web UI end-to-end with a real session (test-only verification). Pre-existing `src/tts/tts.ts` format failure on `main` unrelated to this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the one-line change in `ui/src/ui/views/chat.ts` line 258 to restore `?? session?.inputTokens`.
- Files/config to restore: `ui/src/ui/views/chat.ts`
- Known bad symptoms reviewers should watch for: Context notice never appearing even when context is genuinely near capacity (would require `totalTokens` to be permanently missing for active sessions — unlikely given session-usage persistence).

## Risks and Mitigations

- **Risk:** If `totalTokens` is frequently `undefined` for active sessions, users lose the context-full warning entirely.
  - **Mitigation:** `totalTokens` is populated by `deriveSessionTotalTokens` on every reply with `lastCallUsage` or `promptTokens`. It is only missing on cold/stale sessions where context utilization is unknown anyway — showing nothing is more correct than showing a false alarm.