### PR TITLE
refactor(plugins): route Slack runtime through plugin sdk

### DIFF
--- a/src/plugins/runtime/runtime-slack-ops.runtime.ts
+++ b/src/plugins/runtime/runtime-slack-ops.runtime.ts
@@ -7,7 +7,7 @@ import {
   resolveSlackUserAllowlist as resolveSlackUserAllowlistImpl,
   sendMessageSlack as sendMessageSlackImpl,
   handleSlackAction as handleSlackActionImpl,
-} from "../../../extensions/slack/runtime-api.js";
+} from "../../plugin-sdk/slack.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 
 type RuntimeSlackOps = Pick<

--- a/test/fixtures/plugin-extension-import-boundary-inventory.json
+++ b/test/fixtures/plugin-extension-import-boundary-inventory.json
@@ -8,14 +8,6 @@
     "reason": "imports extension-owned file from src/plugins"
   },
   {
-    "file": "src/plugins/runtime/runtime-slack-ops.runtime.ts",
-    "line": 10,
-    "kind": "import",
-    "specifier": "../../../extensions/slack/runtime-api.js",
-    "resolvedPath": "extensions/slack/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
     "file": "src/plugins/runtime/runtime-telegram-ops.runtime.ts",
     "line": 5,
     "kind": "import",


### PR DESCRIPTION
## Summary
- route `src/plugins/runtime/runtime-slack-ops.runtime.ts` through `src/plugin-sdk/slack.ts`
- remove the stale Slack entry from the plugin-extension import boundary inventory
- reduce the remaining grandfathered direct imports from 5 to 4

## Testing
- pnpm lint:plugins:no-extension-imports
- pnpm test -- src/plugin-sdk/runtime-api-guardrails.test.ts
- pnpm test -- extensions/slack/src/channel.test.ts
- node --import tsx - <<'EON'
import { createRuntimeSlack } from './src/plugins/runtime/runtime-slack.ts';
const runtime = createRuntimeSlack();
console.log(JSON.stringify({
  hasListGroups: typeof runtime.listDirectoryGroupsLive === 'function',
  hasListPeers: typeof runtime.listDirectoryPeersLive === 'function',
  hasProbe: typeof runtime.probeSlack === 'function',
  hasResolveChannel: typeof runtime.resolveChannelAllowlist === 'function',
  hasResolveUser: typeof runtime.resolveUserAllowlist === 'function',
  hasSend: typeof runtime.sendMessageSlack === 'function',
  hasMonitor: typeof runtime.monitorSlackProvider === 'function',
  hasAction: typeof runtime.handleSlackAction === 'function'
}, null, 2));
EON
