### PR TITLE
fix(ui): keep provider-qualified model picker refs intact

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -550,23 +550,45 @@ function resolveConfiguredModels(
 ): ConfiguredModelOption[] {
   const cfg = configForm as ConfigSnapshot | null;
   const models = cfg?.agents?.defaults?.models;
-  if (!models || typeof models !== "object") {
-    return [];
-  }
-  const options: ConfiguredModelOption[] = [];
-  for (const [modelId, modelRaw] of Object.entries(models)) {
-    const trimmed = modelId.trim();
-    if (!trimmed) {
-      continue;
+  const labels = new Map<string, string>();
+
+  if (models && typeof models === "object") {
+    for (const [modelId, modelRaw] of Object.entries(models)) {
+      const trimmed = modelId.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const alias =
+        modelRaw && typeof modelRaw === "object" && "alias" in modelRaw
+          ? typeof (modelRaw as { alias?: unknown }).alias === "string"
+            ? (modelRaw as { alias?: string }).alias?.trim()
+            : undefined
+          : undefined;
+      const key = trimmed.toLowerCase();
+      labels.set(key, alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed);
     }
-    const alias =
-      modelRaw && typeof modelRaw === "object" && "alias" in modelRaw
-        ? typeof (modelRaw as { alias?: unknown }).alias === "string"
-          ? (modelRaw as { alias?: string }).alias?.trim()
-          : undefined
-        : undefined;
-    const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
-    options.push({ value: trimmed, label });
+  }
+
+  const options: ConfiguredModelOption[] = [];
+  const seen = new Set<string>();
+  const addOption = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    options.push({ value: trimmed, label: labels.get(key) ?? trimmed });
+  };
+
+  // Reuse the broader configured-model collector so the overview picker keeps
+  // provider-qualified primary/fallback refs visible even when they are not in
+  // the alias map.
+  for (const modelId of resolveConfiguredCronModelSuggestions(configForm)) {
+    addOption(modelId);
   }
   return options;
 }

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -171,4 +171,59 @@ describe("renderAgents", () => {
 
     expect(skillsTab?.textContent?.trim()).toContain("1");
   });
+
+  it("lists configured provider-qualified model ids in the overview picker", async () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        createProps({
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: {
+                    primary: "minimax-cn/MiniMax-M2.7",
+                    fallbacks: ["google/gemini-3-flash-preview"],
+                  },
+                  models: {
+                    "custom-dashscope-aliyuncs-com/qwen3.5-flash": { alias: "bailian" },
+                  },
+                },
+                list: [{ id: "beta" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-select select");
+    expect(modelSelect).not.toBeNull();
+
+    const options = Array.from(modelSelect?.querySelectorAll("option") ?? []).map((option) => ({
+      value: option.value,
+      label: option.textContent?.trim(),
+    }));
+
+    expect(options).toEqual(
+      expect.arrayContaining([
+        { value: "", label: "Inherit default (minimax-cn/MiniMax-M2.7)" },
+        {
+          value: "custom-dashscope-aliyuncs-com/qwen3.5-flash",
+          label: "bailian (custom-dashscope-aliyuncs-com/qwen3.5-flash)",
+        },
+        { value: "google/gemini-3-flash-preview", label: "google/gemini-3-flash-preview" },
+        { value: "minimax-cn/MiniMax-M2.7", label: "minimax-cn/MiniMax-M2.7" },
+      ]),
+    );
+    expect(options).not.toContainEqual({
+      value: "minimax-cn/MiniMax-M2.7",
+      label: "Current (minimax-cn/MiniMax-M2.7)",
+    });
+  });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -25,12 +25,18 @@ function createSessions(): SessionsListResult {
 function createChatHeaderState(
   overrides: {
     model?: string | null;
+    modelProvider?: string | null;
+    defaultModel?: string | null;
+    defaultModelProvider?: string | null;
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
+  const defaultModel = overrides.defaultModel ?? "gpt-5";
+  const defaultModelProvider = defaultModel ? (overrides.defaultModelProvider ?? "openai") : null;
   let currentModel = overrides.model ?? null;
-  let currentModelProvider = currentModel ? "openai" : null;
+  let currentModelProvider =
+    overrides.modelProvider ?? (currentModel ? defaultModelProvider : null);
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
@@ -68,7 +74,7 @@ function createChatHeaderState(
         ts: 0,
         path: "",
         count: omitSessionFromList ? 0 : 1,
-        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        defaults: { modelProvider: defaultModelProvider, model: defaultModel, contextTokens: null },
         sessions: omitSessionFromList
           ? []
           : [
@@ -95,7 +101,7 @@ function createChatHeaderState(
       ts: 0,
       path: "",
       count: omitSessionFromList ? 0 : 1,
-      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      defaults: { modelProvider: defaultModelProvider, model: defaultModel, contextTokens: null },
       sessions: omitSessionFromList
         ? []
         : [
@@ -764,6 +770,55 @@ describe("chat view", () => {
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
     expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
     expect(state.sessionsResult?.sessions[0]?.modelProvider).toBe("openai");
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps provider-qualified model refs when switching across providers from the chat header picker", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState({
+      defaultModel: "MiniMax-M2.7",
+      defaultModelProvider: "minimax-cn",
+      models: [
+        { id: "MiniMax-M2.7", name: "MiniMax M2.7", provider: "minimax-cn" },
+        {
+          id: "qwen3.5-flash",
+          name: "Qwen 3.5 Flash",
+          provider: "custom-dashscope-aliyuncs-com",
+        },
+        { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview", provider: "google" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+
+    const optionValues = Array.from(modelSelect?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    expect(optionValues).toContain("custom-dashscope-aliyuncs-com/qwen3.5-flash");
+    expect(optionValues).toContain("google/gemini-3-flash-preview");
+    expect(optionValues).not.toContain("qwen3.5-flash");
+    expect(optionValues).not.toContain("gemini-3-flash-preview");
+
+    modelSelect!.value = "custom-dashscope-aliyuncs-com/qwen3.5-flash";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "custom-dashscope-aliyuncs-com/qwen3.5-flash",
+    });
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("qwen3.5-flash");
+    expect(state.sessionsResult?.sessions[0]?.modelProvider).toBe("custom-dashscope-aliyuncs-com");
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
﻿## Summary
- reuse the configured model collector in the agents overview picker so provider-qualified primary, fallback, and allowlisted model refs stay selectable
- add a regression test that keeps the chat header picker sending the full provider-qualified model when switching across providers
- add coverage for the overview picker so it shows configured provider-qualified values instead of falling back to a synthetic `Current (...)` entry

## Testing
- corepack pnpm --dir ui exec vitest run src/ui/views/chat.test.ts src/ui/views/agents.test.ts src/ui/views/agents-utils.test.ts --config vitest.config.ts
- corepack pnpm --dir ui exec vitest run src/ui/chat-model-ref.test.ts src/ui/chat/slash-command-executor.node.test.ts --config vitest.config.ts

Closes #51608
Closes #51510
