### PR TITLE
docs: fix broken link and relative image paths

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -81,7 +81,7 @@ Lark (global) tenants should use [https://open.larksuite.com/app](https://open.l
 2. Fill in the app name + description
 3. Choose an app icon
 
-![Create enterprise app](../images/feishu-step2-create-app.png)
+![Create enterprise app](/images/feishu-step2-create-app.png)
 
 ### 3. Copy credentials
 
@@ -92,7 +92,7 @@ From **Credentials & Basic Info**, copy:
 
 ❗ **Important:** keep the App Secret private.
 
-![Get credentials](../images/feishu-step3-credentials.png)
+![Get credentials](/images/feishu-step3-credentials.png)
 
 ### 4. Configure permissions
 
@@ -126,7 +126,7 @@ On **Permissions**, click **Batch import** and paste:
 }
 ```
 
-![Configure permissions](../images/feishu-step4-permissions.png)
+![Configure permissions](/images/feishu-step4-permissions.png)
 
 ### 5. Enable bot capability
 
@@ -135,7 +135,7 @@ In **App Capability** > **Bot**:
 1. Enable bot capability
 2. Set the bot name
 
-![Enable bot capability](../images/feishu-step5-bot-capability.png)
+![Enable bot capability](/images/feishu-step5-bot-capability.png)
 
 ### 6. Configure event subscription
 
@@ -151,7 +151,7 @@ In **Event Subscription**:
 
 ⚠️ If the gateway is not running, the long-connection setup may fail to save.
 
-![Configure event subscription](../images/feishu-step6-event-subscription.png)
+![Configure event subscription](/images/feishu-step6-event-subscription.png)
 
 ### 7. Publish the app
 
@@ -206,7 +206,7 @@ When using webhook mode, set both `channels.feishu.verificationToken` and `chann
 
 The screenshot below shows where to find the **Verification Token**. The **Encrypt Key** is listed in the same **Encryption** section.
 
-![Verification Token location](../images/feishu-verification-token.png)
+![Verification Token location](/images/feishu-verification-token.png)
 
 ### Configure via environment variables
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -121,7 +121,7 @@ Example:
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration) for the full `plugins.*` schema.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Fix broken internal link `/configuration` -> `/gateway/configuration` in `docs/plugins/manifest.md` (no doc page exists at `/configuration`; the canonical path is `/gateway/configuration`)
- Convert 6 relative image paths (`../images/feishu-*.png`) to Mintlify-standard root-relative paths (`/images/feishu-*.png`) in `docs/channels/feishu.md`

## Test plan

- [ ] Verify the `/gateway/configuration` link resolves correctly on the docs site
- [ ] Verify Feishu setup images render correctly with root-relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)