### PR TITLE
fix(build): add memory-cli as stable dist entry to fix memory_search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
+- Build/memory tools: emit `dist/cli/memory-cli.js` as a stable core entry so runtime `memory_search` loading no longer depends on hashed `memory-cli-*` bundle names. (#51759) Thanks @oliviareid-svg.
 
 ### Fixes
 

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -35,6 +35,7 @@ describe("tsdown config", () => {
     expect(entryKeys(distGraphs[0])).toEqual(
       expect.arrayContaining([
         "index",
+        "cli/memory-cli",
         "plugins/runtime/index",
         "plugin-sdk/compat",
         "plugin-sdk/index",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -169,6 +169,10 @@ function buildCoreDistEntries(): Record<string, string> {
     entry: "src/entry.ts",
     // Ensure this module is bundled as an entry so legacy CLI shims can resolve its exports.
     "cli/daemon-cli": "src/cli/daemon-cli.ts",
+    // Ensure memory-cli is a stable entry so the runtime tools plugin can import
+    // it by a deterministic path instead of a content-hashed chunk name.
+    // See https://github.com/openclaw/openclaw/issues/51676
+    "cli/memory-cli": "src/cli/memory-cli.ts",
     extensionAPI: "src/extensionAPI.ts",
     "infra/warning-filter": "src/infra/warning-filter.ts",
     "telegram/audit": "extensions/telegram/src/audit.ts",


### PR DESCRIPTION
## Summary

- Adds `src/cli/memory-cli.ts` as an explicit entry in `buildCoreDistEntries()` so it emits as `dist/cli/memory-cli.js` with a stable, deterministic path
- This prevents the runtime tools plugin from importing `memory-cli` through a content-hashed chunk (`memory-cli-*.js`) that breaks when the hash changes between builds
- Mirrors the existing pattern used for `cli/daemon-cli`

## Problem

The `memory_search` tool (the mandatory recall step in agent sessions) fails with `ERR_MODULE_NOT_FOUND` because:

1. `src/plugins/runtime/runtime-tools.ts` imports from `../../cli/memory-cli.js`
2. Since `memory-cli` is not an explicit build entry, tsdown emits it as a content-hashed chunk (e.g. `memory-cli-1jB6uC2k.js`)
3. That chunk references another hashed chunk (`manager-runtime-Cl-wnyqx.js`)
4. When the npm package is published with different build conditions, the hashes change but the import references don't, causing `ERR_MODULE_NOT_FOUND`

## Fix

Add `"cli/memory-cli": "src/cli/memory-cli.ts"` to `buildCoreDistEntries()` in `tsdown.config.ts`. This ensures the module is always emitted at `dist/cli/memory-cli.js` — a stable path that doesn't depend on content hashing.

## Test plan

- [ ] Run `pnpm build` and verify `dist/cli/memory-cli.js` exists as a stable entry (no hash suffix)
- [ ] Verify `memory_search` tool loads without `ERR_MODULE_NOT_FOUND`
- [ ] Verify `openclaw memory search` CLI command still works
- [ ] Run existing test suite: `pnpm test`

Fixes #51676