### PR TITLE
test(slack): harden stream-mode edge-case coverage

### DIFF
--- a/extensions/slack/src/stream-mode.test.ts
+++ b/extensions/slack/src/stream-mode.test.ts
@@ -115,6 +115,41 @@ describe("applyAppendOnlyStreamUpdate", () => {
       changed: true,
     });
   });
+
+  it("ignores incoming chunks that are empty after trimEnd", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "   \n\t  ",
+      rendered: "hello",
+      source: "hello",
+    });
+    expect(next).toEqual({ rendered: "hello", source: "hello", changed: false });
+  });
+
+  it("uses rendered prefix when incoming extends rendered text", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "hello world!!!",
+      rendered: "hello world",
+      source: "not-a-prefix",
+    });
+    expect(next).toEqual({
+      rendered: "hello world!!!",
+      source: "hello world!!!",
+      changed: true,
+    });
+  });
+
+  it("does not insert extra newline when rendered already ends with newline", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "second line",
+      rendered: "first line\n",
+      source: "first line",
+    });
+    expect(next).toEqual({
+      rendered: "first line\nsecond line",
+      source: "second line",
+      changed: true,
+    });
+  });
 });
 
 describe("buildStatusFinalPreviewText", () => {
@@ -122,5 +157,14 @@ describe("buildStatusFinalPreviewText", () => {
     expect(buildStatusFinalPreviewText(1)).toBe("Status: thinking..");
     expect(buildStatusFinalPreviewText(2)).toBe("Status: thinking...");
     expect(buildStatusFinalPreviewText(3)).toBe("Status: thinking.");
+  });
+
+  it("handles zero and large update counts consistently", () => {
+    // 0 is clamped to 1
+    expect(buildStatusFinalPreviewText(0)).toBe("Status: thinking..");
+    // 4 -> 4 % 3 = 1 -> two dots
+    expect(buildStatusFinalPreviewText(4)).toBe("Status: thinking..");
+    // 5 -> 5 % 3 = 2 -> three dots
+    expect(buildStatusFinalPreviewText(5)).toBe("Status: thinking...");
   });
 });


### PR DESCRIPTION
## Summary

Refreshes the test-only intent from [#32798](https://github.com/openclaw/openclaw/pull/32798) on latest `main`.

This PR adds Slack stream-mode edge-case coverage for:

- `applyAppendOnlyStreamUpdate`
  - ignores whitespace-only incoming partials after `trimEnd`
  - explicitly exercises the rendered-prefix path (using non-prefix `source`)
  - avoids extra newline when `rendered` already ends with `\n`
- `buildStatusFinalPreviewText`
  - locks dot-cycling boundaries for `updateCount = 0, 4, 5`

## Notes

- Tests only, no runtime behavior changes.
- Single file changed: `extensions/slack/src/stream-mode.test.ts`.