### PR TITLE
fix: use American English in feishu docx-color-text comment

### DIFF
--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -59,7 +59,7 @@ export function parseColorMarkup(content: string): Segment[] {
   // pattern like \[([^\]]+)\] would match any bracket token — e.g. [Q1] —
   // and cause it to consume a later real closing tag ([/red]), silently
   // corrupting the surrounding styled spans.  Restricting the opening tag to
-  // the set of recognised colour/style names prevents that: [Q1] does not
+  // the set of recognized color/style names prevents that: [Q1] does not
   // match the tag alternative and each of its characters falls through to the
   // plain-text alternatives instead.
   //


### PR DESCRIPTION
Replace 'recognised colour' with 'recognized color' in feishu extension per coding style guidelines.