### PR TITLE
docs: use American English "summarizes" in compaction.md

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -80,7 +80,7 @@ Context window is model-specific. OpenClaw uses the model definition from the co
 
 ## Compaction vs pruning
 
-- **Compaction**: summarises and **persists** in JSONL.
+- **Compaction**: summarizes and **persists** in JSONL.
 - **Session pruning**: trims old **tool results** only, **in-memory**, per request.
 
 See [/concepts/session-pruning](/concepts/session-pruning) for pruning details.


### PR DESCRIPTION
## Summary
- Replace British English `summarises` with American English `summarizes` in compaction docs
- Per coding style guideline: "use American English spelling"

## Test plan
- [x] Single-word spelling fix, no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)