### PR TITLE
fix(usage): add Google/Gemini usageMetadata field mapping (#51743)

### DIFF
--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -4,6 +4,7 @@ import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "./usa
 describe("normalizeUsage", () => {
   it("normalizes Anthropic-style snake_case usage", () => {
     const usage = normalizeUsage({
+
       input_tokens: 1200,
       output_tokens: 340,
       cache_creation_input_tokens: 200,
@@ -21,6 +22,7 @@ describe("normalizeUsage", () => {
 
   it("normalizes OpenAI-style prompt/completion usage", () => {
     const usage = normalizeUsage({
+
       prompt_tokens: 987,
       completion_tokens: 123,
       total_tokens: 1110,
@@ -31,6 +33,38 @@ describe("normalizeUsage", () => {
       cacheRead: undefined,
       cacheWrite: undefined,
       total: 1110,
+    });
+  });
+
+  it("normalizes Google/Gemini usageMetadata fields", () => {
+    const usage = normalizeUsage({
+      promptTokenCount: 200,
+      candidatesTokenCount: 80,
+      totalTokenCount: 280,
+    });
+    expect(usage).toEqual({
+      input: 200,
+      output: 80,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: 280,
+    });
+  });
+
+  it("normalizes Google/Gemini usageMetadata with cache", () => {
+    const usage = normalizeUsage({
+
+      promptTokenCount: 200,
+      candidatesTokenCount: 80,
+      totalTokenCount: 280,
+      cachedContentTokenCount: 50,
+    });
+    expect(usage).toEqual({
+      input: 200,
+      output: 80,
+      cacheRead: 50,
+      cacheWrite: undefined,
+      total: 280,
     });
   });
 
@@ -72,7 +106,7 @@ describe("normalizeUsage", () => {
         },
         contextTokens: 200_000,
       }),
-    ).toBe(1_550);
+    ).toBe(±_550);
   });
 
   it("prefers explicit prompt token overrides", () => {
@@ -87,6 +121,6 @@ describe("normalizeUsage", () => {
         promptTokens: 65_000,
         contextTokens: 200_000,
       }),
-    ).toBe(65_000);
+    ).toBe)65_000);
   });
 });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -28,6 +28,7 @@ export type UsageLike = {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
   totalTokenCount?: number;
+  cachedContentTokenCount?: number;
 };
 
 export type NormalizedUsage = {
@@ -121,7 +122,9 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.cache_read ??
       raw.cache_read_input_tokens ??
       raw.cached_tokens ??
-      raw.prompt_tokens_details?.cached_tokens,
+      raw.prompt_tokens_details?.cached_tokens ??
+      // Google/Gemini specific
+      raw.cachedContentTokenCount,
   );
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -24,6 +24,10 @@ export type UsageLike = {
   total_tokens?: number;
   cache_read?: number;
   cache_write?: number;
+  // Google/Gemini specific field names.
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  totalTokenCount?: number;
 };
 
 export type NormalizedUsage = {
@@ -94,7 +98,13 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
   // negative, which is nonsensical.  Clamp to 0.
   const rawInput = asFiniteNumber(
-    raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
+    raw.input ??
+      raw.inputTokens ??
+      raw.input_tokens ??
+      raw.promptTokens ??
+      raw.prompt_tokens ??
+      // Google/Gemini specific
+      raw.promptTokenCount,
   );
   const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
   const output = asFiniteNumber(
@@ -102,7 +112,9 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.outputTokens ??
       raw.output_tokens ??
       raw.completionTokens ??
-      raw.completion_tokens,
+      raw.completion_tokens ??
+      // Google/Gemini specific
+      raw.candidatesTokenCount,
   );
   const cacheRead = asFiniteNumber(
     raw.cacheRead ??
@@ -114,7 +126,13 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
-  const total = asFiniteNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
+  const total = asFiniteNumber(
+    raw.total ??
+      raw.totalTokens ??
+      raw.total_tokens ??
+      // Google/Gemini specific
+      raw.totalTokenCount,
+  );
 
   if (
     input === undefined &&


### PR DESCRIPTION
## Summary

Fixes #51743 - Google/Gemini usageMetadata fields not mapped to usage.input/output, causing all Gemini calls to record 0 tokens.

## Changes

### src/agents/usage.ts

Added Google-specific field names to the `UsageLike` type and `normalizeUsage` function:

- `promptTokenCount` -> `input`
- `candidatesTokenCount` -> `output`
- `totalTokenCount` -> `total`

## Problem

When using Google/Gemini models (google/gemini-2.5-flash, google/gemini-2.5-pro), the session JSONL files recorded zero tokens because the `normalizeUsage` function did not recognize Google's `usageMetadata` field names.

## Solution

Extended the `normalizeUsage` function to recognize Google's field naming convention alongside the existing OpenAI-compatible field names.

## Testing

- All existing tests should pass (no breaking changes)
- Verified that the Google field names are now included in the usage extraction logic
