### PR TITLE
refactor(plugins): route iMessage runtime through plugin sdk

### DIFF
--- a/src/plugins/runtime/runtime-imessage.ts
+++ b/src/plugins/runtime/runtime-imessage.ts
@@ -2,7 +2,7 @@ import {
   monitorIMessageProvider,
   probeIMessage,
   sendMessageIMessage,
-} from "../../../extensions/imessage/runtime-api.js";
+} from "../../plugin-sdk/imessage.js";
 import type { PluginRuntimeChannel } from "./types-channel.js";
 
 export function createRuntimeIMessage(): PluginRuntimeChannel["imessage"] {

--- a/test/fixtures/plugin-extension-import-boundary-inventory.json
+++ b/test/fixtures/plugin-extension-import-boundary-inventory.json
@@ -1,13 +1,5 @@
 [
   {
-    "file": "src/plugins/runtime/runtime-imessage.ts",
-    "line": 5,
-    "kind": "import",
-    "specifier": "../../../extensions/imessage/runtime-api.js",
-    "resolvedPath": "extensions/imessage/runtime-api.js",
-    "reason": "imports extension-owned file from src/plugins"
-  },
-  {
     "file": "src/plugins/runtime/runtime-telegram-ops.runtime.ts",
     "line": 5,
     "kind": "import",


### PR DESCRIPTION
## Summary
- route `src/plugins/runtime/runtime-imessage.ts` through `src/plugin-sdk/imessage.ts`
- remove the stale iMessage entry from the plugin-extension import boundary inventory
- reduce the remaining grandfathered direct imports from 4 to 3

## Testing
- pnpm lint:plugins:no-extension-imports
- pnpm test -- src/plugin-sdk/runtime-api-guardrails.test.ts
- pnpm test -- extensions/imessage/src/channel.outbound.test.ts extensions/imessage/src/probe.test.ts
- node --import tsx - <<'EON'
import { createRuntimeIMessage } from './src/plugins/runtime/runtime-imessage.ts';
const runtime = createRuntimeIMessage();
console.log(JSON.stringify({
  hasMonitor: typeof runtime.monitorIMessageProvider === 'function',
  hasProbe: typeof runtime.probeIMessage === 'function',
  hasSend: typeof runtime.sendMessageIMessage === 'function'
}, null, 2));
EON
