### PR TITLE
fix(webchat): add clipboard fallback for Edge browser copy button

### DIFF
--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,11 +17,31 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  // Try modern Clipboard API first, then fall back to execCommand for
+  // browsers (e.g. Edge) that block clipboard.writeText outside a secure
+  // context or without explicit permission.
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
+    return copyViaExecCommand(text);
+  }
+}
+
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
     return false;
+  } finally {
+    document.body.removeChild(textarea);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `execCommand('copy')` fallback when `navigator.clipboard.writeText` fails
- Edge browser blocks the Clipboard API when the page is not in a secure context or clipboard permission is denied
- The fallback creates a temporary textarea, selects the content, and uses the legacy `document.execCommand('copy')` method

## Motivation
Users on Edge browser (Windows 11) cannot copy code blocks via the copy button — nothing happens on click. The Clipboard API silently fails in Edge's stricter security context handling.

Closes #51664

## Test plan
- [ ] Verify copy button works in Edge browser (Windows)
- [ ] Verify copy button still works in Chrome/Firefox/Safari (no regression)
- [x] Fallback only triggers when `navigator.clipboard.writeText` throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)