### PR TITLE
fix: use American English spelling in extension comments

### DIFF
--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -59,7 +59,7 @@ export function parseColorMarkup(content: string): Segment[] {
   // pattern like \[([^\]]+)\] would match any bracket token — e.g. [Q1] —
   // and cause it to consume a later real closing tag ([/red]), silently
   // corrupting the surrounding styled spans.  Restricting the opening tag to
-  // the set of recognised colour/style names prevents that: [Q1] does not
+  // the set of recognized color/style names prevents that: [Q1] does not
   // match the tag alternative and each of its characters falls through to the
   // plain-text alternatives instead.
   //

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -162,7 +162,7 @@ async function writeCachedCommandHash(
     await fs.writeFile(filePath, hash, "utf-8");
   } catch {
     // Best-effort: failing to cache the hash just means the next restart
-    // will sync commands again, which is the pre-fix behaviour.
+    // will sync commands again, which is the pre-fix behavior.
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace British English spellings with American English in code comments, per repo style guide (CLAUDE.md: "use American spelling and grammar")
- `extensions/telegram/src/bot-native-command-menu.ts`: "behaviour" -> "behavior"
- `extensions/feishu/src/docx-color-text.ts`: "recognised colour" -> "recognized color"

## Test plan
- [x] Comment-only changes, no logic affected
- [x] Pre-commit hooks (format, lint, type-check) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)