### PR TITLE
docs: expand vLLM and SGLang extension READMEs

### DIFF
--- a/extensions/sglang/README.md
+++ b/extensions/sglang/README.md
@@ -1,3 +1,65 @@
 # SGLang Provider
 
-Bundled provider plugin for SGLang discovery and setup.
+Bundled provider plugin for [SGLang](https://github.com/sgl-project/sglang)
+discovery and setup. SGLang is a fast serving framework for large language
+models that exposes an OpenAI-compatible API.
+
+## Enable
+
+The SGLang plugin is bundled and enabled by default. If disabled, re-enable with:
+
+```bash
+openclaw plugins enable sglang
+```
+
+## Authenticate
+
+Interactive setup:
+
+```bash
+openclaw setup --wizard --auth-choice sglang
+```
+
+Non-interactive:
+
+```bash
+openclaw models auth login --provider sglang \
+  --base-url http://localhost:30000/v1 \
+  --model my-model \
+  --set-default
+```
+
+Set the `SGLANG_API_KEY` environment variable if your SGLang server requires
+authentication.
+
+## Config
+
+Provider configuration lives in the main `openclaw.json` under `providers`:
+
+```json5
+{
+  providers: {
+    sglang: {
+      baseUrl: "http://localhost:30000/v1",
+      model: "my-model",
+      apiKeyEnvVar: "SGLANG_API_KEY", // optional
+    },
+  },
+}
+```
+
+Default base URL: `http://localhost:30000/v1`
+
+## Auto-discovery
+
+The plugin probes the default SGLang endpoint on startup. If a running SGLang
+server is detected, it registers automatically as an available provider.
+
+## Full documentation
+
+See https://docs.openclaw.ai/providers/sglang for:
+
+- Server setup and model serving
+- Custom base URLs and API keys
+- Model selection and failover
+- Troubleshooting

--- a/extensions/vllm/README.md
+++ b/extensions/vllm/README.md
@@ -1,3 +1,65 @@
 # vLLM Provider
 
-Bundled provider plugin for vLLM discovery and setup.
+Bundled provider plugin for [vLLM](https://docs.vllm.ai/) discovery and setup.
+vLLM is a high-throughput, memory-efficient inference engine for LLMs that
+exposes an OpenAI-compatible API.
+
+## Enable
+
+The vLLM plugin is bundled and enabled by default. If disabled, re-enable with:
+
+```bash
+openclaw plugins enable vllm
+```
+
+## Authenticate
+
+Interactive setup:
+
+```bash
+openclaw setup --wizard --auth-choice vllm
+```
+
+Non-interactive:
+
+```bash
+openclaw models auth login --provider vllm \
+  --base-url http://localhost:8000/v1 \
+  --model my-model \
+  --set-default
+```
+
+Set the `VLLM_API_KEY` environment variable if your vLLM server requires
+authentication.
+
+## Config
+
+Provider configuration lives in the main `openclaw.json` under `providers`:
+
+```json5
+{
+  providers: {
+    vllm: {
+      baseUrl: "http://localhost:8000/v1",
+      model: "my-model",
+      apiKeyEnvVar: "VLLM_API_KEY", // optional
+    },
+  },
+}
+```
+
+Default base URL: `http://localhost:8000/v1`
+
+## Auto-discovery
+
+The plugin probes the default vLLM endpoint on startup. If a running vLLM
+server is detected, it registers automatically as an available provider.
+
+## Full documentation
+
+See https://docs.openclaw.ai/providers/vllm for:
+
+- Server setup and model serving
+- Custom base URLs and API keys
+- Model selection and failover
+- Troubleshooting


### PR DESCRIPTION
## Summary
- Expanded `extensions/vllm/README.md` from 3-line stub to full README with enable, authenticate, config, auto-discovery, and docs link sections
- Expanded `extensions/sglang/README.md` with the same structure
- Both are self-hosted OpenAI-compatible provider plugins with similar patterns

## Test plan
- [ ] Verify READMEs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)