### PR TITLE
feat(skills): add trading-agents skill for TauricResearch/TradingAgents

### DIFF
--- a/skills/trading-agents/SKILL.md
+++ b/skills/trading-agents/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: trading-agents
-description: "Run TradingAgents multi-agent LLM trading analysis via CLI or Python. Use when: (1) analyzing a stock ticker with fundamental, sentiment, technical, and news analysis, (2) getting AI-powered buy/hold/sell decisions with risk assessment, (3) backtesting trading strategies over date ranges. NOT for: real-time order execution, portfolio management with live brokers, or non-equity asset classes. Requires: Python 3.11+, tradingagents package."
+description: "Run TradingAgents multi-agent LLM trading analysis via CLI. Use when: (1) analyzing a stock ticker with fundamental, sentiment, technical, and news analysis, (2) getting AI-powered buy/hold/sell decisions with risk assessment, (3) backtesting trading strategies over date ranges. NOT for: real-time order execution, portfolio management with live brokers, or non-equity asset classes. Requires: tradingagents CLI (installed via uv tool install)."
 metadata:
   {
     "openclaw":
       {
         "emoji": "📈",
-        "requires": { "bins": ["python3"] },
+        "requires": { "bins": ["tradingagents"] },
         "install":
           [
             {
@@ -41,6 +41,14 @@ TradingAgents deploys specialized LLM-powered agents (fundamental analyst, senti
 
 ## Setup
 
+**CLI only** (installed automatically by OpenClaw via `uv tool install`):
+
+```bash
+uv tool install tradingagents
+```
+
+**CLI + Python import** (if you need `from tradingagents ...` in scripts):
+
 ```bash
 pip install tradingagents
 ```
@@ -57,40 +65,19 @@ export OPENROUTER_API_KEY=...      # OpenRouter (any model)
 
 No extra data API keys needed — defaults to yfinance for market data.
 
-## Quick Analysis (Python one-liner)
-
-```bash
-python3 -c "
-from tradingagents.graph.trading_graph import TradingAgentsGraph
-from tradingagents.default_config import DEFAULT_CONFIG
-config = DEFAULT_CONFIG.copy()
-config['llm_provider'] = 'anthropic'
-config['deep_think_llm'] = 'claude-sonnet-4-20250514'
-config['quick_think_llm'] = 'claude-sonnet-4-20250514'
-ta = TradingAgentsGraph(debug=True, config=config)
-_, decision = ta.propagate('NVDA', '2024-05-10')
-print(decision)
-"
-```
-
 ## CLI Usage
 
-After installing via pip:
+Run the interactive CLI:
 
 ```bash
 tradingagents
 ```
 
-Or if installed from source:
-
-```bash
-cd /path/to/TradingAgents
-python -m cli.main
-```
-
 The CLI provides an interactive interface to select tickers, dates, LLM providers, and research depth.
 
 ## Python Package Usage
+
+> Requires `pip install tradingagents` (not `uv tool install`) for Python import support.
 
 ```python
 from tradingagents.graph.trading_graph import TradingAgentsGraph

--- a/skills/trading-agents/SKILL.md
+++ b/skills/trading-agents/SKILL.md
@@ -24,6 +24,18 @@ metadata:
 
 > From [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) (35k+ stars)
 
+## When to Use
+
+- Analyzing a stock ticker with fundamental, sentiment, technical, and news analysis
+- Getting AI-powered buy/hold/sell decisions with risk assessment
+- Backtesting trading strategies over date ranges
+
+## When NOT to Use
+
+- Real-time order execution or live broker integration
+- Portfolio management with live brokers
+- Analyzing non-equity asset classes
+
 TradingAgents deploys specialized LLM-powered agents (fundamental analyst, sentiment analyst, technical analyst, news analyst, bull/bear researchers, trader, risk manager, portfolio manager) that collaboratively evaluate market conditions and produce trading decisions.
 
 ## Setup
@@ -79,7 +91,7 @@ from tradingagents.default_config import DEFAULT_CONFIG
 # Configure
 config = DEFAULT_CONFIG.copy()
 config["llm_provider"] = "openai"           # or "anthropic", "google", "xai", "ollama"
-config["deep_think_llm"] = "gpt-5-mini"     # heavy reasoning model
+config["deep_think_llm"] = "gpt-5"           # strong reasoning model (e.g. gpt-5, o3)
 config["quick_think_llm"] = "gpt-5-mini"    # fast model for quick tasks
 config["max_debate_rounds"] = 1             # bull vs bear debate rounds
 config["max_risk_discuss_rounds"] = 1       # risk team discussion rounds

--- a/skills/trading-agents/SKILL.md
+++ b/skills/trading-agents/SKILL.md
@@ -10,10 +10,11 @@ metadata:
         "install":
           [
             {
-              "id": "pip",
-              "kind": "pip",
+              "id": "uv",
+              "kind": "uv",
               "package": "tradingagents",
-              "label": "Install TradingAgents (pip)",
+              "bins": ["tradingagents"],
+              "label": "Install TradingAgents (uv pip)",
             },
           ],
       },
@@ -51,6 +52,7 @@ export OPENAI_API_KEY=...          # OpenAI (GPT)
 export GOOGLE_API_KEY=...          # Google (Gemini)
 export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
 export XAI_API_KEY=...             # xAI (Grok)
+export OPENROUTER_API_KEY=...      # OpenRouter (any model)
 ```
 
 No extra data API keys needed — defaults to yfinance for market data.
@@ -73,7 +75,13 @@ print(decision)
 
 ## CLI Usage
 
-If installed from source:
+After installing via pip:
+
+```bash
+tradingagents
+```
+
+Or if installed from source:
 
 ```bash
 cd /path/to/TradingAgents

--- a/skills/trading-agents/SKILL.md
+++ b/skills/trading-agents/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: trading-agents
+description: "Run TradingAgents multi-agent LLM trading analysis via CLI or Python. Use when: (1) analyzing a stock ticker with fundamental, sentiment, technical, and news analysis, (2) getting AI-powered buy/hold/sell decisions with risk assessment, (3) backtesting trading strategies over date ranges. NOT for: real-time order execution, portfolio management with live brokers, or non-equity asset classes. Requires: Python 3.11+, tradingagents package."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📈",
+        "requires": { "bins": ["python3"] },
+        "install":
+          [
+            {
+              "id": "pip",
+              "kind": "pip",
+              "package": "tradingagents",
+              "label": "Install TradingAgents (pip)",
+            },
+          ],
+      },
+  }
+---
+
+# TradingAgents - Multi-Agent LLM Financial Trading Framework
+
+> From [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) (35k+ stars)
+
+TradingAgents deploys specialized LLM-powered agents (fundamental analyst, sentiment analyst, technical analyst, news analyst, bull/bear researchers, trader, risk manager, portfolio manager) that collaboratively evaluate market conditions and produce trading decisions.
+
+## Setup
+
+```bash
+pip install tradingagents
+```
+
+Set at least one LLM provider key:
+
+```bash
+export OPENAI_API_KEY=...          # OpenAI (GPT)
+export GOOGLE_API_KEY=...          # Google (Gemini)
+export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
+export XAI_API_KEY=...             # xAI (Grok)
+```
+
+No extra data API keys needed — defaults to yfinance for market data.
+
+## Quick Analysis (Python one-liner)
+
+```bash
+python3 -c "
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+config = DEFAULT_CONFIG.copy()
+config['llm_provider'] = 'anthropic'
+config['deep_think_llm'] = 'claude-sonnet-4-20250514'
+config['quick_think_llm'] = 'claude-sonnet-4-20250514'
+ta = TradingAgentsGraph(debug=True, config=config)
+_, decision = ta.propagate('NVDA', '2024-05-10')
+print(decision)
+"
+```
+
+## CLI Usage
+
+If installed from source:
+
+```bash
+cd /path/to/TradingAgents
+python -m cli.main
+```
+
+The CLI provides an interactive interface to select tickers, dates, LLM providers, and research depth.
+
+## Python Package Usage
+
+```python
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+# Configure
+config = DEFAULT_CONFIG.copy()
+config["llm_provider"] = "openai"           # or "anthropic", "google", "xai", "ollama"
+config["deep_think_llm"] = "gpt-5-mini"     # heavy reasoning model
+config["quick_think_llm"] = "gpt-5-mini"    # fast model for quick tasks
+config["max_debate_rounds"] = 1             # bull vs bear debate rounds
+config["max_risk_discuss_rounds"] = 1       # risk team discussion rounds
+
+# Data vendors (all default to yfinance, no extra API needed)
+config["data_vendors"] = {
+    "core_stock_apis": "yfinance",
+    "technical_indicators": "yfinance",
+    "fundamental_data": "yfinance",
+    "news_data": "yfinance",
+}
+
+# Initialize and run
+ta = TradingAgentsGraph(debug=True, config=config)
+state, decision = ta.propagate("AAPL", "2024-11-15")
+print(decision)
+
+# After observing actual returns, teach the system
+# ta.reflect_and_remember(position_returns)
+```
+
+## Agent Architecture
+
+The framework mirrors a real trading firm:
+
+1. **Analyst Team** - 4 specialized analysts run in parallel:
+   - Fundamentals Analyst: company financials, intrinsic value
+   - Sentiment Analyst: social media sentiment scoring
+   - News Analyst: macro events, global news impact
+   - Technical Analyst: MACD, RSI, chart patterns
+
+2. **Researcher Team** - Bull vs Bear debate:
+   - Bullish researcher argues for the trade
+   - Bearish researcher argues against
+   - Structured debate produces balanced assessment
+
+3. **Trader Agent** - Synthesizes all reports into a trade proposal
+
+4. **Risk Management** - Evaluates volatility, liquidity, portfolio risk
+
+5. **Portfolio Manager** - Final approve/reject decision
+
+## Supported LLM Providers
+
+| Provider | Config Value | Models |
+|----------|-------------|--------|
+| OpenAI | `"openai"` | gpt-5.2, gpt-5-mini, etc. |
+| Anthropic | `"anthropic"` | claude-sonnet-4-20250514, etc. |
+| Google | `"google"` | gemini-3.1-pro, etc. |
+| xAI | `"xai"` | grok-4, etc. |
+| Ollama | `"ollama"` | Any local model |
+| OpenRouter | `"openrouter"` | Any OpenRouter model |
+
+## Tips
+
+- Use `debug=True` to see each agent's reasoning in real-time
+- Start with `max_debate_rounds=1` for faster results, increase for deeper analysis
+- yfinance is free but rate-limited; use alpha_vantage for production workloads
+- The `reflect_and_remember()` method teaches the system from actual trade outcomes
+- Results are cached in `./results/` directory for review
+
+## Links
+
+- [GitHub](https://github.com/TauricResearch/TradingAgents)
+- [Paper](https://arxiv.org/abs/2412.20138)
+- [Discord](https://discord.com/invite/hk9PGKShPK)

--- a/skills/trading-agents/SKILL.md
+++ b/skills/trading-agents/SKILL.md
@@ -47,7 +47,7 @@ TradingAgents deploys specialized LLM-powered agents (fundamental analyst, senti
 uv tool install tradingagents
 ```
 
-**CLI + Python import** (if you need `from tradingagents ...` in scripts):
+**CLI + Python import** (if you need `from tradingagents ...` in scripts; requires Python 3.10+):
 
 ```bash
 pip install tradingagents


### PR DESCRIPTION
## Summary

Adds a new `trading-agents` skill that integrates the [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) (35k+ stars) multi-agent LLM financial trading framework into OpenClaw.

## What it does

The skill enables OpenClaw agents to run comprehensive stock analysis using TradingAgents' multi-agent architecture that mirrors a real trading firm:

- **Analyst Team**: 4 specialized analysts (fundamental, sentiment, technical, news) running in parallel
- **Researcher Team**: Bull vs bear structured debate for balanced assessment
- **Trader Agent**: Synthesizes all reports into trade proposals
- **Risk Management + Portfolio Manager**: Final risk evaluation and approve/reject

## Features

- Supports multiple LLM providers: OpenAI, Anthropic, Google, xAI, Ollama, OpenRouter
- Free market data via yfinance (no API key needed for data)
- Python one-liner for quick analysis
- Interactive CLI mode
- Configurable debate rounds, risk discussion depth
- Learn from outcomes via `reflect_and_remember()`

## Skill format

Single `SKILL.md` following the standard OpenClaw skill format with:
- Metadata: requires `python3`, pip install `tradingagents`
- Setup instructions for LLM provider keys
- Quick start examples (Python and CLI)
- Full architecture documentation
- Provider compatibility table

## References

- [TradingAgents GitHub](https://github.com/TauricResearch/TradingAgents) — 35k+ stars, Apache-2.0
- [Research Paper](https://arxiv.org/abs/2412.20138)