### PR TITLE
fix: Control UI model picker provider prefix + skip register on snapshot loads

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -586,6 +586,32 @@ describe("model-selection", () => {
       });
       expect(resolved?.alias).toBe("kimi");
     });
+
+    it("resolves alias in model part of qualified ref (Control UI picker bug #51608)", () => {
+      const index = {
+        byAlias: new Map([
+          [
+            "bailian",
+            {
+              alias: "bailian",
+              ref: { provider: "custom-dashscope-aliyuncs-com", model: "qwen3.5-flash" },
+            },
+          ],
+        ]),
+        byKey: new Map(),
+      };
+
+      const resolved = resolveModelRefFromString({
+        raw: "custom-dashscope-aliyuncs-com/bailian",
+        defaultProvider: "minimax-cn",
+        aliasIndex: index,
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "custom-dashscope-aliyuncs-com",
+        model: "qwen3.5-flash",
+      });
+      expect(resolved?.alias).toBe("bailian");
+    });
   });
 
   describe("resolveConfiguredModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -268,6 +268,16 @@ export function resolveModelRefFromString(params: {
   if (!parsed) {
     return null;
   }
+  if (params.aliasIndex) {
+    const modelAliasKey = normalizeAliasKey(parsed.model);
+    const modelAliasMatch = params.aliasIndex.byAlias.get(modelAliasKey);
+    if (modelAliasMatch) {
+      return {
+        ref: { provider: parsed.provider, model: modelAliasMatch.ref.model },
+        alias: modelAliasMatch.alias,
+      };
+    }
+  }
   return { ref: parsed };
 }
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1177,7 +1177,7 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "command-plugin")?.status).toBe("loaded");
-    expect(scoped.commands.map((entry) => entry.command.name)).toEqual(["pair"]);
+    expect(scoped.commands.map((entry) => entry.command.name)).toEqual([]);
     expect(getPluginCommandSpecs("telegram")).toEqual([]);
 
     const active = loadOpenClawPlugins({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1271,30 +1271,35 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       registrationMode,
     });
 
-    try {
-      const result = register(api);
-      if (result && typeof result.then === "function") {
-        registry.diagnostics.push({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message: "plugin register returned a promise; async registration is ignored",
+    if (shouldActivate) {
+      try {
+        const result = register(api);
+        if (result && typeof result.then === "function") {
+          registry.diagnostics.push({
+            level: "warn",
+            pluginId: record.id,
+            source: record.source,
+            message: "plugin register returned a promise; async registration is ignored",
+          });
+        }
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+      } catch (err) {
+        recordPluginError({
+          logger,
+          registry,
+          record,
+          seenIds,
+          pluginId,
+          origin: candidate.origin,
+          error: err,
+          logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+          diagnosticMessagePrefix: "plugin failed during register: ",
         });
       }
+    } else {
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
-    } catch (err) {
-      recordPluginError({
-        logger,
-        registry,
-        record,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        error: err,
-        logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
-        diagnosticMessagePrefix: "plugin failed during register: ",
-      });
     }
   }
 


### PR DESCRIPTION
## Summary

Two fixes bundled together:

### Fix 1: Control UI Model Picker Provider Prefix (#51608)

Fixes issue #51608 where the Control UI model picker sends wrong provider prefix for all models.

When using the Control UI model picker to switch models, requests were incorrectly routed to the primary provider instead of the correct provider for each model when:

1. A model has an alias configured in `agents.defaults.models`
2. The catalog entry has the alias as its `id` field
3. User selects the model, causing the UI to send `provider/alias` (e.g., `custom-dashscope-aliyuncs-com/bailian`)

The server's `resolveModelRefFromString` function parsed `provider/alias` correctly but didn't resolve the `alias` part through the alias index, causing the allowlist check to fail.

**Changes:**
- `src/agents/model-selection.ts`: In `resolveModelRefFromString`, after parsing a qualified `provider/model` ref, check if the `model` part is an alias in the alias index. If so, use the alias's resolved model name instead.
- `src/agents/model-selection.test.ts`: Added test case for the bug fix.

### Fix 2: Skip register() on Non-Activating Snapshot Loads (#51781)

Fixes issue #51781 where `loadOpenClawPlugins` with `activate: false` still invokes each plugin's `register()` function, causing performance overhead from repeated plugin initialization side effects during snapshot loads.

**Changes:**
- `src/plugins/loader.ts`: Skip calling `register()` when `shouldActivate` is false (i.e., when `activate: false` is passed).
- `src/plugins/loader.test.ts`: Updated test to reflect the new expected behavior.

## Testing

- All `resolveModelRefFromString` tests pass (9 tests)
- All `sessions-patch` tests pass (27 tests)
- All `loader.test.ts` tests pass (77 tests)
- TypeScript type check passes
- Lint and format checks pass

Note: One pre-existing test failure in `resolveConfiguredModelRef > sanitizes control characters in providerless-model warnings` is unrelated to this change (Windows symlink permissions issue).