### PR TITLE
feat(brave): add custom baseUrl support for Brave Search API

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -27,8 +27,7 @@ import {
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
-const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
+const BRAVE_DEFAULT_BASE_URL = "https://api.search.brave.com";
 const BRAVE_SEARCH_LANG_CODES = new Set([
   "ar",
   "eu",
@@ -94,6 +93,7 @@ const BRAVE_UI_LANG_LOCALE = /^([a-z]{2})-([a-z]{2})$/i;
 
 type BraveConfig = {
   mode?: string;
+  baseUrl?: string;
 };
 
 type BraveSearchResult = {
@@ -209,6 +209,7 @@ async function runBraveLlmContextSearch(params: {
   country?: string;
   search_lang?: string;
   freshness?: string;
+  baseUrl?: string;
 }): Promise<{
   results: Array<{
     url: string;
@@ -218,7 +219,8 @@ async function runBraveLlmContextSearch(params: {
   }>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
-  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  const base = params.baseUrl || BRAVE_DEFAULT_BASE_URL;
+  const url = new URL(base + "/res/v1/llm/context");
   url.searchParams.set("q", params.query);
   if (params.country) {
     url.searchParams.set("country", params.country);
@@ -265,8 +267,10 @@ async function runBraveWebSearch(params: {
   freshness?: string;
   dateAfter?: string;
   dateBefore?: string;
+  baseUrl?: string;
 }): Promise<Array<Record<string, unknown>>> {
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const base = params.baseUrl || BRAVE_DEFAULT_BASE_URL;
+  const url = new URL(base + "/res/v1/web/search");
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -531,6 +535,7 @@ function createBraveToolDefinition(
           country: country ?? undefined,
           search_lang: normalizedLanguage.search_lang,
           freshness,
+          baseUrl: braveConfig.baseUrl,
         });
         const payload = {
           query,
@@ -567,6 +572,7 @@ function createBraveToolDefinition(
         freshness,
         dateAfter,
         dateBefore,
+        baseUrl: braveConfig.baseUrl,
       });
       const payload = {
         query,


### PR DESCRIPTION
## Summary
- Add `baseUrl` option to `BraveConfig` so users can configure a custom Brave Search API endpoint
- Replace hardcoded `BRAVE_SEARCH_ENDPOINT` / `BRAVE_LLM_CONTEXT_ENDPOINT` with a configurable base URL that defaults to `https://api.search.brave.com`
- Pass `baseUrl` through to both `runBraveLlmContextSearch` and `runBraveWebSearch`

### Configuration

```json5
{
  tools: {
    web: {
      search: {
        provider: "brave",
        apiKey: "your-api-key",
        brave: {
          baseUrl: "https://your-proxy-domain.com"
        }
      }
    }
  }
}
```

## Motivation
Users in regions where `api.search.brave.com` is not directly accessible (e.g. mainland China) need to route through reverse proxies like Cloudflare Workers. This change allows configuring the base URL without code modifications.

Closes #51658

## Test plan
- [x] Verified default behavior unchanged (uses `https://api.search.brave.com` when `baseUrl` is not set)
- [x] Both web search and LLM context endpoints use the configured base URL
- [ ] Manual test with a reverse proxy endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)