### PR TITLE
fix: chat.abort RPC now stops embedded Pi agent, sub-agents, and session queues

### DIFF
--- a/src/gateway/server-methods/chat.abort-embedded-run.test.ts
+++ b/src/gateway/server-methods/chat.abort-embedded-run.test.ts
@@ -45,7 +45,7 @@ describe("chat.abort stops embedded Pi agent and sub-agents", () => {
     });
 
     expect(abortEmbeddedPiRun).toHaveBeenCalledWith("sess-1");
-    expect(clearSessionQueues).toHaveBeenCalled();
+    expect(clearSessionQueues).toHaveBeenCalledWith(["main", "sess-1"]);
     expect(stopSubagentsForRequester).toHaveBeenCalledWith(
       expect.objectContaining({ requesterSessionKey: "main" }),
     );

--- a/src/gateway/server-methods/chat.abort-embedded-run.test.ts
+++ b/src/gateway/server-methods/chat.abort-embedded-run.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createActiveRun,
+  createChatAbortContext,
+  invokeChatAbortHandler,
+} from "./chat.abort.test-helpers.js";
+
+const abortEmbeddedPiRun = vi.fn(() => true);
+vi.mock("../../agents/pi-embedded.js", () => ({ abortEmbeddedPiRun }));
+
+const stopSubagentsForRequester = vi.fn(() => ({ stopped: 0 }));
+vi.mock("../../auto-reply/reply/abort.js", () => ({ stopSubagentsForRequester }));
+
+const clearSessionQueues = vi.fn(() => ({ followupCleared: 0, laneCleared: 0, keys: [] }));
+vi.mock("../../auto-reply/reply/queue.js", () => ({ clearSessionQueues }));
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../session-utils.js")>();
+  return {
+    ...original,
+    loadSessionEntry: () => ({
+      cfg: { agents: {} },
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-1" },
+      canonicalKey: "main",
+    }),
+  };
+});
+
+const { chatHandlers } = await import("./chat.js");
+
+describe("chat.abort stops embedded Pi agent and sub-agents", () => {
+  it("calls abortEmbeddedPiRun when aborting by sessionKey", async () => {
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([["run-1", createActiveRun("main", { sessionId: "sess-1" })]]),
+    });
+    abortEmbeddedPiRun.mockClear();
+    stopSubagentsForRequester.mockClear();
+    clearSessionQueues.mockClear();
+
+    await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main" },
+    });
+
+    expect(abortEmbeddedPiRun).toHaveBeenCalledWith("sess-1");
+    expect(clearSessionQueues).toHaveBeenCalled();
+    expect(stopSubagentsForRequester).toHaveBeenCalledWith(
+      expect.objectContaining({ requesterSessionKey: "main" }),
+    );
+  });
+
+  it("calls abortEmbeddedPiRun when aborting by runId", async () => {
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([["run-1", createActiveRun("main", { sessionId: "sess-1" })]]),
+    });
+    abortEmbeddedPiRun.mockClear();
+    stopSubagentsForRequester.mockClear();
+    clearSessionQueues.mockClear();
+
+    await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main", runId: "run-1" },
+    });
+
+    expect(abortEmbeddedPiRun).toHaveBeenCalledWith("sess-1");
+    expect(clearSessionQueues).toHaveBeenCalledWith(["main", "sess-1"]);
+    expect(stopSubagentsForRequester).toHaveBeenCalledWith(
+      expect.objectContaining({ requesterSessionKey: "main" }),
+    );
+  });
+
+  it("does not call abort functions when run is not found", async () => {
+    const context = createChatAbortContext();
+    abortEmbeddedPiRun.mockClear();
+    stopSubagentsForRequester.mockClear();
+    clearSessionQueues.mockClear();
+
+    await invokeChatAbortHandler({
+      handler: chatHandlers["chat.abort"],
+      context,
+      request: { sessionKey: "main", runId: "nonexistent" },
+    });
+
+    expect(abortEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(clearSessionQueues).not.toHaveBeenCalled();
+    expect(stopSubagentsForRequester).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -4,8 +4,11 @@ import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
+import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
+import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
@@ -1173,6 +1176,15 @@ export const chatHandlers: GatewayRequestHandlers = {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
         return;
       }
+      if (res.aborted) {
+        const { cfg, entry } = loadSessionEntry(rawSessionKey);
+        const sessionId = entry?.sessionId;
+        if (sessionId) {
+          abortEmbeddedPiRun(sessionId);
+        }
+        clearSessionQueues([rawSessionKey, sessionId].filter(Boolean));
+        stopSubagentsForRequester({ cfg, requesterSessionKey: rawSessionKey });
+      }
       respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
       return;
     }
@@ -1214,6 +1226,12 @@ export const chatHandlers: GatewayRequestHandlers = {
           },
         ],
       });
+    }
+    if (res.aborted) {
+      const { cfg } = loadSessionEntry(rawSessionKey);
+      abortEmbeddedPiRun(active.sessionId);
+      clearSessionQueues([rawSessionKey, active.sessionId]);
+      stopSubagentsForRequester({ cfg, requesterSessionKey: rawSessionKey });
     }
     respond(true, {
       ok: true,


### PR DESCRIPTION
## Summary

Fixes #38277

The `chat.abort` RPC handler only aborted HTTP streaming connections but did not stop the embedded Pi agent run, spawned sub-agents, or clear follow-up message queues. Clicking **Stop** in the webchat UI left the agent running and consuming tokens, unlike the `/stop` text command.

## Changes

- Added `abortEmbeddedPiRun(sessionId)`, `clearSessionQueues()`, and `stopSubagentsForRequester()` calls to both abort paths in `chat.abort` (by sessionKey and by runId)
- Both paths are guarded by `res.aborted` to avoid unnecessary work
- Added test file `chat.abort-embedded-run.test.ts` with 3 tests covering both paths + negative case

## How it was tested

- All 11 `chat.abort*` tests pass (3 new + 8 existing)
- Fix mirrors the existing correct implementation in `tryFastAbortFromMessage()` (used by `/stop`)


> This PR was developed with AI assistance.