### PR TITLE
fix(acpx): forward permission flags during session init

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -120,6 +120,8 @@ describe("AcpxRuntime", () => {
     const prompt = logs.find((entry) => entry.kind === "prompt");
     expect(ensure).toBeDefined();
     expect(prompt).toBeDefined();
+    const ensureArgs = (ensure?.args as string[]) ?? [];
+    expect(ensureArgs).toContain("--approve-all");
     expect(prompt?.openclawShell).toBe("acp");
     expect(Array.isArray(prompt?.args)).toBe(true);
     const promptArgs = (prompt?.args as string[]) ?? [];
@@ -149,6 +151,7 @@ describe("AcpxRuntime", () => {
     );
     expect(resumeEntry).toBeDefined();
     const resumeArgs = (resumeEntry?.args as string[]) ?? [];
+    expect(resumeArgs).toContain("--approve-all");
     const resumeFlagIndex = resumeArgs.indexOf("--resume-session");
     expect(resumeFlagIndex).toBeGreaterThanOrEqual(0);
     expect(resumeArgs[resumeFlagIndex + 1]).toBe(resumeSessionId);
@@ -660,7 +663,10 @@ describe("AcpxRuntime", () => {
 
       const logs = await readMockRuntimeLogEntries(logPath);
       expect(logs.some((entry) => entry.kind === "ensure")).toBe(true);
-      expect(logs.some((entry) => entry.kind === "new")).toBe(true);
+      const newEntry = logs.find((entry) => entry.kind === "new");
+      expect(newEntry).toBeDefined();
+      const newArgs = (newEntry?.args as string[]) ?? [];
+      expect(newArgs).toContain("--approve-all");
     } finally {
       delete process.env.MOCK_ACPX_ENSURE_EMPTY;
     }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -442,6 +442,41 @@ describe("AcpxRuntime", () => {
     );
   });
 
+  it("applies updated permission flags when reusing an existing session handle", async () => {
+    const first = await createMockRuntimeFixture({
+      permissionMode: "approve-reads",
+    });
+    const handle = await first.runtime.ensureSession({
+      sessionKey: "agent:claude:acp:permission-updated",
+      agent: "claude",
+      mode: "persistent",
+    });
+
+    const second = await createMockRuntimeFixture({
+      permissionMode: "approve-all",
+    });
+    for await (const _event of second.runtime.runTurn({
+      handle,
+      text: "reuse-updated-permissions",
+      mode: "prompt",
+      requestId: "req-reuse-updated-permissions",
+    })) {
+      // Drain events; assertions inspect the mock runtime log.
+    }
+
+    const logs = await readMockRuntimeLogEntries(second.logPath);
+    const prompt = logs.find(
+      (entry) =>
+        entry.kind === "prompt" &&
+        String(entry.sessionName ?? "") === "agent:claude:acp:permission-updated",
+    );
+    expect(prompt).toBeDefined();
+    const promptArgs = (prompt?.args as string[]) ?? [];
+    expect(promptArgs).toContain("--approve-all");
+    expect(promptArgs).toContain("--non-interactive-permissions");
+    expect(promptArgs).toContain("fail");
+  });
+
   it("supports cancel and close using encoded runtime handle state", async () => {
     const { runtime, logPath, config } = await createMockRuntimeFixture();
     const handle = await runtime.ensureSession({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -293,10 +293,24 @@ export class AcpxRuntime implements AcpRuntime {
         agent: params.agent,
         cwd: params.cwd,
         command,
+        prefix: this.buildSessionInitPrefix(params.cwd),
       }),
       cwd: params.cwd,
       fallbackCode: "ACP_SESSION_INIT_FAILED",
     });
+  }
+
+  private buildSessionInitPrefix(cwd: string): string[] {
+    return [
+      "--format",
+      "json",
+      "--json-strict",
+      "--cwd",
+      cwd,
+      ...buildPermissionArgs(this.config.permissionMode),
+      "--non-interactive-permissions",
+      this.config.nonInteractivePermissions,
+    ];
   }
 
   private async shouldReplaceEnsuredSession(params: {
@@ -439,6 +453,7 @@ export class AcpxRuntime implements AcpRuntime {
             agent,
             cwd,
             command: ["sessions", "ensure", "--name", sessionName],
+            prefix: this.buildSessionInitPrefix(cwd),
           }),
           cwd,
           fallbackCode: "ACP_SESSION_INIT_FAILED",

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -893,16 +893,7 @@ export class AcpxRuntime implements AcpRuntime {
     sessionName: string;
     cwd: string;
   }): Promise<string[]> {
-    const prefix = [
-      "--format",
-      "json",
-      "--json-strict",
-      "--cwd",
-      params.cwd,
-      ...buildPermissionArgs(this.config.permissionMode),
-      "--non-interactive-permissions",
-      this.config.nonInteractivePermissions,
-    ];
+    const prefix = [...this.buildSessionInitPrefix(params.cwd)];
     if (this.config.timeoutSeconds) {
       prefix.push("--timeout", String(this.config.timeoutSeconds));
     }


### PR DESCRIPTION
## Summary

- forward ACPX permission flags during the initial `sessions ensure` / `sessions new` bootstrap path, not just later prompt/exec calls
- share a single session-init argument builder so session bootstrap and prompt execution stay aligned on approval / JSON / cwd flags
- cover the direct ensure path plus the named-session fallback paths with focused runtime tests

## Testing

- `pnpm vitest run extensions/acpx/src/runtime.test.ts`

Fixes #51640
