### PR TITLE
docs: expand vLLM and SGLang provider plugin READMEs

### DIFF
--- a/extensions/sglang/README.md
+++ b/extensions/sglang/README.md
@@ -1,3 +1,71 @@
 # SGLang Provider
 
-Bundled provider plugin for SGLang discovery and setup.
+Bundled provider plugin that connects OpenClaw to a local or self-hosted
+[SGLang](https://github.com/sgl-project/sglang) server via its
+OpenAI-compatible API.
+
+## Enabling
+
+SGLang is a bundled plugin and ships with every OpenClaw install. No extra
+installation step is required.
+
+To opt in, export the environment variable (any value works when the server
+does not enforce authentication):
+
+```bash
+export SGLANG_API_KEY="sglang-local"
+```
+
+Then run `openclaw onboard` and choose **SGLang**, or set the model directly:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "sglang/your-model-id" },
+    },
+  },
+}
+```
+
+## Configuration
+
+By default OpenClaw connects to `http://127.0.0.1:30000/v1`. If your SGLang
+server runs elsewhere, add an explicit provider entry:
+
+```json5
+{
+  models: {
+    providers: {
+      sglang: {
+        baseUrl: "http://your-host:30000/v1",
+        apiKey: "${SGLANG_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "your-model-id",
+            name: "Local SGLang Model",
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+When no explicit provider entry exists and `SGLANG_API_KEY` is set, OpenClaw
+auto-discovers models by querying `GET /v1/models` on the default base URL.
+
+## Environment variables
+
+| Variable         | Purpose                                     |
+| ---------------- | ------------------------------------------- |
+| `SGLANG_API_KEY` | API key sent to the SGLang server           |
+
+## Docs
+
+Full documentation: <https://docs.openclaw.ai/providers/sglang>
+
+Plugin system overview: <https://docs.openclaw.ai/plugin>

--- a/extensions/vllm/README.md
+++ b/extensions/vllm/README.md
@@ -1,3 +1,70 @@
 # vLLM Provider
 
-Bundled provider plugin for vLLM discovery and setup.
+Bundled provider plugin that connects OpenClaw to a local or self-hosted
+[vLLM](https://docs.vllm.ai/) server via its OpenAI-compatible API.
+
+## Enabling
+
+vLLM is a bundled plugin and ships with every OpenClaw install. No extra
+installation step is required.
+
+To opt in, export the environment variable (any value works when the server
+does not enforce authentication):
+
+```bash
+export VLLM_API_KEY="vllm-local"
+```
+
+Then run `openclaw onboard` and choose **vLLM**, or set the model directly:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "vllm/your-model-id" },
+    },
+  },
+}
+```
+
+## Configuration
+
+By default OpenClaw connects to `http://127.0.0.1:8000/v1`. If your vLLM
+server runs elsewhere, add an explicit provider entry:
+
+```json5
+{
+  models: {
+    providers: {
+      vllm: {
+        baseUrl: "http://your-host:8000/v1",
+        apiKey: "${VLLM_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "your-model-id",
+            name: "Local vLLM Model",
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+When no explicit provider entry exists and `VLLM_API_KEY` is set, OpenClaw
+auto-discovers models by querying `GET /v1/models` on the default base URL.
+
+## Environment variables
+
+| Variable       | Purpose                                   |
+| -------------- | ----------------------------------------- |
+| `VLLM_API_KEY` | API key sent to the vLLM server           |
+
+## Docs
+
+Full documentation: <https://docs.openclaw.ai/providers/vllm>
+
+Plugin system overview: <https://docs.openclaw.ai/plugin>


### PR DESCRIPTION
## Summary

- Expand `extensions/vllm/README.md` and `extensions/sglang/README.md` from 3-line stubs to full plugin READMEs
- Each README now covers: description, enabling, configuration, environment variables, and documentation links
- Follows the existing style used by other extension READMEs (e.g. `extensions/voice-call/README.md`)

## Test plan

- [ ] Verify Markdown renders correctly on GitHub
- [ ] Confirm no CODEOWNERS-protected files are touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)