### PR TITLE
fix: use American English "behavior" in telegram bot-native-command-menu

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -162,7 +162,7 @@ async function writeCachedCommandHash(
     await fs.writeFile(filePath, hash, "utf-8");
   } catch {
     // Best-effort: failing to cache the hash just means the next restart
-    // will sync commands again, which is the pre-fix behaviour.
+    // will sync commands again, which is the pre-fix behavior.
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace British English `behaviour` with American English `behavior` in `extensions/telegram/src/bot-native-command-menu.ts`
- Per coding style guideline: "use American English spelling and grammar in code, comments, docs, and UI strings"

## Test plan
- [x] Comment-only change, no logic affected
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)