### PR TITLE
refactor(agents): collect-then-attach media artifacts instead of immediate delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Breaking Changes
+
+- Agents/tools: replace tool media delivery payloads to use `details.media` (instead of `details.reply`) for media artifacts; plugins should emit `details.media` for attachments. (#51731) Thanks @christianklotz.
+
 ### Changes
 
 - Models/Anthropic Vertex: add core `anthropic-vertex` provider support for Claude via Google Vertex AI, including GCP auth/discovery and main run-path routing. (#43356) Thanks @sallyom and @yossiovadia.
@@ -58,7 +62,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/topics: auto-rename DM forum topics on first message with LLM-generated labels, with per-account and per-DM `autoTopicLabel` overrides. (#51502) Thanks @Lukavyi.
 - Docs/plugins: add the community wecom plugin listing to the docs catalog. (#29905) Thanks @sliverp.
 - Models/GitHub Copilot: allow forward-compat dynamic model ids without code updates, while preserving configured provider and per-model overrides for those synthetic models. (#51325) Thanks @fuller-stack-dev.
-- Agents/tools: replace tool media delivery payloads to use `details.media` (instead of `details.reply`) for media artifacts; plugins should emit `details.media` for attachments. (#51731) Thanks @christianklotz.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/topics: auto-rename DM forum topics on first message with LLM-generated labels, with per-account and per-DM `autoTopicLabel` overrides. (#51502) Thanks @Lukavyi.
 - Docs/plugins: add the community wecom plugin listing to the docs catalog. (#29905) Thanks @sliverp.
 - Models/GitHub Copilot: allow forward-compat dynamic model ids without code updates, while preserving configured provider and per-model overrides for those synthetic models. (#51325) Thanks @fuller-stack-dev.
+- Agents/tools: replace tool media delivery payloads to use `details.media` (instead of `details.reply`) for media artifacts; plugins should emit `details.media` for attachments. (#51731) Thanks @christianklotz.
 
 ### Fixes
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -96,7 +96,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
   }
 
-  ctx.flushBlockReplyBuffer();
+  ctx.flushBlockReplyBuffer({ drainOrphanedArtifacts: true });
   // Flush the reply pipeline so the response reaches the channel before
   // compaction wait blocks the run.  This mirrors the pattern used by
   // handleToolExecutionStart and ensures delivery is not held hostage to

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -391,19 +391,29 @@ export function handleMessageEnd(
     // Drain pending media artifacts so they travel with this reply.
     const drained = ctx.drainPendingMediaArtifacts();
     const mergedMediaUrls = [...(mediaUrls ?? []), ...drained.mediaUrls];
-    const mergedAudioAsVoice = audioAsVoice || drained.audioAsVoice;
+    const audioAsVoiceFromDirectives = audioAsVoice;
+    const voiceMediaUrls = drained.voiceMediaUrls;
     // Emit if there's content OR audioAsVoice flag (to propagate the flag).
-    if (
-      hasAssistantVisibleReply({
-        text: cleanedText,
-        mediaUrls: mergedMediaUrls,
-        audioAsVoice: mergedAudioAsVoice,
-      })
-    ) {
+    const shouldEmitStandard = hasAssistantVisibleReply({
+      text: cleanedText,
+      mediaUrls: mergedMediaUrls,
+      audioAsVoice: audioAsVoiceFromDirectives,
+    });
+    if (shouldEmitStandard) {
       emitBlockReplySafely({
         text: cleanedText,
         mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
-        audioAsVoice: mergedAudioAsVoice,
+        audioAsVoice: audioAsVoiceFromDirectives,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      });
+    }
+    if (voiceMediaUrls.length > 0 || drained.audioAsVoice) {
+      emitBlockReplySafely({
+        text: shouldEmitStandard ? undefined : cleanedText,
+        mediaUrls: voiceMediaUrls.length > 0 ? voiceMediaUrls : undefined,
+        audioAsVoice: true,
         replyToId,
         replyToTag,
         replyToCurrent,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -388,12 +388,22 @@ export function handleMessageEnd(
       replyToTag,
       replyToCurrent,
     } = splitResult;
+    // Drain pending media artifacts so they travel with this reply.
+    const drained = ctx.drainPendingMediaArtifacts();
+    const mergedMediaUrls = [...(mediaUrls ?? []), ...drained.mediaUrls];
+    const mergedAudioAsVoice = audioAsVoice || drained.audioAsVoice;
     // Emit if there's content OR audioAsVoice flag (to propagate the flag).
-    if (hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice })) {
+    if (
+      hasAssistantVisibleReply({
+        text: cleanedText,
+        mediaUrls: mergedMediaUrls,
+        audioAsVoice: mergedAudioAsVoice,
+      })
+    ) {
       emitBlockReplySafely({
         text: cleanedText,
-        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
-        audioAsVoice,
+        mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+        audioAsVoice: mergedAudioAsVoice,
         replyToId,
         replyToTag,
         replyToCurrent,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./pi-embedded-subscribe.handlers.tools.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 
-// Minimal mock context factory. Only the fields needed for the media emission path.
+// Minimal mock context factory. Only the fields needed for the media artifact path.
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
@@ -29,6 +29,7 @@ function createMockContext(overrides?: {
       messagingToolSentMediaUrls: [],
       messagingToolSentTargets: [],
       deterministicApprovalPromptSent: false,
+      pendingMediaArtifacts: [],
     },
     log: { debug: vi.fn(), warn: vi.fn() },
     shouldEmitToolResult: vi.fn(() => false),
@@ -79,16 +80,16 @@ async function emitPngMediaToolResult(
   });
 }
 
-async function emitExplicitToolReply(ctx: EmbeddedPiSubscribeContext) {
+async function emitToolWithMediaArtifact(ctx: EmbeddedPiSubscribeContext) {
   await handleToolExecutionEnd(ctx, {
     type: "tool_execution_end",
     toolName: "image_generate",
-    toolCallId: "tc-explicit",
+    toolCallId: "tc-artifact",
     isError: false,
     result: {
       content: [{ type: "text", text: "Generated 1 image." }],
       details: {
-        reply: {
+        media: {
           mediaUrls: ["/tmp/generated.png"],
         },
       },
@@ -108,7 +109,7 @@ async function emitToolMediaResult(ctx: EmbeddedPiSubscribeContext, mediaPathOrU
   });
 }
 
-describe("handleToolExecutionEnd tool media", () => {
+describe("handleToolExecutionEnd media artifacts", () => {
   it("does not warn for read tool when path is provided via file_path alias", async () => {
     const ctx = createMockContext();
 
@@ -122,46 +123,68 @@ describe("handleToolExecutionEnd tool media", () => {
     expect(ctx.log.warn).not.toHaveBeenCalled();
   });
 
-  it("does not emit raw media when verbose is off and tool result has MEDIA: path", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("does not stash artifacts for MEDIA: text in tool output (no implicit parsing)", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await emitPngMediaToolResult(ctx);
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
   });
 
-  it("emits explicit tool reply payloads when verbose is off", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
-
-    await emitExplicitToolReply(ctx);
-
-    expect(onToolResult).toHaveBeenCalledWith({
-      mediaUrls: ["/tmp/generated.png"],
-    });
-  });
-
-  it("does not record explicit tool reply media as messaging-tool sends", async () => {
+  it("stashes media artifact from details.media when verbose is off", async () => {
     const ctx = createMockContext({ shouldEmitToolOutput: false });
 
-    await emitExplicitToolReply(ctx);
+    await emitToolWithMediaArtifact(ctx);
 
-    expect(ctx.state.messagingToolSentMediaUrls).toEqual([]);
+    expect(ctx.state.pendingMediaArtifacts).toEqual([
+      {
+        toolName: "image_generate",
+        artifact: { mediaUrls: ["/tmp/generated.png"] },
+      },
+    ]);
   });
 
-  it("does not emit raw local media from tool output text", async () => {
+  it("stashes media artifact from details.media when verbose is full", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: true });
+
+    await emitToolWithMediaArtifact(ctx);
+
+    expect(ctx.emitToolOutput).toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toEqual([
+      {
+        toolName: "image_generate",
+        artifact: { mediaUrls: ["/tmp/generated.png"] },
+      },
+    ]);
+  });
+
+  it("does not deliver media artifacts via onToolResult", async () => {
     const onToolResult = vi.fn();
     const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await emitToolWithMediaArtifact(ctx);
+
+    // onToolResult should not be called with media — artifacts are stashed, not delivered
+    const mediaCalls = onToolResult.mock.calls.filter(
+      (call: unknown[]) =>
+        call[0] &&
+        typeof call[0] === "object" &&
+        ("mediaUrls" in (call[0] as Record<string, unknown>) ||
+          "mediaUrl" in (call[0] as Record<string, unknown>)),
+    );
+    expect(mediaCalls).toHaveLength(0);
+  });
+
+  it("does not stash artifacts for MEDIA: text from untrusted tools", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await emitToolMediaResult(ctx, "/tmp/secret.png");
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
   });
 
-  it("drops local explicit reply media from untrusted tools", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("drops local media artifact URLs from untrusted tools", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await handleToolExecutionEnd(ctx, {
       type: "tool_execution_end",
@@ -171,70 +194,53 @@ describe("handleToolExecutionEnd tool media", () => {
       result: {
         content: [{ type: "text", text: "Generated 1 file." }],
         details: {
-          reply: {
+          media: {
             mediaUrls: ["/tmp/secret.png"],
           },
         },
       },
     });
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    // Local paths are filtered out for untrusted tools
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
   });
 
-  it("does not emit raw remote media from tool output text", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("allows remote URLs from untrusted tools", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
-    await emitToolMediaResult(ctx, "https://example.com/file.png");
-
-    expect(onToolResult).not.toHaveBeenCalled();
-  });
-
-  it("does NOT emit media when verbose is full (emitToolOutput handles it)", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: true, onToolResult });
-
-    await emitPngMediaToolResult(ctx);
-
-    // onToolResult should NOT be called by the new media path (emitToolOutput handles it).
-    // It may be called by emitToolOutput, but the new block should not fire.
-    // Verify emitToolOutput was called instead.
-    expect(ctx.emitToolOutput).toHaveBeenCalled();
-    // The direct media emission should not have been called with just mediaUrls.
-    const directMediaCalls = onToolResult.mock.calls.filter(
-      (call: unknown[]) =>
-        call[0] &&
-        typeof call[0] === "object" &&
-        "mediaUrls" in (call[0] as Record<string, unknown>) &&
-        !("text" in (call[0] as Record<string, unknown>)),
-    );
-    expect(directMediaCalls).toHaveLength(0);
-  });
-
-  it("still emits explicit tool reply payloads when verbose is full", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: true, onToolResult });
-
-    await emitExplicitToolReply(ctx);
-
-    expect(ctx.emitToolOutput).toHaveBeenCalled();
-    expect(onToolResult).toHaveBeenCalledWith({
-      mediaUrls: ["/tmp/generated.png"],
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "third_party_plugin",
+      toolCallId: "tc-untrusted-remote",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image." }],
+        details: {
+          media: {
+            mediaUrls: ["https://example.com/image.png"],
+          },
+        },
+      },
     });
+
+    expect(ctx.state.pendingMediaArtifacts).toEqual([
+      {
+        toolName: "third_party_plugin",
+        artifact: { mediaUrls: ["https://example.com/image.png"] },
+      },
+    ]);
   });
 
-  it("does NOT emit media for error results", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("does NOT stash artifacts for error results", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await emitPngMediaToolResult(ctx, { isError: true });
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
   });
 
-  it("does NOT emit when tool result has no media", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("does NOT stash artifacts when tool result has no media", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await handleToolExecutionEnd(ctx, {
       type: "tool_execution_end",
@@ -246,56 +252,11 @@ describe("handleToolExecutionEnd tool media", () => {
       },
     });
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
   });
 
-  it("does NOT emit media for <media:audio> placeholder text", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
-
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "tts",
-      toolCallId: "tc-1",
-      isError: false,
-      result: {
-        content: [
-          {
-            type: "text",
-            text: "<media:audio> placeholder with successful preflight voice transcript",
-          },
-        ],
-      },
-    });
-
-    expect(onToolResult).not.toHaveBeenCalled();
-  });
-
-  it("does NOT emit media for malformed MEDIA:-prefixed prose", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
-
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "browser",
-      toolCallId: "tc-1",
-      isError: false,
-      result: {
-        content: [
-          {
-            type: "text",
-            text: "MEDIA:-prefixed paths (lenient whitespace) when loading outbound media",
-          },
-        ],
-      },
-    });
-
-    expect(onToolResult).not.toHaveBeenCalled();
-  });
-
-  it("does not emit media from details.path fallback when no MEDIA: text", async () => {
-    const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+  it("does not stash artifacts for details.path fallback (no implicit extraction)", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
 
     await handleToolExecutionEnd(ctx, {
       type: "tool_execution_end",
@@ -311,6 +272,33 @@ describe("handleToolExecutionEnd tool media", () => {
       },
     });
 
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(ctx.state.pendingMediaArtifacts).toHaveLength(0);
+  });
+
+  it("stashes audio artifact with audioAsVoice", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tc-tts",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated speech audio." }],
+        details: {
+          media: {
+            mediaUrl: "/tmp/voice.opus",
+            audioAsVoice: true,
+          },
+        },
+      },
+    });
+
+    expect(ctx.state.pendingMediaArtifacts).toEqual([
+      {
+        toolName: "tts",
+        artifact: { mediaUrl: "/tmp/voice.opus", audioAsVoice: true },
+      },
+    ]);
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -46,6 +46,7 @@ function createTestContext(): {
       messagingToolSentTargets: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
+      pendingMediaArtifacts: [],
     },
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,
@@ -375,7 +376,7 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.pendingMessagingMediaUrls.has("tool-m2")).toBe(false);
   });
 
-  it("does not treat explicit tool result reply payload media as messaging-tool sends", async () => {
+  it("stashes media artifacts instead of tracking them as messaging-tool sends", async () => {
     const { ctx } = createTestContext();
 
     const startEvt: ToolExecutionStartEvent = {
@@ -394,7 +395,7 @@ describe("messaging tool media URL tracking", () => {
       result: {
         content: [{ type: "text", text: "sent" }],
         details: {
-          reply: {
+          media: {
             mediaUrls: ["file:///img-a.jpg", "file:///img-b.jpg"],
           },
         },
@@ -402,7 +403,14 @@ describe("messaging tool media URL tracking", () => {
     };
     await handleToolExecutionEnd(ctx, endEvt);
 
+    // Media artifacts are stashed, not tracked as messaging sends
     expect(ctx.state.messagingToolSentMediaUrls).toEqual([]);
+    expect(ctx.state.pendingMediaArtifacts).toEqual([
+      {
+        toolName: "message",
+        artifact: { mediaUrls: ["file:///img-a.jpg", "file:///img-b.jpg"] },
+      },
+    ]);
   });
 
   it("trims messagingToolSentMediaUrls to 200 on commit (FIFO)", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -32,6 +32,7 @@ type ToolStartRecord = {
 
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
+const MAX_PENDING_MEDIA_ARTIFACTS = 200;
 
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
@@ -232,6 +233,12 @@ async function emitToolResultOutput(params: {
     const artifact = extractToolMediaArtifact(toolName, result);
     if (artifact) {
       ctx.state.pendingMediaArtifacts.push({ toolName, artifact });
+      if (ctx.state.pendingMediaArtifacts.length > MAX_PENDING_MEDIA_ARTIFACTS) {
+        ctx.state.pendingMediaArtifacts.splice(
+          0,
+          ctx.state.pendingMediaArtifacts.length - MAX_PENDING_MEDIA_ARTIFACTS,
+        );
+      }
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -15,7 +15,7 @@ import type {
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
-  extractToolResultReplyPayload,
+  extractToolMediaArtifact,
   extractToolResultText,
   isToolResultError,
   sanitizeToolResult,
@@ -225,6 +225,16 @@ async function emitToolResultOutput(params: {
   sanitizedResult: unknown;
 }) {
   const { ctx, toolName, meta, isToolError, result, sanitizedResult } = params;
+
+  // Stash media artifacts for the block reply pipeline regardless of whether
+  // onToolResult is wired — artifacts are consumed by block replies, not onToolResult.
+  if (!isToolError) {
+    const artifact = extractToolMediaArtifact(toolName, result);
+    if (artifact) {
+      ctx.state.pendingMediaArtifacts.push({ toolName, artifact });
+    }
+  }
+
   if (!ctx.params.onToolResult) {
     return;
   }
@@ -269,32 +279,11 @@ async function emitToolResultOutput(params: {
     return;
   }
 
-  const explicitReplyPayload = !isToolError
-    ? extractToolResultReplyPayload(toolName, result)
-    : undefined;
-
   if (ctx.shouldEmitToolOutput()) {
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
     }
-    if (!explicitReplyPayload) {
-      return;
-    }
-  }
-
-  if (isToolError) {
-    return;
-  }
-
-  if (!explicitReplyPayload) {
-    return;
-  }
-
-  try {
-    await ctx.params.onToolResult?.(explicitReplyPayload);
-  } catch {
-    // ignore delivery failures
   }
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -118,6 +118,7 @@ export type EmbeddedPiSubscribeContext = {
     addedDuringMessage: boolean;
     chunkerHasBuffered: boolean;
   }) => void;
+  drainPendingMediaArtifacts: () => { mediaUrls: string[]; audioAsVoice: boolean };
   trimMessagingToolSent: () => void;
   ensureCompactionPromise: () => void;
   noteCompactionRetry: () => void;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -118,7 +118,11 @@ export type EmbeddedPiSubscribeContext = {
     addedDuringMessage: boolean;
     chunkerHasBuffered: boolean;
   }) => void;
-  drainPendingMediaArtifacts: () => { mediaUrls: string[]; audioAsVoice: boolean };
+  drainPendingMediaArtifacts: () => {
+    mediaUrls: string[];
+    voiceMediaUrls: string[];
+    audioAsVoice: boolean;
+  };
   trimMessagingToolSent: () => void;
   ensureCompactionPromise: () => void;
   noteCompactionRetry: () => void;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -5,6 +5,7 @@ import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
+import type { ToolMediaArtifact } from "./pi-embedded-subscribe.tools.js";
 import type {
   BlockReplyChunking,
   SubscribeEmbeddedPiSessionParams,
@@ -78,6 +79,8 @@ export type EmbeddedPiSubscribeState = {
   pendingMessagingMediaUrls: Map<string, string[]>;
   deterministicApprovalPromptSent: boolean;
   lastAssistant?: AgentMessage;
+  /** Media artifacts collected from tool results, to be attached to the next block reply. */
+  pendingMediaArtifacts: Array<{ toolName: string; artifact: ToolMediaArtifact }>;
 };
 
 export type EmbeddedPiSubscribeContext = {
@@ -157,6 +160,7 @@ export type ToolHandlerState = Pick<
   | "messagingToolSentTargets"
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"
+  | "pendingMediaArtifacts"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -101,7 +101,7 @@ export type EmbeddedPiSubscribeContext = {
     state: { thinking: boolean; final: boolean; inlineCode?: InlineCodeState },
   ) => string;
   emitBlockChunk: (text: string) => void;
-  flushBlockReplyBuffer: () => void;
+  flushBlockReplyBuffer: (opts?: { drainOrphanedArtifacts?: boolean }) => void;
   emitReasoningStream: (text: string) => void;
   consumeReplyDirectives: (
     text: string,
@@ -169,7 +169,7 @@ export type ToolHandlerContext = {
   state: ToolHandlerState;
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
-  flushBlockReplyBuffer: () => void;
+  flushBlockReplyBuffer: (opts?: { drainOrphanedArtifacts?: boolean }) => void;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;

--- a/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
+++ b/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 import {
+  createSubscribedSessionHarness,
   createTextEndBlockReplyHarness,
   emitAssistantTextDelta,
   emitAssistantTextEnd,
@@ -165,5 +166,56 @@ describe("media artifact collect-then-attach", () => {
       .map((c: unknown[]) => c[0] as BlockReplyPayload)
       .filter((p) => p.mediaUrls?.length);
     expect(anyMedia).toHaveLength(0);
+  });
+
+  it("delivers media exactly once: via onBlockReply, not onToolResult", async () => {
+    const onBlockReply = vi.fn();
+    const onToolResult = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-once",
+      onBlockReply,
+      onToolResult,
+      blockReplyBreak: "text_end",
+    });
+
+    // Tool produces media via details.media
+    emit({
+      type: "tool_execution_start",
+      toolName: "image_generate",
+      toolCallId: "tc-once",
+      args: {},
+    });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-once",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image." }],
+        details: { media: { mediaUrls: ["/tmp/single.png"] } },
+      },
+    });
+    await flush();
+
+    // onToolResult should NOT have been called with the media
+    const toolResultMediaCalls = onToolResult.mock.calls.filter((c: unknown[]) => {
+      const payload = c[0] as Record<string, unknown>;
+      return payload.mediaUrls || payload.mediaUrl;
+    });
+    expect(toolResultMediaCalls).toHaveLength(0);
+
+    // Assistant reply
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Here is your image!" });
+    emitAssistantTextEnd({ emit });
+    await flush();
+
+    // onBlockReply should carry the media exactly once
+    const blockMediaCalls = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.includes("/tmp/single.png"));
+    expect(blockMediaCalls).toHaveLength(1);
+    expect(blockMediaCalls[0].text).toBe("Here is your image!");
   });
 });

--- a/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
+++ b/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
@@ -87,6 +87,57 @@ describe("media artifact collect-then-attach", () => {
     expect(mediaReplies[0].audioAsVoice).toBe(true);
   });
 
+  it("keeps voice artifacts separate when mixed with images", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "tool_execution_start", toolName: "image_generate", toolCallId: "tc-mix-1" });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-mix-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image." }],
+        details: { media: { mediaUrls: ["/tmp/mixed.png"] } },
+      },
+    });
+    await flush();
+
+    emit({ type: "tool_execution_start", toolName: "tts", toolCallId: "tc-mix-2" });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tc-mix-2",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated speech audio." }],
+        details: { media: { mediaUrl: "/tmp/mixed.opus", audioAsVoice: true } },
+      },
+    });
+    await flush();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Here are your outputs." });
+    emitAssistantTextEnd({ emit });
+    await flush();
+
+    const mediaReplies = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.length);
+    const imageReply = mediaReplies.find((p) => p.mediaUrls?.includes("/tmp/mixed.png"));
+    const voiceReply = mediaReplies.find((p) => p.mediaUrls?.includes("/tmp/mixed.opus"));
+
+    expect(imageReply).toBeDefined();
+    expect(imageReply?.audioAsVoice).not.toBe(true);
+    expect(imageReply?.text).toBe("Here are your outputs.");
+
+    expect(voiceReply).toBeDefined();
+    expect(voiceReply?.audioAsVoice).toBe(true);
+  });
+
   it("does not deliver artifacts prematurely on pre-tool flush", async () => {
     const onBlockReply = vi.fn();
     const { emit } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
+++ b/src/agents/pi-embedded-subscribe.media-artifacts.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
+import {
+  createTextEndBlockReplyHarness,
+  emitAssistantTextDelta,
+  emitAssistantTextEnd,
+} from "./pi-embedded-subscribe.e2e-harness.js";
+
+/** Flush microtasks (emitBlockReplySafely dispatches via Promise.resolve). */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("media artifact collect-then-attach", () => {
+  it("emits block reply for streamed text after microtask flush", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emitAssistantTextDelta({ emit, delta: "Hello world" });
+    emitAssistantTextEnd({ emit });
+    await flush();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const payload: BlockReplyPayload = onBlockReply.mock.calls[0][0];
+    expect(payload.text).toBe("Hello world");
+  });
+
+  it("attaches details.media artifact to the next assistant block reply", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    // Tool produces media via details.media (no MEDIA: in text)
+    emit({ type: "tool_execution_start", toolName: "image_generate", toolCallId: "tc2", args: {} });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc2",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image." }],
+        details: { media: { mediaUrls: ["/tmp/cat.png"] } },
+      },
+    });
+    await flush();
+
+    // Next assistant message (no MEDIA: in text)
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Here is your cat!" });
+    emitAssistantTextEnd({ emit });
+    await flush();
+
+    const mediaReplies = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.length);
+    expect(mediaReplies.length).toBeGreaterThan(0);
+    expect(mediaReplies[0].text).toBe("Here is your cat!");
+    expect(mediaReplies[0].mediaUrls).toEqual(["/tmp/cat.png"]);
+  });
+
+  it("flushes orphaned artifacts at agent end when no text follows", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "tool_execution_start", toolName: "tts", toolCallId: "tc3", args: {} });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tc3",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated speech audio." }],
+        details: { media: { mediaUrl: "/tmp/voice.opus", audioAsVoice: true } },
+      },
+    });
+    await flush();
+
+    // No assistant text, agent ends directly
+    emit({ type: "agent_end" });
+    await flush();
+
+    const mediaReplies = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.length || p.audioAsVoice);
+    expect(mediaReplies.length).toBeGreaterThan(0);
+    expect(mediaReplies[0].mediaUrls).toEqual(["/tmp/voice.opus"]);
+    expect(mediaReplies[0].audioAsVoice).toBe(true);
+  });
+
+  it("does not deliver artifacts prematurely on pre-tool flush", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    // First tool produces media
+    emit({ type: "tool_execution_start", toolName: "image_generate", toolCallId: "tc4", args: {} });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc4",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image." }],
+        details: { media: { mediaUrls: ["/tmp/first.png"] } },
+      },
+    });
+    await flush();
+
+    // Second tool starts (triggers flushBlockReplyBuffer)
+    emit({ type: "tool_execution_start", toolName: "browser", toolCallId: "tc5", args: {} });
+    await flush();
+
+    // No standalone media-only reply should exist
+    const prematureMedia = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.includes("/tmp/first.png"));
+    expect(prematureMedia).toHaveLength(0);
+
+    emit({
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tc5",
+      isError: false,
+      result: { content: [{ type: "text", text: "done" }] },
+    });
+    await flush();
+
+    // Assistant reply carries the artifact
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "All done!" });
+    emitAssistantTextEnd({ emit });
+    await flush();
+
+    const withMedia = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.includes("/tmp/first.png"));
+    expect(withMedia.length).toBeGreaterThan(0);
+    expect(withMedia[0].text).toBe("All done!");
+  });
+
+  it("filters local paths from untrusted tools", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "tool_execution_start", toolName: "sketchy_plugin", toolCallId: "tc6", args: {} });
+    await flush();
+    emit({
+      type: "tool_execution_end",
+      toolName: "sketchy_plugin",
+      toolCallId: "tc6",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "done" }],
+        details: { media: { mediaUrls: ["/etc/passwd"] } },
+      },
+    });
+    await flush();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Done." });
+    emitAssistantTextEnd({ emit });
+    emit({ type: "agent_end" });
+    await flush();
+
+    const anyMedia = onBlockReply.mock.calls
+      .map((c: unknown[]) => c[0] as BlockReplyPayload)
+      .filter((p) => p.mediaUrls?.length);
+    expect(anyMedia).toHaveLength(0);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -4,7 +4,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   extractMessagingToolSend,
-  extractToolResultReplyPayload,
+  extractToolMediaArtifact,
 } from "./pi-embedded-subscribe.tools.js";
 
 describe("extractMessagingToolSend", () => {
@@ -61,12 +61,12 @@ describe("extractMessagingToolSend", () => {
   });
 });
 
-describe("extractToolResultReplyPayload", () => {
+describe("extractToolMediaArtifact", () => {
   it("keeps local media paths for trusted core tools", () => {
     expect(
-      extractToolResultReplyPayload("image_generate", {
+      extractToolMediaArtifact("image_generate", {
         details: {
-          reply: {
+          media: {
             mediaUrls: ["/tmp/generated.png"],
           },
         },
@@ -78,9 +78,9 @@ describe("extractToolResultReplyPayload", () => {
 
   it("drops local media paths for untrusted tools", () => {
     expect(
-      extractToolResultReplyPayload("third_party_plugin", {
+      extractToolMediaArtifact("third_party_plugin", {
         details: {
-          reply: {
+          media: {
             mediaUrls: ["/tmp/secret.png"],
           },
         },
@@ -90,9 +90,9 @@ describe("extractToolResultReplyPayload", () => {
 
   it("keeps remote media urls for untrusted tools", () => {
     expect(
-      extractToolResultReplyPayload("third_party_plugin", {
+      extractToolMediaArtifact("third_party_plugin", {
         details: {
-          reply: {
+          media: {
             mediaUrls: ["https://example.com/generated.png"],
           },
         },
@@ -100,5 +100,30 @@ describe("extractToolResultReplyPayload", () => {
     ).toEqual({
       mediaUrls: ["https://example.com/generated.png"],
     });
+  });
+
+  it("extracts audioAsVoice from media artifact", () => {
+    expect(
+      extractToolMediaArtifact("tts", {
+        details: {
+          media: {
+            mediaUrl: "/tmp/voice.opus",
+            audioAsVoice: true,
+          },
+        },
+      }),
+    ).toEqual({
+      mediaUrl: "/tmp/voice.opus",
+      audioAsVoice: true,
+    });
+  });
+
+  it("returns undefined when no media field exists", () => {
+    expect(
+      extractToolMediaArtifact("bash", {
+        content: [{ type: "text", text: "done" }],
+        details: { status: "ok" },
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -185,11 +185,17 @@ function normalizeMediaArtifact(value: unknown): ToolMediaArtifact | undefined {
   if (!mediaUrl && !mediaUrls?.length && !audioAsVoice) {
     return undefined;
   }
-  return {
-    ...(mediaUrl ? { mediaUrl } : {}),
-    ...(mediaUrls?.length ? { mediaUrls } : {}),
-    ...(audioAsVoice ? { audioAsVoice } : {}),
-  };
+  const artifact: ToolMediaArtifact = {};
+  if (mediaUrl) {
+    artifact.mediaUrl = mediaUrl;
+  }
+  if (mediaUrls?.length) {
+    artifact.mediaUrls = mediaUrls;
+  }
+  if (audioAsVoice) {
+    artifact.audioAsVoice = true;
+  }
+  return artifact;
 }
 
 function isToolResultMediaTrusted(toolName: string): boolean {
@@ -201,22 +207,24 @@ function filterMediaArtifactUrls(
   artifact: ToolMediaArtifact,
 ): ToolMediaArtifact | undefined {
   const allowLocalPaths = isToolResultMediaTrusted(toolName);
+  const isAllowed = (url: string) => allowLocalPaths || HTTP_URL_RE.test(url.trim());
   const mediaUrl =
-    typeof artifact.mediaUrl === "string" &&
-    (allowLocalPaths || HTTP_URL_RE.test(artifact.mediaUrl.trim()))
-      ? artifact.mediaUrl
-      : undefined;
-  const mediaUrls = artifact.mediaUrls?.filter(
-    (url) => allowLocalPaths || HTTP_URL_RE.test(url.trim()),
-  );
+    artifact.mediaUrl && isAllowed(artifact.mediaUrl) ? artifact.mediaUrl : undefined;
+  const mediaUrls = artifact.mediaUrls?.filter(isAllowed);
   if (!mediaUrl && !mediaUrls?.length && !artifact.audioAsVoice) {
     return undefined;
   }
-  return {
-    ...(mediaUrl ? { mediaUrl } : {}),
-    ...(mediaUrls?.length ? { mediaUrls } : {}),
-    ...(artifact.audioAsVoice ? { audioAsVoice: true } : {}),
-  };
+  const filtered: ToolMediaArtifact = {};
+  if (mediaUrl) {
+    filtered.mediaUrl = mediaUrl;
+  }
+  if (mediaUrls?.length) {
+    filtered.mediaUrls = mediaUrls;
+  }
+  if (artifact.audioAsVoice) {
+    filtered.audioAsVoice = true;
+  }
+  return filtered;
 }
 
 /**

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -170,16 +170,27 @@ export function extractToolResultText(result: unknown): string | undefined {
   return texts.join("\n");
 }
 
-function normalizeMediaArtifact(value: unknown): ToolMediaArtifact | undefined {
+/**
+ * Parse an unknown value into a ToolMediaArtifact.
+ * An optional `urlFilter` predicate controls which URLs are kept;
+ * when omitted all URLs pass through.
+ */
+function normalizeMediaArtifact(
+  value: unknown,
+  urlFilter?: (url: string) => boolean,
+): ToolMediaArtifact | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
   const record = value as Record<string, unknown>;
-  const mediaUrl = typeof record.mediaUrl === "string" ? record.mediaUrl : undefined;
+  const isValidUrl = (entry: unknown): entry is string =>
+    typeof entry === "string" && entry.trim().length > 0;
+  const isAllowed = (url: string) => !urlFilter || urlFilter(url);
+
+  const mediaUrl =
+    typeof record.mediaUrl === "string" && isAllowed(record.mediaUrl) ? record.mediaUrl : undefined;
   const mediaUrls = Array.isArray(record.mediaUrls)
-    ? record.mediaUrls.filter(
-        (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
-      )
+    ? record.mediaUrls.filter((entry): entry is string => isValidUrl(entry) && isAllowed(entry))
     : undefined;
   const audioAsVoice = record.audioAsVoice === true;
   if (!mediaUrl && !mediaUrls?.length && !audioAsVoice) {
@@ -192,38 +203,10 @@ function normalizeMediaArtifact(value: unknown): ToolMediaArtifact | undefined {
   };
 }
 
-function isToolResultMediaTrusted(toolName: string): boolean {
-  return TRUSTED_TOOL_RESULT_MEDIA.has(normalizeToolName(toolName));
-}
-
-function filterMediaArtifactUrls(
-  toolName: string,
-  artifact: ToolMediaArtifact,
-): ToolMediaArtifact | undefined {
-  const allowLocalPaths = isToolResultMediaTrusted(toolName);
-  const isAllowed = (url: string) => allowLocalPaths || HTTP_URL_RE.test(url.trim());
-  const mediaUrl =
-    artifact.mediaUrl && isAllowed(artifact.mediaUrl) ? artifact.mediaUrl : undefined;
-  const mediaUrls = artifact.mediaUrls?.filter(isAllowed);
-  if (!mediaUrl && !mediaUrls?.length && !artifact.audioAsVoice) {
-    return undefined;
-  }
-  const filtered: ToolMediaArtifact = {};
-  if (mediaUrl) {
-    filtered.mediaUrl = mediaUrl;
-  }
-  if (mediaUrls?.length) {
-    filtered.mediaUrls = mediaUrls;
-  }
-  if (artifact.audioAsVoice) {
-    filtered.audioAsVoice = true;
-  }
-  return filtered;
-}
-
 /**
  * Extract media artifacts from a tool result's `details.media` field.
  * Returns undefined when the tool did not produce any deliverable media.
+ * Untrusted tools have local file paths filtered out (only HTTP URLs pass).
  */
 export function extractToolMediaArtifact(
   toolName: string,
@@ -237,11 +220,12 @@ export function extractToolMediaArtifact(
     record.details && typeof record.details === "object" && !Array.isArray(record.details)
       ? (record.details as Record<string, unknown>)
       : undefined;
-  const raw = normalizeMediaArtifact(record.media) ?? normalizeMediaArtifact(details?.media);
-  if (!raw) {
-    return undefined;
-  }
-  return filterMediaArtifactUrls(toolName, raw);
+  const allowLocalPaths = TRUSTED_TOOL_RESULT_MEDIA.has(normalizeToolName(toolName));
+  const urlFilter = allowLocalPaths ? undefined : (url: string) => HTTP_URL_RE.test(url.trim());
+  return (
+    normalizeMediaArtifact(record.media, urlFilter) ??
+    normalizeMediaArtifact(details?.media, urlFilter)
+  );
 }
 
 /** Resolve all media URLs from a ToolMediaArtifact into a flat list. */

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -1,10 +1,21 @@
-import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 import { normalizeTargetForProvider } from "../infra/outbound/target-normalization.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { collectTextContentBlocks } from "./content-blocks.js";
 import { type MessagingToolSend } from "./pi-embedded-messaging.js";
 import { normalizeToolName } from "./tool-policy.js";
+
+/**
+ * Media artifact declared by a tool in `details.media`.
+ * Describes what the tool produced (files, audio) — not how to deliver it.
+ * The consumer (block reply pipeline) decides delivery.
+ */
+export type ToolMediaArtifact = {
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  /** When true, audio should be sent as a voice bubble, not a file attachment. */
+  audioAsVoice?: boolean;
+};
 
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
@@ -159,12 +170,11 @@ export function extractToolResultText(result: unknown): string | undefined {
   return texts.join("\n");
 }
 
-function normalizeToolResultReplyPayload(value: unknown): ReplyPayload | undefined {
+function normalizeMediaArtifact(value: unknown): ToolMediaArtifact | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
   const record = value as Record<string, unknown>;
-  const text = typeof record.text === "string" ? record.text : undefined;
   const mediaUrl = typeof record.mediaUrl === "string" ? record.mediaUrl : undefined;
   const mediaUrls = Array.isArray(record.mediaUrls)
     ? record.mediaUrls.filter(
@@ -172,21 +182,13 @@ function normalizeToolResultReplyPayload(value: unknown): ReplyPayload | undefin
       )
     : undefined;
   const audioAsVoice = record.audioAsVoice === true;
-  const channelData =
-    record.channelData &&
-    typeof record.channelData === "object" &&
-    !Array.isArray(record.channelData)
-      ? (record.channelData as Record<string, unknown>)
-      : undefined;
-  if (!text && !mediaUrl && !mediaUrls?.length && !audioAsVoice && !channelData) {
+  if (!mediaUrl && !mediaUrls?.length && !audioAsVoice) {
     return undefined;
   }
   return {
-    ...(text !== undefined ? { text } : {}),
     ...(mediaUrl ? { mediaUrl } : {}),
     ...(mediaUrls?.length ? { mediaUrls } : {}),
     ...(audioAsVoice ? { audioAsVoice } : {}),
-    ...(channelData ? { channelData } : {}),
   };
 }
 
@@ -194,60 +196,64 @@ function isToolResultMediaTrusted(toolName: string): boolean {
   return TRUSTED_TOOL_RESULT_MEDIA.has(normalizeToolName(toolName));
 }
 
-function filterToolResultReplyPayloadMedia(toolName: string, payload: ReplyPayload): ReplyPayload {
+function filterMediaArtifactUrls(
+  toolName: string,
+  artifact: ToolMediaArtifact,
+): ToolMediaArtifact | undefined {
   const allowLocalPaths = isToolResultMediaTrusted(toolName);
   const mediaUrl =
-    typeof payload.mediaUrl === "string" &&
-    (allowLocalPaths || HTTP_URL_RE.test(payload.mediaUrl.trim()))
-      ? payload.mediaUrl
+    typeof artifact.mediaUrl === "string" &&
+    (allowLocalPaths || HTTP_URL_RE.test(artifact.mediaUrl.trim()))
+      ? artifact.mediaUrl
       : undefined;
-  const mediaUrls = payload.mediaUrls?.filter(
+  const mediaUrls = artifact.mediaUrls?.filter(
     (url) => allowLocalPaths || HTTP_URL_RE.test(url.trim()),
   );
-  if (
-    mediaUrl === payload.mediaUrl &&
-    mediaUrls?.length === payload.mediaUrls?.length &&
-    (payload.text || mediaUrl || mediaUrls?.length || payload.audioAsVoice || payload.channelData)
-  ) {
-    return payload;
+  if (!mediaUrl && !mediaUrls?.length && !artifact.audioAsVoice) {
+    return undefined;
   }
   return {
-    ...payload,
-    mediaUrl,
-    mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+    ...(mediaUrl ? { mediaUrl } : {}),
+    ...(mediaUrls?.length ? { mediaUrls } : {}),
+    ...(artifact.audioAsVoice ? { audioAsVoice: true } : {}),
   };
 }
 
-export function extractToolResultReplyPayload(
+/**
+ * Extract media artifacts from a tool result's `details.media` field.
+ * Returns undefined when the tool did not produce any deliverable media.
+ */
+export function extractToolMediaArtifact(
   toolName: string,
   result: unknown,
-): ReplyPayload | undefined {
+): ToolMediaArtifact | undefined {
   if (!result || typeof result !== "object") {
     return undefined;
   }
   const record = result as Record<string, unknown>;
-  const payload =
-    normalizeToolResultReplyPayload(record.reply) ??
-    normalizeToolResultReplyPayload(
+  const raw =
+    normalizeMediaArtifact(record.media) ??
+    normalizeMediaArtifact(
       record.details && typeof record.details === "object"
-        ? (record.details as Record<string, unknown>).reply
+        ? (record.details as Record<string, unknown>).media
         : undefined,
     );
-  if (!payload) {
+  if (!raw) {
     return undefined;
   }
-  const filtered = filterToolResultReplyPayloadMedia(toolName, payload);
-  return resolveSendableToolReplyPayload(filtered) ? filtered : undefined;
+  return filterMediaArtifactUrls(toolName, raw);
 }
 
-function resolveSendableToolReplyPayload(payload: ReplyPayload): boolean {
-  return Boolean(
-    payload.text ||
-    payload.mediaUrl ||
-    payload.mediaUrls?.length ||
-    payload.audioAsVoice ||
-    payload.channelData,
-  );
+/** Resolve all media URLs from a ToolMediaArtifact into a flat list. */
+export function resolveMediaArtifactUrls(artifact: ToolMediaArtifact): string[] {
+  const urls: string[] = [];
+  if (artifact.mediaUrl) {
+    urls.push(artifact.mediaUrl);
+  }
+  if (artifact.mediaUrls?.length) {
+    urls.push(...artifact.mediaUrls);
+  }
+  return urls;
 }
 
 export function isToolResultError(result: unknown): boolean {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -231,13 +231,11 @@ export function extractToolMediaArtifact(
     return undefined;
   }
   const record = result as Record<string, unknown>;
-  const raw =
-    normalizeMediaArtifact(record.media) ??
-    normalizeMediaArtifact(
-      record.details && typeof record.details === "object"
-        ? (record.details as Record<string, unknown>).media
-        : undefined,
-    );
+  const details =
+    record.details && typeof record.details === "object" && !Array.isArray(record.details)
+      ? (record.details as Record<string, unknown>)
+      : undefined;
+  const raw = normalizeMediaArtifact(record.media) ?? normalizeMediaArtifact(details?.media);
   if (!raw) {
     return undefined;
   }

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -185,17 +185,11 @@ function normalizeMediaArtifact(value: unknown): ToolMediaArtifact | undefined {
   if (!mediaUrl && !mediaUrls?.length && !audioAsVoice) {
     return undefined;
   }
-  const artifact: ToolMediaArtifact = {};
-  if (mediaUrl) {
-    artifact.mediaUrl = mediaUrl;
-  }
-  if (mediaUrls?.length) {
-    artifact.mediaUrls = mediaUrls;
-  }
-  if (audioAsVoice) {
-    artifact.audioAsVoice = true;
-  }
-  return artifact;
+  return {
+    ...(mediaUrl ? { mediaUrl } : {}),
+    ...(mediaUrls?.length ? { mediaUrls } : {}),
+    ...(audioAsVoice ? { audioAsVoice } : {}),
+  };
 }
 
 function isToolResultMediaTrusted(toolName: string): boolean {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -533,13 +533,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     } = splitResult;
 
     // Drain pending media artifacts from tool results and attach to this block reply.
-    const { mediaUrls: artifactMediaUrls, audioAsVoice: artifactAudioAsVoice } =
-      state.pendingMediaArtifacts.length > 0
-        ? drainPendingMediaArtifacts()
-        : { mediaUrls: [], audioAsVoice: false };
-
-    const mergedMediaUrls = [...(mediaUrls ?? []), ...artifactMediaUrls];
-    const mergedAudioAsVoice = audioAsVoice || artifactAudioAsVoice;
+    const drained = drainPendingMediaArtifacts();
+    const mergedMediaUrls = [...(mediaUrls ?? []), ...drained.mediaUrls];
+    const mergedAudioAsVoice = audioAsVoice || drained.audioAsVoice;
 
     // Skip empty payloads, but always emit if audioAsVoice is set (to propagate the flag)
     if (!cleanedText && mergedMediaUrls.length === 0 && !mergedAudioAsVoice) {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -661,6 +661,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     resetAssistantMessageState,
     resetForCompactionRetry,
     finalizeAssistantTexts,
+    drainPendingMediaArtifacts,
     trimMessagingToolSent,
     ensureCompactionPromise,
     noteCompactionRetry,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -15,6 +15,7 @@ import type {
   EmbeddedPiSubscribeContext,
   EmbeddedPiSubscribeState,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { resolveMediaArtifactUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
@@ -77,6 +78,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
     deterministicApprovalPromptSent: false,
+    pendingMediaArtifacts: [],
   };
   const usageTotals = {
     input: 0,
@@ -515,14 +517,31 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       replyToTag,
       replyToCurrent,
     } = splitResult;
+
+    // Drain pending media artifacts from tool results and attach to this block reply.
+    const artifactMediaUrls: string[] = [];
+    let artifactAudioAsVoice = false;
+    if (state.pendingMediaArtifacts.length > 0) {
+      for (const { artifact } of state.pendingMediaArtifacts) {
+        artifactMediaUrls.push(...resolveMediaArtifactUrls(artifact));
+        if (artifact.audioAsVoice) {
+          artifactAudioAsVoice = true;
+        }
+      }
+      state.pendingMediaArtifacts.length = 0;
+    }
+
+    const mergedMediaUrls = [...(mediaUrls ?? []), ...artifactMediaUrls];
+    const mergedAudioAsVoice = audioAsVoice || artifactAudioAsVoice;
+
     // Skip empty payloads, but always emit if audioAsVoice is set (to propagate the flag)
-    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
+    if (!cleanedText && mergedMediaUrls.length === 0 && !mergedAudioAsVoice) {
       return;
     }
     emitBlockReplySafely({
       text: cleanedText,
-      mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
-      audioAsVoice,
+      mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+      audioAsVoice: mergedAudioAsVoice,
       replyToId,
       replyToTag,
       replyToCurrent,
@@ -541,11 +560,30 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (blockChunker?.hasBuffered()) {
       blockChunker.drain({ force: true, emit: emitBlockChunk });
       blockChunker.reset();
-      return;
-    }
-    if (state.blockBuffer.length > 0) {
+    } else if (state.blockBuffer.length > 0) {
       emitBlockChunk(state.blockBuffer);
       state.blockBuffer = "";
+    }
+
+    // If media artifacts are still pending after flushing text (e.g., the assistant
+    // replied with SILENT_REPLY_TOKEN and produced no block text), emit them as a
+    // standalone media-only block reply so they still reach the user.
+    if (state.pendingMediaArtifacts.length > 0) {
+      const artifactMediaUrls: string[] = [];
+      let artifactAudioAsVoice = false;
+      for (const { artifact } of state.pendingMediaArtifacts) {
+        artifactMediaUrls.push(...resolveMediaArtifactUrls(artifact));
+        if (artifact.audioAsVoice) {
+          artifactAudioAsVoice = true;
+        }
+      }
+      state.pendingMediaArtifacts.length = 0;
+      if (artifactMediaUrls.length > 0 || artifactAudioAsVoice) {
+        emitBlockReplySafely({
+          mediaUrls: artifactMediaUrls.length > 0 ? artifactMediaUrls : undefined,
+          audioAsVoice: artifactAudioAsVoice,
+        });
+      }
     }
   };
 
@@ -596,6 +634,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.successfulCronAdds = 0;
     state.pendingMessagingMediaUrls.clear();
     state.deterministicApprovalPromptSent = false;
+    state.pendingMediaArtifacts.length = 0;
     resetAssistantMessageState(0);
   };
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -474,17 +474,25 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   /** Drain all pending media artifacts and clear the buffer. */
-  const drainPendingMediaArtifacts = (): { mediaUrls: string[]; audioAsVoice: boolean } => {
+  const drainPendingMediaArtifacts = (): {
+    mediaUrls: string[];
+    voiceMediaUrls: string[];
+    audioAsVoice: boolean;
+  } => {
     const mediaUrls: string[] = [];
+    const voiceMediaUrls: string[] = [];
     let audioAsVoice = false;
     for (const { artifact } of state.pendingMediaArtifacts) {
-      mediaUrls.push(...resolveMediaArtifactUrls(artifact));
+      const urls = resolveMediaArtifactUrls(artifact);
       if (artifact.audioAsVoice) {
+        voiceMediaUrls.push(...urls);
         audioAsVoice = true;
+      } else {
+        mediaUrls.push(...urls);
       }
     }
     state.pendingMediaArtifacts.length = 0;
-    return { mediaUrls, audioAsVoice };
+    return { mediaUrls, voiceMediaUrls, audioAsVoice };
   };
 
   const emitBlockChunk = (text: string) => {
@@ -535,20 +543,41 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Drain pending media artifacts from tool results and attach to this block reply.
     const drained = drainPendingMediaArtifacts();
     const mergedMediaUrls = [...(mediaUrls ?? []), ...drained.mediaUrls];
-    const mergedAudioAsVoice = audioAsVoice || drained.audioAsVoice;
+    const audioAsVoiceFromDirectives = audioAsVoice;
+    const voiceMediaUrls = drained.voiceMediaUrls;
 
     // Skip empty payloads, but always emit if audioAsVoice is set (to propagate the flag)
-    if (!cleanedText && mergedMediaUrls.length === 0 && !mergedAudioAsVoice) {
+    if (
+      !cleanedText &&
+      mergedMediaUrls.length === 0 &&
+      voiceMediaUrls.length === 0 &&
+      !audioAsVoiceFromDirectives &&
+      !drained.audioAsVoice
+    ) {
       return;
     }
-    emitBlockReplySafely({
-      text: cleanedText,
-      mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
-      audioAsVoice: mergedAudioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
-    });
+    const shouldEmitStandard =
+      Boolean(cleanedText) || mergedMediaUrls.length > 0 || audioAsVoiceFromDirectives;
+    if (shouldEmitStandard) {
+      emitBlockReplySafely({
+        text: cleanedText,
+        mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+        audioAsVoice: audioAsVoiceFromDirectives,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      });
+    }
+    if (voiceMediaUrls.length > 0 || drained.audioAsVoice) {
+      emitBlockReplySafely({
+        text: shouldEmitStandard ? undefined : cleanedText,
+        mediaUrls: voiceMediaUrls.length > 0 ? voiceMediaUrls : undefined,
+        audioAsVoice: true,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      });
+    }
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
@@ -571,12 +600,20 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Only drain orphaned artifacts at terminal points (agent end), not before
     // tool executions or message resets where later text may still attach them.
     if (opts?.drainOrphanedArtifacts && state.pendingMediaArtifacts.length > 0) {
-      const { mediaUrls: artifactMediaUrls, audioAsVoice: artifactAudioAsVoice } =
-        drainPendingMediaArtifacts();
-      if (artifactMediaUrls.length > 0 || artifactAudioAsVoice) {
+      const {
+        mediaUrls: artifactMediaUrls,
+        voiceMediaUrls: artifactVoiceMediaUrls,
+        audioAsVoice: artifactAudioAsVoice,
+      } = drainPendingMediaArtifacts();
+      if (artifactMediaUrls.length > 0) {
         emitBlockReplySafely({
-          mediaUrls: artifactMediaUrls.length > 0 ? artifactMediaUrls : undefined,
-          audioAsVoice: artifactAudioAsVoice,
+          mediaUrls: artifactMediaUrls,
+        });
+      }
+      if (artifactVoiceMediaUrls.length > 0 || artifactAudioAsVoice) {
+        emitBlockReplySafely({
+          mediaUrls: artifactVoiceMediaUrls.length > 0 ? artifactVoiceMediaUrls : undefined,
+          audioAsVoice: true,
         });
       }
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -473,6 +473,20 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     return output;
   };
 
+  /** Drain all pending media artifacts and clear the buffer. */
+  const drainPendingMediaArtifacts = (): { mediaUrls: string[]; audioAsVoice: boolean } => {
+    const mediaUrls: string[] = [];
+    let audioAsVoice = false;
+    for (const { artifact } of state.pendingMediaArtifacts) {
+      mediaUrls.push(...resolveMediaArtifactUrls(artifact));
+      if (artifact.audioAsVoice) {
+        audioAsVoice = true;
+      }
+    }
+    state.pendingMediaArtifacts.length = 0;
+    return { mediaUrls, audioAsVoice };
+  };
+
   const emitBlockChunk = (text: string) => {
     if (state.suppressBlockChunks) {
       return;
@@ -519,17 +533,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     } = splitResult;
 
     // Drain pending media artifacts from tool results and attach to this block reply.
-    const artifactMediaUrls: string[] = [];
-    let artifactAudioAsVoice = false;
-    if (state.pendingMediaArtifacts.length > 0) {
-      for (const { artifact } of state.pendingMediaArtifacts) {
-        artifactMediaUrls.push(...resolveMediaArtifactUrls(artifact));
-        if (artifact.audioAsVoice) {
-          artifactAudioAsVoice = true;
-        }
-      }
-      state.pendingMediaArtifacts.length = 0;
-    }
+    const { mediaUrls: artifactMediaUrls, audioAsVoice: artifactAudioAsVoice } =
+      state.pendingMediaArtifacts.length > 0
+        ? drainPendingMediaArtifacts()
+        : { mediaUrls: [], audioAsVoice: false };
 
     const mergedMediaUrls = [...(mediaUrls ?? []), ...artifactMediaUrls];
     const mergedAudioAsVoice = audioAsVoice || artifactAudioAsVoice;
@@ -569,15 +576,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // replied with SILENT_REPLY_TOKEN and produced no block text), emit them as a
     // standalone media-only block reply so they still reach the user.
     if (state.pendingMediaArtifacts.length > 0) {
-      const artifactMediaUrls: string[] = [];
-      let artifactAudioAsVoice = false;
-      for (const { artifact } of state.pendingMediaArtifacts) {
-        artifactMediaUrls.push(...resolveMediaArtifactUrls(artifact));
-        if (artifact.audioAsVoice) {
-          artifactAudioAsVoice = true;
-        }
-      }
-      state.pendingMediaArtifacts.length = 0;
+      const { mediaUrls: artifactMediaUrls, audioAsVoice: artifactAudioAsVoice } =
+        drainPendingMediaArtifacts();
       if (artifactMediaUrls.length > 0 || artifactAudioAsVoice) {
         emitBlockReplySafely({
           mediaUrls: artifactMediaUrls.length > 0 ? artifactMediaUrls : undefined,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -556,7 +556,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const consumePartialReplyDirectives = (text: string, options?: { final?: boolean }) =>
     partialReplyDirectiveAccumulator.consume(text, options);
 
-  const flushBlockReplyBuffer = () => {
+  const flushBlockReplyBuffer = (opts?: { drainOrphanedArtifacts?: boolean }) => {
     if (!params.onBlockReply) {
       return;
     }
@@ -568,10 +568,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       state.blockBuffer = "";
     }
 
-    // If media artifacts are still pending after flushing text (e.g., the assistant
-    // replied with SILENT_REPLY_TOKEN and produced no block text), emit them as a
-    // standalone media-only block reply so they still reach the user.
-    if (state.pendingMediaArtifacts.length > 0) {
+    // Only drain orphaned artifacts at terminal points (agent end), not before
+    // tool executions or message resets where later text may still attach them.
+    if (opts?.drainOrphanedArtifacts && state.pendingMediaArtifacts.length > 0) {
       const { mediaUrls: artifactMediaUrls, audioAsVoice: artifactAudioAsVoice } =
         drainPendingMediaArtifacts();
       if (artifactMediaUrls.length > 0 || artifactAudioAsVoice) {

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -212,7 +212,7 @@ describe("createImageGenerateTool", () => {
         },
       ],
       details: {
-        reply: {
+        media: {
           mediaUrls: ["/tmp/generated-1.png", "/tmp/generated-2.png"],
         },
         provider: "openai",

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -498,7 +498,7 @@ export function createImageGenerateTool(options?: {
     label: "Image Generation",
     name: "image_generate",
     description:
-      'Generate new images or edit reference images with the configured or inferred image-generation model. Use action="list" to inspect available providers/models. Generated images are delivered automatically from the tool result reply payload.',
+      'Generate new images or edit reference images with the configured or inferred image-generation model. Use action="list" to inspect available providers/models. Generated images are delivered automatically alongside the assistant reply.',
     parameters: ImageGenerateToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -615,7 +615,7 @@ export function createImageGenerateTool(options?: {
       return {
         content: [{ type: "text", text: lines.join("\n") }],
         details: {
-          reply: {
+          media: {
             mediaUrls: savedImages.map((image) => image.path),
           },
           provider: result.provider,

--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -15,7 +15,7 @@ describe("createTtsTool", () => {
     expect(tool.description).not.toContain("NO_REPLY");
   });
 
-  it("returns an explicit reply payload for generated audio", async () => {
+  it("returns a media artifact for generated audio", async () => {
     vi.spyOn(ttsModule, "textToSpeech").mockResolvedValue({
       success: true,
       audioPath: "/tmp/voice.opus",
@@ -31,7 +31,7 @@ describe("createTtsTool", () => {
       details: {
         audioPath: "/tmp/voice.opus",
         provider: "openai",
-        reply: {
+        media: {
           mediaUrl: "/tmp/voice.opus",
           audioAsVoice: true,
         },

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -21,7 +21,7 @@ export function createTtsTool(opts?: {
   return {
     label: "TTS",
     name: "tts",
-    description: `Convert text to speech. Audio is delivered automatically from the tool result reply payload — reply with ${SILENT_REPLY_TOKEN} after a successful call to avoid duplicate messages.`,
+    description: `Convert text to speech. Audio is delivered automatically alongside the assistant reply — reply with ${SILENT_REPLY_TOKEN} after a successful call to avoid duplicate messages.`,
     parameters: TtsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -40,7 +40,7 @@ export function createTtsTool(opts?: {
           details: {
             audioPath: result.audioPath,
             provider: result.provider,
-            reply: {
+            media: {
               mediaUrl: result.audioPath,
               audioAsVoice: result.voiceCompatible === true,
             },

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -149,6 +149,26 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics[0]?.message).toContain("plugin tool name conflict");
   });
 
+  it("rejects normalized tool name collisions with core tools", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "demo",
+        optional: false,
+        source: "/tmp/demo.js",
+        factory: () => makeTool("BASH"),
+      },
+    ]);
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+      existingToolNames: new Set(["exec"]),
+    });
+
+    expect(tools).toHaveLength(0);
+    expect(registry.diagnostics).toHaveLength(1);
+    expect(registry.diagnostics[0]?.message).toContain("plugin tool name conflict");
+  });
+
   it("suppresses conflict diagnostics when requested", () => {
     const registry = setMultiToolRegistry();
     const tools = resolveWithConflictingCoreName({ suppressNameConflicts: true });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -120,8 +120,15 @@ export function resolvePluginTools(params: {
       continue;
     }
     const nameSet = new Set<string>();
+    const nameSetNormalized = new Set<string>();
     for (const tool of list) {
-      if (nameSet.has(tool.name) || existing.has(tool.name)) {
+      const normalizedToolName = normalizeToolName(tool.name);
+      if (
+        nameSet.has(tool.name) ||
+        existing.has(tool.name) ||
+        nameSetNormalized.has(normalizedToolName) ||
+        existingNormalized.has(normalizedToolName)
+      ) {
         const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
         if (!params.suppressNameConflicts) {
           log.error(message);
@@ -135,7 +142,9 @@ export function resolvePluginTools(params: {
         continue;
       }
       nameSet.add(tool.name);
+      nameSetNormalized.add(normalizedToolName);
       existing.add(tool.name);
+      existingNormalized.add(normalizedToolName);
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional: entry.optional,


### PR DESCRIPTION
## Summary

Architectural improvement on top of #51648. Tools now describe what they produced (`details.media`) instead of declaring delivery instructions (`details.reply`). Media is collected during tool execution and attached to the assistant reply through the block reply pipeline, replacing the immediate `onToolResult` delivery path.

### Changes

**`details.reply` renamed to `details.media`**: tools report produced artifacts, not delivery instructions. The consumer decides delivery.

**Collect-then-attach instead of immediate push**:
- Handler stashes artifacts in `state.pendingMediaArtifacts` (no immediate delivery)
- `emitBlockChunk` drains pending artifacts into the next block reply
- Single delivery path (`onBlockReply`) instead of two competing ones (`onToolResult` + `onBlockReply`)
- `flushBlockReplyBuffer` handles orphaned artifacts when there is no text reply (e.g. `SILENT_REPLY_TOKEN` after TTS)

**`messagingToolSentMediaUrls` kept separate**: artifact URLs are not pushed into this ledger. It tracks media the agent sent outbound via messaging tools (opposite direction from reply delivery). Block streaming already deduplicates via `shouldDropFinalPayloads` / `blockReplyPipeline.hasSentPayload`.

### Files

- `image-generate-tool.ts`, `tts-tool.ts`: `details.reply` to `details.media`
- `pi-embedded-subscribe.tools.ts`: `ToolMediaArtifact` type, `extractToolMediaArtifact` replaces `extractToolResultReplyPayload`, same trust filtering
- `pi-embedded-subscribe.handlers.tools.ts`: stashes artifacts instead of delivering via `onToolResult`
- `pi-embedded-subscribe.handlers.types.ts`: `pendingMediaArtifacts` added to state
- `pi-embedded-subscribe.ts`: `emitBlockChunk` drains artifacts into block replies, `flushBlockReplyBuffer` handles orphans